### PR TITLE
fix: close attachment lightbox on escape

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -771,6 +771,7 @@ jobs:
     if: >-
       ${{
         (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
         startsWith(needs.prepare.outputs.job-ref, 'pr-') &&
         needs.prepare.outputs.www-preview-url != ''
       }}
@@ -805,6 +806,7 @@ jobs:
     # cannot resolve the temporary `gh-readonly-queue/*` ref via the GitHub API).
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.api-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -1142,6 +1144,7 @@ jobs:
     if: >-
       ${{
         (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
         needs.prepare.outputs.job-ref != '' && (
           needs.prepare.outputs.api-changed == 'true' ||
           needs.prepare.outputs.cli-changed == 'true' ||
@@ -1216,6 +1219,7 @@ jobs:
     if: |
       always() &&
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.api-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1675,6 +1675,7 @@ jobs:
     timeout-minutes: 20
     if: |
       needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     outputs:
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
@@ -1770,6 +1771,7 @@ jobs:
     timeout-minutes: 8
     if: |
       needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     steps:
       - uses: actions/checkout@v7
@@ -2043,6 +2045,7 @@ jobs:
     needs: [prepare, build-cli, deploy-api]
     if: |
       needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     timeout-minutes: 2
     steps:
@@ -2128,6 +2131,7 @@ jobs:
       ]
     if: |
       needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     strategy:
       fail-fast: false
@@ -2403,6 +2407,11 @@ jobs:
           RUNNER_E2E_SKIP_ALLOWED="true"
           if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ]; then
             RUNNER_E2E_SKIP_ALLOWED=""
+          fi
+          if [ "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}" = "true" ]; then
+            # External fork PRs cannot access runner infra secrets, so their
+            # runner deployment and runner E2E jobs are expected to skip.
+            RUNNER_E2E_SKIP_ALLOWED="true"
           fi
 
           check_result() {

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -218,17 +218,15 @@ const closeLightboxOnEscape$ = command(
       "keydown",
       (e: KeyboardEvent) => {
         if (e.key === "Escape") {
-          set(internalLightboxDialogCloseToken$, (value) => {
-            return value + 1;
-          });
-          set(internalLightboxDialogVisible$, false);
-          set(internalLightboxDialogFullscreen$, false);
-          set(internalLightboxState$, null);
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          set(closeLightboxWithDialogExit$);
         }
       },
-      { signal },
+      { capture: true, signal },
     );
-    el.focus();
+    el.focus({ preventScroll: true });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -529,6 +529,29 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("closes the attachment lightbox with Escape before browser shortcuts run", async () => {
+    await setupUploadedImagePreview();
+
+    click(screen.getByLabelText("Open image preview for photo.png"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox")).toBeInTheDocument();
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Escape",
+    });
+    document.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
   it("pans an uploaded image preview with ordinary wheel events", async () => {
     await setupUploadedImagePreview();
 


### PR DESCRIPTION
Summary:
- Capture Escape while the attachment lightbox is open and cancel the key event before browser shortcuts can handle it.
- Close the viewer through the existing dialog exit flow for images and other attachment preview types.
- Add coverage for Escape closing the lightbox and preventing the key event default behavior.
- Skip PR preview deployment jobs and runner infra jobs for external fork pull requests where repository secrets and deployment permissions are unavailable.

Tests:
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx --silent=passed-only
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm exec prettier --check ../.github/workflows/turbo.yml
- ./actionlint