### PR TITLE
fix: polish uploaded presentation templates

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -128,6 +128,17 @@ export async function publishThreadListChangedSafely(
 }
 
 /**
+ * Notify the owner that a runner published a reusable presentation template.
+ * The catalog is server-owned, so every open client re-fetches it instead of
+ * trying to reconstruct the new entry from the notification payload.
+ */
+export async function publishPresentationTemplatesChangedSafely(
+  userId: string,
+): Promise<void> {
+  await publishUserSignal([userId], "presentationTemplatesChanged");
+}
+
+/**
  * Notify an open chat thread that server-owned detail fields changed without a
  * request from that client. The client re-fetches the authoritative detail.
  */

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-template-publish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-template-publish.test.ts
@@ -331,6 +331,10 @@ describe("presentation template publish", () => {
       pageCount: 2,
     });
     expect(published.body.coverUrl).not.toBeNull();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "presentationTemplatesChanged",
+      null,
+    );
 
     // The row is usable immediately: nothing is pending on a later transition.
     const listed = await accept(

--- a/turbo/apps/api/src/signals/routes/presentation-templates.ts
+++ b/turbo/apps/api/src/signals/routes/presentation-templates.ts
@@ -12,6 +12,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { db$, writeDb$ } from "../external/db";
+import { publishPresentationTemplatesChangedSafely } from "../external/realtime";
 import { generatePresignedGetUrl } from "../external/s3";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
@@ -127,6 +128,8 @@ const publishInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         ),
       )
     : null;
