### PR TITLE
perf(api): attribute connector projection row latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -364,6 +364,11 @@ const API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES = [
   "api_dispatch_connector_catalog_materialize_runtime_snapshot",
   "api_dispatch_connector_catalog_materialize_server_firewalls",
 ] as const;
+const API_DISPATCH_CONNECTOR_CATALOG_PROJECTION_ROW_ACTION_TYPES = [
+  "api_dispatch_connector_catalog_query_projection_rows",
+  "api_dispatch_connector_catalog_fetch_projection_rows",
+  "api_dispatch_connector_catalog_validate_projection_rows",
+] as const;
 const API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES = [
   "api_dispatch_connector_catalog_validate_schema",
   "api_dispatch_connector_catalog_validate_public_projection",
@@ -371,6 +376,7 @@ const API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES = [
 ] as const;
 const API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES = [
   ...API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+  ...API_DISPATCH_CONNECTOR_CATALOG_PROJECTION_ROW_ACTION_TYPES,
   ...API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES,
 ] as const;
 const CONNECTOR_CATALOG_COUNT_BUCKETS = [
@@ -977,6 +983,23 @@ function expectNoApiDispatchActions(
   const observedActionTypes = apiDispatchActionTypes(events);
   for (const actionType of unexpectedActionTypes) {
     expect(observedActionTypes).not.toContain(actionType);
+  }
+}
+
+function expectProjectionRowReadActionCounts(
+  events: readonly Record<string, unknown>[],
+  expectedCount: number,
+): void {
+  for (const actionType of API_DISPATCH_CONNECTOR_CATALOG_PROJECTION_ROW_ACTION_TYPES) {
+    const matchingEvents = events.filter((event) => {
+      return event.op_type === actionType;
+    });
+    expect(matchingEvents).toHaveLength(expectedCount);
+    for (const event of matchingEvents) {
+      expect(event).toStrictEqual(
+        expect.objectContaining({ span_kind: "nested" }),
+      );
+    }
   }
 }
 
@@ -2435,9 +2458,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "omit a compatibility-filtered connector method",
       ["x"],
     );
+    const filteredEvents = apiDispatchTimingEventsForRun(filteredRun.runId);
+    expectProjectionRowReadActionCounts(filteredEvents, 1);
     expect(
       singleApiDispatchEvent(
-        apiDispatchTimingEventsForRun(filteredRun.runId),
+        filteredEvents,
         "api_dispatch_connector_catalog_load_runtime_snapshot",
       ),
     ).toStrictEqual(
@@ -2542,9 +2567,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "api_dispatch_connector_catalog_load_runtime_snapshot",
       "api_dispatch_connector_catalog_query_projection_identity",
       "api_dispatch_connector_catalog_query_projection_rows",
+      "api_dispatch_connector_catalog_fetch_projection_rows",
+      "api_dispatch_connector_catalog_validate_projection_rows",
       "api_dispatch_connector_catalog_count_projection_rows",
       "api_dispatch_connector_catalog_materialize_projection",
     ]);
