### PR TITLE
test(e2e): verify managed provider fallback completion

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -7,6 +7,7 @@ WORKFLOW="${REPO_ROOT}/.github/workflows/turbo.yml"
 RUNNER_START_HELPER="${REPO_ROOT}/.github/scripts/reconcile-and-start-runner-groups.sh"
 RUNNER_TESTS="${REPO_ROOT}/e2e/tests/03-runner"
 REAL_CLAUDE_TEST="${RUNNER_TESTS}/run-t10-real-claude-smoke.bats"
+MANAGED_FALLBACK_TEST="${RUNNER_TESTS}/run-t24-managed-provider-fallback.bats"
 RUNNER_HELPERS=(
   "${REPO_ROOT}/e2e/helpers/runner-api.bash"
   "${REPO_ROOT}/e2e/helpers/runner-chat.bash"
@@ -53,6 +54,13 @@ fi
 if grep -Fq 'claude-sonnet-4-6' "$REAL_CLAUDE_TEST"; then
   fail "real Claude E2E must not retain the Sonnet 4.6 pin"
 fi
+managed_fallback_switches='{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}'
+for test_file in "$REAL_CLAUDE_TEST" "$MANAGED_FALLBACK_TEST"; do
+  grep -Fq "$managed_fallback_switches" "$test_file" ||
+    fail "parallel real-provider E2Es must preserve the same fallback switches"
+done
+grep -Fq 'VM0_MITM_RUNNER_TOKEN' "$MANAGED_FALLBACK_TEST" ||
+  fail "managed fallback E2E must require trusted failure authentication"
 grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||
   fail "real runner accounts must upgrade through public paid onboarding"
 grep -Fq 'fillStripeCheckout' "$RUNNER_TOKEN" ||
@@ -442,6 +450,7 @@ claude_script = claude_step.fetch("run")
   /api/okou/model-policies
   /api/okou/feature-switches
   realAgentInPreview
+  managedModelProviderFallback
 ].each do |required_fragment|
   unless claude_script.include?(required_fragment)
     raise "real Claude bootstrap must include #{required_fragment}"
@@ -490,6 +499,10 @@ end
 unless run_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
     "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
   raise "runner E2E tests must receive the preview bypass secret"
+end
+expected_failure_token = "${{ contains(matrix.files, 'tests/03-runner/run-t24-managed-provider-fallback.bats') && format('vm0_official_{0}', secrets.OFFICIAL_RUNNER_SECRET) || '' }}"
+unless run_step.dig("env", "VM0_MITM_RUNNER_TOKEN") == expected_failure_token
+  raise "only the managed fallback shard may receive trusted failure authentication"
 end
 unless runner.fetch("steps").any? do |step|
     step["name"] == "Download runner E2E API tokens" &&

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -54,11 +54,6 @@ fi
 if grep -Fq 'claude-sonnet-4-6' "$REAL_CLAUDE_TEST"; then
   fail "real Claude E2E must not retain the Sonnet 4.6 pin"
 fi
-managed_fallback_switches='{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}'
-for test_file in "$REAL_CLAUDE_TEST" "$MANAGED_FALLBACK_TEST"; do
-  grep -Fq "$managed_fallback_switches" "$test_file" ||
-    fail "parallel real-provider E2Es must preserve the same fallback switches"
-done
 grep -Fq 'VM0_MITM_RUNNER_TOKEN' "$MANAGED_FALLBACK_TEST" ||
   fail "managed fallback E2E must require trusted failure authentication"
 grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2714,9 +2714,12 @@ jobs:
 
           curl -fsS "${headers[@]}" \
             -X POST \
-            -d '{"switches":{"realAgentInPreview":true}}' \
+            -d '{"switches":{"realAgentInPreview":true,"managedModelProviderFallback":true}}' \
             "${api_url}/api/okou/feature-switches" \
