### PR TITLE
refactor(api): isolate connector singleton compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -466,6 +466,21 @@ describe("connector account lifecycle routes", () => {
       "Multiple connector accounts require an exact choice",
     );
 
+    const omittedIntent = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          values: { apiKey: "sk-omitted-ambiguous" },
+        },
+      }),
+      [409],
+    );
+    expect(omittedIntent.body.error.message).toBe(
+      "Multiple connector accounts require an exact choice",
+    );
+
     const accounts = await accept(
       accountClient().connections({
         headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8923,6 +8923,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+
     const connected = await connectors.connectManualGrant(
       actor,
       "lark",
@@ -8985,10 +8989,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "available",
     });
-    const [legacyRuntime] = await api.syncConnectorRuntime(run.runId, {
+    const [sourceLessRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ kind: "builtin", connectorSlug: "lark" }],
     });
-    expect(legacyRuntime).toMatchObject({
+    expect(sourceLessRuntime).toMatchObject({
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "available",
     });
@@ -8999,6 +9003,37 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "unresolved",
       reason: "connector-unavailable",
+    });
+
+    await connectors.requestManualGrant(
+      actor,
+      "lark",
+      "api-token",
+      {
+        appId: "lark-sibling-app-id",
+        appSecret: "lark-sibling-app-secret",
+      },
+      {
+        statuses: [200],
+        account: { intent: "add", displayName: "Sibling" },
+      },
+    );
+    const [ambiguousSourceLessRuntime] = await api.syncConnectorRuntime(
+      run.runId,
+      { targets: [{ kind: "builtin", connectorSlug: "lark" }] },
+    );
+    expect(ambiguousSourceLessRuntime).toStrictEqual({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "unresolved",
+      reason: "connector-unavailable",
+    });
+    const [exactRuntimeWithSibling] = await api.syncConnectorRuntime(
+      run.runId,
+      { targets: [larkTarget] },
+    );
+    expect(exactRuntimeWithSibling).toMatchObject({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "available",
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3666,7 +3666,7 @@ function builtinConnectorAccountRequestsForMetadata(args: {
       target: { kind: "builtin", connectorSlug },
       selection:
         metadata.sourceId === undefined
-          ? { kind: "legacy-singleton" }
+          ? { kind: "source-less-runtime-singleton" }
           : { kind: "exact", sourceId: metadata.sourceId },
     };
   });
@@ -3720,7 +3720,7 @@ function builtinConnectorAccountRequestsForFirewall(args: {
       target: { kind: "builtin", connectorSlug },
       selection:
         sourceId === undefined
-          ? { kind: "legacy-singleton" }
+          ? { kind: "source-less-runtime-singleton" }
           : { kind: "exact", sourceId },
     };
   });
@@ -4682,7 +4682,7 @@ async function resolveCurrentCustomConnectorMemberId(args: {
         target,
         selection:
           args.sourceId === undefined
-            ? { kind: "legacy-singleton" }
+            ? { kind: "source-less-runtime-singleton" }
             : { kind: "exact", sourceId: args.sourceId },
       },
     ],

--- a/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
@@ -17,7 +17,7 @@ const storedConnectorAccountMutationDecoder = zodDriverValueDecoder(
 );
 
 export type ConnectorAccountMutation =
-  | { readonly intent: "legacy-singleton" }
+  | { readonly intent: "target-only-client-singleton" }
   | ConnectorAccountMutationIntent;
 
 export function connectorAccountSiblingWritesEnabled(
@@ -29,7 +29,7 @@ export function connectorAccountSiblingWritesEnabled(
 export function normalizeConnectorAccountMutation(
   intent: ConnectorAccountMutationIntent | undefined,
 ): ConnectorAccountMutation {
-  return intent ?? { intent: "legacy-singleton" };
+  return intent ?? { intent: "target-only-client-singleton" };
 }
 
 export function parseStoredConnectorAccountMutationIntent(
@@ -37,15 +37,16 @@ export function parseStoredConnectorAccountMutationIntent(
 ): ConnectorAccountMutationIntent | undefined {
   const mutation: ConnectorAccountMutation =
     value === null
-      ? { intent: "legacy-singleton" }
+      ? { intent: "target-only-client-singleton" }
       : connectorAccountMutationIntentSchema.parse(value);
-  return mutation.intent === "legacy-singleton" ? undefined : mutation;
+  return mutation.intent === "target-only-client-singleton"
+    ? undefined
+    : mutation;
 }
 
 export function storedConnectorAccountMutationSelection(relation: SQLWrapper) {
-  // Keep legacy flows readable during the DB/API rollout, whose observed
-  // exposure can reach 102 minutes. Remove this JSON projection in #27695
-  // after migration 0951's rollback window closes, then select the column.
+  // Keep old authorization state readable until #28589 proves its browser,
+  // state-lifetime, and API rollback gates have drained.
   return sql`
     to_jsonb(${relation}) -> 'account_mutation'
   `.mapWith(storedConnectorAccountMutationDecoder);
@@ -54,8 +55,8 @@ export function storedConnectorAccountMutationSelection(relation: SQLWrapper) {
 export function storedConnectorAccountMutationWrite(
   intent: ConnectorAccountMutationIntent | null | undefined,
 ): { readonly accountMutation?: StoredConnectorAccountMutation } {
-  // Omitting the column keeps old-client inserts legal before migration 0951.
-  // Explicit account callers are released only after that migration is live.
+  // Omitted client intent remains a supported compatibility boundary until
+  // #28589 contracts each applicable route and persisted state authority.
   return intent === null || intent === undefined
     ? {}
     : { accountMutation: intent };

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -20,10 +20,8 @@ const L = logger("connector-account-resolution");
 export type ConnectorAccountSelectionMode =
   | { readonly kind: "exact"; readonly sourceId: string }
   | { readonly kind: "default" }
-  // Target-only callers may act only while one account exists. Source-less
-  // runtime call sites are temporary and tracked for removal in #27695;
-  // legacy target-only mutation APIs keep this fail-closed singleton semantic.
-  | { readonly kind: "legacy-singleton" };
+  | { readonly kind: "target-only-client-singleton" }
+  | { readonly kind: "source-less-runtime-singleton" };
 
 export interface ConnectorAccountResolutionRequest {
   readonly target: ConnectorAccountTarget;
@@ -196,7 +194,7 @@ async function loadDefaultRows(
     );
 }
 
-async function loadLegacyRows(
+async function loadSingletonCompatibilityRows(
   db: ReadonlyDb,
   args: {
     readonly orgId: string;
@@ -205,14 +203,15 @@ async function loadLegacyRows(
   },
 ): Promise<readonly ConnectorAccountIdentityRow[]> {
   const targets = args.requests.flatMap((request) => {
-    return request.selection.kind === "legacy-singleton"
+    return request.selection.kind === "target-only-client-singleton" ||
+      request.selection.kind === "source-less-runtime-singleton"
       ? [request.target]
       : [];
   });
   if (targets.length === 0) {
     return [];
   }
-  const ranked = db.$with("legacy_connector_account_candidates").as(
+  const ranked = db.$with("singleton_connector_account_candidates").as(
     db
       .select({
         ...identitySelection(),
@@ -285,18 +284,24 @@ export async function resolveConnectorAccounts(
     return new Map();
   }
   const normalizedRequests = [...requests.values()];
-  const [exactRows, defaultRows, legacyRows] = await Promise.all([
-    loadExactRows(db, { ...args, requests: normalizedRequests }),
-    loadDefaultRows(db, { ...args, requests: normalizedRequests }),
-    loadLegacyRows(db, { ...args, requests: normalizedRequests }),
-  ]);
+  const [exactRows, defaultRows, singletonCompatibilityRows] =
+    await Promise.all([
+      loadExactRows(db, { ...args, requests: normalizedRequests }),
+      loadDefaultRows(db, { ...args, requests: normalizedRequests }),
+      loadSingletonCompatibilityRows(db, {
+        ...args,
+        requests: normalizedRequests,
+      }),
+    ]);
   const exactById = new Map(
     exactRows.map((row) => {
       return [row.connectorId, row] as const;
     }),
   );
   const defaultByTarget = rowsByTarget(defaultRows);
-  const legacyByTarget = rowsByTarget(legacyRows);
+  const singletonCompatibilityByTarget = rowsByTarget(
+    singletonCompatibilityRows,
+  );
   const resolutions = new Map<string, ConnectorAccountResolution>();
   for (const [key, request] of requests) {
     if (request.selection.kind === "exact") {
@@ -315,7 +320,7 @@ export async function resolveConnectorAccounts(
     const rows =
       request.selection.kind === "default"
         ? defaultByTarget.get(key)
-        : legacyByTarget.get(key);
+        : singletonCompatibilityByTarget.get(key);
     if (!rows || rows.length === 0) {
       resolutions.set(
         key,
@@ -372,9 +377,16 @@ export async function resolveConnectorAccounts(
     defaultRequestCount: normalizedRequests.filter((request) => {
       return request.selection.kind === "default";
     }).length,
-    legacyRequestCount: normalizedRequests.filter((request) => {
-      return request.selection.kind === "legacy-singleton";
-    }).length,
+    targetOnlyClientSingletonRequestCount: normalizedRequests.filter(
+      (request) => {
+        return request.selection.kind === "target-only-client-singleton";
+      },
+    ).length,
+    sourceLessRuntimeSingletonRequestCount: normalizedRequests.filter(
+      (request) => {
+        return request.selection.kind === "source-less-runtime-singleton";
+      },
+    ).length,
     ...outcomeCounts,
   });
   return resolutions;

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -14,7 +14,7 @@ export interface StoredConnectorConnectionRow {
   readonly id: string;
   readonly authMethod: string;
   readonly displayName: string | null;
-  readonly isDefault: boolean | null;
+  readonly isDefault: boolean;
   readonly externalId: string | null;
   readonly externalUsername: string | null;
   readonly externalEmail: string | null;

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -829,7 +829,7 @@ async function loadConnectorAccountForDeletion(
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
       selection: args.sourceId
         ? { kind: "exact", sourceId: args.sourceId }
-        : { kind: "legacy-singleton" },
+        : { kind: "target-only-client-singleton" },
     },
   });
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -98,7 +98,7 @@ async function loadCustomSnapshot(args: {
             },
             selection:
               registration.sourceId === undefined
-                ? { kind: "legacy-singleton" as const }
+                ? { kind: "source-less-runtime-singleton" as const }
                 : {
                     kind: "exact" as const,
                     sourceId: registration.sourceId,
@@ -300,7 +300,7 @@ export async function resolveConnectorRuntimeTargets(args: {
                   },
                   selection:
                     registration.sourceId === undefined
-                      ? { kind: "legacy-singleton" as const }
+                      ? { kind: "source-less-runtime-singleton" as const }
                       : {
                           kind: "exact" as const,
                           sourceId: registration.sourceId,

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -105,7 +105,7 @@ export async function deleteCustomConnectorMemberConnection(
     userId: args.userId,
     request: {
       target: { kind: "custom", customConnectorId: args.connectorId },
-      selection: { kind: "legacy-singleton" },
+      selection: { kind: "target-only-client-singleton" },
     },
   });
   signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- split the overloaded connector singleton selector into target-only client and source-less runtime compatibility boundaries
- preserve one shared fail-closed singleton query while reporting each authority separately
- align the stored connector connection type with the non-null `is_default` schema invariant
- cover omitted client ambiguity and source-less runtime ambiguity at API integration entry points

## Compatibility

- no public API, Runner protocol, database schema, migration, Rust, or Python contract changes
- installed client omission and source-less runtime behavior remain supported
- compatibility removal remains owned by #28589 and #28592 after their independent production gates

## Validation

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts -t "reuses an explicit single account and rejects an ambiguous target"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "keeps refresh-owned connector secrets out of the sandbox environment"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, repository TypeScript checks, file-size check

Closes #28588

Parent: #27695
