### PR TITLE
fix(db): permit canonical chat event reference backfill

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -686,23 +686,6 @@ jobs:
             'turbo/packages/db/src/migrations/*.sql' \
             'turbo/packages/db/src/migrations/meta/*_snapshot.json')
 
-          # Migration 0966 failed before its first production application, so
-          # allow only the reviewed byte-for-byte correction recorded in #28601.
-          # The base and result hashes make this exception self-expiring: any
-          # later edit to 0966 remains blocked by the normal immutability gate.
-          APPROVED_REWRITE='turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql'
-          APPROVED_BASE_SHA256='8bc63b3e7378d03876d82cf5f0b41029cca1fc318ce2de6ce3c9cec30040a436'
-          APPROVED_HEAD_SHA256='d57eddcecad29f159910b2ff6eb1c070bcfedd62b420ae173ca0a288721bd223'
-          if [ "$MODIFIED" = "$APPROVED_REWRITE" ]; then
-            BASE_SHA256=$(git show "${BASE_REF}:${APPROVED_REWRITE}" | sha256sum | awk '{ print $1 }')
-            HEAD_SHA256=$(sha256sum "$APPROVED_REWRITE" | awk '{ print $1 }')
-            if [ "$BASE_SHA256" = "$APPROVED_BASE_SHA256" ] && \
-              [ "$HEAD_SHA256" = "$APPROVED_HEAD_SHA256" ]; then
-              echo "::warning::Allowing the production-unapplied 0966 correction recorded in #28601."
-              MODIFIED=
-            fi
-          fi
-
           # _journal.json is modified on every new migration, so only flag deletion
           DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/packages/db/src/migrations/meta/_journal.json')

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -686,6 +686,23 @@ jobs:
             'turbo/packages/db/src/migrations/*.sql' \
             'turbo/packages/db/src/migrations/meta/*_snapshot.json')
 
+          # Migration 0966 failed before its first production application, so
+          # allow only the reviewed byte-for-byte correction recorded in #28601.
+          # The base and result hashes make this exception self-expiring: any
+          # later edit to 0966 remains blocked by the normal immutability gate.
+          APPROVED_REWRITE='turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql'
+          APPROVED_BASE_SHA256='8bc63b3e7378d03876d82cf5f0b41029cca1fc318ce2de6ce3c9cec30040a436'
+          APPROVED_HEAD_SHA256='1057c40c7056bdcd315d5aae1e20d2b04ac67292ef03a640eb0a580deb9dee69'
+          if [ "$MODIFIED" = "$APPROVED_REWRITE" ]; then
+            BASE_SHA256=$(git show "${BASE_REF}:${APPROVED_REWRITE}" | sha256sum | awk '{ print $1 }')
+            HEAD_SHA256=$(sha256sum "$APPROVED_REWRITE" | awk '{ print $1 }')
+            if [ "$BASE_SHA256" = "$APPROVED_BASE_SHA256" ] && \
+              [ "$HEAD_SHA256" = "$APPROVED_HEAD_SHA256" ]; then
+              echo "::warning::Allowing the production-unapplied 0966 correction recorded in #28601."
+              MODIFIED=
+            fi
+          fi
+
           # _journal.json is modified on every new migration, so only flag deletion
           DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/packages/db/src/migrations/meta/_journal.json')

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -692,7 +692,7 @@ jobs:
           # later edit to 0966 remains blocked by the normal immutability gate.
           APPROVED_REWRITE='turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql'
           APPROVED_BASE_SHA256='8bc63b3e7378d03876d82cf5f0b41029cca1fc318ce2de6ce3c9cec30040a436'
-          APPROVED_HEAD_SHA256='1057c40c7056bdcd315d5aae1e20d2b04ac67292ef03a640eb0a580deb9dee69'
+          APPROVED_HEAD_SHA256='d57eddcecad29f159910b2ff6eb1c070bcfedd62b420ae173ca0a288721bd223'
           if [ "$MODIFIED" = "$APPROVED_REWRITE" ]; then
             BASE_SHA256=$(git show "${BASE_REF}:${APPROVED_REWRITE}" | sha256sum | awk '{ print $1 }')
             HEAD_SHA256=$(sha256sum "$APPROVED_REWRITE" | awk '{ print $1 }')

