### PR TITLE
perf(api): attribute dispatch timing to process residency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -403,6 +403,21 @@ const CONNECTOR_CATALOG_RESOLVED_CONNECTOR_FRACTION_BUCKETS = [
   "76_99_percent",
   "all",
 ] as const;
+const API_PROCESS_AGE_BUCKETS = [
+  "0_1s",
+  "1_10s",
+  "10_60s",
+  "1_5m",
+  "5_15m",
+  "15m_plus",
+] as const;
+const API_PROCESS_DISPATCH_ORDINAL_BUCKETS = [
+  "first",
+  "2_4",
+  "5_16",
+  "17_64",
+  "65_plus",
+] as const;
 const API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_resolve_inputs",
   "api_dispatch_prepare_storage_manifest_ensure_artifacts",
@@ -1101,6 +1116,40 @@ function expectApiDispatchTimingEventsNotToLeak(
   }
 }
 
+function expectApiProcessSnapshot(
+  events: readonly Record<string, unknown>[],
+): unknown {
+  const [firstEvent] = events;
+  if (!firstEvent) {
+    throw new Error("Expected API dispatch timing events");
+  }
+  const ageBucket = firstEvent.api_process_age_bucket;
+  const ordinalBucket = firstEvent.api_process_dispatch_ordinal_bucket;
+  expect(API_PROCESS_AGE_BUCKETS).toContain(ageBucket);
+  expect(API_PROCESS_DISPATCH_ORDINAL_BUCKETS).toContain(ordinalBucket);
+  for (const event of events) {
+    expect(event).toStrictEqual(
+      expect.objectContaining({
+        api_process_age_bucket: ageBucket,
+        api_process_dispatch_ordinal_bucket: ordinalBucket,
+      }),
+    );
+  }
+  return ordinalBucket;
+}
+
+function apiProcessDispatchOrdinalBucketRank(value: unknown): number {
+  const rank = API_PROCESS_DISPATCH_ORDINAL_BUCKETS.findIndex((bucket) => {
+    return bucket === value;
+  });
+  if (rank === -1) {
+    throw new Error(
+      `Unexpected API process dispatch ordinal: ${String(value)}`,
+    );
+  }
+  return rank;
+}
+
 function expectConnectorCatalogLoadTiming(args: {
   readonly events: readonly Record<string, unknown>[];
   readonly acceptedCacheOutcome: "hit" | "miss" | "in_flight";
@@ -1626,6 +1675,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ).toStrictEqual([]);
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    const processOrdinalBucket = expectApiProcessSnapshot(timingEvents);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
     expectApiDispatchSpanKind(
       timingEvents,
@@ -1833,6 +1883,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
     });
     const warmTimingEvents = apiDispatchTimingEventsForRun(warmCreated.runId);
