### PR TITLE
perf(mitm-addon): reuse chat completions extractor across sse events

### DIFF
--- a/crates/runner/mitm-addon/scripts/benchmark_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/scripts/benchmark_openai_chat_completions_usage.py
@@ -1,0 +1,51 @@
+"""Benchmark fresh and reused Chat Completions selective JSON extraction."""
+
+import sys
+from collections.abc import Callable
+from statistics import median
+from time import perf_counter
+
+from usage.openai_chat_completions import _new_extractor
+
+_CYCLES = 10_000
+_REPEATS = 5
+_PAYLOAD = (
+    b'{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"delta":{"content":"x"}}]}'
+)
+_REUSED_EXTRACTOR = _new_extractor()
+
+
+def _fresh_cycle() -> None:
+    extractor = _new_extractor()
+    extractor.feed(_PAYLOAD)
+    extractor.finish()
+
+
+def _reused_cycle() -> None:
+    _REUSED_EXTRACTOR.reset()
+    _REUSED_EXTRACTOR.feed(_PAYLOAD)
+    _REUSED_EXTRACTOR.finish()
+
+
+def _median_duration(cycle: Callable[[], None]) -> float:
+    durations: list[float] = []
+    for _ in range(_REPEATS):
+        started_at = perf_counter()
+        for _ in range(_CYCLES):
+            cycle()
+        durations.append(perf_counter() - started_at)
+    return median(durations)
+
+
+def main() -> None:
+    fresh_duration = _median_duration(_fresh_cycle)
+    reused_duration = _median_duration(_reused_cycle)
+    sys.stdout.write(
+        f"{_CYCLES:,} fresh construction/feed/finish cycles: {fresh_duration:.6f} s\n"
+        f"{_CYCLES:,} reused reset/feed/finish cycles: {reused_duration:.6f} s\n"
+        f"speedup: {fresh_duration / reused_duration:.2f}x\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -339,6 +339,25 @@ class JsonSelectiveExtractor:
         self._slow_work_bytes_remaining = 0
         self._discarded_ascii_work_bytes_remaining = 0
 
+    def reset(self) -> None:
+        """Reset document state while retaining the fixed observation configuration."""
+        self.values.clear()
+        self.array_counts.clear()
+        self.wildcard_array_counts.clear()
+        self.object_present.clear()
+        self.value_present.clear()
+        self._scalar_consistency.clear()
+
+        self._stack.clear()
+        self._root_done = False
+        self._error = None
+        self._string = None
+        self._number = None
+        self._literal = None
+        self._work_units_used = 0
+        self._slow_work_bytes_remaining = 0
+        self._discarded_ascii_work_bytes_remaining = 0
+
     def accepts_more_input(self) -> bool:
         """Return whether later bytes can still affect this document parser.
 

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -147,7 +147,7 @@ class _OpenAIChatCompletionsSseUsageHandler:
     ) -> None:
         self._usage = usage
         self._on_parse_error = on_parse_error
-        self._extractor: JsonSelectiveExtractor | None = None
+        self._extractor = _new_extractor()
         self._data_prefix = bytearray()
         self._data_prefix_complete = True
 
@@ -156,15 +156,11 @@ class _OpenAIChatCompletionsSseUsageHandler:
         return True
 
     def on_event_start(self, event_name: str | None) -> None:
-        self._extractor = _new_extractor()
         self._data_prefix.clear()
         self._data_prefix_complete = True
 
     def on_data(self, chunk: bytes) -> None:
-        extractor = self._extractor
-        if extractor is None:
-            return
-        extractor.feed(chunk)
+        self._extractor.feed(chunk)
 
         remaining = max(_DONE_PREFIX_MAX_BYTES - len(self._data_prefix), 0)
         self._data_prefix.extend(chunk[:remaining])
@@ -175,16 +171,13 @@ class _OpenAIChatCompletionsSseUsageHandler:
         self.on_data(b"\n")
 
     def on_event_end(self, event_name: str | None) -> None:
-        extractor = self._extractor
         data_prefix = bytes(self._data_prefix)
         data_prefix_complete = self._data_prefix_complete
-        self._extractor = None
         self._data_prefix.clear()
         self._data_prefix_complete = True
-        if extractor is None:
-            return
 
-        result = extractor.finish()
+        result = self._extractor.finish()
+        self._extractor.reset()
         if not result.complete:
             if data_prefix_complete and data_prefix.strip() == _DONE_SENTINEL:
                 return
@@ -200,7 +193,7 @@ class _OpenAIChatCompletionsSseUsageHandler:
         self._usage.update(snapshot)
 
     def on_event_discard(self, event_name: str | None) -> None:
-        self._extractor = None
+        self._extractor.reset()
         self._data_prefix.clear()
         self._data_prefix_complete = True
 

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -256,7 +256,7 @@ class TestOpenAIChatCompletionsUsage:
             b"data: "
             + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
             + b"\n\n"
-            + delta * 256
+            + delta * 2_560
             + b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n'
         )
         final_payload = {

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -235,7 +235,7 @@ class TestOpenAIChatCompletionsUsage:
 
         assert webhook.request_count == 0
 
-    def test_long_sse_keeps_final_usage_isolated_from_delta_frames(
+    def test_long_sse_isolates_final_choice_usage_from_prior_frames(
         self,
         tmp_path,
         real_flow,
@@ -252,10 +252,27 @@ class TestOpenAIChatCompletionsUsage:
 
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
-        callback(delta * 256)
         callback(
             b"data: "
-            + _chat_payload(usage_payload={"prompt_tokens": 30, "completion_tokens": 5})
+            + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
+            + b"\n\n"
+            + delta * 256
+        )
+        final_payload = {
+            "id": "chatcmpl_final",
+            "model": "gpt-5.5",
+            "choices": [
+                {
+                    "usage": {
+                        "prompt_tokens": 30,
+                        "completion_tokens": 5,
+                    }
+                }
+            ],
+        }
+        callback(
+            b"data: "
+            + json.dumps(final_payload, separators=(",", ":")).encode()
             + b"\n\ndata: [DONE]\n\n"
         )
 

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -235,6 +235,43 @@ class TestOpenAIChatCompletionsUsage:
 
         assert webhook.request_count == 0
 
+    def test_long_sse_keeps_final_usage_isolated_from_delta_frames(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+        delta = (
+            b'data: {"id":"chatcmpl_delta","model":"gpt-5.5",'
+            b'"choices":[{"delta":{"content":"x"}}]}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        callback(delta * 256)
+        callback(
+            b"data: "
+            + _chat_payload(usage_payload={"prompt_tokens": 30, "completion_tokens": 5})
+            + b"\n\ndata: [DONE]\n\n"
+        )
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        expected_quantities = {
+            "tokens.input": 30,
+            "tokens.output": 5,
+        }
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == (
+            expected_quantities
+        )
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == (
+            expected_quantities
+        )
+
     def test_malformed_sse_fails_closed_with_chat_protocol_diagnostic(
         self,
         tmp_path,

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -235,7 +235,7 @@ class TestOpenAIChatCompletionsUsage:
 
         assert webhook.request_count == 0
 
-    def test_long_sse_isolates_final_choice_usage_from_prior_frames(
+    def test_long_sse_resets_between_all_event_outcomes(
         self,
         tmp_path,
         real_flow,
@@ -257,6 +257,9 @@ class TestOpenAIChatCompletionsUsage:
             + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
             + b"\n\n"
             + delta * 2_560
+            + b'data: {"id":"chatcmpl_discarded"\n'
+            + b"x" * 4_097
+            + b"\n\n"
             + b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n'
         )
         final_payload = {

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -235,7 +235,7 @@ class TestOpenAIChatCompletionsUsage:
 
         assert webhook.request_count == 0
 
-    def test_long_sse_resets_between_all_event_outcomes(
+    def test_long_sse_reports_final_usage_after_discarded_and_malformed_events(
         self,
         tmp_path,
         real_flow,

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -257,6 +257,7 @@ class TestOpenAIChatCompletionsUsage:
             + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
             + b"\n\n"
             + delta * 256
+            + b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n'
         )
         final_payload = {
             "id": "chatcmpl_final",
@@ -288,6 +289,15 @@ class TestOpenAIChatCompletionsUsage:
         assert compact_observation_quantities(webhook.model_usage_observation_events()) == (
             expected_quantities
         )
+        warnings = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("message") == "Model provider SSE usage extraction failed"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["error"] == "incomplete json"
 
     def test_malformed_sse_fails_closed_with_chat_protocol_diagnostic(
         self,


### PR DESCRIPTION
## Summary

- reuse one configured selective JSON extractor for all sequential Chat Completions SSE events in a response stream
- reset only per-document observations, parser state, errors, and work counters after completed or discarded events
- cover long usage-free delta sequences through the real mitmproxy response path and add a focused fresh-versus-reused benchmark

## Scope

- preserves existing accounting, malformed-frame, `[DONE]`, quantity-bound, and concurrent-stream isolation behavior
- does not change APIs, persisted data, migrations, queue payloads, or runner protocols
- leaves non-streaming Chat Completions and other provider parser construction unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_openai_chat_completions_usage.py` — 18 passed
- `uv run --no-sync python -m pytest tests/` — 6,480 passed
- `PYTHONPATH=src uv run --no-sync python scripts/benchmark_openai_chat_completions_usage.py`
  - 10,000 fresh construction/feed/finish cycles: 0.359567 s median
  - 10,000 reused reset/feed/finish cycles: 0.228968 s median
  - 1.57x speedup

Closes #28625