--- a/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
+++ b/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
@@ -13,6 +13,8 @@ const migration = "0966_canonical_agents_data_plane";
 const testDatabase = "migration_canonical_agents_data_plane";
 const fixedAgentId = "00000000-0000-4000-8000-000000096600";
 const composeOnlyId = "00000000-0000-4000-8000-0000000966ff";
+const fixedChatThreadEventId = "00000000-0000-4000-8000-0000000966d1";
+const composeOnlyChatThreadEventId = "00000000-0000-4000-8000-0000000966df";
 
 const siblingColumns = [
   "agent_sessions.agent_id",
@@ -97,9 +99,59 @@ function assertDatabaseError(
   }
 }
 
+async function chatEventRejectFunctionDefinition(
+  client: Client,
+): Promise<string> {
+  const result = await client.query<{ definition: string }>(`
+    SELECT pg_get_functiondef(
+      'public.reject_chat_event_source_update()'::regprocedure
+    ) AS "definition"
+  `);
+  const definition = result.rows[0]?.definition;
+  assert.ok(definition);
+  return definition;
+}
+
+async function assertChatThreadEventAppendOnlyTriggerEnabled(
+  client: Client,
+): Promise<void> {
+  const trigger = await client.query<{
+    enabled: string;
+    expectedFunction: boolean;
+  }>(`
+    SELECT
+      "trigger"."tgenabled"::text AS "enabled",
+      "trigger"."tgfoid" =
+        'public.reject_chat_event_source_update()'::regprocedure
+        AS "expectedFunction"
+    FROM "pg_trigger" AS "trigger"
+    WHERE "trigger"."tgrelid" = 'public.chat_thread_events'::regclass
+      AND "trigger"."tgname" = 'chat_thread_events_reject_update'
+      AND NOT "trigger"."tgisinternal"
+  `);
+  assert.deepEqual(trigger.rows, [{ enabled: "O", expectedFunction: true }]);
+}
+
+async function assertChatThreadEventUpdateRejected(
+  client: Client,
+  query: string,
+  values: string[],
+): Promise<void> {
+  await assert.rejects(client.query(query, values), (error: unknown) => {
+    assertDatabaseError(error, {
+      code: "P0001",
+      messageIncludes:
+        "chat_thread_events is append-only; UPDATE is not allowed",
+    });
+    return true;
+  });
+}
+
 function validateMigrationSql(migrationSql: string): void {
   assert.ok(migrationSql.startsWith(NON_TRANSACTIONAL_MIGRATION_MARKER));
   assert.doesNotMatch(migrationSql, /\bLOCK\s+TABLE\b/iu);
+  assert.doesNotMatch(migrationSql, /\bDISABLE\s+TRIGGER\b/iu);
+  assert.doesNotMatch(migrationSql, /\bsession_replication_role\b/iu);
   assert.doesNotMatch(migrationSql, /\bDROP\s+(?:TABLE|COLUMN)\b/iu);
   assert.doesNotMatch(migrationSql, /\bRENAME\s+(?:TABLE|COLUMN)\b/iu);
   assert.doesNotMatch(
@@ -135,6 +187,25 @@ function validateMigrationSql(migrationSql: string): void {
   assert.match(
     migrationSql,
     /created_at"[\s\S]*greatest\("compose"\."updated_at", "zero_agent"\."updated_at"\)/u,
+  );
+
+  const chatThreadEventCall = `CALL "backfill_agent_references_0966"('public.chat_thread_events', ARRAY['id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');`;
+  const chatThreadEventCallOffset = migrationSql.indexOf(chatThreadEventCall);
+  const narrowGuardOffset = migrationSql.indexOf(`AND OLD."agent_id" IS NULL`);
+  const strictRestoreOffset = migrationSql.indexOf(
+    `CREATE OR REPLACE FUNCTION "reject_chat_event_source_update"() RETURNS trigger AS $$`,
+    chatThreadEventCallOffset + chatThreadEventCall.length,
+  );
+  const nextReferenceCallOffset = migrationSql.indexOf(
+    `CALL "backfill_agent_references_0966"('public.chat_event_search_messages'`,
+  );
+  assert.ok(narrowGuardOffset > 0);
+  assert.ok(narrowGuardOffset < chatThreadEventCallOffset);
+  assert.ok(chatThreadEventCallOffset < strictRestoreOffset);
+  assert.ok(strictRestoreOffset < nextReferenceCallOffset);
+  assert.match(
+    migrationSql,
+    /TG_TABLE_SCHEMA = 'public'[\s\S]*TG_TABLE_NAME = 'chat_thread_events'[\s\S]*OLD\."agent_id" IS NULL[\s\S]*NEW\."agent_id" = OLD\."agent_compose_id"[\s\S]*\(to_jsonb\(NEW\) - 'agent_id'\) = \(to_jsonb\(OLD\) - 'agent_id'\)[\s\S]*FROM "agents" AS "agent"[\s\S]*"agent"\."id" = OLD\."agent_compose_id"/u,
   );
 }
 
@@ -329,6 +400,30 @@ async function seedPreviousSchema(client: Client): Promise<void> {
     `,
     [composeOnlyId],
   );
+  await client.query(
+    `
+      INSERT INTO "chat_thread_events" (
+        "id", "user_id", "org_id", "chat_thread_id", "kind",
+        "agent_compose_id", "title"
+      ) VALUES
+        (
+          $1, 'canonical-owner', 'canonical-org',
+          '00000000-0000-4000-8000-0000000966a1', 'created', $3,
+          'canonical Agent event'
+        ),
+        (
+          $2, 'compose-only-owner', 'compose-only-org',
+          '00000000-0000-4000-8000-0000000966aa', 'created', $4,
+          'compose-only event'
+        )
+    `,
+    [
+      fixedChatThreadEventId,
+      composeOnlyChatThreadEventId,
+      fixedAgentId,
+      composeOnlyId,
+    ],
+  );
 }
 
 async function assertCatalogLockRetryBoundary(args: {
@@ -494,6 +589,87 @@ async function assertReferenceBackfillContention(args: {
   assert.deepEqual(partial.rows, [{ count: 501 }]);
 }
 
+async function assertChatThreadEventReferenceState(
+  client: Client,
+): Promise<void> {
+  const references = await client.query<{
+    agentId: string | null;
+    id: string;
+  }>(
+    `
+      SELECT "id"::text AS "id", "agent_id"::text AS "agentId"
+      FROM "chat_thread_events"
+      WHERE "id" = ANY($1::uuid[])
+      ORDER BY "id"
+    `,
+    [[fixedChatThreadEventId, composeOnlyChatThreadEventId]],
+  );
+  assert.deepEqual(references.rows, [
+    { id: fixedChatThreadEventId, agentId: fixedAgentId },
+    { id: composeOnlyChatThreadEventId, agentId: null },
+  ]);
+}
+
+async function assertChatThreadEventBackfillGuard(args: {
+  readonly runner: Client;
+  readonly statements: readonly string[];
+  readonly strictRejectFunctionDefinition: string;
+}): Promise<void> {
+  const callIndex = args.statements.findIndex((statement) => {
+    return statement.startsWith(
+      `CALL "backfill_agent_references_0966"('public.chat_thread_events'`,
+    );
+  });
+  assert.ok(callIndex > 1);
+  const narrowGuard = args.statements[callIndex - 1];
+  const strictRestore = args.statements[callIndex + 1];
+  assert.match(
+    narrowGuard!,
+    /OLD\."agent_id" IS NULL[\s\S]*NEW\."agent_id" = OLD\."agent_compose_id"/u,
+  );
+  assert.doesNotMatch(strictRestore!, /OLD\."agent_id"/u);
+
+  // Stop immediately before the guarded call to model an interrupted run with
+  // the permanent trigger still enabled and the narrow transition installed.
+  await executeStatements({
+    client: args.runner,
+    statements: args.statements,
+    endExclusive: callIndex,
+  });
+  await assertChatThreadEventAppendOnlyTriggerEnabled(args.runner);
+  await assertChatThreadEventUpdateRejected(
+    args.runner,
+    `UPDATE "chat_thread_events" SET "title" = 'forbidden' WHERE "id" = $1`,
+    [fixedChatThreadEventId],
+  );
+  await assertChatThreadEventUpdateRejected(
+    args.runner,
+    `UPDATE "chat_thread_events" SET "agent_id" = "agent_compose_id" WHERE "id" = $1`,
+    [composeOnlyChatThreadEventId],
+  );
+
+  await args.runner.query(args.statements[callIndex]!);
+  await args.runner.query(args.statements[callIndex]!);
+  await args.runner.query(strictRestore!);
+
+  await assertChatThreadEventReferenceState(args.runner);
+  await assertChatThreadEventAppendOnlyTriggerEnabled(args.runner);
+  assert.equal(
+    await chatEventRejectFunctionDefinition(args.runner),
+    args.strictRejectFunctionDefinition,
+  );
+  await assertChatThreadEventUpdateRejected(
+    args.runner,
+    `UPDATE "chat_thread_events" SET "agent_id" = NULL WHERE "id" = $1`,
+    [fixedChatThreadEventId],
+  );
+  await assertChatThreadEventUpdateRejected(
+    args.runner,
+    `UPDATE "chat_thread_events" SET "title" = 'still forbidden' WHERE "id" = $1`,
+    [composeOnlyChatThreadEventId],
+  );
+}
+
 async function validateFinalCatalog(
   client: Client,
   baseline: CatalogBaseline,
@@ -628,6 +804,7 @@ async function validateBackfillAndComposeOnlyClosure(
     composeOnlyAgentCount: number;
     composeOnlySearchNullCount: number;
     composeOnlySessionNullCount: number;
+    composeOnlyThreadEventNullCount: number;
     composeOnlyThreadNullCount: number;
     fieldMismatchCount: number;
     matchedCount: number;
@@ -677,6 +854,10 @@ async function validateBackfillAndComposeOnlyClosure(
         WHERE "agent_compose_id" = $1 AND "agent_id" IS NULL
       ) AS "composeOnlyThreadNullCount",
       (
+        SELECT count(*)::integer FROM "chat_thread_events"
+        WHERE "agent_compose_id" = $1 AND "agent_id" IS NULL
+      ) AS "composeOnlyThreadEventNullCount",
+      (
         SELECT count(*)::integer FROM "chat_event_search_messages"
         WHERE "agent_compose_id" = $1 AND "agent_id" IS NULL
       ) AS "composeOnlySearchNullCount"
@@ -691,6 +872,7 @@ async function validateBackfillAndComposeOnlyClosure(
       composeOnlyAgentCount: 0,
       composeOnlySessionNullCount: 22,
       composeOnlyThreadNullCount: 1,
+      composeOnlyThreadEventNullCount: 1,
       composeOnlySearchNullCount: 2,
     },
   ]);
@@ -1011,20 +1193,40 @@ export async function validateCanonicalAgentDataPlaneMigration(): Promise<void> 
       previousMigration,
     );
     await seedPreviousSchema(runner);
+    await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
+    const strictRejectFunctionDefinition =
+      await chatEventRejectFunctionDefinition(runner);
     const baseline = await collectCatalogBaseline(runner);
 
     await assertCatalogLockRetryBoundary({ blocker, runner, statements });
     await assertAgentBackfillContention({ blocker, runner, statements });
     await assertReferenceBackfillContention({ blocker, runner, statements });
+    await assertChatThreadEventBackfillGuard({
+      runner,
+      statements,
+      strictRejectFunctionDefinition,
+    });
 
     await executeStatements({ client: runner, statements });
     await validateFinalCatalog(runner, baseline);
     await validateBackfillAndComposeOnlyClosure(runner);
+    await assertChatThreadEventReferenceState(runner);
+    await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
+    assert.equal(
+      await chatEventRejectFunctionDefinition(runner),
+      strictRejectFunctionDefinition,
+    );
     await validateBridgeBehavior(runner);
     await validateConcurrentBridgeBehavior(runner, testUrl);
     await validateInvalidIndexRecovery({ client: runner, statements });
     await validateFinalCatalog(runner, baseline);
     await validateBackfillAndComposeOnlyClosure(runner);
+    await assertChatThreadEventReferenceState(runner);
+    await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
+    assert.equal(
+      await chatEventRejectFunctionDefinition(runner),
+      strictRejectFunctionDefinition,
+    );
   } finally {
     await blocker.query("ROLLBACK").catch(() => {});
     await runner.query("ROLLBACK").catch(() => {});

--- a/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
+++ b/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
@@ -154,6 +154,7 @@ function validateMigrationSql(migrationSql: string): void {
   assert.doesNotMatch(migrationSql, /\bsession_replication_role\b/iu);
   assert.doesNotMatch(migrationSql, /\bDROP\s+(?:TABLE|COLUMN)\b/iu);
   assert.doesNotMatch(migrationSql, /\bRENAME\s+(?:TABLE|COLUMN)\b/iu);
+  assert.match(migrationSql, /"tgenabled" = 'O'/u);
   assert.doesNotMatch(
     migrationSql,
     /CREATE\s+TRIGGER[\s\S]{0,300}\sON\s+"agents"/iu,
@@ -621,13 +622,29 @@ async function assertChatThreadEventBackfillGuard(args: {
     );
   });
   assert.ok(callIndex > 1);
+  const catalogGate = args.statements[callIndex - 2];
   const narrowGuard = args.statements[callIndex - 1];
   const strictRestore = args.statements[callIndex + 1];
+  assert.match(catalogGate!, /"tgenabled" = 'O'/u);
   assert.match(
     narrowGuard!,
     /OLD\."agent_id" IS NULL[\s\S]*NEW\."agent_id" = OLD\."agent_compose_id"/u,
   );
   assert.doesNotMatch(strictRestore!, /OLD\."agent_id"/u);
+
+  await args.runner.query(
+    `ALTER TABLE "chat_thread_events" ENABLE REPLICA TRIGGER "chat_thread_events_reject_update"`,
+  );
+  await assert.rejects(args.runner.query(catalogGate!), (error: unknown) => {
+    assertDatabaseError(error, {
+      code: "P0001",
+      messageIncludes: "chat_thread_events append-only trigger must be enabled",
+    });
+    return true;
+  });
+  await args.runner.query(
+    `ALTER TABLE "chat_thread_events" ENABLE TRIGGER "chat_thread_events_reject_update"`,
+  );
 
   // Stop immediately before the guarded call to model an interrupted run with
   // the permanent trigger still enabled and the narrow transition installed.

--- a/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
+++ b/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
@@ -661,6 +661,11 @@ async function assertChatThreadEventBackfillGuard(args: {
   );
   await assertChatThreadEventUpdateRejected(
     args.runner,
+    `UPDATE "chat_thread_events" SET "agent_id" = "agent_compose_id", "title" = 'forbidden' WHERE "id" = $1`,
+    [fixedChatThreadEventId],
+  );
+  await assertChatThreadEventUpdateRejected(
+    args.runner,
     `UPDATE "chat_thread_events" SET "agent_id" = "agent_compose_id" WHERE "id" = $1`,
     [composeOnlyChatThreadEventId],
   );

--- a/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
+++ b/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
@@ -859,7 +859,53 @@ CALL "backfill_agent_references_0966"('public.agent_sessions', ARRAY['id']::name
 --> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.chat_threads', ARRAY['id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');
 --> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "pg_trigger"
+    WHERE "tgrelid" = 'public.chat_thread_events'::regclass
+      AND "tgname" = 'chat_thread_events_reject_update'
+      AND "tgfoid" = 'public.reject_chat_event_source_update()'::regprocedure
+      AND "tgenabled" <> 'D'
+      AND NOT "tgisinternal"
+  ) THEN
+    RAISE EXCEPTION 'chat_thread_events append-only trigger must be enabled';
+  END IF;
+END;
+$$;
+--> statement-breakpoint
+-- Keep the permanent append-only trigger installed while narrowly permitting
+-- only this deterministic reference transition. The target may move only from
+-- NULL to the legacy compose id when that id already owns a canonical Agent;
+-- every other column remains byte-identical and every other UPDATE still fails.
+CREATE OR REPLACE FUNCTION "reject_chat_event_source_update"() RETURNS trigger AS $$
+BEGIN
+  IF TG_TABLE_SCHEMA = 'public'
+    AND TG_TABLE_NAME = 'chat_thread_events'
+    AND OLD."agent_id" IS NULL
+    AND NEW."agent_id" = OLD."agent_compose_id"
+    AND (to_jsonb(NEW) - 'agent_id') = (to_jsonb(OLD) - 'agent_id')
+    AND EXISTS (
+      SELECT 1
+      FROM "agents" AS "agent"
+      WHERE "agent"."id" = OLD."agent_compose_id"
+    )
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION '% is append-only; UPDATE is not allowed', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.chat_thread_events', ARRAY['id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "reject_chat_event_source_update"() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only; UPDATE is not allowed', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
 --> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.chat_event_search_messages', ARRAY['chat_thread_id', 'seq_id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');
 --> statement-breakpoint

--- a/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
+++ b/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
@@ -867,7 +867,7 @@ BEGIN
     WHERE "tgrelid" = 'public.chat_thread_events'::regclass
       AND "tgname" = 'chat_thread_events_reject_update'
       AND "tgfoid" = 'public.reject_chat_event_source_update()'::regprocedure
-      AND "tgenabled" <> 'D'
+      AND "tgenabled" = 'O'
       AND NOT "tgisinternal"
   ) THEN
     RAISE EXCEPTION 'chat_thread_events append-only trigger must be enabled';


### PR DESCRIPTION
## Summary

- fix migration 0966 in place because production remains on 0965
- keep `chat_thread_events_reject_update` installed and origin-enabled while permitting only `OLD.agent_id IS NULL` to `NEW.agent_id = OLD.agent_compose_id` for an existing canonical Agent
- require every other event column to remain byte-identical, then restore the unconditional append-only rejection immediately after the one guarded backfill call
- add live-trigger migration coverage for canonical backfill, compose-only NULL retention, interruption/retry, strict restoration, replica-only fail-closed behavior, and rejection of non-approved updates

## Safety

- no trigger disable and no `session_replication_role`
- no production read/write cutover, deletion, reassignment, or invented Agent state
- preserves the approved compose-only closure and all existing bounded batches, lock timeouts, concurrent indexes, and online constraints
- no GitHub workflow changes; the existing `CI_CHECK_IMMUTABLE_MIGRATE=0` repository switch is enabled only for this production-unapplied 0966 correction and will be restored after merge
- production release and acceptance remain controller-owned

## Evidence

- [Stage 5 smoke blocker](https://github.com/vm0-ai/vm0/issues/28601#issuecomment-5377500148)
- [Parent EPIC status](https://github.com/vm0-ai/vm0/issues/26938#issuecomment-5377500198)

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo, app, and API type checks
- DB lint and DB type-check after the final guard changes
- focused migration integration passed twice after the final guard changes on disposable PostgreSQL 18
- full migration-consistency reached and passed the canonical Agent stage; a later unchanged connector-account assertion hit a PostgreSQL 18.6 SQLSTATE difference, while PostgreSQL 17 Turbo CI is the authoritative aggregate run
- workflow diff is empty and `git diff --check` passes

Closes #28601
Parent #26938