### PR TITLE
refactor(api): remove source-less connector credential fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -733,6 +733,22 @@ function customConnectorRuntimeRegistration(
   return registration;
 }
 
+function builtinConnectorRuntimeRegistration(
+  context: ExecutionContext,
+  connectorSlug: string,
+): Extract<
+  ExecutionContext["connectorRuntimeTargets"][number],
+  { readonly kind: "builtin" }
+> {
+  const registration = context.connectorRuntimeTargets.find((target) => {
+    return target.kind === "builtin" && target.connectorSlug === connectorSlug;
+  });
+  if (!registration || registration.kind !== "builtin") {
+    throw new Error("Expected a built-in connector runtime registration");
+  }
+  return registration;
+}
+
 function availableCustomConnectorRuntime(
   result: ConnectorRuntimeSyncResult | undefined,
 ): AvailableCustomConnectorRuntime {
@@ -8385,6 +8401,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         encryptedSecrets: claim.encryptedSecrets,
         authHeaders: { Authorization: `Bearer \${{ secrets.X_TOKEN }}` },
         secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
       },
       [200],
     );
@@ -8915,6 +8933,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
           "X-Figma-Token": figmaTokenTemplate,
         },
         secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
       },
       [200],
     );
@@ -8924,6 +8944,22 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(resolved.body.headers).toStrictEqual({
       "X-Figma-Token": "figd_bdd",
     });
+
+    const missingSource = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          "X-Figma-Token": figmaTokenTemplate,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+      },
+      [424],
+    );
+    if (missingSource.status !== 424) {
+      throw new Error("Expected a missing built-in connector source");
+    }
+    expect(missingSource.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -9001,12 +9037,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "available",
     });
-    const [sourceLessRuntime] = await api.syncConnectorRuntime(run.runId, {
+    const [missingSourceRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ kind: "builtin", connectorSlug: "lark" }],
     });
-    expect(sourceLessRuntime).toMatchObject({
+    expect(missingSourceRuntime).toStrictEqual({
       target: { kind: "builtin", connectorSlug: "lark" },
-      state: "available",
+      state: "unresolved",
+      reason: "connector-unavailable",
     });
     const [missingExactRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ ...larkTarget, sourceId: wrongTargetConnection.id }],
@@ -9030,15 +9067,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         account: { intent: "add", displayName: "Sibling" },
       },
     );
-    const [ambiguousSourceLessRuntime] = await api.syncConnectorRuntime(
-      run.runId,
-      { targets: [{ kind: "builtin", connectorSlug: "lark" }] },
-    );
-    expect(ambiguousSourceLessRuntime).toStrictEqual({
-      target: { kind: "builtin", connectorSlug: "lark" },
-      state: "unresolved",
-      reason: "connector-unavailable",
-    });
     const [exactRuntimeWithSibling] = await api.syncConnectorRuntime(
       run.runId,
       { targets: [larkTarget] },
@@ -9773,6 +9801,38 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expiresAt: null,
     });
 
+    const [missingSourceRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [
+        {
+          kind: "custom",
+          customConnectorId: custom.id,
+          baseUrlVars: target.baseUrlVars,
+        },
+      ],
+    });
+    expect(missingSourceRuntime).toStrictEqual({
+      target: targetIdentity,
+      state: "absent",
+      reason: "connector-unavailable",
+    });
+    const missingSourceAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        ...currentAuthBody,
+        matchedFirewall: {
+          name: currentAuthBody.matchedFirewall.name,
+          apiId: currentAuthBody.matchedFirewall.apiId,
+          customConnectorId: currentAuthBody.matchedFirewall.customConnectorId,
+          routingVariables: currentAuthBody.matchedFirewall.routingVariables,
+        },
+      },
+      [424],
+    );
+    if (missingSourceAuth.status !== 424) {
+      throw new Error("Expected a missing custom connector source");
+    }
+    expect(missingSourceAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+
     const [missingExactRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ ...target, sourceId: wrongTargetConnection.id }],
     });
@@ -10299,9 +10359,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         },
       ],
     });
-    expect(
-      availableCustomConnectorRuntime(legacySourceResult).firewall,
-    ).toStrictEqual(initialRuntime.firewall);
+    expect(legacySourceResult).toStrictEqual({
+      target: { kind: "custom", customConnectorId: mcp.id },
+      state: "absent",
+      reason: "connector-unavailable",
+    });
     const [missingExactResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ ...target, sourceId: randomUUID() }],
     });