+    expectProjectionRowReadActionCounts(missEvents, 2);
     for (const events of concurrentEvents) {
       expectNoApiDispatchActions(events, [
         "api_dispatch_connector_catalog_query_identity",
@@ -2567,6 +2595,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(missLoad).not.toHaveProperty(
       "connector_catalog_accepted_cache_outcome",
     );
+    expectApiDispatchTimingEventsNotToLeak(missEvents, [
+      "runtime-projection-unknown",
+      "x-projection-access",
+      "x-projection-refresh",
+    ]);
     const coldRun = concurrentRuns[missIndex];
     if (coldRun === undefined) {
       throw new Error("Expected the cold runtime projection run");
@@ -2593,11 +2626,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ]);
     expectNoApiDispatchActions(repeatedEvents, [
       "api_dispatch_connector_catalog_query_projection_rows",
+      "api_dispatch_connector_catalog_fetch_projection_rows",
+      "api_dispatch_connector_catalog_validate_projection_rows",
       "api_dispatch_connector_catalog_count_projection_rows",
       "api_dispatch_connector_catalog_materialize_projection",
       "api_dispatch_connector_catalog_query_identity",
       ...API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES,
     ]);
+    expectProjectionRowReadActionCounts(repeatedEvents, 0);
     expect(
       singleApiDispatchEvent(
         repeatedEvents,
@@ -2638,9 +2674,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const fallbackRun = await createProjectedRun(
       "incomplete runtime projection",
     );
+    const fallbackEvents = apiDispatchTimingEventsForRun(fallbackRun.runId);
+    expectProjectionRowReadActionCounts(fallbackEvents, 1);
     expect(
       singleApiDispatchEvent(
-        apiDispatchTimingEventsForRun(fallbackRun.runId),
+        fallbackEvents,
         "api_dispatch_connector_catalog_load_runtime_snapshot",
       ),
     ).toStrictEqual(
@@ -2660,9 +2698,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const repairedRun = await createProjectedRun(
       "reconciled runtime projection",
     );
+    const repairedEvents = apiDispatchTimingEventsForRun(repairedRun.runId);
+    expectProjectionRowReadActionCounts(repairedEvents, 1);
     expect(
       singleApiDispatchEvent(
-        apiDispatchTimingEventsForRun(repairedRun.runId),
+        repairedEvents,
         "api_dispatch_connector_catalog_load_runtime_snapshot",
       ),
     ).toStrictEqual(
@@ -2704,9 +2744,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       },
     });
     clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectProjectionRowReadActionCounts(timingEvents, 2);
     expect(
       singleApiDispatchEvent(
-        apiDispatchTimingEventsForRun(run.runId),
+        timingEvents,
         "api_dispatch_connector_catalog_load_runtime_snapshot",
       ),
     ).toStrictEqual(

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -241,6 +241,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_connector_catalog_load_runtime_snapshot"
   | "api_dispatch_connector_catalog_query_projection_identity"
   | "api_dispatch_connector_catalog_query_projection_rows"
+  | "api_dispatch_connector_catalog_fetch_projection_rows"
+  | "api_dispatch_connector_catalog_validate_projection_rows"
   | "api_dispatch_connector_catalog_count_projection_rows"
   | "api_dispatch_connector_catalog_materialize_projection"
   | "api_dispatch_connector_catalog_query_identity"

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
@@ -80,7 +80,13 @@ type ConnectorCatalogRuntimeProjectionIdentityRead =
       >;
     };
 
-type ConnectorCatalogRuntimeProjectionRowsRead =
+interface ConnectorCatalogRuntimeProjectionRow {
+  readonly connectorSlug: ConnectorSlug;
+  readonly connectorDigest: string;
+  readonly connector: unknown;
+}
+
+export type ConnectorCatalogRuntimeProjectionRowsRead =
   | {
       readonly kind: "ready";
       readonly connectors: readonly ConnectorCatalogArtifactConnector[];
@@ -397,16 +403,15 @@ function projectionIdentityWhere(
   );
 }
 
-export async function readConnectorCatalogRuntimeProjectionRows(args: {
+export async function queryConnectorCatalogRuntimeProjectionRows(args: {
   readonly db: ReadonlyDb;
   readonly projection: ConnectorCatalogRuntimeProjectionReadyIdentity;
   readonly connectorSlugs: readonly ConnectorSlug[];
-}): Promise<ConnectorCatalogRuntimeProjectionRowsRead> {
+}): Promise<readonly ConnectorCatalogRuntimeProjectionRow[]> {
   if (args.connectorSlugs.length === 0) {
-    return { kind: "ready", connectors: [], missingConnectorSlugs: [] };
+    return [];
   }
-  const connectorSlugs = [...new Set(args.connectorSlugs)];
-  const rows = await args.db
+  return await args.db
     .select({
       connectorSlug: connectorCatalogRuntimeProjections.connectorSlug,
       connectorDigest: connectorCatalogRuntimeProjections.connectorDigest,
@@ -417,18 +422,24 @@ export async function readConnectorCatalogRuntimeProjectionRows(args: {
       and(
         projectionIdentityWhere(args.projection.identity),
         inArray(connectorCatalogRuntimeProjections.connectorSlug, [
-          ...connectorSlugs,
+          ...args.connectorSlugs,
         ]),
       ),
     );
+}
+
+export function validateConnectorCatalogRuntimeProjectionRows(args: {
+  readonly rows: readonly ConnectorCatalogRuntimeProjectionRow[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
+}): ConnectorCatalogRuntimeProjectionRowsRead {
   const rowBySlug = new Map(
-    rows.map((row) => {
+    args.rows.map((row) => {
       return [row.connectorSlug, row] as const;
     }),
   );
   const connectors: ConnectorCatalogArtifactConnector[] = [];
   const missingConnectorSlugs: ConnectorSlug[] = [];
-  for (const connectorSlug of connectorSlugs) {
+  for (const connectorSlug of args.connectorSlugs) {
     const row = rowBySlug.get(connectorSlug);
     if (row === undefined) {
       missingConnectorSlugs.push(connectorSlug);

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -47,11 +47,13 @@ import type { ConnectorFeatureStates } from "./connector-catalog-feature-states"
 import { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
 import {
   countConnectorCatalogRuntimeProjectionRows,
+  queryConnectorCatalogRuntimeProjectionRows,
   readConnectorCatalogRuntimeProjectionIdentity,
-  readConnectorCatalogRuntimeProjectionRows,
+  validateConnectorCatalogRuntimeProjectionRows,
   type ConnectorCatalogRuntimeProjectionFallbackReason,
   type ConnectorCatalogRuntimeProjectionIdentity,
   type ConnectorCatalogRuntimeProjectionReadyIdentity,
+  type ConnectorCatalogRuntimeProjectionRowsRead,
 } from "./connector-catalog-runtime-projection.service";
 import {
   createAcceptedConnectorServerFirewallCatalog,
@@ -898,6 +900,42 @@ function materializeProjectedRuntimeSelection(args: {
   return selection;
 }
 
+async function readProjectedRuntimeRows(args: {
+  readonly db: ReadonlyDb;
+  readonly timing: ConnectorCatalogLoadTiming;
+  readonly projection: ConnectorCatalogRuntimeProjectionReadyIdentity;
+  readonly connectorSlugs: readonly ConnectorSlug[];
+}): Promise<ConnectorCatalogRuntimeProjectionRowsRead> {
+  if (args.connectorSlugs.length === 0) {
+    return { kind: "ready", connectors: [], missingConnectorSlugs: [] };
+  }
+  return await args.timing.measure(
+    "api_dispatch_connector_catalog_query_projection_rows",
+    async () => {
+      const connectorSlugs = [...new Set(args.connectorSlugs)];
+      const rows = await args.timing.measure(
+        "api_dispatch_connector_catalog_fetch_projection_rows",
+        async () => {
+          return await queryConnectorCatalogRuntimeProjectionRows({
+            db: args.db,
+            projection: args.projection,
+            connectorSlugs,
+          });
+        },
+      );
+      return args.timing.measureSync(
+        "api_dispatch_connector_catalog_validate_projection_rows",
+        () => {
+          return validateConnectorCatalogRuntimeProjectionRows({
+            rows,
+            connectorSlugs,
+          });
+        },
+      );
+    },
+  );
+}
+
 async function buildProjectedRuntimeSelection(args: {
   readonly db: ReadonlyDb;
   readonly timing: ConnectorCatalogLoadTiming;
@@ -913,16 +951,12 @@ async function buildProjectedRuntimeSelection(args: {
       runtimeConnectorSlugs: args.runtimeConnectorSlugs,
       metadataConnectorSlugs: args.metadataConnectorSlugs,
     });
-    const rows = await args.timing.measure(
-      "api_dispatch_connector_catalog_query_projection_rows",
-      async () => {
-        return await readConnectorCatalogRuntimeProjectionRows({
-          db: args.db,
-          projection,
-          connectorSlugs: selectedConnectorSlugs,
-        });
-      },
-    );
+    const rows = await readProjectedRuntimeRows({
+      db: args.db,
+      timing: args.timing,
+      projection,
+      connectorSlugs: selectedConnectorSlugs,
+    });
     if (rows.kind === "fallback") {
       return await completeRuntimeSelectionBuildFallback({
         ...args,
@@ -956,16 +990,12 @@ async function buildProjectedRuntimeSelection(args: {
     );
     const confirmedRows =
       actualConnectorCount === projection.identity.connectorCount
-        ? await args.timing.measure(
-            "api_dispatch_connector_catalog_query_projection_rows",
-            async () => {
-              return await readConnectorCatalogRuntimeProjectionRows({
-                db: args.db,
-                projection,
-                connectorSlugs: rows.missingConnectorSlugs,
-              });
-            },
-          )
+        ? await readProjectedRuntimeRows({
+            db: args.db,
+            timing: args.timing,
+            projection,
+            connectorSlugs: rows.missingConnectorSlugs,
+          })
         : undefined;
     const latest = await args.timing.measure(
       "api_dispatch_connector_catalog_query_projection_identity",


### PR DESCRIPTION
## Summary

- split connector runtime projection row reads into nested fetch and validation timing actions
- retain the existing complete projection-row parent timing action and all current runtime behavior
- cover cold reads, warm exact cache hits, incomplete projections, and identity retry reads in route integration tests

## Scope

- no database schema or query predicate changes
- no cache, fallback, materialization, runner protocol, or externally visible behavior changes
- no optimization is included; this PR only attributes the measured latency before choosing one

## Tests

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/services/api-dispatch-timing.service.ts apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts apps/api/src/signals/services/connector-catalog-runtime.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (176 passed)
- `pnpm knip`
- `lefthook run pre-commit`
- `git diff --cached --check`

Closes #28634

Parent: #28275

Broader objective: #24203
