### PR TITLE
feat(api): spike pi first-turn memory handoff

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -37,6 +37,7 @@ import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { modelStatsRoutes } from "./routes/model-stats";
 import { presentationImagesRoutes } from "./routes/presentation-images";
+import { piSessionHandoffSpikeRoutes } from "./routes/pi-session-handoff-spike";
 import { piSessionPreparationSpikeRoutes } from "./routes/pi-session-preparation-spike";
 import { registryResourceDownloadRoutes } from "./routes/registry-resources-download";
 import { runnersRoutes } from "./routes/runners";
@@ -197,6 +198,7 @@ import { webFileUrlRoutes } from "./routes/web-file-url";
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,
   ...buildInfoRoutes,
+  ...piSessionHandoffSpikeRoutes,
   ...piSessionPreparationSpikeRoutes,
   ...authMeRoutes,
   ...cliAuthRoutes,

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -37,6 +37,7 @@ import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { modelStatsRoutes } from "./routes/model-stats";
 import { presentationImagesRoutes } from "./routes/presentation-images";
+import { piSessionPreparationSpikeRoutes } from "./routes/pi-session-preparation-spike";
 import { registryResourceDownloadRoutes } from "./routes/registry-resources-download";
 import { runnersRoutes } from "./routes/runners";
 import { userExportRoutes } from "./routes/user-export";
@@ -196,6 +197,7 @@ import { webFileUrlRoutes } from "./routes/web-file-url";
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,
   ...buildInfoRoutes,
+  ...piSessionPreparationSpikeRoutes,
   ...authMeRoutes,
   ...cliAuthRoutes,
   ...desktopAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-session-handoff-spike.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-session-handoff-spike.test.ts
