### PR TITLE
feat(api): add safe single-account connector disconnect

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -373,6 +373,27 @@ describe("POST /api/zero/chat-threads", () => {
         target: { kind: "builtin", connectorSlug: "openai" },
       },
     ]);
+    createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
+    const disconnect = await accept(
+      connectorAccountsClient().disconnectSingleAccount({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+      [409],
+    );
+    expect(disconnect.body.error.message).toBe(
+      "Connector account is selected by chat threads",
+    );
+    const preservedAfterDisconnect = await accept(
+      connectorSelectionsClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(preservedAfterDisconnect.body.selections).toStrictEqual(
+      selections.body.selections,
+    );
     const readToken = zeroToken({
       userId: fixture.userId,
       orgId: fixture.orgId,
@@ -686,6 +707,32 @@ describe("POST /api/zero/chat-threads", () => {
       }),
     ).toStrictEqual(
       expect.arrayContaining([httpConnectionId, mcpConnectionId]),
+    );
+
+    createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
+    for (const customConnectorId of [httpConnector.id, mcpConnector.id]) {
+      const disconnect = await accept(
+        connectorAccountsClient().disconnectSingleAccount({
+          headers: { authorization: "Bearer clerk-session" },
+          body: {
+            target: { kind: "custom", customConnectorId },
+          },
+        }),
+        [409],
+      );
+      expect(disconnect.body.error.message).toBe(
+        "Connector account is selected by chat threads",
+      );
+    }
+    const preservedAfterDisconnect = await accept(
+      connectorSelectionsClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(preservedAfterDisconnect.body.selections).toStrictEqual(
+      selections.body.selections,
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -496,13 +496,22 @@ describe("POST /api/zero/chat-threads", () => {
       [200],
     );
     createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
-    await accept(
+    const [concurrentSelectionWrite, concurrentDisconnect] = await Promise.all([
+      connectorSelectionsClient().update({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: created.body.id },
+        body: {
+          connectionId: connection.id,
+          target: { kind: "builtin", connectorSlug: "openai" },
+        },
+      }),
       connectorAccountsClient().disconnectSingleAccount({
         headers: { authorization: "Bearer clerk-session" },
         body: { target: { kind: "builtin", connectorSlug: "openai" } },
       }),
-      [204],
-    );
+    ]);
+    expect([200, 400]).toContain(concurrentSelectionWrite.status);
+    expect(concurrentDisconnect.status).toBe(204);
     const afterDisconnect = await accept(
       connectorSelectionsClient().get({
         headers: { authorization: `Bearer ${token}` },

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -265,21 +265,17 @@ describe("POST /api/zero/chat-threads", () => {
     );
     expect(impact.body.explicitSelectionCount).toBe(1);
 
-    const reassigned = await accept(
+    const deletedSelectedAccount = await accept(
       connectorAccountsClient().delete({
         headers: { authorization: "Bearer clerk-session" },
         params: { connectionId: secondResponse.body.id },
         body: {
           target: { kind: "builtin", connectorSlug: "openai" },
-          selectionResolution: {
-            kind: "reassign",
-            connectionId: firstResponse.body.id,
-          },
         },
       }),
       [200],
     );
-    expect(reassigned.body.resolvedSelectionCount).toBe(1);
+    expect(deletedSelectedAccount.body.resolvedSelectionCount).toBe(1);
 
     const selected = await accept(
       connectorSelectionsClient().get({
@@ -288,12 +284,7 @@ describe("POST /api/zero/chat-threads", () => {
       }),
       [200],
     );
-    expect(selected.body.selections).toStrictEqual([
-      {
-        connectionId: firstResponse.body.id,
-        target: { kind: "builtin", connectorSlug: "openai" },
-      },
-    ]);
+    expect(selected.body.selections).toStrictEqual([]);
     const inherited = await accept(
       connectorSelectionsClient().get({
         headers: { authorization: `Bearer ${token}` },
@@ -304,18 +295,17 @@ describe("POST /api/zero/chat-threads", () => {
     expect(inherited.body.selections).toStrictEqual([]);
 
     createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
-    const cleared = await accept(
+    const deletedRemainingAccount = await accept(
       connectorAccountsClient().delete({
         headers: { authorization: "Bearer clerk-session" },
         params: { connectionId: firstResponse.body.id },
         body: {
           target: { kind: "builtin", connectorSlug: "openai" },
-          selectionResolution: { kind: "clear" },
         },
       }),
       [200],
     );
-    expect(cleared.body.resolvedSelectionCount).toBe(1);
+    expect(deletedRemainingAccount.body.resolvedSelectionCount).toBe(0);
     const afterClear = await accept(
       connectorSelectionsClient().get({
         headers: { authorization: `Bearer ${token}` },
@@ -373,27 +363,6 @@ describe("POST /api/zero/chat-threads", () => {
         target: { kind: "builtin", connectorSlug: "openai" },
       },
     ]);
-    createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
-    const disconnect = await accept(
-      connectorAccountsClient().disconnectSingleAccount({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { target: { kind: "builtin", connectorSlug: "openai" } },
-      }),
-      [409],
-    );
-    expect(disconnect.body.error.message).toBe(
-      "Connector account is selected by chat threads",
-    );
-    const preservedAfterDisconnect = await accept(
-      connectorSelectionsClient().get({
-        headers: { authorization: `Bearer ${token}` },
-        params: { id: created.body.id },
-      }),
-      [200],
-    );
-    expect(preservedAfterDisconnect.body.selections).toStrictEqual(
-      selections.body.selections,
-    );
     const readToken = zeroToken({
       userId: fixture.userId,
       orgId: fixture.orgId,
@@ -515,6 +484,33 @@ describe("POST /api/zero/chat-threads", () => {
       }),
       [400],
     );
+    await accept(
+      connectorSelectionsClient().update({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: created.body.id },
+        body: {
+          connectionId: connection.id,
+          target: { kind: "builtin", connectorSlug: "openai" },
+        },
+      }),
+      [200],
+    );
+    createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
+    await accept(
+      connectorAccountsClient().disconnectSingleAccount({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+      [204],
+    );
+    const afterDisconnect = await accept(
+      connectorSelectionsClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(afterDisconnect.body.selections).toStrictEqual([]);
   });
 
   it("rejects connector selections while connector accounts are disabled", async () => {
@@ -711,29 +707,24 @@ describe("POST /api/zero/chat-threads", () => {
 
     createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
     for (const customConnectorId of [httpConnector.id, mcpConnector.id]) {
-      const disconnect = await accept(
+      await accept(
         connectorAccountsClient().disconnectSingleAccount({
           headers: { authorization: "Bearer clerk-session" },
           body: {
             target: { kind: "custom", customConnectorId },
           },
         }),
-        [409],
-      );
-      expect(disconnect.body.error.message).toBe(
-        "Connector account is selected by chat threads",
+        [204],
       );
     }
-    const preservedAfterDisconnect = await accept(
+    const afterDisconnect = await accept(
       connectorSelectionsClient().get({
         headers: { authorization: `Bearer ${token}` },
         params: { id: created.body.id },
       }),
       [200],
     );
-    expect(preservedAfterDisconnect.body.selections).toStrictEqual(
-      selections.body.selections,
-    );
+    expect(afterDisconnect.body.selections).toStrictEqual([]);
   });
 
   it("creates a titled thread with ZERO_TOKEN chat-thread:write capability", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -497,7 +497,7 @@ describe("connector account lifecycle routes", () => {
     expect(accounts.body.connections).toHaveLength(2);
   });
 
-  it("serializes concurrent explicit single-account writes", async () => {
+  it("serializes concurrent single-account writes and disconnects", async () => {
     const fixture = await seedFixture();
     await setConnectorAccountsEnabled(fixture, true);
 
@@ -995,7 +995,7 @@ describe("connector account lifecycle routes", () => {
         { id: work.id, displayName: "Work", isDefault: true },
       ]);
 
-      await accept(
+      const disconnects = await Promise.all([
         accountClient().disconnectSingleAccount({
           headers: authHeaders(),
           body: {
@@ -1005,8 +1005,25 @@ describe("connector account lifecycle routes", () => {
             },
           },
         }),
-        [204],
-      );
+        accountClient().disconnectSingleAccount({
+          headers: authHeaders(),
+          body: {
+            target: {
+              kind: "custom",
+              customConnectorId: definition.body.id,
+            },
+          },
+        }),
+      ]);
+      expect(
+        disconnects
+          .map((response) => {
+            return response.status;
+          })
+          .sort((left, right) => {
+            return left - right;
+          }),
+      ).toStrictEqual([204, 404]);
       const disconnected = await accept(
         accountClient().connections({
           headers: authHeaders(),
@@ -1019,22 +1036,6 @@ describe("connector account lifecycle routes", () => {
         [200],
       );
       expect(disconnected.body.connections).toStrictEqual([]);
-
-      const missingDisconnect = await accept(
-        accountClient().disconnectSingleAccount({
-          headers: authHeaders(),
-          body: {
-            target: {
-              kind: "custom",
-              customConnectorId: definition.body.id,
-            },
-          },
-        }),
-        [404],
-      );
-      expect(missingDisconnect.body.error.message).toBe(
-        "Connector account not found",
-      );
     },
   );
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -16,7 +16,7 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
-import { setupApp } from "../../../__tests__/test-helpers";
+import { setupApp, setupRawAppRequest } from "../../../__tests__/test-helpers";
 import { connectorAccountRoutes } from "../connector-accounts";
 import { connectorsRoutes } from "../connectors";
 import { customConnectorsRoutes } from "../custom-connectors";
@@ -37,6 +37,10 @@ const routes = Object.freeze([
   ...customConnectorDisconnectRoutes,
   ...customConnectorsValuesSetRoutes,
   ...featureSwitchesRoutes,
+]);
+const legacyDisconnectRoutes = Object.freeze([
+  ...connectorsRoutes,
+  ...customConnectorDisconnectRoutes,
 ]);
 
 interface Fixture {
@@ -396,6 +400,26 @@ describe("connector account lifecycle routes", () => {
       [200],
     );
     expect(accounts.body.connections).toHaveLength(2);
+
+    const disconnect = await accept(
+      accountClient().disconnectSingleAccount({
+        headers: authHeaders(),
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+      [409],
+    );
+    expect(disconnect.body.error.message).toBe(
+      "Multiple connector accounts require an exact choice",
+    );
+
+    const preserved = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+      }),
+      [200],
+    );
+    expect(preserved.body.connections).toHaveLength(2);
     expect(
       accounts.body.connections.filter((account) => {
         return account.isDefault;
@@ -513,6 +537,77 @@ describe("connector account lifecycle routes", () => {
       displayName: null,
       isDefault: true,
     });
+
+    const disconnects = await Promise.all([
+      accountClient().disconnectSingleAccount({
+        headers: authHeaders(),
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+      accountClient().disconnectSingleAccount({
+        headers: authHeaders(),
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+    ]);
+    expect(
+      disconnects
+        .map((response) => {
+          return response.status;
+        })
+        .sort((left, right) => {
+          return left - right;
+        }),
+    ).toStrictEqual([204, 404]);
+
+    const disconnectedAccounts = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+      }),
+      [200],
+    );
+    expect(disconnectedAccounts.body.connections).toStrictEqual([]);
+  });
+
+  it("keeps accounts intact when a new client reaches an old API", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+
+    const account = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "single-account" },
+          values: { apiKey: "sk-old-api" },
+        },
+      }),
+      [200],
+    );
+
+    const oldApiResponse = await setupRawAppRequest({
+      context,
+      routes: legacyDisconnectRoutes,
+    })("/api/connector-accounts/single-account", {
+      method: "DELETE",
+      headers: {
+        ...authHeaders(),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        target: { kind: "builtin", connectorSlug: "openai" },
+      }),
+    });
+    expect(oldApiResponse.status).toBe(404);
+
+    const preserved = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+      }),
+      [200],
+    );
+    expect(preserved.body.connections).toMatchObject([{ id: account.body.id }]);
   });
 
   it("paginates and searches more than one hundred accounts", async () => {
@@ -782,6 +877,22 @@ describe("connector account lifecycle routes", () => {
           .sort(),
       ).toStrictEqual(["Personal", "Work"]);
 
+      const safeDisconnect = await accept(
+        accountClient().disconnectSingleAccount({
+          headers: authHeaders(),
+          body: {
+            target: {
+              kind: "custom",
+              customConnectorId: definition.body.id,
+            },
+          },
+        }),
+        [409],
+      );
+      expect(safeDisconnect.body.error.message).toBe(
+        "Multiple connector accounts require an exact choice",
+      );
+
       const legacyDisconnect = await accept(
         customConnectorConnectionClient().disconnect({
           headers: authHeaders(),
@@ -883,6 +994,47 @@ describe("connector account lifecycle routes", () => {
       expect(remaining.body.connections).toMatchObject([
         { id: work.id, displayName: "Work", isDefault: true },
       ]);
+
+      await accept(
+        accountClient().disconnectSingleAccount({
+          headers: authHeaders(),
+          body: {
+            target: {
+              kind: "custom",
+              customConnectorId: definition.body.id,
+            },
+          },
+        }),
+        [204],
+      );
+      const disconnected = await accept(
+        accountClient().connections({
+          headers: authHeaders(),
+          query: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+            limit: 100,
+          },
+        }),
+        [200],
+      );
+      expect(disconnected.body.connections).toStrictEqual([]);
+
+      const missingDisconnect = await accept(
+        accountClient().disconnectSingleAccount({
+          headers: authHeaders(),
+          body: {
+            target: {
+              kind: "custom",
+              customConnectorId: definition.body.id,
+            },
+          },
+        }),
+        [404],
+      );
+      expect(missingDisconnect.body.error.message).toBe(
+        "Connector account not found",
+      );
     },
   );
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -123,7 +123,6 @@ async function cleanupFixture(fixture: Fixture): Promise<void> {
           params: { connectionId: account.id },
           body: {
             target: { kind: "builtin", connectorSlug: "openai" },
-            selectionResolution: { kind: "clear" },
           },
         }),
         [200, 404],
@@ -157,7 +156,6 @@ async function cleanupFixture(fixture: Fixture): Promise<void> {
                 kind: "custom",
                 customConnectorId: definition.id,
               },
-              selectionResolution: { kind: "clear" },
             },
           }),
           [200, 404],
@@ -315,31 +313,12 @@ describe("connector account lifecycle routes", () => {
       hasSibling: true,
     });
 
-    const invalidReplacement = await accept(
-      accountClient().delete({
-        headers: authHeaders(),
-        params: { connectionId: second.body.id },
-        body: {
-          target: { kind: "builtin", connectorSlug: "openai" },
-          selectionResolution: {
-            kind: "reassign",
-            connectionId: randomUUID(),
-          },
-        },
-      }),
-      [409],
-    );
-    expect(invalidReplacement.body.error.message).toBe(
-      "Replacement connector account is not available",
-    );
-
     const deleted = await accept(
       accountClient().delete({
         headers: authHeaders(),
         params: { connectionId: second.body.id },
         body: {
           target: { kind: "builtin", connectorSlug: "openai" },
-          selectionResolution: { kind: "clear" },
         },
       }),
       [200],
@@ -969,7 +948,6 @@ describe("connector account lifecycle routes", () => {
               kind: "custom",
               customConnectorId: definition.body.id,
             },
-            selectionResolution: { kind: "clear" },
           },
         }),
         [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2266,6 +2266,22 @@ describe("Feishu integration", () => {
       "This connector is managed by its integration",
     );
 
+    const managedAccountDisconnect = await accept(
+      connectorAccountsClient().disconnectSingleAccount({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          target: {
+            kind: "custom",
+            customConnectorId: managedConnector.id,
+          },
+        },
+      }),
+      [403],
+    );
+    expect(managedAccountDisconnect.body.error.message).toBe(
+      "This connector is managed by its integration",
+    );
+
     const unchangedConnectorList = await accept(
       customConnectorClient.list({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -29,7 +29,6 @@ import {
 } from "../services/model-selection.service";
 import { chatThreadModelPinColumns } from "../services/chat-thread-model.service";
 import { chatThreadServiceTierFromCodex } from "../services/chat-thread-event.service";
-import { prepareChatThreadConnectorSelections } from "../services/chat-thread-connector-selection.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -121,17 +120,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       return notFound("Resource not found");
     }
   }
-  const preparedConnectorSelections =
-    await prepareChatThreadConnectorSelections(writeDb, {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      agentId: body.data.agentId,
-      selections: connectorSelections,
-    });
-  signal.throwIfAborted();
-  if (preparedConnectorSelections.kind === "invalid") {
-    return badRequestMessage(preparedConnectorSelections.message);
-  }
   const callerRunId =
     auth.tokenType === "sandbox" || auth.tokenType === "zero"
       ? auth.runId
@@ -200,11 +188,14 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       codexServiceTier,
       selectedVideoModel,
       selectedImageModel,
-      connectorSelections: preparedConnectorSelections.selections,
+      connectorSelections,
     },
     signal,
   );
   signal.throwIfAborted();
+  if (thread.kind === "invalid_connector_selection") {
+    return badRequestMessage(thread.message);
+  }
 
   await publishThreadListChanged(auth.userId);
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -7,6 +7,7 @@ import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
@@ -22,8 +23,14 @@ import {
 } from "../services/connector-account-lifecycle.service";
 import { commitConnectorRuntimeMutation } from "../services/connector-runtime-wakeup.service";
 import { deleteConnectorLocalState$ } from "../services/connector-data.service";
-import { deleteCustomConnectorAccount$ } from "../services/custom-connector.service";
+import {
+  deleteCustomConnectorAccount$,
+  disconnectCustomConnector$,
+  integrationManagedCustomConnectorMutationForbidden,
+} from "../services/custom-connector.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
+
+const log = logger("api:connector-account-mutation");
 
 const connectorAccountsEnabled$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -197,6 +204,145 @@ const deletionImpactInner$ = computed(async (get) => {
   };
 });
 
+type SingleAccountDisconnectOutcome =
+  | "missing"
+  | "ambiguous"
+  | "referenced"
+  | "managed"
+  | "deleted";
+
+function observeSingleAccountDisconnect(args: {
+  readonly targetKind: ConnectorAccountTarget["kind"];
+  readonly outcome: SingleAccountDisconnectOutcome;
+  readonly accountCardinality?: "zero" | "one" | "multiple";
+}): void {
+  log.debug("Resolved single-account connector disconnect", {
+    targetKind: args.targetKind,
+    outcome: args.outcome,
+    ...(args.accountCardinality
+      ? { accountCardinality: args.accountCardinality }
+      : {}),
+  });
+}
+
+const disconnectSingleAccountInner$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
+    const auth = get(organizationAuthContext$);
+    const body = await get(
+      bodyResultOf(connectorAccountsContract.disconnectSingleAccount),
+    );
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    if (body.data.target.kind === "builtin") {
+      const result = await set(
+        deleteConnectorLocalState$,
+        {
+          orgId: auth.orgId,
+          userId: auth.userId,
+          connectorSlug: body.data.target.connectorSlug,
+          selectionResolution: { kind: "reject" },
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (typeof result !== "string") {
+        observeSingleAccountDisconnect({
+          targetKind: "builtin",
+          outcome: "deleted",
+          accountCardinality: "one",
+        });
+        return { status: 204 as const, body: undefined };
+      }
+      if (result === "missing") {
+        observeSingleAccountDisconnect({
+          targetKind: "builtin",
+          outcome: "missing",
+          accountCardinality: "zero",
+        });
+        return notFound("Connector account not found");
+      }
+      if (result === "ambiguous") {
+        observeSingleAccountDisconnect({
+          targetKind: "builtin",
+          outcome: "ambiguous",
+          accountCardinality: "multiple",
+        });
+        return conflict("Multiple connector accounts require an exact choice");
+      }
+      if (result === "referenced") {
+        observeSingleAccountDisconnect({
+          targetKind: "builtin",
+          outcome: "referenced",
+          accountCardinality: "one",
+        });
+        return conflict("Connector account is selected by chat threads");
+      }
+      throw new Error(
+        "Single-account built-in deletion returned an exact-account result",
+      );
+    }
+
+    const result = await set(
+      disconnectCustomConnector$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        connectorId: body.data.target.customConnectorId,
+        selectionResolution: { kind: "reject" },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result === "deleted") {
+      observeSingleAccountDisconnect({
+        targetKind: "custom",
+        outcome: "deleted",
+        accountCardinality: "one",
+      });
+      return { status: 204 as const, body: undefined };
+    }
+    if (result === "missing-account") {
+      observeSingleAccountDisconnect({
+        targetKind: "custom",
+        outcome: "missing",
+        accountCardinality: "zero",
+      });
+      return notFound("Connector account not found");
+    }
+    if (result === "missing-definition") {
+      observeSingleAccountDisconnect({
+        targetKind: "custom",
+        outcome: "missing",
+      });
+      return notFound("Connector target not found");
+    }
+    if (result === "ambiguous") {
+      observeSingleAccountDisconnect({
+        targetKind: "custom",
+        outcome: "ambiguous",
+        accountCardinality: "multiple",
+      });
+      return conflict("Multiple connector accounts require an exact choice");
+    }
+    if (result === "referenced") {
+      observeSingleAccountDisconnect({
+        targetKind: "custom",
+        outcome: "referenced",
+        accountCardinality: "one",
+      });
+      return conflict("Connector account is selected by chat threads");
+    }
+    observeSingleAccountDisconnect({
+      targetKind: "custom",
+      outcome: "managed",
+    });
+    return integrationManagedCustomConnectorMutationForbidden();
+  },
+);
+
 const deleteInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
@@ -253,6 +399,9 @@ const deleteInner$ = command(
       if (result === "invalid-replacement") {
         return conflict("Replacement connector account is not available");
       }
+      if (result === "referenced") {
+        return conflict("Connector account is selected by chat threads");
+      }
       throw new Error("Exact connector account deletion returned no result");
     }
     if (result.kind === "missing" || result.kind === "managed") {
@@ -260,6 +409,9 @@ const deleteInner$ = command(
     }
     if (result.kind === "invalid-replacement") {
       return conflict("Replacement connector account is not available");
+    }
+    if (result.kind === "referenced") {
+      return conflict("Connector account is selected by chat threads");
     }
     return {
       status: 200 as const,
@@ -304,6 +456,10 @@ export const connectorAccountRoutes: readonly RouteEntry[] = [
   {
     route: connectorAccountsContract.deletionImpact,
     handler: authRoute(readAuth, deletionImpactInner$),
+  },
+  {
+    route: connectorAccountsContract.disconnectSingleAccount,
+    handler: authRoute(writeAuth, disconnectSingleAccountInner$),
   },
   {
     route: connectorAccountsContract.delete,

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -207,7 +207,6 @@ const deletionImpactInner$ = computed(async (get) => {
 type SingleAccountDisconnectOutcome =
   | "missing"
   | "ambiguous"
-  | "referenced"
   | "managed"
   | "deleted";
 
@@ -243,12 +242,11 @@ const disconnectSingleAccountInner$ = command(
           orgId: auth.orgId,
           userId: auth.userId,
           connectorSlug: body.data.target.connectorSlug,
-          selectionResolution: { kind: "reject" },
         },
         signal,
       );
       signal.throwIfAborted();
-      if (typeof result !== "string") {
+      if (result === "deleted") {
         observeSingleAccountDisconnect({
           targetKind: "builtin",
           outcome: "deleted",
@@ -272,14 +270,6 @@ const disconnectSingleAccountInner$ = command(
         });
         return conflict("Multiple connector accounts require an exact choice");
       }
-      if (result === "referenced") {
-        observeSingleAccountDisconnect({
-          targetKind: "builtin",
-          outcome: "referenced",
-          accountCardinality: "one",
-        });
-        return conflict("Connector account is selected by chat threads");
-      }
       throw new Error(
         "Single-account built-in deletion returned an exact-account result",
       );
@@ -291,7 +281,7 @@ const disconnectSingleAccountInner$ = command(
         orgId: auth.orgId,
         userId: auth.userId,
         connectorId: body.data.target.customConnectorId,
-        selectionResolution: { kind: "reject" },
+        requireAccount: true,
       },
       signal,
     );
@@ -326,14 +316,6 @@ const disconnectSingleAccountInner$ = command(
         accountCardinality: "multiple",
       });
       return conflict("Multiple connector accounts require an exact choice");
-    }
-    if (result === "referenced") {
-      observeSingleAccountDisconnect({
-        targetKind: "custom",
-        outcome: "referenced",
-        accountCardinality: "one",
-      });
-      return conflict("Connector account is selected by chat threads");
     }
     observeSingleAccountDisconnect({
       targetKind: "custom",
@@ -373,7 +355,6 @@ const deleteInner$ = command(
               userId: auth.userId,
               connectorSlug: body.data.target.connectorSlug,
               sourceId: params.connectionId,
-              selectionResolution: body.data.selectionResolution,
             },
             signal,
           )
@@ -384,7 +365,6 @@ const deleteInner$ = command(
               userId: auth.userId,
               connectorId: body.data.target.customConnectorId,
               memberConnectorId: params.connectionId,
-              selectionResolution: body.data.selectionResolution,
             },
             signal,
           );
@@ -396,22 +376,10 @@ const deleteInner$ = command(
       if (result === "ambiguous") {
         return conflict("Multiple connector accounts require an exact choice");
       }
-      if (result === "invalid-replacement") {
-        return conflict("Replacement connector account is not available");
-      }
-      if (result === "referenced") {
-        return conflict("Connector account is selected by chat threads");
-      }
       throw new Error("Exact connector account deletion returned no result");
     }
     if (result.kind === "missing" || result.kind === "managed") {
       return notFound("Connector account not found");
-    }
-    if (result.kind === "invalid-replacement") {
-      return conflict("Replacement connector account is not available");
-    }
-    if (result.kind === "referenced") {
-      return conflict("Connector account is selected by chat threads");
     }
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/custom-connectors-disconnect.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-disconnect.ts
@@ -37,7 +37,7 @@ const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (result === "managed") {
     return integrationManagedCustomConnectorMutationForbidden();
   }
-  if (result === "referenced" || result === "missing-account") {
+  if (result === "missing-account") {
     throw new Error("Legacy custom connector deletion returned a safe result");
   }
 

--- a/turbo/apps/api/src/signals/routes/custom-connectors-disconnect.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-disconnect.ts
@@ -1,10 +1,14 @@
 import { command } from "ccstate";
 import { zeroCustomConnectorConnectionContract } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 
+import { conflict, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { disconnectCustomConnector$ } from "../services/custom-connector.service";
+import {
+  disconnectCustomConnector$,
+  integrationManagedCustomConnectorMutationForbidden,
+} from "../services/custom-connector.service";
 import type { RouteEntry } from "../route-entry";
 
 const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -24,8 +28,17 @@ const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
   signal.throwIfAborted();
-  if (result) {
-    return result;
+  if (result === "missing-definition") {
+    return notFound("Custom connector not found");
+  }
+  if (result === "ambiguous") {
+    return conflict("Multiple connector accounts require an exact choice");
+  }
+  if (result === "managed") {
+    return integrationManagedCustomConnectorMutationForbidden();
+  }
+  if (result === "referenced" || result === "missing-account") {
+    throw new Error("Legacy custom connector deletion returned a safe result");
   }
 
   return { status: 204 as const, body: undefined };

--- a/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
@@ -27,6 +27,7 @@ import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSelection,
 } from "./connector-catalog-runtime.service";
+import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
 interface OwnedChatThread {
   readonly agentId: string;
@@ -226,7 +227,7 @@ export async function listChatThreadConnectorSelections(
 }
 
 export async function prepareChatThreadConnectorSelections(
-  db: ReadonlyDb,
+  db: Tx,
   args: {
     readonly orgId: string;
     readonly userId: string;
@@ -250,6 +251,17 @@ export async function prepareChatThreadConnectorSelections(
   }
 
   const selections = [...byTarget.values()];
+  for (const selection of [...selections].sort((left, right) => {
+    return connectorAccountTargetKey(left.target).localeCompare(
+      connectorAccountTargetKey(right.target),
+    );
+  })) {
+    await lockConnectorAccountTarget(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      target: selection.target,
+    });
+  }
   const scope = await loadAgentConnectorScope(db, args);
   const snapshot = await loadSnapshotForBuiltinTargets(db, selections);
   for (const selection of byTarget.values()) {

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -65,6 +65,7 @@ import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecy
 import { disableThreadBoundWorkflowAutomations } from "./workflow-user-automation-thread.service";
 import {
   insertInitialChatThreadConnectorSelections,
+  prepareChatThreadConnectorSelections,
   type PreparedChatThreadConnectorSelection,
 } from "./chat-thread-connector-selection.service";
 
@@ -629,7 +630,7 @@ export const createChatThread$ = command(
     { set },
     args: {
       readonly userId: string;
-      readonly orgId?: string | null;
+      readonly orgId: string;
       readonly agentComposeId: string;
       readonly title: string | undefined;
       readonly clientThreadId: string | undefined;
@@ -644,9 +645,32 @@ export const createChatThread$ = command(
       readonly connectorSelections?: readonly PreparedChatThreadConnectorSelection[];
     },
     signal: AbortSignal,
-  ): Promise<{ id: string; createdAt: Date }> => {
+  ): Promise<
+    | {
+        readonly kind: "created";
+        readonly id: string;
+        readonly createdAt: Date;
+      }
+    | {
+        readonly kind: "invalid_connector_selection";
+        readonly message: string;
+      }
+  > => {
     const writeDb = set(writeDb$);
     const thread = await writeDb.transaction(async (tx) => {
+      const preparedConnectorSelections =
+        await prepareChatThreadConnectorSelections(tx, {
+          orgId: args.orgId,
+          userId: args.userId,
+          agentId: args.agentComposeId,
+          selections: args.connectorSelections ?? [],
+        });
+      if (preparedConnectorSelections.kind === "invalid") {
+        return {
+          kind: "invalid_connector_selection" as const,
+          message: preparedConnectorSelections.message,
+        };
+      }
       const [createdThread] = await tx
         .insert(chatThreads)
         .values({
@@ -671,7 +695,7 @@ export const createChatThread$ = command(
       }
       await insertInitialChatThreadConnectorSelections(tx, {
         chatThreadId: createdThread.id,
-        selections: args.connectorSelections ?? [],
+        selections: preparedConnectorSelections.selections,
       });
       await appendChatThreadEvent(tx, {
         kind: "created",
@@ -689,7 +713,7 @@ export const createChatThread$ = command(
         selectedImageModel: args.selectedImageModel,
         createdAt: createdThread.createdAt,
       });
-      return createdThread;
+      return { kind: "created" as const, ...createdThread };
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -876,7 +876,7 @@ type PreparedConnectorAccountDeletion =
     };
 
 export async function prepareConnectorAccountDeletion(
-  db: Db,
+  db: Tx,
   args: {
     readonly orgId: string;
     readonly userId: string;

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -2,7 +2,6 @@ import { Buffer } from "node:buffer";
 
 import type {
   ConnectorAccountConnection,
-  ConnectorAccountDeleteResolution,
   ConnectorAccountSummary,
   ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
@@ -870,21 +869,11 @@ export async function connectorAccountDeletionImpact(
 
 type PreparedConnectorAccountDeletion =
   | { readonly kind: "missing" }
-  | { readonly kind: "invalid-replacement" }
-  | { readonly kind: "referenced" }
   | {
       readonly kind: "ready";
       readonly resolvedSelectionCount: number;
       readonly promotedDefaultConnectionId: string | null;
     };
-
-export interface ConnectorAccountRejectDeletionPolicy {
-  readonly kind: "reject";
-}
-
-export type ConnectorAccountDeletionSelectionPolicy =
-  | ConnectorAccountDeleteResolution
-  | ConnectorAccountRejectDeletionPolicy;
 
 export async function prepareConnectorAccountDeletion(
   db: Db,
@@ -893,7 +882,6 @@ export async function prepareConnectorAccountDeletion(
     readonly userId: string;
     readonly target: ConnectorAccountTarget;
     readonly connectionId: string;
-    readonly selectionResolution: ConnectorAccountDeletionSelectionPolicy;
   },
 ): Promise<PreparedConnectorAccountDeletion> {
   await lockConnectorAccountTarget(db, args);
@@ -918,57 +906,12 @@ export async function prepareConnectorAccountDeletion(
     ...args,
     excludedConnectionId: args.connectionId,
   });
-  if (args.selectionResolution.kind === "reject") {
-    const [selection] = await db
-      .select({ connectorId: chatThreadConnectorSelections.connectorId })
-      .from(chatThreadConnectorSelections)
-      .where(eq(chatThreadConnectorSelections.connectorId, args.connectionId))
-      .limit(1);
-    if (selection) {
-      return { kind: "referenced" };
-    }
-  } else if (args.selectionResolution.kind === "reassign") {
-    const [replacement] = await db
-      .select({ id: connectors.id })
-      .from(connectors)
-      .where(
-        and(
-          eq(connectors.id, args.selectionResolution.connectionId),
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          targetCondition(args.target),
-          ne(connectors.id, args.connectionId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!replacement) {
-      return { kind: "invalid-replacement" };
-    }
-  }
-
   const resolvedSelectionCount =
-    args.selectionResolution.kind === "reject"
-      ? 0
-      : ((args.selectionResolution.kind === "reassign"
-          ? await db
-              .update(chatThreadConnectorSelections)
-              .set({ connectorId: args.selectionResolution.connectionId })
-              .where(
-                eq(
-                  chatThreadConnectorSelections.connectorId,
-                  args.connectionId,
-                ),
-              )
-          : await db
-              .delete(chatThreadConnectorSelections)
-              .where(
-                eq(
-                  chatThreadConnectorSelections.connectorId,
-                  args.connectionId,
-                ),
-              )
-        ).rowCount ?? 0);
+    (
+      await db
+        .delete(chatThreadConnectorSelections)
+        .where(eq(chatThreadConnectorSelections.connectorId, args.connectionId))
+    ).rowCount ?? 0;
 
   let promotedDefaultConnectionId: string | null = null;
   if (account.isDefault && sibling) {

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -871,11 +871,20 @@ export async function connectorAccountDeletionImpact(
 type PreparedConnectorAccountDeletion =
   | { readonly kind: "missing" }
   | { readonly kind: "invalid-replacement" }
+  | { readonly kind: "referenced" }
   | {
       readonly kind: "ready";
       readonly resolvedSelectionCount: number;
       readonly promotedDefaultConnectionId: string | null;
     };
+
+export interface ConnectorAccountRejectDeletionPolicy {
+  readonly kind: "reject";
+}
+
+export type ConnectorAccountDeletionSelectionPolicy =
+  | ConnectorAccountDeleteResolution
+  | ConnectorAccountRejectDeletionPolicy;
 
 export async function prepareConnectorAccountDeletion(
   db: Db,
@@ -884,7 +893,7 @@ export async function prepareConnectorAccountDeletion(
     readonly userId: string;
     readonly target: ConnectorAccountTarget;
     readonly connectionId: string;
-    readonly selectionResolution: ConnectorAccountDeleteResolution;
+    readonly selectionResolution: ConnectorAccountDeletionSelectionPolicy;
   },
 ): Promise<PreparedConnectorAccountDeletion> {
   await lockConnectorAccountTarget(db, args);
@@ -909,7 +918,16 @@ export async function prepareConnectorAccountDeletion(
     ...args,
     excludedConnectionId: args.connectionId,
   });
-  if (args.selectionResolution.kind === "reassign") {
+  if (args.selectionResolution.kind === "reject") {
+    const [selection] = await db
+      .select({ connectorId: chatThreadConnectorSelections.connectorId })
+      .from(chatThreadConnectorSelections)
+      .where(eq(chatThreadConnectorSelections.connectorId, args.connectionId))
+      .limit(1);
+    if (selection) {
+      return { kind: "referenced" };
+    }
+  } else if (args.selectionResolution.kind === "reassign") {
     const [replacement] = await db
       .select({ id: connectors.id })
       .from(connectors)
@@ -929,19 +947,28 @@ export async function prepareConnectorAccountDeletion(
     }
   }
 
-  const resolvedSelections =
-    args.selectionResolution.kind === "reassign"
-      ? await db
-          .update(chatThreadConnectorSelections)
-          .set({ connectorId: args.selectionResolution.connectionId })
-          .where(
-            eq(chatThreadConnectorSelections.connectorId, args.connectionId),
-          )
-      : await db
-          .delete(chatThreadConnectorSelections)
-          .where(
-            eq(chatThreadConnectorSelections.connectorId, args.connectionId),
-          );
+  const resolvedSelectionCount =
+    args.selectionResolution.kind === "reject"
+      ? 0
+      : ((args.selectionResolution.kind === "reassign"
+          ? await db
+              .update(chatThreadConnectorSelections)
+              .set({ connectorId: args.selectionResolution.connectionId })
+              .where(
+                eq(
+                  chatThreadConnectorSelections.connectorId,
+                  args.connectionId,
+                ),
+              )
+          : await db
+              .delete(chatThreadConnectorSelections)
+              .where(
+                eq(
+                  chatThreadConnectorSelections.connectorId,
+                  args.connectionId,
+                ),
+              )
+        ).rowCount ?? 0);
 
   let promotedDefaultConnectionId: string | null = null;
   if (account.isDefault && sibling) {
@@ -958,7 +985,7 @@ export async function prepareConnectorAccountDeletion(
 
   return {
     kind: "ready",
-    resolvedSelectionCount: resolvedSelections.rowCount ?? 0,
+    resolvedSelectionCount,
     promotedDefaultConnectionId,
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -8,10 +8,7 @@ import {
   type ScopeDiffResponse,
 } from "@okouai/api-contracts/contracts/connector-schemas";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type {
-  ConnectorAccountDeleteResolution,
-  ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { ConnectorSearchItem } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodGrantMetadata,
@@ -83,7 +80,10 @@ import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.servic
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
-import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
+import {
+  prepareConnectorAccountDeletion,
+  type ConnectorAccountDeletionSelectionPolicy,
+} from "./connector-account-lifecycle.service";
 import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import {
   replaceConnectorConnection,
@@ -868,7 +868,7 @@ async function prepareBuiltinConnectorAccountDeletion(
     readonly userId: string;
     readonly connectorSlug: string;
     readonly connectionId: string;
-    readonly selectionResolution?: ConnectorAccountDeleteResolution;
+    readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
   },
 ) {
   return await prepareConnectorAccountDeletion(db, {
@@ -881,7 +881,7 @@ async function prepareBuiltinConnectorAccountDeletion(
 }
 
 function completedConnectorDeletionResult(
-  selectionResolution: ConnectorAccountDeleteResolution | undefined,
+  selectionResolution: ConnectorAccountDeletionSelectionPolicy | undefined,
   deletion: {
     readonly resolvedSelectionCount: number;
     readonly promotedDefaultConnectionId: string | null;
@@ -892,6 +892,18 @@ function completedConnectorDeletionResult(
     : ("deleted" as const);
 }
 
+type DeleteConnectorLocalStateResult =
+  | "deleted"
+  | "missing"
+  | "ambiguous"
+  | "invalid-replacement"
+  | "referenced"
+  | {
+      readonly kind: "deleted";
+      readonly resolvedSelectionCount: number;
+      readonly promotedDefaultConnectionId: string | null;
+    };
+
 export const deleteConnectorLocalState$ = command(
   async (
     { get, set },
@@ -901,20 +913,10 @@ export const deleteConnectorLocalState$ = command(
       readonly connectorSlug: string;
       readonly sourceId?: string;
       readonly snapshot?: ConnectorRuntimeSnapshot | null;
-      readonly selectionResolution?: ConnectorAccountDeleteResolution;
+      readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
     },
     signal: AbortSignal,
-  ): Promise<
-    | "deleted"
-    | "missing"
-    | "ambiguous"
-    | "invalid-replacement"
-    | {
-        readonly kind: "deleted";
-        readonly resolvedSelectionCount: number;
-        readonly promotedDefaultConnectionId: string | null;
-      }
-  > => {
+  ): Promise<DeleteConnectorLocalStateResult> => {
     const writeDb = set(writeDb$);
     const snapshot =
       args.snapshot === undefined

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -80,10 +80,7 @@ import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.servic
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
-import {
-  prepareConnectorAccountDeletion,
-  type ConnectorAccountDeletionSelectionPolicy,
-} from "./connector-account-lifecycle.service";
+import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
 import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import {
   replaceConnectorConnection,
@@ -857,10 +854,6 @@ async function loadConnectorAccountForDeletion(
   return connector ? { kind: "resolved", connector } : { kind: "missing" };
 }
 
-// Target-only disconnect callers omit the exact selection resolution and
-// expect the legacy string result. Default them to clear and preserve that
-// result until #27695, after the account UI ships and the ~2 day
-// old-web-client window closes.
 async function prepareBuiltinConnectorAccountDeletion(
   db: Tx,
   args: {
@@ -868,7 +861,6 @@ async function prepareBuiltinConnectorAccountDeletion(
     readonly userId: string;
     readonly connectorSlug: string;
     readonly connectionId: string;
-    readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
   },
 ) {
   return await prepareConnectorAccountDeletion(db, {
@@ -876,18 +868,17 @@ async function prepareBuiltinConnectorAccountDeletion(
     userId: args.userId,
     target: { kind: "builtin", connectorSlug: args.connectorSlug },
     connectionId: args.connectionId,
-    selectionResolution: args.selectionResolution ?? { kind: "clear" },
   });
 }
 
 function completedConnectorDeletionResult(
-  selectionResolution: ConnectorAccountDeletionSelectionPolicy | undefined,
+  exactAccount: boolean,
   deletion: {
     readonly resolvedSelectionCount: number;
     readonly promotedDefaultConnectionId: string | null;
   },
 ) {
-  return selectionResolution
+  return exactAccount
     ? { kind: "deleted" as const, ...deletion }
     : ("deleted" as const);
 }
@@ -896,8 +887,6 @@ type DeleteConnectorLocalStateResult =
   | "deleted"
   | "missing"
   | "ambiguous"
-  | "invalid-replacement"
-  | "referenced"
   | {
       readonly kind: "deleted";
       readonly resolvedSelectionCount: number;
@@ -913,7 +902,6 @@ export const deleteConnectorLocalState$ = command(
       readonly connectorSlug: string;
       readonly sourceId?: string;
       readonly snapshot?: ConnectorRuntimeSnapshot | null;
-      readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
     },
     signal: AbortSignal,
   ): Promise<DeleteConnectorLocalStateResult> => {
@@ -1029,7 +1017,7 @@ export const deleteConnectorLocalState$ = command(
     signal.throwIfAborted();
 
     return completedConnectorDeletionResult(
-      args.selectionResolution,
+      args.sourceId !== undefined,
       deleteResult.deletion,
     );
   },

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -10,11 +10,7 @@ import {
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
 import { resolveConnectorAccount } from "./connector-account-resolution.service";
-import {
-  prepareConnectorAccountDeletion,
-  type ConnectorAccountDeletionSelectionPolicy,
-  type ConnectorAccountRejectDeletionPolicy,
-} from "./connector-account-lifecycle.service";
+import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
 export type PreparedCustomConnectorValue =
@@ -95,13 +91,9 @@ export async function upsertCustomConnectorStoredValues(
 
 export async function deleteCustomConnectorMemberConnection(
   db: Tx,
-  args: CustomConnectorMemberConnection & {
-    readonly selectionResolution?: ConnectorAccountRejectDeletionPolicy;
-  },
+  args: CustomConnectorMemberConnection,
   signal: AbortSignal,
-): Promise<
-  "deleted" | "missing" | "ambiguous" | "invalid-replacement" | "referenced"
-> {
+): Promise<"deleted" | "missing" | "ambiguous"> {
   await lockConnectorAccountTarget(db, {
     orgId: args.orgId,
     userId: args.userId,
@@ -122,20 +114,6 @@ export async function deleteCustomConnectorMemberConnection(
   }
   if (resolution.kind !== "resolved") {
     return "missing";
-  }
-  if (args.selectionResolution) {
-    const deletion = await deleteCustomConnectorMemberConnectionExact(
-      db,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorId: args.connectorId,
-        memberConnectorId: resolution.account.connectorId,
-        selectionResolution: args.selectionResolution,
-      },
-      signal,
-    );
-    return deletion.kind;
   }
   await deleteCustomConnectorMemberConnectionById(
     db,
@@ -186,13 +164,10 @@ export async function deleteCustomConnectorMemberConnectionExact(
   db: Tx,
   args: CustomConnectorMemberConnection & {
     readonly memberConnectorId: string;
-    readonly selectionResolution: ConnectorAccountDeletionSelectionPolicy;
   },
   signal: AbortSignal,
 ): Promise<
   | { readonly kind: "missing" }
-  | { readonly kind: "invalid-replacement" }
-  | { readonly kind: "referenced" }
   | {
       readonly kind: "deleted";
       readonly resolvedSelectionCount: number;
@@ -204,7 +179,6 @@ export async function deleteCustomConnectorMemberConnectionExact(
     userId: args.userId,
     target: { kind: "custom", customConnectorId: args.connectorId },
     connectionId: args.memberConnectorId,
-    selectionResolution: args.selectionResolution,
   });
   signal.throwIfAborted();
   if (deletion.kind !== "ready") {

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -1,5 +1,4 @@
 import { and, eq } from "drizzle-orm";
-import type { ConnectorAccountDeleteResolution } from "@okouai/api-contracts/contracts/connector-accounts";
 import { connectors } from "@okouai/db/schema/connector";
 
 import type { Db } from "../external/db";
@@ -11,7 +10,11 @@ import {
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
 import { resolveConnectorAccount } from "./connector-account-resolution.service";
-import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
+import {
+  prepareConnectorAccountDeletion,
+  type ConnectorAccountDeletionSelectionPolicy,
+} from "./connector-account-lifecycle.service";
+import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
 export type PreparedCustomConnectorValue =
   | {
@@ -90,10 +93,20 @@ export async function upsertCustomConnectorStoredValues(
 }
 
 export async function deleteCustomConnectorMemberConnection(
-  db: Db,
-  args: CustomConnectorMemberConnection,
+  db: Tx,
+  args: CustomConnectorMemberConnection & {
+    readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
+  },
   signal: AbortSignal,
-): Promise<"deleted" | "missing" | "ambiguous"> {
+): Promise<
+  "deleted" | "missing" | "ambiguous" | "invalid-replacement" | "referenced"
+> {
+  await lockConnectorAccountTarget(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    target: { kind: "custom", customConnectorId: args.connectorId },
+  });
+  signal.throwIfAborted();
   const resolution = await resolveConnectorAccount(db, {
     orgId: args.orgId,
     userId: args.userId,
@@ -108,6 +121,20 @@ export async function deleteCustomConnectorMemberConnection(
   }
   if (resolution.kind !== "resolved") {
     return "missing";
+  }
+  if (args.selectionResolution) {
+    const deletion = await deleteCustomConnectorMemberConnectionExact(
+      db,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorId: args.connectorId,
+        memberConnectorId: resolution.account.connectorId,
+        selectionResolution: args.selectionResolution,
+      },
+      signal,
+    );
+    return deletion.kind;
   }
   await deleteCustomConnectorMemberConnectionById(
     db,
@@ -158,12 +185,13 @@ export async function deleteCustomConnectorMemberConnectionExact(
   db: Tx,
   args: CustomConnectorMemberConnection & {
     readonly memberConnectorId: string;
-    readonly selectionResolution: ConnectorAccountDeleteResolution;
+    readonly selectionResolution: ConnectorAccountDeletionSelectionPolicy;
   },
   signal: AbortSignal,
 ): Promise<
   | { readonly kind: "missing" }
   | { readonly kind: "invalid-replacement" }
+  | { readonly kind: "referenced" }
   | {
       readonly kind: "deleted";
       readonly resolvedSelectionCount: number;

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -13,6 +13,7 @@ import { resolveConnectorAccount } from "./connector-account-resolution.service"
 import {
   prepareConnectorAccountDeletion,
   type ConnectorAccountDeletionSelectionPolicy,
+  type ConnectorAccountRejectDeletionPolicy,
 } from "./connector-account-lifecycle.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
@@ -95,7 +96,7 @@ export async function upsertCustomConnectorStoredValues(
 export async function deleteCustomConnectorMemberConnection(
   db: Tx,
   args: CustomConnectorMemberConnection & {
-    readonly selectionResolution?: ConnectorAccountDeletionSelectionPolicy;
+    readonly selectionResolution?: ConnectorAccountRejectDeletionPolicy;
   },
   signal: AbortSignal,
 ): Promise<

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -2997,58 +2997,75 @@ export const disconnectCustomConnector$ = command(
   ): Promise<DisconnectCustomConnectorResult> => {
     const writeDb = set(writeDb$);
     let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
-    const disconnected = await writeDb.transaction(async (tx) => {
-      const [connector] = await tx
-        .select({
-          id: orgCustomConnectors.id,
-          oauthProviderAdapter: orgCustomConnectorOauthConfigs.providerAdapter,
-        })
-        .from(orgCustomConnectors)
-        .leftJoin(
-          orgCustomConnectorOauthConfigs,
-          and(
-            eq(
-              orgCustomConnectorOauthConfigs.connectorId,
-              orgCustomConnectors.id,
+    const disconnected = await commitConnectorRuntimeMutation(
+      writeDb.transaction(async (tx) => {
+        const [connector] = await tx
+          .select({
+            id: orgCustomConnectors.id,
+            oauthProviderAdapter:
+              orgCustomConnectorOauthConfigs.providerAdapter,
+          })
+          .from(orgCustomConnectors)
+          .leftJoin(
+            orgCustomConnectorOauthConfigs,
+            and(
+              eq(
+                orgCustomConnectorOauthConfigs.connectorId,
+                orgCustomConnectors.id,
+              ),
+              eq(
+                orgCustomConnectorOauthConfigs.orgId,
+                orgCustomConnectors.orgId,
+              ),
             ),
-            eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
-          ),
-        )
-        .where(
-          and(
-            eq(orgCustomConnectors.id, args.connectorId),
-            eq(orgCustomConnectors.orgId, args.orgId),
-          ),
-        )
-        .for("update", { of: orgCustomConnectors })
-        .limit(1);
-      signal.throwIfAborted();
-      if (!connector) {
-        return "missing-definition" as const;
-      }
-      if (
-        isIntegrationManagedCustomConnectorProviderAdapter(
-          connector.oauthProviderAdapter,
-        )
-      ) {
-        return "managed" as const;
-      }
-      const result = await deleteCustomConnectorMemberConnection(
-        tx,
-        args,
-        signal,
-      );
-      if (result === "invalid-replacement") {
-        throw new Error(
-          "Single-account custom connector deletion resolved a replacement",
+          )
+          .where(
+            and(
+              eq(orgCustomConnectors.id, args.connectorId),
+              eq(orgCustomConnectors.orgId, args.orgId),
+            ),
+          )
+          .for("update", { of: orgCustomConnectors })
+          .limit(1);
+        signal.throwIfAborted();
+        if (!connector) {
+          return "missing-definition" as const;
+        }
+        if (
+          isIntegrationManagedCustomConnectorProviderAdapter(
+            connector.oauthProviderAdapter,
+          )
+        ) {
+          return "managed" as const;
+        }
+        const result = await deleteCustomConnectorMemberConnection(
+          tx,
+          args,
+          signal,
         );
-      }
-      return result === "missing" && !args.selectionResolution
-        ? ("deleted" as const)
-        : result === "missing"
-          ? ("missing-account" as const)
-          : result;
-    });
+        if (result === "invalid-replacement") {
+          throw new Error(
+            "Single-account custom connector deletion resolved a replacement",
+          );
+        }
+        return result === "missing" && !args.selectionResolution
+          ? ("deleted" as const)
+          : result === "missing"
+            ? ("missing-account" as const)
+            : result;
+      }),
+      (result) => {
+        return result === "deleted" && args.selectionResolution
+          ? {
+              db: writeDb,
+              scope: { orgId: args.orgId, userId: args.userId },
+              targets: [
+                { kind: "custom", customConnectorId: args.connectorId },
+              ],
+            }
+          : undefined;
+      },
+    );
     if (signal.aborted) {
       postCommitAbort = { reason: signal.reason };
     }

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -98,6 +98,7 @@ import {
   connectorAccountSiblingWritesEnabled,
   normalizeConnectorAccountMutation,
 } from "./connector-account-mutation.service";
+import type { ConnectorAccountRejectDeletionPolicy } from "./connector-account-lifecycle.service";
 import type { Tx } from "../../lib/db-types";
 
 const L = logger("CustomConnectorService");
@@ -2973,6 +2974,14 @@ export const setCustomConnectorValues$ = command(
   },
 );
 
+type DisconnectCustomConnectorResult =
+  | "deleted"
+  | "missing-definition"
+  | "missing-account"
+  | "ambiguous"
+  | "referenced"
+  | "managed";
+
 export const disconnectCustomConnector$ = command(
   async (
     { set },
@@ -2980,11 +2989,10 @@ export const disconnectCustomConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly connectorId: string;
+      readonly selectionResolution?: ConnectorAccountRejectDeletionPolicy;
     },
     signal: AbortSignal,
-  ): Promise<
-    NotFoundResponse | ConflictResponse | ForbiddenResponse | undefined
-  > => {
+  ): Promise<DisconnectCustomConnectorResult> => {
     const writeDb = set(writeDb$);
     let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const disconnected = await writeDb.transaction(async (tx) => {
@@ -3014,33 +3022,35 @@ export const disconnectCustomConnector$ = command(
         .limit(1);
       signal.throwIfAborted();
       if (!connector) {
-        return false;
+        return "missing-definition" as const;
       }
       if (
         isIntegrationManagedCustomConnectorProviderAdapter(
           connector.oauthProviderAdapter,
         )
       ) {
-        return integrationManagedCustomConnectorMutationForbidden();
+        return "managed" as const;
       }
       const result = await deleteCustomConnectorMemberConnection(
         tx,
         args,
         signal,
       );
-      if (result === "ambiguous") {
-        return conflict("Multiple connector accounts require an exact choice");
+      if (result === "invalid-replacement") {
+        throw new Error(
+          "Single-account custom connector deletion resolved a replacement",
+        );
       }
-      return true;
+      return result === "missing" && !args.selectionResolution
+        ? ("deleted" as const)
+        : result === "missing"
+          ? ("missing-account" as const)
+          : result;
     });
     if (signal.aborted) {
       postCommitAbort = { reason: signal.reason };
     }
-    if (disconnected === false) {
-      signal.throwIfAborted();
-      return notFound("Custom connector not found");
-    }
-    if (disconnected !== true) {
+    if (disconnected !== "deleted") {
       signal.throwIfAborted();
       return disconnected;
     }
@@ -3049,7 +3059,7 @@ export const disconnectCustomConnector$ = command(
       signal,
       postCommitAbort,
     );
-    return undefined;
+    return "deleted";
   },
 );
 

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -2982,6 +2982,8 @@ type DisconnectCustomConnectorResult =
   | "referenced"
   | "managed";
 
+// The target-only custom route omits selectionResolution and retains its
+// legacy idempotent, selection-clearing behavior until #27695's drain gate.
 export const disconnectCustomConnector$ = command(
   async (
     { set },

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -23,10 +23,7 @@ import {
   type CustomConnectorValueInput,
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/zero-custom-connectors";
-import type {
-  ConnectorAccountDeleteResolution,
-  ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   canonicalizeFirewallBaseUrl,
   expandHostWildcardsInBaseUrl,
@@ -98,7 +95,6 @@ import {
   connectorAccountSiblingWritesEnabled,
   normalizeConnectorAccountMutation,
 } from "./connector-account-mutation.service";
-import type { ConnectorAccountRejectDeletionPolicy } from "./connector-account-lifecycle.service";
 import type { Tx } from "../../lib/db-types";
 
 const L = logger("CustomConnectorService");
@@ -2979,11 +2975,8 @@ type DisconnectCustomConnectorResult =
   | "missing-definition"
   | "missing-account"
   | "ambiguous"
-  | "referenced"
   | "managed";
 
-// The target-only custom route omits selectionResolution and retains its
-// legacy idempotent, selection-clearing behavior until #27695's drain gate.
 export const disconnectCustomConnector$ = command(
   async (
     { set },
@@ -2991,7 +2984,7 @@ export const disconnectCustomConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly connectorId: string;
-      readonly selectionResolution?: ConnectorAccountRejectDeletionPolicy;
+      readonly requireAccount?: true;
     },
     signal: AbortSignal,
   ): Promise<DisconnectCustomConnectorResult> => {
@@ -3038,24 +3031,10 @@ export const disconnectCustomConnector$ = command(
         ) {
           return "managed" as const;
         }
-        const result = await deleteCustomConnectorMemberConnection(
-          tx,
-          args,
-          signal,
-        );
-        if (result === "invalid-replacement") {
-          throw new Error(
-            "Single-account custom connector deletion resolved a replacement",
-          );
-        }
-        return result === "missing" && !args.selectionResolution
-          ? ("deleted" as const)
-          : result === "missing"
-            ? ("missing-account" as const)
-            : result;
+        return await deleteCustomConnectorMemberConnection(tx, args, signal);
       }),
       (result) => {
-        return result === "deleted" && args.selectionResolution
+        return result === "deleted"
           ? {
               db: writeDb,
               scope: { orgId: args.orgId, userId: args.userId },
@@ -3069,9 +3048,15 @@ export const disconnectCustomConnector$ = command(
     if (signal.aborted) {
       postCommitAbort = { reason: signal.reason };
     }
-    if (disconnected !== "deleted") {
+    const outcome =
+      disconnected === "missing"
+        ? args.requireAccount
+          ? ("missing-account" as const)
+          : ("deleted" as const)
+        : disconnected;
+    if (outcome !== "deleted") {
       signal.throwIfAborted();
-      return disconnected;
+      return outcome;
     }
     await publishCustomConnectorUserInvalidationAfterCommit(
       args.userId,
@@ -3090,7 +3075,6 @@ export const deleteCustomConnectorAccount$ = command(
       readonly userId: string;
       readonly connectorId: string;
       readonly memberConnectorId: string;
-      readonly selectionResolution: ConnectorAccountDeleteResolution;
     },
     signal: AbortSignal,
   ) => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  connectorAccountsContract,
   connectorAccountDisplayNameSchema,
   connectorAccountDeleteResolutionSchema,
   connectorAccountListQuerySchema,
@@ -133,6 +134,27 @@ describe("connector account contracts", () => {
     expect(
       connectorAccountDeleteResolutionSchema.safeParse({ kind: "reassign" })
         .success,
+    ).toBe(false);
+  });
+
+  it("accepts only a target for safe single-account disconnect", () => {
+    expect(
+      connectorAccountsContract.disconnectSingleAccount.body.parse({
+        target: { kind: "builtin", connectorSlug: "github" },
+      }),
+    ).toStrictEqual({
+      target: { kind: "builtin", connectorSlug: "github" },
+    });
+    expect(
+      connectorAccountsContract.disconnectSingleAccount.body.parse({
+        target: { kind: "custom", customConnectorId },
+      }),
+    ).toStrictEqual({ target: { kind: "custom", customConnectorId } });
+    expect(
+      connectorAccountsContract.disconnectSingleAccount.body.safeParse({
+        target: { kind: "builtin", connectorSlug: "github" },
+        connectionId,
+      }).success,
     ).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   connectorAccountsContract,
   connectorAccountDisplayNameSchema,
-  connectorAccountDeleteResolutionSchema,
   connectorAccountListQuerySchema,
   connectorAccountMutationIntentSchema,
   connectorAccountSelectionSchema,
@@ -121,19 +120,19 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("requires an explicit sparse-selection deletion resolution", () => {
+  it("accepts only an exact target for account deletion", () => {
     expect(
-      connectorAccountDeleteResolutionSchema.parse({ kind: "clear" }),
-    ).toStrictEqual({ kind: "clear" });
-    expect(
-      connectorAccountDeleteResolutionSchema.parse({
-        kind: "reassign",
-        connectionId,
+      connectorAccountsContract.delete.body.parse({
+        target: { kind: "builtin", connectorSlug: "github" },
       }),
-    ).toStrictEqual({ kind: "reassign", connectionId });
+    ).toStrictEqual({
+      target: { kind: "builtin", connectorSlug: "github" },
+    });
     expect(
-      connectorAccountDeleteResolutionSchema.safeParse({ kind: "reassign" })
-        .success,
+      connectorAccountsContract.delete.body.safeParse({
+        target: { kind: "builtin", connectorSlug: "github" },
+        selectionResolution: { kind: "clear" },
+      }).success,
     ).toBe(false);
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -13,6 +13,7 @@ import {
   userConnectorUpdateSchema,
 } from "../user-connectors";
 import { connectorCatalogContract } from "../connector-catalog";
+import { connectorAccountsContract } from "../connector-accounts";
 import {
   connectorCheckDiagnosticResultSchema,
   connectorCheckRequestSchema,
@@ -369,6 +370,12 @@ describe("connector path parameter contracts", () => {
       params: { connectorSlug: "github" },
       headers: {},
     });
+    await initClient(connectorAccountsContract, config).disconnectSingleAccount(
+      {
+        headers: {},
+        body: { target: { kind: "builtin", connectorSlug: "github" } },
+      },
+    );
     await initClient(connectorCatalogContract, config).permissions({
       params: { connectorSlug: "github" },
       headers: {},
@@ -381,6 +388,7 @@ describe("connector path parameter contracts", () => {
 
     expect(paths).toStrictEqual([
       "https://api.example.test/api/connectors/github",
+      "https://api.example.test/api/connector-accounts/single-account",
       "https://api.example.test/api/connector-catalog/github/permissions",
       "https://api.example.test/api/connectors/github/callback?responseMode=json",
     ]);

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -235,6 +235,21 @@ export const connectorAccountsContract = c.router({
     },
     summary: "Plan deletion of an exact connector account",
   },
+  disconnectSingleAccount: {
+    method: "DELETE",
+    path: "/api/connector-accounts/single-account",
+    headers: authHeadersSchema,
+    body: connectorAccountExactTargetBodySchema,
+    responses: {
+      204: c.noBody(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Disconnect a safe single connector account",
+  },
   delete: {
     method: "DELETE",
     path: "/api/connector-accounts/:connectionId",

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -130,19 +130,6 @@ export const connectorAccountSummarySchema = z
   })
   .strict();
 
-export const connectorAccountDeleteResolutionSchema = z.discriminatedUnion(
-  "kind",
-  [
-    z.object({ kind: z.literal("clear") }).strict(),
-    z
-      .object({
-        kind: z.literal("reassign"),
-        connectionId: z.uuid(),
-      })
-      .strict(),
-  ],
-);
-
 const connectorAccountPathParamsSchema = z.object({
   connectionId: z.uuid(),
 });
@@ -255,12 +242,7 @@ export const connectorAccountsContract = c.router({
     path: "/api/connector-accounts/:connectionId",
     headers: authHeadersSchema,
     pathParams: connectorAccountPathParamsSchema,
-    body: z
-      .object({
-        target: connectorAccountTargetSchema,
-        selectionResolution: connectorAccountDeleteResolutionSchema,
-      })
-      .strict(),
+    body: connectorAccountExactTargetBodySchema,
     responses: {
       200: z.object({
         deletedConnectionId: z.uuid(),
@@ -271,7 +253,6 @@ export const connectorAccountsContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
-      409: apiErrorSchema,
     },
     summary: "Delete an exact connector account",
   },
@@ -288,9 +269,6 @@ export type ConnectorAccountSelection = z.infer<
 >;
 export type ConnectorAccountMutationIntent = z.infer<
   typeof connectorAccountMutationIntentSchema
->;
-export type ConnectorAccountDeleteResolution = z.infer<
-  typeof connectorAccountDeleteResolutionSchema
 >;
 export type ConnectorAccountSummary = z.infer<
   typeof connectorAccountSummarySchema

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -755,13 +755,11 @@ export {
   connectorAccountTargetQuerySchema,
   connectorAccountListQuerySchema,
   connectorAccountSummarySchema,
-  connectorAccountDeleteResolutionSchema,
   connectorAccountsContract,
   type ConnectorAccountTarget,
   type ConnectorAccountConnection,
   type ConnectorAccountSelection,
   type ConnectorAccountMutationIntent,
-  type ConnectorAccountDeleteResolution,
   type ConnectorAccountSummary,
 } from "./connector-accounts";
 


### PR DESCRIPTION
## Summary

- add the canonical `DELETE /api/connector-accounts/single-account` operation for compact clients
- reject only ambiguous targets; a sole account is deleted even when threads selected it
- atomically remove every sparse thread preference referencing an explicitly deleted account so affected threads resume current-default inheritance
- align exact account deletion with the same invariant and remove the public clear/reassign prerequisite
- serialize thread selection writes and thread creation with account deletion through the shared target lock, preventing FK errors or stale preferences under races
- preserve built-in cleanup/revocation, custom runner wakeup and invalidation, deterministic default promotion, and Integration-managed Feishu exclusion
- keep temporary account unavailability distinct: admission may fall back, but the stored preference remains while the account still exists

## Compatibility

- old compact clients continue using the existing built-in and custom target-only disconnect routes until #27695 completes its production drain
- the exact account-manager delete contract now requires only the logical target; the account-aware settings UI has not shipped and remains blocked on this API correction
- new compact clients calling an old API receive a missing-route response instead of invoking a legacy handler
- no database migration, Platform UI change, Runner protocol change, or connector permission-state change is included

## Validation

- affected-file Prettier
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts exec tsc --noEmit --pretty false`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-accounts.test.ts src/contracts/__tests__/connector-client-contract.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts src/signals/routes/__tests__/chat-threads-create.test.ts src/signals/routes/__tests__/feishu-integration.test.ts --maxWorkers=4 --silent=passed-only`
- pre-commit hooks, including repository-wide `pnpm knip` and `pnpm check-types`

Closes #28591

Delivery parent: #28570

Umbrella: #22832
