### PR TITLE
docs(cli): explain when to pass --model for image generation

### DIFF
--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -803,6 +803,12 @@ describe("okou generate image command", () => {
     expect(helpOutput).toContain("nano-banana-2");
     expect(helpOutput).toContain("seedream5-pro");
     expect(helpOutput).toContain("seedream5-lite");
+    expect(normalizedHelpOutput).toContain(
+      "Omit it to generate with the model this chat is set to. Pass it only when the user names a specific model.",
+    );
+    expect(normalizedHelpOutput).toContain(
+      "(default: the model this chat is set to)",
+    );
     expect(normalizedHelpOutput).toContain("support varies");
     expect(helpOutput).toContain("3840x2160");
     expect(helpOutput).toContain("edges divisible by 16");

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -1,4 +1,4 @@
-import { Command, InvalidArgumentError } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import chalk from "chalk";
 import { generateWebImage } from "../../lib/api/domains/web";
 import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
@@ -258,10 +258,14 @@ export function createImageGenerateCommand(
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
     .option("--json", "Print the complete generation result as JSON")
-    .option(
-      "--model <model>",
-      "Model: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4, seedream5-pro, seedream5-lite, or nano-banana-2",
-      IMAGE_MODEL_CONFIGS[DEFAULT_IMAGE_MODEL].alias,
+    .addOption(
+      new Option(
+        "--model <model>",
+        "Model: gpt-image-1, gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4, seedream5-pro, seedream5-lite, or nano-banana-2. Omit it to generate with the model this chat is set to. Pass it only when the user names a specific model.",
+      ).default(
+        IMAGE_MODEL_CONFIGS[DEFAULT_IMAGE_MODEL].alias,
+        "the model this chat is set to",
+      ),
     )
     .option(
       "--size <size>",


### PR DESCRIPTION
## Problem

`okou generate image --help` listed the image models but never said *when* an agent should pass `--model`. Two consequences:

- The rendered default read `(default: "gpt-image-1")`, which contradicts the run-level default injected for a chat thread.
- An agent that merely sees 11 model names tends to pick one out of habit, which silently overrides the model the user selected in the chat picker.

The runtime path is already correct: `resolveImageRequestModel` uses `command.getOptionValueSource("model")` and strips the Commander default from the request whenever a run default exists, so an omitted `--model` really does reach the server as "no model" and the chat selection applies. This PR only makes the help text say so.

## Change

- `--model` help now ends with: *"Omit it to generate with the model this chat is set to. Pass it only when the user names a specific model."*
- The Commander default is kept (behavior unchanged, `getOptionValueSource` still reports `default`), but its rendered annotation is now `(default: the model this chat is set to)` instead of the misleading literal alias.
- Help assertions added to the existing CLI help test.

## Notes

Wording matches the phrasing being standardized for video; the stale `ignored inside an agent run` phrasing was deliberately not copied.