### PR TITLE
ci: run production migration smoke for pull requests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -652,6 +652,28 @@ jobs:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
         run: pnpm test:migration-consistency
 
+  production-migration-smoke:
+    needs: prepare
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.prepare.outputs.migration-changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    environment:
+      name: production
+      deployment: false
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: ./.github/actions/toolchain-init
+      - uses: ./.github/actions/production-migration-smoke
+        with:
+          neon-api-key: ${{ secrets.NEON_API_KEY }}
+          neon-project-id: ${{ vars.NEON_PROJECT_ID }}
+          branch-name: pr-smoke/migrate-${{ github.event.pull_request.number }}-${{ github.run_id }}-${{ github.run_attempt }}
+
   test-cli:
     needs: [detect-turbo-ts-checks]
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'


### PR DESCRIPTION
## Summary

- Run the production migration smoke action for same-repository pull requests that change migrations, database schema, or persistent JSONB contracts.
- Use the production environment configuration to create, migrate, and delete an expiring Neon branch cloned from production.

## Scope

- The smoke job is not part of `ci-gate-turbo`.
- It does not run for fork pull requests, pushes, merge-group events, or unrelated changes.
- It reuses the existing `.github/actions/production-migration-smoke` action without adding PR-state polling or other orchestration.

## Validation

- `pnpm exec prettier --write ../.github/workflows/turbo.yml`
- `actionlint .github/workflows/turbo.yml` (actionlint 1.7.12)
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `git diff --check`
