### PR TITLE
refactor(cli): send explicit single-account connector intent

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -83,6 +83,7 @@ describe("okou connector connect command", () => {
     ]);
 
     expect(receivedBody).toStrictEqual({
+      account: { intent: "single-account" },
       authMethod: "api-token",
       values: {
         apiToken: "secret-token",
@@ -121,6 +122,7 @@ describe("okou connector connect command", () => {
     ]);
 
     expect(receivedBody).toStrictEqual({
+      account: { intent: "single-account" },
       authMethod: "api-token",
       values: {
         apiKey: "sk-test",
@@ -163,6 +165,7 @@ describe("okou connector connect command", () => {
 
     expect(receivedType).toBe(connectorSlug);
     expect(receivedBody).toStrictEqual({
+      account: { intent: "single-account" },
       authMethod,
       values: { apiKey: "secret-token" },
     });
@@ -357,6 +360,44 @@ describe("okou connector connect command", () => {
 
     const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorOutput).toContain("Connector is not available");
+    expect(errorOutput).not.toContain("secret-token");
+  });
+
+  it("surfaces ambiguous account conflicts without retrying or printing secret values", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCount += 1;
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Multiple connector accounts require an exact choice",
+                code: "CONFLICT",
+              },
+            },
+            { status: 409 },
+          );
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "zendesk",
+        "--value",
+        "apiToken=secret-token",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCount).toBe(1);
+    const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorOutput).toContain(
+      "409: Multiple connector accounts require an exact choice",
+    );
     expect(errorOutput).not.toContain("secret-token");
   });
 });

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -175,7 +175,11 @@ export async function connectConnectorManualGrant(
 
   const result = await client.connect({
     params: { connectorSlug },
-    body: { authMethod, values },
+    body: {
+      account: { intent: "single-account" },
+      authMethod,
+      values,
+    },
   });
 
   if (result.status === 200) {


### PR DESCRIPTION
## Summary

- send explicit `single-account` mutation intent from the current CLI manual-grant request
- preserve the existing compact CLI flags, success output, JSON output, and secret redaction
- cover the exact request body and user-visible ambiguous-account conflict without retries

## Scope

This client-only change uses the account-aware API contract already delivered by #28587. It does not change API semantics, permissions, account-aware CLI UX, or the omitted-intent compatibility boundary for installed legacy CLI versions.

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/cli lint`
- `cd turbo && pnpm -F @okouai/cli check-types`
- `cd turbo && pnpm -F @okouai/cli exec vitest run src/commands/connector/__tests__/connect.test.ts`
- `cd turbo && pnpm knip --workspace @okouai/cli`
- pre-commit full Turbo Knip and type checks

Closes #28590

Parent delivery issue: #28570
Umbrella context: #22832