+    const warmProcessOrdinalBucket = expectApiProcessSnapshot(warmTimingEvents);
+    expect(
+      apiProcessDispatchOrdinalBucketRank(warmProcessOrdinalBucket),
+    ).toBeGreaterThanOrEqual(
+      apiProcessDispatchOrdinalBucketRank(processOrdinalBucket),
+    );
     expectNoApiDispatchActions(
       warmTimingEvents,
       API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -4,6 +4,7 @@ import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 
 import { env } from "../../lib/env";
 import { normalizeBuildCommitSha } from "../../lib/build-info";
+import { singleton } from "../../lib/singleton";
 import { now } from "../../lib/time";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { safeSync } from "../utils";
@@ -13,6 +14,65 @@ export type ApiDispatchTimingDimensions = Readonly<Record<string, string>>;
 export type ApiDispatchTimingDimensionsInput =
   | ApiDispatchTimingDimensions
   | (() => ApiDispatchTimingDimensions | undefined);
+
+type ApiProcessAgeBucket =
+  | "0_1s"
+  | "1_10s"
+  | "10_60s"
+  | "1_5m"
+  | "5_15m"
+  | "15m_plus";
+type ApiProcessDispatchOrdinalBucket =
+  | "first"
+  | "2_4"
+  | "5_16"
+  | "17_64"
+  | "65_plus";
+
+interface ApiProcessDispatchState {
+  ordinal: number;
+}
+
+const apiProcessDispatchState = singleton((): ApiProcessDispatchState => {
+  return { ordinal: 0 };
+});
+
+function apiProcessAgeBucket(processAgeMs: number): ApiProcessAgeBucket {
+  if (processAgeMs < 1000) {
+    return "0_1s";
+  }
+  if (processAgeMs < 10_000) {
+    return "1_10s";
+  }
+  if (processAgeMs < 60_000) {
+    return "10_60s";
+  }
+  if (processAgeMs < 300_000) {
+    return "1_5m";
+  }
+  if (processAgeMs < 900_000) {
+    return "5_15m";
+  }
+  return "15m_plus";
+}
+
+function claimApiProcessDispatchOrdinal(): ApiProcessDispatchOrdinalBucket {
+  const state = apiProcessDispatchState();
+  state.ordinal = Math.min(state.ordinal + 1, 65);
+  if (state.ordinal === 1) {
+    return "first";
+  }
+  if (state.ordinal <= 4) {
+    return "2_4";
+  }
+  if (state.ordinal <= 16) {
+    return "5_16";
+  }
+  if (state.ordinal <= 64) {
+    return "17_64";
+  }
+  return "65_plus";
+}
 
 export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_agent_run"
@@ -255,6 +315,10 @@ interface ApiDispatchTimingRecord {
 
 export class ApiDispatchTimingCollector {
   private readonly records: ApiDispatchTimingRecord[] = [];
+  private readonly processAgeBucket = apiProcessAgeBucket(performance.now());
+  private processDispatchOrdinalBucket:
+    | ApiProcessDispatchOrdinalBucket
+    | undefined;
 
   private recordDuration(
     actionType: ApiDispatchTimingActionType,
@@ -338,6 +402,17 @@ export class ApiDispatchTimingCollector {
     readonly dimensions?: ApiDispatchTimingDimensions;
   }): void {
     const records = this.records.splice(0);
+    // Goal scheduling can construct a collector for an empty drain. Only a
+    // run-associated telemetry flush should advance the dispatch ordinal.
+    if (records.length === 0) {
+      recordSandboxOperations([]);
+      return;
+    }
+    this.processDispatchOrdinalBucket ??= claimApiProcessDispatchOrdinal();
+    const processDimensions = {
+      api_process_age_bucket: this.processAgeBucket,
+      api_process_dispatch_ordinal_bucket: this.processDispatchOrdinalBucket,
+    } satisfies ApiDispatchTimingDimensions;
     const apiCommitSha = normalizeBuildCommitSha(env("GIT_COMMIT_SHA"));
     recordSandboxOperations(
       records.map((record) => {
@@ -351,6 +426,7 @@ export class ApiDispatchTimingCollector {
           dimensions: {
             ...args.dimensions,
             ...record.dimensions,
+            ...processDimensions,
             runner_group: args.runnerGroup,
             profile: args.profile,
             dispatch_path: args.dispatchPath,


### PR DESCRIPTION
## Summary

- add bounded API process-age and dispatch-ordinal dimensions to every non-empty API dispatch timing flush
- capture process age at collector construction while claiming the ordinal only for run-associated telemetry, excluding empty goal drains
- verify allowed values, per-run consistency, monotonic bounded ordering, and sensitive-value exclusions through real API routes

## Telemetry

- `api_process_age_bucket`: `0_1s`, `1_10s`, `10_60s`, `1_5m`, `5_15m`, `15m_plus`
- `api_process_dispatch_ordinal_bucket`: `first`, `2_4`, `5_16`, `17_64`, `65_plus`

The dimensions are generic across goal, Web, and other dispatch paths that use `ApiDispatchTimingCollector`. They contain no process, deployment instance, tenant, session, or catalog identifiers.

## Exclusions

- no cache, scheduler, queue, Runner, API contract, database, or frontend behavior changes
- no process or deployment instance identifier
- no optimization decision before the post-deployment cohort is analyzed

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (176 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm check-types` (pre-commit hook)

Closes #28620

Parent context: #24203
