### PR TITLE
perf(api): attribute connector projection validation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -368,6 +368,8 @@ const API_DISPATCH_CONNECTOR_CATALOG_PROJECTION_ROW_ACTION_TYPES = [
   "api_dispatch_connector_catalog_query_projection_rows",
   "api_dispatch_connector_catalog_fetch_projection_rows",
   "api_dispatch_connector_catalog_validate_projection_rows",
+  "api_dispatch_connector_catalog_parse_projection_rows",
+  "api_dispatch_connector_catalog_verify_projection_row_digests",
 ] as const;
 const API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES = [
   "api_dispatch_connector_catalog_validate_schema",
@@ -997,8 +999,12 @@ function expectProjectionRowReadActionCounts(
     expect(matchingEvents).toHaveLength(expectedCount);
     for (const event of matchingEvents) {
       expect(event).toStrictEqual(
-        expect.objectContaining({ span_kind: "nested" }),
+        expect.objectContaining({
+          duration_ms: expect.any(Number),
+          span_kind: "nested",
+        }),
       );
+      expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
     }
   }
 }
@@ -2784,9 +2790,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         allowedCustomConnectorIds: [],
       },
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectProjectionRowReadActionCounts(timingEvents, 1);
     expect(
       singleApiDispatchEvent(
-        apiDispatchTimingEventsForRun(run.runId),
+        timingEvents,
         "api_dispatch_connector_catalog_load_runtime_snapshot",
       ),
     ).toStrictEqual(

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -243,6 +243,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_connector_catalog_query_projection_rows"
   | "api_dispatch_connector_catalog_fetch_projection_rows"
   | "api_dispatch_connector_catalog_validate_projection_rows"
+  | "api_dispatch_connector_catalog_parse_projection_rows"
+  | "api_dispatch_connector_catalog_verify_projection_row_digests"
   | "api_dispatch_connector_catalog_count_projection_rows"
   | "api_dispatch_connector_catalog_materialize_projection"
   | "api_dispatch_connector_catalog_query_identity"
@@ -322,7 +324,7 @@ export class ApiDispatchTimingCollector {
     | ApiProcessDispatchOrdinalBucket
     | undefined;
 
-  private recordDuration(
+  recordDuration(
     actionType: ApiDispatchTimingActionType,
     spanKind: ApiDispatchTimingSpanKind,
     durationMs: number,

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -1,9 +1,16 @@
+import { performance } from "node:perf_hooks";
+
+import { now } from "../../lib/time";
 import type {
   ApiDispatchTimingActionType,
   ApiDispatchTimingCollector,
   ApiDispatchTimingDimensions,
 } from "./api-dispatch-timing.service";
-import type { ConnectorCatalogRuntimeProjectionFallbackReason } from "./connector-catalog-runtime-projection.service";
+import type {
+  ConnectorCatalogRuntimeProjectionFallbackReason,
+  ConnectorCatalogRuntimeProjectionValidationTiming,
+} from "./connector-catalog-runtime-projection.service";
+import { safeSync } from "../utils";
 
 type AcceptedConnectorCatalogCacheOutcome = "hit" | "miss" | "in_flight";
 type AcceptedConnectorCatalogCacheMissReason =
@@ -265,6 +272,65 @@ export class ConnectorCatalogLoadTiming {
     operation: () => T,
   ): T {
     return this.collector.measureSync(actionType, "nested", operation);
+  }
+
+  measureProjectionRowValidation<T>(
+    operation: (timing: ConnectorCatalogRuntimeProjectionValidationTiming) => T,
+  ): T {
+    let parseDurationMs = 0;
+    let digestDurationMs = 0;
+    const measurePhase = <T>(
+      phase: "parse" | "digest",
+      phaseOperation: () => T,
+    ): T => {
+      const startedAt = performance.now();
+      const result = safeSync(phaseOperation);
+      const durationMs = performance.now() - startedAt;
+      if (phase === "parse") {
+        parseDurationMs += durationMs;
+      } else {
+        digestDurationMs += durationMs;
+      }
+      if ("error" in result) {
+        throw result.error;
+      }
+      return result.ok;
+    };
+    const timing: ConnectorCatalogRuntimeProjectionValidationTiming = {
+      measureParse<T>(phaseOperation: () => T): T {
+        return measurePhase("parse", phaseOperation);
+      },
+      measureDigest<T>(phaseOperation: () => T): T {
+        return measurePhase("digest", phaseOperation);
+      },
+    };
+    return this.measureSync(
+      "api_dispatch_connector_catalog_validate_projection_rows",
+      () => {
+        const result = safeSync(() => {
+          return operation(timing);
+        });
+        // Validation short-circuits per requested connector. Accumulate its
+        // interleaved phases instead of reordering work or logging per row.
+        const finishedAt = now();
+        this.collector.recordDuration(
+          "api_dispatch_connector_catalog_parse_projection_rows",
+          "nested",
+          parseDurationMs,
+          finishedAt,
+        );
+        this.collector.recordDuration(
+          "api_dispatch_connector_catalog_verify_projection_row_digests",
+          "nested",
+          digestDurationMs,
+          finishedAt,
+        );
+        if ("error" in result) {
+          throw result.error;
+        }
+        return result.ok;
+      },
+    );
   }
 
   async measureComplete<T>(operation: () => T | Promise<T>): Promise<T> {

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
@@ -100,6 +100,11 @@ export type ConnectorCatalogRuntimeProjectionRowsRead =
       >;
     };
 
+export interface ConnectorCatalogRuntimeProjectionValidationTiming {
+  measureParse<T>(operation: () => T): T;
+  measureDigest<T>(operation: () => T): T;
+}
+
 interface ProjectionSchemaAvailabilityCache {
   available: boolean;
 }
@@ -431,6 +436,7 @@ export async function queryConnectorCatalogRuntimeProjectionRows(args: {
 export function validateConnectorCatalogRuntimeProjectionRows(args: {
   readonly rows: readonly ConnectorCatalogRuntimeProjectionRow[];
   readonly connectorSlugs: readonly ConnectorSlug[];
+  readonly timing: ConnectorCatalogRuntimeProjectionValidationTiming;
 }): ConnectorCatalogRuntimeProjectionRowsRead {
   const rowBySlug = new Map(
     args.rows.map((row) => {
@@ -445,19 +451,27 @@ export function validateConnectorCatalogRuntimeProjectionRows(args: {
       missingConnectorSlugs.push(connectorSlug);
       continue;
     }
-    const connector = connectorCatalogArtifactConnectorSchema.safeParse(
-      row.connector,
-    );
-    if (!connector.success || connector.data.slug !== row.connectorSlug) {
+    const connector = args.timing.measureParse(() => {
+      const parsed = connectorCatalogArtifactConnectorSchema.safeParse(
+        row.connector,
+      );
+      return parsed.success && parsed.data.slug === row.connectorSlug
+        ? parsed.data
+        : undefined;
+    });
+    if (connector === undefined) {
       return { kind: "fallback", reason: "malformed" };
     }
-    if (
-      connectorCatalogRuntimeProjectionDigest(connector.data) !==
-      row.connectorDigest
-    ) {
+    const digestMatches = args.timing.measureDigest(() => {
+      return (
+        connectorCatalogRuntimeProjectionDigest(connector) ===
+        row.connectorDigest
+      );
+    });
+    if (!digestMatches) {
       return { kind: "fallback", reason: "digest_mismatch" };
     }
-    connectors.push(connector.data);
+    connectors.push(connector);
   }
   return { kind: "ready", connectors, missingConnectorSlugs };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -923,15 +923,13 @@ async function readProjectedRuntimeRows(args: {
           });
         },
       );
-      return args.timing.measureSync(
-        "api_dispatch_connector_catalog_validate_projection_rows",
-        () => {
-          return validateConnectorCatalogRuntimeProjectionRows({
-            rows,
-            connectorSlugs,
-          });
-        },
-      );
+      return args.timing.measureProjectionRowValidation((timing) => {
+        return validateConnectorCatalogRuntimeProjectionRows({
+          rows,
+          connectorSlugs,
+          timing,
+        });
+      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- split projection-row validation into fixed parse/schema and canonical digest timing children
- accumulate interleaved per-row work so requested-order short-circuit and fallback precedence stay unchanged
- retain the existing complete validation action and cover one/two-attempt, cache-hit, empty, digest-fallback, and privacy behavior through the real run route

## Scope

- observability only; no database schema, projection representation, digest algorithm, validation policy, cache, fallback, public API, queue, Runner, frontend, credential, permission, routing, firewall, billing, or connector behavior change
- both child actions are emitted once per actual validation attempt, independent of connector count, with no new dimensions or private/high-cardinality values
- row indexing and control-flow overhead remain visible as residual time in the existing aggregate validation action

## Tests

- `pnpm exec prettier --check apps/api/src/signals/services/api-dispatch-timing.service.ts apps/api/src/signals/services/connector-catalog-load-timing.service.ts apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts apps/api/src/signals/services/connector-catalog-runtime.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (176 passed)
- `pnpm knip`
- `lefthook run pre-commit`
- `git diff --cached --check`

Closes #28661

Parent: #28275

Broader objective: #24203
