### PR TITLE
test(e2e): stabilize model picker geometry lookup

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1026,20 +1026,10 @@ async function openModelPickerAndReadGeometry(
   await page
     .getByRole("combobox", { name: "Claude Fable 5", exact: true })
     .click();
-  const listbox = page.getByRole("listbox");
-  await expect(listbox).toBeVisible();
-  return listbox.evaluate((element) => {
-    let scrollContainer = element.parentElement;
-    while (scrollContainer) {
-      const overflowY = getComputedStyle(scrollContainer).overflowY;
-      if (overflowY === "auto" || overflowY === "scroll") {
-        break;
-      }
-      scrollContainer = scrollContainer.parentElement;
-    }
-    if (!scrollContainer) {
-      throw new Error("Model picker scroll container unavailable");
-    }
+  const scrollContainer = page.locator('[data-slot="select-content"]');
+  await expect(scrollContainer).toBeVisible();
+  await expect(scrollContainer.getByRole("option").first()).toBeVisible();
+  return scrollContainer.evaluate((element) => {
     const options = Array.from(
       element.querySelectorAll<HTMLElement>('[role="option"]'),
     ).filter((option) => {
@@ -1051,10 +1041,10 @@ async function openModelPickerAndReadGeometry(
       throw new Error("Model picker row geometry unavailable");
     }
     return {
-      clientHeight: scrollContainer.clientHeight,
+      clientHeight: element.clientHeight,
       optionCount: options.length,
       rowStep: second.top - first.top,
-      scrollHeight: scrollContainer.scrollHeight,
+      scrollHeight: element.scrollHeight,
     };
   });
 }


### PR DESCRIPTION
## Summary

- locate the model picker by its stable `select-content` slot
- wait for a visible option before reading popup geometry
- measure the actual overflow owner instead of walking up from a transient `listbox` role

## Scope

- test-only change; no product behavior or component markup changes
- no retries, timeout increases, or skipped coverage

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (39 tests passed)
- `git diff --check`
- Focused Playwright validation against staging was attempted twice, but both runs stopped in the unchanged setup test because the onboarding page remained on `Loading your workspace`; the target model-picker test did not run locally and will be exercised by the PR preview CI.

Closes #28660
