### PR TITLE
fix: prioritize bold in rich text editors

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -130,12 +130,22 @@ export const toggleSidebarOff$ = command(({ get, set }) => {
   }
 });
 
+function isRichTextEditorTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("[data-rich-text-editor]") !== null
+  );
+}
+
 export const setupGlobalKeyboardShortcuts$ = command(
   ({ set }, signal: AbortSignal) => {
     setupGlobalShortcut(
       {
         "mod+b": {
           allowInEditableTarget: true,
+          shouldHandle: (event) => {
+            return !isRichTextEditorTarget(event.target);
+          },
           run: () => {
             set(toggleSidebarOff$);
           },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
@@ -1,10 +1,15 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterAll, describe, expect, it, vi } from "vitest";
 
 import {
   chatThreadByIdContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  zeroAgentInstructionsContract,
+  zeroAgentsByIdContract,
+} from "@vm0/api-contracts/contracts/zero-agents";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -81,6 +86,27 @@ function prepareDefaultAgent(): void {
   ]);
 }
 
+function prepareAgentInstructions(content: string): void {
+  prepareDefaultAgent();
+  context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+    return respond(200, {
+      agentId: AGENT_ID,
+      ownerId: "test-user-123",
+      description: null,
+      displayName: "Zero",
+      sound: null,
+      avatarUrl: null,
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+      visibility: "public",
+    });
+  });
+  context.mocks.api(zeroAgentInstructionsContract.get, ({ respond }) => {
+    return respond(200, { content, filename: null });
+  });
+}
+
 function createThread(id: string, title: string): SidebarThread {
   return {
     id,
@@ -135,6 +161,51 @@ afterAll(() => {
 });
 
 describe("zero sidebar mac shortcuts", () => {
+  it("uses cmd+b to bold agent instructions without collapsing the sidebar", async () => {
+    const user = userEvent.setup({ delay: null });
+    prepareAgentInstructions("Review release notes");
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}?tab=instructions`,
+    });
+
+    await screen.findByRole("heading", { name: "Zero" });
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[contenteditable="true"][aria-label="Instructions editor"]',
+        ),
+      ).toBeInstanceOf(HTMLElement);
+    });
+    const editor = document.querySelector(
+      '[contenteditable="true"][aria-label="Instructions editor"]',
+    );
+    if (!(editor instanceof HTMLElement)) {
+      throw new Error("instructions editor not found");
+    }
+    await waitFor(() => {
+      expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+    });
+
+    await user.click(editor);
+    await user.keyboard("{Meta>}a{/Meta}");
+    fireEvent.keyDown(editor, {
+      key: "b",
+      code: "KeyB",
+      keyCode: 66,
+      metaKey: true,
+    });
+
+    await waitFor(() => {
+      expect(editor.querySelector("strong")).toHaveTextContent(
+        "Review release notes",
+      );
+    });
+    expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Expand sidebar")).not.toBeInTheDocument();
+  });
+
   it("toggles the sidebar with cmd+b while the chat composer is focused", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([createThread(THREAD_ID, "Release plan")]);

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -218,6 +218,7 @@ export function TiptapInstructionsEditor({
       attributes: {
         class: editorClassName,
         "aria-label": ariaLabel,
+        "data-rich-text-editor": "",
         "data-placeholder": placeholder,
       },
     },


### PR DESCRIPTION
## Summary

- let rich text instruction editors handle Mod+B for bold formatting
- preserve the global sidebar shortcut in the chat composer and other existing contexts
- add a macOS integration regression test for agent instructions

## Tests

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-instructions-tab.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`