@@ -10391,8 +10453,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       {
         targets: [
           {
-            kind: "custom",
-            customConnectorId: mcp.id,
+            ...target,
             baseUrlVars: { unexpected: "value" },
           },
         ],
@@ -10648,14 +10709,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
+    const runtimeTarget = customConnectorRuntimeRegistration(
+      claim,
+      runtimeConnector.id,
+    );
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [
-        {
-          kind: "custom",
-          customConnectorId: runtimeConnector.id,
-          baseUrlVars: {},
-        },
-      ],
+      targets: [runtimeTarget],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { body: authBody } = customConnectorRuntimeAuthBody(
@@ -11666,14 +11725,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       base: "https://mcp-oauth.example.test/oauth/mcp",
       permissions: [],
     });
+    const runtimeTarget = customConnectorRuntimeRegistration(claim, mcp.id);
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [
-        {
-          kind: "custom",
-          customConnectorId: mcp.id,
-          baseUrlVars: {},
-        },
-      ],
+      targets: [runtimeTarget],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { body: authBody } = customConnectorRuntimeAuthBody(
@@ -11789,21 +11843,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       throw new Error("Expected the proposed custom connector firewall API");
     }
     expect(customApi.base).toBe(`https://xn--mnich-kva.${rand}.test/v1/`);
-    const pinnedTarget = claim.connectorRuntimeTargets.find((target) => {
-      return (
-        target.kind === "custom" &&
-        target.customConnectorId === saved.connector.id
-      );
-    });
+    const pinnedTarget = customConnectorRuntimeRegistration(
+      claim,
+      saved.connector.id,
+    );
     expect(pinnedTarget).toStrictEqual({
       kind: "custom",
       customConnectorId: saved.connector.id,
       baseUrlVars: { subdomain: "münich" },
       sourceId: expect.any(String),
     });
-    if (!pinnedTarget) {
-      throw new Error("Expected the proposed custom connector runtime target");
-    }
     expect(customApi.auth?.headers?.Authorization).toBe(
       `Bearer \${{ secrets.${secretKey} }}`,
     );
@@ -11864,6 +11913,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         name: internalName,
         apiId: `${internalName}:0`,
         customConnectorId: saved.connector.id,
+        sourceId: pinnedTarget.sourceId,
         routingVariables: { subdomain: "münich" },
       },
     };
@@ -13103,6 +13153,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       action: "deny",
     });
     const snapshotClaim = await api.claimRunnerJob(snapshotRun.runId);
+    const snapshotSlackTarget = builtinConnectorRuntimeRegistration(
+      snapshotClaim,
+      "slack",
+    );
     expect(snapshotClaim.networkPolicies?.slack?.deny).toContain("chat:write");
     expect(snapshotClaim.networkPolicies?.slack?.allow).not.toContain(
       "chat:write",
@@ -13115,7 +13169,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       {
         targets: [
           { kind: "builtin", connectorSlug: "missing-builtin" },
-          { kind: "builtin", connectorSlug: "slack" },
+          snapshotSlackTarget,
         ],
       },
       [200],
@@ -13160,7 +13214,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const [refreshedRuntime] = await api.syncConnectorRuntime(
       snapshotRun.runId,
-      { targets: [{ kind: "builtin", connectorSlug: "slack" }] },
+      { targets: [snapshotSlackTarget] },
     );
     if (refreshedRuntime?.state !== "available") {
       throw new Error("Expected refreshed connector runtime to be available");
@@ -13523,6 +13577,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       modelProvider: "anthropic-api-key",
     });
     const claim = await api.claimRunnerJob(parent.runId);
