### PR TITLE
fix(db): use native keyset for search agent backfill

### DIFF
--- a/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
+++ b/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
@@ -15,6 +15,12 @@ const fixedAgentId = "00000000-0000-4000-8000-000000096600";
 const composeOnlyId = "00000000-0000-4000-8000-0000000966ff";
 const fixedChatThreadEventId = "00000000-0000-4000-8000-0000000966d1";
 const composeOnlyChatThreadEventId = "00000000-0000-4000-8000-0000000966df";
+const matchedSearchRowCount = 1001;
+const matchedSearchThreadIds = [
+  "00000000-0000-4000-8000-0000000966b1",
+  "00000000-0000-4000-8000-0000000966b2",
+  "00000000-0000-4000-8000-0000000966b3",
+] as const;
 
 const siblingColumns = [
   "agent_sessions.agent_id",
@@ -159,15 +165,21 @@ function validateMigrationSql(migrationSql: string): void {
     migrationSql,
     /CREATE\s+TRIGGER[\s\S]{0,300}\sON\s+"agents"/iu,
   );
-  assert.equal(migrationSql.match(/LIMIT 500/gu)?.length, 2);
-  assert.equal(migrationSql.match(/FOR UPDATE[^\n]*SKIP LOCKED/gu)?.length, 2);
+  assert.equal(migrationSql.match(/LIMIT 500/gu)?.length, 3);
+  assert.equal(migrationSql.match(/FOR UPDATE[^\n]*SKIP LOCKED/gu)?.length, 3);
   assert.equal(
     migrationSql.match(/^CREATE INDEX CONCURRENTLY IF NOT EXISTS /gmu)?.length,
     replacementIndexes.length,
   );
   assert.equal(
     migrationSql.match(/^CALL "backfill_agent_references_0966"/gmu)?.length,
-    siblingColumns.length,
+    siblingColumns.length - 1,
+  );
+  assert.equal(
+    migrationSql.match(
+      /^CALL "backfill_chat_event_search_agent_references_0966"/gmu,
+    )?.length,
+    1,
   );
   assert.equal(
     migrationSql.match(/^CALL "ensure_agent_foreign_key_0966"/gmu)?.length,
@@ -185,6 +197,18 @@ function validateMigrationSql(migrationSql: string): void {
   assert.match(migrationSql, /SET LOCAL lock_timeout = '1s'/u);
   assert.match(migrationSql, /transaction_timeout = '5min'/u);
   assert.match(migrationSql, /p_no_progress_timeout > interval '30 seconds'/u);
+  assert.equal(
+    migrationSql.match(/^SET statement_timeout = '2h';$/gmu)?.length,
+    1,
+  );
+  assert.doesNotMatch(
+    migrationSql,
+    /CALL "backfill_agent_references_0966"\('public\.chat_event_search_messages'/u,
+  );
+  assert.doesNotMatch(
+    migrationSql,
+    /(?:DROP|REINDEX)[^;]*chat_event_search_messages_tsv_idx/iu,
+  );
   assert.match(
     migrationSql,
     /created_at"[\s\S]*greatest\("compose"\."updated_at", "zero_agent"\."updated_at"\)/u,
@@ -198,7 +222,7 @@ function validateMigrationSql(migrationSql: string): void {
     chatThreadEventCallOffset + chatThreadEventCall.length,
   );
   const nextReferenceCallOffset = migrationSql.indexOf(
-    `CALL "backfill_agent_references_0966"('public.chat_event_search_messages'`,
+    `CALL "backfill_chat_event_search_agent_references_0966"`,
   );
   assert.ok(narrowGuardOffset > 0);
   assert.ok(narrowGuardOffset < chatThreadEventCallOffset);
@@ -207,6 +231,67 @@ function validateMigrationSql(migrationSql: string): void {
   assert.match(
     migrationSql,
     /TG_TABLE_SCHEMA = 'public'[\s\S]*TG_TABLE_NAME = 'chat_thread_events'[\s\S]*OLD\."agent_id" IS NULL[\s\S]*NEW\."agent_id" = OLD\."agent_compose_id"[\s\S]*\(to_jsonb\(NEW\) - 'agent_id'\) = \(to_jsonb\(OLD\) - 'agent_id'\)[\s\S]*FROM "agents" AS "agent"[\s\S]*"agent"\."id" = OLD\."agent_compose_id"/u,
+  );
+
+  const genericProcedureOffset = migrationSql.indexOf(
+    `CREATE OR REPLACE PROCEDURE "backfill_agent_references_0966"`,
+  );
+  const searchProcedureOffset = migrationSql.indexOf(
+    `CREATE OR REPLACE PROCEDURE "backfill_chat_event_search_agent_references_0966"`,
+  );
+  const firstReferenceCallOffset = migrationSql.indexOf(
+    `CALL "backfill_agent_references_0966"`,
+    searchProcedureOffset,
+  );
+  assert.ok(genericProcedureOffset > 0);
+  assert.ok(genericProcedureOffset < searchProcedureOffset);
+  assert.ok(searchProcedureOffset < firstReferenceCallOffset);
+  const genericProcedureSql = migrationSql.slice(
+    genericProcedureOffset,
+    searchProcedureOffset,
+  );
+  const searchProcedureSql = migrationSql.slice(
+    searchProcedureOffset,
+    firstReferenceCallOffset,
+  );
+  assert.match(genericProcedureSql, /jsonb_build_array/u);
+  assert.doesNotMatch(genericProcedureSql, /chat_event_search_messages/u);
+  assert.doesNotMatch(searchProcedureSql, /jsonb_build_array|::text/u);
+  assert.match(
+    searchProcedureSql,
+    /v_scan_after_chat_thread_id uuid := NULL;[\s\S]*v_scan_after_seq_id bigint := NULL;/u,
+  );
+  assert.match(
+    searchProcedureSql,
+    /\("source"\."chat_thread_id", "source"\."seq_id"\) >[\s\S]*\(v_scan_after_chat_thread_id, v_scan_after_seq_id\)/u,
+  );
+  assert.match(
+    searchProcedureSql,
+    /ORDER BY "source"\."chat_thread_id", "source"\."seq_id"[\s\S]*LIMIT 500[\s\S]*FOR UPDATE OF "source" SKIP LOCKED/u,
+  );
+  assert.match(
+    searchProcedureSql,
+    /INNER JOIN "agents" AS "agent"[\s\S]*"agent"\."id" = "scan"\."agent_compose_id"/u,
+  );
+  assert.match(
+    searchProcedureSql,
+    /SET "agent_id" = "target"\."agent_compose_id"/u,
+  );
+
+  const statements = splitMigrationStatements(migrationSql);
+  const searchCallIndex = statements.findIndex((statement) => {
+    return statement.startsWith(
+      `CALL "backfill_chat_event_search_agent_references_0966"`,
+    );
+  });
+  assert.ok(searchCallIndex > 0);
+  assert.equal(
+    statements[searchCallIndex - 1],
+    "SET statement_timeout = '2h';",
+  );
+  assert.equal(
+    statements[searchCallIndex + 1],
+    "SET statement_timeout = '30min';",
   );
 }
 
@@ -369,6 +454,32 @@ async function seedPreviousSchema(client: Client): Promise<void> {
       FROM generate_series(1, 22) AS "fixture"("position")
     `,
     [composeOnlyId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_threads" ("id", "user_id", "agent_compose_id")
+      SELECT "thread_id", 'canonical-owner', $2
+      FROM unnest($1::uuid[]) AS "fixture"("thread_id")
+    `,
+    [[...matchedSearchThreadIds], fixedAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_event_search_messages" (
+        "chat_thread_id", "seq_id", "user_id", "org_id",
+        "agent_compose_id", "role", "created_at", "text", "text_bigram"
+      )
+      SELECT
+        ($1::uuid[])[1 + (("position" - 1) / 334)],
+        1 + (("position" - 1) % 334),
+        'canonical-owner', 'canonical-org', $2,
+        CASE WHEN "position" % 2 = 0 THEN 'assistant' ELSE 'user' END,
+        timestamp '2026-08-21 00:00:00' + "position" * interval '1 second',
+        'production search message ' || "position",
+        'productionsearchtoken ' || "position"
+      FROM generate_series(1, $3::integer) AS "fixture"("position")
+    `,
+    [[...matchedSearchThreadIds], fixedAgentId, matchedSearchRowCount],
   );
   await client.query(
     `
@@ -590,6 +701,181 @@ async function assertReferenceBackfillContention(args: {
   assert.deepEqual(partial.rows, [{ count: 501 }]);
 }
 
+async function explainWithSequentialScansDisabled(
+  client: Client,
+  query: string,
+  values: string[],
+  disableBitmapScans = false,
+): Promise<string> {
+  await client.query("BEGIN");
+  await client.query("SET LOCAL enable_seqscan = off");
+  if (disableBitmapScans) {
+    await client.query("SET LOCAL enable_bitmapscan = off");
+  }
+  const result = await client.query<{
+    readonly "QUERY PLAN": unknown;
+  }>(query, values);
+  await client.query("COMMIT");
+  const plan = result.rows[0]?.["QUERY PLAN"];
+  assert.ok(plan);
+  return JSON.stringify(plan);
+}
+
+async function assertChatSearchNativePrimaryKeyPlan(
+  client: Client,
+): Promise<void> {
+  const plan = await explainWithSequentialScansDisabled(
+    client,
+    `
+      EXPLAIN (FORMAT JSON, COSTS OFF)
+      SELECT "source"."chat_thread_id", "source"."seq_id"
+      FROM "chat_event_search_messages" AS "source"
+      WHERE ("source"."chat_thread_id", "source"."seq_id") >
+          ($1::uuid, $2::bigint)
+        AND "source"."agent_id" IS DISTINCT FROM
+          "source"."agent_compose_id"
+      ORDER BY "source"."chat_thread_id", "source"."seq_id"
+      LIMIT 500
+      FOR UPDATE OF "source" SKIP LOCKED
+    `,
+    [matchedSearchThreadIds[0], "0"],
+    true,
+  );
+  assert.ok(
+    plan.includes(
+      '"Index Name":"chat_event_search_messages_chat_thread_id_seq_id_pk"',
+    ),
+    plan,
+  );
+  assert.ok(!plan.includes('"Node Type":"Sort"'), plan);
+}
+
+async function assertChatSearchBackfillContention(args: {
+  readonly blocker: Client;
+  readonly runner: Client;
+  readonly statements: readonly string[];
+}): Promise<void> {
+  const callIndex = args.statements.findIndex((statement) => {
+    return statement.startsWith(
+      `CALL "backfill_chat_event_search_agent_references_0966"`,
+    );
+  });
+  assert.ok(callIndex > 0);
+
+  await executeStatements({
+    client: args.runner,
+    statements: args.statements,
+    endExclusive: callIndex,
+  });
+  await assertChatSearchNativePrimaryKeyPlan(args.runner);
+
+  const locked = await args.runner.query<{
+    chatThreadId: string;
+    seqId: string;
+  }>(
+    `
+      SELECT "chat_thread_id"::text AS "chatThreadId",
+        "seq_id"::text AS "seqId"
+      FROM "chat_event_search_messages"
+      WHERE "agent_compose_id" = $1
+      ORDER BY "chat_thread_id", "seq_id"
+      LIMIT 1
+    `,
+    [fixedAgentId],
+  );
+  assert.equal(locked.rows.length, 1);
+  await args.blocker.query("BEGIN");
+  await args.blocker.query(
+    `
+      SELECT 1
+      FROM "chat_event_search_messages"
+      WHERE "chat_thread_id" = $1 AND "seq_id" = $2::bigint
+      FOR UPDATE
+    `,
+    [locked.rows[0]!.chatThreadId, locked.rows[0]!.seqId],
+  );
+  try {
+    await assert.rejects(
+      args.runner.query(
+        `CALL "backfill_chat_event_search_agent_references_0966"(interval '100 milliseconds')`,
+      ),
+      (error: unknown) => {
+        assertDatabaseError(error, {
+          code: "P0001",
+          messageIncludes:
+            "Canonical Agent search reference backfill made no progress",
+        });
+        return true;
+      },
+    );
+  } finally {
+    await args.blocker.query("ROLLBACK");
+  }
+
+  const interrupted = await args.runner.query<{
+    composeOnlyNullCount: number;
+    matchedNullCount: number;
+    matchedTargetCount: number;
+  }>(
+    `
+      SELECT
+        count(*) FILTER (
+          WHERE "agent_compose_id" = $1 AND "agent_id" = $1
+        )::integer AS "matchedTargetCount",
+        count(*) FILTER (
+          WHERE "agent_compose_id" = $1 AND "agent_id" IS NULL
+        )::integer AS "matchedNullCount",
+        count(*) FILTER (
+          WHERE "agent_compose_id" = $2 AND "agent_id" IS NULL
+        )::integer AS "composeOnlyNullCount"
+      FROM "chat_event_search_messages"
+    `,
+    [fixedAgentId, composeOnlyId],
+  );
+  assert.deepEqual(interrupted.rows, [
+    {
+      matchedTargetCount: matchedSearchRowCount - 1,
+      matchedNullCount: 1,
+      composeOnlyNullCount: 2,
+    },
+  ]);
+
+  await args.runner.query(
+    `CALL "backfill_chat_event_search_agent_references_0966"(interval '30 seconds')`,
+  );
+  await args.runner.query(
+    `CALL "backfill_chat_event_search_agent_references_0966"(interval '30 seconds')`,
+  );
+  await args.runner.query(args.statements[callIndex + 1]!);
+
+  const committedBatches = await args.runner.query<{
+    largestBatch: number;
+    matchedTargetCount: number;
+    transactionCount: number;
+  }>(
+    `
+      SELECT
+        sum("batch_count")::integer AS "matchedTargetCount",
+        count(*)::integer AS "transactionCount",
+        max("batch_count")::integer AS "largestBatch"
+      FROM (
+        SELECT "xmin"::text, count(*)::integer AS "batch_count"
+        FROM "chat_event_search_messages"
+        WHERE "agent_compose_id" = $1 AND "agent_id" = $1
+        GROUP BY "xmin"::text
+      ) AS "committed_batch"
+    `,
+    [fixedAgentId],
+  );
+  assert.deepEqual(committedBatches.rows, [
+    {
+      matchedTargetCount: matchedSearchRowCount,
+      transactionCount: 4,
+      largestBatch: 500,
+    },
+  ]);
+}
+
 async function assertChatThreadEventReferenceState(
   client: Client,
 ): Promise<void> {
@@ -692,6 +978,64 @@ async function assertChatThreadEventBackfillGuard(args: {
   );
 }
 
+async function validateChatSearchStorageAndIndex(
+  client: Client,
+): Promise<void> {
+  const storage = await client.query<{
+    generatedKind: string;
+    indexedCount: number;
+    indexDefinition: string;
+    ready: boolean;
+    valid: boolean;
+  }>(
+    `
+      SELECT
+        "attribute"."attgenerated"::text AS "generatedKind",
+        "index"."indisready" AS "ready",
+        "index"."indisvalid" AS "valid",
+        pg_get_indexdef("index"."indexrelid") AS "indexDefinition",
+        (
+          SELECT count(*)::integer
+          FROM "chat_event_search_messages"
+          WHERE "agent_compose_id" = $1
+            AND "tsv" @@ to_tsquery('simple', 'productionsearchtoken')
+        ) AS "indexedCount"
+      FROM "pg_attribute" AS "attribute"
+      INNER JOIN "pg_index" AS "index"
+        ON "index"."indrelid" = "attribute"."attrelid"
+      INNER JOIN "pg_class" AS "index_relation"
+        ON "index_relation"."oid" = "index"."indexrelid"
+      WHERE "attribute"."attrelid" =
+          'public.chat_event_search_messages'::regclass
+        AND "attribute"."attname" = 'tsv'
+        AND "index_relation"."relname" =
+          'chat_event_search_messages_tsv_idx'
+    `,
+    [fixedAgentId],
+  );
+  assert.equal(storage.rows.length, 1);
+  assert.equal(storage.rows[0]!.generatedKind, "s");
+  assert.equal(storage.rows[0]!.ready, true);
+  assert.equal(storage.rows[0]!.valid, true);
+  assert.equal(storage.rows[0]!.indexedCount, matchedSearchRowCount);
+  assert.match(storage.rows[0]!.indexDefinition, /USING gin \(tsv\)$/u);
+
+  const plan = await explainWithSequentialScansDisabled(
+    client,
+    `
+      EXPLAIN (FORMAT JSON, COSTS OFF)
+      SELECT "chat_thread_id", "seq_id"
+      FROM "chat_event_search_messages"
+      WHERE "tsv" @@ to_tsquery('simple', 'productionsearchtoken')
+    `,
+    [],
+  );
+  assert.ok(
+    plan.includes('"Index Name":"chat_event_search_messages_tsv_idx"'),
+    plan,
+  );
+}
+
 async function validateFinalCatalog(
   client: Client,
   baseline: CatalogBaseline,
@@ -786,6 +1130,7 @@ async function validateFinalCatalog(
     WHERE "namespace"."nspname" = 'public'
       AND "procedure"."proname" = ANY(ARRAY[
         'backfill_agents_0966', 'backfill_agent_references_0966',
+        'backfill_chat_event_search_agent_references_0966',
         'ensure_agent_foreign_key_0966',
         'ensure_agent_reference_check_0966'
       ])
@@ -829,6 +1174,7 @@ async function validateBackfillAndComposeOnlyClosure(
     composeOnlyThreadEventNullCount: number;
     composeOnlyThreadNullCount: number;
     fieldMismatchCount: number;
+    matchedSearchCount: number;
     matchedCount: number;
     targetCount: number;
   }>(
@@ -882,9 +1228,13 @@ async function validateBackfillAndComposeOnlyClosure(
       (
         SELECT count(*)::integer FROM "chat_event_search_messages"
         WHERE "agent_compose_id" = $1 AND "agent_id" IS NULL
-      ) AS "composeOnlySearchNullCount"
+      ) AS "composeOnlySearchNullCount",
+      (
+        SELECT count(*)::integer FROM "chat_event_search_messages"
+        WHERE "agent_compose_id" = $2 AND "agent_id" = $2
+      ) AS "matchedSearchCount"
   `,
-    [composeOnlyId],
+    [composeOnlyId, fixedAgentId],
   );
   assert.deepEqual(parity.rows, [
     {
@@ -896,6 +1246,7 @@ async function validateBackfillAndComposeOnlyClosure(
       composeOnlyThreadNullCount: 1,
       composeOnlyThreadEventNullCount: 1,
       composeOnlySearchNullCount: 2,
+      matchedSearchCount: matchedSearchRowCount,
     },
   ]);
 }
@@ -1228,10 +1579,12 @@ export async function validateCanonicalAgentDataPlaneMigration(): Promise<void> 
       statements,
       strictRejectFunctionDefinition,
     });
+    await assertChatSearchBackfillContention({ blocker, runner, statements });
 
     await executeStatements({ client: runner, statements });
     await validateFinalCatalog(runner, baseline);
     await validateBackfillAndComposeOnlyClosure(runner);
+    await validateChatSearchStorageAndIndex(runner);
     await assertChatThreadEventReferenceState(runner);
     await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
     assert.equal(
@@ -1243,6 +1596,7 @@ export async function validateCanonicalAgentDataPlaneMigration(): Promise<void> 
     await validateInvalidIndexRecovery({ client: runner, statements });
     await validateFinalCatalog(runner, baseline);
     await validateBackfillAndComposeOnlyClosure(runner);
+    await validateChatSearchStorageAndIndex(runner);
     await assertChatThreadEventReferenceState(runner);
     await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
     assert.equal(

--- a/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
+++ b/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
@@ -705,7 +705,7 @@ $$;
 COMMIT;
 --> statement-breakpoint
 
--- One procedure owns all 12 explicit reference cohorts. Each cohort supplies
+-- One procedure owns the 11 small explicit reference cohorts. Each supplies
 -- its immutable primary-key columns; the JSONB key is only a stable scan
 -- cursor and is never persisted or emitted.
 CREATE OR REPLACE PROCEDURE "backfill_agent_references_0966"(
@@ -737,7 +737,6 @@ BEGIN
     (p_table = 'public.agent_sessions'::regclass AND p_key_columns = ARRAY['id']::name[] AND p_legacy_column = 'agent_compose_id' AND p_target_column = 'agent_id')
     OR (p_table = 'public.chat_threads'::regclass AND p_key_columns = ARRAY['id']::name[] AND p_legacy_column = 'agent_compose_id' AND p_target_column = 'agent_id')
     OR (p_table = 'public.chat_thread_events'::regclass AND p_key_columns = ARRAY['id']::name[] AND p_legacy_column = 'agent_compose_id' AND p_target_column = 'agent_id')
-    OR (p_table = 'public.chat_event_search_messages'::regclass AND p_key_columns = ARRAY['chat_thread_id', 'seq_id']::name[] AND p_legacy_column = 'agent_compose_id' AND p_target_column = 'agent_id')
     OR (p_table = 'public.telegram_installations'::regclass AND p_key_columns = ARRAY['telegram_bot_id']::name[] AND p_legacy_column = 'default_compose_id' AND p_target_column = 'default_agent_id')
     OR (p_table = 'public.feishu_org_installations'::regclass AND p_key_columns = ARRAY['id']::name[] AND p_legacy_column = 'default_compose_id' AND p_target_column = 'default_agent_id')
     OR (p_table = 'public.github_installations'::regclass AND p_key_columns = ARRAY['id']::name[] AND p_legacy_column = 'default_compose_id' AND p_target_column = 'default_agent_id')
@@ -853,6 +852,146 @@ BEGIN
 END;
 $$;
 --> statement-breakpoint
+
+-- The large search projection uses its native (uuid, bigint) primary key as
+-- the scan cursor. This keeps both the keyset predicate and ordering directly
+-- usable by the existing composite primary-key index while preserving the
+-- same restartable, short-transaction ownership contract as the small cohorts.
+CREATE OR REPLACE PROCEDURE "backfill_chat_event_search_agent_references_0966"(
+  p_no_progress_timeout interval
+)
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_scan_after_chat_thread_id uuid := NULL;
+  v_scan_after_seq_id bigint := NULL;
+  v_scan_count integer;
+  v_matched_count integer;
+  v_updated_count integer;
+  v_next_chat_thread_id uuid;
+  v_next_seq_id bigint;
+  v_remaining boolean;
+  v_no_progress_started_at timestamp with time zone := clock_timestamp();
+BEGIN
+  IF
+    p_no_progress_timeout IS NULL
+    OR p_no_progress_timeout <= interval '0 seconds'
+    OR p_no_progress_timeout > interval '30 seconds'
+  THEN
+    RAISE EXCEPTION 'Canonical Agent search reference backfill no-progress timeout must be between 0 and 30 seconds';
+  END IF;
+
+  SET LOCAL lock_timeout = '1s';
+  SET LOCAL transaction_timeout = '5min';
+
+  LOOP
+    WITH "scan" AS MATERIALIZED (
+      SELECT
+        "source"."ctid" AS "row_ctid",
+        "source"."chat_thread_id",
+        "source"."seq_id",
+        "source"."agent_compose_id"
+      FROM "chat_event_search_messages" AS "source"
+      WHERE (
+          v_scan_after_chat_thread_id IS NULL
+          OR ("source"."chat_thread_id", "source"."seq_id") >
+            (v_scan_after_chat_thread_id, v_scan_after_seq_id)
+        )
+        AND "source"."agent_id" IS DISTINCT FROM
+          "source"."agent_compose_id"
+      ORDER BY "source"."chat_thread_id", "source"."seq_id"
+      LIMIT 500
+      FOR UPDATE OF "source" SKIP LOCKED
+    ),
+    "batch" AS MATERIALIZED (
+      SELECT "scan"."row_ctid", "scan"."chat_thread_id", "scan"."seq_id"
+      FROM "scan"
+      INNER JOIN "agents" AS "agent"
+        ON "agent"."id" = "scan"."agent_compose_id"
+    ),
+    "updated" AS (
+      UPDATE "chat_event_search_messages" AS "target"
+      SET "agent_id" = "target"."agent_compose_id"
+      FROM "batch"
+      WHERE "target"."ctid" = "batch"."row_ctid"
+      RETURNING "batch"."chat_thread_id", "batch"."seq_id"
+    )
+    SELECT
+      coalesce(
+        (
+          SELECT "chat_thread_id"
+          FROM "scan"
+          ORDER BY "chat_thread_id" DESC, "seq_id" DESC
+          LIMIT 1
+        ),
+        v_scan_after_chat_thread_id
+      ),
+      coalesce(
+        (
+          SELECT "seq_id"
+          FROM "scan"
+          ORDER BY "chat_thread_id" DESC, "seq_id" DESC
+          LIMIT 1
+        ),
+        v_scan_after_seq_id
+      ),
+      (SELECT count(*) FROM "scan"),
+      (SELECT count(*) FROM "batch"),
+      (SELECT count(*) FROM "updated")
+    INTO
+      v_next_chat_thread_id,
+      v_next_seq_id,
+      v_scan_count,
+      v_matched_count,
+      v_updated_count;
+
+    IF v_updated_count <> v_matched_count THEN
+      RAISE EXCEPTION 'Canonical Agent search reference backfill lost batch ownership';
+    END IF;
+
+    IF v_scan_count > 0 THEN
+      v_scan_after_chat_thread_id := v_next_chat_thread_id;
+      v_scan_after_seq_id := v_next_seq_id;
+    END IF;
+
+    IF v_updated_count > 0 THEN
+      v_no_progress_started_at := clock_timestamp();
+    END IF;
+
+    COMMIT;
+    SET LOCAL lock_timeout = '1s';
+    SET LOCAL transaction_timeout = '5min';
+
+    IF v_scan_count > 0 THEN
+      PERFORM pg_sleep(0.01);
+      CONTINUE;
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM "chat_event_search_messages" AS "source"
+      INNER JOIN "agents" AS "agent"
+        ON "agent"."id" = "source"."agent_compose_id"
+      WHERE "source"."agent_id" IS DISTINCT FROM
+        "source"."agent_compose_id"
+    )
+    INTO v_remaining;
+
+    IF NOT v_remaining THEN
+      EXIT;
+    END IF;
+
+    IF clock_timestamp() - v_no_progress_started_at >= p_no_progress_timeout THEN
+      RAISE EXCEPTION 'Canonical Agent search reference backfill made no progress for % while eligible rows remained',
+        p_no_progress_timeout;
+    END IF;
+
+    v_scan_after_chat_thread_id := NULL;
+    v_scan_after_seq_id := NULL;
+    PERFORM pg_sleep(0.01);
+  END LOOP;
+END;
+$$;
+--> statement-breakpoint
 SET statement_timeout = '30min';
 --> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.agent_sessions', ARRAY['id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');
@@ -907,7 +1046,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 --> statement-breakpoint
-CALL "backfill_agent_references_0966"('public.chat_event_search_messages', ARRAY['chat_thread_id', 'seq_id']::name[], 'agent_compose_id', 'agent_id', interval '30 seconds');
+SET statement_timeout = '2h';
+--> statement-breakpoint
+CALL "backfill_chat_event_search_agent_references_0966"(interval '30 seconds');
+--> statement-breakpoint
+SET statement_timeout = '30min';
 --> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.telegram_installations', ARRAY['telegram_bot_id']::name[], 'default_compose_id', 'default_agent_id', interval '30 seconds');
 --> statement-breakpoint
@@ -924,6 +1067,8 @@ CALL "backfill_agent_references_0966"('public.agentphone_user_agent_preferences'
 CALL "backfill_agent_references_0966"('public.telegram_user_agent_preferences', ARRAY['user_id', 'org_id']::name[], 'selected_compose_id', 'selected_agent_id', interval '30 seconds');
 --> statement-breakpoint
 CALL "backfill_agent_references_0966"('public.feishu_user_agent_preferences', ARRAY['user_id', 'org_id']::name[], 'selected_compose_id', 'selected_agent_id', interval '30 seconds');
+--> statement-breakpoint
+DROP PROCEDURE IF EXISTS "backfill_chat_event_search_agent_references_0966"(interval);
 --> statement-breakpoint
 DROP PROCEDURE IF EXISTS "backfill_agent_references_0966"(regclass, name[], name, name, interval);
 --> statement-breakpoint
@@ -1740,6 +1885,7 @@ BEGIN
     AND "pg_proc"."proname" = ANY(ARRAY[
       'backfill_agents_0966',
       'backfill_agent_references_0966',
+      'backfill_chat_event_search_agent_references_0966',
       'ensure_agent_foreign_key_0966',
       'ensure_agent_reference_check_0966'
     ]);


### PR DESCRIPTION
## Summary

- remove `chat_event_search_messages` from the generic JSON-text reference backfill
- traverse the existing `(chat_thread_id, seq_id)` primary key with typed `uuid` / `bigint` keyset cursors in committed batches of at most 500 rows
- preserve compose-only NULL references, the stored `tsv` column, its GIN index, all online index/constraint phases, and the additive-only application boundary
- raise the overall statement timeout to two hours only for this optimized cohort and restore 30 minutes immediately afterward

## Production blocker

Production smoke run `32550986307` reached canonical Agent parity, then timed out while the generic procedure ordered `chat_event_search_messages` through `jsonb_build_array(... )::text`. Production remains on migration 0965, so this corrects the unapplied 0966 in place.

## Verification

- `DATABASE_URL=postgresql://user@127.0.0.1:55432/postgres pnpm exec tsx scripts/test-canonical-agent-data-plane.ts`
  - production-shaped 1001-row search cohort across three threads
  - native composite-PK plan with no JSON cursor
  - locked-row skip, no-progress failure, committed partial progress, retry, and idempotence
  - four committed update transactions with no batch above 500 rows
  - matched closure and exact compose-only NULL preservation
  - stored generated `tsv` values and live GIN index plan
  - subsequent concurrent indexes and validated constraints
- `pnpm format`
- `pnpm lint`
- `pnpm knip`
- staged workspace, Platform, and API type checks
- `pnpm -F @okouai/db lint`
- `pnpm -F @okouai/db check-types`
- `pnpm -F @okouai/db test:migration-consistency` reached and passed the canonical Agent migration, fresh replay, runner-timeout, and retry validators; the broader PostgreSQL 18 run later stopped in the unchanged connector-account-expansion validator because its existing RESTRICT-FK assertion expects a different diagnostic

Refs #28601