-            | jq -e '.effectiveSwitches.realAgentInPreview == true' \
+            | jq -e '
+                .effectiveSwitches.realAgentInPreview == true and
+                .effectiveSwitches.managedModelProviderFallback == true
+              ' \
             >/dev/null
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -2840,6 +2843,7 @@ jobs:
             "${test_files[@]}"
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          VM0_MITM_RUNNER_TOKEN: ${{ contains(matrix.files, 'tests/03-runner/run-t24-managed-provider-fallback.bats') && format('vm0_official_{0}', secrets.OFFICIAL_RUNNER_SECRET) || '' }}
       - name: Print runner E2E trace log
         if: always()
         shell: bash

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -19,10 +19,11 @@ setup_file() {
     local feature_switches
     feature_switches="$(runner_api_curl "/api/feature-switches" \
         -X POST \
-        -d '{"switches":{"realAgentInPreview":true,"piLoop":true}}')"
+        -d '{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}')"
     jq -e '
         .effectiveSwitches.realAgentInPreview == true and
-        .effectiveSwitches.piLoop == true
+        .effectiveSwitches.piLoop == true and
+        .effectiveSwitches.managedModelProviderFallback == true
     ' <<<"$feature_switches" >/dev/null
 
     export RUNNER_AGENT_ID

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -19,11 +19,10 @@ setup_file() {
     local feature_switches
     feature_switches="$(runner_api_curl "/api/feature-switches" \
         -X POST \
-        -d '{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}')"
+        -d '{"switches":{"realAgentInPreview":true,"piLoop":true}}')"
     jq -e '
         .effectiveSwitches.realAgentInPreview == true and
-        .effectiveSwitches.piLoop == true and
-        .effectiveSwitches.managedModelProviderFallback == true
+        .effectiveSwitches.piLoop == true
     ' <<<"$feature_switches" >/dev/null
 
     export RUNNER_AGENT_ID

--- a/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
@@ -19,12 +19,9 @@ setup() {
     runner_e2e_setup_test
 
     local feature_switches
-    feature_switches="$(runner_api_curl "/api/feature-switches" \
-        -X POST \
-        -d '{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}')"
+    feature_switches="$(runner_api_curl "/api/feature-switches")"
     jq -e '
         .effectiveSwitches.realAgentInPreview == true and
-        .effectiveSwitches.piLoop == true and
         .effectiveSwitches.managedModelProviderFallback == true
     ' <<<"$feature_switches" >/dev/null
 }

--- a/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
@@ -7,7 +7,7 @@ load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 BATS_TEST_TIMEOUT=600
-MANAGED_FALLBACK_MODEL="gpt-5.6-sol"
+MANAGED_FALLBACK_MODEL="gpt-5.6-luna"
 
 setup() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
