### PR TITLE
fix(python): share model response classification

### DIFF
--- a/crates/runner/mitm-addon/src/http_response_classification.py
+++ b/crates/runner/mitm-addon/src/http_response_classification.py
@@ -1,0 +1,32 @@
+"""Canonical transport classification for HTTP responses."""
+
+from mitmproxy import http
+
+_HTTP_STATUS_SUCCESS_MIN = 200
+_HTTP_STATUS_NO_CONTENT = 204
+_HTTP_STATUS_RESET_CONTENT = 205
+_HTTP_STATUS_REDIRECT_MIN = 300
+_HTTP_STATUS_NOT_MODIFIED = 304
+_HTTP_OWS_CHARS = " \t"
+
+
+def can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
+    """Return whether HTTP semantics permit content on this response."""
+    status_code = response.status_code
+    if status_code < _HTTP_STATUS_SUCCESS_MIN or status_code in (
+        _HTTP_STATUS_NO_CONTENT,
+        _HTTP_STATUS_RESET_CONTENT,
+        _HTTP_STATUS_NOT_MODIFIED,
+    ):
+        return False
+    method = flow.request.method.upper()
+    if method == "HEAD":
+        return False
+    return method != "CONNECT" or status_code >= _HTTP_STATUS_REDIRECT_MIN
+
+
+def has_event_stream_media_type(response: http.Response) -> bool:
+    """Return whether the normalized response media type is exactly SSE."""
+    content_type = response.headers.get("content-type", "")
+    media_type = content_type.partition(";")[0].strip(_HTTP_OWS_CHARS).lower()
+    return media_type == "text/event-stream"

--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -14,6 +14,7 @@ from mitmproxy import http
 import body_decoding
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import http_response_classification
 import openai_responses_events
 import platform_api
 import runtime_url_parsing
@@ -233,7 +234,7 @@ def configure_response_parser(flow: http.HTTPFlow) -> Callable[[bytes], None] | 
             flow_state.protocol == "openai_responses_websocket"
             and response.status_code == _HTTP_STATUS_SWITCHING_PROTOCOLS
         )
-        or not _response_can_have_body(flow, response)
+        or not http_response_classification.can_have_body(flow, response)
     ):
         return None
 
@@ -253,7 +254,7 @@ def configure_response_parser(flow: http.HTTPFlow) -> Callable[[bytes], None] | 
         return None
 
     parser: _JsonResponseParser | _SseResponseParser
