### PR TITLE
fix(python): classify openrouter 500 responses by body

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -729,9 +729,8 @@ def _failure_kind_from_http_status(status: int, firewall_name: str) -> FailureKi
         _HTTP_STATUS_SITE_OVERLOADED,
     ):
         return "provider_unavailable"
-    if (
-        status == _HTTP_STATUS_INTERNAL_SERVER_ERROR
-        and firewall_name != "model-provider:openrouter"
+    if status == _HTTP_STATUS_INTERNAL_SERVER_ERROR and not firewall_name.startswith(
+        "model-provider:openrouter-"
     ):
         return "provider_unavailable"
     return None

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -325,7 +325,8 @@ def test_openrouter_edge_timeout_reports_normalized_failure(
     flow = _make_flow(
         real_flow,
         tmp_path / "proxy.jsonl",
-        firewall_name="model-provider:openrouter",
+        firewall_name="model-provider:openrouter-api-key",
+        request_path="/api/v1/messages",
         response_status=524,
     )
 
@@ -774,27 +775,49 @@ def test_ineligible_http_response_is_not_reported(
     assert _reported_payloads(model_provider_failure_api) == []
 
 
-def test_openrouter_schema_error_is_not_reported(
+@pytest.mark.parametrize(
+    ("firewall_name", "request_path"),
+    [
+        ("model-provider:openrouter-api-key", "/api/v1/messages"),
+        ("model-provider:openrouter-codex", "/api/v1/responses"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("body", "expected_payloads"),
+    [
+        (
+            b'{"error":{"code":400,"message":"Invalid tool definition: '
+            b'function is required","metadata":{"error_type":"invalid_request"}}}',
+            [],
+        ),
+        (
+            b'{"error":{"metadata":{"error_type":"provider_unavailable"}}}',
+            [{"failureKind": "provider_unavailable"}],
+        ),
+    ],
+)
+def test_openrouter_http_500_is_classified_from_body(
     tmp_path,
     real_flow,
     mitm_ctx,
+    firewall_name: str,
+    request_path: str,
+    body: bytes,
+    expected_payloads: list[dict[str, str]],
     model_provider_failure_api,
 ):
-    body = (
-        b'{"error":{"code":400,"message":"Invalid tool definition: '
-        b'function is required","metadata":{"error_type":"invalid_request"}}}'
-    )
     flow = _make_flow(
         real_flow,
         tmp_path / "proxy.jsonl",
-        firewall_name="model-provider:openrouter",
-        response_status=400,
+        firewall_name=firewall_name,
+        request_path=request_path,
+        response_status=500,
         response_body=body,
     )
 
     _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
 
-    assert _reported_payloads(model_provider_failure_api) == []
+    assert _reported_payloads(model_provider_failure_api) == expected_payloads
 
 
 def test_overlapping_inference_flows_report_independent_failures(
@@ -830,13 +853,13 @@ def test_overlapping_inference_flows_report_independent_failures(
             "provider_unavailable",
         ),
         (
-            "model-provider:openrouter",
+            "model-provider:openrouter-codex",
             "/api/v1/chat/completions",
             b'data: {"choices":[{"error":{"metadata":{"error_type":"provider_overloaded"}}}]}\n\n',
             "provider_unavailable",
         ),
         (
-            "model-provider:openrouter",
+            "model-provider:openrouter-codex",
             "/api/v1/responses",
             b"event: response.failed\n"
             b'data: {"type":"response.failed","response":{"status":"failed",'
@@ -1054,7 +1077,8 @@ def test_openrouter_stable_failure_survives_response_interruption(
     flow = _make_flow(
         real_flow,
         tmp_path / "proxy.jsonl",
-        firewall_name="model-provider:openrouter",
+        firewall_name="model-provider:openrouter-codex",
+        request_path="/api/v1/responses",
         response_status=500,
         response_body=body,
     )


### PR DESCRIPTION
## Summary

- defer OpenRouter HTTP 500 classification to the response body for both production firewall variants
- keep request, schema, and tool-capability errors from opening false provider cooldowns
- replace stale firewall fixtures and cover both `invalid_request` and confirmed `provider_unavailable` outcomes

## Scope

This does not enable managed-model fallback, change route selection, or change `Retry-After` handling.

Closes #28643

Parent objective: #28148

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`6513 passed`)
