### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -3703,9 +3703,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",


### PR DESCRIPTION
## Summary

- update `crc32fast` from 1.5.0 to 1.5.1
- update `log` from 0.4.33 to 0.4.34
- update `uuid` from 1.24.1 to 1.25.0
- keep Cargo manifests unchanged; no manual dependency constraints were adjusted

## Blocked dependencies

- `generic-array` remains at 0.14.7 (0.14.9 available) because `crypto-common` 0.1.7 requires exactly 0.14.7 through the active `runner` dependency graph (`digest` -> `crc-fast` -> `aws-smithy-checksums` -> `aws-sdk-s3`)

## Validation

- `cargo test --workspace --exclude runner --no-fail-fast` passed, including doctests
- `cargo check -p runner` passed
- `cargo test -p runner --no-fail-fast` is blocked on current `main` by an unrelated test-only `-D warnings` failure: unused import `AsyncReadExt` in `runner/src/network_logs.rs:716`
- final `cargo update --verbose` reported zero additional updates on the latest `main`