@@ -1,4 +1,5 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { gzipSync, zstdCompressSync } from "node:zlib";
 
 import {
   DeleteObjectsCommand,
@@ -6,6 +7,12 @@ import {
   HeadObjectCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
+import { MemoryPiSession } from "@okouai/pi-agent-runtime";
+import {
+  SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
+} from "@okouai/api-contracts/contracts/runners";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -19,6 +26,44 @@ import {
 const context = testContext();
 const BUCKET = "pi-session-handoff-spike-test";
 const FUTURE_DEADLINE_MS = 8_000_000_000_000_000;
+const ENCODINGS = [
+  SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_ZSTD,
+] as const;
+type Encoding = (typeof ENCODINGS)[number];
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalJsonl(sessionId: string): string {
+  const session = MemoryPiSession.create({
+    cwd: "/home/user/workspace",
+    id: sessionId,
+  });
+  session.appendMessage({
+    role: "user",
+    content: "historical question",
+    timestamp: 1,
+  });
+  return session.toJsonl();
+}
+
+function encodeHistory(jsonl: string, encoding: Encoding): Buffer {
+  const source = Buffer.from(jsonl);
+  switch (encoding) {
+    case SESSION_HISTORY_ENCODING_GZIP: {
+      return gzipSync(source);
+    }
+    case SESSION_HISTORY_ENCODING_ZSTD: {
+      return zstdCompressSync(source);
+    }
+    case SESSION_HISTORY_ENCODING_IDENTITY: {
+      return source;
+    }
+  }
+}
 
 function requiredKey(key: string | undefined): string {
   if (!key) {
@@ -50,26 +95,60 @@ function apiClient() {
   );
 }
 
+function recordedPutObjectKeys(): string[] {
+  return context.mocks.s3.send.mock.calls.flatMap(([command]) => {
+    return command instanceof PutObjectCommand
+      ? [requiredKey(command.input.Key)]
+      : [];
+  });
+}
+
+async function prepareSource(args: {
+  readonly encoding: Encoding;
+  readonly jsonl: string;
+  readonly sessionId: string;
+}) {
+  const raw = Buffer.from(args.jsonl);
+  const encoded = encodeHistory(args.jsonl, args.encoding);
+  const source = {
+    session_id: args.sessionId,
+    history_hash: sha256(raw),
+    encoding: args.encoding,
+    raw_size: raw.byteLength,
+    encoded_size: encoded.byteLength,
+  };
+  const prepared = await accept(
+    apiClient().prepareSource({ body: source }),
+    [200],
+  );
+  context.sessionHistoryBlobs.set(prepared.body.source_key, encoded);
+  return { encoded, prepared, source };
+}
+
 beforeEach(() => {
-  const objects = new Map<string, Buffer>();
   mockEnv("ENV", "development");
   mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
   context.mocks.s3.send.mockImplementation((command: unknown) => {
     if (command instanceof PutObjectCommand) {
-      objects.set(
+      context.sessionHistoryBlobs.set(
         requiredKey(command.input.Key),
         objectBody(command.input.Body),
       );
       return Promise.resolve({});
     }
     if (command instanceof HeadObjectCommand) {
-      const body = objects.get(requiredKey(command.input.Key));
+      const body = context.sessionHistoryBlobs.get(
+        requiredKey(command.input.Key),
+      );
       return body
         ? Promise.resolve({ ContentLength: body.byteLength })
         : Promise.reject(missingObject());
     }
     if (command instanceof GetObjectCommand) {
-      const body = objects.get(requiredKey(command.input.Key));
+      const stored = context.sessionHistoryBlobs.get(
+        requiredKey(command.input.Key),
+      );
+      const body = stored ? Buffer.from(stored) : undefined;
       return body
         ? Promise.resolve({
             Body: bodyStream(body),
@@ -79,7 +158,7 @@ beforeEach(() => {
     }
     if (command instanceof DeleteObjectsCommand) {
       for (const object of command.input.Delete?.Objects ?? []) {
-        objects.delete(requiredKey(object.Key));
+        context.sessionHistoryBlobs.delete(requiredKey(object.Key));
       }
       return Promise.resolve({});
     }
@@ -118,76 +197,247 @@ describe("Pi session handoff spike", () => {
     });
   });
 
-  it("publishes one hash pointer and resumes the native JSONL through R2", async () => {
-    const published = await accept(apiClient().publish({ body: {} }), [200]);
-    expect(published.body.canonical_history_hash).not.toBe(
-      published.body.handoff_history_hash,
-    );
-    expect(published.body.filesystem_materialized).toBeFalsy();
+  it("loads H0 in every checkpoint encoding and resumes one guarded handoff", async () => {
+    for (const encoding of ENCODINGS) {
+      const sessionId = randomUUID();
+      const handoffId = randomUUID();
+      const prompt = `continue ${encoding} session exactly once`;
+      const sourceUpload = await prepareSource({
+        encoding,
+        jsonl: canonicalJsonl(sessionId),
+        sessionId,
+      });
 
-    const ready = await accept(
+      const waiting = await accept(
+        apiClient().status({
+          params: { handoffId },
+          query: { deadline_ms: FUTURE_DEADLINE_MS },
+        }),
+        [200],
+      );
+      expect(waiting.body).toStrictEqual({
+        ok: true,
+        state: "waiting",
+        handoff_pointer_present: false,
+      });
+
+      const writesBeforePublish = recordedPutObjectKeys().length;
+      const published = await accept(
+        apiClient().publish({
+          body: {
+            handoff_id: handoffId,
+            source: sourceUpload.source,
+            prompt,
+          },
+        }),
+        [200],
+      );
+      expect(published.body).toMatchObject({
+        handoff_id: handoffId,
+        session_id: sessionId,
+        base_history_hash: sourceUpload.source.history_hash,
+        base_history_encoding: encoding,
+        base_history_bytes: sourceUpload.source.raw_size,
+        base_encoded_bytes: sourceUpload.source.encoded_size,
+        base_message_count: 1,
+        handoff_message_count: 3,
+        prompt_occurrences: 1,
+        tool_calls: 2,
+        pointer_published_after_history: true,
+        filesystem_materialized: false,
+      });
+      expect(published.body.handoff_history_hash).not.toBe(
+        published.body.base_history_hash,
+      );
+      expect(
+        recordedPutObjectKeys().slice(
+          writesBeforePublish,
+          writesBeforePublish + 2,
+        ),
+      ).toStrictEqual([
+        expect.stringContaining(
+          `/blobs/${published.body.handoff_history_hash}.blob`,
+        ),
+        expect.stringMatching(/\/handoff\.json$/),
+      ]);
+      expect(
+        context.sessionHistoryBlobs.get(sourceUpload.prepared.body.source_key),
+      ).toStrictEqual(sourceUpload.encoded);
+
+      const ready = await accept(
+        apiClient().status({
+          params: { handoffId },
+          query: { deadline_ms: FUTURE_DEADLINE_MS },
+        }),
+        [200],
+      );
+      expect(ready.body).toStrictEqual({
+        ok: true,
+        state: "resume",
+        handoff_pointer_present: true,
+      });
+
+      const expired = await accept(
+        apiClient().status({
+          params: { handoffId },
+          query: { deadline_ms: 0 },
+        }),
+        [200],
+      );
+      expect(expired.body).toStrictEqual({
+        ok: true,
+        state: "timeout",
+        handoff_pointer_present: true,
+      });
+
+      const mismatched = await accept(
+        apiClient().resume({
+          params: { handoffId },
+          body: {
+            session_id: randomUUID(),
+            base_history_hash: published.body.base_history_hash,
+          },
+        }),
+        [409],
+      );
+      expect(mismatched.body.error).toContain("does not match sandbox H0");
+
+      const resumed = await accept(
+        apiClient().resume({
+          params: { handoffId },
+          body: {
+            session_id: sessionId,
+            base_history_hash: published.body.base_history_hash,
+          },
+        }),
+        [200],
+      );
+      expect(resumed.body).toMatchObject({
+        session_id: sessionId,
+        base_history_hash: published.body.base_history_hash,
+        handoff_history_hash: published.body.handoff_history_hash,
+        downloaded_handoff_history_hash: published.body.handoff_history_hash,
+        tool_results: 2,
+        prompt_occurrences: 1,
+        base_history_preserved: true,
+        final_history_preserved: true,
+        cleanup_completed: true,
+      });
+      expect(resumed.body.final_downloaded_history_hash).toBe(
+        resumed.body.final_history_hash,
+      );
+      expect(resumed.body.final_history_hash).not.toBe(
+        resumed.body.handoff_history_hash,
+      );
+      expect(resumed.body.final_history_bytes).toBeGreaterThan(
+        resumed.body.handoff_history_bytes,
+      );
+      expect(
+        context.sessionHistoryBlobs.get(sourceUpload.prepared.body.source_key),
+      ).toStrictEqual(sourceUpload.encoded);
+      expect(
+        context.sessionHistoryBlobs.has(resumed.body.final_history_key),
+      ).toBeTruthy();
+
+      const cleaned = await accept(
+        apiClient().status({
+          params: { handoffId },
+          query: { deadline_ms: FUTURE_DEADLINE_MS },
+        }),
+        [200],
+      );
+      expect(cleaned.body).toStrictEqual({
+        ok: true,
+        state: "waiting",
+        handoff_pointer_present: false,
+      });
+      await accept(
+        apiClient().resume({
+          params: { handoffId },
+          body: {
+            session_id: sessionId,
+            base_history_hash: published.body.base_history_hash,
+          },
+        }),
+        [404],
+      );
+      const artifactsCleaned = await accept(
+        apiClient().cleanupArtifacts({
+          params: { handoffId },
+          body: {
+            base_history_hash: published.body.base_history_hash,
+            base_history_encoding: encoding,
+            final_history_hash: resumed.body.final_history_hash,
+          },
+        }),
+        [200],
+      );
+      expect(artifactsCleaned.body.cleanup_completed).toBeTruthy();
+      expect(
+        context.sessionHistoryBlobs.has(sourceUpload.prepared.body.source_key),
+      ).toBeFalsy();
+      expect(
+        context.sessionHistoryBlobs.has(resumed.body.final_history_key),
+      ).toBeFalsy();
+    }
+  });
+
+  it("rejects corrupt or misidentified H0 before publishing a pointer", async () => {
+    const sessionId = randomUUID();
+    const jsonl = canonicalJsonl(sessionId);
+    const sourceUpload = await prepareSource({
+      encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+      jsonl,
+      sessionId,
+    });
+    const corrupted = Buffer.from(jsonl);
+    corrupted[corrupted.byteLength - 2] = 0x20;
+    context.sessionHistoryBlobs.set(
+      sourceUpload.prepared.body.source_key,
+      corrupted,
+    );
+    const corruptHandoffId = randomUUID();
+
+    const corrupt = await accept(
+      apiClient().publish({
+        body: {
+          handoff_id: corruptHandoffId,
+          source: sourceUpload.source,
+          prompt: "must fall back to sandbox",
+        },
+      }),
+      [400],
+    );
+    expect(corrupt.body.error).toBe("Pi source history hash mismatch");
+    expect(recordedPutObjectKeys()).toStrictEqual([]);
+    const stillWaiting = await accept(
       apiClient().status({
-        params: { handoffId: published.body.handoff_id },
+        params: { handoffId: corruptHandoffId },
         query: { deadline_ms: FUTURE_DEADLINE_MS },
       }),
       [200],
     );
-    expect(ready.body).toStrictEqual({
-      ok: true,
-      state: "resume",
-      handoff_pointer_present: true,
-    });
+    expect(stillWaiting.body.state).toBe("waiting");
 
-    const expired = await accept(
-      apiClient().status({
-        params: { handoffId: published.body.handoff_id },
-        query: { deadline_ms: 0 },
-      }),
-      [200],
-    );
-    expect(expired.body).toStrictEqual({
-      ok: true,
-      state: "timeout",
-      handoff_pointer_present: true,
+    const validSource = await prepareSource({
+      encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+      jsonl,
+      sessionId: randomUUID(),
     });
-
-    const resumed = await accept(
-      apiClient().resume({
-        params: { handoffId: published.body.handoff_id },
-        body: {},
+    const misidentifiedHandoffId = randomUUID();
+    const misidentified = await accept(
+      apiClient().publish({
+        body: {
+          handoff_id: misidentifiedHandoffId,
+          source: validSource.source,
+          prompt: "must also fall back",
+        },
       }),
-      [200],
+      [400],
     );
-    expect(resumed.body.session_id).toBe(published.body.session_id);
-    expect(resumed.body.source_history_hash).toBe(
-      published.body.handoff_history_hash,
+    expect(misidentified.body.error).toBe(
+      "Pi source history session ID mismatch",
     );
-    expect(resumed.body.downloaded_history_hash).toBe(
-      resumed.body.source_history_hash,
-    );
-    expect(resumed.body.final_downloaded_history_hash).toBe(
-      resumed.body.final_history_hash,
-    );
-    expect(resumed.body.final_history_hash).not.toBe(
-      resumed.body.source_history_hash,
-    );
-    expect(resumed.body.final_history_bytes).toBeGreaterThan(
-      resumed.body.source_history_bytes,
-    );
-    expect(resumed.body.tool_results).toBe(1);
-    expect(resumed.body.cleanup_completed).toBeTruthy();
-
-    const cleaned = await accept(
-      apiClient().status({
-        params: { handoffId: published.body.handoff_id },
-        query: { deadline_ms: FUTURE_DEADLINE_MS },
-      }),
-      [200],
-    );
-    expect(cleaned.body).toStrictEqual({
-      ok: true,
-      state: "waiting",
-      handoff_pointer_present: false,
-    });
+    expect(recordedPutObjectKeys()).toStrictEqual([]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-session-handoff-spike.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-session-handoff-spike.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import {
+  piSessionHandoffSpikeContract,
+  piSessionHandoffSpikeRoutes,
+} from "../pi-session-handoff-spike";
+
+const context = testContext();
+const BUCKET = "pi-session-handoff-spike-test";
+const FUTURE_DEADLINE_MS = 8_000_000_000_000_000;
+
+function requiredKey(key: string | undefined): string {
+  if (!key) {
+    throw new Error("Expected an S3 object key");
+  }
+  return key;
+}
+
+function objectBody(body: unknown): Buffer {
+  if (typeof body === "string" || Buffer.isBuffer(body)) {
+    return Buffer.from(body);
+  }
+  throw new Error("Expected a string or Buffer S3 body");
+}
+
+async function* bodyStream(body: Buffer): AsyncGenerator<Buffer> {
+  yield body;
+}
+
+function missingObject(): Error {
+  const error = new Error("Not found");
+  error.name = "NotFound";
+  return error;
+}
+
+function apiClient() {
+  return setupApp({ context, routes: piSessionHandoffSpikeRoutes })(
+    piSessionHandoffSpikeContract,
+  );
+}
+
+beforeEach(() => {
+  const objects = new Map<string, Buffer>();
+  mockEnv("ENV", "development");
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    if (command instanceof PutObjectCommand) {
+      objects.set(
+        requiredKey(command.input.Key),
+        objectBody(command.input.Body),
+      );
+      return Promise.resolve({});
+    }
+    if (command instanceof HeadObjectCommand) {
+      const body = objects.get(requiredKey(command.input.Key));
+      return body
+        ? Promise.resolve({ ContentLength: body.byteLength })
+        : Promise.reject(missingObject());
+    }
+    if (command instanceof GetObjectCommand) {
+      const body = objects.get(requiredKey(command.input.Key));
+      return body
+        ? Promise.resolve({
+            Body: bodyStream(body),
+            ContentLength: body.byteLength,
+          })
+        : Promise.reject(missingObject());
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      for (const object of command.input.Delete?.Objects ?? []) {
+        objects.delete(requiredKey(object.Key));
+      }
+      return Promise.resolve({});
+    }
+    throw new Error("Unexpected S3 command");
+  });
+});
+
+describe("Pi session handoff spike", () => {
+  it("derives waiting and timeout from one absent pointer and one deadline", async () => {
+    const handoffId = randomUUID();
+
+    const waiting = await accept(
+      apiClient().status({
+        params: { handoffId },
+        query: { deadline_ms: FUTURE_DEADLINE_MS },
+      }),
+      [200],
+    );
+    expect(waiting.body).toStrictEqual({
+      ok: true,
+      state: "waiting",
+      handoff_pointer_present: false,
+    });
+
+    const timedOut = await accept(
+      apiClient().status({
+        params: { handoffId },
+        query: { deadline_ms: 0 },
+      }),
+      [200],
+    );
+    expect(timedOut.body).toStrictEqual({
+      ok: true,
+      state: "timeout",
+      handoff_pointer_present: false,
+    });
+  });
+
+  it("publishes one hash pointer and resumes the native JSONL through R2", async () => {
+    const published = await accept(apiClient().publish({ body: {} }), [200]);
+    expect(published.body.canonical_history_hash).not.toBe(
+      published.body.handoff_history_hash,
+    );
+    expect(published.body.filesystem_materialized).toBeFalsy();
+
+    const ready = await accept(
+      apiClient().status({
+        params: { handoffId: published.body.handoff_id },
+        query: { deadline_ms: FUTURE_DEADLINE_MS },
+      }),
+      [200],
+    );
+    expect(ready.body).toStrictEqual({
+      ok: true,
+      state: "resume",
+      handoff_pointer_present: true,
+    });
+
+    const expired = await accept(
+      apiClient().status({
+        params: { handoffId: published.body.handoff_id },
+        query: { deadline_ms: 0 },
+      }),
+      [200],
+    );
+    expect(expired.body).toStrictEqual({
+      ok: true,
+      state: "timeout",
+      handoff_pointer_present: true,
+    });
+
+    const resumed = await accept(
+      apiClient().resume({
+        params: { handoffId: published.body.handoff_id },
+        body: {},
+      }),
+      [200],
+    );
+    expect(resumed.body.session_id).toBe(published.body.session_id);
+    expect(resumed.body.source_history_hash).toBe(
+      published.body.handoff_history_hash,
+    );
+    expect(resumed.body.downloaded_history_hash).toBe(
+      resumed.body.source_history_hash,
+    );
+    expect(resumed.body.final_downloaded_history_hash).toBe(
+      resumed.body.final_history_hash,
+    );
+    expect(resumed.body.final_history_hash).not.toBe(
+      resumed.body.source_history_hash,
+    );
+    expect(resumed.body.final_history_bytes).toBeGreaterThan(
+      resumed.body.source_history_bytes,
+    );
+    expect(resumed.body.tool_results).toBe(1);
+    expect(resumed.body.cleanup_completed).toBeTruthy();
+
+    const cleaned = await accept(
+      apiClient().status({
+        params: { handoffId: published.body.handoff_id },
+        query: { deadline_ms: FUTURE_DEADLINE_MS },
+      }),
+      [200],
+    );
+    expect(cleaned.body).toStrictEqual({
+      ok: true,
+      state: "waiting",
+      handoff_pointer_present: false,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/pi-session-handoff-spike.ts
+++ b/turbo/apps/api/src/signals/routes/pi-session-handoff-spike.ts
@@ -1,7 +1,14 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 
 import { MemoryPiSession } from "@okouai/pi-agent-runtime";
 import { resumePendingPiToolCalls } from "@okouai/pi-agent-runtime/node";
+import {
+  RESUME_SESSION_HISTORY_MAX_BYTES,
+  SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
+  sessionHistoryEncodingSchema,
+} from "@okouai/api-contracts/contracts/runners";
 import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
 import { command } from "ccstate";
 import { z } from "zod";
@@ -13,10 +20,16 @@ import { request$ } from "../context/hono";
 import {
   deleteS3Objects,
   downloadS3Buffer,
+  downloadS3BufferWithMaxBytes,
+  generatePresignedPutUrl,
   putS3Object,
   s3ObjectHead,
 } from "../external/s3";
 import type { RouteEntry } from "../route-entry";
+import {
+  gunzipSessionHistoryBufferWithMaxBytes,
+  unzstdSessionHistoryBufferWithMaxBytes,
+} from "../services/session-history-decompression";
 import { safeJsonParse } from "../utils";
 import {
   isTestEndpointAllowed,
@@ -26,20 +39,49 @@ import {
 const c = initContract();
 const historyHashSchema = z.string().regex(/^[a-f0-9]{64}$/);
 const handoffIdSchema = z.uuid();
+const sourceReferenceSchema = z.object({
+  session_id: z.uuid(),
+  history_hash: historyHashSchema,
+  encoding: sessionHistoryEncodingSchema,
+  raw_size: z.int().positive().max(RESUME_SESSION_HISTORY_MAX_BYTES),
+  encoded_size: z.int().positive().max(RESUME_SESSION_HISTORY_MAX_BYTES),
+});
 const handoffManifestSchema = z.object({
-  schemaVersion: z.literal(1),
+  schemaVersion: z.literal(2),
   sessionId: z.uuid(),
-  historyHash: historyHashSchema,
+  baseHistoryHash: historyHashSchema,
+  baseHistoryEncoding: sessionHistoryEncodingSchema,
+  handoffHistoryHash: historyHashSchema,
+  handoffHistoryBytes: z.int().positive(),
+  promptHash: historyHashSchema,
+  toolCallCount: z.int().positive(),
+});
+
+const sourcePrepareResponseSchema = z.object({
+  ok: z.literal(true),
+  upload_url: z.url(),
+  source_key: z.string().min(1),
+  content_type: z.literal("application/octet-stream"),
 });
 
 const publishResponseSchema = z.object({
   ok: z.literal(true),
   handoff_id: handoffIdSchema,
   session_id: z.uuid(),
-  canonical_history_hash: historyHashSchema,
+  base_history_hash: historyHashSchema,
   handoff_history_hash: historyHashSchema,
-  history_bytes: z.int().positive(),
+  base_history_encoding: sessionHistoryEncodingSchema,
+  base_history_bytes: z.int().positive(),
+  base_encoded_bytes: z.int().positive(),
+  handoff_history_bytes: z.int().positive(),
+  base_message_count: z.int().nonnegative(),
+  handoff_message_count: z.int().positive(),
+  prompt_occurrences: z.int().nonnegative(),
+  tool_calls: z.int().positive(),
+  r2_source_read_ms: z.number().nonnegative(),
+  history_parse_ms: z.number().nonnegative(),
   r2_write_ms: z.number().nonnegative(),
+  pointer_published_after_history: z.literal(true),
   filesystem_materialized: z.literal(false),
 });
 
@@ -54,23 +96,51 @@ const resumeResponseSchema = z.object({
   ok: z.literal(true),
   handoff_id: handoffIdSchema,
   session_id: z.uuid(),
-  source_history_hash: historyHashSchema,
-  downloaded_history_hash: historyHashSchema,
+  base_history_hash: historyHashSchema,
+  handoff_history_hash: historyHashSchema,
+  downloaded_handoff_history_hash: historyHashSchema,
   final_history_hash: historyHashSchema,
   final_downloaded_history_hash: historyHashSchema,
-  source_history_bytes: z.int().positive(),
+  final_history_key: z.string().min(1),
+  handoff_history_bytes: z.int().positive(),
   final_history_bytes: z.int().positive(),
   tool_results: z.int().positive(),
+  prompt_occurrences: z.int().nonnegative(),
   r2_read_ms: z.number().nonnegative(),
   r2_checkpoint_ms: z.number().nonnegative(),
+  base_history_preserved: z.literal(true),
+  final_history_preserved: z.literal(true),
+  cleanup_completed: z.literal(true),
+});
+
+const artifactCleanupResponseSchema = z.object({
+  ok: z.literal(true),
   cleanup_completed: z.literal(true),
 });
 
 export const piSessionHandoffSpikeContract = c.router({
+  prepareSource: {
+    method: "POST",
+    path: "/api/test/pi-session-handoff-spike/source/prepare",
+    body: sourceReferenceSchema,
+    responses: {
+      200: sourcePrepareResponseSchema,
+      400: z.object({ error: z.unknown() }),
+      404: z.string(),
+    },
+    summary: "Prepare a direct R2 upload for a canonical Pi session",
+  },
   publish: {
     method: "POST",
     path: "/api/test/pi-session-handoff-spike",
-    body: z.object({}),
+    body: z.object({
+      handoff_id: handoffIdSchema,
+      source: sourceReferenceSchema,
+      prompt: z
+        .string()
+        .min(1)
+        .max(1024 * 1024),
+    }),
     responses: {
       200: publishResponseSchema,
       400: z.object({ error: z.unknown() }),
@@ -95,26 +165,63 @@ export const piSessionHandoffSpikeContract = c.router({
     method: "POST",
     path: "/api/test/pi-session-handoff-spike/:handoffId/resume",
     pathParams: z.object({ handoffId: handoffIdSchema }),
-    body: z.object({}),
+    body: z.object({
+      session_id: z.uuid(),
+      base_history_hash: historyHashSchema,
+    }),
     responses: {
       200: resumeResponseSchema,
       400: z.object({ error: z.unknown() }),
+      409: z.object({ error: z.string() }),
       404: z.string(),
     },
     summary: "Resume and complete a Pi session from an R2 handoff",
   },
+  cleanupArtifacts: {
+    method: "POST",
+    path: "/api/test/pi-session-handoff-spike/:handoffId/artifacts/cleanup",
+    pathParams: z.object({ handoffId: handoffIdSchema }),
+    body: z.object({
+      base_history_hash: historyHashSchema,
+      base_history_encoding: sessionHistoryEncodingSchema,
+      final_history_hash: historyHashSchema,
+    }),
+    responses: {
+      200: artifactCleanupResponseSchema,
+      400: z.object({ error: z.unknown() }),
+      404: z.string(),
+    },
+    summary: "Clean up canonical artifacts created by the handoff spike",
+  },
 });
 
+const prepareSourceBody$ = bodyResultOf(
+  piSessionHandoffSpikeContract.prepareSource,
+);
 const publishBody$ = bodyResultOf(piSessionHandoffSpikeContract.publish);
 const statusParams$ = pathParamsOf(piSessionHandoffSpikeContract.status);
 const statusQuery$ = queryOf(piSessionHandoffSpikeContract.status);
 const resumeParams$ = pathParamsOf(piSessionHandoffSpikeContract.resume);
 const resumeBody$ = bodyResultOf(piSessionHandoffSpikeContract.resume);
+const cleanupArtifactsParams$ = pathParamsOf(
+  piSessionHandoffSpikeContract.cleanupArtifacts,
+);
+const cleanupArtifactsBody$ = bodyResultOf(
+  piSessionHandoffSpikeContract.cleanupArtifacts,
+);
 
 const HANDOFF_PREFIX = "spikes/pi-session-handoffs";
-const SPIKE_CWD = "/home/user/workspace";
-const SPIKE_TOOL_CALL_ID = "api-first-turn-tool-call";
-const SPIKE_TOOL_PATH = "/home/user/.pi/agent/skills/example/SKILL.md";
+const SOURCE_UPLOAD_TTL_SECONDS = 60 * 60;
+const SPIKE_TOOL_CALLS = [
+  {
+    id: "api-first-turn-tool-call-skill",
+    path: "/home/user/.pi/agent/skills/example/SKILL.md",
+  },
+  {
+    id: "api-first-turn-tool-call-agent",
+    path: "/home/user/.pi/agent/agents/example.md",
+  },
+] as const;
 
 function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
@@ -130,6 +237,46 @@ function handoffManifestKey(handoffId: string): string {
 
 function handoffHistoryKey(handoffId: string, historyHash: string): string {
   return `${handoffPrefix(handoffId)}/blobs/${historyHash}.blob`;
+}
+
+function sourceHistoryKey(
+  historyHash: string,
+  encoding: z.infer<typeof sessionHistoryEncodingSchema>,
+): string {
+  const suffix =
+    encoding === SESSION_HISTORY_ENCODING_GZIP
+      ? ".jsonl.gz"
+      : encoding === SESSION_HISTORY_ENCODING_ZSTD
+        ? ".jsonl.zst"
+        : ".jsonl";
+  return `${HANDOFF_PREFIX}/sources/${historyHash}${suffix}`;
+}
+
+async function decodeSourceHistory(args: {
+  readonly buffer: Buffer;
+  readonly encoding: z.infer<typeof sessionHistoryEncodingSchema>;
+  readonly key: string;
+  readonly maxRawBytes: number;
+}): Promise<Buffer> {
+  switch (args.encoding) {
+    case SESSION_HISTORY_ENCODING_GZIP: {
+      return await gunzipSessionHistoryBufferWithMaxBytes(
+        args.key,
+        args.buffer,
+        args.maxRawBytes,
+      );
+    }
+    case SESSION_HISTORY_ENCODING_ZSTD: {
+      return await unzstdSessionHistoryBufferWithMaxBytes(
+        args.key,
+        args.buffer,
+        args.maxRawBytes,
+      );
+    }
+    case SESSION_HISTORY_ENCODING_IDENTITY: {
+      return args.buffer;
+    }
+  }
 }
 
 function appendAssistantText(
@@ -162,33 +309,26 @@ function appendAssistantText(
   });
 }
 
-function apiHandoffSession(sessionId: string): {
-  readonly canonicalJsonl: string;
-  readonly handoffJsonl: string;
-} {
-  const session = MemoryPiSession.create({ cwd: SPIKE_CWD, id: sessionId });
+function appendApiFirstTurn(
+  session: MemoryPiSession,
+  prompt: string,
+  timestamp: number,
+): void {
   session.appendMessage({
     role: "user",
-    content: "historical question",
-    timestamp: 1,
-  });
-  appendAssistantText(session, "historical answer", 2);
-  const canonicalJsonl = session.toJsonl();
-  session.appendMessage({
-    role: "user",
-    content: "read the example skill",
-    timestamp: 3,
+    content: prompt,
+    timestamp,
   });
   session.appendMessage({
     role: "assistant",
-    content: [
-      {
-        type: "toolCall",
-        id: SPIKE_TOOL_CALL_ID,
+    content: SPIKE_TOOL_CALLS.map((toolCall) => {
+      return {
+        type: "toolCall" as const,
+        id: toolCall.id,
         name: "read",
-        arguments: { path: SPIKE_TOOL_PATH },
-      },
-    ],
+        arguments: { path: toolCall.path },
+      };
+    }),
     api: "faux",
     provider: "faux",
     model: "faux-1",
@@ -207,10 +347,58 @@ function apiHandoffSession(sessionId: string): {
       },
     },
     stopReason: "toolUse",
-    timestamp: 4,
+    timestamp: timestamp + 1,
   });
-  return { canonicalJsonl, handoffJsonl: session.toJsonl() };
 }
+
+function countPromptOccurrences(
+  session: MemoryPiSession,
+  expectedPromptHash: string,
+): number {
+  return session.buildSessionContext().messages.filter((message) => {
+    return (
+      message.role === "user" &&
+      typeof message.content === "string" &&
+      sha256(message.content) === expectedPromptHash
+    );
+  }).length;
+}
+
+const preparePiSessionHandoffSource$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(prepareSourceBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const source = bodyResult.data;
+    const key = sourceHistoryKey(source.history_hash, source.encoding);
+    const uploadUrl = await get(
+      generatePresignedPutUrl(
+        env("R2_USER_STORAGES_BUCKET_NAME"),
+        key,
+        "application/octet-stream",
+        SOURCE_UPLOAD_TTL_SECONDS,
+        true,
+      ),
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        upload_url: uploadUrl,
+        source_key: key,
+        content_type: "application/octet-stream" as const,
+      },
+    };
+  },
+);
 
 const publishPiSessionHandoffSpike$ = command(
   async ({ get }, signal: AbortSignal) => {
@@ -223,17 +411,73 @@ const publishPiSessionHandoffSpike$ = command(
       return bodyResult.response;
     }
 
-    const handoffId = randomUUID();
-    const sessionId = randomUUID();
-    const { canonicalJsonl, handoffJsonl } = apiHandoffSession(sessionId);
-    const canonicalHistoryHash = sha256(canonicalJsonl);
-    const historyHash = sha256(handoffJsonl);
-    const manifest = handoffManifestSchema.parse({
-      schemaVersion: 1,
-      sessionId,
-      historyHash,
-    });
+    const { handoff_id: handoffId, prompt, source } = bodyResult.data;
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const sourceKey = sourceHistoryKey(source.history_hash, source.encoding);
+    const sourceReadStartedAt = performance.now();
+    const encodedSource = await get(
+      downloadS3BufferWithMaxBytes(
+        bucket,
+        sourceKey,
+        source.encoded_size,
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    if (encodedSource.byteLength !== source.encoded_size) {
+      return {
+        status: 400 as const,
+        body: { error: "Pi source history encoded size mismatch" },
+      };
+    }
+    const sourceBuffer = await decodeSourceHistory({
+      buffer: encodedSource,
+      encoding: source.encoding,
+      key: sourceKey,
+      maxRawBytes: source.raw_size,
+    });
+    signal.throwIfAborted();
+    if (sourceBuffer.byteLength !== source.raw_size) {
+      return {
+        status: 400 as const,
+        body: { error: "Pi source history raw size mismatch" },
+      };
+    }
+    if (sha256(sourceBuffer) !== source.history_hash) {
+      return {
+        status: 400 as const,
+        body: { error: "Pi source history hash mismatch" },
+      };
+    }
+    const r2SourceReadMs = performance.now() - sourceReadStartedAt;
+
+    const parseStartedAt = performance.now();
+    const session = MemoryPiSession.fromJsonl(sourceBuffer.toString("utf8"));
+    if (session.getSessionId() !== source.session_id) {
+      return {
+        status: 400 as const,
+        body: { error: "Pi source history session ID mismatch" },
+      };
+    }
+    const baseMessageCount = session.buildSessionContext().messages.length;
+    appendApiFirstTurn(session, prompt, now());
+    const handoffJsonl = session.toJsonl();
+    const handoffMessageCount = session.buildSessionContext().messages.length;
+    const promptHash = sha256(prompt);
+    const promptOccurrences = countPromptOccurrences(session, promptHash);
+    const historyParseMs = performance.now() - parseStartedAt;
+    const historyHash = sha256(handoffJsonl);
+    const handoffHistoryBytes = Buffer.byteLength(handoffJsonl);
+    const manifest = handoffManifestSchema.parse({
+      schemaVersion: 2,
+      sessionId: source.session_id,
+      baseHistoryHash: source.history_hash,
+      baseHistoryEncoding: source.encoding,
+      handoffHistoryHash: historyHash,
+      handoffHistoryBytes,
+      promptHash,
+      toolCallCount: SPIKE_TOOL_CALLS.length,
+    });
     const writeStartedAt = performance.now();
     await get(
       putS3Object(
@@ -261,11 +505,21 @@ const publishPiSessionHandoffSpike$ = command(
       body: {
         ok: true as const,
         handoff_id: handoffId,
-        session_id: sessionId,
-        canonical_history_hash: canonicalHistoryHash,
+        session_id: source.session_id,
+        base_history_hash: source.history_hash,
         handoff_history_hash: historyHash,
-        history_bytes: Buffer.byteLength(handoffJsonl),
+        base_history_encoding: source.encoding,
+        base_history_bytes: sourceBuffer.byteLength,
+        base_encoded_bytes: encodedSource.byteLength,
+        handoff_history_bytes: handoffHistoryBytes,
+        base_message_count: baseMessageCount,
+        handoff_message_count: handoffMessageCount,
+        prompt_occurrences: promptOccurrences,
+        tool_calls: SPIKE_TOOL_CALLS.length,
+        r2_source_read_ms: r2SourceReadMs,
+        history_parse_ms: historyParseMs,
         r2_write_ms: performance.now() - writeStartedAt,
+        pointer_published_after_history: true as const,
         filesystem_materialized: false as const,
       },
     };
@@ -326,16 +580,38 @@ const resumePiSessionHandoffSpike$ = command(
     const manifest = handoffManifestSchema.parse(
       safeJsonParse(manifestBuffer.toString("utf8")),
     );
-    const sourceKey = handoffHistoryKey(handoffId, manifest.historyHash);
+    if (
+      bodyResult.data.session_id !== manifest.sessionId ||
+      bodyResult.data.base_history_hash !== manifest.baseHistoryHash
+    ) {
+      return {
+        status: 409 as const,
+        body: { error: "Pi handoff base session does not match sandbox H0" },
+      };
+    }
+    const sourceKey = handoffHistoryKey(handoffId, manifest.handoffHistoryHash);
     const sourceBuffer = await get(downloadS3Buffer(bucket, sourceKey));
     signal.throwIfAborted();
     const downloadedHistoryHash = sha256(sourceBuffer);
-    if (downloadedHistoryHash !== manifest.historyHash) {
+    if (
+      sourceBuffer.byteLength !== manifest.handoffHistoryBytes ||
+      downloadedHistoryHash !== manifest.handoffHistoryHash
+    ) {
       throw new Error("Pi handoff history hash mismatch");
     }
     const r2ReadMs = performance.now() - readStartedAt;
 
     const session = MemoryPiSession.fromJsonl(sourceBuffer.toString("utf8"));
+    if (session.getSessionId() !== manifest.sessionId) {
+      throw new Error("Pi handoff session ID mismatch");
+    }
+    const promptOccurrences = countPromptOccurrences(
+      session,
+      manifest.promptHash,
+    );
+    if (promptOccurrences !== 1) {
+      throw new Error("Pi handoff prompt was not preserved exactly once");
+    }
     const toolResults = await resumePendingPiToolCalls(
       {
         session,
@@ -357,7 +633,10 @@ const resumePiSessionHandoffSpike$ = command(
       },
       signal,
     );
-    appendAssistantText(session, "sandbox continuation complete", 5);
+    if (toolResults.length !== manifest.toolCallCount) {
+      throw new Error("Pi handoff pending tool count mismatch");
+    }
+    appendAssistantText(session, "sandbox continuation complete", now());
     const finalJsonl = session.toJsonl();
     const finalHistoryHash = sha256(finalJsonl);
     const finalKey = handoffHistoryKey(handoffId, finalHistoryHash);
@@ -375,7 +654,7 @@ const resumePiSessionHandoffSpike$ = command(
     }
     const r2CheckpointMs = performance.now() - checkpointStartedAt;
 
-    await get(deleteS3Objects(bucket, [manifestKey, sourceKey, finalKey]));
+    await get(deleteS3Objects(bucket, [manifestKey, sourceKey]));
     signal.throwIfAborted();
 
     return {
@@ -384,15 +663,51 @@ const resumePiSessionHandoffSpike$ = command(
         ok: true as const,
         handoff_id: handoffId,
         session_id: manifest.sessionId,
-        source_history_hash: manifest.historyHash,
-        downloaded_history_hash: downloadedHistoryHash,
+        base_history_hash: manifest.baseHistoryHash,
+        handoff_history_hash: manifest.handoffHistoryHash,
+        downloaded_handoff_history_hash: downloadedHistoryHash,
         final_history_hash: finalHistoryHash,
         final_downloaded_history_hash: finalDownloadedHistoryHash,
-        source_history_bytes: sourceBuffer.byteLength,
+        final_history_key: finalKey,
+        handoff_history_bytes: sourceBuffer.byteLength,
         final_history_bytes: finalBuffer.byteLength,
         tool_results: toolResults.length,
+        prompt_occurrences: promptOccurrences,
         r2_read_ms: r2ReadMs,
         r2_checkpoint_ms: r2CheckpointMs,
+        base_history_preserved: true as const,
+        final_history_preserved: true as const,
+        cleanup_completed: true as const,
+      },
+    };
+  },
+);
+
+const cleanupPiSessionHandoffArtifacts$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const { handoffId } = get(cleanupArtifactsParams$);
+    const bodyResult = await get(cleanupArtifactsBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const body = bodyResult.data;
+    await get(
+      deleteS3Objects(env("R2_USER_STORAGES_BUCKET_NAME"), [
+        sourceHistoryKey(body.base_history_hash, body.base_history_encoding),
+        handoffHistoryKey(handoffId, body.final_history_hash),
+      ]),
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
         cleanup_completed: true as const,
       },
     };
@@ -400,6 +715,10 @@ const resumePiSessionHandoffSpike$ = command(
 );
 
 export const piSessionHandoffSpikeRoutes: readonly RouteEntry[] = [
+  {
+    route: piSessionHandoffSpikeContract.prepareSource,
+    handler: preparePiSessionHandoffSource$,
+  },
   {
     route: piSessionHandoffSpikeContract.publish,
     handler: publishPiSessionHandoffSpike$,
@@ -411,5 +730,9 @@ export const piSessionHandoffSpikeRoutes: readonly RouteEntry[] = [
   {
     route: piSessionHandoffSpikeContract.resume,
     handler: resumePiSessionHandoffSpike$,
+  },
+  {
+    route: piSessionHandoffSpikeContract.cleanupArtifacts,
+    handler: cleanupPiSessionHandoffArtifacts$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/pi-session-handoff-spike.ts
+++ b/turbo/apps/api/src/signals/routes/pi-session-handoff-spike.ts
@@ -1,0 +1,415 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { MemoryPiSession } from "@okouai/pi-agent-runtime";
+import { resumePendingPiToolCalls } from "@okouai/pi-agent-runtime/node";
+import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
+import { command } from "ccstate";
+import { z } from "zod";
+
+import { env } from "../../lib/env";
+import { now } from "../../lib/time";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
+import { request$ } from "../context/hono";
+import {
+  deleteS3Objects,
+  downloadS3Buffer,
+  putS3Object,
+  s3ObjectHead,
+} from "../external/s3";
+import type { RouteEntry } from "../route-entry";
+import { safeJsonParse } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const c = initContract();
+const historyHashSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const handoffIdSchema = z.uuid();
+const handoffManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  sessionId: z.uuid(),
+  historyHash: historyHashSchema,
+});
+
+const publishResponseSchema = z.object({
+  ok: z.literal(true),
+  handoff_id: handoffIdSchema,
+  session_id: z.uuid(),
+  canonical_history_hash: historyHashSchema,
+  handoff_history_hash: historyHashSchema,
+  history_bytes: z.int().positive(),
+  r2_write_ms: z.number().nonnegative(),
+  filesystem_materialized: z.literal(false),
+});
+
+const handoffStateSchema = z.enum(["waiting", "resume", "timeout"]);
+const statusResponseSchema = z.object({
+  ok: z.literal(true),
+  state: handoffStateSchema,
+  handoff_pointer_present: z.boolean(),
+});
+
+const resumeResponseSchema = z.object({
+  ok: z.literal(true),
+  handoff_id: handoffIdSchema,
+  session_id: z.uuid(),
+  source_history_hash: historyHashSchema,
+  downloaded_history_hash: historyHashSchema,
+  final_history_hash: historyHashSchema,
+  final_downloaded_history_hash: historyHashSchema,
+  source_history_bytes: z.int().positive(),
+  final_history_bytes: z.int().positive(),
+  tool_results: z.int().positive(),
+  r2_read_ms: z.number().nonnegative(),
+  r2_checkpoint_ms: z.number().nonnegative(),
+  cleanup_completed: z.literal(true),
+});
+
+export const piSessionHandoffSpikeContract = c.router({
+  publish: {
+    method: "POST",
+    path: "/api/test/pi-session-handoff-spike",
+    body: z.object({}),
+    responses: {
+      200: publishResponseSchema,
+      400: z.object({ error: z.unknown() }),
+      404: z.string(),
+    },
+    summary: "Publish a one-shot Pi session handoff through R2",
+  },
+  status: {
+    method: "GET",
+    path: "/api/test/pi-session-handoff-spike/:handoffId",
+    pathParams: z.object({ handoffId: handoffIdSchema }),
+    query: z.object({
+      deadline_ms: z.coerce.number().int().nonnegative(),
+    }),
+    responses: {
+      200: statusResponseSchema,
+      404: z.string(),
+    },
+    summary: "Resolve a Pi handoff from one pointer and one deadline",
+  },
+  resume: {
+    method: "POST",
+    path: "/api/test/pi-session-handoff-spike/:handoffId/resume",
+    pathParams: z.object({ handoffId: handoffIdSchema }),
+    body: z.object({}),
+    responses: {
+      200: resumeResponseSchema,
+      400: z.object({ error: z.unknown() }),
+      404: z.string(),
+    },
+    summary: "Resume and complete a Pi session from an R2 handoff",
+  },
+});
+
+const publishBody$ = bodyResultOf(piSessionHandoffSpikeContract.publish);
+const statusParams$ = pathParamsOf(piSessionHandoffSpikeContract.status);
+const statusQuery$ = queryOf(piSessionHandoffSpikeContract.status);
+const resumeParams$ = pathParamsOf(piSessionHandoffSpikeContract.resume);
+const resumeBody$ = bodyResultOf(piSessionHandoffSpikeContract.resume);
+
+const HANDOFF_PREFIX = "spikes/pi-session-handoffs";
+const SPIKE_CWD = "/home/user/workspace";
+const SPIKE_TOOL_CALL_ID = "api-first-turn-tool-call";
+const SPIKE_TOOL_PATH = "/home/user/.pi/agent/skills/example/SKILL.md";
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function handoffPrefix(handoffId: string): string {
+  return `${HANDOFF_PREFIX}/${handoffId}`;
+}
+
+function handoffManifestKey(handoffId: string): string {
+  return `${handoffPrefix(handoffId)}/handoff.json`;
+}
+
+function handoffHistoryKey(handoffId: string, historyHash: string): string {
+  return `${handoffPrefix(handoffId)}/blobs/${historyHash}.blob`;
+}
+
+function appendAssistantText(
+  session: MemoryPiSession,
+  text: string,
+  timestamp: number,
+): void {
+  session.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "faux",
+    provider: "faux",
+    model: "faux-1",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp,
+  });
+}
+
+function apiHandoffSession(sessionId: string): {
+  readonly canonicalJsonl: string;
+  readonly handoffJsonl: string;
+} {
+  const session = MemoryPiSession.create({ cwd: SPIKE_CWD, id: sessionId });
+  session.appendMessage({
+    role: "user",
+    content: "historical question",
+    timestamp: 1,
+  });
+  appendAssistantText(session, "historical answer", 2);
+  const canonicalJsonl = session.toJsonl();
+  session.appendMessage({
+    role: "user",
+    content: "read the example skill",
+    timestamp: 3,
+  });
+  session.appendMessage({
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: SPIKE_TOOL_CALL_ID,
+        name: "read",
+        arguments: { path: SPIKE_TOOL_PATH },
+      },
+    ],
+    api: "faux",
+    provider: "faux",
+    model: "faux-1",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "toolUse",
+    timestamp: 4,
+  });
+  return { canonicalJsonl, handoffJsonl: session.toJsonl() };
+}
+
+const publishPiSessionHandoffSpike$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(publishBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const handoffId = randomUUID();
+    const sessionId = randomUUID();
+    const { canonicalJsonl, handoffJsonl } = apiHandoffSession(sessionId);
+    const canonicalHistoryHash = sha256(canonicalJsonl);
+    const historyHash = sha256(handoffJsonl);
+    const manifest = handoffManifestSchema.parse({
+      schemaVersion: 1,
+      sessionId,
+      historyHash,
+    });
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const writeStartedAt = performance.now();
+    await get(
+      putS3Object(
+        bucket,
+        handoffHistoryKey(handoffId, historyHash),
+        handoffJsonl,
+        "application/x-ndjson",
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    await get(
+      putS3Object(
+        bucket,
+        handoffManifestKey(handoffId),
+        JSON.stringify(manifest),
+        "application/json",
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        handoff_id: handoffId,
+        session_id: sessionId,
+        canonical_history_hash: canonicalHistoryHash,
+        handoff_history_hash: historyHash,
+        history_bytes: Buffer.byteLength(handoffJsonl),
+        r2_write_ms: performance.now() - writeStartedAt,
+        filesystem_materialized: false as const,
+      },
+    };
+  },
+);
+
+const readPiSessionHandoffSpikeStatus$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const { handoffId } = get(statusParams$);
+    const { deadline_ms: deadlineMs } = get(statusQuery$);
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const head = await get(s3ObjectHead(bucket, handoffManifestKey(handoffId)));
+    signal.throwIfAborted();
+    const pointerPresent = head.kind === "found";
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        state:
+          now() >= deadlineMs
+            ? ("timeout" as const)
+            : pointerPresent
+              ? ("resume" as const)
+              : ("waiting" as const),
+        handoff_pointer_present: pointerPresent,
+      },
+    };
+  },
+);
+
+const resumePiSessionHandoffSpike$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const { handoffId } = get(resumeParams$);
+    const bodyResult = await get(resumeBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const manifestKey = handoffManifestKey(handoffId);
+    const manifestHead = await get(s3ObjectHead(bucket, manifestKey));
+    signal.throwIfAborted();
+    if (manifestHead.kind === "missing") {
+      return { status: 404 as const, body: "Not found" };
+    }
+
+    const readStartedAt = performance.now();
+    const manifestBuffer = await get(downloadS3Buffer(bucket, manifestKey));
+    signal.throwIfAborted();
+    const manifest = handoffManifestSchema.parse(
+      safeJsonParse(manifestBuffer.toString("utf8")),
+    );
+    const sourceKey = handoffHistoryKey(handoffId, manifest.historyHash);
+    const sourceBuffer = await get(downloadS3Buffer(bucket, sourceKey));
+    signal.throwIfAborted();
+    const downloadedHistoryHash = sha256(sourceBuffer);
+    if (downloadedHistoryHash !== manifest.historyHash) {
+      throw new Error("Pi handoff history hash mismatch");
+    }
+    const r2ReadMs = performance.now() - readStartedAt;
+
+    const session = MemoryPiSession.fromJsonl(sourceBuffer.toString("utf8"));
+    const toolResults = await resumePendingPiToolCalls(
+      {
+        session,
+        tools: [
+          {
+            name: "read",
+            execute(args: Record<string, unknown>) {
+              return Promise.resolve({
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `skill body for ${String(args.path)}`,
+                  },
+                ],
+              });
+            },
+          },
+        ],
+      },
+      signal,
+    );
+    appendAssistantText(session, "sandbox continuation complete", 5);
+    const finalJsonl = session.toJsonl();
+    const finalHistoryHash = sha256(finalJsonl);
+    const finalKey = handoffHistoryKey(handoffId, finalHistoryHash);
+
+    const checkpointStartedAt = performance.now();
+    await get(
+      putS3Object(bucket, finalKey, finalJsonl, "application/x-ndjson", signal),
+    );
+    signal.throwIfAborted();
+    const finalBuffer = await get(downloadS3Buffer(bucket, finalKey));
+    signal.throwIfAborted();
+    const finalDownloadedHistoryHash = sha256(finalBuffer);
+    if (finalDownloadedHistoryHash !== finalHistoryHash) {
+      throw new Error("Pi final checkpoint history hash mismatch");
+    }
+    const r2CheckpointMs = performance.now() - checkpointStartedAt;
+
+    await get(deleteS3Objects(bucket, [manifestKey, sourceKey, finalKey]));
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        handoff_id: handoffId,
+        session_id: manifest.sessionId,
+        source_history_hash: manifest.historyHash,
+        downloaded_history_hash: downloadedHistoryHash,
+        final_history_hash: finalHistoryHash,
+        final_downloaded_history_hash: finalDownloadedHistoryHash,
+        source_history_bytes: sourceBuffer.byteLength,
+        final_history_bytes: finalBuffer.byteLength,
+        tool_results: toolResults.length,
+        r2_read_ms: r2ReadMs,
+        r2_checkpoint_ms: r2CheckpointMs,
+        cleanup_completed: true as const,
+      },
+    };
+  },
+);
+
+export const piSessionHandoffSpikeRoutes: readonly RouteEntry[] = [
+  {
+    route: piSessionHandoffSpikeContract.publish,
+    handler: publishPiSessionHandoffSpike$,
+  },
+  {
+    route: piSessionHandoffSpikeContract.status,
+    handler: readPiSessionHandoffSpikeStatus$,
+  },
+  {
+    route: piSessionHandoffSpikeContract.resume,
+    handler: resumePiSessionHandoffSpike$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/pi-session-preparation-spike.ts
+++ b/turbo/apps/api/src/signals/routes/pi-session-preparation-spike.ts
@@ -1,0 +1,156 @@
+import {
+  formatPiSkillCatalogForPrompt,
+  MemoryPiSession,
+} from "@okouai/pi-agent-runtime";
+import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
+import { command } from "ccstate";
+import { z } from "zod";
+
+import { bodyResultOf } from "../context/request";
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const c = initContract();
+
+const preparationBodySchema = z.object({
+  entry_count: z.int().min(0).max(20_000),
+  content_bytes: z.int().min(0).max(1024),
+  skill_count: z.int().min(0).max(1000).default(100),
+});
+
+const preparationResponseSchema = z.object({
+  ok: z.literal(true),
+  entry_count: z.int().nonnegative(),
+  message_count: z.int().nonnegative(),
+  skill_count: z.int().nonnegative(),
+  input_bytes: z.int().nonnegative(),
+  output_bytes: z.int().nonnegative(),
+  generation_ms: z.number().nonnegative(),
+  parse_ms: z.number().nonnegative(),
+  context_ms: z.number().nonnegative(),
+  serialize_ms: z.number().nonnegative(),
+  skill_discovery_ms: z.number().nonnegative(),
+  total_preparation_ms: z.number().nonnegative(),
+  rss_mb: z.number().nonnegative(),
+  filesystem_materialized: z.literal(false),
+});
+
+const piSessionPreparationSpikeContract = c.router({
+  run: {
+    method: "POST",
+    path: "/api/test/pi-session-preparation-spike",
+    body: preparationBodySchema,
+    responses: {
+      200: preparationResponseSchema,
+      400: z.object({ error: z.string() }),
+      404: z.string(),
+    },
+    summary: "Measure filesystem-free Pi session preparation in preview",
+  },
+});
+
+const preparationBody$ = bodyResultOf(piSessionPreparationSpikeContract.run);
+const SESSION_ID = "00000000-0000-4000-8000-000000000123";
+const SESSION_CWD = "/home/user/workspace";
+const SKILL_ROOT = "/home/user/.pi/agent/skills";
+
+function syntheticSessionJsonl(
+  entryCount: number,
+  contentBytes: number,
+): string {
+  const session = MemoryPiSession.create({
+    cwd: SESSION_CWD,
+    id: SESSION_ID,
+  });
+  const content = "x".repeat(contentBytes);
+  for (let index = 0; index < entryCount; index += 1) {
+    session.appendMessage({
+      role: "user",
+      content,
+      timestamp: index,
+    });
+  }
+  return session.toJsonl();
+}
+
+function syntheticSkills(skillCount: number) {
+  return Array.from({ length: skillCount }, (_, index) => {
+    return {
+      name: `spike-skill-${index.toString()}`,
+      slug: `spike-skill-${index.toString()}`,
+      description: `Synthetic discovery metadata ${index.toString()}`,
+    };
+  });
+}
+
+const runPiSessionPreparationSpike$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(preparationBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const startedAt = performance.now();
+    const generationStartedAt = performance.now();
+    const jsonl = syntheticSessionJsonl(
+      bodyResult.data.entry_count,
+      bodyResult.data.content_bytes,
+    );
+    const generationMs = performance.now() - generationStartedAt;
+
+    const parseStartedAt = performance.now();
+    const session = MemoryPiSession.fromJsonl(jsonl);
+    const parseMs = performance.now() - parseStartedAt;
+
+    const contextStartedAt = performance.now();
+    const context = session.buildSessionContext();
+    const contextMs = performance.now() - contextStartedAt;
+
+    const serializeStartedAt = performance.now();
+    const outputJsonl = session.toJsonl();
+    const serializeMs = performance.now() - serializeStartedAt;
+
+    const skillStartedAt = performance.now();
+    formatPiSkillCatalogForPrompt({
+      skillRoot: SKILL_ROOT,
+      skills: syntheticSkills(bodyResult.data.skill_count),
+    });
+    const skillDiscoveryMs = performance.now() - skillStartedAt;
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        entry_count: bodyResult.data.entry_count,
+        message_count: context.messages.length,
+        skill_count: bodyResult.data.skill_count,
+        input_bytes: Buffer.byteLength(jsonl),
+        output_bytes: Buffer.byteLength(outputJsonl),
+        generation_ms: generationMs,
+        parse_ms: parseMs,
+        context_ms: contextMs,
+        serialize_ms: serializeMs,
+        skill_discovery_ms: skillDiscoveryMs,
+        total_preparation_ms: performance.now() - startedAt,
+        rss_mb: process.memoryUsage().rss / 1024 / 1024,
+        filesystem_materialized: false as const,
+      },
+    };
+  },
+);
+
+export const piSessionPreparationSpikeRoutes: readonly RouteEntry[] = [
+  {
+    route: piSessionPreparationSpikeContract.run,
+    handler: runPiSessionPreparationSpike$,
+  },
+];

--- a/turbo/packages/pi-agent-runtime/src/index.ts
+++ b/turbo/packages/pi-agent-runtime/src/index.ts
@@ -1,3 +1,22 @@
 export { isPiAgentModelSupported } from "./model";
+export {
+  MemoryPiSession,
+  piAssistantRequiresHandoff,
+  runPiFirstModelTurn,
+  runPiModelTurn,
+} from "./session-memory";
+export { formatPiSkillCatalogForPrompt } from "./resources";
 export { PI_OPENAI_COMPATIBLE_PROVIDERS } from "./types";
+export type {
+  CreateMemoryPiSessionOptions,
+  PiModelTurnResult,
+  PiSessionTranscript,
+  RunPiFirstModelTurnOptions,
+  RunPiModelTurnOptions,
+} from "./session-memory";
+export type {
+  PiPreheatedAgentsFile,
+  PiPreheatedResourceSnapshot,
+  PiSkillCatalogEntry,
+} from "./resources";
 export type { PiAgentModelConfig, PiOpenAICompatibleProvider } from "./types";

--- a/turbo/packages/pi-agent-runtime/src/node.ts
+++ b/turbo/packages/pi-agent-runtime/src/node.ts
@@ -1,2 +1,8 @@
 export { runPiOfficialRpcMode } from "./rpc";
+export { resumePendingPiToolCalls } from "./session-recovery";
+export type {
+  PiSandboxToolExecutor,
+  PiSandboxToolResult,
+  ResumePendingPiToolCallsOptions,
+} from "./session-recovery";
 export * from "./index";

--- a/turbo/packages/pi-agent-runtime/src/resources.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.test.ts
@@ -1,0 +1,80 @@
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createSyntheticSourceInfo,
+  formatSkillsForPrompt,
+  type Skill,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatPiSkillCatalogForPrompt } from "./resources";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("preheated Pi resource discovery", () => {
+  it("formats the native discovery prompt from metadata without skill files", async () => {
+    const skillRoot = await mkdtemp(join(tmpdir(), "pi-skill-catalog-"));
+    temporaryDirectories.push(skillRoot);
+    const missingSkillFile = join(skillRoot, "release-check", "SKILL.md");
+    await expect(access(missingSkillFile)).rejects.toThrow();
+
+    const prompt = formatPiSkillCatalogForPrompt({
+      skillRoot,
+      skills: [
+        {
+          name: "release-check",
+          slug: "release-check",
+          description: "Inspect a release before deployment.",
+        },
+        {
+          name: "manual-only",
+          slug: "manual-only",
+          description: "Only available through explicit invocation.",
+          disableModelInvocation: true,
+        },
+      ],
+    });
+
+    expect(prompt).toContain("<name>release-check</name>");
+    expect(prompt).toContain(
+      "<description>Inspect a release before deployment.</description>",
+    );
+    expect(prompt).toContain(`<location>${missingSkillFile}</location>`);
+    expect(prompt).not.toContain("manual-only");
+    const officialSkills: Skill[] = [
+      {
+        name: "release-check",
+        description: "Inspect a release before deployment.",
+        filePath: missingSkillFile,
+        baseDir: join(skillRoot, "release-check"),
+        sourceInfo: createSyntheticSourceInfo(missingSkillFile, {
+          source: "test",
+        }),
+        disableModelInvocation: false,
+      },
+      {
+        name: "manual-only",
+        description: "Only available through explicit invocation.",
+        filePath: join(skillRoot, "manual-only", "SKILL.md"),
+        baseDir: join(skillRoot, "manual-only"),
+        sourceInfo: createSyntheticSourceInfo(
+          join(skillRoot, "manual-only", "SKILL.md"),
+          { source: "test" },
+        ),
+        disableModelInvocation: true,
+      },
+    ];
+    expect(prompt).toBe(formatSkillsForPrompt(officialSkills));
+    await expect(access(missingSkillFile)).rejects.toThrow();
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/resources.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.test.ts
@@ -3,10 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  createAgentSession,
   createSyntheticSourceInfo,
+  DefaultResourceLoader,
   formatSkillsForPrompt,
+  SessionManager,
   type Skill,
 } from "@earendil-works/pi-coding-agent";
+import { createFauxCore } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { formatPiSkillCatalogForPrompt } from "./resources";
@@ -76,5 +80,85 @@ describe("preheated Pi resource discovery", () => {
     ];
     expect(prompt).toBe(formatSkillsForPrompt(officialSkills));
     await expect(access(missingSkillFile)).rejects.toThrow();
+  });
+
+  it("lets Pi build its system prompt from preheated metadata and context", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-resource-loader-"));
+    temporaryDirectories.push(root);
+    const cwd = join(root, "workspace");
+    const agentDir = join(root, "agent");
+    const agentsPath = join(cwd, "AGENTS.md");
+    const skillPath = join(agentDir, "skills", "release-check", "SKILL.md");
+    await expect(access(agentsPath)).rejects.toThrow();
+    await expect(access(skillPath)).rejects.toThrow();
+
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+      systemPrompt: "preheated Pi base prompt",
+      appendSystemPrompt: [],
+      agentsFilesOverride() {
+        return {
+          agentsFiles: [
+            {
+              path: agentsPath,
+              content: "Use the repository-native validation workflow.",
+            },
+          ],
+        };
+      },
+      skillsOverride() {
+        return {
+          skills: [
+            {
+              name: "release-check",
+              description: "Inspect a release before deployment.",
+              filePath: skillPath,
+              baseDir: join(agentDir, "skills", "release-check"),
+              sourceInfo: createSyntheticSourceInfo(skillPath, {
+                source: "preheated",
+              }),
+              disableModelInvocation: false,
+            },
+          ],
+          diagnostics: [],
+        };
+      },
+    });
+    await loader.reload();
+    const faux = createFauxCore({
+      api: "pi-resource-spike",
+      provider: "pi-resource-spike",
+    });
+    const { session } = await createAgentSession({
+      cwd,
+      agentDir,
+      model: faux.getModel(),
+      tools: ["read"],
+      resourceLoader: loader,
+      sessionManager: SessionManager.inMemory(cwd),
+    });
+
+    expect(session.systemPrompt).toContain("preheated Pi base prompt");
+    expect(session.systemPrompt).toContain(
+      `<project_instructions path="${agentsPath}">\nUse the repository-native validation workflow.`,
+    );
+    expect(session.systemPrompt).toContain("<name>release-check</name>");
+    expect(session.systemPrompt).toContain(
+      "<description>Inspect a release before deployment.</description>",
+    );
+    expect(session.systemPrompt).toContain(`<location>${skillPath}</location>`);
+    expect(session.systemPrompt).toContain(`Current working directory: ${cwd}`);
+    expect(session.getActiveToolNames()).toStrictEqual(["read"]);
+    expect(session.sessionManager.getSessionFile()).toBeUndefined();
+    session.dispose();
+
+    await expect(access(agentsPath)).rejects.toThrow();
+    await expect(access(skillPath)).rejects.toThrow();
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/resources.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.ts
@@ -19,13 +19,18 @@ export interface PiPreheatedResourceSnapshot {
   readonly skills: readonly PiSkillCatalogEntry[];
 }
 
+const XML_CHARACTER_ENTITIES: Readonly<Record<string, string>> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
 function escapeXml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
+  return value.replace(/[&<>"']/gu, (character) => {
+    return XML_CHARACTER_ENTITIES[character] ?? character;
+  });
 }
 
 /** Format Pi's native skill discovery block without reading any skill body. */

--- a/turbo/packages/pi-agent-runtime/src/resources.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.ts
@@ -1,0 +1,61 @@
+import { posix } from "node:path";
+
+export interface PiSkillCatalogEntry {
+  readonly name: string;
+  readonly slug: string;
+  readonly description: string;
+  readonly disableModelInvocation?: boolean;
+}
+
+export interface PiPreheatedAgentsFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface PiPreheatedResourceSnapshot {
+  /** AGENTS.md contents are prompt input and therefore remain fully preheated. */
+  readonly agentsFiles: readonly PiPreheatedAgentsFile[];
+  /** Skill bodies stay outside the snapshot; discovery needs catalog metadata. */
+  readonly skills: readonly PiSkillCatalogEntry[];
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** Format Pi's native skill discovery block without reading any skill body. */
+export function formatPiSkillCatalogForPrompt(args: {
+  readonly skillRoot: string;
+  readonly skills: readonly PiSkillCatalogEntry[];
+}): string {
+  const visibleSkills = args.skills.filter((skill) => {
+    return !skill.disableModelInvocation;
+  });
+  if (visibleSkills.length === 0) {
+    return "";
+  }
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    "Use the read tool to load a skill's file when the task matches its description.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of visibleSkills) {
+    const location = posix.join(args.skillRoot, skill.slug, "SKILL.md");
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(
+      `    <description>${escapeXml(skill.description)}</description>`,
+    );
+    lines.push(`    <location>${escapeXml(location)}</location>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -1,0 +1,297 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+  fauxToolCall,
+  Type,
+  type Context,
+} from "@earendil-works/pi-ai";
+import {
+  convertToLlm,
+  CURRENT_SESSION_VERSION,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resumePendingPiToolCalls } from "./session-recovery";
+import {
+  MemoryPiSession,
+  runPiFirstModelTurn,
+  runPiModelTurn,
+} from "./session-memory";
+
+const SESSION_ID = "00000000-0000-4000-8000-000000000123";
+const TOOL_CALL_ID = "tool-call-from-api";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "pi-memory-spike-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("Pi API first-turn memory spike", () => {
+  it("round-trips native JSONL from API memory into sandbox file recovery", async () => {
+    const directory = await temporaryDirectory();
+    const nativeSession = SessionManager.create(
+      "/home/user/workspace",
+      directory,
+      {
+        id: SESSION_ID,
+      },
+    );
+    nativeSession.appendMessage({
+      role: "user",
+      content: "historical question",
+      timestamp: 1,
+    });
+    nativeSession.appendMessage(
+      fauxAssistantMessage("historical answer", { timestamp: 2 }),
+    );
+    const nativeSessionFile = nativeSession.getSessionFile();
+    if (!nativeSessionFile) {
+      throw new Error("Expected the native Pi session to have a file");
+    }
+    const nativeJsonl = await readFile(nativeSessionFile, "utf8");
+
+    const memorySession = MemoryPiSession.fromJsonl(nativeJsonl);
+    expect(memorySession.toJsonl()).toBe(nativeJsonl);
+
+    let apiContext: Context | undefined;
+    const faux = createFauxCore({
+      api: "pi-memory-spike",
+      provider: "pi-memory-spike",
+    });
+    faux.setResponses([
+      (context, options) => {
+        apiContext = context;
+        expect(options?.sessionId).toBe(SESSION_ID);
+        return fauxAssistantMessage(
+          fauxToolCall(
+            "read",
+            { path: "/home/user/.pi/agent/skills/example/SKILL.md" },
+            { id: TOOL_CALL_ID },
+          ),
+          { stopReason: "toolUse", timestamp: 4 },
+        );
+      },
+    ]);
+    const firstTurn = await runPiFirstModelTurn({
+      model: faux.getModel(),
+      prompt: "use the example skill",
+      session: memorySession,
+      stream: faux.streamSimple,
+      systemPrompt: "preheated Pi system prompt",
+      timestamp: 3,
+      tools: [
+        {
+          name: "read",
+          description: "Read a file",
+          parameters: Type.Object({ path: Type.String() }),
+        },
+      ],
+    });
+
+    expect(firstTurn.handoffRequired).toBe(true);
+    expect(faux.state.callCount).toBe(1);
+    expect(apiContext?.systemPrompt).toBe("preheated Pi system prompt");
+    expect(
+      apiContext?.messages.map((message) => {
+        return message.role;
+      }),
+    ).toStrictEqual(["user", "assistant", "user"]);
+    expect(await readFile(nativeSessionFile, "utf8")).toBe(nativeJsonl);
+
+    const handoffJsonl = memorySession.toJsonl();
+    expect(handoffJsonl.startsWith(nativeJsonl)).toBe(true);
+    const sandboxSessionFile = join(directory, "sandbox-handoff.jsonl");
+    await writeFile(sandboxSessionFile, handoffJsonl);
+    const sandboxSession = SessionManager.open(sandboxSessionFile);
+    expect(sandboxSession.getSessionId()).toBe(SESSION_ID);
+    expect(sandboxSession.buildSessionContext().messages.at(-1)).toStrictEqual(
+      JSON.parse(JSON.stringify(firstTurn.assistantMessage)) as unknown,
+    );
+
+    const executeRead = vi.fn(async (args: Record<string, unknown>) => {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `skill body for ${String(args.path)}`,
+          },
+        ],
+      };
+    });
+    const toolResults = await resumePendingPiToolCalls({
+      session: sandboxSession,
+      tools: [{ name: "read", execute: executeRead }],
+    });
+    expect(executeRead).toHaveBeenCalledExactlyOnceWith(
+      { path: "/home/user/.pi/agent/skills/example/SKILL.md" },
+      undefined,
+    );
+    expect(toolResults).toMatchObject([
+      {
+        role: "toolResult",
+        toolCallId: TOOL_CALL_ID,
+        toolName: "read",
+        isError: false,
+      },
+    ]);
+
+    faux.appendResponses([
+      (context) => {
+        expect(context.messages.at(-1)).toMatchObject({
+          role: "toolResult",
+          toolCallId: TOOL_CALL_ID,
+        });
+        return fauxAssistantMessage("sandbox continuation complete", {
+          timestamp: 5,
+        });
+      },
+    ]);
+    const sandboxTurn = await runPiModelTurn({
+      model: faux.getModel(),
+      session: sandboxSession,
+      stream: faux.streamSimple,
+      systemPrompt: "preheated Pi system prompt",
+    });
+    expect(sandboxTurn.handoffRequired).toBe(false);
+    expect(faux.state.callCount).toBe(2);
+
+    const reopenedSession = SessionManager.open(sandboxSessionFile);
+    expect(reopenedSession.buildSessionContext().messages.at(-1)).toMatchObject(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "sandbox continuation complete" }],
+      },
+    );
+    await expect(
+      resumePendingPiToolCalls({
+        session: reopenedSession,
+        tools: [{ name: "read", execute: executeRead }],
+      }),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("uses Pi's own migration before emitting sandbox-compatible JSONL", async () => {
+    const legacyJsonl = [
+      {
+        type: "session",
+        id: SESSION_ID,
+        timestamp: "2025-01-01T00:00:00.000Z",
+        cwd: "/home/user/workspace",
+      },
+      {
+        type: "message",
+        timestamp: "2025-01-01T00:00:01.000Z",
+        message: {
+          role: "user",
+          content: "legacy message",
+          timestamp: 1,
+        },
+      },
+    ]
+      .map((entry) => {
+        return JSON.stringify(entry);
+      })
+      .join("\n");
+    const memorySession = MemoryPiSession.fromJsonl(legacyJsonl);
+
+    expect(memorySession.getHeader().version).toBe(CURRENT_SESSION_VERSION);
+    expect(memorySession.getEntries()[0]).toMatchObject({
+      type: "message",
+      parentId: null,
+    });
+
+    const directory = await temporaryDirectory();
+    const migratedFile = join(directory, "migrated.jsonl");
+    await writeFile(migratedFile, memorySession.toJsonl());
+    const nativeSession = SessionManager.open(migratedFile);
+    expect(nativeSession.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "legacy message" },
+    ]);
+  });
+
+  it("matches Pi's compacted context projection before the model call", async () => {
+    const directory = await temporaryDirectory();
+    const nativeSession = SessionManager.create(
+      "/home/user/workspace",
+      directory,
+      { id: SESSION_ID },
+    );
+    nativeSession.appendMessage({
+      role: "user",
+      content: "summarized user turn",
+      timestamp: 1,
+    });
+    nativeSession.appendMessage(
+      fauxAssistantMessage("summarized assistant turn", { timestamp: 2 }),
+    );
+    const firstKeptEntryId = nativeSession.appendMessage({
+      role: "user",
+      content: "kept user turn",
+      timestamp: 3,
+    });
+    nativeSession.appendCompaction(
+      "summary generated by Pi",
+      firstKeptEntryId,
+      42,
+    );
+    nativeSession.appendCustomMessageEntry(
+      "api-marker",
+      "custom context entry",
+      true,
+    );
+    nativeSession.appendMessage(
+      fauxAssistantMessage("assistant after compaction", { timestamp: 4 }),
+    );
+    const nativeSessionFile = nativeSession.getSessionFile();
+    if (!nativeSessionFile) {
+      throw new Error("Expected the native Pi session to have a file");
+    }
+
+    const memorySession = MemoryPiSession.fromJsonl(
+      await readFile(nativeSessionFile, "utf8"),
+    );
+    const nativeContext =
+      SessionManager.open(nativeSessionFile).buildSessionContext();
+    expect(memorySession.buildSessionContext()).toStrictEqual(nativeContext);
+
+    let apiContext: Context | undefined;
+    const faux = createFauxCore({
+      api: "pi-memory-spike",
+      provider: "pi-memory-spike",
+    });
+    faux.setResponses([
+      (context) => {
+        apiContext = context;
+        return fauxAssistantMessage("continued after compaction", {
+          timestamp: 5,
+        });
+      },
+    ]);
+    await runPiModelTurn({
+      model: faux.getModel(),
+      session: memorySession,
+      stream: faux.streamSimple,
+      systemPrompt: "preheated Pi system prompt",
+    });
+
+    expect(apiContext?.messages).toStrictEqual(
+      convertToLlm(nativeContext.messages),
+    );
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -186,6 +186,69 @@ describe("Pi API first-turn memory spike", () => {
     ).resolves.toStrictEqual([]);
   });
 
+  it("emits a native checkpoint when the API turn completes without tools", async () => {
+    const directory = await temporaryDirectory();
+    const nativeSession = SessionManager.create(
+      "/home/user/workspace",
+      directory,
+      { id: SESSION_ID },
+    );
+    nativeSession.appendMessage({
+      role: "user",
+      content: "historical question",
+      timestamp: 1,
+    });
+    nativeSession.appendMessage(
+      fauxAssistantMessage("historical answer", { timestamp: 2 }),
+    );
+    const nativeSessionFile = nativeSession.getSessionFile();
+    if (!nativeSessionFile) {
+      throw new Error("Expected the native Pi session to have a file");
+    }
+    const nativeJsonl = await readFile(nativeSessionFile, "utf8");
+    const memorySession = MemoryPiSession.fromJsonl(nativeJsonl);
+    const faux = createFauxCore({
+      api: "pi-memory-spike",
+      provider: "pi-memory-spike",
+    });
+    faux.setResponses([
+      fauxAssistantMessage("completed entirely in the API slot", {
+        timestamp: 4,
+      }),
+    ]);
+
+    const firstTurn = await runPiFirstModelTurn({
+      model: faux.getModel(),
+      prompt: "answer without using a tool",
+      session: memorySession,
+      stream: faux.streamSimple,
+      systemPrompt: "preheated Pi system prompt",
+      timestamp: 3,
+    });
+
+    expect(firstTurn.handoffRequired).toBe(false);
+    expect(memorySession.toJsonl().startsWith(nativeJsonl)).toBe(true);
+    expect(
+      memorySession.buildSessionContext().messages.filter((message) => {
+        return (
+          message.role === "user" &&
+          message.content === "answer without using a tool"
+        );
+      }),
+    ).toHaveLength(1);
+
+    const checkpointFile = join(directory, "api-complete.jsonl");
+    await writeFile(checkpointFile, memorySession.toJsonl());
+    const reopenedSession = SessionManager.open(checkpointFile);
+    expect(reopenedSession.getSessionId()).toBe(SESSION_ID);
+    expect(reopenedSession.buildSessionContext().messages.at(-1)).toMatchObject(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "completed entirely in the API slot" }],
+      },
+    );
+  });
+
   it("uses Pi's own migration before emitting sandbox-compatible JSONL", async () => {
     const legacyJsonl = [
       {

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -1,0 +1,513 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type Api,
+  type Context,
+  type Message,
+  type Model,
+  type SimpleStreamOptions,
+  type StreamFunction,
+  type Tool,
+} from "@earendil-works/pi-ai";
+import type {
+  FileEntry,
+  SessionContext,
+  SessionEntry,
+  SessionHeader,
+} from "@earendil-works/pi-coding-agent";
+
+const CURRENT_SESSION_VERSION = 3;
+const COMPACTION_SUMMARY_PREFIX =
+  "The conversation history before this point was compacted into the following summary:\n\n<summary>\n";
+const COMPACTION_SUMMARY_SUFFIX = "\n</summary>";
+const BRANCH_SUMMARY_PREFIX =
+  "The following is a summary of a branch that this conversation came back from:\n\n<summary>\n";
+const BRANCH_SUMMARY_SUFFIX = "</summary>";
+
+export interface PiSessionTranscript {
+  appendMessage(message: Message): string;
+  buildSessionContext(): SessionContext;
+  getSessionId(): string;
+}
+
+export interface CreateMemoryPiSessionOptions {
+  readonly cwd: string;
+  readonly id?: string;
+  readonly parentSession?: string;
+}
+
+export interface RunPiModelTurnOptions<TApi extends Api = Api> {
+  readonly model: Model<TApi>;
+  readonly session: PiSessionTranscript;
+  readonly stream: StreamFunction<TApi, SimpleStreamOptions>;
+  readonly systemPrompt: string;
+  readonly tools?: Tool[];
+  readonly streamOptions?: Omit<SimpleStreamOptions, "sessionId">;
+}
+
+export interface RunPiFirstModelTurnOptions<
+  TApi extends Api = Api,
+> extends RunPiModelTurnOptions<TApi> {
+  readonly prompt: string;
+  readonly timestamp?: number;
+}
+
+export interface PiModelTurnResult {
+  readonly assistantMessage: AssistantMessage;
+  readonly handoffRequired: boolean;
+}
+
+function assertSessionHeader(entry: FileEntry | undefined): SessionHeader {
+  if (entry?.type !== "session" || typeof entry.id !== "string") {
+    throw new Error("Pi session JSONL must start with a session header");
+  }
+  return entry;
+}
+
+function generateEntryId(existingIds: ReadonlySet<string>): string {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const id = randomUUID().slice(0, 8);
+    if (!existingIds.has(id)) {
+      return id;
+    }
+  }
+  return randomUUID();
+}
+
+function serializeFileEntries(entries: readonly FileEntry[]): string {
+  return `${entries
+    .map((entry) => {
+      return JSON.stringify(entry);
+    })
+    .join("\n")}\n`;
+}
+
+function parseSessionEntries(jsonl: string): FileEntry[] {
+  const entries: FileEntry[] = [];
+  for (const line of jsonl.trim().split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      entries.push(JSON.parse(line) as FileEntry);
+    } catch {
+      // Match Pi's file loader: one malformed line does not hide later entries.
+    }
+  }
+  return entries;
+}
+
+function migrateSessionEntries(entries: FileEntry[]): void {
+  const header = entries.find((entry) => {
+    return entry.type === "session";
+  });
+  const version = header?.version ?? 1;
+  if (version < 2) {
+    const ids = new Set<string>();
+    let previousId: string | null = null;
+    for (const entry of entries) {
+      if (entry.type === "session") {
+        entry.version = 2;
+        continue;
+      }
+      entry.id = generateEntryId(ids);
+      entry.parentId = previousId;
+      ids.add(entry.id);
+      previousId = entry.id;
+      if (entry.type === "compaction") {
+        const legacy = entry as typeof entry & {
+          firstKeptEntryIndex?: number;
+        };
+        if (typeof legacy.firstKeptEntryIndex === "number") {
+          const target = entries[legacy.firstKeptEntryIndex];
+          if (target && target.type !== "session") {
+            entry.firstKeptEntryId = target.id;
+          }
+          delete legacy.firstKeptEntryIndex;
+        }
+      }
+    }
+  }
+  if (version < 3) {
+    for (const entry of entries) {
+      if (entry.type === "session") {
+        entry.version = 3;
+      } else if (
+        entry.type === "message" &&
+        (entry.message as { role?: string }).role === "hookMessage"
+      ) {
+        (entry.message as { role: string }).role = "custom";
+      }
+    }
+  }
+}
+
+function sessionPath(
+  entries: readonly SessionEntry[],
+  leafId: string | null,
+): SessionEntry[] {
+  if (leafId === null) {
+    return [];
+  }
+  const byId = new Map(
+    entries.map((entry) => {
+      return [entry.id, entry] as const;
+    }),
+  );
+  let current = byId.get(leafId) ?? entries.at(-1);
+  const path: SessionEntry[] = [];
+  while (current) {
+    path.push(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return path.reverse();
+}
+
+function contextEntries(path: readonly SessionEntry[]): SessionEntry[] {
+  let compactionIndex = -1;
+  for (let index = 0; index < path.length; index += 1) {
+    if (path[index]?.type === "compaction") {
+      compactionIndex = index;
+    }
+  }
+  if (compactionIndex === -1) {
+    return [...path];
+  }
+  const compaction = path[compactionIndex];
+  if (!compaction || compaction.type !== "compaction") {
+    return [...path];
+  }
+  const result: SessionEntry[] = [compaction];
+  let keep = false;
+  for (let index = 0; index < compactionIndex; index += 1) {
+    const entry = path[index];
+    if (!entry) {
+      continue;
+    }
+    if (entry.id === compaction.firstKeptEntryId) {
+      keep = true;
+    }
+    if (keep) {
+      result.push(entry);
+    }
+  }
+  result.push(...path.slice(compactionIndex + 1));
+  return result;
+}
+
+type PiContextMessage = SessionContext["messages"][number];
+
+function entryContextMessages(entry: SessionEntry): PiContextMessage[] {
+  if (entry.type === "message") {
+    const message = entry.message;
+    if (
+      (message.role === "user" ||
+        message.role === "assistant" ||
+        message.role === "toolResult") &&
+      message.content == null
+    ) {
+      return [{ ...message, content: [] } as PiContextMessage];
+    }
+    return [message];
+  }
+  if (entry.type === "custom_message") {
+    return [
+      {
+        role: "custom",
+        customType: entry.customType,
+        content: entry.content ?? [],
+        display: entry.display,
+        details: entry.details,
+        timestamp: new Date(entry.timestamp).getTime(),
+      },
+    ];
+  }
+  if (entry.type === "branch_summary" && entry.summary) {
+    return [
+      {
+        role: "branchSummary",
+        summary: entry.summary,
+        fromId: entry.fromId,
+        timestamp: new Date(entry.timestamp).getTime(),
+      },
+    ];
+  }
+  if (entry.type === "compaction") {
+    return [
+      {
+        role: "compactionSummary",
+        summary: entry.summary,
+        tokensBefore: entry.tokensBefore,
+        timestamp: new Date(entry.timestamp).getTime(),
+      },
+    ];
+  }
+  return [];
+}
+
+function buildSessionContext(
+  entries: readonly SessionEntry[],
+  leafId: string | null,
+): SessionContext {
+  const path = sessionPath(entries, leafId);
+  let thinkingLevel = "off";
+  let model: SessionContext["model"] = null;
+  for (const entry of path) {
+    if (entry.type === "thinking_level_change") {
+      thinkingLevel = entry.thinkingLevel;
+    } else if (entry.type === "model_change") {
+      model = { provider: entry.provider, modelId: entry.modelId };
+    } else if (entry.type === "message" && entry.message.role === "assistant") {
+      model = {
+        provider: entry.message.provider,
+        modelId: entry.message.model,
+      };
+    }
+  }
+  return {
+    messages: contextEntries(path).flatMap(entryContextMessages),
+    thinkingLevel,
+    model,
+  };
+}
+
+function bashExecutionToText(
+  message: Extract<PiContextMessage, { role: "bashExecution" }>,
+): string {
+  let text = `Ran \`${message.command}\`\n`;
+  text += message.output ? `\`\`\`\n${message.output}\n\`\`\`` : "(no output)";
+  if (message.cancelled) {
+    text += "\n\n(command cancelled)";
+  } else if (
+    message.exitCode !== null &&
+    message.exitCode !== undefined &&
+    message.exitCode !== 0
+  ) {
+    text += `\n\nCommand exited with code ${message.exitCode}`;
+  }
+  if (message.truncated && message.fullOutputPath) {
+    text += `\n\n[Output truncated. Full output: ${message.fullOutputPath}]`;
+  }
+  return text;
+}
+
+function convertToLlm(messages: readonly PiContextMessage[]): Message[] {
+  return messages.flatMap((message): Message[] => {
+    switch (message.role) {
+      case "bashExecution": {
+        return message.excludeFromContext
+          ? []
+          : [
+              {
+                role: "user",
+                content: [{ type: "text", text: bashExecutionToText(message) }],
+                timestamp: message.timestamp,
+              },
+            ];
+      }
+      case "custom": {
+        return [
+          {
+            role: "user",
+            content:
+              typeof message.content === "string"
+                ? [{ type: "text", text: message.content }]
+                : message.content,
+            timestamp: message.timestamp,
+          },
+        ];
+      }
+      case "branchSummary": {
+        return [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text:
+                  BRANCH_SUMMARY_PREFIX +
+                  message.summary +
+                  BRANCH_SUMMARY_SUFFIX,
+              },
+            ],
+            timestamp: message.timestamp,
+          },
+        ];
+      }
+      case "compactionSummary": {
+        return [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text:
+                  COMPACTION_SUMMARY_PREFIX +
+                  message.summary +
+                  COMPACTION_SUMMARY_SUFFIX,
+              },
+            ],
+            timestamp: message.timestamp,
+          },
+        ];
+      }
+      case "user":
+      case "assistant":
+      case "toolResult": {
+        return [message];
+      }
+    }
+  });
+}
+
+/**
+ * A byte-backed adapter for Pi's native JSONL session format.
+ *
+ * Its versioned parser, migrations, context projection, and message conversion
+ * mirror Pi's native format and are cross-checked against the official runtime.
+ * Keeping the compatibility layer small avoids loading Pi's full TUI/RPC entry
+ * point during a serverless cold start. Persistence stays under the caller's
+ * control, so API runtimes need no temporary filesystem while sandboxes can
+ * reopen the returned bytes with SessionManager.open().
+ */
+export class MemoryPiSession implements PiSessionTranscript {
+  readonly #header: SessionHeader;
+  readonly #entries: SessionEntry[];
+  readonly #entryIds: Set<string>;
+  #leafId: string | null;
+
+  private constructor(header: SessionHeader, entries: SessionEntry[]) {
+    this.#header = header;
+    this.#entries = entries;
+    this.#entryIds = new Set(
+      entries.map((entry) => {
+        return entry.id;
+      }),
+    );
+    this.#leafId = entries.at(-1)?.id ?? null;
+  }
+
+  static create(options: CreateMemoryPiSessionOptions): MemoryPiSession {
+    const header: SessionHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: options.id ?? randomUUID(),
+      timestamp: new Date().toISOString(),
+      cwd: options.cwd,
+      parentSession: options.parentSession,
+    };
+    return new MemoryPiSession(header, []);
+  }
+
+  static fromJsonl(jsonl: string): MemoryPiSession {
+    const fileEntries = parseSessionEntries(jsonl);
+    const header = assertSessionHeader(fileEntries[0]);
+    migrateSessionEntries(fileEntries);
+    return new MemoryPiSession(header, fileEntries.slice(1) as SessionEntry[]);
+  }
+
+  appendMessage(message: Message): string {
+    const id = generateEntryId(this.#entryIds);
+    const entry: SessionEntry = {
+      type: "message",
+      id,
+      parentId: this.#leafId,
+      timestamp: new Date().toISOString(),
+      message,
+    };
+    this.#entries.push(entry);
+    this.#entryIds.add(id);
+    this.#leafId = id;
+    return id;
+  }
+
+  buildSessionContext(): SessionContext {
+    return buildSessionContext(this.#entries, this.#leafId);
+  }
+
+  getEntries(): SessionEntry[] {
+    return [...this.#entries];
+  }
+
+  getHeader(): SessionHeader {
+    return { ...this.#header };
+  }
+
+  getSessionId(): string {
+    return this.#header.id;
+  }
+
+  toJsonl(): string {
+    return serializeFileEntries([this.#header, ...this.#entries]);
+  }
+}
+
+function piReasoningLevel(
+  context: SessionContext,
+): SimpleStreamOptions["reasoning"] {
+  switch (context.thinkingLevel) {
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max": {
+      return context.thinkingLevel;
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+async function consumeAssistantMessage(
+  stream: AssistantMessageEventStream,
+): Promise<AssistantMessage> {
+  for await (const _event of stream) {
+    // The first-turn slot persists only the final native Pi message. Streaming
+    // projection remains the API caller's responsibility.
+  }
+  return await stream.result();
+}
+
+export function piAssistantRequiresHandoff(message: AssistantMessage): boolean {
+  return message.content.some((content) => {
+    return content.type === "toolCall";
+  });
+}
+
+export async function runPiModelTurn<TApi extends Api>(
+  options: RunPiModelTurnOptions<TApi>,
+): Promise<PiModelTurnResult> {
+  const sessionContext = options.session.buildSessionContext();
+  const context: Context = {
+    systemPrompt: options.systemPrompt,
+    messages: convertToLlm(sessionContext.messages),
+    tools: options.tools,
+  };
+  const responseStream = options.stream(options.model, context, {
+    ...options.streamOptions,
+    reasoning:
+      options.streamOptions?.reasoning ?? piReasoningLevel(sessionContext),
+    sessionId: options.session.getSessionId(),
+  });
+  const assistantMessage = await consumeAssistantMessage(responseStream);
+  options.session.appendMessage(assistantMessage);
+  return {
+    assistantMessage,
+    handoffRequired: piAssistantRequiresHandoff(assistantMessage),
+  };
+}
+
+export async function runPiFirstModelTurn<TApi extends Api>(
+  options: RunPiFirstModelTurnOptions<TApi>,
+): Promise<PiModelTurnResult> {
+  options.session.appendMessage({
+    role: "user",
+    content: options.prompt,
+    timestamp: options.timestamp ?? Date.now(),
+  });
+  return await runPiModelTurn(options);
+}

--- a/turbo/packages/pi-agent-runtime/src/session-recovery.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-recovery.ts
@@ -4,7 +4,8 @@ import type {
   ToolCall,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
-import type { SessionManager } from "@earendil-works/pi-coding-agent";
+
+import type { PiSessionTranscript } from "./session-memory";
 
 export interface PiSandboxToolResult {
   readonly content: (TextContent | ImageContent)[];
@@ -21,11 +22,16 @@ export interface PiSandboxToolExecutor {
 }
 
 export interface ResumePendingPiToolCallsOptions {
-  readonly session: SessionManager;
+  readonly session: Pick<
+    PiSessionTranscript,
+    "appendMessage" | "buildSessionContext"
+  >;
   readonly tools: readonly PiSandboxToolExecutor[];
 }
 
-function pendingToolCalls(session: SessionManager): ToolCall[] {
+function pendingToolCalls(
+  session: ResumePendingPiToolCallsOptions["session"],
+): ToolCall[] {
   const messages = session.buildSessionContext().messages;
   let assistantIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {

--- a/turbo/packages/pi-agent-runtime/src/session-recovery.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-recovery.ts
@@ -1,0 +1,112 @@
+import type {
+  ImageContent,
+  TextContent,
+  ToolCall,
+  ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import type { SessionManager } from "@earendil-works/pi-coding-agent";
+
+export interface PiSandboxToolResult {
+  readonly content: (TextContent | ImageContent)[];
+  readonly details?: unknown;
+  readonly isError?: boolean;
+}
+
+export interface PiSandboxToolExecutor {
+  readonly name: string;
+  execute(
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<PiSandboxToolResult>;
+}
+
+export interface ResumePendingPiToolCallsOptions {
+  readonly session: SessionManager;
+  readonly tools: readonly PiSandboxToolExecutor[];
+}
+
+function pendingToolCalls(session: SessionManager): ToolCall[] {
+  const messages = session.buildSessionContext().messages;
+  let assistantIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "assistant") {
+      assistantIndex = index;
+      break;
+    }
+  }
+  if (assistantIndex === -1) {
+    return [];
+  }
+  const assistantMessage = messages[assistantIndex];
+  if (assistantMessage?.role !== "assistant") {
+    return [];
+  }
+  const resolvedIds = new Set(
+    messages.slice(assistantIndex + 1).flatMap((message) => {
+      return message.role === "toolResult" ? [message.toolCallId] : [];
+    }),
+  );
+  return assistantMessage.content.filter((content): content is ToolCall => {
+    return content.type === "toolCall" && !resolvedIds.has(content.id);
+  });
+}
+
+function failedToolResult(error: unknown): PiSandboxToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: error instanceof Error ? error.message : String(error),
+      },
+    ],
+    isError: true,
+  };
+}
+
+async function executeToolCall(
+  toolCall: ToolCall,
+  toolsByName: ReadonlyMap<string, PiSandboxToolExecutor>,
+  signal?: AbortSignal,
+): Promise<ToolResultMessage> {
+  const executor = toolsByName.get(toolCall.name);
+  let result: PiSandboxToolResult;
+  try {
+    if (!executor) {
+      throw new Error(
+        `Tool "${toolCall.name}" is not available in the sandbox`,
+      );
+    }
+    result = await executor.execute(toolCall.arguments, signal);
+  } catch (error) {
+    result = failedToolResult(error);
+  }
+  return {
+    role: "toolResult",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    content: result.content,
+    details: result.details,
+    isError: result.isError ?? false,
+    timestamp: Date.now(),
+  };
+}
+
+/** Execute only the unresolved tool batch left by the API first-turn slot. */
+export async function resumePendingPiToolCalls(
+  options: ResumePendingPiToolCallsOptions,
+  signal?: AbortSignal,
+): Promise<ToolResultMessage[]> {
+  const toolsByName = new Map(
+    options.tools.map((tool) => {
+      return [tool.name, tool] as const;
+    }),
+  );
+  const results: ToolResultMessage[] = [];
+  for (const toolCall of pendingToolCalls(options.session)) {
+    signal?.throwIfAborted();
+    const result = await executeToolCall(toolCall, toolsByName, signal);
+    options.session.appendMessage(result);
+    results.push(result);
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary

- add a filesystem-free, byte-backed adapter for Pi's native v3 JSONL session format
- preheat AGENTS.md contents and skill discovery metadata through Pi's official resource-loader overrides while leaving skill bodies lazy
- extend the preview-only handoff probe so the API starts from a real prior canonical H0 in R2 instead of fabricating a new session
- validate a one-shot `waiting -> resume | timeout` rendezvous, guarded H1 recovery, multi-tool continuation, and an R2-backed H2 checkpoint

## Handoff data flow

1. The previous sandbox checkpoint is `H0`. The spike client creates it with Pi's official file-backed `SessionManager` and uploads its identity/gzip/zstd representation directly to R2 through a presigned PUT; the body does not pass through Vercel.
2. The sandbox/coordinator allocates `handoffId` before the API publishes anything, so it can observe a real `waiting` state.
3. The API downloads the bounded H0 object into memory, decodes it, verifies encoded size, raw size, SHA-256, and Pi session ID, then restores it with `MemoryPiSession` without materializing `/tmp`.
4. The API appends the current user prompt once and the first assistant tool-call turn, writes content-addressed H1, and only then writes the small manifest pointer.
5. The manifest carries `sessionId`, `baseHistoryHash`, H1 hash/size, prompt hash, and pending tool count. The sandbox must present the same H0 session ID and base hash before it can resume.
6. The sandbox-side probe reads H1, verifies it, executes both unresolved tools exactly once, appends tool results and the continuation, writes H2, and verifies H2 by downloading and hashing it again.
7. The one-shot pointer and H1 are removed after resume. Canonical H0 and H2 remain in R2 until the preview-only artifact cleanup endpoint removes them explicitly.

The spike intentionally adds no CAS, generation counter, claim row, or second timeout. Timeout still wins over a late pointer, and the existing run lifecycle remains the intended authority for terminal state.

## What this spike validates

- an existing native Pi JSONL session can be loaded and extended in a serverless API request without a temporary filesystem
- identity, gzip, and zstd representations use the existing bounded decompression path and preserve the raw content hash
- H1 is published before its manifest pointer, the current prompt occurs exactly once, and two pending tool calls resume exactly once
- a sandbox with the wrong H0 session identity cannot consume a valid handoff
- corrupt, oversized, or misidentified H0 inputs fail before the pointer is published, leaving ordinary sandbox timeout/fallback available
- H2 remains a native Pi JSONL checkpoint with a verified R2 copy, while the one-shot handoff objects are reclaimed
- a no-tool API first turn can also emit JSONL that Pi's official `SessionManager.open()` reopens directly
- Pi 0.84.1's official `DefaultResourceLoader` can build the native system prompt from preheated AGENTS.md contents and skill metadata even when neither AGENTS.md nor any `SKILL.md` body exists on disk
- compaction, custom-message context projection, and legacy migration remain compatible with Pi 0.84.1

## Validation

### Local

- Prettier check passed for all changed files
- API and `@okouai/pi-agent-runtime` lint passed for the changed files/package
- `pnpm knip` passed (configuration hints only)
- API and `@okouai/pi-agent-runtime` type checks passed
- `session-memory.test.ts`: 4/4 passed
- `resources.test.ts`: 2/2 passed
- the targeted API test requires the repository test Postgres, which was not present locally; CI ran it with the normal fixture

### CI

- `pi-session-handoff-spike.test.ts`: 3/3 passed in `test-api (6)`
- all eight API test shards passed
- format, ESLint, Knip, and TypeScript checks passed

### PR Preview

Target: `https://pr-28250-api.vm6.ai`  
Deployed merge SHA: `871407dae105f76c42e52dd3b26e9dd75b95f3ca` (second parent is head `45b015c082b1be0f6a786998056a3d0e3ae50f53`)

The live client generated H0 with Pi's official `SessionManager`: 1,600 messages, 1,264,407 raw bytes.

| H0 encoding | Encoded bytes | R2 read + decode | Parse/context/append | H1 write + pointer | H1 read | H2 checkpoint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| identity | 1,264,407 | 259.7 ms | 36.5 ms | 767.5 ms | 330.2 ms | 360.6 ms |
| gzip | 32,161 | 189.2 ms | 27.0 ms | 665.7 ms | 432.8 ms | 585.4 ms |
| zstd | 28,968 | 215.6 ms | 26.0 ms | 697.3 ms | 880.1 ms | 481.5 ms |

- PASS — preallocated ID reports `waiting` before publication, then `resume`; the same pointer reports `timeout` after the sole deadline expires
- PASS — H0 hash/session checks pass for all three encodings; `filesystem_materialized=false`
- PASS — base context grows from 1,600 to 1,602 messages; the new prompt occurs once; H1 is written before the manifest
- PASS — a mismatched sandbox session receives 409 without consuming the pointer
- PASS — exactly two unresolved tools produce two tool results; H1 and downloaded H1 hashes match
- PASS — H2 and downloaded H2 hashes match; canonical H0/H2 remain present while pointer/H1 are removed
- PASS — a second resume receives 404; explicit preview cleanup removes the preserved test artifacts
- PASS — corrupt H0 returns 400 and leaves the state at `waiting`; a declared H0 larger than 128 MiB is rejected by the request contract

Browser evidence (API origin only, 1440x900, Headless Chrome 151; no onboarding, account fixture, or feature switches involved):

![Pi handoff preview route](https://cdn.okou.io/artifacts/pkytes7c4a.png)

## Spike boundary

**Draft / do not merge yet.** The probes return 404 in production. This does not wire the production run-activation path, a real LLM call, runner dispatch, sandbox guest polling, the existing timeout sweeper, or the DB pointer update for the final canonical H2 checkpoint. The Preview resume endpoint simulates the sandbox-side request in a separate serverless invocation; official file-backed sandbox interoperability is covered by the runtime tests. Skill bodies are still expected to be read lazily by sandbox tools after handoff.