### PR TITLE
feat(connectors): enable direct okou oauth callbacks for four providers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -32,12 +32,21 @@ const OKOU_API_ORIGIN = "https://api.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const LOCAL_ORIGIN = "http://localhost:3000";
 const LOCAL_WEB_ORIGIN = "https://www.vm0.ai:8443";
+const BOX_OAUTH_TOKEN_URL = "https://api.box.com/oauth2/token";
+const BOX_CURRENT_USER_URL = "https://api.box.com/2.0/users/me";
 const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
 const CLOUDFLARE_USERINFO_URL = "https://dash.cloudflare.com/oauth2/userinfo";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_OPENID_USERINFO_URL =
   "https://openidconnect.googleapis.com/v1/userinfo";
+const HUBSPOT_OAUTH_TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
+const HUBSPOT_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens";
+const META_ADS_OAUTH_TOKEN_URL =
+  "https://graph.facebook.com/v22.0/oauth/access_token";
+const META_ADS_USER_URL = "https://graph.facebook.com/v22.0/me";
 const NOTION_OAUTH_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
+const TIKTOK_ADS_OAUTH_TOKEN_URL =
+  "https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/";
 const AIRTABLE_OAUTH_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
 const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
 const AUTH_REQUEST_USER_ID_PREFIX = "user_zero_connectors_oauth_start_";
@@ -68,6 +77,8 @@ function mockAuthenticatedSession(): void {
 }
 
 function mockOAuthEnv(): void {
+  mockOptionalEnv("BOX_OAUTH_CLIENT_ID", "box-test-client-id");
+  mockOptionalEnv("BOX_OAUTH_CLIENT_SECRET", "box-test-client-secret");
   mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
   mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "test-client-secret");
   mockOptionalEnv("AIRTABLE_OAUTH_CLIENT_ID", "airtable-test-client-id");
@@ -82,12 +93,24 @@ function mockOAuthEnv(): void {
   );
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-test-client-id");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-test-client-secret");
+  mockOptionalEnv("HUBSPOT_OAUTH_CLIENT_ID", "hubspot-test-client-id");
+  mockOptionalEnv("HUBSPOT_OAUTH_CLIENT_SECRET", "hubspot-test-client-secret");
   mockOptionalEnv("LINEAR_OAUTH_CLIENT_ID", "linear-test-client-id");
   mockOptionalEnv("LINEAR_OAUTH_CLIENT_SECRET", "linear-test-client-secret");
+  mockOptionalEnv("META_ADS_OAUTH_CLIENT_ID", "meta-ads-test-client-id");
+  mockOptionalEnv(
+    "META_ADS_OAUTH_CLIENT_SECRET",
+    "meta-ads-test-client-secret",
+  );
   mockOptionalEnv("NOTION_OAUTH_CLIENT_ID", "notion-test-client-id");
   mockOptionalEnv("NOTION_OAUTH_CLIENT_SECRET", "notion-test-client-secret");
   mockOptionalEnv("SLACK_OAUTH_CLIENT_ID", "test-slack-client-id");
   mockOptionalEnv("SLACK_OAUTH_CLIENT_SECRET", "test-slack-client-secret");
+  mockOptionalEnv("TIKTOK_ADS_OAUTH_CLIENT_ID", "tiktok-ads-test-client-id");
+  mockOptionalEnv(
+    "TIKTOK_ADS_OAUTH_CLIENT_SECRET",
+    "tiktok-ads-test-client-secret",
+  );
   mockOptionalEnv("X_OAUTH_CLIENT_ID", "x-test-client-id");
   mockOptionalEnv("X_OAUTH_CLIENT_SECRET", "x-test-client-secret");
 }
@@ -475,6 +498,293 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     expect(tokenBodies).toHaveLength(1);
     expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
   });