@@ -149,7 +149,7 @@ report_managed_model_failure() {
     run jq -e '
         .cliAgentType == "codex" and
         .environment.OPENAI_BASE_URL == "https://openrouter.ai/api/v1" and
-        .environment.OPENAI_MODEL == "openai/gpt-5.6-sol" and
+        .environment.OPENAI_MODEL == "openai/gpt-5.6-luna" and
         any(.firewalls[]?;
             .kind == "builtin" and
             .name == "model-provider:openrouter-codex"

--- a/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
@@ -146,10 +146,10 @@ report_managed_model_failure() {
     run runner_api_curl "/api/runs/${fallback_run_id}/context"
     assert_success
     fallback_context="$output"
-    run jq -e '
+    run jq -e --arg model "openai/${MANAGED_FALLBACK_MODEL}" '
         .cliAgentType == "codex" and
         .environment.OPENAI_BASE_URL == "https://openrouter.ai/api/v1" and
-        .environment.OPENAI_MODEL == "openai/gpt-5.6-luna" and
+        .environment.OPENAI_MODEL == $model and
         any(.firewalls[]?;
             .kind == "builtin" and
             .name == "model-provider:openrouter-codex"

--- a/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-managed-provider-fallback.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+
+# Deployed VM0-managed fallback completion after a trusted exact-route cooldown.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+BATS_TEST_TIMEOUT=600
+MANAGED_FALLBACK_MODEL="gpt-5.6-sol"
+
+setup() {
+    local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
+    export E2E_API_TOKEN E2E_API_URL
+    E2E_API_TOKEN="$(jq -er '.token | select(type == "string" and length > 0)' "$credentials")"
+    E2E_API_URL="$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials")"
+    runner_e2e_require_environment
+    : "${VM0_MITM_RUNNER_TOKEN:?managed fallback E2E requires trusted failure authentication}"
+    runner_e2e_setup_test
+
+    local feature_switches
+    feature_switches="$(runner_api_curl "/api/feature-switches" \
+        -X POST \
+        -d '{"switches":{"realAgentInPreview":true,"piLoop":true,"managedModelProviderFallback":true}}')"
+    jq -e '
+        .effectiveSwitches.realAgentInPreview == true and
+        .effectiveSwitches.piLoop == true and
+        .effectiveSwitches.managedModelProviderFallback == true
+    ' <<<"$feature_switches" >/dev/null
+}
+
+teardown() {
+    runner_e2e_teardown_test
+}
+
+report_managed_model_failure() {
+    local run_id="$1"
+    local base_url token
+    local -a headers
+    base_url="$(runner_api_url)" || return
+    token="${VM0_MITM_RUNNER_TOKEN:?managed fallback E2E requires trusted failure authentication}"
+    headers=(
+        -H "Authorization: Bearer $token"
+        -H "Content-Type: application/json"
+    )
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        headers+=(
+            -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET"
+        )
+    fi
+
+    curl --fail-with-body --silent --show-error \
+        --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
+        --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
+        "${headers[@]}" \
+        -X POST \
+        -d '{"failureKind":"rate_limit","retryAfterSeconds":30}' \
+        "${base_url}/api/runners/runs/${run_id}/model-provider-failures"
+}
+
+@test "a later managed run completes through the OpenRouter fallback" {
+    run create_runner_agent "e2e-managed-fallback-${TEST_ID}"
+    assert_success
+    AGENT_ID="$output"
+
+    run set_runner_agent_instructions \
+        "$AGENT_ID" \
+        "Managed provider fallback completion test instructions."
+    assert_success
+
+    run runner_api_curl "/api/model-policies"
+    assert_success
+    run jq -e --arg model "$MANAGED_FALLBACK_MODEL" '
+        any(.policies[]?;
+            .model == $model and
+            .defaultProviderType == "vm0" and
+            .credentialScope == "org" and
+            .modelProviderId == null
+        )
+    ' <<<"$output"
+    assert_success
+
+    local nonce primary_expected primary_response primary_context
+    local primary_session_id
+    nonce="$(_runner_uuid)"
+    primary_expected="RESULT=primary-${nonce%%-*}"
+    run runner_chat_send \
+        "$AGENT_ID" \
+        "Reply only ${primary_expected}" \
+        "" \
+        "$MANAGED_FALLBACK_MODEL"
+    assert_success
+    RUN_ID="$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")"
+    THREAD_ID="$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")"
+
+    run runner_wait_for_run "$RUN_ID" 180
+    assert_success
+    primary_response="$output"
+    primary_session_id="$(jq -er \
+        '.result.agentSessionId | select(type == "string" and length > 0)' \
+        <<<"$primary_response")"
+
+    run _wait_for_runner_chat_output \
+        "$THREAD_ID" \
+        "$RUN_ID" \
+        "$primary_expected" \
+        60
+    assert_success
+
+    run runner_api_curl "/api/runs/${RUN_ID}/context"
+    assert_success
+    primary_context="$output"
+    run jq -e --arg model "$MANAGED_FALLBACK_MODEL" '
+        .cliAgentType == "codex" and
+        .environment.OPENAI_MODEL == $model and
+        (.environment | has("OPENAI_BASE_URL") | not) and
+        any(.firewalls[]?;
+            .kind == "builtin" and
+            .name == "model-provider:openai-api-key"
+        )
+    ' <<<"$primary_context"
+    assert_success
+
+    run report_managed_model_failure "$RUN_ID"
+    assert_success
+    run jq -e '. == {"outcome":"recorded"}' <<<"$output"
+    assert_success
+
+    local fallback_expected fallback_result fallback_run_id
+    local fallback_session_id fallback_context
+    fallback_expected="RESULT=fallback-${nonce%%-*}"
+    run runner_chat_send_after_completion \
+        "$AGENT_ID" \
+        "$THREAD_ID" \
+        "$RUN_ID" \
+        "Reply only ${fallback_expected}" \
+        "$fallback_expected" \
+        180
+    assert_success
+    fallback_result="$output"
+    fallback_run_id="$(runner_chat_field "$fallback_result" '.runId')"
+    fallback_session_id="$(runner_chat_field "$fallback_result" '.sessionId')"
+    [[ "$fallback_session_id" != "$primary_session_id" ]]
+    RUN_ID="$fallback_run_id"
+
+    run runner_api_curl "/api/runs/${fallback_run_id}/context"
+    assert_success
+    fallback_context="$output"
+    run jq -e '
+        .cliAgentType == "codex" and
+        .environment.OPENAI_BASE_URL == "https://openrouter.ai/api/v1" and
+        .environment.OPENAI_MODEL == "openai/gpt-5.6-sol" and
+        any(.firewalls[]?;
+            .kind == "builtin" and
+            .name == "model-provider:openrouter-codex"
+        )
+    ' <<<"$fallback_context"
+    assert_success
+}


### PR DESCRIPTION
## Summary

- add a deployed runner E2E that completes a VM0-managed OpenAI run, records a short trusted exact-route cooldown, and requires the next same-thread run to complete through the real OpenRouter fallback
- use `gpt-5.6-luna` for the two real Codex runs to reduce provider cost without changing the OpenAI-to-OpenRouter route transition being tested
- prove the route transition through public run context, user-visible output, terminal completion, and session rotation
- enable fallback once in the dedicated account bootstrap and keep the fallback test read-only for shared feature-switch state
- expose official failure authentication only to the shard containing this test and extend the workflow contract checks for that wiring

## Scope

- production feature-switch defaults remain off
- no API, database, migration, runner, mitmproxy, or model catalog behavior changes
- this E2E starts from a trusted normalized failure report; existing API and Python integration tests remain responsible for proxy discovery, classification, and delivery

## Validation

- `cd turbo && pnpm prettier --write --ignore-unknown ../.github/workflows/turbo.yml ../.github/scripts/tests/turbo-playwright-runner-workflow-test.sh ../e2e/tests/03-runner/run-t10-real-claude-smoke.bats ../e2e/tests/03-runner/run-t24-managed-provider-fallback.bats`
- `shellcheck --severity=error .github/scripts/tests/turbo-playwright-runner-workflow-test.sh e2e/tests/03-runner/run-t10-real-claude-smoke.bats e2e/tests/03-runner/run-t24-managed-provider-fallback.bats`
- `cd e2e && ./test/libs/bats/bin/bats --count tests/03-runner/run-t10-real-claude-smoke.bats tests/03-runner/run-t24-managed-provider-fallback.bats` (4 tests)
- `cd e2e && pnpm test` (39 passed)
- `cd e2e && pnpm check-types`
- runner shard generation: new fallback file discovered exactly once in a non-empty shard
- workflow YAML parsed and the changed fallback bootstrap plus shard-scoped token assertions passed through the available Node YAML parser
- `lefthook run pre-commit`

The repository's Ruby workflow contract script passed its shell assertions but could not run its Ruby/YAML section locally because this container does not include Ruby; PR CI remains authoritative for that script and for the deployed real-provider E2E.

The Luna substitution and final concurrency simplification were revalidated with the targeted formatter, ShellCheck, four-test BATS count, deterministic shard generation, the 39-test E2E package suite, E2E type checking, and the pre-commit hook.

Closes #28710

Parent: #28148