-    if _has_event_stream_media_type(response):
+    if http_response_classification.has_event_stream_media_type(response):
         parser = _SseResponseParser(
             flow_state.protocol,
             lambda outcome: _settle_http_flow(flow, flow_state, outcome),
@@ -611,17 +612,6 @@ def _websocket_flow_state(flow: http.HTTPFlow) -> _FlowState | None:
     return flow_state
 
 
-def _response_can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
-    if flow.request.method.upper() == "HEAD":
-        return False
-    return response.status_code not in (101, 204, 205, 304)
-
-
-def _has_event_stream_media_type(response: http.Response) -> bool:
-    content_type = response.headers.get("content-type", "")
-    return content_type.partition(";")[0].strip(" \t").lower() == "text/event-stream"
-
-
 def _upstream_connection_failed(flow: http.HTTPFlow) -> bool:
     return bool(flow.server_conn.error) or (
         not flow.server_conn.connected and flow.client_conn.connected
@@ -643,12 +633,14 @@ def _extract_json(body: bytes) -> JsonExtractionResult:
 
 
 def _finish_response_body(flow: http.HTTPFlow, protocol: _Protocol) -> _Outcome:
+    response = flow.response
+    if response is None or not http_response_classification.can_have_body(flow, response):
+        return _unknown_outcome()
     finish = flow.metadata.pop(_RESPONSE_FINISH, None)
     if callable(finish):
         parsed_outcome = finish()
         return parsed_outcome if isinstance(parsed_outcome, _Outcome) else _unknown_outcome()
-    response = flow.response
-    if response is not None and response.raw_content:
+    if response.raw_content:
         parser = _JsonResponseParser(protocol)
         parser.feed(response.raw_content)
         return parser.finish()

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -25,6 +25,7 @@ import claude_output_timing
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_header_syntax
+import http_response_classification
 import model_provider_failure
 import model_websocket_usage
 import runtime_url_parsing
@@ -36,17 +37,13 @@ from usage.underbilling import log_usage_underbilling
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK_MIN = 200
-_HTTP_STATUS_NO_CONTENT = 204
-_HTTP_STATUS_RESET_CONTENT = 205
 _HTTP_STATUS_REDIRECT_MIN = 300
-_HTTP_STATUS_NOT_MODIFIED = 304
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION = "connector_response_report_on_interruption"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
-_HTTP_OWS_CHARS = " \t"
 
 _ANTHROPIC_MESSAGES_SSE_PROTOCOL = "anthropic_messages_sse"
 _OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL = "openai_chat_completions_sse"
@@ -91,22 +88,16 @@ def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
     return "anthropic_messages"
 
 
-def _response_has_event_stream_media_type(response: http.Response) -> bool:
-    content_type = response.headers.get("content-type", "")
-    media_type = content_type.partition(";")[0].strip(_HTTP_OWS_CHARS).lower()
-    return media_type == "text/event-stream"
-
-
 def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
     """Return whether terminal model usage may parse a buffered JSON body."""
     response = flow.response
     if (
         response is None
-        or not _response_can_have_body(flow, response)
+        or not http_response_classification.can_have_body(flow, response)
         or not usage.is_model_provider_usage_observable(flow)
     ):
         return False
-    if _response_has_event_stream_media_type(response):
+    if http_response_classification.has_event_stream_media_type(response):
         return False
     return not _is_confirmed_websocket_upgrade_response(flow)
 
@@ -161,26 +152,11 @@ def _anthropic_lifecycle_observer(
     return observe
 
 
-def _response_can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
-    """Return whether HTTP semantics permit content on this response."""
-    status_code = response.status_code
-    if status_code < _HTTP_STATUS_OK_MIN or status_code in (
-        _HTTP_STATUS_NO_CONTENT,
-        _HTTP_STATUS_RESET_CONTENT,
-        _HTTP_STATUS_NOT_MODIFIED,
-    ):
-        return False
-    method = flow.request.method.upper()
-    if method == "HEAD":
-        return False
-    return method != "CONNECT" or status_code >= _HTTP_STATUS_REDIRECT_MIN
-
-
 def _maybe_log_response_encoding_inspection_risk(
     flow: http.HTTPFlow,
     response: http.Response,
 ) -> None:
-    if not _response_can_have_body(flow, response):
+    if not http_response_classification.can_have_body(flow, response):
         return
     skip_reason = body_decoding.stream_decode_skip_reason(response.headers)
     if skip_reason is None:
@@ -218,10 +194,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     ):
         model_websocket_usage.activate(flow)
         return _ResponseUsageStreamSetup(None, False)
-    if not _response_can_have_body(flow, response):
+    if not http_response_classification.can_have_body(flow, response):
         return _ResponseUsageStreamSetup(None, False)
     if model_protocol is not None:
-        if _response_has_event_stream_media_type(response):
+        if http_response_classification.has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
             openai_recoverable_usage: dict = {}
@@ -338,7 +314,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             _maybe_log_response_encoding_inspection_risk(flow, response)
         return _ResponseUsageStreamSetup(
             None,
-            _response_can_have_body(flow, response)
+            http_response_classification.can_have_body(flow, response)
             and body_decoding.can_decode_json_usage_body(response.headers)
             and usage.needs_connector_response_buffer_fallback(flow),
         )

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -29,6 +29,7 @@ def _make_flow(
     *,
     firewall_name: str = "model-provider:openai-api-key",
     request_path: str = "/v1/chat/completions",
+    request_method: str = "POST",
     response_status: int = 200,
     response_body: bytes | None = None,
     response_headers: http.Headers | None = None,
@@ -36,7 +37,7 @@ def _make_flow(
     flow = real_flow(
         host="api.openai.com",
         path=request_path,
-        method="POST",
+        method=request_method,
         response_status=response_status,
         response_body=response_body,
         response_headers=response_headers,
@@ -237,6 +238,115 @@ def test_later_success_does_not_retract_report(
     success_body = b'{"choices":[]}'
     success_flow = _make_flow(real_flow, proxy_log_path, response_body=success_body)
     _finish_http_flow(success_flow, body=success_body, mitm_ctx=mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("request_method", "response_status"),
+    [
+        pytest.param("POST", 103, id="informational"),
+        pytest.param("POST", 204, id="no-content"),
+        pytest.param("POST", 205, id="reset-content"),
+        pytest.param("POST", 304, id="not-modified"),
+        pytest.param("HEAD", 200, id="head"),
+        pytest.param("CONNECT", 200, id="successful-connect"),
+    ],
+)
+def test_bodyless_response_skips_usage_and_failure_observers(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    request_method: str,
+    response_status: int,
+    model_provider_failure_api,
+):
+    body = b'{"status":"failed","error":{"code":"server_error"}}'
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        request_method=request_method,
+        response_status=response_status,
+        response_body=body,
+        response_headers=header_map({"content-type": "application/json"}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+
+    assert "model_json_usage_finish" not in flow.metadata
+    assert "model_sse_usage_finish" not in flow.metadata
+    stream = response_stream(flow)
+    assert stream(body) == body
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
+@pytest.mark.parametrize(
+    ("content_type", "body", "usage_finish_key"),
+    [
+        pytest.param(
+            "Text/Event-Stream; Charset=UTF-8",
+            b"event: error\n"
+            b'data: {"type":"error","code":"server_error",'
+            b'"message":"provider failed","param":null}\n\n',
+            "model_sse_usage_finish",
+            id="parameterized-sse",
+        ),
+        pytest.param(
+            'application/json; profile="text/event-stream"',
+            b'{"status":"failed","error":{"code":"server_error"}}',
+            "model_json_usage_finish",
+            id="sse-profile-lookalike",
+        ),
+        pytest.param(
+            "text/event-stream+json",
+            b'{"status":"failed","error":{"code":"server_error"}}',
+            "model_json_usage_finish",
+            id="sse-suffix-lookalike",
+        ),
+    ],
+)
+def test_media_type_classification_is_shared_by_usage_and_failure_observers(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    content_type: str,
+    body: bytes,
+    usage_finish_key: str,
+    model_provider_failure_api,
+):
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": content_type}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+
+    assert usage_finish_key in flow.metadata
+    other_usage_finish_key = (
+        "model_json_usage_finish"
+        if usage_finish_key == "model_sse_usage_finish"
+        else "model_sse_usage_finish"
+    )
+    assert other_usage_finish_key not in flow.metadata
+    stream = response_stream(flow)
+    assert stream(body) == body
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
 
     assert _reported_payloads(model_provider_failure_api) == [
         {"failureKind": "provider_unavailable"}


### PR DESCRIPTION
## Summary

- centralize HTTP response body eligibility and exact SSE media-type classification in one dependency-light module
- apply the canonical body rule to both streamed provider-failure parsing and the terminal raw-body fallback
- cover bodyless responses, parameterized SSE, and SSE lookalikes through admitted usage and failure observers on the public addon hooks

## Behavior and compatibility

Provider-failure inspection now ignores informational responses, 204, 205, 304, `HEAD`, and successful `CONNECT` responses consistently with usage inspection. Ordinary JSON/SSE usage accounting, failure classification, byte accounting, response pass-through, and reporting behavior are unchanged.

This PR does not change persisted data, public APIs, queue payloads, runner protocols, migrations, or deployment compatibility boundaries.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6488 passed)

Closes #28626
