### PR TITLE
fix(db): preserve deleted snapshot anchors

### DIFF
--- a/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
+++ b/turbo/packages/db/scripts/test-canonical-agent-data-plane.ts
@@ -15,6 +15,13 @@ const fixedAgentId = "00000000-0000-4000-8000-000000096600";
 const composeOnlyId = "00000000-0000-4000-8000-0000000966ff";
 const fixedChatThreadEventId = "00000000-0000-4000-8000-0000000966d1";
 const composeOnlyChatThreadEventId = "00000000-0000-4000-8000-0000000966df";
+const deletedSnapshotAgentId = "00000000-0000-4000-8000-0000000966c0";
+const deletedSnapshotThreadId = "00000000-0000-4000-8000-0000000966c1";
+const deletedSnapshotOlderEventId = "00000000-0000-4000-8000-0000000966c2";
+const deletedSnapshotAnchorEventId = "00000000-0000-4000-8000-0000000966c3";
+const ordinaryOrphanAgentId = "00000000-0000-4000-8000-0000000966c4";
+const ordinaryOrphanThreadId = "00000000-0000-4000-8000-0000000966c5";
+const ordinaryOrphanEventId = "00000000-0000-4000-8000-0000000966c6";
 const matchedSearchRowCount = 1001;
 const matchedSearchThreadIds = [
   "00000000-0000-4000-8000-0000000966b1",
@@ -293,6 +300,40 @@ function validateMigrationSql(migrationSql: string): void {
     statements[searchCallIndex + 1],
     "SET statement_timeout = '30min';",
   );
+
+  const snapshotAnchorClassificationOffset = migrationSql.indexOf(
+    `IF v_spec.table_oid = 'public.chat_thread_events'::regclass THEN`,
+  );
+  const genericClassificationOffset = migrationSql.indexOf(
+    "    ELSE",
+    snapshotAnchorClassificationOffset,
+  );
+  assert.ok(snapshotAnchorClassificationOffset > 0);
+  assert.ok(genericClassificationOffset > snapshotAnchorClassificationOffset);
+  const snapshotAnchorClassificationSql = migrationSql.slice(
+    snapshotAnchorClassificationOffset,
+    genericClassificationOffset,
+  );
+  assert.match(
+    snapshotAnchorClassificationSql,
+    /LEFT JOIN "agents" AS "agent"[\s\S]*LEFT JOIN "agent_composes" AS "compose"[\s\S]*LEFT JOIN "zero_agents" AS "zero_agent"/u,
+  );
+  assert.match(
+    snapshotAnchorClassificationSql,
+    /NOT EXISTS \([\s\S]*FROM "chat_threads" AS "live_thread"[\s\S]*"live_thread"\."id" = "source"\."chat_thread_id"/u,
+  );
+  assert.match(
+    snapshotAnchorClassificationSql,
+    /EXISTS \([\s\S]*FROM "chat_thread_snapshots" AS "snapshot"[\s\S]*"snapshot"\."user_id" = "source"\."user_id"[\s\S]*"snapshot"\."org_id" = "source"\."org_id"[\s\S]*"snapshot"\."latest_event_id" = "source"\."id"/u,
+  );
+  assert.match(
+    snapshotAnchorClassificationSql,
+    /"agent"\."id" IS NULL[\s\S]*"compose"\."id" IS NULL[\s\S]*"zero_agent"\."id" IS NULL[\s\S]*NOT EXISTS \([\s\S]*"chat_threads"[\s\S]*EXISTS \([\s\S]*"chat_thread_snapshots"/u,
+  );
+  assert.match(
+    migrationSql,
+    /deleted_snapshot_anchor_null %[\s\S]*v_deleted_snapshot_anchor_null/u,
+  );
 }
 
 async function collectCatalogBaseline(
@@ -361,6 +402,161 @@ function assertBaselineRetained(
       assert.ok(observedEntries.has(entry), `missing legacy ${kind}: ${entry}`);
     }
   }
+}
+
+async function seedDeletedSnapshotAnchor(client: Client): Promise<void> {
+  await client.query(
+    `
+      INSERT INTO "agent_composes" (
+        "id", "user_id", "name", "org_id", "created_at", "updated_at"
+      ) VALUES (
+        $1, 'deleted-anchor-owner', 'deleted-anchor-agent',
+        'deleted-anchor-org', timestamp '2026-01-01 00:00:00',
+        timestamp '2026-01-02 00:00:00'
+      )
+    `,
+    [deletedSnapshotAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "zero_agents" (
+        "id", "org_id", "owner", "name", "created_at", "updated_at"
+      ) VALUES (
+        $1, 'deleted-anchor-org', 'deleted-anchor-owner',
+        'deleted-anchor-agent', timestamp '2026-01-01 00:00:00',
+        timestamp '2026-01-02 00:00:00'
+      )
+    `,
+    [deletedSnapshotAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_threads" (
+        "id", "user_id", "agent_compose_id", "title", "created_at",
+        "updated_at"
+      ) VALUES (
+        $1, 'deleted-anchor-owner', $2, 'Deleted anchor thread',
+        timestamp '2026-01-01 00:00:00', timestamp '2026-01-02 00:00:00'
+      )
+    `,
+    [deletedSnapshotThreadId, deletedSnapshotAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_thread_events" (
+        "id", "user_id", "org_id", "chat_thread_id", "kind",
+        "agent_compose_id", "title", "created_at"
+      ) VALUES
+        (
+          $1, 'deleted-anchor-owner', 'deleted-anchor-org', $3, 'created',
+          $4, 'Deleted anchor thread', timestamp '2026-01-01 00:00:00'
+        ),
+        (
+          $2, 'deleted-anchor-owner', 'deleted-anchor-org', $3, 'deleted',
+          $4, NULL, timestamp '2026-01-02 00:00:00'
+        )
+    `,
+    [
+      deletedSnapshotOlderEventId,
+      deletedSnapshotAnchorEventId,
+      deletedSnapshotThreadId,
+      deletedSnapshotAgentId,
+    ],
+  );
+
+  await client.query(`DELETE FROM "agent_composes" WHERE "id" = $1`, [
+    deletedSnapshotAgentId,
+  ]);
+  const cascaded = await client.query<{
+    composeCount: number;
+    eventCount: number;
+    threadCount: number;
+    zeroAgentCount: number;
+  }>(
+    `
+      SELECT
+        (SELECT count(*)::integer FROM "agent_composes" WHERE "id" = $1)
+          AS "composeCount",
+        (SELECT count(*)::integer FROM "zero_agents" WHERE "id" = $1)
+          AS "zeroAgentCount",
+        (SELECT count(*)::integer FROM "chat_threads" WHERE "id" = $2)
+          AS "threadCount",
+        (
+          SELECT count(*)::integer FROM "chat_thread_events"
+          WHERE "id" = ANY($3::uuid[])
+        ) AS "eventCount"
+    `,
+    [
+      deletedSnapshotAgentId,
+      deletedSnapshotThreadId,
+      [deletedSnapshotOlderEventId, deletedSnapshotAnchorEventId],
+    ],
+  );
+  assert.deepEqual(cascaded.rows, [
+    { composeCount: 0, zeroAgentCount: 0, threadCount: 0, eventCount: 2 },
+  ]);
+
+  await client.query(
+    `
+      INSERT INTO "chat_thread_snapshots" (
+        "user_id", "org_id", "latest_event_id", "latest_event_seq_id",
+        "chat_threads", "created_at", "updated_at"
+      )
+      SELECT
+        "event"."user_id", "event"."org_id", "event"."id",
+        "event"."seq_id", '[]'::jsonb, timestamp '2026-02-01 00:00:00',
+        timestamp '2026-02-01 00:00:00'
+      FROM "chat_thread_events" AS "event"
+      WHERE "event"."id" = $1
+    `,
+    [deletedSnapshotAnchorEventId],
+  );
+  const compacted = await client.query<{ prunedCount: number }>(`
+    WITH "pruned" AS (
+      DELETE FROM "chat_thread_events" AS "event"
+      USING "chat_thread_snapshots" AS "snapshot"
+      INNER JOIN "chat_thread_events" AS "marker"
+        ON "marker"."id" = "snapshot"."latest_event_id"
+        AND "marker"."seq_id" = "snapshot"."latest_event_seq_id"
+        AND "marker"."user_id" = "snapshot"."user_id"
+        AND "marker"."org_id" = "snapshot"."org_id"
+      WHERE "event"."user_id" = "snapshot"."user_id"
+        AND "event"."org_id" = "snapshot"."org_id"
+        AND "event"."created_at" < timestamp '2026-02-01 00:00:00'
+        AND "event"."seq_id" < "marker"."seq_id"
+      RETURNING 1
+    )
+    SELECT count(*)::integer AS "prunedCount" FROM "pruned"
+  `);
+  assert.deepEqual(compacted.rows, [{ prunedCount: 1 }]);
+
+  const retained = await client.query<{
+    anchorCount: number;
+    olderCount: number;
+    snapshotCount: number;
+  }>(
+    `
+      SELECT
+        (
+          SELECT count(*)::integer FROM "chat_thread_events"
+          WHERE "id" = $1
+        ) AS "anchorCount",
+        (
+          SELECT count(*)::integer FROM "chat_thread_events"
+          WHERE "id" = $2
+        ) AS "olderCount",
+        (
+          SELECT count(*)::integer FROM "chat_thread_snapshots"
+          WHERE "user_id" = 'deleted-anchor-owner'
+            AND "org_id" = 'deleted-anchor-org'
+            AND "latest_event_id" = $1
+        ) AS "snapshotCount"
+    `,
+    [deletedSnapshotAnchorEventId, deletedSnapshotOlderEventId],
+  );
+  assert.deepEqual(retained.rows, [
+    { anchorCount: 1, olderCount: 0, snapshotCount: 1 },
+  ]);
 }
 
 async function seedPreviousSchema(client: Client): Promise<void> {
@@ -536,6 +732,7 @@ async function seedPreviousSchema(client: Client): Promise<void> {
       composeOnlyId,
     ],
   );
+  await seedDeletedSnapshotAnchor(client);
 }
 
 async function assertCatalogLockRetryBoundary(args: {
@@ -895,6 +1092,110 @@ async function assertChatThreadEventReferenceState(
     { id: fixedChatThreadEventId, agentId: fixedAgentId },
     { id: composeOnlyChatThreadEventId, agentId: null },
   ]);
+}
+
+async function assertDeletedSnapshotAnchorState(client: Client): Promise<void> {
+  const state = await client.query<{
+    agentCount: number;
+    agentId: string | null;
+    composeCount: number;
+    eventCount: number;
+    snapshotCount: number;
+    threadCount: number;
+    zeroAgentCount: number;
+  }>(
+    `
+      SELECT
+        (
+          SELECT count(*)::integer FROM "chat_thread_events"
+          WHERE "id" = $1
+        ) AS "eventCount",
+        (
+          SELECT "agent_id"::text FROM "chat_thread_events"
+          WHERE "id" = $1
+        ) AS "agentId",
+        (
+          SELECT count(*)::integer FROM "agents" WHERE "id" = $2
+        ) AS "agentCount",
+        (
+          SELECT count(*)::integer FROM "agent_composes" WHERE "id" = $2
+        ) AS "composeCount",
+        (
+          SELECT count(*)::integer FROM "zero_agents" WHERE "id" = $2
+        ) AS "zeroAgentCount",
+        (
+          SELECT count(*)::integer FROM "chat_threads" WHERE "id" = $3
+        ) AS "threadCount",
+        (
+          SELECT count(*)::integer FROM "chat_thread_snapshots"
+          WHERE "user_id" = 'deleted-anchor-owner'
+            AND "org_id" = 'deleted-anchor-org'
+            AND "latest_event_id" = $1
+        ) AS "snapshotCount"
+    `,
+    [
+      deletedSnapshotAnchorEventId,
+      deletedSnapshotAgentId,
+      deletedSnapshotThreadId,
+    ],
+  );
+  assert.deepEqual(state.rows, [
+    {
+      eventCount: 1,
+      agentId: null,
+      agentCount: 0,
+      composeCount: 0,
+      zeroAgentCount: 0,
+      threadCount: 0,
+      snapshotCount: 1,
+    },
+  ]);
+}
+
+async function assertOrdinaryOrphanFailsPostflight(args: {
+  readonly runner: Client;
+  readonly statements: readonly string[];
+}): Promise<void> {
+  const postflight = args.statements.find((statement) => {
+    return statement.includes(
+      "Canonical Agent reference parity failed for %: valid_missing %",
+    );
+  });
+  assert.ok(postflight);
+
+  await args.runner.query(
+    `
+      INSERT INTO "chat_thread_events" (
+        "id", "user_id", "org_id", "chat_thread_id", "kind",
+        "agent_compose_id", "title", "created_at"
+      ) VALUES (
+        $1, 'ordinary-orphan-owner', 'ordinary-orphan-org', $2, 'created',
+        $3, 'Ordinary orphan', timestamp '2026-01-03 00:00:00'
+      )
+    `,
+    [ordinaryOrphanEventId, ordinaryOrphanThreadId, ordinaryOrphanAgentId],
+  );
+  const orphan = await args.runner.query<{ agentId: string | null }>(
+    `
+      SELECT "agent_id"::text AS "agentId"
+      FROM "chat_thread_events" WHERE "id" = $1
+    `,
+    [ordinaryOrphanEventId],
+  );
+  assert.deepEqual(orphan.rows, [{ agentId: null }]);
+
+  await assert.rejects(args.runner.query(postflight), (error: unknown) => {
+    assertDatabaseError(error, {
+      code: "P0001",
+      messageIncludes: "unclassified_null 1",
+    });
+    return true;
+  });
+
+  await args.runner.query(`DELETE FROM "chat_thread_events" WHERE "id" = $1`, [
+    ordinaryOrphanEventId,
+  ]);
+  await args.runner.query(postflight);
 }
 
 async function assertChatThreadEventBackfillGuard(args: {
@@ -1586,6 +1887,8 @@ export async function validateCanonicalAgentDataPlaneMigration(): Promise<void> 
     await validateBackfillAndComposeOnlyClosure(runner);
     await validateChatSearchStorageAndIndex(runner);
     await assertChatThreadEventReferenceState(runner);
+    await assertDeletedSnapshotAnchorState(runner);
+    await assertOrdinaryOrphanFailsPostflight({ runner, statements });
     await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
     assert.equal(
       await chatEventRejectFunctionDefinition(runner),
@@ -1598,6 +1901,7 @@ export async function validateCanonicalAgentDataPlaneMigration(): Promise<void> 
     await validateBackfillAndComposeOnlyClosure(runner);
     await validateChatSearchStorageAndIndex(runner);
     await assertChatThreadEventReferenceState(runner);
+    await assertDeletedSnapshotAnchorState(runner);
     await assertChatThreadEventAppendOnlyTriggerEnabled(runner);
     assert.equal(
       await chatEventRejectFunctionDefinition(runner),

--- a/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
+++ b/turbo/packages/db/src/migrations/0966_canonical_agents_data_plane.sql
@@ -1591,7 +1591,8 @@ ALTER TABLE "feishu_user_agent_preferences" VALIDATE CONSTRAINT "feishu_user_age
 --> statement-breakpoint
 
 -- Aggregate-only postflight: exact canonical parity, exact legacy-reference
--- equality, and only current compose-only identities may retain a NULL sibling.
+-- equality, and only current compose-only identities or exact deleted-entity
+-- snapshot anchors in chat_thread_events may retain a NULL sibling.
 BEGIN;
 --> statement-breakpoint
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
@@ -1608,7 +1609,9 @@ DECLARE
   v_target_only bigint;
   v_unclassified_null bigint;
   v_compose_only_null bigint;
+  v_deleted_snapshot_anchor_null bigint;
   v_allowed_compose_only_null_total bigint := 0;
+  v_allowed_deleted_snapshot_anchor_null_total bigint := 0;
   v_existing_final_missing bigint;
   v_existing_final_missing_total bigint := 0;
   v_matched_count bigint;
@@ -1638,56 +1641,140 @@ BEGIN
       ('public.feishu_user_agent_preferences'::regclass, 'selected_compose_id'::name, 'selected_agent_id'::name, false)
     ) AS "spec"("table_oid", "legacy_column", "target_column", "allows_compose_only")
   LOOP
-    EXECUTE format(
-      $query$
+    IF v_spec.table_oid = 'public.chat_thread_events'::regclass THEN
       SELECT
         count(*) FILTER (
-          WHERE "source".%1$I IS NOT NULL
-            AND "source".%2$I IS NULL
+          WHERE "source"."agent_compose_id" IS NOT NULL
+            AND "source"."agent_id" IS NULL
             AND "agent"."id" IS NOT NULL
         ),
         count(*) FILTER (
-          WHERE "source".%2$I IS NOT NULL
-            AND "source".%2$I IS DISTINCT FROM "source".%1$I
+          WHERE "source"."agent_id" IS NOT NULL
+            AND "source"."agent_id" IS DISTINCT FROM "source"."agent_compose_id"
         ),
         count(*) FILTER (
-          WHERE "source".%2$I IS NOT NULL
-            AND "source".%1$I IS NULL
+          WHERE "source"."agent_id" IS NOT NULL
+            AND "source"."agent_compose_id" IS NULL
         ),
         count(*) FILTER (
-          WHERE "source".%1$I IS NOT NULL
-            AND "source".%2$I IS NULL
+          WHERE "source"."agent_compose_id" IS NOT NULL
+            AND "source"."agent_id" IS NULL
             AND "agent"."id" IS NULL
             AND NOT (
               "compose"."id" IS NOT NULL
               AND "zero_agent"."id" IS NULL
             )
+            AND NOT (
+              "compose"."id" IS NULL
+              AND "zero_agent"."id" IS NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM "chat_threads" AS "live_thread"
+                WHERE "live_thread"."id" = "source"."chat_thread_id"
+              )
+              AND EXISTS (
+                SELECT 1
+                FROM "chat_thread_snapshots" AS "snapshot"
+                WHERE "snapshot"."user_id" = "source"."user_id"
+                  AND "snapshot"."org_id" = "source"."org_id"
+                  AND "snapshot"."latest_event_id" = "source"."id"
+              )
+            )
         ),
         count(*) FILTER (
-          WHERE "source".%1$I IS NOT NULL
-            AND "source".%2$I IS NULL
+          WHERE "source"."agent_compose_id" IS NOT NULL
+            AND "source"."agent_id" IS NULL
             AND "agent"."id" IS NULL
             AND "compose"."id" IS NOT NULL
             AND "zero_agent"."id" IS NULL
+        ),
+        count(*) FILTER (
+          WHERE "source"."agent_compose_id" IS NOT NULL
+            AND "source"."agent_id" IS NULL
+            AND "agent"."id" IS NULL
+            AND "compose"."id" IS NULL
+            AND "zero_agent"."id" IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "chat_threads" AS "live_thread"
+              WHERE "live_thread"."id" = "source"."chat_thread_id"
+            )
+            AND EXISTS (
+              SELECT 1
+              FROM "chat_thread_snapshots" AS "snapshot"
+              WHERE "snapshot"."user_id" = "source"."user_id"
+                AND "snapshot"."org_id" = "source"."org_id"
+                AND "snapshot"."latest_event_id" = "source"."id"
+            )
         )
-      FROM %3$s AS "source"
+      INTO
+        v_valid_missing,
+        v_mismatch,
+        v_target_only,
+        v_unclassified_null,
+        v_compose_only_null,
+        v_deleted_snapshot_anchor_null
+      FROM "chat_thread_events" AS "source"
       LEFT JOIN "agents" AS "agent"
-        ON "agent"."id" = "source".%1$I
+        ON "agent"."id" = "source"."agent_compose_id"
       LEFT JOIN "agent_composes" AS "compose"
-        ON "compose"."id" = "source".%1$I
+        ON "compose"."id" = "source"."agent_compose_id"
       LEFT JOIN "zero_agents" AS "zero_agent"
-        ON "zero_agent"."id" = "source".%1$I
-      $query$,
-      v_spec.legacy_column,
-      v_spec.target_column,
-      v_spec.table_oid
-    )
-    INTO
-      v_valid_missing,
-      v_mismatch,
-      v_target_only,
-      v_unclassified_null,
-      v_compose_only_null;
+        ON "zero_agent"."id" = "source"."agent_compose_id";
+    ELSE
+      v_deleted_snapshot_anchor_null := 0;
+
+      EXECUTE format(
+        $query$
+        SELECT
+          count(*) FILTER (
+            WHERE "source".%1$I IS NOT NULL
+              AND "source".%2$I IS NULL
+              AND "agent"."id" IS NOT NULL
+          ),
+          count(*) FILTER (
+            WHERE "source".%2$I IS NOT NULL
+              AND "source".%2$I IS DISTINCT FROM "source".%1$I
+          ),
+          count(*) FILTER (
+            WHERE "source".%2$I IS NOT NULL
+              AND "source".%1$I IS NULL
+          ),
+          count(*) FILTER (
+            WHERE "source".%1$I IS NOT NULL
+              AND "source".%2$I IS NULL
+              AND "agent"."id" IS NULL
+              AND NOT (
+                "compose"."id" IS NOT NULL
+                AND "zero_agent"."id" IS NULL
+              )
+          ),
+          count(*) FILTER (
+            WHERE "source".%1$I IS NOT NULL
+              AND "source".%2$I IS NULL
+              AND "agent"."id" IS NULL
+              AND "compose"."id" IS NOT NULL
+              AND "zero_agent"."id" IS NULL
+          )
+        FROM %3$s AS "source"
+        LEFT JOIN "agents" AS "agent"
+          ON "agent"."id" = "source".%1$I
+        LEFT JOIN "agent_composes" AS "compose"
+          ON "compose"."id" = "source".%1$I
+        LEFT JOIN "zero_agents" AS "zero_agent"
+          ON "zero_agent"."id" = "source".%1$I
+        $query$,
+        v_spec.legacy_column,
+        v_spec.target_column,
+        v_spec.table_oid
+      )
+      INTO
+        v_valid_missing,
+        v_mismatch,
+        v_target_only,
+        v_unclassified_null,
+        v_compose_only_null;
+    END IF;
 
     IF
       v_valid_missing <> 0
@@ -1696,17 +1783,21 @@ BEGIN
       OR v_unclassified_null <> 0
       OR (NOT v_spec.allows_compose_only AND v_compose_only_null <> 0)
     THEN
-      RAISE EXCEPTION 'Canonical Agent reference parity failed for %: valid_missing %, mismatch %, target_only %, unclassified_null %, compose_only_null %',
+      RAISE EXCEPTION 'Canonical Agent reference parity failed for %: valid_missing %, mismatch %, target_only %, unclassified_null %, compose_only_null %, deleted_snapshot_anchor_null %',
         v_spec.table_oid,
         v_valid_missing,
         v_mismatch,
         v_target_only,
         v_unclassified_null,
-        v_compose_only_null;
+        v_compose_only_null,
+        v_deleted_snapshot_anchor_null;
     END IF;
 
     v_allowed_compose_only_null_total :=
       v_allowed_compose_only_null_total + v_compose_only_null;
+    v_allowed_deleted_snapshot_anchor_null_total :=
+      v_allowed_deleted_snapshot_anchor_null_total +
+      v_deleted_snapshot_anchor_null;
   END LOOP;
 
   FOR v_spec IN
@@ -1895,10 +1986,11 @@ BEGIN
       v_temporary_procedure_count;
   END IF;
 
-  RAISE NOTICE 'Canonical Agent postflight: matched=%, target=%, allowed_compose_only_null_references=%, existing_final_missing=%, bridges=%, validated_fks=%, validated_checks=%',
+  RAISE NOTICE 'Canonical Agent postflight: matched=%, target=%, allowed_compose_only_null_references=%, allowed_deleted_snapshot_anchor_null_references=%, existing_final_missing=%, bridges=%, validated_fks=%, validated_checks=%',
     v_matched_count,
     v_target_count,
     v_allowed_compose_only_null_total,
+    v_allowed_deleted_snapshot_anchor_null_total,
     v_existing_final_missing_total,
     v_bridge_trigger_count,
     v_validated_fk_count,


### PR DESCRIPTION
## Summary

- classify only exact deleted-entity snapshot-anchor events as an allowed NULL canonical reference in migration 0966
- require the canonical Agent, legacy Agent rows, and live Thread to be absent while the same user/org snapshot points exactly to the event
- keep compose-only classification independent and add production-shaped regression coverage for cascade deletion, compaction retention, fail-closed ordinary orphans, retry, and final catalog completion

## Scope

- modifies only the production-unapplied migration 0966 and its focused migration test
- preserves the retained event and its NULL `agent_id`; no data rewrite, synthesized Agent, runtime cursor/compaction change, read/write cutover, or workflow change
- leaves the append-only guard, typed search keyset, bounded batches, short transactions, concurrent indexes, and online constraints unchanged

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --log-order grouped`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/db run lint`
- `pnpm --filter @okouai/db run check-types`
- `pnpm exec tsx scripts/test-canonical-agent-data-plane.ts` against temporary PostgreSQL 18
- `pnpm --filter @okouai/db run test:migration-consistency` reached and passed the canonical Agent focused migration, runner timeout, Stage 6 retry/fresh replay, and preflight cases; the broader run then stopped at the existing unrelated connector-account RESTRICT error-message assertion

Refs #28601