+    const slackTarget = builtinConnectorRuntimeRegistration(claim, "slack");
     const claimedPolicy = claim.networkPolicies?.slack;
     if (!claimedPolicy) {
       throw new Error("Expected shared-version Slack policy");
@@ -13561,7 +13616,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
 
     const [refreshed] = await api.syncConnectorRuntime(parent.runId, {
-      targets: [{ kind: "builtin", connectorSlug: "slack" }],
+      targets: [slackTarget],
     });
     if (refreshed?.state !== "available") {
       throw new Error("Expected refreshed connector runtime to be available");

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -5,6 +5,7 @@ import { delay } from "signal-timers";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 
 import { mockOptionalEnv } from "../../../lib/env";
 import {
@@ -90,6 +91,48 @@ async function firewallRun(): Promise<{
     actor,
     runId: run.runId,
     headers: fw.sandboxHeaders(actor, run.runId),
+  };
+}
+
+async function exactSecretConnectorSources(
+  actor: ApiTestUser,
+  sources: Readonly<Record<string, ConnectorSlug>>,
+  platformSecretNames: readonly string[] = [],
+): Promise<{
+  readonly secretConnectorMap: Readonly<Record<string, ConnectorSlug>>;
+  readonly secretConnectorMetadataMap: Readonly<
+    Record<
+      string,
+      | { readonly sourceType: "connector"; readonly sourceId: string }
+      | { readonly sourceType: "platform-secret" }
+    >
+  >;
+}> {
+  const connectors = createConnectorBddApi(context);
+  const entries = await Promise.all(
+    Object.entries(sources).map(async ([secretName, connectorSlug]) => {
+      const metadata = !platformSecretNames.includes(secretName)
+        ? {
+            sourceType: "connector" as const,
+            sourceId: (
+              await connectors.readConnectorBySlug(actor, connectorSlug)
+            ).id,
+          }
+        : { sourceType: "platform-secret" as const };
+      return [secretName, { connectorSlug, metadata }] as const;
+    }),
+  );
+  return {
+    secretConnectorMap: Object.fromEntries(
+      entries.map(([secretName, source]) => {
+        return [secretName, source.connectorSlug];
+      }),
+    ),
+    secretConnectorMetadataMap: Object.fromEntries(
+      entries.map(([secretName, source]) => {
+        return [secretName, source.metadata];
+      }),
+    ),
   };
 }
 
@@ -273,11 +316,16 @@ describe("FW-2: template resolution without connector refresh", () => {
     const fw = createFirewallApi(context);
     const connectorsApi = createConnectorBddApi(context);
     const { actor, headers } = await firewallRun();
-    await connectorsApi.connectManualGrant(actor, "jira", "api-token", {
-      apiToken: "current-jira-token",
-      domain: "current.atlassian.net",
-      email: "current@example.test",
-    });
+    const jiraConnection = await connectorsApi.connectManualGrant(
+      actor,
+      "jira",
+      "api-token",
+      {
+        apiToken: "current-jira-token",
+        domain: "current.atlassian.net",
+        email: "current@example.test",
+      },
+    );
     const body = {
       encryptedSecrets: fw.encryptedSecretsBody({}),
       authHeaders: {
@@ -292,6 +340,7 @@ describe("FW-2: template resolution without connector refresh", () => {
         name: "jira",
         apiId: "jira:0",
         connectorSlug: "jira" as const,
+        sourceId: jiraConnection.id,
         routingVariables: {
           JIRA_DOMAIN: "run-start.atlassian.net",
         },
@@ -474,7 +523,9 @@ describe("FW-3: billable firewall lease", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
         firewallBillable: true,
       },
       [402],
@@ -536,7 +587,9 @@ describe("FW-3: billable firewall lease", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
       firewallBillable: true,
     };
     const leaseBefore = Math.floor(now() / 1000);
@@ -741,7 +794,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
       },
       [424],
     );
@@ -776,7 +831,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
       },
       [200],
     );
@@ -814,7 +871,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
         forceRefresh: true,
       },
       [200],
@@ -844,7 +903,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
       },
       [200],
     );
@@ -885,6 +946,11 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
 
     await connectAws();
     const decryptGate = gateFirstStoredSecretDecrypt();
+    const awsSecretSources = await exactSecretConnectorSources(actor, {
+      AWS_ACCESS_KEY_ID: "aws",
+      AWS_SECRET_ACCESS_KEY: "aws",
+      AWS_SESSION_TOKEN: "aws",
+    });
     const pendingAuth = fw.requestFirewallAuth(
       headers,
       {
@@ -894,11 +960,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
           "X-AWS-Secret-Access-Key": secretTemplate("AWS_SECRET_ACCESS_KEY"),
           "X-AWS-Session-Token": secretTemplate("AWS_SESSION_TOKEN"),
         },
-        secretConnectorMap: {
-          AWS_ACCESS_KEY_ID: "aws",
-          AWS_SECRET_ACCESS_KEY: "aws",
-          AWS_SESSION_TOKEN: "aws",
-        },
+        ...awsSecretSources,
       },
       [200],
     );
