### PR TITLE
fix(python): clamp managed provider retry-after delays

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -742,8 +742,13 @@ def _retry_after_seconds(status: int, headers: http.Headers) -> int | None:
     values = headers.get_all("Retry-After")
     if len(values) != 1 or not values[0].isascii() or not values[0].isdigit():
         return None
-    seconds = int(values[0])
-    return min(max(seconds, 1), _MAX_RETRY_AFTER_SECONDS)
+    digits = values[0].lstrip("0")
+    if not digits:
+        return 1
+    maximum = str(_MAX_RETRY_AFTER_SECONDS)
+    if len(digits) > len(maximum) or (len(digits) == len(maximum) and digits > maximum):
+        return _MAX_RETRY_AFTER_SECONDS
+    return int(digits)
 
 
 def _has_error_value(result: JsonExtractionResult) -> bool:

--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -743,7 +743,7 @@ def _retry_after_seconds(status: int, headers: http.Headers) -> int | None:
     if len(values) != 1 or not values[0].isascii() or not values[0].isdigit():
         return None
     seconds = int(values[0])
-    return seconds if 1 <= seconds <= _MAX_RETRY_AFTER_SECONDS else None
+    return min(max(seconds, 1), _MAX_RETRY_AFTER_SECONDS)
 
 
 def _has_error_value(result: JsonExtractionResult) -> bool:

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -540,20 +540,20 @@ def test_shutdown_cancels_queued_reports(
 
 
 @pytest.mark.parametrize(
-    ("status", "retry_after", "expected_kind"),
+    ("status", "retry_after", "expected_kind", "expected_seconds"),
     [
-        (429, "301", "rate_limit"),
-        (429, "Fri, 21 Aug 2026 12:00:00 GMT", "rate_limit"),
-        (401, "120", "authentication"),
+        (429, "0", "rate_limit", 1),
+        (503, "301", "provider_unavailable", 300),
     ],
 )
-def test_untrusted_retry_after_is_omitted(
+def test_numeric_retry_after_is_clamped(
     tmp_path,
     real_flow,
     mitm_ctx,
     status: int,
     retry_after: str,
     expected_kind: str,
+    expected_seconds: int,
     model_provider_failure_api,
 ):
     flow = _make_flow(
@@ -561,6 +561,40 @@ def test_untrusted_retry_after_is_omitted(
         tmp_path / "proxy.jsonl",
         response_status=status,
         response_headers=header_map({"retry-after": retry_after}),
+    )
+
+    _finish_http_flow(flow, body=None, mitm_ctx=mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": expected_kind, "retryAfterSeconds": expected_seconds}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("status", "retry_after_values", "expected_kind"),
+    [
+        (429, ("invalid",), "rate_limit"),
+        (429, ("Fri, 21 Aug 2026 12:00:00 GMT",), "rate_limit"),
+        (429, ("120", "121"), "rate_limit"),
+        (401, ("120",), "authentication"),
+    ],
+)
+def test_unusable_retry_after_is_omitted(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    status: int,
+    retry_after_values: tuple[str, ...],
+    expected_kind: str,
+    model_provider_failure_api,
+):
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        response_status=status,
+        response_headers=http.Headers(
+            [(b"retry-after", value.encode()) for value in retry_after_values]
+        ),
     )
 
     _finish_http_flow(flow, body=None, mitm_ctx=mitm_ctx)

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -544,6 +544,13 @@ def test_shutdown_cancels_queued_reports(
     [
         (429, "0", "rate_limit", 1),
         (503, "301", "provider_unavailable", 300),
+        pytest.param(
+            503,
+            "9" * 5_000,
+            "provider_unavailable",
+            300,
+            id="long-numeric-delay",
+        ),
     ],
 )
 def test_numeric_retry_after_is_clamped(


### PR DESCRIPTION
## Summary

- clamp a single numeric provider `Retry-After` value to the existing 1–300 second cooldown interval
- bound arbitrarily long numeric values without converting an oversized integer
- preserve omission for malformed, duplicated, HTTP-date, and ineligible-status headers
- cover lower and upper bounds through the public mitmproxy hooks and outgoing failure-report boundary

## Compatibility

The runner continues sending the existing optional positive integer field with a maximum of 300. No API, database, feature-switch, billing, guest, or current-run lifecycle behavior changes.

## Validation

- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py` — 72 passed
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6517 passed, 59 existing warnings

Closes #28650

Parent context: #28148. This removes one blocker for #28195; production qualification and canary work remain out of scope.
