### PR TITLE
feat(platform): one-step avatar template selection with shared tile cards

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
+++ b/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
@@ -11,7 +11,7 @@ import type { SupportedLocale } from "../../i18n/resources.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { locale$ } from "../locale.ts";
-import { onRejection } from "../utils.ts";
+import { onRejection, resetSignal } from "../utils.ts";
 
 const AVATAR_TEMPLATE_PAGE_SIZE = 24;
 const AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE = 100;
@@ -550,13 +550,68 @@ export function createAvatarTemplatePickerSignals() {
     set(voiceCatalog.resetAvatarTemplateVoiceCatalog$);
     set(internalSelectedAvatar$, null);
   });
+  const internalQuickSelectingAvatarId$ = state<number | null>(null);
+  const avatarTemplateQuickSelectingId$ = computed((get) => {
+    return get(internalQuickSelectingAvatarId$);
+  });
+  const quickSelectAttempt$ = resetSignal();
+  // Resolves the recommended voice without entering the voice-picker step, so
+  // it derives the voice filters itself instead of writing them to the
+  // voice-catalog state the way selectAvatarTemplateForVoice$ does.
+  const quickSelectAvatarTemplateVoice$ = command(
+    async (
+      { get, set },
+      avatar: ZeroAvatarVideoAvatar,
+      parentSignal: AbortSignal,
+    ): Promise<ZeroAvatarVideoVoice | null> => {
+      const signal = set(quickSelectAttempt$, parentSignal);
+      set(internalQuickSelectingAvatarId$, avatar.id);
+      // A superseding click owns the pending state now; clearing on an
+      // aborted attempt would drop the newer card's spinner.
+      const clearPending = () => {
+        if (!signal.aborted) {
+          set(internalQuickSelectingAvatarId$, null);
+        }
+      };
+      const avatarFilters = get(avatarCatalog.avatarTemplateFilters$);
+      const locale = get(locale$);
+      const voiceFilters = voiceFiltersForAvatar(avatar, avatarFilters, locale);
+      const client = get(zeroClient$)(zeroAvatarVideoContract, {
+        apiBase: "api",
+      });
+      const result = await onRejection(
+        accept(
+          client.voices({
+            query: recommendedVoiceQuery(
+              avatar,
+              avatarFilters,
+              voiceFilters,
+              locale,
+            ),
+            fetchOptions: { signal },
+          }),
+          [200],
+          signal,
+        ),
+        clearPending,
+      );
+      signal.throwIfAborted();
+      clearPending();
+      return recommendedVoiceFromCandidates(
+        result.body.voices,
+        avatarFilters.ethnicity,
+      );
+    },
+  );
 
   return {
     ...avatarCatalog,
     ...voiceCatalog,
     selectedAvatarTemplateForVoice$,
     avatarTemplateRecommendedVoice$,
+    avatarTemplateQuickSelectingId$,
     selectAvatarTemplateForVoice$,
     clearAvatarTemplateVoiceSelection$,
+    quickSelectAvatarTemplateVoice$,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -168,14 +168,34 @@ function mockVoiceCatalog({
   observedQueries = [],
   filterReady,
   pageTwoReady,
+  emptyRecommendation = false,
 }: {
   readonly observedQueries?: ZeroAvatarVideoVoicesQuery[];
   readonly filterReady?: TestDeferred;
   readonly pageTwoReady?: TestDeferred;
+  readonly emptyRecommendation?: boolean;
 } = {}): void {
   const alternateVoice = createAlternateVoice();
   const selectedVoice = createSelectedVoice();
   const secondVoice = createSecondVoice();
+  function voicesFor(
+    query: ZeroAvatarVideoVoicesQuery,
+    loadingFilterOptions: boolean,
+  ) {
+    if (loadingFilterOptions) {
+      return [alternateVoice, selectedVoice];
+    }
+    if (query.pageSize === 100) {
+      return emptyRecommendation ? [] : [alternateVoice, selectedVoice];
+    }
+    if (query.page === 2) {
+      return [secondVoice];
+    }
+    if (query.language === "english") {
+      return [selectedVoice];
+    }
+    return [alternateVoice, selectedVoice];
+  }
   context.mocks.api(
     zeroAvatarVideoContract.voices,
     async ({ query, respond }) => {
@@ -197,19 +217,8 @@ function mockVoiceCatalog({
         query.gender === undefined &&
         query.age === undefined &&
         query.useCase === undefined;
-      const loadingRecommendation =
-        query.pageSize === 100 && query.language !== undefined;
-      const voices = loadingFilterOptions
-        ? [alternateVoice, selectedVoice]
-        : loadingRecommendation
-          ? [alternateVoice, selectedVoice]
-          : query.page === 2
-            ? [secondVoice]
-            : query.language === "english"
-              ? [selectedVoice]
-              : [alternateVoice, selectedVoice];
       return respond(200, {
-        voices,
+        voices: voicesFor(query, loadingFilterOptions),
         hasMore:
           query.page === 1 && (query.pageSize === 24 || loadingFilterOptions),
         filterOptions: loadingFilterOptions
@@ -760,6 +769,7 @@ describe("chat composer templates", () => {
     const avatarFirstPage = createAvatarFirstPage();
     const selectedAvatar = createSelectedAvatar();
     const observedQueries: ZeroAvatarVideoAvatarsQuery[] = [];
+    const observedVoiceQueries: ZeroAvatarVideoVoicesQuery[] = [];
     const avatarFilterReady = context.mocks.deferred<void>();
     const avatarPageTwoReady = context.mocks.deferred<void>();
     const playSpy = vi
@@ -774,7 +784,7 @@ describe("chat composer templates", () => {
       filterReady: avatarFilterReady,
       pageTwoReady: avatarPageTwoReady,
     });
-    mockVoiceCatalog();
+    mockVoiceCatalog({ observedQueries: observedVoiceQueries });
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     const dialog = await openAvatarPicker(user);
@@ -877,10 +887,20 @@ describe("chat composer templates", () => {
     );
     await user.click(selectAvatar);
 
-    await within(dialog).findByText("Choose a voice for Ada");
-    await expect(
-      within(dialog).findByLabelText("Preview avatar video Ada"),
-    ).resolves.toBeInTheDocument();
+    // Selecting an avatar resolves the recommended voice and completes the
+    // template in one step; the voice picker never opens.
+    await expectInlineTemplateInComposer("Ada");
+    expect(
+      screen.queryByText("Choose a voice for Ada"),
+    ).not.toBeInTheDocument();
+    expect(observedVoiceQueries).toContainEqual({
+      page: 1,
+      pageSize: 100,
+      language: "english",
+      gender: "male",
+      age: "young",
+      useCase: "advertisement",
+    });
     expect(observedQueries).toStrictEqual([
       { page: 1, pageSize: 24, aspectRatio: "portrait" },
       { page: 1, pageSize: 24, aspectRatio: "landscape" },
@@ -936,11 +956,14 @@ describe("chat composer templates", () => {
 
     const dialog = await openAvatarPicker(user);
     await selectAvatarRecommendationFilters(user, dialog);
+    // The voice picker is an optional path behind the card's voice entry;
+    // reaching it must not commit a template.
     await user.click(
-      await within(dialog).findByLabelText("Select template Ada"),
+      await within(dialog).findByLabelText("Choose a voice for Ada"),
     );
 
     await within(dialog).findByText("Choose a voice for Ada");
+    expect(composerInlineTemplates()).toHaveLength(0);
     await expect(
       within(dialog).findByLabelText("Preview avatar video Ada"),
     ).resolves.toBeInTheDocument();
@@ -1113,16 +1136,17 @@ describe("chat composer templates", () => {
     ).toStrictEqual([{ page: 1, pageSize: 100 }]);
   });
 
-  it("sends the selected avatar and voice", async () => {
+  it("sends the selected avatar with the recommended voice", async () => {
     const user = userEvent.setup({ delay: null });
     const selectedAvatar = createSelectedAvatar();
-    const selectedVoice = createSelectedVoice();
+    const recommendedVoice = createAlternateVoice();
     const observedQueries: ZeroAvatarVideoAvatarsQuery[] = [];
+    const observedVoiceQueries: ZeroAvatarVideoVoicesQuery[] = [];
     mockAvatarCatalog({
       observedQueries,
       firstPage: [selectedAvatar],
     });
-    mockVoiceCatalog();
+    mockVoiceCatalog({ observedQueries: observedVoiceQueries });
     let submittedTemplate: GenerationTemplateRequest | undefined;
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
@@ -1142,12 +1166,17 @@ describe("chat composer templates", () => {
       });
     });
     await user.click(within(dialog).getByLabelText("Select template Ada"));
-    await within(dialog).findByText("Choose a voice for Ada");
-    await user.click(
-      await within(dialog).findByLabelText("Select voice Christopher"),
-    );
 
     await expectInlineTemplateInComposer("Ada");
+    // Without an ethnicity filter the first recommendation candidate wins.
+    expect(observedVoiceQueries).toContainEqual({
+      page: 1,
+      pageSize: 100,
+      language: "english",
+      gender: "male",
+      age: "young",
+      useCase: "informative_educational",
+    });
     await appendAndSend(user, "Introduce our new product");
 
     await waitFor(() => {
@@ -1158,7 +1187,7 @@ describe("chat composer templates", () => {
           avatarOptions: {
             titleSnapshot: selectedAvatar.name,
             previewUrl: selectedAvatar.coverUrl,
-            voiceId: selectedVoice.id,
+            voiceId: recommendedVoice.id,
             aspectRatio: "landscape" as const,
           },
         },
@@ -1177,7 +1206,7 @@ describe("chat composer templates", () => {
 
     const dialog = await openAvatarPicker(user);
     await user.click(
-      await within(dialog).findByLabelText("Select template Ada"),
+      await within(dialog).findByLabelText("Choose a voice for Ada"),
     );
     await within(dialog).findByText("Choose a voice for Ada");
     await user.click(
@@ -1188,11 +1217,16 @@ describe("chat composer templates", () => {
     await expectInlineTemplateInComposer("Ada");
 
     // Reopening from the inline chip hands the stored template back to the
-    // picker, so the voice it carries must still read as the chosen one.
+    // picker, so the card and the voice it carries must still read as chosen.
     await user.click(await screen.findByLabelText("Preview template Ada"));
     const reopened = await screen.findByRole("dialog");
+    await waitFor(() => {
+      expect(
+        within(reopened).getByLabelText("Select template Ada"),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
     await user.click(
-      await within(reopened).findByLabelText("Select template Ada"),
+      await within(reopened).findByLabelText("Choose a voice for Ada"),
     );
 
     await waitFor(() => {
@@ -1203,6 +1237,31 @@ describe("chat composer templates", () => {
     expect(
       within(reopened).getByLabelText(`Select voice ${alternateVoice.name}`),
     ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("opens the voice picker when no recommendation matches", async () => {
+    const user = userEvent.setup({ delay: null });
+    const selectedAvatar = createSelectedAvatar();
+    const selectedVoice = createSelectedVoice();
+    mockAvatarCatalog({ firstPage: [selectedAvatar] });
+    mockVoiceCatalog({ emptyRecommendation: true });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    const dialog = await openAvatarPicker(user);
+    await user.click(
+      await within(dialog).findByLabelText("Select template Ada"),
+    );
+
+    // With no recommendable voice the one-step path cannot complete, so the
+    // picker falls through to the manual voice step instead of selecting.
+    await within(dialog).findByText("Choose a voice for Ada");
+    expect(composerInlineTemplates()).toHaveLength(0);
+    await user.click(
+      await within(dialog).findByLabelText(
+        `Select voice ${selectedVoice.name}`,
+      ),
+    );
+    await expectInlineTemplateInComposer("Ada");
   });
 
   it("disables send while a template draft attachment is uploading", async () => {

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -1116,9 +1116,9 @@ function AvatarVoiceCatalog({
     <section className="flex min-h-0 min-w-0 flex-col">
       <div
         data-avatar-voice-list-scroll=""
-        // Same ring allowance as the avatar grid, for the voice cards' focus
-        // ring at the container edges.
-        className="-m-1 min-h-0 flex-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        // Top allowance for the first voice card's focus ring; the bottom
+        // padding mirrors the catalog panel.
+        className="min-h-0 flex-1 overflow-y-auto pb-6 pt-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         onScroll={handleVoiceScroll}
       >
         {catalog.state === "hasError" ? (
@@ -1169,7 +1169,7 @@ function AvatarVoicePickerContent({
   return (
     <div
       data-avatar-voice-picker=""
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden px-6"
     >
       <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-5 overflow-hidden md:grid-cols-[minmax(210px,0.72fr)_minmax(0,1.55fr)] md:grid-rows-1">
         <div
@@ -1237,10 +1237,10 @@ function AvatarCatalogPickerContent({
   return (
     <div
       data-avatar-template-grid-scroll=""
-      // The selection ring draws 2px outside each card (ring + offset), so the
-      // scroll container pads by the same allowance and pulls it back with a
-      // negative margin — otherwise edge rows clip the ring.
-      className="-m-1 min-h-0 flex-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      // Pads itself like the other category panels: the ring draws 2px
+      // outside each card, and pt-0.5 is exactly that allowance, so edge rows
+      // keep their ring inside this clip box.
+      className="min-h-0 flex-1 overflow-y-auto px-6 pb-6 pt-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       onScroll={handleAvatarScroll}
     >
       {catalog.state === "hasError" ? (

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeft,
+  AudioLines,
   Check,
   Loader2,
   Pause,
@@ -44,9 +45,21 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isSelectedAvatarTemplate } from "../../signals/zero-page/avatar-template-selection.ts";
 import type { ComposerSignals } from "../../signals/zero-page/composer-signals.ts";
+import {
+  TEMPLATE_TILE_CAPTION,
+  TEMPLATE_TILE_MEDIA,
+  TEMPLATE_TILE_NAME,
+  TEMPLATE_TILE_RING,
+  TEMPLATE_TILE_RING_SELECTED,
+  TEMPLATE_TILE_SCRIM,
+  TEMPLATE_TILE_USE,
+  TEMPLATE_TILE_WRAPPER,
+} from "./template-tile.ts";
 
-const AVATAR_CARD_SHADOW =
-  "shadow-[0_2px_12px_hsl(220_12%_50%/0.04),0_0_0_0.5px_hsl(220_12%_50%/0.02)]";
+// Mirrors TEMPLATE_TILE_USE's reveal rules on the opposite corner, styled as a
+// neutral overlay so the primary Use pill keeps the visual lead.
+const AVATAR_TILE_VOICE =
+  "absolute bottom-2 left-2 z-20 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-lg bg-background/85 text-foreground backdrop-blur-sm transition-opacity duration-150 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:group-hover/tile:opacity-100";
 const ALL_FILTER_VALUE = "__all__";
 const CATALOG_AUTO_LOAD_THRESHOLD_PX = 320;
 
@@ -365,58 +378,29 @@ function AvatarTemplateMedia({
   );
 }
 
-function avatarTemplateCardClass(selected: boolean): string {
-  return cn(
-    "group relative flex min-w-0 flex-col overflow-hidden rounded-xl border bg-card text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-    AVATAR_CARD_SHADOW,
-    selected ? "border-primary" : "border-border",
-  );
-}
-
-function AvatarTemplateCardContent({
-  avatar,
-  aspectRatio,
-  selected,
-}: {
-  readonly avatar: ZeroAvatarVideoAvatar;
-  readonly aspectRatio: "portrait" | "landscape";
-  readonly selected: boolean;
-}) {
-  return (
-    <>
-      <AvatarTemplateMedia avatar={avatar} aspectRatio={aspectRatio} />
-      <div className="flex min-h-11 items-center justify-between gap-2 px-3 py-2.5">
-        <p className="min-w-0 truncate text-sm font-semibold text-foreground">
-          {avatar.name}
-        </p>
-        {selected && (
-          <span
-            className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
-            aria-hidden="true"
-          >
-            <Check size={13} />
-          </span>
-        )}
-      </div>
-    </>
-  );
-}
-
 function AvatarTemplateCard({
   avatar,
   aspectRatio,
   selected,
-  onSelect,
+  quickSelecting,
+  onUse,
+  onChooseVoice,
 }: {
   readonly avatar: ZeroAvatarVideoAvatar;
   readonly aspectRatio: "portrait" | "landscape";
   readonly selected: boolean;
-  readonly onSelect: (avatar: ZeroAvatarVideoAvatar) => void;
+  readonly quickSelecting: boolean;
+  readonly onUse: (avatar: ZeroAvatarVideoAvatar) => void;
+  readonly onChooseVoice: (avatar: ZeroAvatarVideoAvatar) => void;
 }) {
   const { t } = useTranslation();
+  const use = () => {
+    onUse(avatar);
+  };
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       aria-label={t(
         ($) => {
           return $.artifacts.templates.selectTemplate;
@@ -424,21 +408,78 @@ function AvatarTemplateCard({
         { title: avatar.name },
       )}
       aria-pressed={selected}
-      onClick={() => {
-        onSelect(avatar);
+      aria-busy={quickSelecting || undefined}
+      onClick={use}
+      onKeyDown={(event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          use();
+        }
       }}
-      className={avatarTemplateCardClass(selected)}
       onFocus={playAvatarTemplatePreview}
       onBlur={resetAvatarTemplatePreview}
       onMouseEnter={playAvatarTemplatePreview}
       onMouseLeave={resetAvatarTemplatePreview}
+      className={cn(TEMPLATE_TILE_WRAPPER, "focus-visible:outline-none")}
     >
-      <AvatarTemplateCardContent
-        avatar={avatar}
-        aspectRatio={aspectRatio}
-        selected={selected}
-      />
-    </button>
+      <div
+        className={cn(
+          TEMPLATE_TILE_MEDIA,
+          TEMPLATE_TILE_RING,
+          avatarMediaAspectClass(aspectRatio),
+          "group-focus-visible/tile:ring-1 group-focus-visible/tile:ring-ring",
+          selected && TEMPLATE_TILE_RING_SELECTED,
+        )}
+      >
+        <AvatarTemplateMedia avatar={avatar} aspectRatio={aspectRatio} />
+        <div className={TEMPLATE_TILE_SCRIM} />
+        {selected ? (
+          <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+            <Check size={14} />
+          </span>
+        ) : null}
+        <button
+          type="button"
+          aria-label={t(
+            ($) => {
+              return $.artifacts.templates.chooseVoice;
+            },
+            { title: avatar.name },
+          )}
+          onClick={(event) => {
+            event.stopPropagation();
+            onChooseVoice(avatar);
+          }}
+          className={AVATAR_TILE_VOICE}
+        >
+          <AudioLines size={15} />
+        </button>
+        {/* The wrapper owns the click and the accessible name; the pill is a
+            visual affordance only, so the card exposes a single button. */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            TEMPLATE_TILE_USE,
+            "pointer-events-none inline-flex items-center group-focus-visible/tile:opacity-100",
+            quickSelecting && "[@media(hover:hover)]:opacity-100",
+          )}
+        >
+          {quickSelecting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            t(($) => {
+              return $.artifacts.templates.use;
+            })
+          )}
+        </span>
+      </div>
+      <div className={TEMPLATE_TILE_CAPTION}>
+        <p className={TEMPLATE_TILE_NAME}>{avatar.name}</p>
+      </div>
+    </div>
   );
 }
 
@@ -901,13 +942,8 @@ function AvatarVoiceCard({
         }
       }}
       className={cn(
-        "group/voice flex cursor-pointer items-center gap-3 rounded-xl border bg-card p-3 transition-colors duration-200 hover:border-foreground/20 hover:bg-card-hover hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        AVATAR_CARD_SHADOW,
-        selected
-          ? "border-primary bg-primary/[0.04]"
-          : recommended
-            ? "border-primary/40 bg-primary/[0.025]"
-            : "border-border",
+        "group/voice flex cursor-pointer items-center gap-3 rounded-xl border bg-card p-3 transition-colors duration-200 hover:border-foreground/20 hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        selected ? "border-primary bg-primary/[0.04]" : "border-border",
       )}
     >
       <VoicePreviewControl voice={voice} />
@@ -1001,17 +1037,18 @@ function SelectedAvatarCard({
             )
           : undefined
       }
-      className={avatarTemplateCardClass(false)}
+      className="flex min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card"
       onFocus={playAvatarTemplatePreview}
       onBlur={resetAvatarTemplatePreview}
       onMouseEnter={playAvatarTemplatePreview}
       onMouseLeave={resetAvatarTemplatePreview}
     >
-      <AvatarTemplateCardContent
-        avatar={avatar}
-        aspectRatio={aspectRatio}
-        selected={false}
-      />
+      <AvatarTemplateMedia avatar={avatar} aspectRatio={aspectRatio} />
+      <div className="flex min-h-11 items-center px-3 py-2.5">
+        <p className="min-w-0 truncate text-sm font-medium text-foreground">
+          {avatar.name}
+        </p>
+      </div>
     </div>
   );
 }
@@ -1153,11 +1190,16 @@ function AvatarCatalogPickerContent({
   signals,
   value,
   onUse,
+  onChooseVoice,
 }: {
   readonly signals: ComposerSignals;
   readonly value: GenerationTemplateRequest | undefined;
   readonly onUse: (avatar: ZeroAvatarVideoAvatar) => void;
+  readonly onChooseVoice: (avatar: ZeroAvatarVideoAvatar) => void;
 }) {
+  const quickSelectingId = useGet(
+    signals.template.avatarTemplateQuickSelectingId$,
+  );
   const catalog = useLoadable(signals.template.avatarTemplateCatalogPage$);
   const lastCatalog = useLastResolved(
     signals.template.avatarTemplateCatalogPage$,
@@ -1214,7 +1256,9 @@ function AvatarCatalogPickerContent({
                     avatar={avatar}
                     aspectRatio={filters.aspectRatio}
                     selected={isSelectedAvatarTemplate(avatar, value)}
-                    onSelect={onUse}
+                    quickSelecting={quickSelectingId === avatar.id}
+                    onUse={onUse}
+                    onChooseVoice={onChooseVoice}
                   />
                 );
               })}
@@ -1269,9 +1313,11 @@ export function AvatarTemplatePickerContent({
   const clearVoiceSelection = useSet(
     signals.template.clearAvatarTemplateVoiceSelection$,
   );
+  const quickSelect = useSet(signals.template.quickSelectAvatarTemplateVoice$);
   const aspectRatio = useGet(
     signals.template.avatarTemplateFilters$,
   ).aspectRatio;
+  const pageSignal = useGet(pageSignal$);
 
   if (selectedAvatar) {
     return (
@@ -1292,6 +1338,23 @@ export function AvatarTemplatePickerContent({
       signals={signals}
       value={value}
       onUse={(avatar) => {
+        const applyWithRecommendedVoice = async () => {
+          const voice = await quickSelect(avatar, pageSignal);
+          if (voice) {
+            onSelect(avatar, voice, aspectRatio);
+            return;
+          }
+          // No voice matched the recommendation query, so the user has to
+          // pick one manually.
+          selectAvatar(avatar);
+        };
+        detach(
+          applyWithRecommendedVoice(),
+          Reason.DomCallback,
+          "avatar quick select",
+        );
+      }}
+      onChooseVoice={(avatar) => {
         selectAvatar(avatar);
       }}
     />

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -56,10 +56,12 @@ import {
   TEMPLATE_TILE_WRAPPER,
 } from "./template-tile.ts";
 
-// Mirrors TEMPLATE_TILE_USE's reveal rules on the opposite corner, styled as a
-// neutral overlay so the primary Use pill keeps the visual lead.
+// Overlay placement and TEMPLATE_TILE_USE's reveal rules for the voice entry;
+// the button chrome itself comes from the Button primitive. The solid hover
+// keeps the control readable over photos, where the quiet variant's
+// translucent state layer would let the artwork bleed through.
 const AVATAR_TILE_VOICE =
-  "absolute bottom-2 left-2 z-20 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-lg bg-background/85 text-foreground backdrop-blur-sm transition-opacity duration-150 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:group-hover/tile:opacity-100";
+  "absolute bottom-2 left-2 z-20 border border-border/60 bg-background/85 text-foreground backdrop-blur-sm transition-opacity duration-150 hover:bg-background [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:group-hover/tile:opacity-100";
 const ALL_FILTER_VALUE = "__all__";
 const CATALOG_AUTO_LOAD_THRESHOLD_PX = 320;
 
@@ -441,8 +443,10 @@ function AvatarTemplateCard({
             <Check size={14} />
           </span>
         ) : null}
-        <button
+        <Button
           type="button"
+          variant="quiet"
+          size="icon-sm"
           aria-label={t(
             ($) => {
               return $.artifacts.templates.chooseVoice;
@@ -455,8 +459,8 @@ function AvatarTemplateCard({
           }}
           className={AVATAR_TILE_VOICE}
         >
-          <AudioLines size={15} />
-        </button>
+          <AudioLines />
+        </Button>
         {/* The wrapper owns the click and the accessible name; the pill is a
             visual affordance only, so the card exposes a single button. */}
         <span
@@ -1112,7 +1116,9 @@ function AvatarVoiceCatalog({
     <section className="flex min-h-0 min-w-0 flex-col">
       <div
         data-avatar-voice-list-scroll=""
-        className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        // Same ring allowance as the avatar grid, for the voice cards' focus
+        // ring at the container edges.
+        className="-m-1 min-h-0 flex-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         onScroll={handleVoiceScroll}
       >
         {catalog.state === "hasError" ? (
@@ -1231,7 +1237,10 @@ function AvatarCatalogPickerContent({
   return (
     <div
       data-avatar-template-grid-scroll=""
-      className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      // The selection ring draws 2px outside each card (ring + offset), so the
+      // scroll container pads by the same allowance and pulls it back with a
+      // negative margin — otherwise edge rows clip the ring.
+      className="-m-1 min-h-0 flex-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       onScroll={handleAvatarScroll}
     >
       {catalog.state === "hasError" ? (

--- a/turbo/apps/platform/src/views/zero-page/template-tile.ts
+++ b/turbo/apps/platform/src/views/zero-page/template-tile.ts
@@ -1,0 +1,22 @@
+/**
+ * Gallery tile shared by every template picker category (video, website,
+ * workflow, presentation, avatar). Hover feedback comes from the scrim and the
+ * Use pill alone — the card already carries a hairline border, so a hover ring
+ * only doubled it. The ring is reserved for the selected state, offset so it
+ * is drawn outside the card and keeps a gap from the artwork.
+ */
+export const TEMPLATE_TILE_WRAPPER = "group/tile relative cursor-pointer";
+export const TEMPLATE_TILE_RING =
+  "rounded-xl ring-offset-1 ring-offset-card transition-shadow duration-150";
+export const TEMPLATE_TILE_RING_SELECTED = "ring-1 ring-primary";
+export const TEMPLATE_TILE_MEDIA =
+  "relative overflow-hidden border border-gray-200 bg-muted";
+export const TEMPLATE_TILE_SCRIM =
+  "pointer-events-none absolute inset-x-0 bottom-0 z-[15] h-14 bg-gradient-to-t from-black/45 to-transparent opacity-0 transition-opacity duration-150 group-hover/tile:opacity-100";
+export const TEMPLATE_TILE_USE =
+  "absolute bottom-2 right-2 z-20 h-[30px] rounded-lg bg-primary px-3 text-[12.5px] font-medium text-primary-foreground opacity-100 transition-opacity duration-150 hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:group-hover/tile:opacity-100";
+// Caption metrics track the illustration card: same text size, and enough
+// breathing room under the artwork that the title never crowds it.
+export const TEMPLATE_TILE_CAPTION = "flex items-baseline gap-2 px-2 pb-2 pt-2";
+export const TEMPLATE_TILE_NAME =
+  "min-w-0 truncate text-sm font-medium leading-5 text-foreground";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -231,6 +231,16 @@ import {
   AvatarTemplatePickerToolbar,
 } from "./avatar-template-picker.tsx";
 import {
+  TEMPLATE_TILE_CAPTION,
+  TEMPLATE_TILE_MEDIA,
+  TEMPLATE_TILE_NAME,
+  TEMPLATE_TILE_RING,
+  TEMPLATE_TILE_RING_SELECTED,
+  TEMPLATE_TILE_SCRIM,
+  TEMPLATE_TILE_USE,
+  TEMPLATE_TILE_WRAPPER,
+} from "./template-tile.ts";
+import {
   VideoModelPickerRow,
   VideoTemplateOptionsPopover,
 } from "./video-template-options-popover.tsx";
@@ -1103,28 +1113,6 @@ function VideoTemplatePreview({ item }: { item: VideoTemplateItem }) {
  */
 const TEMPLATE_CARD_SHADOW =
   "shadow-[0_2px_12px_hsl(220_12%_50%/0.04),0_0_0_0.5px_hsl(220_12%_50%/0.02)]";
-
-/**
- * Gallery tile. Hover feedback comes from the scrim and the Use pill alone —
- * the card already carries a hairline border, so a hover ring only doubled it.
- * The ring is reserved for the selected state, offset so it is drawn outside
- * the card and keeps a gap from the artwork.
- */
-const TEMPLATE_TILE_WRAPPER = "group/tile relative cursor-pointer";
-const TEMPLATE_TILE_RING =
-  "rounded-xl ring-offset-1 ring-offset-card transition-shadow duration-150";
-const TEMPLATE_TILE_RING_SELECTED = "ring-1 ring-primary";
-const TEMPLATE_TILE_MEDIA =
-  "relative overflow-hidden border border-gray-200 bg-muted";
-const TEMPLATE_TILE_SCRIM =
-  "pointer-events-none absolute inset-x-0 bottom-0 z-[15] h-14 bg-gradient-to-t from-black/45 to-transparent opacity-0 transition-opacity duration-150 group-hover/tile:opacity-100";
-const TEMPLATE_TILE_USE =
-  "absolute bottom-2 right-2 z-20 h-[30px] rounded-lg bg-primary px-3 text-[12.5px] font-medium text-primary-foreground opacity-100 transition-opacity duration-150 hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:group-hover/tile:opacity-100";
-// Caption metrics track the illustration card: same text size, and enough
-// breathing room under the artwork that the title never crowds it.
-const TEMPLATE_TILE_CAPTION = "flex items-baseline gap-2 px-2 pb-2 pt-2";
-const TEMPLATE_TILE_NAME =
-  "min-w-0 truncate text-sm font-medium leading-5 text-foreground";
 
 function VideoTemplateCard({
   item,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5403,7 +5403,10 @@ function TemplatePickerCategoryContent({
 
   if (selectedCategory === "avatar" && hasAvatarTab) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6">
+      // No padding here: like the other category panels, the picker's own
+      // scroll containers pad themselves so the selection ring is not clipped
+      // at their edges.
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <AvatarTemplatePickerContent
           signals={signals}
           value={value}


### PR DESCRIPTION
## Problem

Avatar was the only template category with a mandatory two-step flow: clicking a card did not select — it opened a full-screen voice picker, even though a five-dimension recommendation system (locale language, avatar gender/age, scene/style → use case, ethnicity → accent) already computes a good default and the voice click closes the dialog with no confirm step. The avatar card also spoke its own visual language: whole-card hover lift + custom double shadow + in-card footer name/check, vs. the shared tile pattern (scrim + Use pill on hover, ring + corner check) used by video/website/workflow/presentation cards.

## Change

**Flow**
- Clicking an avatar card resolves the recommended voice and completes the template in one step (matching every other category). A spinner shows in the Use pill while the recommendation resolves; repeated clicks are mutually exclusive via `resetSignal()`.
- The voice picker stays fully available behind a voice entry on the card (bottom-left, revealed on hover like the Use pill). It shows the carried voice as selected and is entered automatically when the recommendation query returns no voice.

**Visuals**
- `TEMPLATE_TILE_*` constants move from `zero-chat-composer.tsx` to a shared `template-tile.ts` (avoids a composer↔picker import cycle); the avatar card now renders from them: scrim + Use on hover, `ring-1 ring-primary` + corner check when selected, caption below the artwork, `font-medium` name.
- Custom `AVATAR_CARD_SHADOW` removed everywhere (grid card, voice card, selected-avatar card). The selected-avatar display card in the voice step loses its interactive hover lift.
- Recommended voice card keeps the badge but drops the tinted `border-primary/40` full-card treatment.

The avatar template feature is gated by the existing `FeatureSwitchKey.JoggAiBuiltIn`; no new switch is added for this redesign of its internal flow.

## Tests

`chat-composer-template-picker.test.tsx` (32 pass):
- one-step selection: card click → recommendation query (pageSize 100 + derived filters) → inline template with recommended `voiceId`, voice page never opens
- send path asserts the submitted template carries the recommended voice id
- voice entry: opens the picker without committing a template; recommendation pin, filters, pagination, preview, and manual selection unchanged
- reopen: card shows `aria-pressed`, carried voice reads selected in the voice picker
- new fallback test: empty recommendation → voice picker opens, manual pick completes the template

## Verification

- `check-types`, workspace lint, and the test file pass locally.
- Static render of the shipped class strings (extracted from source) against real `globals.css` tokens in light + dark: default/hover/selected/pending tile states, voice-card states, and a video tile as the consistency anchor. Not exercised in a live browser in this environment — the PR preview is the place for an interactive pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