@@ -944,7 +1006,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1017,7 +1081,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1084,7 +1150,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     context.mocks.axiomLogging.warn.mockClear();
@@ -1143,7 +1211,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1190,7 +1260,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1235,7 +1307,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_TOKEN: "test-oauth",
+        })),
       },
       [502],
     );
@@ -1263,7 +1337,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1323,7 +1399,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const timedOut = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1372,7 +1450,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const failed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1419,7 +1499,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("LARK_TOKEN")}`,
       },
-      secretConnectorMap: { LARK_TOKEN: "lark" },
+      ...(await exactSecretConnectorSources(actor, {
+        LARK_TOKEN: "lark",
+      })),
     };
 
     const malformed = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1473,7 +1555,9 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_TOKEN: "test-oauth",
+      })),
     };
 
     const refreshed = await fw.requestFirewallAuth(headers, body, [200]);
@@ -1517,7 +1601,9 @@ describe("FW-6: manual-grant api-token refresh without a provider client", () =>
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_API_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_API_TOKEN: "test-oauth" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_API_TOKEN: "test-oauth",
+        })),
       },
       [200],
     );
@@ -1553,7 +1639,9 @@ describe("FW-7: client-unconfigured and mixed-reason refresh failures", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
         },
-        secretConnectorMap: { NOTION_TOKEN: "notion" },
+        ...(await exactSecretConnectorSources(actor, {
+          NOTION_TOKEN: "notion",
+        })),
       },
       [502],
     );
@@ -1597,10 +1685,10 @@ describe("FW-7: client-unconfigured and mixed-reason refresh failures", () => {
           Authorization: `Bearer ${secretTemplate("NOTION_TOKEN")}`,
           "X-Test": `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
         },
-        secretConnectorMap: {
+        ...(await exactSecretConnectorSources(actor, {
           NOTION_TOKEN: "notion",
           TEST_OAUTH_TOKEN: "test-oauth",
-        },
+        })),
       },
       [502],
     );
@@ -1631,7 +1719,9 @@ describe("FW-8: static access tokens and unavailable sources", () => {
       authHeaders: {
         Authorization: `Bearer ${secretTemplate("TEST_OAUTH_DEVICE_TOKEN")}`,
       },
-      secretConnectorMap: { TEST_OAUTH_DEVICE_TOKEN: "test-oauth-device" },
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_DEVICE_TOKEN: "test-oauth-device",
+      })),
     };
 
     const expired = await fw.requestFirewallAuth(headers, body, [502]);
