### PR TITLE
test(db): assert built-in model key vendor typmod

### DIFF
--- a/turbo/packages/db/scripts/test-built-in-model-keys-permanent.ts
+++ b/turbo/packages/db/scripts/test-built-in-model-keys-permanent.ts
@@ -84,6 +84,29 @@ async function validateCanonicalColumnOrder(client: Client): Promise<void> {
   ]);
 }
 
+async function validateCanonicalVendorType(client: Client): Promise<void> {
+  const vendorType = await client.query<{ formattedType: string }>(`
+    SELECT pg_catalog.format_type(
+      "attribute"."atttypid",
+      "attribute"."atttypmod"
+    ) AS "formattedType"
+    FROM "pg_catalog"."pg_attribute" AS "attribute"
+    INNER JOIN "pg_catalog"."pg_class" AS "relation"
+      ON "relation"."oid" = "attribute"."attrelid"
+    INNER JOIN "pg_catalog"."pg_namespace" AS "namespace"
+      ON "namespace"."oid" = "relation"."relnamespace"
+    WHERE "namespace"."nspname" = 'public'
+      AND "relation"."relname" = 'built_in_model_keys'
+      AND "relation"."relkind" = 'r'
+      AND "attribute"."attname" = 'vendor'
+      AND "attribute"."attnum" > 0
+      AND NOT "attribute"."attisdropped"
+  `);
+  assert.deepEqual(vendorType.rows, [
+    { formattedType: "character varying(50)" },
+  ]);
+}
+
 async function validateCanonicalRowLock(
   client: Client,
   databaseUrl: string,
@@ -278,9 +301,11 @@ export async function validatePermanentBuiltInModelKeyState(
   await client.connect();
   try {
     await validateCanonicalColumnOrder(client);
+    await validateCanonicalVendorType(client);
     await validateCanonicalStatements(client, databaseUrl);
 
     console.log("   ✅ canonical current-schema column order is enforced");
+    console.log("   ✅ canonical vendor type is character varying(50)");
     console.log(
       "   ✅ canonical statements preserve unrelated rows and support conflict handling, returning, and row locks\n",
     );


### PR DESCRIPTION
## Summary

- Add an exact permanent assertion for the `built_in_model_keys.vendor` PostgreSQL typmod through `pg_catalog.format_type(atttypid, atttypmod)`.
- Preserve the existing canonical column-order, statement, conflict, `RETURNING`, and row-locking assertions.
- Keep the existing migration-consistency integration unchanged: the permanent validator still runs against both the complete historical migration replay database and the regenerated current-schema database.

Related: #28608

## Assertion proof

The validator requires the catalog result to equal `character varying(50)` exactly:

| Physical type | `format_type` result | Validator result |
| --- | --- | --- |
| `varchar(50)` | `character varying(50)` | passes |
| unbounded `varchar` | `character varying` | fails |
| `varchar(49)` | `character varying(49)` | fails |

This proves the length typmod independently of the Drizzle declaration and of `information_schema.columns.data_type`, which reports all three variants as `character varying`.

## Verification

- Changed-file Prettier: passed
- DB lint: passed
- DB type-check: passed
- Full Turbo lint: passed
- Knip: passed
- Staged non-API, Platform, and API type-checks: passed
- Complete local migration replay on a disposable PostgreSQL 18 database: passed
- Focused permanent validator on canonical `varchar(50)`: passed
- Focused mutation proof: unbounded `varchar` failed with actual `character varying`; `varchar(49)` failed with actual `character varying(49)`; restoring `varchar(50)` passed
- Residual retired-transition search: empty
- `git diff --check`: passed

The required PR pipeline remains the complete migration-consistency gate, including `test-migrate`.
