### PR TITLE
refactor(runner): centralize idle sandbox activation

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1184,6 +1184,18 @@ async fn speculative_unpark_failure_destroys_before_fresh_fallback() {
 }
 
 #[tokio::test]
+async fn speculative_unpark_panic_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Default,
+        None,
+        |overrides| {
+            overrides.push_unpark_panic("simulated speculative unpark panic");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn speculative_guest_restore_failure_destroys_before_fresh_fallback() {
     assert_speculation_failure_falls_back_to_fresh(
         GuestTimezoneIntent::Default,

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -567,6 +567,11 @@ pub enum IdleUnparkResult {
     },
 }
 
+enum IdleActivationFailure {
+    Returned(String),
+    Panicked,
+}
+
 impl IdleEntry {
     pub(super) fn reuse_key(&self) -> &str {
         self.metadata.reuse_key()
@@ -594,6 +599,30 @@ impl IdleEntry {
     /// idle entry. On failure the entry becomes an idle-owned destroy job so
     /// callers cannot keep using a partially unparked sandbox.
     pub async fn try_unpark_for_run(mut self, run_id: RunId) -> IdleUnparkResult {
+        match self.activate_for_run(run_id).await {
+            Ok(()) => {
+                let (sandbox, budget_lease) = self.into_reuse_parts();
+                IdleUnparkResult::Reused {
+                    sandbox: Box::new(sandbox),
+                    budget_lease,
+                }
+            }
+            Err(IdleActivationFailure::Returned(error)) => IdleUnparkResult::Failed {
+                destroy_job: Box::new(
+                    self.into_destroy_job_abandoning_workspace_promotion("unpark_failed"),
+                ),
+                error,
+            },
+            Err(IdleActivationFailure::Panicked) => IdleUnparkResult::Failed {
+                destroy_job: Box::new(
+                    self.into_destroy_job_abandoning_workspace_promotion("unpark_panicked"),
+                ),
+                error: "sandbox unpark panicked".into(),
+            },
+        }
+    }
+
+    async fn activate_for_run(&mut self, run_id: RunId) -> Result<(), IdleActivationFailure> {
         let activation = async {
             self.resources
                 .sandbox
@@ -601,25 +630,9 @@ impl IdleEntry {
             self.resources.sandbox.unpark().await
         };
         match AssertUnwindSafe(activation).catch_unwind().await {
-            Ok(Ok(())) => {
-                let (sandbox, budget_lease) = self.into_reuse_parts();
-                IdleUnparkResult::Reused {
-                    sandbox: Box::new(sandbox),
-                    budget_lease,
-                }
-            }
-            Ok(Err(e)) => IdleUnparkResult::Failed {
-                destroy_job: Box::new(
-                    self.into_destroy_job_abandoning_workspace_promotion("unpark_failed"),
-                ),
-                error: e.to_string(),
-            },
-            Err(_) => IdleUnparkResult::Failed {
-                destroy_job: Box::new(
-                    self.into_destroy_job_abandoning_workspace_promotion("unpark_panicked"),
-                ),
-                error: "sandbox unpark panicked".into(),
-            },
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => Err(IdleActivationFailure::Returned(error.to_string())),
+            Err(_) => Err(IdleActivationFailure::Panicked),
         }
     }
 
@@ -738,30 +751,24 @@ impl ReservedIdleSandbox {
     }
 
     pub(crate) async fn try_unpark_for_speculation(
-        mut self,
+        self,
         run_id: RunId,
     ) -> SpeculativeIdleUnparkResult {
-        let activation = async {
-            self.entry
-                .resources
-                .sandbox
-                .bind_run_control(&run_id.to_string())?;
-            self.entry.resources.sandbox.unpark().await
-        };
-        match AssertUnwindSafe(activation).catch_unwind().await {
-            Ok(Ok(())) => SpeculativeIdleUnparkResult::Ready(Box::new(SpeculativeIdleSandbox {
-                entry: self.entry,
-            })),
-            Ok(Err(error)) => SpeculativeIdleUnparkResult::Failed {
-                destroy_job: Box::new(
-                    self.entry.into_destroy_job_abandoning_workspace_promotion(
+        let mut entry = self.entry;
+        match entry.activate_for_run(run_id).await {
+            Ok(()) => {
+                SpeculativeIdleUnparkResult::Ready(Box::new(SpeculativeIdleSandbox { entry }))
+            }
+            Err(IdleActivationFailure::Returned(error)) => {
+                SpeculativeIdleUnparkResult::Failed {
+                    destroy_job: Box::new(entry.into_destroy_job_abandoning_workspace_promotion(
                         "speculative_unpark_failed",
-                    ),
-                ),
-                error: error.to_string(),
-            },
-            Err(_) => SpeculativeIdleUnparkResult::Failed {
-                destroy_job: Box::new(self.entry.into_destroy_job_abandoning_workspace_promotion(
+                    )),
+                    error,
+                }
+            }
+            Err(IdleActivationFailure::Panicked) => SpeculativeIdleUnparkResult::Failed {
+                destroy_job: Box::new(entry.into_destroy_job_abandoning_workspace_promotion(
                     "speculative_unpark_panicked",
                 )),
                 error: "sandbox unpark panicked".into(),


### PR DESCRIPTION
## Summary

- centralize run-bound idle activation in one private `IdleEntry` primitive that owns run-control binding, unpark ordering, returned-error classification, and panic containment
- preserve normal and speculative result types, budget-lease ownership, workspace-promotion abandonment reasons, telemetry, and fresh-fallback behavior at their existing wrapper boundaries
- cover speculative unpark panic recovery through the runner main-loop integration path

## Scope and compatibility

- no public API, persisted data, queue payload, guest protocol, sandbox trait, migration, or cross-version contract changes
- teardown-time workspace promotion remains separate because it does not bind a new run-control identity

## Validation

- `cargo fmt --all -- --check`
- focused normal/speculative success and all `unpark` tests: 14 passed
- `cargo test -p runner`: 3231 passed, 0 failed; guest inventory integration test passed
- `cargo clippy -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- repository pre-commit Rust fmt, Clippy, rustdoc, file-size, and commitlint hooks

Closes #28618