@@ -1671,7 +1761,9 @@ describe("FW-8: static access tokens and unavailable sources", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("TEST_OAUTH_DEVICE_TOKEN")}`,
         },
-        secretConnectorMap: { TEST_OAUTH_DEVICE_TOKEN: "test-oauth-device" },
+        ...(await exactSecretConnectorSources(actor, {
+          TEST_OAUTH_DEVICE_TOKEN: "test-oauth-device",
+        })),
       },
       [200],
     );
@@ -2221,15 +2313,14 @@ describe("FW-10: platform connector secrets", () => {
           Authorization: `Bearer ${secretTemplate("GOOGLE_ADS_TOKEN")}`,
           "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
         },
-        secretConnectorMap: {
-          GOOGLE_ADS_TOKEN: "google-ads",
-          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
-        },
-        secretConnectorMetadataMap: {
-          GOOGLE_ADS_DEVELOPER_TOKEN: {
-            sourceType: "platform-secret" as const,
+        ...(await exactSecretConnectorSources(
+          actor,
+          {
+            GOOGLE_ADS_TOKEN: "google-ads",
+            GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
           },
-        },
+          ["GOOGLE_ADS_DEVELOPER_TOKEN"],
+        )),
       },
       [200],
     );

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3694,18 +3694,22 @@ function builtinConnectorAccountRequestsForMetadata(args: {
   readonly connectorSlugs: readonly string[];
   readonly metadataByAccessSource: ReadonlyMap<string, SecretConnectorMetadata>;
 }): readonly ConnectorAccountResolutionRequest[] {
-  return args.connectorSlugs.map((connectorSlug) => {
+  return args.connectorSlugs.flatMap((connectorSlug) => {
     const metadata = resolveRefreshMetadata(
       connectorSlug,
       args.metadataByAccessSource.get(connectorSlug),
     );
-    return {
-      target: { kind: "builtin", connectorSlug },
-      selection:
-        metadata.sourceId === undefined
-          ? { kind: "source-less-runtime-singleton" }
-          : { kind: "exact", sourceId: metadata.sourceId },
-    };
+    return metadata.sourceId === undefined
+      ? []
+      : [
+          {
+            target: { kind: "builtin" as const, connectorSlug },
+            selection: {
+              kind: "exact" as const,
+              sourceId: metadata.sourceId,
+            },
+          },
+        ];
   });
 }
 
@@ -3748,18 +3752,20 @@ function builtinConnectorAccountRequestsForFirewall(args: {
   return firewallAuthReferencedConnectorSlugs({
     body: args.body,
     referencedSecretKeys: new Set(args.referencedSecretKeys),
-  }).map((connectorSlug) => {
-    const [sourceId] = builtinConnectorSourceIdsForFirewall({
+  }).flatMap((connectorSlug) => {
+    const sourceIds = builtinConnectorSourceIdsForFirewall({
       ...args,
       connectorSlug,
     });
-    return {
-      target: { kind: "builtin", connectorSlug },
-      selection:
-        sourceId === undefined
-          ? { kind: "source-less-runtime-singleton" }
-          : { kind: "exact", sourceId },
-    };
+    const [sourceId] = sourceIds;
+    return sourceIds.size === 1 && sourceId !== undefined
+      ? [
+          {
+            target: { kind: "builtin" as const, connectorSlug },
+            selection: { kind: "exact" as const, sourceId },
+          },
+        ]
+      : [];
   });
 }
 
@@ -4705,7 +4711,7 @@ async function resolveCurrentCustomConnectorMemberId(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly customConnectorId: string;
-  readonly sourceId?: string;
+  readonly sourceId: string;
 }): Promise<string | undefined> {
   const target = {
     kind: "custom" as const,
@@ -4717,10 +4723,7 @@ async function resolveCurrentCustomConnectorMemberId(args: {
     requests: [
       {
         target,
-        selection:
-          args.sourceId === undefined
-            ? { kind: "source-less-runtime-singleton" }
-            : { kind: "exact", sourceId: args.sourceId },
+        selection: { kind: "exact", sourceId: args.sourceId },
       },
     ],
   });
@@ -4737,7 +4740,7 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly customConnectorId: string;
-  readonly sourceId?: string;
+  readonly sourceId: string;
 }): Promise<CurrentCustomConnectorAuthRefsResolution> {
   const memberConnectorId = await resolveCurrentCustomConnectorMemberId(args);
   if (memberConnectorId === undefined) {
@@ -4879,7 +4882,7 @@ async function prepareCurrentCustomConnectorFirewallAuth(args: {
   readonly orgId: string;
   readonly referenced: ReferencedAuthKeys;
   readonly customConnectorId: string;
-  readonly sourceId?: string;
+  readonly sourceId: string;
   readonly routingVariables: Record<string, string>;
 }): Promise<FirewallAuthPreparation<PreparedCustomFirewallAuth>> {
   // The trusted host already matched this request against its effective
@@ -4891,7 +4894,7 @@ async function prepareCurrentCustomConnectorFirewallAuth(args: {
     orgId: args.orgId,
     userId: args.auth.userId,
     customConnectorId: args.customConnectorId,
-    ...(args.sourceId === undefined ? {} : { sourceId: args.sourceId }),
+    sourceId: args.sourceId,
   });
   if (authRefsResolution.kind === "unavailable") {
     return { ok: false, response: connectorNotConfigured() };
@@ -5369,18 +5372,18 @@ export async function resolveFirewallAuth(
     );
   }
   const preparation = customConnectorId
-    ? await prepareCurrentCustomConnectorFirewallAuth({
-        db,
-        auth,
-        body,
-        orgId,
-        referenced,
-        customConnectorId,
-        ...(matchedFirewall.sourceId === undefined
-          ? {}
-          : { sourceId: matchedFirewall.sourceId }),
-        routingVariables: matchedFirewall.routingVariables,
-      })
+    ? matchedFirewall.sourceId === undefined
+      ? { ok: false as const, response: connectorNotConfigured() }
+      : await prepareCurrentCustomConnectorFirewallAuth({
+          db,
+          auth,
+          body,
+          orgId,
+          referenced,
+          customConnectorId,
+          sourceId: matchedFirewall.sourceId,
+          routingVariables: matchedFirewall.routingVariables,
+        })
     : await prepareNonCustomFirewallAuth({
         db,
         auth,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -5371,27 +5371,32 @@ export async function resolveFirewallAuth(
       "Matched connector source does not match secret metadata",
     );
   }
-  const preparation = customConnectorId
-    ? matchedFirewall.sourceId === undefined
-      ? { ok: false as const, response: connectorNotConfigured() }
-      : await prepareCurrentCustomConnectorFirewallAuth({
-          db,
-          auth,
-          body,
-          orgId,
-          referenced,
-          customConnectorId,
-          sourceId: matchedFirewall.sourceId,
-          routingVariables: matchedFirewall.routingVariables,
-        })
-    : await prepareNonCustomFirewallAuth({
-        db,
-        auth,
-        body,
-        orgId,
-        referenced,
-        forceRefreshStartedAtMicros,
-      });
+  let preparation;
+  if (customConnectorId) {
+    const sourceId = matchedFirewall.sourceId;
+    if (sourceId === undefined) {
+      return connectorNotConfigured();
+    }
+    preparation = await prepareCurrentCustomConnectorFirewallAuth({
+      db,
+      auth,
+      body,
+      orgId,
+      referenced,
+      customConnectorId,
+      sourceId,
+      routingVariables: matchedFirewall.routingVariables,
+    });
+  } else {
+    preparation = await prepareNonCustomFirewallAuth({
+      db,
+      auth,
+      body,
+      orgId,
+      referenced,
+      forceRefreshStartedAtMicros,
+    });
+  }
   if (!preparation.ok) {
     return preparation.response;
   }

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -20,8 +20,7 @@ const L = logger("connector-account-resolution");
 export type ConnectorAccountSelectionMode =
   | { readonly kind: "exact"; readonly sourceId: string }
   | { readonly kind: "default" }
-  | { readonly kind: "target-only-client-singleton" }
-  | { readonly kind: "source-less-runtime-singleton" };
+  | { readonly kind: "target-only-client-singleton" };
 
 export interface ConnectorAccountResolutionRequest {
   readonly target: ConnectorAccountTarget;
@@ -194,7 +193,7 @@ async function loadDefaultRows(
     );
 }
 
-async function loadSingletonCompatibilityRows(
+async function loadTargetOnlyClientSingletonRows(
   db: ReadonlyDb,
   args: {
     readonly orgId: string;
@@ -203,15 +202,14 @@ async function loadSingletonCompatibilityRows(
   },
 ): Promise<readonly ConnectorAccountIdentityRow[]> {
   const targets = args.requests.flatMap((request) => {
-    return request.selection.kind === "target-only-client-singleton" ||
-      request.selection.kind === "source-less-runtime-singleton"
+    return request.selection.kind === "target-only-client-singleton"
       ? [request.target]
       : [];
   });
   if (targets.length === 0) {
     return [];
   }
-  const ranked = db.$with("singleton_connector_account_candidates").as(
+  const ranked = db.$with("target_only_connector_account_candidates").as(
     db
       .select({
         ...identitySelection(),
@@ -284,11 +282,11 @@ export async function resolveConnectorAccounts(
     return new Map();
   }
   const normalizedRequests = [...requests.values()];
-  const [exactRows, defaultRows, singletonCompatibilityRows] =
+  const [exactRows, defaultRows, targetOnlyClientSingletonRows] =
     await Promise.all([
       loadExactRows(db, { ...args, requests: normalizedRequests }),
       loadDefaultRows(db, { ...args, requests: normalizedRequests }),
-      loadSingletonCompatibilityRows(db, {
+      loadTargetOnlyClientSingletonRows(db, {
         ...args,
         requests: normalizedRequests,
       }),
@@ -299,8 +297,8 @@ export async function resolveConnectorAccounts(
     }),
   );
   const defaultByTarget = rowsByTarget(defaultRows);
-  const singletonCompatibilityByTarget = rowsByTarget(
-    singletonCompatibilityRows,
+  const targetOnlyClientSingletonByTarget = rowsByTarget(
+    targetOnlyClientSingletonRows,
   );
   const resolutions = new Map<string, ConnectorAccountResolution>();
   for (const [key, request] of requests) {
@@ -320,7 +318,7 @@ export async function resolveConnectorAccounts(
     const rows =
       request.selection.kind === "default"
         ? defaultByTarget.get(key)
-        : singletonCompatibilityByTarget.get(key);
+        : targetOnlyClientSingletonByTarget.get(key);
     if (!rows || rows.length === 0) {
       resolutions.set(
         key,
@@ -380,11 +378,6 @@ export async function resolveConnectorAccounts(
     targetOnlyClientSingletonRequestCount: normalizedRequests.filter(
       (request) => {
         return request.selection.kind === "target-only-client-singleton";
-      },
-    ).length,
-    sourceLessRuntimeSingletonRequestCount: normalizedRequests.filter(
-      (request) => {
-        return request.selection.kind === "source-less-runtime-singleton";
       },
     ).length,
     ...outcomeCounts,

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -90,20 +90,21 @@ async function loadCustomSnapshot(args: {
       const accountResolutions = await resolveConnectorAccounts(tx, {
         orgId: args.scope.orgId,
         userId: args.scope.userId,
-        requests: args.registrations.map((registration) => {
-          return {
-            target: {
-              kind: "custom" as const,
-              customConnectorId: registration.customConnectorId,
-            },
-            selection:
-              registration.sourceId === undefined
-                ? { kind: "source-less-runtime-singleton" as const }
-                : {
+        requests: args.registrations.flatMap((registration) => {
+          return registration.sourceId === undefined
+            ? []
+            : [
+                {
+                  target: {
+                    kind: "custom" as const,
+                    customConnectorId: registration.customConnectorId,
+                  },
+                  selection: {
                     kind: "exact" as const,
                     sourceId: registration.sourceId,
                   },
-          };
+                },
+              ];
         }),
       });
       const resolvedAccountIds =
@@ -291,20 +292,18 @@ export async function resolveConnectorRuntimeTargets(args: {
         orgId: args.scope.orgId,
         userId: args.scope.userId,
         requests: args.targets.flatMap((registration) => {
-          return registration.kind === "builtin"
+          return registration.kind === "builtin" &&
+            registration.sourceId !== undefined
             ? [
                 {
                   target: {
                     kind: "builtin" as const,
                     connectorSlug: registration.connectorSlug,
                   },
-                  selection:
-                    registration.sourceId === undefined
-                      ? { kind: "source-less-runtime-singleton" as const }
-                      : {
-                          kind: "exact" as const,
-                          sourceId: registration.sourceId,
-                        },
+                  selection: {
+                    kind: "exact" as const,
+                    sourceId: registration.sourceId,
+                  },
                 },
               ]
             : [];


### PR DESCRIPTION
## Summary

- remove the source-less runtime singleton mode and its shared resolver SQL/telemetry path
- resolve built-in and custom runtime sync/firewall credentials only from an exact `sourceId`
- keep optional wire parsing and return the existing connector-unavailable/not-configured outcomes when source metadata is absent
- preserve admission default selection and the separate target-only compact-client compatibility mode

## Compatibility

- no database, persisted-state, frontend, CLI, queue payload, Runner, or Python protocol change
- no API drain or forced frontend upgrade is required; missing connector source metadata disables only that connector capability
- exact source propagation across API, Runner, proxy registry, and Python remains unchanged

## Merge gate

**Do not merge yet.** API `1.478.0` reached production on 2026-08-23 at approximately 04:45 UTC. Before merge:

- recheck that production rollback targets remain descendants of #27754 and #28131
- verify a complete two-hour post-deploy Runner window has zero `sourceLessRuntimeSingletonRequestCount` events in Axiom

The implementation and review are intentionally prepared before this operational gate; any non-zero event requires tracing the remaining producer instead of merging this cleanup.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=1 --silent=passed-only` (229 passed)
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- focused Runner exact-source, runtime-sync, type, and registry tests (5 passed)
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_auth.py tests/test_registry_builtin_catalog_resolution.py tests/test_registry_builtin_core_cache.py` (71 passed)

Closes #28592

Parent context: #27695