+  await publishPresentationTemplatesChangedSafely(auth.userId);
+  signal.throwIfAborted();
   return {
     status: 200 as const,
     body: presentationTemplateSummary(row, coverUrl, auth.userId),

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -598,8 +598,6 @@
       "categories": "Vorlagenkategorien",
       "category": "Vorlagenkategorie",
       "chooseVoice": "Stimme für {{title}} auswählen",
-      "deleteImportedTemplateDescription": "Dadurch wird die Vorlage für alle Personen entfernt, die darauf zugreifen können. Diese Aktion kann nicht rückgängig gemacht werden.",
-      "deleteImportedTemplateTitle": "{{title}} löschen?",
       "filters": {
         "age": "Alter",
         "all": "Alle",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -598,8 +598,6 @@
       "categories": "Template categories",
       "category": "Template category",
       "chooseVoice": "Choose a voice for {{title}}",
-      "deleteImportedTemplateDescription": "This removes the template for everyone who can access it. This action cannot be undone.",
-      "deleteImportedTemplateTitle": "Delete {{title}}?",
       "filters": {
         "age": "Age",
         "all": "All",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -615,8 +615,6 @@
       "categories": "Categorías de plantilla",
       "category": "Categoría de plantilla",
       "chooseVoice": "Elige una voz para {{title}}",
-      "deleteImportedTemplateDescription": "Esto elimina la plantilla para todas las personas que pueden acceder a ella. Esta acción no se puede deshacer.",
-      "deleteImportedTemplateTitle": "¿Eliminar {{title}}?",
       "filters": {
         "age": "Edad",
         "all": "Todos",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -615,8 +615,6 @@
       "categories": "Catégories de modèles",
       "category": "Catégorie de modèle",
       "chooseVoice": "Choisir une voix pour {{title}}",
-      "deleteImportedTemplateDescription": "Cela supprime le modèle pour toutes les personnes qui y ont accès. Cette action est irréversible.",
-      "deleteImportedTemplateTitle": "Supprimer {{title}} ?",
       "filters": {
         "age": "Âge",
         "all": "Tous",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -598,8 +598,6 @@
       "categories": "टेम्पलेट श्रेणियां",
       "category": "टेम्पलेट श्रेणी",
       "chooseVoice": "{{title}} के लिए आवाज़ चुनें",
-      "deleteImportedTemplateDescription": "यह टेम्पलेट उन सभी लोगों के लिए हटा दिया जाएगा जिनके पास इसकी पहुँच है। यह कार्रवाई पूर्ववत नहीं की जा सकती।",
-      "deleteImportedTemplateTitle": "{{title}} हटाएँ?",
       "filters": {
         "age": "आयु",
         "all": "सभी",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -598,8 +598,6 @@
       "categories": "Kategori template",
       "category": "Kategori template",
       "chooseVoice": "Pilih suara untuk {{title}}",
-      "deleteImportedTemplateDescription": "Tindakan ini menghapus templat untuk semua orang yang dapat mengaksesnya. Tindakan ini tidak dapat dibatalkan.",
-      "deleteImportedTemplateTitle": "Hapus {{title}}?",
       "filters": {
         "age": "Usia",
         "all": "Semua",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -615,8 +615,6 @@
       "categories": "Categorie di modelli",
       "category": "Categoria modello",
       "chooseVoice": "Scegli una voce per {{title}}",
-      "deleteImportedTemplateDescription": "Questa operazione rimuove il modello per chiunque possa accedervi e non può essere annullata.",
-      "deleteImportedTemplateTitle": "Eliminare {{title}}?",
       "filters": {
         "age": "Età",
         "all": "Tutti",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -598,8 +598,6 @@
       "categories": "テンプレートのカテゴリ",
       "category": "テンプレートカテゴリ",
       "chooseVoice": "{{title}}の音声を選択",
-      "deleteImportedTemplateDescription": "このテンプレートにアクセスできるすべてのユーザーから削除されます。この操作は元に戻せません。",
-      "deleteImportedTemplateTitle": "{{title}}を削除しますか？",
       "filters": {
         "age": "年齢",
         "all": "すべて",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -598,8 +598,6 @@
       "categories": "템플릿 카테고리",
       "category": "템플릿 카테고리",
       "chooseVoice": "{{title}}의 음성 선택",
-      "deleteImportedTemplateDescription": "이 템플릿에 액세스할 수 있는 모든 사용자에게서 템플릿이 제거됩니다. 이 작업은 실행 취소할 수 없습니다.",
-      "deleteImportedTemplateTitle": "{{title}}을(를) 삭제할까요?",
       "filters": {
         "age": "연령",
         "all": "전체",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -615,8 +615,6 @@
       "categories": "Categorias de modelo",
       "category": "Categoria de modelo",
       "chooseVoice": "Escolha uma voz para {{title}}",
-      "deleteImportedTemplateDescription": "Isso remove o modelo para todas as pessoas que têm acesso a ele. Esta ação não pode ser desfeita.",
-      "deleteImportedTemplateTitle": "Excluir {{title}}?",
       "filters": {
         "age": "Idade",
         "all": "Todos",

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -15,6 +15,7 @@ import { setupUserPreferenceRealtime$ } from "./external/user-model-preference.t
 import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
 import { setupRealtime$ } from "./realtime.ts";
 import { setupBillingRealtime$ } from "./zero-page/billing.ts";
+import { subscribePresentationTemplatesChanged$ } from "./zero-page/presentation-template-library.ts";
 import { subscribeCustomConnectorListChanged$ } from "./zero-page/settings/custom-connectors.ts";
 import { featureSwitch$ } from "./external/feature-switch.ts";
 import { selectSharedDatabaseMode$ } from "./shared-database-mode.ts";
@@ -51,6 +52,7 @@ export const setupAuthenticatedDaemons$ = command(
       set(subscribeEventDrivenChatThreads$, signal),
       set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),
+      set(subscribePresentationTemplatesChanged$, signal),
       set(setupUserPreferenceRealtime$, signal),
       sharedDatabaseEnabled
         ? set(prewarmSharedUnreadChatEvents$, signal)

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -505,7 +505,7 @@ export function createComposerSignals(
     feedback,
     quoteOnlyFeedbackEnabled$,
   );
-  const ui = createComposerUiSignals(eventSignals.latestCompletedRunEventId$);
+  const ui = createComposerUiSignals();
   const submission = createComposerSubmissionSignals(
     options,
     eventSignals,
@@ -637,16 +637,6 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     );
     return Promise.resolve(running && !lastAssistantCancelled);
   });
-  const latestCompletedRunEventId$ = computed((get): string | null => {
-    const events = get(chatEvents$);
-    for (let index = events.length - 1; index >= 0; index--) {
-      const event = events[index];
-      if (event?.eventType === "run.completed") {
-        return event.id;
-      }
-    }
-    return null;
-  });
   const actionsLoading$ = computed(async (get): Promise<boolean> => {
     await get(hasEvents$);
     return false;
@@ -682,7 +672,6 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     pendingEvents$,
     activeGoalObjective$,
     hasEvents$,
-    latestCompletedRunEventId$,
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -505,7 +505,7 @@ export function createComposerSignals(
     feedback,
     quoteOnlyFeedbackEnabled$,
   );
-  const ui = createComposerUiSignals();
+  const ui = createComposerUiSignals(eventSignals.latestCompletedRunEventId$);
   const submission = createComposerSubmissionSignals(
     options,
     eventSignals,
@@ -637,6 +637,16 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     );
     return Promise.resolve(running && !lastAssistantCancelled);
   });
+  const latestCompletedRunEventId$ = computed((get): string | null => {
+    const events = get(chatEvents$);
+    for (let index = events.length - 1; index >= 0; index--) {
+      const event = events[index];
+      if (event?.eventType === "run.completed") {
+        return event.id;
+      }
+    }
+    return null;
+  });
   const actionsLoading$ = computed(async (get): Promise<boolean> => {
     await get(hasEvents$);
     return false;
@@ -672,6 +682,7 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     pendingEvents$,
     activeGoalObjective$,
     hasEvents$,
+    latestCompletedRunEventId$,
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import {
   presentationTemplatesContract,
   type PresentationTemplateDetail,
@@ -23,34 +23,66 @@ const presentationTemplatesVersion$ = state(0);
  * `accept` would surface that as an error toast on a dialog the user opened to
  * browse built-in templates.
  */
-export const presentationTemplates$ = computed(
-  async (get): Promise<readonly PresentationTemplateSummary[]> => {
-    if (!get(presentationTemplateImportEnabled$)) {
-      return [];
-    }
-    get(presentationTemplatesVersion$);
-    const client = get(apiClient$)(presentationTemplatesContract);
-    const result = await accept(client.list(), [200]);
-    return result.body;
-  },
-);
-
 /**
- * Refetch the catalog after a mutation. Page-level consumers load and retain
- * the catalog before the picker opens so opening the dialog never swaps signed
- * cover URLs while they are visible.
+ * Refetch the catalog after a mutation or after the picker closes. Refreshing
+ * while the picker is hidden lets page-level consumers prewarm replacement
+ * signed cover URLs without swapping images in the visible dialog.
  */
-const refreshPresentationTemplates$ = command(({ get, set }) => {
+export const refreshPresentationTemplates$ = command(({ get, set }) => {
   set(presentationTemplatesVersion$, get(presentationTemplatesVersion$) + 1);
 });
+
+function createImportedPresentationTemplates$(
+  latestCompletedRunEventId$: Computed<string | null>,
+) {
+  return computed(
+    async (get): Promise<readonly PresentationTemplateSummary[]> => {
+      if (!get(presentationTemplateImportEnabled$)) {
+        return [];
+      }
+      // The analysis run publishes an imported deck outside this browser's
+      // mutation commands. A new successful terminal event therefore refreshes
+      // the catalog before the user opens the picker again.
+      get(latestCompletedRunEventId$);
+      get(presentationTemplatesVersion$);
+      const client = get(apiClient$)(presentationTemplatesContract);
+      const result = await accept(client.list(), [200]);
+      return result.body;
+    },
+  );
+}
 
 interface ImportedPresentationTemplateHover {
   readonly templateId: string;
   readonly index: number;
 }
 
+function createImportedPresentationTemplateHoverSignals() {
+  const internalCardHover$ = state<ImportedPresentationTemplateHover | null>(
+    null,
+  );
+  const importedPresentationTemplateCardHover$ = computed((get) => {
+    return get(internalCardHover$);
+  });
+  const setImportedPresentationTemplateCardHover$ = command(
+    ({ set }, hover: ImportedPresentationTemplateHover | null) => {
+      set(internalCardHover$, hover);
+    },
+  );
+  return {
+    internalCardHover$,
+    importedPresentationTemplateCardHover$,
+    setImportedPresentationTemplateCardHover$,
+  };
+}
+
 /** Dialog-scoped state and mutations for persisted uploaded templates. */
-export function createImportedPresentationTemplateSignals() {
+export function createImportedPresentationTemplateSignals(
+  latestCompletedRunEventId$: Computed<string | null>,
+) {
+  const importedPresentationTemplates$ = createImportedPresentationTemplates$(
+    latestCompletedRunEventId$,
+  );
   const internalRequestedTemplateId$ = state<string | null>(null);
   const internalDetailVersion$ = state(0);
   const importedPresentationTemplateRequestedId$ = computed((get) => {
@@ -102,17 +134,11 @@ export function createImportedPresentationTemplateSignals() {
     },
   );
 
-  const internalCardHover$ = state<ImportedPresentationTemplateHover | null>(
-    null,
-  );
-  const importedPresentationTemplateCardHover$ = computed((get) => {
-    return get(internalCardHover$);
-  });
-  const setImportedPresentationTemplateCardHover$ = command(
-    ({ set }, hover: ImportedPresentationTemplateHover | null) => {
-      set(internalCardHover$, hover);
-    },
-  );
+  const {
+    internalCardHover$,
+    importedPresentationTemplateCardHover$,
+    setImportedPresentationTemplateCardHover$,
+  } = createImportedPresentationTemplateHoverSignals();
 
   const updateImportedPresentationTemplate$ = command(
     async (
@@ -169,6 +195,7 @@ export function createImportedPresentationTemplateSignals() {
   });
 
   return {
+    importedPresentationTemplates$,
     importedPresentationTemplateRequestedId$,
     importedPresentationTemplateDetail$,
     requestImportedPresentationTemplateDetail$,

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
@@ -25,9 +25,9 @@ const presentationTemplatesVersion$ = state(0);
  * browse built-in templates.
  */
 /**
- * Refetch the catalog after a mutation or after the picker closes. Refreshing
- * while the picker is hidden lets page-level consumers prewarm replacement
- * signed cover URLs without swapping images in the visible dialog.
+ * Refetch the catalog after a mutation or as the picker opens. Page-level
+ * consumers load it while the picker is hidden, and `useLastResolved` keeps
+ * that prefetched result visible during this authoritative revalidation.
  */
 export const refreshPresentationTemplates$ = command(({ get, set }) => {
   set(presentationTemplatesVersion$, get(presentationTemplatesVersion$) + 1);
@@ -51,6 +51,7 @@ export const subscribePresentationTemplatesChanged$ = command(
       {
         topic: "presentationTemplatesChanged",
         loopCommand$: refreshPresentationTemplatesFromRealtime$,
+        options: { runOnSubscribe: true },
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
@@ -36,14 +36,11 @@ export const presentationTemplates$ = computed(
 );
 
 /**
- * Refetch the catalog.
- *
- * The picker calls this as it opens rather than reading a session-long cache,
- * because both facts it renders go stale on their own: an import finishes
- * minutes after the deck was handed over, in a thread the user navigates away
- * from, and every cover URL is a short-lived signed URL.
+ * Refetch the catalog after a mutation. Page-level consumers load and retain
+ * the catalog before the picker opens so opening the dialog never swaps signed
+ * cover URLs while they are visible.
  */
-export const refreshPresentationTemplates$ = command(({ get, set }) => {
+const refreshPresentationTemplates$ = command(({ get, set }) => {
   set(presentationTemplatesVersion$, get(presentationTemplatesVersion$) + 1);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-library.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import {
   presentationTemplatesContract,
   type PresentationTemplateDetail,
@@ -8,6 +8,7 @@ import {
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { presentationTemplateImportEnabled$ } from "./presentation-template-import.ts";
 
 export type { PresentationTemplateDetail, PresentationTemplateSummary };
@@ -32,18 +33,36 @@ export const refreshPresentationTemplates$ = command(({ get, set }) => {
   set(presentationTemplatesVersion$, get(presentationTemplatesVersion$) + 1);
 });
 
-function createImportedPresentationTemplates$(
-  latestCompletedRunEventId$: Computed<string | null>,
-) {
+const refreshPresentationTemplatesFromRealtime$ = command(({ set }) => {
+  set(refreshPresentationTemplates$);
+  return false;
+});
+
+/**
+ * A template is published by the analysis runner, outside any composer or
+ * browser mutation. Subscribe once at the authenticated workspace boundary so
+ * navigation cannot strand a newly published deck in the thread that started
+ * the analysis.
+ */
+export const subscribePresentationTemplatesChanged$ = command(
+  async ({ set }, signal: AbortSignal): Promise<void> => {
+    await set(
+      setAblyLoop$,
+      {
+        topic: "presentationTemplatesChanged",
+        loopCommand$: refreshPresentationTemplatesFromRealtime$,
+      },
+      signal,
+    );
+  },
+);
+
+function createImportedPresentationTemplates$() {
   return computed(
     async (get): Promise<readonly PresentationTemplateSummary[]> => {
       if (!get(presentationTemplateImportEnabled$)) {
         return [];
       }
-      // The analysis run publishes an imported deck outside this browser's
-      // mutation commands. A new successful terminal event therefore refreshes
-      // the catalog before the user opens the picker again.
-      get(latestCompletedRunEventId$);
       get(presentationTemplatesVersion$);
       const client = get(apiClient$)(presentationTemplatesContract);
       const result = await accept(client.list(), [200]);
@@ -77,12 +96,8 @@ function createImportedPresentationTemplateHoverSignals() {
 }
 
 /** Dialog-scoped state and mutations for persisted uploaded templates. */
-export function createImportedPresentationTemplateSignals(
-  latestCompletedRunEventId$: Computed<string | null>,
-) {
-  const importedPresentationTemplates$ = createImportedPresentationTemplates$(
-    latestCompletedRunEventId$,
-  );
+export function createImportedPresentationTemplateSignals() {
+  const importedPresentationTemplates$ = createImportedPresentationTemplates$();
   const internalRequestedTemplateId$ = state<string | null>(null);
   const internalDetailVersion$ = state(0);
   const importedPresentationTemplateRequestedId$ = computed((get) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -361,10 +361,10 @@ function createTemplatePickerDialogSignals() {
   const setTemplatePickerOpen$ = command(({ set }, open: boolean) => {
     set(internalTemplatePickerSkipEnterAnimation$, false);
     set(internalTemplatePickerOpen$, open);
-    if (!open) {
-      // Refresh only after the dialog disappears. The always-mounted composer
-      // consumer then prewarms the next signed covers without changing visible
-      // image URLs while the user is browsing.
+    if (open) {
+      // The always-mounted composer has already prefetched the catalog. This
+      // revalidates external mutations and expiring signed URLs while
+      // useLastResolved keeps that prefetched result on screen.
       set(refreshPresentationTemplates$);
     }
   });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import type { GenerationTemplateRequest } from "@okouai/api-contracts/contracts/chat-threads";
 import type { PresentationTemplateItem } from "@okouai/core/presentation-template-items";
 import { localStorageSignals } from "../external/local-storage.ts";
@@ -878,15 +878,13 @@ function createPresentationTemplateDetailNavigationSignals(
   };
 }
 
-export function createComposerUiSignals(
-  latestCompletedRunEventId$: Computed<string | null>,
-) {
+export function createComposerUiSignals() {
   const basic = createBasicComposerUiSignals();
   const list = createTemplatePickerListSignals();
   const cards = createTemplateCardSignals();
   const detail = createTemplateDetailStateSignals();
   const importedPresentationTemplates =
-    createImportedPresentationTemplateSignals(latestCompletedRunEventId$);
+    createImportedPresentationTemplateSignals();
   const resources = createTemplatePreviewResourceSignals(list, cards, detail);
   const applySelection$ =
     createApplyPresentationTemplateDetailSelectionSignal(detail);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -11,10 +11,7 @@ import {
 } from "../../views/zero-page/presentation-html-preview.ts";
 import { readableAttachmentResourceUrl } from "../../views/zero-page/zero-attachment-url.ts";
 import { createAvatarTemplatePickerSignals } from "./avatar-template-picker.ts";
-import {
-  createImportedPresentationTemplateSignals,
-  refreshPresentationTemplates$,
-} from "./presentation-template-library.ts";
+import { createImportedPresentationTemplateSignals } from "./presentation-template-library.ts";
 import type { VideoRunOptionsPatch } from "./video-run-options.ts";
 
 // ---------------------------------------------------------------------------
@@ -361,11 +358,6 @@ function createTemplatePickerDialogSignals() {
   const setTemplatePickerOpen$ = command(({ set }, open: boolean) => {
     set(internalTemplatePickerSkipEnterAnimation$, false);
     set(internalTemplatePickerOpen$, open);
-    if (open) {
-      // Opening is the moment the imported catalog has to be current: an import
-      // started here finishes later in another thread, and cover URLs expire.
-      set(refreshPresentationTemplates$);
-    }
   });
 
   const internalTemplatePickerReferenceValue$ =

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import type { GenerationTemplateRequest } from "@okouai/api-contracts/contracts/chat-threads";
 import type { PresentationTemplateItem } from "@okouai/core/presentation-template-items";
 import { localStorageSignals } from "../external/local-storage.ts";
@@ -11,7 +11,10 @@ import {
 } from "../../views/zero-page/presentation-html-preview.ts";
 import { readableAttachmentResourceUrl } from "../../views/zero-page/zero-attachment-url.ts";
 import { createAvatarTemplatePickerSignals } from "./avatar-template-picker.ts";
-import { createImportedPresentationTemplateSignals } from "./presentation-template-library.ts";
+import {
+  createImportedPresentationTemplateSignals,
+  refreshPresentationTemplates$,
+} from "./presentation-template-library.ts";
 import type { VideoRunOptionsPatch } from "./video-run-options.ts";
 
 // ---------------------------------------------------------------------------
@@ -358,6 +361,12 @@ function createTemplatePickerDialogSignals() {
   const setTemplatePickerOpen$ = command(({ set }, open: boolean) => {
     set(internalTemplatePickerSkipEnterAnimation$, false);
     set(internalTemplatePickerOpen$, open);
+    if (!open) {
+      // Refresh only after the dialog disappears. The always-mounted composer
+      // consumer then prewarms the next signed covers without changing visible
+      // image URLs while the user is browsing.
+      set(refreshPresentationTemplates$);
+    }
   });
 
   const internalTemplatePickerReferenceValue$ =
@@ -869,13 +878,15 @@ function createPresentationTemplateDetailNavigationSignals(
   };
 }
 
-export function createComposerUiSignals() {
+export function createComposerUiSignals(
+  latestCompletedRunEventId$: Computed<string | null>,
+) {
   const basic = createBasicComposerUiSignals();
   const list = createTemplatePickerListSignals();
   const cards = createTemplateCardSignals();
   const detail = createTemplateDetailStateSignals();
   const importedPresentationTemplates =
-    createImportedPresentationTemplateSignals();
+    createImportedPresentationTemplateSignals(latestCompletedRunEventId$);
   const resources = createTemplatePreviewResourceSignals(list, cards, detail);
   const applySelection$ =
     createApplyPresentationTemplateDetailSelectionSignal(detail);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -13,6 +13,7 @@ import type {
   GenerationTemplateRequest,
   UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import { presentationTemplatesContract } from "@okouai/api-contracts/contracts/presentation-templates";
 import {
   avatarVideoContract,
   type AvatarVideoAvatarsQuery,
@@ -3360,35 +3361,50 @@ describe("chat composer templates", () => {
   it("lists uploaded decks ahead of built-ins and uses one in the next message", async () => {
     const user = userEvent.setup({ delay: null });
     let submittedTemplate: GenerationTemplateRequest | undefined;
+    let listRequestCount = 0;
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
       onRunCreate(body) {
         submittedTemplate = sentInlineTemplate(body.userMessage);
       },
     });
-    setMockPresentationTemplates([
-      {
-        id: "8f5c9a1e-6f7d-4a2b-9c3e-0d1a2b3c4d5e",
-        title: "Brand system",
-        sourceFilename: "brand-system.pptx",
-        coverUrl: "https://example.com/imported-cover.png",
-        pageCount: 18,
-        visibility: "public",
-        canManage: false,
-        pageUrls: [
-          "https://example.com/imported-cover.png",
-          "https://example.com/imported-page-2.png",
-        ],
-        createdAt: "2026-08-21T02:41:59.522Z",
-        updatedAt: "2026-08-21T02:41:59.522Z",
-      },
-    ]);
+    const importedTemplate = {
+      id: "8f5c9a1e-6f7d-4a2b-9c3e-0d1a2b3c4d5e",
+      title: "Brand system",
+      sourceFilename: "brand-system.pptx",
+      coverUrl: "https://example.com/imported-cover.png",
+      pageCount: 18,
+      visibility: "public" as const,
+      canManage: false,
+      pageUrls: [
+        "https://example.com/imported-cover.png",
+        "https://example.com/imported-page-2.png",
+      ],
+      createdAt: "2026-08-21T02:41:59.522Z",
+      updatedAt: "2026-08-21T02:41:59.522Z",
+    };
+    setMockPresentationTemplates([importedTemplate]);
+    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      listRequestCount += 1;
+      const { pageUrls: _pageUrls, ...summary } = importedTemplate;
+      return respond(200, [summary]);
+    });
 
     detachedSetupPage({
       context,
       featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
       path: `/chats/${THREAD_ID}`,
     });
+
+    await waitFor(() => {
+      expect(listRequestCount).toBe(1);
+      expect(
+        document.querySelector(
+          'img[src="https://example.com/imported-cover.png"]',
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
     click(
       await waitFor(() => {
@@ -3411,6 +3427,8 @@ describe("chat composer templates", () => {
       "src",
       "https://example.com/imported-cover.png",
     );
+    expect(within(card).queryByText("1/18")).not.toBeInTheDocument();
+    expect(listRequestCount).toBe(1);
 
     // Grid order is the import tile, then this user's decks, then the
     // built-ins: a returning user looks for their own deck first.
@@ -3512,13 +3530,14 @@ describe("chat composer templates", () => {
       "https://example.com/imported-page-3.png",
     );
     expect(screen.queryByText("Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText(/brand-system\.pptx/)).not.toBeInTheDocument();
 
     const titleInput = screen.getByRole("textbox", {
       name: "Rename template",
     });
     await fill(titleInput, "Brand refresh");
     const renameButton = queryAllByRoleFast("button").find((candidate) => {
-      return candidate.textContent?.trim() === "Rename template";
+      return candidate.getAttribute("aria-label") === "Rename template";
     });
     if (!renameButton) {
       throw new Error("Imported template Rename button not found");
@@ -3545,13 +3564,7 @@ describe("chat composer templates", () => {
       throw new Error("Imported template Delete button not found");
     }
     await user.click(initialDeleteButton);
-    await expect(
-      screen.findByText("Delete Brand refresh?"),
-    ).resolves.toBeInTheDocument();
-    const deleteButtons = queryAllByRoleFast("button").filter((candidate) => {
-      return candidate.textContent?.trim() === "Delete";
-    });
-    await user.click(deleteButtons[deleteButtons.length - 1]!);
+    expect(screen.queryByText("Delete Brand refresh?")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(
         document.querySelector(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3448,6 +3448,71 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("revalidates a prefetched uploaded deck on its first picker open", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    const prefetchedCatalogLoaded = context.mocks.deferred<void>();
+    const revalidatedCatalogLoaded = context.mocks.deferred<void>();
+    const templateId = "7e4d2a91-40f8-4ea0-b685-e8653776f912";
+    const prefetchedTemplate = {
+      id: templateId,
+      title: "Draft deck",
+      sourceFilename: "brand-system.pptx",
+      coverUrl: "https://example.com/old-signed-cover.png",
+      pageCount: 6,
+      visibility: "public" as const,
+      canManage: false,
+      createdAt: "2026-08-23T03:00:00.000Z",
+      updatedAt: "2026-08-23T03:00:00.000Z",
+    };
+    const revalidatedTemplate = {
+      ...prefetchedTemplate,
+      title: "Current deck",
+      coverUrl: "https://example.com/current-signed-cover.png",
+      updatedAt: "2026-08-23T03:14:00.000Z",
+    };
+    let catalog = [prefetchedTemplate];
+    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      if (catalog[0]?.title === prefetchedTemplate.title) {
+        prefetchedCatalogLoaded.resolve();
+      } else {
+        revalidatedCatalogLoaded.resolve();
+      }
+      return respond(200, catalog);
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await prefetchedCatalogLoaded.promise;
+    catalog = [revalidatedTemplate];
+    await user.click(screen.getByLabelText("Template"));
+    await revalidatedCatalogLoaded.promise;
+
+    const dialog = screen.getByRole("dialog");
+    const card = await waitFor(() => {
+      const found = dialog.querySelector(
+        `[data-imported-presentation-template="${templateId}"]`,
+      );
+      if (!(found instanceof HTMLElement)) {
+        throw new Error("Revalidated template card not found");
+      }
+      return found;
+    });
+    expect(within(card).getByText("Current deck")).toBeInTheDocument();
+    expect(within(card).getByRole("img")).toHaveAttribute(
+      "src",
+      "https://example.com/current-signed-cover.png",
+    );
+    expect(within(dialog).queryByText("Draft deck")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Select template Current deck"));
+    await expectInlineTemplateInComposer("Current deck");
+  });
+
   it("makes a template published after navigating away usable in the other thread", async () => {
     const user = userEvent.setup({ delay: null });
     const analysisCatalogLoaded = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -37,6 +37,8 @@ import {
   context,
   AGENT_ID,
   THREAD_ID,
+  SUGGESTED_THREAD_ID,
+  linkByText,
   tabByText,
   presentationTemplateGridScrollContainer,
   mockActiveTemplateThread,
@@ -3446,9 +3448,11 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("makes a template published by a completed analysis run usable without reloading", async () => {
+  it("makes a template published after navigating away usable in the other thread", async () => {
     const user = userEvent.setup({ delay: null });
-    const initialCatalogLoaded = context.mocks.deferred<void>();
+    const analysisCatalogLoaded = context.mocks.deferred<void>();
+    const otherThreadCatalogLoaded = context.mocks.deferred<void>();
+    const publishedCatalogLoaded = context.mocks.deferred<void>();
     const publishedTemplate = {
       id: "9a6d0b2f-7a8e-4c3d-9f1a-2b3c4d5e6f70",
       title: "Fresh deck",
@@ -3461,15 +3465,37 @@ describe("chat composer templates", () => {
       updatedAt: "2026-08-23T03:00:00.000Z",
     };
     let catalog: (typeof publishedTemplate)[] = [];
-    let initialCatalogPending = true;
+    let viewingOtherThread = false;
     context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
-      if (initialCatalogPending) {
-        initialCatalogPending = false;
-        initialCatalogLoaded.resolve();
+      if (catalog.length > 0 && !publishedCatalogLoaded.settled()) {
+        publishedCatalogLoaded.resolve();
+      }
+      if (viewingOtherThread) {
+        if (!otherThreadCatalogLoaded.settled()) {
+          otherThreadCatalogLoaded.resolve();
+        }
+      } else if (!analysisCatalogLoaded.settled()) {
+        analysisCatalogLoaded.resolve();
       }
       return respond(200, catalog);
     });
     const lifecycle = mockChatLifecycle(context, { threadId: THREAD_ID });
+    lifecycle.setThreadList([
+      {
+        id: THREAD_ID,
+        title: "Template analysis",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-08-23T02:58:00.000Z",
+        updatedAt: "2026-08-23T03:00:00.000Z",
+      },
+      {
+        id: SUGGESTED_THREAD_ID,
+        title: "Other deck work",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-08-23T02:57:00.000Z",
+        updatedAt: "2026-08-23T02:59:00.000Z",
+      },
+    ]);
 
     detachedSetupPage({
       context,
@@ -3477,16 +3503,37 @@ describe("chat composer templates", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    await initialCatalogLoaded.promise;
+    await analysisCatalogLoaded.promise;
     await appendAndSend(user, "Analyze my uploaded deck");
     await waitFor(() => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
 
+    viewingOtherThread = true;
+    await user.click(linkByText("Other deck work"));
+    const otherThreadContainer = await waitFor(() => {
+      expect(document.title).toBe("Other deck work | VM0");
+      const container = document.querySelector(
+        `[data-chat-thread-container-id="${SUGGESTED_THREAD_ID}"]`,
+      );
+      if (!(container instanceof HTMLElement)) {
+        throw new Error("Other thread container not found");
+      }
+      return container;
+    });
+    await otherThreadCatalogLoaded.promise;
+
     catalog = [publishedTemplate];
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("presentationTemplatesChanged"),
+      ).toBeTruthy();
+    });
+    context.mocks.ably.trigger("presentationTemplatesChanged");
+    await publishedCatalogLoaded.promise;
     lifecycle.completeRun("Template published");
 
-    click(await screen.findByLabelText("Template"));
+    click(within(otherThreadContainer).getByLabelText("Template"));
     await expect(screen.findByText("Fresh deck")).resolves.toBeInTheDocument();
     await user.click(screen.getByLabelText("Select template Fresh deck"));
     await expectInlineTemplateInComposer("Fresh deck");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3361,7 +3361,6 @@ describe("chat composer templates", () => {
   it("lists uploaded decks ahead of built-ins and uses one in the next message", async () => {
     const user = userEvent.setup({ delay: null });
     let submittedTemplate: GenerationTemplateRequest | undefined;
-    let listRequestCount = 0;
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
       onRunCreate(body) {
@@ -3384,27 +3383,12 @@ describe("chat composer templates", () => {
       updatedAt: "2026-08-21T02:41:59.522Z",
     };
     setMockPresentationTemplates([importedTemplate]);
-    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
-      listRequestCount += 1;
-      const { pageUrls: _pageUrls, ...summary } = importedTemplate;
-      return respond(200, [summary]);
-    });
 
     detachedSetupPage({
       context,
       featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
       path: `/chats/${THREAD_ID}`,
     });
-
-    await waitFor(() => {
-      expect(listRequestCount).toBe(1);
-      expect(
-        document.querySelector(
-          'img[src="https://example.com/imported-cover.png"]',
-        ),
-      ).toBeInTheDocument();
-    });
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
     click(
       await waitFor(() => {
@@ -3427,8 +3411,6 @@ describe("chat composer templates", () => {
       "src",
       "https://example.com/imported-cover.png",
     );
-    expect(within(card).queryByText("1/18")).not.toBeInTheDocument();
-    expect(listRequestCount).toBe(1);
 
     // Grid order is the import tile, then this user's decks, then the
     // built-ins: a returning user looks for their own deck first.
@@ -3462,6 +3444,52 @@ describe("chat composer templates", () => {
         },
       });
     });
+  });
+
+  it("makes a template published by a completed analysis run usable without reloading", async () => {
+    const user = userEvent.setup({ delay: null });
+    const initialCatalogLoaded = context.mocks.deferred<void>();
+    const publishedTemplate = {
+      id: "9a6d0b2f-7a8e-4c3d-9f1a-2b3c4d5e6f70",
+      title: "Fresh deck",
+      sourceFilename: "fresh-deck.pptx",
+      coverUrl: "https://example.com/fresh-deck-cover.png",
+      pageCount: 12,
+      visibility: "private" as const,
+      canManage: true,
+      createdAt: "2026-08-23T03:00:00.000Z",
+      updatedAt: "2026-08-23T03:00:00.000Z",
+    };
+    let catalog: (typeof publishedTemplate)[] = [];
+    let initialCatalogPending = true;
+    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      if (initialCatalogPending) {
+        initialCatalogPending = false;
+        initialCatalogLoaded.resolve();
+      }
+      return respond(200, catalog);
+    });
+    const lifecycle = mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await initialCatalogLoaded.promise;
+    await appendAndSend(user, "Analyze my uploaded deck");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+
+    catalog = [publishedTemplate];
+    lifecycle.completeRun("Template published");
+
+    click(await screen.findByLabelText("Template"));
+    await expect(screen.findByText("Fresh deck")).resolves.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Select template Fresh deck"));
+    await expectInlineTemplateInComposer("Fresh deck");
   });
 
   it("scrubs every uploaded slide and manages an owned template from its detail view", async () => {
@@ -3529,9 +3557,6 @@ describe("chat composer templates", () => {
       "src",
       "https://example.com/imported-page-3.png",
     );
-    expect(screen.queryByText("Theme")).not.toBeInTheDocument();
-    expect(screen.queryByText(/brand-system\.pptx/)).not.toBeInTheDocument();
-
     const titleInput = screen.getByRole("textbox", {
       name: "Rename template",
     });
@@ -3564,7 +3589,6 @@ describe("chat composer templates", () => {
       throw new Error("Imported template Delete button not found");
     }
     await user.click(initialDeleteButton);
-    expect(screen.queryByText("Delete Brand refresh?")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(
         document.querySelector(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -23,10 +23,9 @@ import {
   presentationTemplateImportEnabled$,
   PRESENTATION_TEMPLATE_IMPORT_ACCEPT,
 } from "../../signals/zero-page/presentation-template-import.ts";
-import {
-  presentationTemplates$,
-  type PresentationTemplateDetail,
-  type PresentationTemplateSummary,
+import type {
+  PresentationTemplateDetail,
+  PresentationTemplateSummary,
 } from "../../signals/zero-page/presentation-template-library.ts";
 import { desktopProductDisplayName } from "../../i18n/desktop-product.ts";
 import { equalArrays } from "../../lib/equality.ts";
@@ -5709,7 +5708,8 @@ function PptTemplateGrid({
   const importEnabled = useGet(presentationTemplateImportEnabled$);
   // Import tile, then accessible uploaded decks (owned decks are sorted first),
   // then the built-in templates.
-  const importedTemplates = useLastResolved(presentationTemplates$) ?? [];
+  const importedTemplates =
+    useLastResolved(signals.template.importedPresentationTemplates$) ?? [];
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {importEnabled ? (
@@ -5842,7 +5842,8 @@ function TemplatePickerDialog({
     presentationItems.find((item) => {
       return item.slug === previewSlug;
     }) ?? null;
-  const importedTemplates = useLastResolved(presentationTemplates$) ?? [];
+  const importedTemplates =
+    useLastResolved(signals.template.importedPresentationTemplates$) ?? [];
   const importedPreviewSummary =
     importedTemplates.find((template) => {
       return template.id === importedPreviewId;
@@ -6602,7 +6603,8 @@ function ComposerTemplateAttachmentSync({
   );
   const readSelectedTemplate = useSet(signals.template.readSelectedTemplate$);
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
-  const importedTemplates = useLastResolved(presentationTemplates$) ?? [];
+  const importedTemplates =
+    useLastResolved(signals.template.importedPresentationTemplates$) ?? [];
   const attachment = selectedComposerTemplateAttachment(
     picker?.value,
     importedTemplates,
@@ -6712,7 +6714,8 @@ function TemplatePickerButton({
     signals.template.setTemplatePickerReferenceValue$,
   );
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
-  const importedTemplates = useLastResolved(presentationTemplates$) ?? [];
+  const importedTemplates =
+    useLastResolved(signals.template.importedPresentationTemplates$) ?? [];
   const selectedTitle = selectedTemplateTitle(picker.value, importedTemplates);
   const selectedCategory = resolveTemplatePickerCategory({
     category,
@@ -8129,7 +8132,8 @@ function useComposerTemplatePicker(
   const value = useGet(signals.template.generationTemplate$);
   const setValue = useSet(signals.template.setGenerationTemplate$);
   const insertTemplate = useSet(signals.template.insertTemplate$);
-  const importedTemplates = useLastResolved(presentationTemplates$) ?? [];
+  const importedTemplates =
+    useLastResolved(signals.template.importedPresentationTemplates$) ?? [];
   const notifyDraftChanged = useComposerDraftChange(signals);
   return (
     inlineComposerTemplatePicker({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4947,16 +4947,12 @@ function importedPresentationTemplateSlideIndex(
 function ImportedPptCardMediaControls({
   template,
   selected,
-  activeSlideIndex,
-  slideCount,
   loading,
   onPreview,
   onSelect,
 }: {
   template: PresentationTemplateSummary;
   selected: boolean;
-  activeSlideIndex: number;
-  slideCount: number;
   loading: boolean;
   onPreview: () => void;
   onSelect: () => void;
@@ -4981,9 +4977,6 @@ function ImportedPptCardMediaControls({
           <Check size={14} />
         </span>
       ) : null}
-      <span className="pointer-events-none absolute right-2 top-2 z-20 rounded-md border border-border bg-background/90 px-1.5 py-0.5 text-[10px] font-semibold text-foreground shadow-sm backdrop-blur">
-        {activeSlideIndex + 1}/{slideCount}
-      </span>
       <button
         type="button"
         aria-label={t(
@@ -5073,8 +5066,6 @@ function ImportedPptCardMedia({
       <ImportedPptCardMediaControls
         template={template}
         selected={selected}
-        activeSlideIndex={activeSlideIndex}
-        slideCount={slideCount}
         loading={loading}
         onPreview={onPreview}
         onSelect={onSelect}
@@ -5210,9 +5201,12 @@ function ImportedPresentationTemplateRenameControl({
   onRename: (title: string) => void;
 }) {
   const { t } = useTranslation();
+  const label = t(($) => {
+    return $.artifacts.templates.renameImportedTemplate;
+  });
   return (
     <form
-      className="space-y-2"
+      className="flex min-w-0 items-center gap-1.5"
       onSubmit={(event) => {
         event.preventDefault();
         const nextTitle = new FormData(event.currentTarget).get("title");
@@ -5221,30 +5215,32 @@ function ImportedPresentationTemplateRenameControl({
         }
       }}
     >
-      <label className="text-xs font-medium text-muted-foreground">
-        {t(($) => {
-          return $.artifacts.templates.renameImportedTemplate;
-        })}
-        <Input
-          key={title}
-          name="title"
-          defaultValue={title}
-          required
-          maxLength={255}
-          className="mt-2"
-        />
-      </label>
-      <Button
-        type="submit"
-        variant="outline"
-        size="sm"
-        disabled={updating}
-        className="w-full"
-      >
-        {t(($) => {
-          return $.artifacts.templates.renameImportedTemplate;
-        })}
-      </Button>
+      <Input
+        key={title}
+        name="title"
+        aria-label={label}
+        defaultValue={title}
+        required
+        maxLength={255}
+        className="h-10 min-w-0 flex-1 border-transparent bg-transparent px-1 text-xl font-semibold hover:border-[hsl(var(--gray-400))]"
+      />
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="submit"
+              variant="quiet"
+              size="icon-sm"
+              disabled={updating}
+              aria-label={label}
+              className="shrink-0"
+            >
+              {updating ? <Loader2 className="animate-spin" /> : <Check />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </form>
   );
 }
@@ -5260,7 +5256,7 @@ function ImportedPresentationTemplateVisibilityControl({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="mt-4 space-y-2">
+    <div className="space-y-2">
       <p className="text-xs font-medium text-muted-foreground">
         {t(($) => {
           return $.workflows.detail.metadata.visibility;
@@ -5299,48 +5295,6 @@ function ImportedPresentationTemplateVisibilityControl({
   );
 }
 
-function ImportedPresentationTemplateOwnerEditControls({
-  summary,
-  title,
-  visibility,
-  signals,
-}: {
-  summary: PresentationTemplateSummary;
-  title: string;
-  visibility: PresentationTemplateSummary["visibility"];
-  signals: ComposerSignals;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const [updateLoadable, updateTemplate] = useLoadableSet(
-    signals.template.updateImportedPresentationTemplate$,
-  );
-  const updating = updateLoadable.state === "loading";
-  const update = (
-    body: { title: string } | { visibility: "private" | "public" },
-  ) => {
-    detach(updateTemplate(summary.id, body, pageSignal), Reason.DomCallback);
-  };
-  return (
-    <>
-      <div className="my-5 border-t border-border" />
-      <ImportedPresentationTemplateRenameControl
-        title={title}
-        updating={updating}
-        onRename={(nextTitle) => {
-          update({ title: nextTitle });
-        }}
-      />
-      <ImportedPresentationTemplateVisibilityControl
-        visibility={visibility}
-        updating={updating}
-        onChange={(nextVisibility) => {
-          update({ visibility: nextVisibility });
-        }}
-      />
-    </>
-  );
-}
-
 function ImportedPresentationTemplateUseButton({
   template,
   onSelect,
@@ -5372,11 +5326,9 @@ function ImportedPresentationTemplateUseButton({
 
 function ImportedPresentationTemplateDeleteControl({
   summary,
-  title,
   signals,
 }: {
   summary: PresentationTemplateSummary;
-  title: string;
   signals: ComposerSignals;
 }) {
   const { t } = useTranslation();
@@ -5386,63 +5338,21 @@ function ImportedPresentationTemplateDeleteControl({
   );
   const deleting = deleteLoadable.state === "loading";
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="quiet"
-          size="sm"
-          disabled={deleting}
-          className="mt-2 w-full text-destructive hover:text-destructive"
-        >
-          {t(($) => {
-            return $.chat.actions.delete;
-          })}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-72 space-y-3 p-4">
-        <div>
-          <p className="font-medium text-foreground">
-            {t(
-              ($) => {
-                return $.artifacts.templates.deleteImportedTemplateTitle;
-              },
-              { title },
-            )}
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {t(($) => {
-              return $.artifacts.templates.deleteImportedTemplateDescription;
-            })}
-          </p>
-        </div>
-        <div className="flex justify-end gap-2">
-          <PopoverClose asChild>
-            <Button type="button" variant="outline" size="sm">
-              {t(($) => {
-                return $.chat.actions.cancel;
-              })}
-            </Button>
-          </PopoverClose>
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            disabled={deleting}
-            onClick={() => {
-              detach(
-                deleteTemplate(summary.id, pageSignal),
-                Reason.DomCallback,
-              );
-            }}
-          >
-            {t(($) => {
-              return $.chat.actions.delete;
-            })}
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <Button
+      type="button"
+      variant="quiet"
+      size="sm"
+      disabled={deleting}
+      className="mt-2 w-full text-destructive hover:text-destructive"
+      onClick={() => {
+        detach(deleteTemplate(summary.id, pageSignal), Reason.DomCallback);
+      }}
+    >
+      {deleting ? <Loader2 className="animate-spin" /> : null}
+      {t(($) => {
+        return $.chat.actions.delete;
+      })}
+    </Button>
   );
 }
 
@@ -5450,7 +5360,6 @@ function ImportedPresentationTemplateSidebar({
   summary,
   detail,
   title,
-  sourceFilename,
   slideCount,
   onSelect,
   signals,
@@ -5458,22 +5367,37 @@ function ImportedPresentationTemplateSidebar({
   summary: PresentationTemplateSummary;
   detail: PresentationTemplateDetail | null;
   title: string;
-  sourceFilename: string;
   slideCount: number;
   onSelect: (template: PresentationTemplateSummary) => void;
   signals: ComposerSignals;
 }) {
   const { t } = useTranslation();
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateTemplate] = useLoadableSet(
+    signals.template.updateImportedPresentationTemplate$,
+  );
   const activeTemplate = detail === null ? summary : detail;
+  const updating = updateLoadable.state === "loading";
+  const update = (
+    body: { title: string } | { visibility: "private" | "public" },
+  ) => {
+    detach(updateTemplate(summary.id, body, pageSignal), Reason.DomCallback);
+  };
   return (
     <div className="flex flex-col lg:sticky lg:top-0">
       <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
-        <h3 className="text-xl font-semibold text-foreground">{title}</h3>
-        <p
-          className="mt-1 truncate text-xs text-muted-foreground"
-          title={sourceFilename}
-        >
-          {sourceFilename} ·{" "}
+        {activeTemplate.canManage ? (
+          <ImportedPresentationTemplateRenameControl
+            title={title}
+            updating={updating}
+            onRename={(nextTitle) => {
+              update({ title: nextTitle });
+            }}
+          />
+        ) : (
+          <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+        )}
+        <p className="mt-1 text-xs text-muted-foreground">
           {t(
             ($) => {
               return $.artifacts.templates.importedSlides;
@@ -5482,12 +5406,16 @@ function ImportedPresentationTemplateSidebar({
           )}
         </p>
         {activeTemplate.canManage ? (
-          <ImportedPresentationTemplateOwnerEditControls
-            summary={summary}
-            title={title}
-            visibility={activeTemplate.visibility}
-            signals={signals}
-          />
+          <>
+            <div className="my-5 border-t border-border" />
+            <ImportedPresentationTemplateVisibilityControl
+              visibility={activeTemplate.visibility}
+              updating={updating}
+              onChange={(nextVisibility) => {
+                update({ visibility: nextVisibility });
+              }}
+            />
+          </>
         ) : null}
         <ImportedPresentationTemplateUseButton
           template={activeTemplate}
@@ -5496,7 +5424,6 @@ function ImportedPresentationTemplateSidebar({
         {activeTemplate.canManage ? (
           <ImportedPresentationTemplateDeleteControl
             summary={summary}
-            title={title}
             signals={signals}
           />
         ) : null}
@@ -5692,7 +5619,6 @@ function ImportedPresentationTemplatePreviewPage({
       : null;
   const activeTemplate = detail === null ? summary : detail;
   const title = activeTemplate.title;
-  const sourceFilename = activeTemplate.sourceFilename;
   const pageUrls =
     detail === null
       ? summary.coverUrl === null
@@ -5750,7 +5676,6 @@ function ImportedPresentationTemplatePreviewPage({
           summary={summary}
           detail={detail}
           title={title}
-          sourceFilename={sourceFilename}
           slideCount={slideCount}
           onSelect={onSelect}
           signals={signals}
@@ -6682,6 +6607,11 @@ function ComposerTemplateAttachmentSync({
     picker?.value,
     importedTemplates,
   );
+  const importedTemplateCoverUrls = uniqueTemplatePreviewImageUrls(
+    importedTemplates.flatMap((template) => {
+      return template.coverUrl === null ? [] : [template.coverUrl];
+    }),
+  ).slice(0, TEMPLATE_PREWARM_IMAGE_COUNT);
   const openPicker = (category: string) => {
     prewarmTemplatePreviewImages(
       runtime,
@@ -6702,25 +6632,46 @@ function ComposerTemplateAttachmentSync({
   };
 
   return (
-    <button
-      key={composerTemplateAttachmentLifecycleKey(attachment)}
-      ref={setLifecycleRef}
-      type="button"
-      hidden
-      data-template-type={attachment?.type}
-      data-template-title={attachment?.title}
-      data-template-category={attachment?.category}
-      data-template-preview-url={attachment?.previewImageUrl}
-      onClick={(event) => {
-        const action = event.currentTarget.dataset.templateAction;
-        if (action === "open") {
-          openPicker(event.currentTarget.dataset.templateCategory ?? "slides");
-        } else if (action === "remove") {
-          picker?.onChange(undefined);
-          onDraftChange?.();
-        }
-      }}
-    />
+    <>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute size-px overflow-hidden opacity-0"
+      >
+        {importedTemplateCoverUrls.map((coverUrl) => {
+          return (
+            <img
+              key={coverUrl}
+              alt=""
+              src={coverUrl}
+              loading="eager"
+              decoding="async"
+              fetchPriority="low"
+            />
+          );
+        })}
+      </span>
+      <button
+        key={composerTemplateAttachmentLifecycleKey(attachment)}
+        ref={setLifecycleRef}
+        type="button"
+        hidden
+        data-template-type={attachment?.type}
+        data-template-title={attachment?.title}
+        data-template-category={attachment?.category}
+        data-template-preview-url={attachment?.previewImageUrl}
+        onClick={(event) => {
+          const action = event.currentTarget.dataset.templateAction;
+          if (action === "open") {
+            openPicker(
+              event.currentTarget.dataset.templateCategory ?? "slides",
+            );
+          } else if (action === "remove") {
+            picker?.onChange(undefined);
+            onDraftChange?.();
+          }
+        }}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- remove the slide counter badge from uploaded presentation template cards
- simplify the uploaded-template detail sidebar by hiding the source filename and making the title directly editable
- preload the uploaded-template catalog and cover images before the picker opens, using low-priority image requests without blocking other composer flows
- delete owned uploaded templates immediately without a confirmation popover

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace apps/platform`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx -t 'lists uploaded decks|scrubs every uploaded slide' --maxWorkers=1`
- `pnpm exec prettier --check <changed files>`
