### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2755,9 +2755,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- update `cc` from 1.4.3 to 1.4.4
- update `rustls-webpki` from 0.103.14 to 0.103.15
- keep Cargo manifests unchanged; no manual version constraints were adjusted

## Blocked dependencies

- `generic-array` remains at 0.14.7 (0.14.9 is available) because `crypto-common` 0.1.7 requires exactly 0.14.7. The active runner path is `runner -> aws-sdk-s3 -> aws-smithy-checksums -> crc-fast -> digest -> crypto-common -> generic-array`.

## Validation

- `cargo test --workspace --exclude runner --no-fail-fast` (passed, including doctests, with inherited process-control endpoint variables unset)
- `cargo check -p runner --bin runner` (passed)
- `cargo test -p runner --test guest_inventory --no-fail-fast` (passed)
- `cargo test -p runner --no-fail-fast` is blocked on current `main` under Rust 1.98.0 by an unused `AsyncReadExt` import in `runner/src/network_logs.rs:716`; the identical failure was reproduced with the original lockfile