+
+  it("uses the direct Okou App callback for Box and reuses its exact redirect URI", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(BOX_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "box-test-token",
+          refresh_token: "box-refresh-token",
+          expires_in: 3600,
+          scope: "root_readwrite",
+        });
+      }),
+      http.get(BOX_CURRENT_USER_URL, () => {
+        return HttpResponse.json({
+          id: "box-user-123",
+          name: "Box Test User",
+          login: "box@example.test",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("box", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://account.box.com/api/oauth2/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "box-test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.okou.ai/connectors/box/callback");
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/box/callback?${new URLSearchParams({
+        code: "box-authorization-code",
+        state,
+      })}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("uses the direct Okou App callback for HubSpot and reuses its exact redirect URI", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(HUBSPOT_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "hubspot-test-token",
+          refresh_token: "hubspot-refresh-token",
+          expires_in: 1800,
+        });
+      }),
+      http.get(`${HUBSPOT_TOKEN_INFO_URL}/hubspot-test-token`, () => {
+        return HttpResponse.json({
+          user_id: 123,
+          user: "hubspot@example.test",
+          hub_domain: "example.test",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("hubspot", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://app.hubspot.com/oauth/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "hubspot-test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.okou.ai/connectors/hubspot/callback");
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/hubspot/callback?${new URLSearchParams(
+        {
+          code: "hubspot-authorization-code",
+          state,
+        },
+      )}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("uses the direct Okou App callback for Meta Ads and reuses its exact redirect URI", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(META_ADS_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "meta-ads-short-lived-token",
+          token_type: "bearer",
+          expires_in: 3600,
+        });
+      }),
+      http.get(META_ADS_OAUTH_TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "meta-ads-long-lived-token",
+          token_type: "bearer",
+          expires_in: 5_184_000,
+        });
+      }),
+      http.get(META_ADS_USER_URL, () => {
+        return HttpResponse.json({
+          id: "meta-ads-user-123",
+          name: "Meta Ads Test User",
+          email: "meta-ads@example.test",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("meta-ads", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://www.facebook.com/v22.0/dialog/oauth",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "meta-ads-test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe(
+      "https://app.okou.ai/connectors/meta-ads/callback",
+    );
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/meta-ads/callback?${new URLSearchParams(
+        {
+          code: "meta-ads-authorization-code",
+          state,
+        },
+      )}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("uses the direct Okou App callback for TikTok Ads without adding a token redirect URI", async () => {
+    const tokenBodies: unknown[] = [];
+    server.use(
+      http.post(TIKTOK_ADS_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(await request.json());
+        return HttpResponse.json({
+          data: {
+            access_token: "tiktok-ads-test-token",
+            advertiser_ids: ["1234567890"],
+          },
+          request_id: "tiktok-ads-request-id",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("tiktok-ads", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://business-api.tiktok.com/portal/auth",
+    );
+    expect(authorizationUrl.searchParams.get("app_id")).toBe(
+      "tiktok-ads-test-client-id",
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.okou.ai/connectors/tiktok-ads/callback",
+    );
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/tiktok-ads/callback?${new URLSearchParams(
+        {
+          auth_code: "tiktok-ads-authorization-code",
+          state,
+        },
+      )}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toStrictEqual([
+      {
+        app_id: "tiktok-ads-test-client-id",
+        secret: "tiktok-ads-test-client-secret",
+        auth_code: "tiktok-ads-authorization-code",
+      },
+    ]);
+  });
+
+  it.each(["box", "hubspot", "meta-ads", "tiktok-ads"] as const)(
+    "keeps the VM0 App callback for %s",
+    async (connectorSlug) => {
+      mockEnv("APP_URL", "https://app.vm0.ai");
+      mockAuthenticatedSession();
+
+      const response = await requestOauthStart(connectorSlug, {
+        callbackTarget: "app",
+        headers: authHeaders(),
+        origin: API_ORIGIN,
+      });
+
+      expect(response.status).toBe(200);
+      const authorizationUrl = await authorizationUrlFromResponse(response);
+      expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+        `https://app.vm0.ai/connectors/${connectorSlug}/callback`,
+      );
+      expectOauthState(authorizationUrl);
+      await rejectProviderAuthorization(authorizationUrl);
+    },
+  );
+
+  it.each(["box", "hubspot", "meta-ads", "tiktok-ads"] as const)(
+    "keeps an omitted %s callback target on the existing Web callback",
+    async (connectorSlug) => {
+      mockAuthenticatedSession();
+
+      const response = await requestOauthStart(connectorSlug, {
+        headers: authHeaders(),
+        origin: OKOU_API_ORIGIN,
+      });
+
+      expect(response.status).toBe(200);
+      const authorizationUrl = await authorizationUrlFromResponse(response);
+      expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+        `${WEB_ORIGIN}/api/connectors/${connectorSlug}/callback`,
+      );
+      expectOkouOauthState(authorizationUrl);
+      await rejectProviderAuthorization(authorizationUrl);
+    },
+  );
 
   it("uses the direct Okou App callback for Notion and reuses its exact redirect URI", async () => {
     const tokenBodies: unknown[] = [];

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -648,8 +648,8 @@ describe("workflows", () => {
         reason: "The workflow reads Gmail messages.",
       },
       {
-        connectorSlug: "box",
-        reason: "The workflow reads Box files.",
+        connectorSlug: "missing-connector",
+        reason: "The workflow reads an unavailable connector.",
       },
     ]);
 

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -656,6 +656,18 @@ const connectors = [
     ],
   }),
   connector({
+    connectorSlug: "box",
+    label: "Box",
+    authMethods: [
+      standardOauthMethod({
+        connectorSlug: "box",
+        prefix: "BOX",
+        tokenEnvironmentNames: ["BOX_TOKEN"],
+        scopes: ["root_readwrite"],
+      }),
+    ],
+  }),
+  connector({
     connectorSlug: "bentoml",
     label: "BentoML",
     authMethods: [
@@ -1029,6 +1041,18 @@ const connectors = [
     ],
   }),
   connector({
+    connectorSlug: "hubspot",
+    label: "HubSpot",
+    authMethods: [
+      standardOauthMethod({
+        connectorSlug: "hubspot",
+        prefix: "HUBSPOT",
+        tokenEnvironmentNames: ["HUBSPOT_TOKEN"],
+        scopes: ["oauth"],
+      }),
+    ],
+  }),
+  connector({
     connectorSlug: "insforge",
     label: "InsForge",
     authMethods: [
@@ -1149,6 +1173,26 @@ const connectors = [
         prefix: "LINEAR",
         tokenEnvironmentNames: ["LINEAR_TOKEN"],
         scopes: ["read", "write"],
+      }),
+    ],
+  }),
+  connector({
+    connectorSlug: "meta-ads",
+    label: "Meta Ads",
+    authMethods: [
+      standardOauthMethod({
+        connectorSlug: "meta-ads",
+        prefix: "META_ADS",
+        tokenEnvironmentNames: ["META_ADS_TOKEN"],
+        scopes: [
+          "ads_management",
+          "ads_read",
+          "business_management",
+          "pages_manage_ads",
+          "pages_read_engagement",
+          "pages_show_list",
+          "public_profile",
+        ],
       }),
     ],
   }),
@@ -1687,6 +1731,22 @@ const connectors = [
           ),
         },
         startOptions: [selectStartOption("environment")],
+      }),
+    ],
+  }),
+  connector({
+    connectorSlug: "tiktok-ads",
+    label: "TikTok Ads",
+    authMethods: [
+      providerMethod({
+        connectorSlug: "tiktok-ads",
+        authMethodId: "oauth",
+        values: {
+          accessToken: secret("TIKTOK_ADS_ACCESS_TOKEN"),
+        },
+        envBindings: {
+          TIKTOK_ADS_TOKEN: secret("TIKTOK_ADS_ACCESS_TOKEN"),
+        },
       }),
     ],
   }),

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -4,6 +4,7 @@ import { getConnectorAuthProviderRegistrationCapabilities } from "../auth-provid
 import { isConnectorDirectOkouOauthCallbackReady } from "../app-oauth-callback";
 
 const DIRECT_OKOU_READY_CONNECTORS = [
+  "box",
   "cloudflare",
   "gmail",
   "google-ads",
@@ -18,10 +19,13 @@ const DIRECT_OKOU_READY_CONNECTORS = [
   "google-meet",
   "google-search-console",
   "google-sheets",
+  "hubspot",
+  "meta-ads",
   "microsoft-365",
   "notion",
   "outlook-calendar",
   "outlook-mail",
+  "tiktok-ads",
   "youtube",
 ] as const;
 

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -8,6 +8,7 @@ const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
 // every provider is ready, unlisted connectors must keep their VM0 App callback.
 const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
   new Set([
+    "box",
     "cloudflare",
     "gmail",
     "google-ads",
@@ -22,10 +23,13 @@ const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
     "google-meet",
     "google-search-console",
     "google-sheets",
+    "hubspot",
+    "meta-ads",
     "microsoft-365",
     "notion",
     "outlook-calendar",
     "outlook-mail",
+    "tiktok-ads",
     "youtube",
   ]);
 


### PR DESCRIPTION
## Summary

- Add exactly `box`, `hubspot`, `meta-ads`, and `tiktok-ads` to the direct Okou App OAuth callback readiness set.
- Cover trusted Okou App direct callbacks and successful `app.okou.ai/connector/success` redirects while preserving VM0 App callbacks and the existing omitted-target API/Web behavior.
- Verify that Box, HubSpot, and Meta Ads code exchanges reuse the exact redirect URI persisted at authorization start.
- Verify TikTok Ads callbacks use `auth_code` and that its provider-specific token request does not contain `redirect_uri`.
- Extend only the accepted connector catalog test fixture needed by the route integration tests.
- Keep the workflow-readiness unavailable-connector test explicit now that Box is present in the accepted catalog fixture.

## Safety

- No provider console, OAuth client, credential, scope, CORS, Box feature switch, database, or provider protocol changes.
- Existing Slack legacy behavior, unready providers, denial/error handling, state validation, PKCE, OpenID, device auth, custom connectors, and dedicated Slack/Teams/Feishu flows remain unchanged.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; existing warnings only)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/connectors exec vitest run src/__tests__/app-oauth-callback.test.ts` (27/27 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/connectors-oauth-start.test.ts` (37/37 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/workflows.test.ts -t "fails the whole readiness check when any model slug is unavailable"` (1/1 passed)
- Exact Prettier checks and `git diff --check` passed for all changed files.
- Self-reviewed the actual diff against every issue acceptance criterion; the readiness-set change is limited to the four requested connectors.

After `main` advanced, the branch was most recently rebased onto `8a6a043acd0725a1c799ec70f8c8590658341ac8`, and the focused tests, exact formatting check, API type check, and diff check were rerun successfully.

The full local Vitest suite and a local dev server were intentionally not run. Full verification is delegated to the PR pipeline per repository guidance.

## Rollout status

Production OAuth success and denial verification for all four connectors remains pending until this change reaches production through the normal release process.

Closes #28612
Refs #28381
