### PR TITLE
fix(rust): align mock codex rollout paths

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
 name = "guest-contracts"
 version = "0.11.13"
 dependencies = [
+ "chrono",
  "libc",
  "process-control-ipc",
  "serde",

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
-chrono.workspace = true
+chrono = { workspace = true, features = ["alloc"] }
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
+chrono.workspace = true
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/guest-contracts/src/codex_session_path.rs
+++ b/crates/guest-contracts/src/codex_session_path.rs
@@ -1,0 +1,39 @@
+//! Shared Codex session path layout.
+
+use chrono::{DateTime, Utc};
+
+use crate::codex_thread_id::CodexThreadId;
+
+/// Build the canonical Codex rollout path relative to the Codex home.
+///
+/// The returned path has the form
+/// `sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<thread-id>.jsonl`.
+pub fn codex_rollout_relative_path(thread_id: &CodexThreadId, timestamp: DateTime<Utc>) -> String {
+    format!(
+        "sessions/{}/{}/{}/rollout-{}-{}.jsonl",
+        timestamp.format("%Y"),
+        timestamp.format("%m"),
+        timestamp.format("%d"),
+        timestamp.format("%Y-%m-%dT%H-%M-%S"),
+        thread_id.as_str(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_canonical_rollout_relative_path() {
+        let thread_id = CodexThreadId::parse("019e9154-c304-70f0-adde-36efb1be1701")
+            .expect("valid Codex thread id");
+        let timestamp = DateTime::parse_from_rfc3339("2026-06-04T07:18:08Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+
+        assert_eq!(
+            codex_rollout_relative_path(&thread_id, timestamp),
+            "sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+        );
+    }
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod active_input;
 pub mod active_input_receipts;
 pub mod cli_agent_session_id;
+pub mod codex_session_path;
 pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -8,7 +8,7 @@ use super::messages::{
     write_split_json_line_prefix, write_success, write_turn_completion_notifications,
     write_turn_notifications, write_turn_start_notifications,
 };
-use super::persistence::{InputEventContext, persist_input_events};
+use super::persistence::{InputEventContext, persist_input_events, session_rollout_timestamp};
 use super::scenario::Scenario;
 use super::{AppServerState, INVALID_REQUEST, PendingResponse, ServerAction, spawn_stderr_holder};
 use guest_contracts::stdout_framing::CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES;
@@ -114,11 +114,13 @@ impl AppServerState {
             }
         }
         let thread_id = Uuid::now_v7().to_string();
+        let rollout_timestamp = session_rollout_timestamp()?;
         self.set_current_thread(
             thread_id.clone(),
             params.get("runtimeWorkspaceRoots").is_some(),
             string_param(params, "model").map(str::to_string),
             string_param(params, "modelProvider").map(str::to_string),
+            rollout_timestamp,
         );
         let response_thread_id = if self.scenario == Scenario::ThreadStartInvalidThreadId {
             "not-a-valid-codex-thread-id"
@@ -215,11 +217,13 @@ impl AppServerState {
             )?;
             return Ok(ServerAction::Continue);
         }
+        let rollout_timestamp = session_rollout_timestamp()?;
         self.set_current_thread(
             thread_id.to_string(),
             params.get("runtimeWorkspaceRoots").is_some(),
             string_param(params, "model").map(str::to_string),
             string_param(params, "modelProvider").map(str::to_string),
+            rollout_timestamp,
         );
         let response_thread_id = if self.scenario == Scenario::ResumeDifferentThreadId {
             "0193abcd-ef01-7234-89ab-cdef01234568"
@@ -276,6 +280,7 @@ impl AppServerState {
             current_thread.thread_request_has_runtime_workspace_roots;
         let thread_request_model = current_thread.thread_request_model.clone();
         let thread_request_model_provider = current_thread.thread_request_model_provider.clone();
+        let rollout_timestamp = current_thread.rollout_timestamp;
         let inputs = match text_inputs(params) {
             Ok(inputs) => inputs,
             Err(message) => {
@@ -302,6 +307,7 @@ impl AppServerState {
                 thread_request_has_runtime_workspace_roots,
                 thread_request_model: thread_request_model.as_deref(),
                 thread_request_model_provider: thread_request_model_provider.as_deref(),
+                rollout_timestamp: &rollout_timestamp,
                 turn_params: params,
             },
             &inputs,
@@ -484,6 +490,7 @@ impl AppServerState {
             current_thread.thread_request_has_runtime_workspace_roots;
         let thread_request_model = current_thread.thread_request_model.clone();
         let thread_request_model_provider = current_thread.thread_request_model_provider.clone();
+        let rollout_timestamp = current_thread.rollout_timestamp;
         let inputs = match text_inputs(params) {
             Ok(inputs) => inputs,
             Err(message) => {
@@ -501,6 +508,7 @@ impl AppServerState {
                 thread_request_has_runtime_workspace_roots,
                 thread_request_model: thread_request_model.as_deref(),
                 thread_request_model_provider: thread_request_model_provider.as_deref(),
+                rollout_timestamp: &rollout_timestamp,
                 turn_params: params,
             },
             &inputs,

--- a/crates/guest-mock-codex/src/app_server/mod.rs
+++ b/crates/guest-mock-codex/src/app_server/mod.rs
@@ -3,6 +3,7 @@ mod messages;
 mod persistence;
 mod scenario;
 
+use chrono::{DateTime, Utc};
 use messages::{write_json_line, write_success};
 use persistence::session_artifact_thread_id;
 use scenario::Scenario;
@@ -81,6 +82,7 @@ struct AppServerThread {
     thread_request_has_runtime_workspace_roots: bool,
     thread_request_model: Option<String>,
     thread_request_model_provider: Option<String>,
+    rollout_timestamp: DateTime<Utc>,
 }
 
 impl AppServerState {
@@ -234,6 +236,7 @@ impl AppServerState {
         thread_request_has_runtime_workspace_roots: bool,
         thread_request_model: Option<String>,
         thread_request_model_provider: Option<String>,
+        rollout_timestamp: DateTime<Utc>,
     ) {
         let artifact_thread_id = self
             .session_artifact_thread_ids
@@ -247,6 +250,7 @@ impl AppServerState {
             thread_request_has_runtime_workspace_roots,
             thread_request_model,
             thread_request_model_provider,
+            rollout_timestamp,
         });
     }
 

--- a/crates/guest-mock-codex/src/app_server/persistence.rs
+++ b/crates/guest-mock-codex/src/app_server/persistence.rs
@@ -1,8 +1,10 @@
 use crate::session;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
-use std::io;
+use std::{env, io};
 use uuid::Uuid;
+
+pub(super) const MOCK_CODEX_SESSION_TIMESTAMP_ENV: &str = "MOCK_CODEX_SESSION_TIMESTAMP";
 
 pub(super) struct InputEventContext<'a> {
     pub(super) artifact_thread_id: &'a str,
@@ -12,6 +14,7 @@ pub(super) struct InputEventContext<'a> {
     pub(super) thread_request_has_runtime_workspace_roots: bool,
     pub(super) thread_request_model: Option<&'a str>,
     pub(super) thread_request_model_provider: Option<&'a str>,
+    pub(super) rollout_timestamp: &'a DateTime<Utc>,
     pub(super) turn_params: &'a Value,
 }
 
@@ -52,10 +55,25 @@ pub(super) fn persist_input_events(
     let home = session::codex_home();
     session::persist_resume_session(
         &home,
-        Utc::now().date_naive(),
+        context.rollout_timestamp.to_owned(),
         context.artifact_thread_id,
         &events,
     )
+}
+
+pub(super) fn session_rollout_timestamp() -> io::Result<DateTime<Utc>> {
+    let Some(value) = env::var_os(MOCK_CODEX_SESSION_TIMESTAMP_ENV) else {
+        return Ok(Utc::now());
+    };
+    let value = value.into_string().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{MOCK_CODEX_SESSION_TIMESTAMP_ENV} must be valid UTF-8"),
+        )
+    })?;
+    DateTime::parse_from_rfc3339(&value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))
 }
 
 pub(super) fn session_artifact_thread_id(thread_id: &str) -> String {

--- a/crates/guest-mock-codex/src/session.rs
+++ b/crates/guest-mock-codex/src/session.rs
@@ -1,11 +1,13 @@
-use chrono::NaiveDate;
+use chrono::{DateTime, Utc};
+use guest_contracts::{
+    codex_session_path::codex_rollout_relative_path, codex_thread_id::CodexThreadId,
+};
 use serde_json::Value;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use uuid::Uuid;
 
 #[cfg(unix)]
 use std::ffi::CString;
@@ -32,50 +34,36 @@ pub fn codex_home() -> PathBuf {
     PathBuf::from(home).join(".codex")
 }
 
-/// Build the session file path, with `today` injected for testability.
-///
-/// Layout: `<codex_home>/sessions/YYYY/MM/DD/<thread_id>.jsonl`
-pub fn build_session_path(
+fn build_session_path(
     codex_home: &Path,
-    today: NaiveDate,
-    thread_id: &str,
-) -> io::Result<PathBuf> {
-    validate_thread_id(thread_id)?;
-    let yyyy = today.format("%Y").to_string();
-    let mm = today.format("%m").to_string();
-    let dd = today.format("%d").to_string();
-    Ok(codex_home
-        .join("sessions")
-        .join(yyyy)
-        .join(mm)
-        .join(dd)
-        .join(format!("{thread_id}.jsonl")))
+    timestamp: DateTime<Utc>,
+    thread_id: &CodexThreadId,
+) -> PathBuf {
+    codex_home.join(codex_rollout_relative_path(thread_id, timestamp))
 }
 
 pub(crate) fn persist_resume_session(
     codex_home: &Path,
-    today: NaiveDate,
+    timestamp: DateTime<Utc>,
     thread_id: &str,
     events: &[Value],
 ) -> io::Result<()> {
-    validate_thread_id(thread_id)?;
-    let _lock = lock_session(codex_home, thread_id)?;
-    let path = if let Some(path) = find_session_file_for_thread(codex_home, thread_id)? {
+    let thread_id = validate_thread_id(thread_id)?;
+    let _lock = lock_session(codex_home, thread_id.as_str())?;
+    let path = if let Some(path) = find_session_file_for_thread(codex_home, &thread_id)? {
         path
     } else {
-        build_session_path(codex_home, today, thread_id)?
+        build_session_path(codex_home, timestamp, &thread_id)
     };
     let mut existing = read_session_bytes_for_append_in_store(codex_home, &path)?;
     append_events_to_jsonl_bytes(&mut existing, events)?;
     write_session_bytes_in_store(codex_home, &path, existing)
 }
 
-fn validate_thread_id(thread_id: &str) -> io::Result<()> {
-    let parsed = Uuid::parse_str(thread_id).map_err(|_| invalid_thread_id_error(thread_id))?;
-    if parsed.to_string() != thread_id {
-        return Err(invalid_thread_id_error(thread_id));
-    }
-    Ok(())
+fn validate_thread_id(thread_id: &str) -> io::Result<CodexThreadId> {
+    CodexThreadId::parse(thread_id)
+        .filter(|parsed| parsed.as_str() == thread_id)
+        .ok_or_else(|| invalid_thread_id_error(thread_id))
 }
 
 fn invalid_thread_id_error(thread_id: &str) -> io::Error {
@@ -251,9 +239,11 @@ pub fn find_session_file(codex_home: &Path) -> io::Result<Option<PathBuf>> {
     Ok(session_files(codex_home)?.into_iter().next())
 }
 
-fn find_session_file_for_thread(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {
-    validate_thread_id(thread_id)?;
-    let id_norm = thread_id.replace('-', "");
+fn find_session_file_for_thread(
+    codex_home: &Path,
+    thread_id: &CodexThreadId,
+) -> io::Result<Option<PathBuf>> {
+    let id_norm = thread_id.filename_key();
     let matches = session_artifacts_for_resume(codex_home)?
         .into_iter()
         .filter(|path| {
@@ -267,7 +257,7 @@ fn find_session_file_for_thread(codex_home: &Path, thread_id: &str) -> io::Resul
         })
         .collect::<io::Result<Vec<_>>>()?;
     if matches.len() > 1 {
-        return Err(ambiguous_session_files_error(thread_id, &matches));
+        return Err(ambiguous_session_files_error(thread_id.as_str(), &matches));
     }
     Ok(matches.into_iter().next())
 }
@@ -648,33 +638,4 @@ fn lock_session(codex_home: &Path, thread_id: &str) -> io::Result<SessionLock> {
 #[cfg(not(unix))]
 fn lock_session(_codex_home: &Path, _thread_id: &str) -> io::Result<SessionLock> {
     Ok(SessionLock)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn build_session_path_zero_pads() {
-        let home = Path::new("/tmp/.codex");
-        let day = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-        let thread_id = "00000000-0000-0000-0000-000000000001";
-        let p = build_session_path(home, day, thread_id).unwrap();
-        assert_eq!(
-            p,
-            PathBuf::from(format!("/tmp/.codex/sessions/2026/01/05/{thread_id}.jsonl"))
-        );
-    }
-
-    #[test]
-    fn build_session_path_typical() {
-        let home = Path::new("/var/codex");
-        let day = NaiveDate::from_ymd_opt(2026, 12, 31).unwrap();
-        let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
-        let p = build_session_path(home, day, thread_id).unwrap();
-        assert_eq!(
-            p,
-            PathBuf::from(format!("/var/codex/sessions/2026/12/31/{thread_id}.jsonl"))
-        );
-    }
 }

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -12,6 +12,7 @@ use crate::support::{BIN, ChildWaitOutcome, require_session_file, run, wait_chil
 
 const APP_SERVER_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const APP_SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const MOCK_CODEX_SESSION_TIMESTAMP_ENV: &str = "MOCK_CODEX_SESSION_TIMESTAMP";
 
 pub(crate) struct AppServerProcess {
     child: Option<Child>,
@@ -174,7 +175,7 @@ pub(crate) fn spawn_app_server(
     spawn_app_server_with_env(codex_home, args, scenario, &[])
 }
 
-fn spawn_app_server_with_env(
+pub(crate) fn spawn_app_server_with_env(
     codex_home: &Path,
     args: &[&str],
     scenario: Option<&str>,
@@ -183,6 +184,7 @@ fn spawn_app_server_with_env(
     let mut cmd = Command::new(BIN);
     cmd.env("CODEX_HOME", codex_home).args(args);
     cmd.env_remove("MOCK_CODEX_APP_SERVER_SCENARIO");
+    cmd.env_remove(MOCK_CODEX_SESSION_TIMESTAMP_ENV);
     if let Some(value) = scenario {
         cmd.env("MOCK_CODEX_APP_SERVER_SCENARIO", value);
     }

--- a/crates/guest-mock-codex/tests/integration/session_filesystem.rs
+++ b/crates/guest-mock-codex/tests/integration/session_filesystem.rs
@@ -6,17 +6,30 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::PathBuf;
 
 #[cfg(unix)]
-use chrono::{Datelike, Utc};
+use chrono::{DateTime, Utc};
+#[cfg(unix)]
+use guest_contracts::{
+    codex_session_path::codex_rollout_relative_path, codex_thread_id::CodexThreadId,
+};
 use guest_mock_codex::{session_artifacts, session_files};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::app_server::{AppServerProcess, initialize_params, spawn_app_server, text_input};
+use crate::app_server::{
+    AppServerProcess, MOCK_CODEX_SESSION_TIMESTAMP_ENV, initialize_params,
+    spawn_app_server_with_env, text_input,
+};
 
 const THREAD_ID: &str = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+const SESSION_TIMESTAMP: &str = "2026-06-09T12:34:56Z";
 
 fn spawn_resumed_app_server(codex_home: &Path) -> std::io::Result<AppServerProcess> {
-    let mut server = spawn_app_server(codex_home, &["app-server", "--stdio"], None)?;
+    let mut server = spawn_app_server_with_env(
+        codex_home,
+        &["app-server", "--stdio"],
+        None,
+        &[(MOCK_CODEX_SESSION_TIMESTAMP_ENV, SESSION_TIMESTAMP)],
+    )?;
     server.request(1, "initialize", initialize_params())?;
     let resumed = server.request(
         2,
@@ -61,14 +74,14 @@ fn assert_turn_persistence_rejected(codex_home: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(unix)]
-fn current_session_path(codex_home: &Path) -> PathBuf {
-    let today = Utc::now().date_naive();
-    codex_home
-        .join("sessions")
-        .join(format!("{:04}", today.year()))
-        .join(format!("{:02}", today.month()))
-        .join(format!("{:02}", today.day()))
-        .join(format!("{THREAD_ID}.jsonl"))
+fn current_session_path(codex_home: &Path) -> std::io::Result<PathBuf> {
+    let timestamp = DateTime::parse_from_rfc3339(SESSION_TIMESTAMP)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?
+        .with_timezone(&Utc);
+    let thread_id = CodexThreadId::parse(THREAD_ID).ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid test thread id")
+    })?;
+    Ok(codex_home.join(codex_rollout_relative_path(&thread_id, timestamp)))
 }
 
 #[test]
@@ -121,10 +134,7 @@ fn app_server_rejects_symlinked_session_parent_without_outside_writes() -> std::
     let outside_year = dir.path().join("outside-year");
     std::fs::create_dir_all(&sessions)?;
     std::fs::create_dir_all(&outside_year)?;
-    let current_year = Utc::now().date_naive().year();
-    for year in [current_year, current_year + 1] {
-        std::os::unix::fs::symlink(&outside_year, sessions.join(format!("{year:04}")))?;
-    }
+    std::os::unix::fs::symlink(&outside_year, sessions.join("2026"))?;
 
     assert_turn_persistence_rejected(dir.path())?;
 
@@ -150,7 +160,7 @@ fn app_server_rejects_special_lock_file_without_hanging() -> std::io::Result<()>
 #[test]
 fn app_server_rejects_special_session_file_without_hanging() -> std::io::Result<()> {
     let dir = TempDir::new()?;
-    let session_path = current_session_path(dir.path());
+    let session_path = current_session_path(dir.path())?;
     if let Some(parent) = session_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -168,7 +178,7 @@ fn app_server_rejects_symlinked_fallback_without_overwriting_target() -> std::io
     let dir = TempDir::new()?;
     let outside_path = dir.path().join("outside.jsonl");
     std::fs::write(&outside_path, "outside must survive")?;
-    let session_path = current_session_path(dir.path());
+    let session_path = current_session_path(dir.path())?;
     if let Some(parent) = session_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -187,11 +197,11 @@ fn app_server_rejects_symlinked_fallback_without_overwriting_target() -> std::io
 #[test]
 fn app_server_rejects_duplicate_matching_sessions_without_modifying_them() -> std::io::Result<()> {
     let dir = TempDir::new()?;
-    let first_path = dir
-        .path()
-        .join(format!("sessions/2001/01/01/{THREAD_ID}.jsonl"));
+    let first_path = dir.path().join(format!(
+        "sessions/2001/01/01/rollout-2001-01-01T00-00-00-{THREAD_ID}.jsonl"
+    ));
     let second_path = dir.path().join(format!(
-        "sessions/2001/01/02/rollout-restored-{THREAD_ID}.jsonl"
+        "sessions/2001/01/02/rollout-2001-01-02T00-00-00-{THREAD_ID}.jsonl"
     ));
     for (path, contents) in [(&first_path, "first\n"), (&second_path, "second\n")] {
         if let Some(parent) = path.parent() {
@@ -213,9 +223,11 @@ fn session_files_skip_symlinked_files_and_dirs() -> std::io::Result<()> {
     let sessions = dir.path().join("sessions");
     let day_dir = sessions.join("2026/06/09");
     std::fs::create_dir_all(&day_dir)?;
-    let real_file = day_dir.join("00000000-0000-0000-0000-000000000001.jsonl");
+    let real_file =
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000001.jsonl");
     std::fs::write(&real_file, "{}\n")?;
-    let linked_file = day_dir.join("00000000-0000-0000-0000-000000000002.jsonl");
+    let linked_file =
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000002.jsonl");
     std::os::unix::fs::symlink(&real_file, &linked_file)?;
     std::os::unix::fs::symlink(&sessions, sessions.join("loop"))?;
 
@@ -232,12 +244,13 @@ fn session_files_skip_dangling_jsonl_symlinks() -> std::io::Result<()> {
     let sessions = dir.path().join("sessions");
     let day_dir = sessions.join("2026/06/09");
     std::fs::create_dir_all(&day_dir)?;
-    let real_file = day_dir.join("00000000-0000-0000-0000-000000000001.jsonl");
+    let real_file =
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000001.jsonl");
     std::fs::write(&real_file, "{}\n")?;
     let missing_target = dir.path().join("missing/codex-session.jsonl");
     std::os::unix::fs::symlink(
         missing_target,
-        day_dir.join("00000000-0000-0000-0000-000000000002.jsonl"),
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000002.jsonl"),
     )?;
 
     let files = session_files(dir.path())?;
@@ -252,9 +265,11 @@ fn session_files_skip_jsonl_symlink_loops() -> std::io::Result<()> {
     let sessions = dir.path().join("sessions");
     let day_dir = sessions.join("2026/06/09");
     std::fs::create_dir_all(&day_dir)?;
-    let real_file = day_dir.join("00000000-0000-0000-0000-000000000001.jsonl");
+    let real_file =
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000001.jsonl");
     std::fs::write(&real_file, "{}\n")?;
-    let looped_file = day_dir.join("00000000-0000-0000-0000-000000000002.jsonl");
+    let looped_file =
+        day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000002.jsonl");
     std::os::unix::fs::symlink(&looped_file, &looped_file)?;
 
     let files = session_files(dir.path())?;
@@ -282,7 +297,7 @@ fn session_artifacts_skip_symlinked_root_dir() -> std::io::Result<()> {
     let real_day_dir = real_sessions.join("2026/06/09");
     std::fs::create_dir_all(&real_day_dir)?;
     std::fs::write(
-        real_day_dir.join("00000000-0000-0000-0000-000000000001.jsonl"),
+        real_day_dir.join("rollout-2026-06-09T00-00-00-00000000-0000-0000-0000-000000000001.jsonl"),
         "{}\n",
     )?;
     std::os::unix::fs::symlink(&real_sessions, dir.path().join("sessions"))?;

--- a/crates/guest-mock-codex/tests/integration/session_resume.rs
+++ b/crates/guest-mock-codex/tests/integration/session_resume.rs
@@ -1,16 +1,28 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use chrono::{DateTime, Utc};
+use guest_contracts::{
+    codex_session_path::codex_rollout_relative_path, codex_thread_id::CodexThreadId,
+};
 use guest_mock_codex::{read_session_file, session_files};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::app_server::{initialize_params, spawn_app_server, text_input};
+use crate::app_server::{
+    MOCK_CODEX_SESSION_TIMESTAMP_ENV, initialize_params, spawn_app_server_with_env, text_input,
+};
 
 const THREAD_ID: &str = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+const SESSION_TIMESTAMP: &str = "2026-06-09T12:34:56Z";
 
 fn persist_resume_turn(codex_home: &Path, thread_id: &str, prompt: &str) -> std::io::Result<()> {
-    let mut server = spawn_app_server(codex_home, &["app-server", "--stdio"], None)?;
+    let mut server = spawn_app_server_with_env(
+        codex_home,
+        &["app-server", "--stdio"],
+        None,
+        &[(MOCK_CODEX_SESSION_TIMESTAMP_ENV, SESSION_TIMESTAMP)],
+    )?;
     server.request(1, "initialize", initialize_params())?;
     let resumed = server.request(
         2,
@@ -38,6 +50,35 @@ fn persist_resume_turn(codex_home: &Path, thread_id: &str, prompt: &str) -> std:
             .is_some()
     );
     assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+fn expected_fallback_path(codex_home: &Path) -> std::io::Result<std::path::PathBuf> {
+    let timestamp = DateTime::parse_from_rfc3339(SESSION_TIMESTAMP)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?
+        .with_timezone(&Utc);
+    let thread_id = CodexThreadId::parse(THREAD_ID).ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid test thread id")
+    })?;
+    Ok(codex_home.join(codex_rollout_relative_path(&thread_id, timestamp)))
+}
+
+#[test]
+fn app_server_resume_creates_canonical_rollout_for_unknown_thread() -> std::io::Result<()> {
+    let dir = TempDir::new()?;
+    let session_path = expected_fallback_path(dir.path())?;
+
+    persist_resume_turn(dir.path(), THREAD_ID, "turn-1")?;
+
+    assert_eq!(session_files(dir.path())?, vec![session_path.clone()]);
+    let events = read_session_file(&session_path)?;
+    assert_eq!(
+        events
+            .iter()
+            .filter_map(|event| event.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>(),
+        vec!["turn-1"]
+    );
     Ok(())
 }
 
@@ -70,9 +111,9 @@ fn app_server_resume_appends_restored_rollout_without_parsing_history() -> std::
 #[test]
 fn concurrent_app_server_resume_writes_preserve_all_inputs() -> std::io::Result<()> {
     let dir = TempDir::new()?;
-    let session_path = dir
-        .path()
-        .join(format!("sessions/2001/01/01/{THREAD_ID}.jsonl"));
+    let session_path = dir.path().join(format!(
+        "sessions/2001/01/01/rollout-2001-01-01T00-00-00-{THREAD_ID}.jsonl"
+    ));
     if let Some(parent) = session_path.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -11,24 +11,13 @@ use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::types::ExecutionContext;
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
-use guest_contracts::codex_thread_id::CodexThreadId;
+use guest_contracts::{
+    codex_session_path::codex_rollout_relative_path, codex_thread_id::CodexThreadId,
+};
 
 const CODEX_SESSION_CLEANUP_SCRIPT: &str =
     include_str!("../../../scripts/codex-session-cleanup.sh");
 const INVALID_CODEX_CLEANUP_OUTPUT: &str = "invalid codex session cleanup output";
-
-fn codex_restore_logical_rollout_path(
-    session_id: &str,
-    timestamp: chrono::DateTime<chrono::Utc>,
-) -> String {
-    format!(
-        "{CANONICAL_CODEX_SESSIONS_DIR}/{}/{}/{}/rollout-{}-{session_id}.jsonl",
-        timestamp.format("%Y"),
-        timestamp.format("%m"),
-        timestamp.format("%d"),
-        timestamp.format("%Y-%m-%dT%H-%M-%S"),
-    )
-}
 
 fn codex_restore_rollout_timestamp(
     session: &MaterializedResumeSession,
@@ -60,7 +49,10 @@ pub(super) async fn restore_codex_session(
     } else {
         (session.history_bytes(), "")
     };
-    let fallback_logical_path = codex_restore_logical_rollout_path(session_id, timestamp);
+    let fallback_logical_path = format!(
+        "{CANONICAL_CODEX_HOME_DIR}/{}",
+        codex_rollout_relative_path(&thread_id, timestamp)
+    );
 
     let logical_path = cleanup_existing_codex_session_files(
         sandbox,


### PR DESCRIPTION
## Summary

- centralize the canonical Codex rollout relative-path layout in `guest-contracts`
- make the Codex mock persist new sessions with a stable full UTC rollout timestamp
- keep runner restore output unchanged while routing fallback construction through the shared contract
- preserve exact append-to-existing-path behavior and filesystem hardening coverage
- declare the Chrono feature required when `guest-contracts` is compiled independently

## Exclusions

- runner cleanup-output parsing and destination validation remain independent at the guest trust boundary
- existing restored session files are not renamed or migrated
- no API, database, queue, or runner/guest wire contract changes

## Validation

- `cargo check --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-mock-codex -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-mock-codex -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-mock-codex -p runner --all-features --no-deps`
- pre-commit Rust formatting, Clippy, documentation, and file-size checks

Closes #28678
