### PR TITLE
refactor(platform): use explicit single-account connector operations

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -21,10 +21,10 @@ import {
   zeroConnectorManualGrantContract,
   zeroConnectorNoAuthGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
-  zeroConnectorsBySlugContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { zeroCustomConnectorsContract } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 import { getAllFeatureStates } from "@okouai/core/feature-switch";
 import { FEATURE_SWITCH_CACHE_KEY } from "../../signals/external/feature-switch-state.ts";
@@ -411,23 +411,32 @@ export const apiConnectorsHandlers = [
     return respond(200, { permissions });
   }),
 
-  mockApi(zeroConnectorsBySlugContract.delete, ({ params, respond }) => {
-    const connectorSlug = params.connectorSlug;
-    const existing = mockConnectors.find((c) => {
-      return c.slug === connectorSlug;
-    });
+  mockApi(
+    connectorAccountsContract.disconnectSingleAccount,
+    ({ body, respond }) => {
+      if (body.target.kind === "custom") {
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      }
 
-    if (!existing) {
-      return respond(404, {
-        error: { message: "Connector not found", code: "NOT_FOUND" },
+      const connectorSlug = body.target.connectorSlug;
+      const existing = mockConnectors.find((c) => {
+        return c.slug === connectorSlug;
       });
-    }
 
-    mockConnectors = mockConnectors.filter((c) => {
-      return c.slug !== connectorSlug;
-    });
-    return respond(204);
-  }),
+      if (!existing) {
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      }
+
+      mockConnectors = mockConnectors.filter((c) => {
+        return c.slug !== connectorSlug;
+      });
+      return respond(204);
+    },
+  ),
 
   mockApi(
     zeroConnectorManualGrantContract.connect,

--- a/turbo/apps/platform/src/signals/connector-domain.ts
+++ b/turbo/apps/platform/src/signals/connector-domain.ts
@@ -1,4 +1,5 @@
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
@@ -19,3 +20,7 @@ export type PlatformWorkflowConnectorReadinessEntry =
   WorkflowConnectorReadinessEntry;
 export type PlatformWorkflowConnectorReadinessResponse =
   WorkflowConnectorReadinessResponse;
+
+export const singleAccountConnectorMutation = {
+  intent: "single-account",
+} satisfies ConnectorAccountMutationIntent;

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -1,8 +1,6 @@
 import { command, computed, state, type Computed } from "ccstate";
-import {
-  zeroConnectorsMainContract,
-  zeroConnectorsBySlugContract,
-} from "@okouai/api-contracts/contracts/zero-connectors";
+import { zeroConnectorsMainContract } from "@okouai/api-contracts/contracts/zero-connectors";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorCatalogContract,
   type PublicConnectorCatalogDiscoveryResponse,
@@ -123,10 +121,12 @@ export const reloadConnectors$ = command(({ set }) => {
 export const deleteConnector$ = command(
   async ({ get, set }, connectorSlug: ConnectorSlug, signal: AbortSignal) => {
     const createClient = get(apiClient$);
-    const client = createClient(zeroConnectorsBySlugContract);
+    const client = createClient(connectorAccountsContract);
     await accept(
-      client.delete({
-        params: { connectorSlug },
+      client.disconnectSingleAccount({
+        body: {
+          target: { kind: "builtin", connectorSlug },
+        },
         fetchOptions: { signal },
       }),
       [204],

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -58,9 +58,10 @@ import { IN_VITEST } from "../../../env.ts";
 import { connectorRedirectingPath } from "../../connectors-page/connector-redirecting.ts";
 import { isConnectorChangedPayloadFor } from "../../connector-change.ts";
 import { i18n } from "../../../i18n/index.ts";
-import type {
-  PlatformConnector,
-  PlatformConnectorCatalogStatusItem,
+import {
+  singleAccountConnectorMutation,
+  type PlatformConnector,
+  type PlatformConnectorCatalogStatusItem,
 } from "../../connector-domain.ts";
 
 const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
@@ -905,6 +906,7 @@ export const submitManualGrant$ = command(
           connectorClient.connect({
             params: { connectorSlug },
             body: {
+              account: singleAccountConnectorMutation,
               authMethod,
               authorizeAgent: true,
               ...(options.agentId ? { agentId: options.agentId } : {}),
@@ -978,6 +980,7 @@ export const connectConnectorNoAuth$ = command(
           connectorClient.connect({
             params: { connectorSlug },
             body: {
+              account: singleAccountConnectorMutation,
               authMethod,
               authorizeAgent: true,
               ...(options.agentId ? { agentId: options.agentId } : {}),
@@ -1166,6 +1169,7 @@ function connectorOAuthDeviceAuthStartBody(
 ) {
   const optionEntries = Object.entries(args.startOptions ?? {});
   return {
+    account: singleAccountConnectorMutation,
     authMethod: args.authMethod,
     authorizeAgent: true as const,
     ...(args.options.agentId ? { agentId: args.options.agentId } : {}),
@@ -1787,6 +1791,7 @@ export const connectConnectorExternalCode$ = command(
             client.create({
               params: { connectorSlug },
               body: {
+                account: singleAccountConnectorMutation,
                 authMethod,
                 authorizeAgent: true,
                 ...(args.agentId ? { agentId: args.agentId } : {}),
@@ -2163,6 +2168,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 }).start({
                   params: { connectorSlug: args.connectorSlug },
                   body: {
+                    account: singleAccountConnectorMutation,
                     authMethod: args.method.id,
                     authorizeAgent: true,
                     ...(args.agentId ? { agentId: args.agentId } : {}),
@@ -2177,6 +2183,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 }).start({
                   params: { connectorSlug: args.connectorSlug },
                   body: {
+                    account: singleAccountConnectorMutation,
                     authMethod: args.method.id,
                     authorizeAgent: true,
                     ...(isConnectorAppOauthCallbackEnabled(args.connectorSlug)

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
   zeroCustomConnectorByIdContract,
-  zeroCustomConnectorConnectionContract,
   zeroCustomConnectorOAuth2Contract,
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
@@ -13,6 +12,7 @@ import {
   type CustomConnectorValueInput,
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/zero-custom-connectors";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   zeroAgentCustomConnectorsContract,
   type AgentCustomConnectorGrants,
@@ -26,6 +26,7 @@ import { agents$ } from "../../agent.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { setLoop, withCleanup } from "../../utils.ts";
+import { singleAccountConnectorMutation } from "../../connector-domain.ts";
 
 const internalReload$ = state(0);
 const internalAuthorizedAgentsReload$ = state(0);
@@ -375,7 +376,10 @@ const setCustomConnectorValuesForTarget$ = command(
     const result = await accept(
       client.set({
         params: { id: args.id },
-        body: { values: [...args.values] },
+        body: {
+          account: singleAccountConnectorMutation,
+          values: [...args.values],
+        },
         fetchOptions: { signal },
       }),
       [200],
@@ -459,10 +463,12 @@ export const setCustomConnectorValuesForAgent$ = command(
 export const disconnectCustomConnector$ = command(
   async ({ get, set }, id: string, signal: AbortSignal): Promise<void> => {
     const createClient = get(apiClient$);
-    const client = createClient(zeroCustomConnectorConnectionContract);
+    const client = createClient(connectorAccountsContract);
     await accept(
-      client.disconnect({
-        params: { id },
+      client.disconnectSingleAccount({
+        body: {
+          target: { kind: "custom", customConnectorId: id },
+        },
         fetchOptions: { signal },
       }),
       [204],
@@ -505,7 +511,7 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
         const result = await accept(
           client.start({
             params: { id: args.id },
-            body: {},
+            body: { account: singleAccountConnectorMutation },
             fetchOptions: { signal },
           }),
           [200],

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -900,6 +900,7 @@ describe("onboarding flow", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("ahrefs");
         expect(body.authMethod).toBe("api-token");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         expect(body.authorizeAgent).toBeTruthy();
         expect(body.agentId).toBeUndefined();
         return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -476,6 +476,7 @@ describe("chat composer connector connection", () => {
       ({ body, params, respond }) => {
         expect(params.id).toBe(connector.id);
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           values: [{ key: "secret", kind: "secret", value: "acme-secret" }],
         });
         connected = true;
@@ -643,6 +644,7 @@ describe("chat composer connector connection", () => {
         connectCount += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1475,6 +1475,7 @@ describe("chat event action cards", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("gmail");
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "oauth",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -1596,6 +1597,7 @@ describe("chat event action cards", () => {
       zeroConnectorOauthStartContract.start,
       ({ body, respond }) => {
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "oauth",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -1701,6 +1703,7 @@ describe("chat event action cards", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -2653,6 +2656,7 @@ describe("chat event action cards", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("future-connector");
         expect(body.agentId).toBe(AGENT_ID);
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         expect(body.authorizeAgent).toBeTruthy();
         connected = true;
         authorized = true;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -19,7 +19,14 @@ import {
   browserContract,
   type BrowserSession,
 } from "@okouai/api-contracts/contracts/browser";
-import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
+import {
+  connectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@okouai/api-contracts/contracts/connector-catalog";
+import {
+  zeroConnectorOauthStartContract,
+  zeroConnectorsMainContract,
+} from "@okouai/api-contracts/contracts/zero-connectors";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import { describe, expect, it, vi } from "vitest";
 
@@ -141,6 +148,45 @@ function googleDriveConnector(): ConnectorResponse {
     tokenExpiresAt: null,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function googleDriveCatalogStatus(): PublicConnectorCatalogStatusItem {
+  return {
+    slug: "google-drive",
+    label: "Google Drive",
+    description: "Store artifacts in Google Drive",
+    icon: {
+      url: "https://icons.example.test/google-drive.svg",
+      invertInDarkMode: false,
+    },
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [
+      {
+        id: "oauth",
+        label: "OAuth",
+        description: null,
+        grantKind: "auth-code",
+        manualFields: [],
+        startOptions: [],
+      },
+    ],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: "oauth",
+    connectNotice: null,
   };
 }
 
@@ -608,6 +654,138 @@ describe("thread-owned utility sidebar", () => {
 
     await waitFor(() => {
       expect(agentAuthorized).toBeTruthy();
+      expect(artifactSynced).toBeTruthy();
+      expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
+    });
+  });
+
+  it("connects Google Drive from an artifact with explicit compact account intent", async () => {
+    const user = userEvent.setup({ delay: null });
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-connect-notes.md";
+    const summary = catalogArtifact({ title: "drive-connect-notes.md" });
+    const artifactFiles = [
+      threadArtifactFile(markdownUrl, {
+        id: "artifact-drive-connect-notes",
+        filename: "drive-connect-notes.md",
+        googleDriveSync: { status: "disconnected" },
+      }),
+    ];
+
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/markdown",
+            filename: "drive-connect-notes.md",
+            fileId: "f0000000-0000-4000-a000-000000000004",
+            summary,
+            url: markdownUrl,
+          }),
+        ],
+      ]),
+    );
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+      return respond(200, { connectors: [googleDriveCatalogStatus()] });
+    });
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Connect notes\n\nReady for Drive.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+
+    let connectorConnected = false;
+    let agentAuthorized = false;
+    let oauthStarted = false;
+    let artifactSynced = false;
+    context.mocks.api(zeroConnectorsMainContract.list, ({ respond }) => {
+      return respond(200, {
+        connectors: connectorConnected ? [googleDriveConnector()] : [],
+        connectorProvidedBindings: [],
+      });
+    });
+    context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
+      expect(params.id).toBe(AGENT_ID);
+      return respond(200, {
+        enabledConnectorSlugs: agentAuthorized ? ["google-drive"] : [],
+      });
+    });
+    context.mocks.api(userConnectorsContract.update, ({ never }) => {
+      return never();
+    });
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.connectorSlug).toBe("google-drive");
+        expect(body).toStrictEqual({
+          account: { intent: "single-account" },
+          authMethod: "oauth",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+          callbackTarget: "app",
+        });
+        oauthStarted = true;
+        connectorConnected = true;
+        agentAuthorized = true;
+        authWindow.close();
+        return respond(200, {
+          authorizationUrl: "https://accounts.google.test/drive/authorize",
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadArtifactsContract.syncGoogleDrive,
+      ({ body, respond }) => {
+        expect(connectorConnected).toBeTruthy();
+        expect(agentAuthorized).toBeTruthy();
+        expect(body).toStrictEqual({
+          runId: "run-sidebar",
+          fileId: "artifact-drive-connect-notes",
+        });
+        artifactFiles[0] = {
+          ...artifactFiles[0]!,
+          googleDriveSync: {
+            status: "synced",
+            id: "drive-file-connect-notes",
+            name: "drive-connect-notes.md",
+            webViewLink: "https://drive.test/drive-connect-notes",
+          },
+        };
+        artifactSynced = true;
+        return respond(200, {
+          id: "drive-file-connect-notes",
+          name: "drive-connect-notes.md",
+          webViewLink: "https://drive.test/drive-connect-notes",
+        });
+      },
+    );
+
+    setupChatThread({ artifactFiles });
+    await openCatalogArtifact("drive-connect-notes.md");
+    await screen.findByText("Ready for Drive.");
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Connect Google Drive")).toBeEnabled();
+    });
+    await user.click(menuItemByText("Connect Google Drive"));
+
+    await waitFor(() => {
+      expect(oauthStarted).toBeTruthy();
+    });
+    context.mocks.ably.trigger("connector:changed", {
+      connectorSlug: "google-drive",
+    });
+
+    await waitFor(() => {
       expect(artifactSynced).toBeTruthy();
       expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1,7 +1,6 @@
 import { CLIENT_FORCE_UPGRADE_STATUS } from "@okouai/api-contracts/contracts/client-headers";
 import {
   zeroCustomConnectorByIdContract,
-  zeroCustomConnectorConnectionContract,
   zeroCustomConnectorOAuth2Contract,
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
@@ -10,6 +9,7 @@ import {
   type CustomConnectorMcpResponse,
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/zero-custom-connectors";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   zeroAgentCustomConnectorsContract,
   type AgentCustomConnectorGrant,
@@ -24,6 +24,7 @@ import {
   zeroConnectorNoAuthGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorScopeDiffContract,
+  zeroConnectorsBySlugContract,
   zeroConnectorsMainContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
@@ -439,6 +440,7 @@ function mockCustomConnectorStory(): {
   context.mocks.api(
     zeroCustomConnectorValuesContract.set,
     ({ params, body, respond }) => {
+      expect(body.account).toStrictEqual({ intent: "single-account" });
       let updated: CustomConnectorHttpResponse | undefined;
       connectors = connectors.map((connector) => {
         if (connector.id !== params.id) {
@@ -461,10 +463,14 @@ function mockCustomConnectorStory(): {
     },
   );
   context.mocks.api(
-    zeroCustomConnectorConnectionContract.disconnect,
-    ({ params, respond }) => {
+    connectorAccountsContract.disconnectSingleAccount,
+    ({ body, respond }) => {
+      if (body.target.kind !== "custom") {
+        throw new Error("Expected a custom connector disconnect target");
+      }
+      const customConnectorId = body.target.customConnectorId;
       connectors = connectors.map((connector) => {
-        return connector.id === params.id
+        return connector.id === customConnectorId
           ? {
               ...connector,
               connected: false,
@@ -1258,6 +1264,7 @@ describe("connectors page", () => {
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("meta-ads");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         expect(body.callbackTarget).toBe("app");
         return respond(200, {
           authorizationUrl: "https://oauth.test/meta-ads/authorize",
@@ -1303,10 +1310,25 @@ describe("connectors page", () => {
 
   it("disconnects a connected catalog connector from the options menu", async () => {
     mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);
+    const disconnectTargets: unknown[] = [];
+    let legacyDisconnectCount = 0;
+    context.mocks.api(
+      connectorAccountsContract.disconnectSingleAccount,
+      ({ body, respond }) => {
+        disconnectTargets.push(body.target);
+        context.mocks.data.connectors([]);
+        return respond(204);
+      },
+    );
+    context.mocks.api(zeroConnectorsBySlugContract.delete, ({ respond }) => {
+      legacyDisconnectCount += 1;
+      return respond(204);
+    });
 
     detachedSetupPage({
       context,
       path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: false },
     });
 
     await waitFor(() => {
@@ -1323,6 +1345,54 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Connect GitHub")).toBeInTheDocument();
     });
+    expect(disconnectTargets).toStrictEqual([
+      { kind: "builtin", connectorSlug: "github" },
+    ]);
+    expect(legacyDisconnectCount).toBe(0);
+  });
+
+  it("keeps a connector connected when compact disconnect is ambiguous", async () => {
+    mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);
+    let disconnectCount = 0;
+    let legacyDisconnectCount = 0;
+    context.mocks.api(
+      connectorAccountsContract.disconnectSingleAccount,
+      ({ body, respond }) => {
+        disconnectCount += 1;
+        expect(body.target).toStrictEqual({
+          kind: "builtin",
+          connectorSlug: "github",
+        });
+        return respond(409, {
+          error: {
+            code: "CONFLICT",
+            message: "Choose an account before disconnecting",
+          },
+        });
+      },
+    );
+    context.mocks.api(zeroConnectorsBySlugContract.delete, ({ respond }) => {
+      legacyDisconnectCount += 1;
+      return respond(204);
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const card = await waitFor(() => {
+      return connectorCardByLabel("GitHub");
+    });
+    click(within(card).getByLabelText("More options"));
+    click(menuItemByText("Disconnect"));
+
+    await expect(
+      screen.findByText("Choose an account before disconnecting"),
+    ).resolves.toBeInTheDocument();
+    expect(within(card).getByText("@octocat")).toBeInTheDocument();
+    expect(disconnectCount).toBe(1);
+    expect(legacyDisconnectCount).toBe(0);
+
+    click(within(card).getByLabelText("More options"));
+    expect(menuItemByText("Disconnect")).toBeInTheDocument();
   });
 
   it("moves scope review into the connector options menu", async () => {
@@ -2106,6 +2176,7 @@ describe("connectors page", () => {
       zeroConnectorOpenIdStartContract.start,
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe(connectorSlug);
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         expect(body.authMethod).toBe(authMethod);
         return respond(200, {
           authorizationUrl: "https://openid.test/partner-steam/authorize",
@@ -2475,6 +2546,7 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         connectCount += 1;
         expect(params.connectorSlug).toBe("stripe");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         expect(body.authMethod).toBe("api");
         expect(body.authorizeAgent).toBeTruthy();
         expect(body.agentId).toBeUndefined();
@@ -2697,6 +2769,7 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         startCount += 1;
         expect(params.connectorSlug).toBe("stripe");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         capturedOptions = body.options ?? null;
         return respond(200, {
           sessionId: "00000000-0000-4000-8000-000000000010",
@@ -2825,6 +2898,7 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         submitCount += 1;
         expect(params.connectorSlug).toBe("axiom");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         submittedValues = body.values;
         return respond(200, {
           id: crypto.randomUUID(),
@@ -3349,6 +3423,21 @@ describe("connectors page", () => {
   it("connects AWS without a post-connect permission dialog", async () => {
     mockConnectors([]);
     context.mocks.browser.open(createMockAuthWindow());
+    context.mocks.api(
+      zeroConnectorExternalCodeSessionContract.create,
+      ({ body, params, respond }) => {
+        expect(params.connectorSlug).toBe("aws");
+        expect(body.account).toStrictEqual({ intent: "single-account" });
+        return respond(200, {
+          sessionId: "00000000-0000-4000-8000-000000000002",
+          sessionToken: "mock-aws-external-code-session-token",
+          connectorSlug: "aws",
+          status: "pending",
+          authorizationUrl: "https://oauth.test/aws/external-code",
+          expiresIn: 600,
+        });
+      },
+    );
 
     detachedSetupPage({
       context,
@@ -3914,6 +4003,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroCustomConnectorValuesContract.set,
       ({ body, respond }) => {
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         submittedValues = body.values;
         connected = true;
         return respond(200, {
@@ -4222,6 +4312,7 @@ describe("connectors page", () => {
         if (!connector) {
           throw new Error("Expected an MCP custom connector");
         }
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         savedValues = body.values;
         connector = {
           ...connector,
@@ -4233,11 +4324,15 @@ describe("connectors page", () => {
       },
     );
     context.mocks.api(
-      zeroCustomConnectorConnectionContract.disconnect,
-      ({ respond }) => {
+      connectorAccountsContract.disconnectSingleAccount,
+      ({ body, respond }) => {
         if (!connector) {
           throw new Error("Expected an MCP custom connector");
         }
+        expect(body.target).toStrictEqual({
+          kind: "custom",
+          customConnectorId: connector.id,
+        });
         disconnectCount += 1;
         connector = {
           ...connector,
@@ -4519,10 +4614,11 @@ describe("connectors page", () => {
     );
     context.mocks.api(
       zeroCustomConnectorOAuth2Contract.start,
-      ({ respond }) => {
+      ({ body, respond }) => {
         if (!connector) {
           throw new Error("Expected an OAuth MCP custom connector");
         }
+        expect(body.account).toStrictEqual({ intent: "single-account" });
         oauthStartCount += 1;
         connector = {
           ...connector,
@@ -4683,8 +4779,12 @@ describe("connectors page", () => {
       },
     );
     context.mocks.api(
-      zeroCustomConnectorConnectionContract.disconnect,
-      ({ respond }) => {
+      connectorAccountsContract.disconnectSingleAccount,
+      ({ body, respond }) => {
+        expect(body.target).toStrictEqual({
+          kind: "custom",
+          customConnectorId: connector.id,
+        });
         disconnectCount += 1;
         connector = {
           ...connector,
@@ -5018,7 +5118,9 @@ describe("connectors page", () => {
       zeroCustomConnectorOAuth2Contract.start,
       ({ params, body, respond }) => {
         expect(params.id).toBe(connector?.id);
-        expect(body).toStrictEqual({});
+        expect(body).toStrictEqual({
+          account: { intent: "single-account" },
+        });
         oauthStartCount += 1;
         if (!connector) {
           throw new Error("Expected custom connector to exist");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -120,6 +120,7 @@ function mockConnectorOauthStart(): { readonly authWindow: Window } {
     zeroConnectorOauthStartContract.start,
     ({ body, params, respond }) => {
       expect(body).toStrictEqual({
+        account: { intent: "single-account" },
         authMethod: "oauth",
         agentId: AGENT_ID,
         authorizeAgent: true,
@@ -148,6 +149,7 @@ function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
     zeroConnectorOpenIdStartContract.start,
     ({ body, params, respond }) => {
       expect(body).toStrictEqual({
+        account: { intent: "single-account" },
         authMethod: "openid",
         agentId: AGENT_ID,
         authorizeAgent: true,
@@ -526,6 +528,7 @@ describe("directed connector authorize page", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -734,6 +734,7 @@ describe("directed connector connect page", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
+          account: { intent: "single-account" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -51,7 +51,10 @@ import {
   getOnlyAvailableCatalogBrowserAuthMethodDetail,
   type ConnectorCatalogBrowserAuthMethodDetail,
 } from "../../signals/zero-page/settings/connectors.ts";
-import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
+import {
+  singleAccountConnectorMutation,
+  type PlatformConnectorCatalogStatusItem,
+} from "../../signals/connector-domain.ts";
 import {
   copyAttachmentLinkToClipboard,
   publicAttachmentUrl,
@@ -200,6 +203,7 @@ function startGoogleDriveConnectAndRun(
       const request = {
         params: { connectorSlug: params.connector.slug },
         body: {
+          account: singleAccountConnectorMutation,
           authMethod: params.authMethod.id,
           agentId,
           authorizeAgent: true as const,


### PR DESCRIPTION
## Summary

- send the typed explicit `single-account` mutation from every compact built-in and custom Platform connection flow
- use the safe target-scoped single-account disconnect operation for built-in and user-managed custom connectors, without legacy fallback
- cover direct Artifact Google Drive authorization, feature-off behavior, ambiguous disconnect conflicts, and custom HTTP/MCP flows in page integration tests

## Exclusions

- no visible account list, picker, label, or multi-account settings UI
- no API, database, Runner, permission-scope, or Integration-managed connector lifecycle changes

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/app lint`
- `cd turbo && pnpm -F @okouai/app check-types`
- `cd turbo && pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/thread-sidebar.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx src/views/zero-page/__tests__/chat-event-action-cards.test.tsx src/views/onboarding/__tests__/onboarding-flow.test.tsx --maxWorkers=4 --silent=passed-only` (227 tests)
- `cd turbo && pnpm knip --workspace @okouai/app`
- pre-commit hook: full Turbo Knip and `pnpm check-types`

Closes #28586

Parent delivery issue: #28570
Umbrella context: #22832
