### PR TITLE
refactor(api): drop the branded compatibility rows with no traffic

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -14,6 +14,7 @@ import { feishuConnectRoutes } from "../signals/routes/feishu-connect";
 import { feishuOauthRoutes } from "../signals/routes/feishu-oauth";
 import { imageRecognitionRoutes } from "../signals/routes/image-recognition";
 import { imageShareXRoutes } from "../signals/routes/image-share-x";
+import { mapsRoutes } from "../signals/routes/maps";
 import { orgReadRoutes } from "../signals/routes/org-read";
 import { peopleSearchRoutes } from "../signals/routes/people-search";
 import { queuePositionRoutes } from "../signals/routes/queue-position";
@@ -110,11 +111,16 @@ const MIGRATED_TABLE: Readonly<Record<string, readonly string[]>> = {
   ],
 };
 
-// The seven operations #28417 moved off `/api/okou/maps/**`, written out rather
-// than read from `mapsContract` or `MIGRATED_BRANDED_PATHS`, so dropping a
-// contract path or a table row fails the test that uses this.
-const MAPS_OPERATIONS = [
-  "geocode",
+// The maps operations that still owe a branded form. #28417 moved seven off
+// `/api/okou/maps/**`; #28709 removed the six that took no branded request in
+// the retained window, leaving the one a published CLI was still calling.
+// Written out rather than read from `mapsContract` or `MIGRATED_BRANDED_PATHS`,
+// so dropping a contract path or a table row fails the test that uses this.
+const MAPS_OPERATIONS = ["geocode"] as const;
+
+// The maps operations #28709 retired. Listed separately, and asserted to be
+// absent, so restoring a row without restoring its evidence fails here.
+const RETIRED_MAPS_OPERATIONS = [
   "reverse-geocode",
   "directions",
   "places/search",
@@ -123,11 +129,11 @@ const MAPS_OPERATIONS = [
   "osm/render",
 ] as const;
 
-// The five operations #28357 moved off `/api/okou/weather/**`, written out
-// rather than read from `weatherContract` or `MIGRATED_BRANDED_PATHS`, so
-// dropping a contract path or a table row fails the test that uses this.
-const WEATHER_OPERATIONS = [
-  "current",
+// The weather twin of the two lists above: #28357 moved five operations off
+// `/api/okou/weather/**` and #28709 kept only the one with measured traffic.
+const WEATHER_OPERATIONS = ["current"] as const;
+
+const RETIRED_WEATHER_OPERATIONS = [
   "forecast/hourly",
   "forecast/daily",
   "history/hourly",
@@ -157,29 +163,13 @@ const BRANDED_PATHS_OWED = [
 // appends its own rows.
 const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28421
-  "/api/me/model-provider-accounts/:id": [
-    "/api/okou/me/model-provider-accounts/:id",
-    "/api/zero/me/model-provider-accounts/:id",
-  ],
   "/api/me/model-provider-accounts/:id/activate": [
     "/api/okou/me/model-provider-accounts/:id/activate",
     "/api/zero/me/model-provider-accounts/:id/activate",
   ],
-  "/api/me/model-provider-accounts/:id/subscription-reset": [
-    "/api/okou/me/model-provider-accounts/:id/subscription-reset",
-    "/api/zero/me/model-provider-accounts/:id/subscription-reset",
-  ],
   "/api/me/model-providers": [
     "/api/okou/me/model-providers",
     "/api/zero/me/model-providers",
-  ],
-  "/api/me/model-providers/:type": [
-    "/api/okou/me/model-providers/:type",
-    "/api/zero/me/model-providers/:type",
-  ],
-  "/api/me/model-providers/:type/subscription-reset": [
-    "/api/okou/me/model-providers/:type/subscription-reset",
-    "/api/zero/me/model-providers/:type/subscription-reset",
   ],
   "/api/onboarding/complete": [
     "/api/okou/onboarding/complete",
@@ -199,7 +189,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/user-preferences",
   ],
   // #28418
-  "/api/browsers": ["/api/okou/browsers", "/api/zero/browsers"],
   "/api/browsers/current": [
     "/api/okou/browsers/current",
     "/api/zero/browsers/current",
@@ -215,10 +204,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/finance/profile",
   ],
   "/api/finance/quote": ["/api/okou/finance/quote", "/api/zero/finance/quote"],
-  "/api/finance/search": [
-    "/api/okou/finance/search",
-    "/api/zero/finance/search",
-  ],
   "/api/mcp-connectors": [
     "/api/okou/mcp-connectors",
     "/api/zero/mcp-connectors",
@@ -231,11 +216,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/seo/keyword-ideas",
     "/api/zero/seo/keyword-ideas",
   ],
-  "/api/seo/ranked-keywords": [
-    "/api/okou/seo/ranked-keywords",
-    "/api/zero/seo/ranked-keywords",
-  ],
-  "/api/seo/serp": ["/api/okou/seo/serp", "/api/zero/seo/serp"],
   // #28415
   "/api/built-in-generations/:generationId": [
     "/api/okou/built-in-generations/:generationId",
@@ -254,7 +234,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/goal": ["/api/okou/goal", "/api/zero/goal"],
   "/api/goal/block": ["/api/okou/goal/block", "/api/zero/goal/block"],
   "/api/goal/complete": ["/api/okou/goal/complete", "/api/zero/goal/complete"],
-  "/api/goal/pause": ["/api/okou/goal/pause", "/api/zero/goal/pause"],
   "/api/goal/resume": ["/api/okou/goal/resume", "/api/zero/goal/resume"],
   "/api/host/deployments/:deploymentId/complete": [
     "/api/okou/host/deployments/:deploymentId/complete",
@@ -300,7 +279,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/artifacts/catalog/:artifactId",
     "/api/zero/artifacts/catalog/:artifactId",
   ],
-  "/api/logs": ["/api/okou/logs", "/api/zero/logs"],
   "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
   "/api/push-subscriptions": [
     "/api/okou/push-subscriptions",
@@ -311,10 +289,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/realtime/token",
   ],
   "/api/runs/:id": ["/api/okou/runs/:id", "/api/zero/runs/:id"],
-  "/api/runs/:id/cancel": [
-    "/api/okou/runs/:id/cancel",
-    "/api/zero/runs/:id/cancel",
-  ],
   "/api/runs/:id/context": [
     "/api/okou/runs/:id/context",
     "/api/zero/runs/:id/context",
@@ -344,25 +318,13 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:id/computer-use-host",
     "/api/zero/chat-threads/:id/computer-use-host",
   ],
-  "/api/chat-threads/:id/connector-selections": [
-    "/api/okou/chat-threads/:id/connector-selections",
-    "/api/zero/chat-threads/:id/connector-selections",
-  ],
   "/api/chat-threads/:id/draft": [
     "/api/okou/chat-threads/:id/draft",
     "/api/zero/chat-threads/:id/draft",
   ],
-  "/api/chat-threads/:id/image-model": [
-    "/api/okou/chat-threads/:id/image-model",
-    "/api/zero/chat-threads/:id/image-model",
-  ],
   "/api/chat-threads/:id/mark-read": [
     "/api/okou/chat-threads/:id/mark-read",
     "/api/zero/chat-threads/:id/mark-read",
-  ],
-  "/api/chat-threads/:id/mark-unread": [
-    "/api/okou/chat-threads/:id/mark-unread",
-    "/api/zero/chat-threads/:id/mark-unread",
   ],
   "/api/chat-threads/:id/metadata": [
     "/api/okou/chat-threads/:id/metadata",
@@ -384,10 +346,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:id/unpin",
     "/api/zero/chat-threads/:id/unpin",
   ],
-  "/api/chat-threads/:id/video-model": [
-    "/api/okou/chat-threads/:id/video-model",
-    "/api/zero/chat-threads/:id/video-model",
-  ],
   "/api/chat-threads/:threadId/artifacts": [
     "/api/okou/chat-threads/:threadId/artifacts",
     "/api/zero/chat-threads/:threadId/artifacts",
@@ -408,10 +366,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/browser/open",
     "/api/zero/chat-threads/:threadId/browser/open",
   ],
-  "/api/chat-threads/:threadId/browser/resize": [
-    "/api/okou/chat-threads/:threadId/browser/resize",
-    "/api/zero/chat-threads/:threadId/browser/resize",
-  ],
   "/api/chat-threads/:threadId/event-rows": [
     "/api/okou/chat-threads/:threadId/event-rows",
     "/api/zero/chat-threads/:threadId/event-rows",
@@ -428,10 +382,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/goal/pause",
     "/api/zero/chat-threads/:threadId/goal/pause",
   ],
-  "/api/chat-threads/:threadId/shared-threads": [
-    "/api/okou/chat-threads/:threadId/shared-threads",
-    "/api/zero/chat-threads/:threadId/shared-threads",
-  ],
   "/api/chat-threads/:threadId/workflow-automations": [
     "/api/okou/chat-threads/:threadId/workflow-automations",
     "/api/zero/chat-threads/:threadId/workflow-automations",
@@ -446,35 +396,10 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   ],
   "/api/chat/events": ["/api/okou/chat/events", "/api/zero/chat/events"],
   "/api/chat/search": ["/api/okou/chat/search", "/api/zero/chat/search"],
-  "/api/image-share/x": ["/api/okou/image-share/x", "/api/zero/image-share/x"],
-  "/api/queue-position": [
-    "/api/okou/queue-position",
-    "/api/zero/queue-position",
-  ],
-  "/api/shared-threads/:id": [
-    "/api/okou/shared-threads/:id",
-    "/api/zero/shared-threads/:id",
-  ],
-  "/api/shared-threads/:id/meta": [
-    "/api/okou/shared-threads/:id/meta",
-    "/api/zero/shared-threads/:id/meta",
-  ],
   // #28457: the billing surface.
-  "/api/billing/auto-recharge": [
-    "/api/okou/billing/auto-recharge",
-    "/api/zero/billing/auto-recharge",
-  ],
   "/api/billing/checkout": [
     "/api/okou/billing/checkout",
     "/api/zero/billing/checkout",
-  ],
-  "/api/billing/checkout/complete": [
-    "/api/okou/billing/checkout/complete",
-    "/api/zero/billing/checkout/complete",
-  ],
-  "/api/billing/checkout/confirm": [
-    "/api/okou/billing/checkout/confirm",
-    "/api/zero/billing/checkout/confirm",
   ],
   "/api/billing/concurrency-checkout": [
     "/api/okou/billing/concurrency-checkout",
@@ -484,41 +409,17 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/concurrency-checkout/preview",
     "/api/zero/billing/concurrency-checkout/preview",
   ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/cancel": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/cancel",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/cancel",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/changes/confirm": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/confirm",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/confirm",
-  ],
   "/api/billing/concurrency-subscriptions/:subscriptionId/changes/preview": [
     "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
     "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/restore": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/restore",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/restore",
-  ],
-  "/api/billing/credit-checkout": [
-    "/api/okou/billing/credit-checkout",
-    "/api/zero/billing/credit-checkout",
   ],
   "/api/billing/credit-checkout/confirm": [
     "/api/okou/billing/credit-checkout/confirm",
     "/api/zero/billing/credit-checkout/confirm",
   ],
-  "/api/billing/downgrade": [
-    "/api/okou/billing/downgrade",
-    "/api/zero/billing/downgrade",
-  ],
   "/api/billing/invoices": [
     "/api/okou/billing/invoices",
     "/api/zero/billing/invoices",
-  ],
-  "/api/billing/invoices/receipts": [
-    "/api/okou/billing/invoices/receipts",
-    "/api/zero/billing/invoices/receipts",
   ],
   "/api/billing/portal": [
     "/api/okou/billing/portal",
@@ -527,10 +428,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/redeem-code": [
     "/api/okou/billing/redeem-code",
     "/api/zero/billing/redeem-code",
-  ],
-  "/api/billing/redeem/:campaign": [
-    "/api/okou/billing/redeem/:campaign",
-    "/api/zero/billing/redeem/:campaign",
   ],
   "/api/billing/restore": [
     "/api/okou/billing/restore",
@@ -548,10 +445,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/usage-pack-checkout",
     "/api/zero/billing/usage-pack-checkout",
   ],
-  "/api/billing/usage-pack-checkout/confirm": [
-    "/api/okou/billing/usage-pack-checkout/confirm",
-    "/api/zero/billing/usage-pack-checkout/confirm",
-  ],
   "/api/billing/usage-pack-credits": [
     "/api/okou/billing/usage-pack-credits",
     "/api/zero/billing/usage-pack-credits",
@@ -560,33 +453,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/usage-pack-migration",
     "/api/zero/billing/usage-pack-migration",
   ],
-  "/api/billing/usage-pack-migration/:migrationId/confirm": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/confirm",
-    "/api/zero/billing/usage-pack-migration/:migrationId/confirm",
-  ],
-  "/api/billing/usage-pack-migration/:migrationId/revision/confirm": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/revision/confirm",
-    "/api/zero/billing/usage-pack-migration/:migrationId/revision/confirm",
-  ],
-  "/api/billing/usage-pack-migration/:migrationId/revision/preview": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/revision/preview",
-    "/api/zero/billing/usage-pack-migration/:migrationId/revision/preview",
-  ],
-  "/api/billing/usage-pack-migration/preview": [
-    "/api/okou/billing/usage-pack-migration/preview",
-    "/api/zero/billing/usage-pack-migration/preview",
-  ],
   "/api/billing/usage-pack-subscription": [
     "/api/okou/billing/usage-pack-subscription",
     "/api/zero/billing/usage-pack-subscription",
-  ],
-  "/api/billing/usage-pack-subscription/changes/:changeId/confirm": [
-    "/api/okou/billing/usage-pack-subscription/changes/:changeId/confirm",
-    "/api/zero/billing/usage-pack-subscription/changes/:changeId/confirm",
-  ],
-  "/api/billing/usage-pack-subscription/changes/preview": [
-    "/api/okou/billing/usage-pack-subscription/changes/preview",
-    "/api/zero/billing/usage-pack-subscription/changes/preview",
   ],
   "/api/billing/usage-pack-subscription/subscription-change/confirm": [
     "/api/okou/billing/usage-pack-subscription/subscription-change/confirm",
@@ -601,18 +470,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/audit-events",
     "/api/zero/computer-use/audit-events",
   ],
-  "/api/computer-use/authorization-requests": [
-    "/api/okou/computer-use/authorization-requests",
-    "/api/zero/computer-use/authorization-requests",
-  ],
-  "/api/computer-use/authorization-requests/:requestToken": [
-    "/api/okou/computer-use/authorization-requests/:requestToken",
-    "/api/zero/computer-use/authorization-requests/:requestToken",
-  ],
-  "/api/computer-use/authorization-requests/:requestToken/apply": [
-    "/api/okou/computer-use/authorization-requests/:requestToken/apply",
-    "/api/zero/computer-use/authorization-requests/:requestToken/apply",
-  ],
   "/api/computer-use/commands": [
     "/api/okou/computer-use/commands",
     "/api/zero/computer-use/commands",
@@ -620,10 +477,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/computer-use/commands/:commandId": [
     "/api/okou/computer-use/commands/:commandId",
     "/api/zero/computer-use/commands/:commandId",
-  ],
-  "/api/computer-use/commands/:commandId/plugin-content": [
-    "/api/okou/computer-use/commands/:commandId/plugin-content",
-    "/api/zero/computer-use/commands/:commandId/plugin-content",
   ],
   "/api/computer-use/commands/:commandId/screenshot": [
     "/api/okou/computer-use/commands/:commandId/screenshot",
@@ -653,10 +506,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/hosts/start",
     "/api/zero/computer-use/hosts/start",
   ],
-  "/api/computer-use/plugin-commands": [
-    "/api/okou/computer-use/plugin-commands",
-    "/api/zero/computer-use/plugin-commands",
-  ],
   "/api/computer-use/write-commands": [
     "/api/okou/computer-use/write-commands",
     "/api/zero/computer-use/write-commands",
@@ -665,62 +514,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/integrations/feishu": [
     "/api/okou/integrations/feishu",
     "/api/zero/integrations/feishu",
-  ],
-  "/api/integrations/feishu/app-id": [
-    "/api/okou/integrations/feishu/app-id",
-    "/api/zero/integrations/feishu/app-id",
-  ],
-  "/api/integrations/feishu/connect": [
-    "/api/okou/integrations/feishu/connect",
-    "/api/zero/integrations/feishu/connect",
-  ],
-  "/api/integrations/feishu/download-file": [
-    "/api/okou/integrations/feishu/download-file",
-    "/api/zero/integrations/feishu/download-file",
-  ],
-  "/api/integrations/feishu/installations/:installationId": [
-    "/api/okou/integrations/feishu/installations/:installationId",
-    "/api/zero/integrations/feishu/installations/:installationId",
-  ],
-  "/api/integrations/feishu/installations/:installationId/connect": [
-    "/api/okou/integrations/feishu/installations/:installationId/connect",
-    "/api/zero/integrations/feishu/installations/:installationId/connect",
-  ],
-  "/api/integrations/feishu/message": [
-    "/api/okou/integrations/feishu/message",
-    "/api/zero/integrations/feishu/message",
-  ],
-  "/api/integrations/feishu/upload-file/complete": [
-    "/api/okou/integrations/feishu/upload-file/complete",
-    "/api/zero/integrations/feishu/upload-file/complete",
-  ],
-  "/api/integrations/feishu/upload-file/init": [
-    "/api/okou/integrations/feishu/upload-file/init",
-    "/api/zero/integrations/feishu/upload-file/init",
-  ],
-  "/api/integrations/github/upload-file/complete": [
-    "/api/okou/integrations/github/upload-file/complete",
-    "/api/zero/integrations/github/upload-file/complete",
-  ],
-  "/api/integrations/github/upload-file/init": [
-    "/api/okou/integrations/github/upload-file/init",
-    "/api/zero/integrations/github/upload-file/init",
-  ],
-  "/api/integrations/phone/download-file": [
-    "/api/okou/integrations/phone/download-file",
-    "/api/zero/integrations/phone/download-file",
-  ],
-  "/api/integrations/phone/message": [
-    "/api/okou/integrations/phone/message",
-    "/api/zero/integrations/phone/message",
-  ],
-  "/api/integrations/phone/upload-file/complete": [
-    "/api/okou/integrations/phone/upload-file/complete",
-    "/api/zero/integrations/phone/upload-file/complete",
-  ],
-  "/api/integrations/phone/upload-file/init": [
-    "/api/okou/integrations/phone/upload-file/init",
-    "/api/zero/integrations/phone/upload-file/init",
   ],
   "/api/integrations/slack": [
     "/api/okou/integrations/slack",
@@ -750,56 +543,12 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/integrations/strapi",
     "/api/zero/integrations/strapi",
   ],
-  "/api/integrations/strapi/:integrationId": [
-    "/api/okou/integrations/strapi/:integrationId",
-    "/api/zero/integrations/strapi/:integrationId",
-  ],
-  "/api/integrations/strapi/:integrationId/check-test": [
-    "/api/okou/integrations/strapi/:integrationId/check-test",
-    "/api/zero/integrations/strapi/:integrationId/check-test",
-  ],
-  "/api/integrations/strapi/:integrationId/secret": [
-    "/api/okou/integrations/strapi/:integrationId/secret",
-    "/api/zero/integrations/strapi/:integrationId/secret",
-  ],
   "/api/integrations/teams/connect": [
     "/api/okou/integrations/teams/connect",
     "/api/zero/integrations/teams/connect",
   ],
-  "/api/integrations/teams/message": [
-    "/api/okou/integrations/teams/message",
-    "/api/zero/integrations/teams/message",
-  ],
-  "/api/integrations/teams/upload-file/complete": [
-    "/api/okou/integrations/teams/upload-file/complete",
-    "/api/zero/integrations/teams/upload-file/complete",
-  ],
-  "/api/integrations/teams/upload-file/init": [
-    "/api/okou/integrations/teams/upload-file/init",
-    "/api/zero/integrations/teams/upload-file/init",
-  ],
-  "/api/integrations/telegram/bots": [
-    "/api/okou/integrations/telegram/bots",
-    "/api/zero/integrations/telegram/bots",
-  ],
-  "/api/integrations/telegram/message": [
-    "/api/okou/integrations/telegram/message",
-    "/api/zero/integrations/telegram/message",
-  ],
-  "/api/integrations/telegram/upload-file/complete": [
-    "/api/okou/integrations/telegram/upload-file/complete",
-    "/api/zero/integrations/telegram/upload-file/complete",
-  ],
-  "/api/integrations/telegram/upload-file/init": [
-    "/api/okou/integrations/telegram/upload-file/init",
-    "/api/zero/integrations/telegram/upload-file/init",
-  ],
   // #28460: the connector catalog, the connector connections, the custom
   // connectors, the model provider connections, and the user permission grants.
-  "/api/connector-catalog": [
-    "/api/okou/connector-catalog",
-    "/api/zero/connector-catalog",
-  ],
   "/api/connector-catalog/:connectorSlug": [
     "/api/okou/connector-catalog/:connectorSlug",
     "/api/zero/connector-catalog/:connectorSlug",
@@ -825,93 +574,25 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/connectors/:connectorSlug",
     "/api/zero/connectors/:connectorSlug",
   ],
-  "/api/connectors/:connectorSlug/external-code/sessions": [
-    "/api/okou/connectors/:connectorSlug/external-code/sessions",
-    "/api/zero/connectors/:connectorSlug/external-code/sessions",
-  ],
-  "/api/connectors/:connectorSlug/external-code/sessions/:sessionId/complete": [
-    "/api/okou/connectors/:connectorSlug/external-code/sessions/:sessionId/complete",
-    "/api/zero/connectors/:connectorSlug/external-code/sessions/:sessionId/complete",
-  ],
   "/api/connectors/:connectorSlug/manual-grant": [
     "/api/okou/connectors/:connectorSlug/manual-grant",
     "/api/zero/connectors/:connectorSlug/manual-grant",
-  ],
-  "/api/connectors/:connectorSlug/no-auth": [
-    "/api/okou/connectors/:connectorSlug/no-auth",
-    "/api/zero/connectors/:connectorSlug/no-auth",
-  ],
-  "/api/connectors/:connectorSlug/oauth/device/sessions": [
-    "/api/okou/connectors/:connectorSlug/oauth/device/sessions",
-    "/api/zero/connectors/:connectorSlug/oauth/device/sessions",
-  ],
-  "/api/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll": [
-    "/api/okou/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll",
-    "/api/zero/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll",
   ],
   "/api/connectors/:connectorSlug/oauth/start": [
     "/api/okou/connectors/:connectorSlug/oauth/start",
     "/api/zero/connectors/:connectorSlug/oauth/start",
   ],
-  "/api/connectors/:connectorSlug/openid/start": [
-    "/api/okou/connectors/:connectorSlug/openid/start",
-    "/api/zero/connectors/:connectorSlug/openid/start",
-  ],
-  "/api/connectors/:connectorSlug/scope-diff": [
-    "/api/okou/connectors/:connectorSlug/scope-diff",
-    "/api/zero/connectors/:connectorSlug/scope-diff",
-  ],
   "/api/connectors/diagnostics/check": [
     "/api/okou/connectors/diagnostics/check",
     "/api/zero/connectors/diagnostics/check",
-  ],
-  "/api/connectors/search": [
-    "/api/okou/connectors/search",
-    "/api/zero/connectors/search",
-  ],
-  "/api/connectors/steam/player": [
-    "/api/okou/connectors/steam/player",
-    "/api/zero/connectors/steam/player",
   ],
   "/api/custom-connectors": [
     "/api/okou/custom-connectors",
     "/api/zero/custom-connectors",
   ],
-  "/api/custom-connectors/:id": [
-    "/api/okou/custom-connectors/:id",
-    "/api/zero/custom-connectors/:id",
-  ],
-  "/api/custom-connectors/:id/connection": [
-    "/api/okou/custom-connectors/:id/connection",
-    "/api/zero/custom-connectors/:id/connection",
-  ],
-  "/api/custom-connectors/:id/oauth2/start": [
-    "/api/okou/custom-connectors/:id/oauth2/start",
-    "/api/zero/custom-connectors/:id/oauth2/start",
-  ],
-  "/api/custom-connectors/:id/permissions": [
-    "/api/okou/custom-connectors/:id/permissions",
-    "/api/zero/custom-connectors/:id/permissions",
-  ],
-  "/api/custom-connectors/:id/values": [
-    "/api/okou/custom-connectors/:id/values",
-    "/api/zero/custom-connectors/:id/values",
-  ],
-  "/api/custom-connectors/oauth2/callback": [
-    "/api/okou/custom-connectors/oauth2/callback",
-    "/api/zero/custom-connectors/oauth2/callback",
-  ],
-  "/api/custom-connectors/proposals/save": [
-    "/api/okou/custom-connectors/proposals/save",
-    "/api/zero/custom-connectors/proposals/save",
-  ],
   "/api/model-provider-connections": [
     "/api/okou/model-provider-connections",
     "/api/zero/model-provider-connections",
-  ],
-  "/api/model-provider-connections/:id": [
-    "/api/okou/model-provider-connections/:id",
-    "/api/zero/model-provider-connections/:id",
   ],
   "/api/user-permission-grants": [
     "/api/okou/user-permission-grants",
@@ -924,18 +605,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes. The
   // paths a provider console holds are not in this slice and stay branded;
   // they are covered by `provider-console-paths.test.ts`.
-  "/api/feishu/connect": [
-    "/api/okou/feishu/connect",
-    "/api/zero/feishu/connect",
-  ],
-  "/api/feishu/connect/status": [
-    "/api/okou/feishu/connect/status",
-    "/api/zero/feishu/connect/status",
-  ],
-  "/api/feishu/oauth/connect": [
-    "/api/okou/feishu/oauth/connect",
-    "/api/zero/feishu/oauth/connect",
-  ],
   "/api/slack/channels": [
     "/api/okou/slack/channels",
     "/api/zero/slack/channels",
@@ -947,11 +616,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/slack/oauth/install": [
     "/api/okou/slack/oauth/install",
     "/api/zero/slack/oauth/install",
-  ],
-  "/api/teams/connect": ["/api/okou/teams/connect", "/api/zero/teams/connect"],
-  "/api/teams/oauth/connect": [
-    "/api/okou/teams/oauth/connect",
-    "/api/zero/teams/oauth/connect",
   ],
   // #28465. Keys hold their path parameters verbatim, because the table is
   // matched against `entry.route.path` rather than an expanded request path.
@@ -978,22 +642,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/model-providers",
     "/api/zero/model-providers",
   ],
-  "/api/model-providers/:type": [
-    "/api/okou/model-providers/:type",
-    "/api/zero/model-providers/:type",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions",
-    "/api/zero/model-providers/claude-code/device-auth/sessions",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions/cancel": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions/cancel",
-    "/api/zero/model-providers/claude-code/device-auth/sessions/cancel",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions/complete": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions/complete",
-    "/api/zero/model-providers/claude-code/device-auth/sessions/complete",
-  ],
   "/api/model-providers/codex/device-auth/sessions": [
     "/api/okou/model-providers/codex/device-auth/sessions",
     "/api/zero/model-providers/codex/device-auth/sessions",
@@ -1007,7 +655,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/model-providers/codex/device-auth/sessions/complete",
   ],
   "/api/org": ["/api/okou/org", "/api/zero/org"],
-  "/api/org/delete": ["/api/okou/org/delete", "/api/zero/org/delete"],
   "/api/org/invite": ["/api/okou/org/invite", "/api/zero/org/invite"],
   "/api/org/invite/purchase/:purchaseId/confirm": [
     "/api/okou/org/invite/purchase/:purchaseId/confirm",
@@ -1017,13 +664,8 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/org/invite/purchase/preview",
     "/api/zero/org/invite/purchase/preview",
   ],
-  "/api/org/leave": ["/api/okou/org/leave", "/api/zero/org/leave"],
   "/api/org/logo": ["/api/okou/org/logo", "/api/zero/org/logo"],
   "/api/org/members": ["/api/okou/org/members", "/api/zero/org/members"],
-  "/api/org/membership-requests": [
-    "/api/okou/org/membership-requests",
-    "/api/zero/org/membership-requests",
-  ],
   "/api/usage/members": ["/api/okou/usage/members", "/api/zero/usage/members"],
   "/api/usage/record": ["/api/okou/usage/record", "/api/zero/usage/record"],
   // #28461
@@ -1045,10 +687,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/agents/:id/user-connectors",
     "/api/zero/agents/:id/user-connectors",
   ],
-  "/api/morning-brief/trigger": [
-    "/api/okou/morning-brief/trigger",
-    "/api/zero/morning-brief/trigger",
-  ],
   "/api/workflow-automations": [
     "/api/okou/workflow-automations",
     "/api/zero/workflow-automations",
@@ -1065,14 +703,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflow-automations/:id/enable",
     "/api/zero/workflow-automations/:id/enable",
   ],
-  "/api/workflow-automations/:id/run": [
-    "/api/okou/workflow-automations/:id/run",
-    "/api/zero/workflow-automations/:id/run",
-  ],
-  "/api/workflow-automations/:id/webhook-secret": [
-    "/api/okou/workflow-automations/:id/webhook-secret",
-    "/api/zero/workflow-automations/:id/webhook-secret",
-  ],
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
   "/api/workflows/:workflowId": [
     "/api/okou/workflows/:workflowId",
@@ -1081,26 +711,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/workflows/:workflowId/automations": [
     "/api/okou/workflows/:workflowId/automations",
     "/api/zero/workflows/:workflowId/automations",
-  ],
-  "/api/workflows/:workflowId/chat-thread": [
-    "/api/okou/workflows/:workflowId/chat-thread",
-    "/api/zero/workflows/:workflowId/chat-thread",
-  ],
-  "/api/workflows/:workflowId/connector-readiness": [
-    "/api/okou/workflows/:workflowId/connector-readiness",
-    "/api/zero/workflows/:workflowId/connector-readiness",
-  ],
-  "/api/workflows/:workflowId/copy": [
-    "/api/okou/workflows/:workflowId/copy",
-    "/api/zero/workflows/:workflowId/copy",
-  ],
-  "/api/workflows/:workflowId/demote": [
-    "/api/okou/workflows/:workflowId/demote",
-    "/api/zero/workflows/:workflowId/demote",
-  ],
-  "/api/workflows/:workflowId/publish": [
-    "/api/okou/workflows/:workflowId/publish",
-    "/api/zero/workflows/:workflowId/publish",
   ],
   "/api/workflows/:workflowId/run": [
     "/api/okou/workflows/:workflowId/run",
@@ -1124,25 +734,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/avatar-video/avatars",
     "/api/zero/avatar-video/avatars",
   ],
-  "/api/avatar-video/generate": [
-    "/api/okou/avatar-video/generate",
-    "/api/zero/avatar-video/generate",
-  ],
   "/api/avatar-video/voices": [
     "/api/okou/avatar-video/voices",
     "/api/zero/avatar-video/voices",
-  ],
-  "/api/banking/accounts": [
-    "/api/okou/banking/accounts",
-    "/api/zero/banking/accounts",
-  ],
-  "/api/banking/balances": [
-    "/api/okou/banking/balances",
-    "/api/zero/banking/balances",
-  ],
-  "/api/banking/transactions": [
-    "/api/okou/banking/transactions",
-    "/api/zero/banking/transactions",
   ],
   "/api/browser/authorization-requests": [
     "/api/okou/browser/authorization-requests",
@@ -1156,18 +750,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/browser/authorization-requests/:requestToken/apply",
     "/api/zero/browser/authorization-requests/:requestToken/apply",
   ],
-  "/api/email/inbound": ["/api/okou/email/inbound", "/api/zero/email/inbound"],
-  "/api/github/oauth/connect": [
-    "/api/okou/github/oauth/connect",
-    "/api/zero/github/oauth/connect",
-  ],
   "/api/mail/drafts/:mailDraftId": [
     "/api/okou/mail/drafts/:mailDraftId",
     "/api/zero/mail/drafts/:mailDraftId",
-  ],
-  "/api/mail/drafts/:mailDraftId/attachments/:partId": [
-    "/api/okou/mail/drafts/:mailDraftId/attachments/:partId",
-    "/api/zero/mail/drafts/:mailDraftId/attachments/:partId",
   ],
   "/api/mail/drafts/:mailDraftId/send": [
     "/api/okou/mail/drafts/:mailDraftId/send",
@@ -1186,10 +771,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/presentation-templates/:templateId",
     "/api/zero/presentation-templates/:templateId",
   ],
-  "/api/strapi/events/:integrationId": [
-    "/api/okou/strapi/events/:integrationId",
-    "/api/zero/strapi/events/:integrationId",
-  ],
   "/api/uploads/complete": [
     "/api/okou/uploads/complete",
     "/api/zero/uploads/complete",
@@ -1205,10 +786,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/uploads/prepare": [
     "/api/okou/uploads/prepare",
     "/api/zero/uploads/prepare",
-  ],
-  "/api/video-io/generate": [
-    "/api/okou/video-io/generate",
-    "/api/zero/video-io/generate",
   ],
   "/api/voice-io/quota": [
     "/api/okou/voice-io/quota",
@@ -1229,10 +806,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // only thing registering them now — the events one is what keeps the two
   // production Feishu installations delivering to the URL each of them holds in
   // its own Feishu app console.
-  "/api/integrations/feishu/oauth/callback": [
-    "/api/okou/feishu/oauth/callback",
-    "/api/zero/feishu/oauth/callback",
-  ],
   "/api/webhooks/feishu/events/:installationId": [
     "/api/okou/feishu/events/:installationId",
     "/api/zero/feishu/events/:installationId",
@@ -1240,26 +813,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28565: the connector-account reads and writes and the managed SocialKit
   // request, the two contracts that were added while #28278 was in flight and
   // so appeared in no slice's inventory.
-  "/api/connector-accounts": [
-    "/api/okou/connector-accounts",
-    "/api/zero/connector-accounts",
-  ],
-  "/api/connector-accounts/:connectionId": [
-    "/api/okou/connector-accounts/:connectionId",
-    "/api/zero/connector-accounts/:connectionId",
-  ],
-  "/api/connector-accounts/:connectionId/default": [
-    "/api/okou/connector-accounts/:connectionId/default",
-    "/api/zero/connector-accounts/:connectionId/default",
-  ],
-  "/api/connector-accounts/:connectionId/deletion-impact": [
-    "/api/okou/connector-accounts/:connectionId/deletion-impact",
-    "/api/zero/connector-accounts/:connectionId/deletion-impact",
-  ],
-  "/api/connector-accounts/connections": [
-    "/api/okou/connector-accounts/connections",
-    "/api/zero/connector-accounts/connections",
-  ],
   "/api/social/request": [
     "/api/okou/social/request",
     "/api/zero/social/request",
@@ -1573,7 +1126,6 @@ describe("branded paths for migrated neutral routes", () => {
     // back from `MIGRATED_BRANDED_PATHS`.
     const families = [
       { routes: feishuConnectRoutes, suffix: "integrations/feishu" },
-      { routes: feishuConnectRoutes, suffix: "integrations/feishu/app-id" },
       { routes: slackConnectRoutes, suffix: "integrations/slack/connect" },
       { routes: teamsConnectRoutes, suffix: "integrations/teams/connect" },
       { routes: strapiIntegrationsRoutes, suffix: "integrations/strapi" },
@@ -1619,22 +1171,11 @@ describe("branded paths for migrated neutral routes", () => {
         method: "GET",
         suffix: "avatar-video/voices",
       },
-      {
-        routes: avatarVideoRoutes,
-        method: "POST",
-        suffix: "avatar-video/generate",
-      },
-      { routes: bankingRoutes, method: "POST", suffix: "banking/accounts" },
       { routes: peopleSearchRoutes, method: "POST", suffix: "people-search" },
       {
         routes: uploadsPrepareRoutes,
         method: "POST",
         suffix: "uploads/prepare",
-      },
-      {
-        routes: videoIoGenerateRoutes,
-        method: "POST",
-        suffix: "video-io/generate",
       },
       { routes: voiceIoQuotaRoutes, method: "GET", suffix: "voice-io/quota" },
       { routes: webFileUrlRoutes, method: "GET", suffix: "web/file-url" },
@@ -1687,6 +1228,31 @@ describe("branded paths for migrated neutral routes", () => {
     }).not.toThrow();
   });
 
+  // A count, restated here as a literal, over the inventory above. The
+  // per-family cases prove that the rows still listed are served and that the
+  // ones #28709 dropped are not; this proves the inventory itself is complete,
+  // so a later change that removes a still-needed row fails a test instead of
+  // passing because nothing enumerated it.
+  //
+  // `MIGRATED_ROUTE_PATHS` carries every row but the two the maps and weather
+  // cases own, which is why the total below is two higher than its size. Raise
+  // both numbers only with the request-log evidence #26701 requires — an
+  // unexplained edit here is the failure this is for.
+  it("holds the branded rows this suite has evidence for and no others", () => {
+    const MIGRATED_ROWS_WITH_OWN_CASE = 2;
+    const MIGRATED_BRANDED_ROW_COUNT = 184;
+
+    expect(
+      Object.keys(MIGRATED_ROUTE_PATHS).length + MIGRATED_ROWS_WITH_OWN_CASE,
+    ).toBe(MIGRATED_BRANDED_ROW_COUNT);
+
+    // The rows the maps and weather cases own, named rather than counted, so
+    // the arithmetic above cannot be satisfied by the wrong two rows.
+    for (const owned of ["/api/maps/geocode", "/api/weather/current"]) {
+      expect(MIGRATED_ROUTE_PATHS).not.toHaveProperty(owned);
+    }
+  });
+
   // The route-table assertion above rebuilds the composition itself, so it
   // cannot see how `createAppWithRoutes` wires it. This one goes through the
   // app factory production uses: if `withMigratedBrandedPaths` were dropped
@@ -1724,23 +1290,72 @@ describe("branded paths for migrated neutral routes", () => {
     }
   });
 
-  // The #28459 twin of the two assertions above, for the chat slice. Every
-  // caller of these routes in this repository derives its URL from the
-  // contract, so a request-level case is the only place a dropped row shows
-  // up as the 404 a released client would get. Requests are unauthenticated,
-  // so the status is whatever the auth layer returns — the point is that all
-  // three forms reach the same handler instead of falling through to 404.
-  it("serves the migrated chat-slice paths through the production app factory", async () => {
+  // The inverse of every assertion above, and the one #28709 exists for. A row
+  // this table no longer holds must 404 on both branded forms while its neutral
+  // path keeps answering, which is the whole observable effect of removing one.
+  //
+  // Driven through the production app factory with named routes rather than
+  // over the table's length, so a row that comes back — or a removal that took
+  // the neutral registration with it — fails here. Requests are
+  // unauthenticated, so the neutral status is whatever the auth layer returns;
+  // the point is that it is not the 404 the branded forms now give.
+  //
+  // These endpoints are the retired half of the families the tests above still
+  // cover, so each pair reads against a sibling that was kept. `queue-position`
+  // and `image-share/x` were the whole of the #28459 request-level case before
+  // this change, which is why that test is gone rather than shortened.
+  it("stops serving the branded forms of the rows #28709 removed", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
 
-    const families = [
+    const retired = [
       { routes: queuePositionRoutes, method: "GET", suffix: "queue-position" },
       { routes: imageShareXRoutes, method: "POST", suffix: "image-share/x" },
+      { routes: bankingRoutes, method: "POST", suffix: "banking/accounts" },
+      {
+        routes: videoIoGenerateRoutes,
+        method: "POST",
+        suffix: "video-io/generate",
+      },
+      {
+        routes: avatarVideoRoutes,
+        method: "POST",
+        suffix: "avatar-video/generate",
+      },
+      {
+        routes: connectorAccountRoutes,
+        method: "GET",
+        suffix: "connector-accounts",
+      },
+      {
+        routes: feishuConnectRoutes,
+        method: "GET",
+        suffix: "integrations/feishu/app-id",
+      },
+      {
+        routes: feishuBrowserConnectRoutes,
+        method: "GET",
+        suffix: "feishu/connect",
+      },
+      {
+        routes: teamsBrowserConnectRoutes,
+        method: "GET",
+        suffix: "teams/connect",
+      },
+      {
+        routes: teamsOauthRoutes,
+        method: "GET",
+        suffix: "teams/oauth/connect",
+      },
+      {
+        routes: feishuOauthRoutes,
+        method: "GET",
+        suffix: "feishu/oauth/connect",
+      },
     ] as const;
 
-    for (const { routes, method, suffix } of families) {
+    for (const { routes, method, suffix } of retired) {
       const app = createAppWithRoutes({ signal: context.signal, routes });
 
       async function statusFor(path: string): Promise<number> {
@@ -1756,13 +1371,68 @@ describe("branded paths for migrated neutral routes", () => {
       const okou = await statusFor(`/api/okou/${suffix}`);
       const zero = await statusFor(`/api/zero/${suffix}`);
 
-      expect({ suffix, neutral, okou, zero }).toStrictEqual({
+      expect({ suffix, okou, zero }).toStrictEqual({
         suffix,
-        neutral,
-        okou: neutral,
-        zero: neutral,
+        okou: 404,
+        zero: 404,
       });
-      expect(neutral).not.toBe(404);
+      expect(neutral, `Expected /api/${suffix} to still resolve`).not.toBe(404);
+    }
+  });
+
+  // The maps and weather twin of the case above. Those two families kept one
+  // operation each, so the retired ones are asserted against a sibling that is
+  // still served in the same app rather than in isolation.
+  it("stops serving the branded maps and weather operations #28709 removed", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+
+    const families = [
+      {
+        routes: mapsRoutes,
+        prefix: "maps",
+        kept: MAPS_OPERATIONS,
+        retired: RETIRED_MAPS_OPERATIONS,
+      },
+      {
+        routes: weatherRoutes,
+        prefix: "weather",
+        kept: WEATHER_OPERATIONS,
+        retired: RETIRED_WEATHER_OPERATIONS,
+      },
+    ] as const;
+
+    for (const { routes, prefix, kept, retired } of families) {
+      const app = createAppWithRoutes({ signal: context.signal, routes });
+
+      async function statusFor(path: string): Promise<number> {
+        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        });
+        return response.status;
+      }
+
+      for (const operation of retired) {
+        const neutral = await statusFor(`/api/${prefix}/${operation}`);
+        const okou = await statusFor(`/api/okou/${prefix}/${operation}`);
+        const zero = await statusFor(`/api/zero/${prefix}/${operation}`);
+
+        expect({ operation, okou, zero }).toStrictEqual({
+          operation,
+          okou: 404,
+          zero: 404,
+        });
+        expect(neutral).not.toBe(404);
+      }
+
+      for (const operation of kept) {
+        const okou = await statusFor(`/api/okou/${prefix}/${operation}`);
+
+        expect({ operation, okou }).not.toStrictEqual({ operation, okou: 404 });
+      }
     }
   });
 
@@ -1818,14 +1488,9 @@ describe("branded paths for migrated neutral routes", () => {
     });
 
     const families = [
-      { routes: feishuBrowserConnectRoutes, suffix: "feishu/connect" },
-      { routes: feishuBrowserConnectRoutes, suffix: "feishu/connect/status" },
-      { routes: feishuOauthRoutes, suffix: "feishu/oauth/connect" },
       { routes: slackChannelsRoutes, suffix: "slack/channels" },
       { routes: slackOauthRoutes, suffix: "slack/oauth/connect" },
       { routes: slackOauthRoutes, suffix: "slack/oauth/install" },
-      { routes: teamsBrowserConnectRoutes, suffix: "teams/connect" },
-      { routes: teamsOauthRoutes, suffix: "teams/oauth/connect" },
     ];
 
     for (const { routes, suffix } of families) {
@@ -1957,23 +1622,7 @@ describe("branded paths for migrated neutral routes", () => {
       isAuthenticated: false,
     });
 
-    const connectionId = "11111111-2222-4333-8444-555555555555";
     const endpoints = [
-      {
-        routes: connectorAccountRoutes,
-        method: "GET",
-        suffix: "connector-accounts",
-      },
-      {
-        routes: connectorAccountRoutes,
-        method: "GET",
-        suffix: "connector-accounts/connections",
-      },
-      {
-        routes: connectorAccountRoutes,
-        method: "POST",
-        suffix: `connector-accounts/${connectionId}/default`,
-      },
       { routes: socialRoutes, method: "POST", suffix: "social/request" },
     ] as const;
 

--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -5,19 +5,12 @@ import { z } from "zod";
 import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
 import { avatarVideoRoutes } from "../signals/routes/avatar-video";
-import { bankingRoutes } from "../signals/routes/banking";
 import { billingStatusRoutes } from "../signals/routes/billing-status";
-import { connectorAccountRoutes } from "../signals/routes/connector-accounts";
 import { featureSwitchesRoutes } from "../signals/routes/feature-switches";
-import { feishuBrowserConnectRoutes } from "../signals/routes/feishu-browser-connect";
 import { feishuConnectRoutes } from "../signals/routes/feishu-connect";
-import { feishuOauthRoutes } from "../signals/routes/feishu-oauth";
 import { imageRecognitionRoutes } from "../signals/routes/image-recognition";
-import { imageShareXRoutes } from "../signals/routes/image-share-x";
-import { mapsRoutes } from "../signals/routes/maps";
 import { orgReadRoutes } from "../signals/routes/org-read";
 import { peopleSearchRoutes } from "../signals/routes/people-search";
-import { queuePositionRoutes } from "../signals/routes/queue-position";
 import { scrapeRoutes } from "../signals/routes/scrape";
 import { slackChannelsRoutes } from "../signals/routes/slack-channels";
 import { slackConnectRoutes } from "../signals/routes/slack-connect";
@@ -25,12 +18,10 @@ import { slackOauthRoutes } from "../signals/routes/slack-oauth";
 import { socialRoutes } from "../signals/routes/social";
 import { strapiIntegrationsRoutes } from "../signals/routes/strapi-integrations";
 import { teamsBotRoutes } from "../signals/routes/teams-bot";
-import { teamsBrowserConnectRoutes } from "../signals/routes/teams-browser-connect";
 import { teamsConnectRoutes } from "../signals/routes/teams-connect";
 import { teamsOauthRoutes } from "../signals/routes/teams-oauth";
 import { translationRoutes } from "../signals/routes/translation";
 import { uploadsPrepareRoutes } from "../signals/routes/uploads-prepare";
-import { videoIoGenerateRoutes } from "../signals/routes/video-io-generate";
 import { voiceIoQuotaRoutes } from "../signals/routes/voice-io-quota";
 import { weatherRoutes } from "../signals/routes/weather";
 import { webFileUrlRoutes } from "../signals/routes/web-file-url";
@@ -118,27 +109,9 @@ const MIGRATED_TABLE: Readonly<Record<string, readonly string[]>> = {
 // so dropping a contract path or a table row fails the test that uses this.
 const MAPS_OPERATIONS = ["geocode"] as const;
 
-// The maps operations #28709 retired. Listed separately, and asserted to be
-// absent, so restoring a row without restoring its evidence fails here.
-const RETIRED_MAPS_OPERATIONS = [
-  "reverse-geocode",
-  "directions",
-  "places/search",
-  "places/details",
-  "osm/download",
-  "osm/render",
-] as const;
-
-// The weather twin of the two lists above: #28357 moved five operations off
+// The weather twin of the list above: #28357 moved five operations off
 // `/api/okou/weather/**` and #28709 kept only the one with measured traffic.
 const WEATHER_OPERATIONS = ["current"] as const;
-
-const RETIRED_WEATHER_OPERATIONS = [
-  "forecast/hourly",
-  "forecast/daily",
-  "history/hourly",
-  "air-quality/current",
-] as const;
 
 function registeredPaths(entries: readonly RouteEntry[]): readonly string[] {
   return entries.map((entry) => {
@@ -1229,15 +1202,22 @@ describe("branded paths for migrated neutral routes", () => {
   });
 
   // A count, restated here as a literal, over the inventory above. The
-  // per-family cases prove that the rows still listed are served and that the
-  // ones #28709 dropped are not; this proves the inventory itself is complete,
-  // so a later change that removes a still-needed row fails a test instead of
-  // passing because nothing enumerated it.
+  // per-family cases prove that every row the inventory lists is served on both
+  // branded forms; this proves the inventory itself is complete, so a later
+  // change that removes a still-needed row fails a test instead of passing
+  // because nothing enumerated it.
+  //
+  // That is the guard #28709 left behind when it took the table from 314 rows
+  // to 184. It deliberately did not leave a case asserting the removed rows now
+  // 404: `docs/fallback.md` section 1 rules that class out, and the route table
+  // already proves the registration is gone. What needs a test is the opposite
+  // direction — a row disappearing without the request-log evidence #26701
+  // requires — which is what this count and the per-family cases catch.
   //
   // `MIGRATED_ROUTE_PATHS` carries every row but the two the maps and weather
   // cases own, which is why the total below is two higher than its size. Raise
-  // both numbers only with the request-log evidence #26701 requires — an
-  // unexplained edit here is the failure this is for.
+  // both numbers only with that evidence; an unexplained edit here is the
+  // failure this is for.
   it("holds the branded rows this suite has evidence for and no others", () => {
     const MIGRATED_ROWS_WITH_OWN_CASE = 2;
     const MIGRATED_BRANDED_ROW_COUNT = 184;
@@ -1287,152 +1267,6 @@ describe("branded paths for migrated neutral routes", () => {
         zero: neutral,
       });
       expect(neutral).not.toBe(404);
-    }
-  });
-
-  // The inverse of every assertion above, and the one #28709 exists for. A row
-  // this table no longer holds must 404 on both branded forms while its neutral
-  // path keeps answering, which is the whole observable effect of removing one.
-  //
-  // Driven through the production app factory with named routes rather than
-  // over the table's length, so a row that comes back — or a removal that took
-  // the neutral registration with it — fails here. Requests are
-  // unauthenticated, so the neutral status is whatever the auth layer returns;
-  // the point is that it is not the 404 the branded forms now give.
-  //
-  // These endpoints are the retired half of the families the tests above still
-  // cover, so each pair reads against a sibling that was kept. `queue-position`
-  // and `image-share/x` were the whole of the #28459 request-level case before
-  // this change, which is why that test is gone rather than shortened.
-  it("stops serving the branded forms of the rows #28709 removed", async () => {
-    context.mocks.clerk.authenticateRequest.mockResolvedValue({
-      isAuthenticated: false,
-    });
-
-    const retired = [
-      { routes: queuePositionRoutes, method: "GET", suffix: "queue-position" },
-      { routes: imageShareXRoutes, method: "POST", suffix: "image-share/x" },
-      { routes: bankingRoutes, method: "POST", suffix: "banking/accounts" },
-      {
-        routes: videoIoGenerateRoutes,
-        method: "POST",
-        suffix: "video-io/generate",
-      },
-      {
-        routes: avatarVideoRoutes,
-        method: "POST",
-        suffix: "avatar-video/generate",
-      },
-      {
-        routes: connectorAccountRoutes,
-        method: "GET",
-        suffix: "connector-accounts",
-      },
-      {
-        routes: feishuConnectRoutes,
-        method: "GET",
-        suffix: "integrations/feishu/app-id",
-      },
-      {
-        routes: feishuBrowserConnectRoutes,
-        method: "GET",
-        suffix: "feishu/connect",
-      },
-      {
-        routes: teamsBrowserConnectRoutes,
-        method: "GET",
-        suffix: "teams/connect",
-      },
-      {
-        routes: teamsOauthRoutes,
-        method: "GET",
-        suffix: "teams/oauth/connect",
-      },
-      {
-        routes: feishuOauthRoutes,
-        method: "GET",
-        suffix: "feishu/oauth/connect",
-      },
-    ] as const;
-
-    for (const { routes, method, suffix } of retired) {
-      const app = createAppWithRoutes({ signal: context.signal, routes });
-
-      async function statusFor(path: string): Promise<number> {
-        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-          method,
-          headers: { "content-type": "application/json" },
-          ...(method === "POST" ? { body: "{}" } : {}),
-        });
-        return response.status;
-      }
-
-      const neutral = await statusFor(`/api/${suffix}`);
-      const okou = await statusFor(`/api/okou/${suffix}`);
-      const zero = await statusFor(`/api/zero/${suffix}`);
-
-      expect({ suffix, okou, zero }).toStrictEqual({
-        suffix,
-        okou: 404,
-        zero: 404,
-      });
-      expect(neutral, `Expected /api/${suffix} to still resolve`).not.toBe(404);
-    }
-  });
-
-  // The maps and weather twin of the case above. Those two families kept one
-  // operation each, so the retired ones are asserted against a sibling that is
-  // still served in the same app rather than in isolation.
-  it("stops serving the branded maps and weather operations #28709 removed", async () => {
-    context.mocks.clerk.authenticateRequest.mockResolvedValue({
-      isAuthenticated: false,
-    });
-
-    const families = [
-      {
-        routes: mapsRoutes,
-        prefix: "maps",
-        kept: MAPS_OPERATIONS,
-        retired: RETIRED_MAPS_OPERATIONS,
-      },
-      {
-        routes: weatherRoutes,
-        prefix: "weather",
-        kept: WEATHER_OPERATIONS,
-        retired: RETIRED_WEATHER_OPERATIONS,
-      },
-    ] as const;
-
-    for (const { routes, prefix, kept, retired } of families) {
-      const app = createAppWithRoutes({ signal: context.signal, routes });
-
-      async function statusFor(path: string): Promise<number> {
-        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: "{}",
-        });
-        return response.status;
-      }
-
-      for (const operation of retired) {
-        const neutral = await statusFor(`/api/${prefix}/${operation}`);
-        const okou = await statusFor(`/api/okou/${prefix}/${operation}`);
-        const zero = await statusFor(`/api/zero/${prefix}/${operation}`);
-
-        expect({ operation, okou, zero }).toStrictEqual({
-          operation,
-          okou: 404,
-          zero: 404,
-        });
-        expect(neutral).not.toBe(404);
-      }
-
-      for (const operation of kept) {
-        const okou = await statusFor(`/api/okou/${prefix}/${operation}`);
-
-        expect({ operation, okou }).not.toStrictEqual({ operation, okou: 404 });
-      }
     }
   });
 

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -196,6 +196,26 @@ export function withApiNamespaceAliases(
  * `JOB_TIMEOUT` drain. An installed CLI or desktop build has no window at all,
  * which is why removal is gated on #26701's request-log evidence rather than on
  * a date.
+ *
+ * #28709 applied that gate to the whole table for the first time and took it
+ * from 314 rows to 184. Each removed row had no request on either branded form
+ * across the 6.3 days `vm0-request-log-prod` retained, measured per row rather
+ * than from a truncated top-N summary — the log holds about 6,300 distinct
+ * branded path templates, most of them scanner noise, so a ranked query that
+ * stops short buries exactly the low-traffic rows this gate is deciding. The
+ * check matched each row's branded forms as patterns rather than as literals,
+ * because a CORS preflight is logged under its request path rather than the
+ * route template it never matched.
+ *
+ * Two classes of row survived that check and are why the table is 184 rather
+ * than 135. Forty-six rows took measured traffic on a branded form inside the
+ * window, all of it from released App and CLI builds, so they are still serving
+ * a caller. Three rows took none and stay anyway, because for them silence is
+ * the expected reading rather than evidence: the two `desktop/updates` rows are
+ * a one-shot download an installed macOS build asks for when its owner clicks
+ * it, and the Feishu events row is delivered to by an app console we cannot
+ * edit. None of those holders drains on a deploy, so a quiet week measures how
+ * often the surface is used, not whether it is still owed.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 
@@ -214,54 +234,14 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // drain is the floor for removal, not the condition: these rows retire under
   // #26701's evidence rules like every other row in this file.
   "/api/maps/geocode": ["/api/okou/maps/geocode", "/api/zero/maps/geocode"],
-  "/api/maps/reverse-geocode": [
-    "/api/okou/maps/reverse-geocode",
-    "/api/zero/maps/reverse-geocode",
-  ],
-  "/api/maps/directions": [
-    "/api/okou/maps/directions",
-    "/api/zero/maps/directions",
-  ],
-  "/api/maps/places/search": [
-    "/api/okou/maps/places/search",
-    "/api/zero/maps/places/search",
-  ],
-  "/api/maps/places/details": [
-    "/api/okou/maps/places/details",
-    "/api/zero/maps/places/details",
-  ],
-  "/api/maps/osm/download": [
-    "/api/okou/maps/osm/download",
-    "/api/zero/maps/osm/download",
-  ],
-  "/api/maps/osm/render": [
-    "/api/okou/maps/osm/render",
-    "/api/zero/maps/osm/render",
-  ],
   // #28421: personal model providers, onboarding, team, and user preferences.
-  "/api/me/model-provider-accounts/:id": [
-    "/api/okou/me/model-provider-accounts/:id",
-    "/api/zero/me/model-provider-accounts/:id",
-  ],
   "/api/me/model-provider-accounts/:id/activate": [
     "/api/okou/me/model-provider-accounts/:id/activate",
     "/api/zero/me/model-provider-accounts/:id/activate",
   ],
-  "/api/me/model-provider-accounts/:id/subscription-reset": [
-    "/api/okou/me/model-provider-accounts/:id/subscription-reset",
-    "/api/zero/me/model-provider-accounts/:id/subscription-reset",
-  ],
   "/api/me/model-providers": [
     "/api/okou/me/model-providers",
     "/api/zero/me/model-providers",
-  ],
-  "/api/me/model-providers/:type": [
-    "/api/okou/me/model-providers/:type",
-    "/api/zero/me/model-providers/:type",
-  ],
-  "/api/me/model-providers/:type/subscription-reset": [
-    "/api/okou/me/model-providers/:type/subscription-reset",
-    "/api/zero/me/model-providers/:type/subscription-reset",
   ],
   "/api/onboarding/complete": [
     "/api/okou/onboarding/complete",
@@ -294,22 +274,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/weather/current",
     "/api/zero/weather/current",
   ],
-  "/api/weather/forecast/hourly": [
-    "/api/okou/weather/forecast/hourly",
-    "/api/zero/weather/forecast/hourly",
-  ],
-  "/api/weather/forecast/daily": [
-    "/api/okou/weather/forecast/daily",
-    "/api/zero/weather/forecast/daily",
-  ],
-  "/api/weather/history/hourly": [
-    "/api/okou/weather/history/hourly",
-    "/api/zero/weather/history/hourly",
-  ],
-  "/api/weather/air-quality/current": [
-    "/api/okou/weather/air-quality/current",
-    "/api/zero/weather/air-quality/current",
-  ],
   // #28418: the browser, finance, SEO, and MCP connector routes. The callers
   // these rows keep working are a released web or app client, which holds the
   // branded path until a refresh loads a build that derives the neutral one
@@ -318,7 +282,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // lifetime. Neither window is the removal condition on its own: a row is
   // removed under #26701's evidence rules, because the request log retains
   // about three days and cannot tell a drained caller from a weekly one.
-  "/api/browsers": ["/api/okou/browsers", "/api/zero/browsers"],
   "/api/browsers/current": [
     "/api/okou/browsers/current",
     "/api/zero/browsers/current",
@@ -334,10 +297,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/finance/profile",
   ],
   "/api/finance/quote": ["/api/okou/finance/quote", "/api/zero/finance/quote"],
-  "/api/finance/search": [
-    "/api/okou/finance/search",
-    "/api/zero/finance/search",
-  ],
   "/api/mcp-connectors": [
     "/api/okou/mcp-connectors",
     "/api/zero/mcp-connectors",
@@ -350,11 +309,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/seo/keyword-ideas",
     "/api/zero/seo/keyword-ideas",
   ],
-  "/api/seo/ranked-keywords": [
-    "/api/okou/seo/ranked-keywords",
-    "/api/zero/seo/ranked-keywords",
-  ],
-  "/api/seo/serp": ["/api/okou/seo/serp", "/api/zero/seo/serp"],
   // #28415. Published CLI builds poll generation status and post image
   // generations at the `okou` form — `getBuiltInGenerationStatus` and
   // `generateWebImage` build those URLs by hand rather than from the contract,
@@ -397,7 +351,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/goal": ["/api/okou/goal", "/api/zero/goal"],
   "/api/goal/block": ["/api/okou/goal/block", "/api/zero/goal/block"],
   "/api/goal/complete": ["/api/okou/goal/complete", "/api/zero/goal/complete"],
-  "/api/goal/pause": ["/api/okou/goal/pause", "/api/zero/goal/pause"],
   "/api/goal/resume": ["/api/okou/goal/resume", "/api/zero/goal/resume"],
   "/api/host/deployments/:deploymentId/complete": [
     "/api/okou/host/deployments/:deploymentId/complete",
@@ -450,7 +403,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/artifacts/catalog/:artifactId",
     "/api/zero/artifacts/catalog/:artifactId",
   ],
-  "/api/logs": ["/api/okou/logs", "/api/zero/logs"],
   "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
   "/api/push-subscriptions": [
     "/api/okou/push-subscriptions",
@@ -461,10 +413,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/realtime/token",
   ],
   "/api/runs/:id": ["/api/okou/runs/:id", "/api/zero/runs/:id"],
-  "/api/runs/:id/cancel": [
-    "/api/okou/runs/:id/cancel",
-    "/api/zero/runs/:id/cancel",
-  ],
   "/api/runs/:id/context": [
     "/api/okou/runs/:id/context",
     "/api/zero/runs/:id/context",
@@ -483,17 +431,17 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   ],
   "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
   // #28459: the chat threads themselves, the chat event and search readers,
-  // shared threads, per-thread browser sessions, per-thread goals, workflow
-  // automations, queue position, and the X image share. Every caller in this
-  // repository derives its URL from the contract, so nothing here still asks
-  // for a branded form. Released builds do: a browser tab holding
-  // already-loaded platform code keeps calling the `okou` path it was built
-  // against until it navigates or reloads, the ~2 day old-web-client window in
-  // `docs/fallback.md` section 7; a commit-addressed CLI package pinned by an
-  // execution context's `CLI_PKG_URL` holds it for that context's queue and
-  // claimed-run lifetime; and the `okou-app` share worker deployed to
-  // Cloudflare Pages reads `shared-threads/:id/meta` from a build that ships
-  // separately from this one. The `zero` form was reachable through the
+  // per-thread browser sessions, per-thread goals, and workflow automations.
+  // The slice also covered shared threads, queue position and the X image
+  // share; #28709 removed those rows on zero-traffic evidence, which is why the
+  // `okou-app` share worker no longer appears among the holders below. Every
+  // caller in this repository derives its URL from the contract, so nothing
+  // here still asks for a branded form. Released builds do: a browser tab
+  // holding already-loaded platform code keeps calling the `okou` path it was
+  // built against until it navigates or reloads, the ~2 day old-web-client
+  // window in `docs/fallback.md` section 7; and a commit-addressed CLI package
+  // pinned by an execution context's `CLI_PKG_URL` holds it for that context's
+  // queue and claimed-run lifetime. The `zero` form was reachable through the
   // blanket expansion until the contract moved. All of it is owed, and a row
   // retires under #26701's evidence rules rather than on any of those clocks.
   //
@@ -508,25 +456,13 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:id/computer-use-host",
     "/api/zero/chat-threads/:id/computer-use-host",
   ],
-  "/api/chat-threads/:id/connector-selections": [
-    "/api/okou/chat-threads/:id/connector-selections",
-    "/api/zero/chat-threads/:id/connector-selections",
-  ],
   "/api/chat-threads/:id/draft": [
     "/api/okou/chat-threads/:id/draft",
     "/api/zero/chat-threads/:id/draft",
   ],
-  "/api/chat-threads/:id/image-model": [
-    "/api/okou/chat-threads/:id/image-model",
-    "/api/zero/chat-threads/:id/image-model",
-  ],
   "/api/chat-threads/:id/mark-read": [
     "/api/okou/chat-threads/:id/mark-read",
     "/api/zero/chat-threads/:id/mark-read",
-  ],
-  "/api/chat-threads/:id/mark-unread": [
-    "/api/okou/chat-threads/:id/mark-unread",
-    "/api/zero/chat-threads/:id/mark-unread",
   ],
   "/api/chat-threads/:id/metadata": [
     "/api/okou/chat-threads/:id/metadata",
@@ -548,10 +484,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:id/unpin",
     "/api/zero/chat-threads/:id/unpin",
   ],
-  "/api/chat-threads/:id/video-model": [
-    "/api/okou/chat-threads/:id/video-model",
-    "/api/zero/chat-threads/:id/video-model",
-  ],
   "/api/chat-threads/:threadId/artifacts": [
     "/api/okou/chat-threads/:threadId/artifacts",
     "/api/zero/chat-threads/:threadId/artifacts",
@@ -572,10 +504,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/browser/open",
     "/api/zero/chat-threads/:threadId/browser/open",
   ],
-  "/api/chat-threads/:threadId/browser/resize": [
-    "/api/okou/chat-threads/:threadId/browser/resize",
-    "/api/zero/chat-threads/:threadId/browser/resize",
-  ],
   "/api/chat-threads/:threadId/event-rows": [
     "/api/okou/chat-threads/:threadId/event-rows",
     "/api/zero/chat-threads/:threadId/event-rows",
@@ -592,10 +520,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/goal/pause",
     "/api/zero/chat-threads/:threadId/goal/pause",
   ],
-  "/api/chat-threads/:threadId/shared-threads": [
-    "/api/okou/chat-threads/:threadId/shared-threads",
-    "/api/zero/chat-threads/:threadId/shared-threads",
-  ],
   "/api/chat-threads/:threadId/workflow-automations": [
     "/api/okou/chat-threads/:threadId/workflow-automations",
     "/api/zero/chat-threads/:threadId/workflow-automations",
@@ -610,19 +534,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   ],
   "/api/chat/events": ["/api/okou/chat/events", "/api/zero/chat/events"],
   "/api/chat/search": ["/api/okou/chat/search", "/api/zero/chat/search"],
-  "/api/image-share/x": ["/api/okou/image-share/x", "/api/zero/image-share/x"],
-  "/api/queue-position": [
-    "/api/okou/queue-position",
-    "/api/zero/queue-position",
-  ],
-  "/api/shared-threads/:id": [
-    "/api/okou/shared-threads/:id",
-    "/api/zero/shared-threads/:id",
-  ],
-  "/api/shared-threads/:id/meta": [
-    "/api/okou/shared-threads/:id/meta",
-    "/api/zero/shared-threads/:id/meta",
-  ],
   // #28457: the billing surface — plan and usage-pack checkout, concurrency
   // subscriptions, credit purchase, the Stripe portal, invoices, and code
   // redemption. Every caller derives its URL from the contract, so nothing in
@@ -637,21 +548,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // by symmetry — #28701 dropped its `LEGACY_ZERO_PATHS` row because these rows
   // are what serve it, not because the evidence expired. Both forms are
   // removable only under #26701's evidence rules, like every other row here.
-  "/api/billing/auto-recharge": [
-    "/api/okou/billing/auto-recharge",
-    "/api/zero/billing/auto-recharge",
-  ],
   "/api/billing/checkout": [
     "/api/okou/billing/checkout",
     "/api/zero/billing/checkout",
-  ],
-  "/api/billing/checkout/complete": [
-    "/api/okou/billing/checkout/complete",
-    "/api/zero/billing/checkout/complete",
-  ],
-  "/api/billing/checkout/confirm": [
-    "/api/okou/billing/checkout/confirm",
-    "/api/zero/billing/checkout/confirm",
   ],
   "/api/billing/concurrency-checkout": [
     "/api/okou/billing/concurrency-checkout",
@@ -661,41 +560,17 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/concurrency-checkout/preview",
     "/api/zero/billing/concurrency-checkout/preview",
   ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/cancel": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/cancel",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/cancel",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/changes/confirm": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/confirm",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/confirm",
-  ],
   "/api/billing/concurrency-subscriptions/:subscriptionId/changes/preview": [
     "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
     "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/restore": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/restore",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/restore",
-  ],
-  "/api/billing/credit-checkout": [
-    "/api/okou/billing/credit-checkout",
-    "/api/zero/billing/credit-checkout",
   ],
   "/api/billing/credit-checkout/confirm": [
     "/api/okou/billing/credit-checkout/confirm",
     "/api/zero/billing/credit-checkout/confirm",
   ],
-  "/api/billing/downgrade": [
-    "/api/okou/billing/downgrade",
-    "/api/zero/billing/downgrade",
-  ],
   "/api/billing/invoices": [
     "/api/okou/billing/invoices",
     "/api/zero/billing/invoices",
-  ],
-  "/api/billing/invoices/receipts": [
-    "/api/okou/billing/invoices/receipts",
-    "/api/zero/billing/invoices/receipts",
   ],
   "/api/billing/portal": [
     "/api/okou/billing/portal",
@@ -704,10 +579,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/redeem-code": [
     "/api/okou/billing/redeem-code",
     "/api/zero/billing/redeem-code",
-  ],
-  "/api/billing/redeem/:campaign": [
-    "/api/okou/billing/redeem/:campaign",
-    "/api/zero/billing/redeem/:campaign",
   ],
   "/api/billing/restore": [
     "/api/okou/billing/restore",
@@ -725,10 +596,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/usage-pack-checkout",
     "/api/zero/billing/usage-pack-checkout",
   ],
-  "/api/billing/usage-pack-checkout/confirm": [
-    "/api/okou/billing/usage-pack-checkout/confirm",
-    "/api/zero/billing/usage-pack-checkout/confirm",
-  ],
   "/api/billing/usage-pack-credits": [
     "/api/okou/billing/usage-pack-credits",
     "/api/zero/billing/usage-pack-credits",
@@ -737,33 +604,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/usage-pack-migration",
     "/api/zero/billing/usage-pack-migration",
   ],
-  "/api/billing/usage-pack-migration/:migrationId/confirm": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/confirm",
-    "/api/zero/billing/usage-pack-migration/:migrationId/confirm",
-  ],
-  "/api/billing/usage-pack-migration/:migrationId/revision/confirm": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/revision/confirm",
-    "/api/zero/billing/usage-pack-migration/:migrationId/revision/confirm",
-  ],
-  "/api/billing/usage-pack-migration/:migrationId/revision/preview": [
-    "/api/okou/billing/usage-pack-migration/:migrationId/revision/preview",
-    "/api/zero/billing/usage-pack-migration/:migrationId/revision/preview",
-  ],
-  "/api/billing/usage-pack-migration/preview": [
-    "/api/okou/billing/usage-pack-migration/preview",
-    "/api/zero/billing/usage-pack-migration/preview",
-  ],
   "/api/billing/usage-pack-subscription": [
     "/api/okou/billing/usage-pack-subscription",
     "/api/zero/billing/usage-pack-subscription",
-  ],
-  "/api/billing/usage-pack-subscription/changes/:changeId/confirm": [
-    "/api/okou/billing/usage-pack-subscription/changes/:changeId/confirm",
-    "/api/zero/billing/usage-pack-subscription/changes/:changeId/confirm",
-  ],
-  "/api/billing/usage-pack-subscription/changes/preview": [
-    "/api/okou/billing/usage-pack-subscription/changes/preview",
-    "/api/zero/billing/usage-pack-subscription/changes/preview",
   ],
   "/api/billing/usage-pack-subscription/subscription-change/confirm": [
     "/api/okou/billing/usage-pack-subscription/subscription-change/confirm",
@@ -795,18 +638,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/audit-events",
     "/api/zero/computer-use/audit-events",
   ],
-  "/api/computer-use/authorization-requests": [
-    "/api/okou/computer-use/authorization-requests",
-    "/api/zero/computer-use/authorization-requests",
-  ],
-  "/api/computer-use/authorization-requests/:requestToken": [
-    "/api/okou/computer-use/authorization-requests/:requestToken",
-    "/api/zero/computer-use/authorization-requests/:requestToken",
-  ],
-  "/api/computer-use/authorization-requests/:requestToken/apply": [
-    "/api/okou/computer-use/authorization-requests/:requestToken/apply",
-    "/api/zero/computer-use/authorization-requests/:requestToken/apply",
-  ],
   "/api/computer-use/commands": [
     "/api/okou/computer-use/commands",
     "/api/zero/computer-use/commands",
@@ -814,10 +645,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/computer-use/commands/:commandId": [
     "/api/okou/computer-use/commands/:commandId",
     "/api/zero/computer-use/commands/:commandId",
-  ],
-  "/api/computer-use/commands/:commandId/plugin-content": [
-    "/api/okou/computer-use/commands/:commandId/plugin-content",
-    "/api/zero/computer-use/commands/:commandId/plugin-content",
   ],
   "/api/computer-use/commands/:commandId/screenshot": [
     "/api/okou/computer-use/commands/:commandId/screenshot",
@@ -847,23 +674,22 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/computer-use/hosts/start",
     "/api/zero/computer-use/hosts/start",
   ],
-  "/api/computer-use/plugin-commands": [
-    "/api/okou/computer-use/plugin-commands",
-    "/api/zero/computer-use/plugin-commands",
-  ],
   "/api/computer-use/write-commands": [
     "/api/okou/computer-use/write-commands",
     "/api/zero/computer-use/write-commands",
   ],
   // #28423: the integration control plane and the CLI messaging and file
-  // surfaces for Feishu, Slack, Microsoft Teams, Telegram, GitHub, AgentPhone,
-  // and Strapi. Two callers hold a branded form independently of the contract:
-  // `downloadFeishuFile` and `downloadPhoneFile` in the CLI build their URL by
-  // hand, so a published package keeps asking for the `okou` path it shipped
-  // with. Every other caller derives its URL from the contract, which a
-  // published CLI package still embeds at the version it was built from, and
-  // the `zero` form was reachable through the blanket expansion until the
-  // contract moved. Both are owed.
+  // surfaces. The slice covered Feishu, Slack, Microsoft Teams, Telegram,
+  // GitHub, AgentPhone and Strapi; #28709 removed the Telegram, GitHub,
+  // AgentPhone and Feishu messaging and file rows on zero-traffic evidence, so
+  // what remains is the Slack messaging and file surface plus the Feishu,
+  // Slack, Teams and Strapi control-plane reads. That removal also retired
+  // `downloadFeishuFile` and `downloadPhoneFile`, the two CLI callers that
+  // built a branded URL by hand rather than from the contract. Every remaining
+  // caller derives its URL from the contract, which a published CLI package
+  // still embeds at the version it was built from, and the `zero` form was
+  // reachable through the blanket expansion until the contract moved. Both are
+  // owed.
   //
   // Surfaces: commit-addressed CLI packages pinned by execution contexts
   // created before this deploy, which drain over the queue lifetime plus
@@ -877,62 +703,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/integrations/feishu": [
     "/api/okou/integrations/feishu",
     "/api/zero/integrations/feishu",
-  ],
-  "/api/integrations/feishu/app-id": [
-    "/api/okou/integrations/feishu/app-id",
-    "/api/zero/integrations/feishu/app-id",
-  ],
-  "/api/integrations/feishu/connect": [
-    "/api/okou/integrations/feishu/connect",
-    "/api/zero/integrations/feishu/connect",
-  ],
-  "/api/integrations/feishu/download-file": [
-    "/api/okou/integrations/feishu/download-file",
-    "/api/zero/integrations/feishu/download-file",
-  ],
-  "/api/integrations/feishu/installations/:installationId": [
-    "/api/okou/integrations/feishu/installations/:installationId",
-    "/api/zero/integrations/feishu/installations/:installationId",
-  ],
-  "/api/integrations/feishu/installations/:installationId/connect": [
-    "/api/okou/integrations/feishu/installations/:installationId/connect",
-    "/api/zero/integrations/feishu/installations/:installationId/connect",
-  ],
-  "/api/integrations/feishu/message": [
-    "/api/okou/integrations/feishu/message",
-    "/api/zero/integrations/feishu/message",
-  ],
-  "/api/integrations/feishu/upload-file/complete": [
-    "/api/okou/integrations/feishu/upload-file/complete",
-    "/api/zero/integrations/feishu/upload-file/complete",
-  ],
-  "/api/integrations/feishu/upload-file/init": [
-    "/api/okou/integrations/feishu/upload-file/init",
-    "/api/zero/integrations/feishu/upload-file/init",
-  ],
-  "/api/integrations/github/upload-file/complete": [
-    "/api/okou/integrations/github/upload-file/complete",
-    "/api/zero/integrations/github/upload-file/complete",
-  ],
-  "/api/integrations/github/upload-file/init": [
-    "/api/okou/integrations/github/upload-file/init",
-    "/api/zero/integrations/github/upload-file/init",
-  ],
-  "/api/integrations/phone/download-file": [
-    "/api/okou/integrations/phone/download-file",
-    "/api/zero/integrations/phone/download-file",
-  ],
-  "/api/integrations/phone/message": [
-    "/api/okou/integrations/phone/message",
-    "/api/zero/integrations/phone/message",
-  ],
-  "/api/integrations/phone/upload-file/complete": [
-    "/api/okou/integrations/phone/upload-file/complete",
-    "/api/zero/integrations/phone/upload-file/complete",
-  ],
-  "/api/integrations/phone/upload-file/init": [
-    "/api/okou/integrations/phone/upload-file/init",
-    "/api/zero/integrations/phone/upload-file/init",
   ],
   "/api/integrations/slack": [
     "/api/okou/integrations/slack",
@@ -962,49 +732,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/integrations/strapi",
     "/api/zero/integrations/strapi",
   ],
-  "/api/integrations/strapi/:integrationId": [
-    "/api/okou/integrations/strapi/:integrationId",
-    "/api/zero/integrations/strapi/:integrationId",
-  ],
-  "/api/integrations/strapi/:integrationId/check-test": [
-    "/api/okou/integrations/strapi/:integrationId/check-test",
-    "/api/zero/integrations/strapi/:integrationId/check-test",
-  ],
-  "/api/integrations/strapi/:integrationId/secret": [
-    "/api/okou/integrations/strapi/:integrationId/secret",
-    "/api/zero/integrations/strapi/:integrationId/secret",
-  ],
   "/api/integrations/teams/connect": [
     "/api/okou/integrations/teams/connect",
     "/api/zero/integrations/teams/connect",
-  ],
-  "/api/integrations/teams/message": [
-    "/api/okou/integrations/teams/message",
-    "/api/zero/integrations/teams/message",
-  ],
-  "/api/integrations/teams/upload-file/complete": [
-    "/api/okou/integrations/teams/upload-file/complete",
-    "/api/zero/integrations/teams/upload-file/complete",
-  ],
-  "/api/integrations/teams/upload-file/init": [
-    "/api/okou/integrations/teams/upload-file/init",
-    "/api/zero/integrations/teams/upload-file/init",
-  ],
-  "/api/integrations/telegram/bots": [
-    "/api/okou/integrations/telegram/bots",
-    "/api/zero/integrations/telegram/bots",
-  ],
-  "/api/integrations/telegram/message": [
-    "/api/okou/integrations/telegram/message",
-    "/api/zero/integrations/telegram/message",
-  ],
-  "/api/integrations/telegram/upload-file/complete": [
-    "/api/okou/integrations/telegram/upload-file/complete",
-    "/api/zero/integrations/telegram/upload-file/complete",
-  ],
-  "/api/integrations/telegram/upload-file/init": [
-    "/api/okou/integrations/telegram/upload-file/init",
-    "/api/zero/integrations/telegram/upload-file/init",
   ],
   // #28460: the connector catalog, the connector connections and their
   // authorization starts, the custom connectors, the model provider
@@ -1016,10 +746,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // queue lifetime plus claimed execution, bounded by the runner's 2h
   // `JOB_TIMEOUT`. Neither window is the removal condition on its own: a row
   // retires under the #26701 evidence gate above, like every other row here.
-  "/api/connector-catalog": [
-    "/api/okou/connector-catalog",
-    "/api/zero/connector-catalog",
-  ],
   "/api/connector-catalog/:connectorSlug": [
     "/api/okou/connector-catalog/:connectorSlug",
     "/api/zero/connector-catalog/:connectorSlug",
@@ -1045,93 +771,25 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/connectors/:connectorSlug",
     "/api/zero/connectors/:connectorSlug",
   ],
-  "/api/connectors/:connectorSlug/external-code/sessions": [
-    "/api/okou/connectors/:connectorSlug/external-code/sessions",
-    "/api/zero/connectors/:connectorSlug/external-code/sessions",
-  ],
-  "/api/connectors/:connectorSlug/external-code/sessions/:sessionId/complete": [
-    "/api/okou/connectors/:connectorSlug/external-code/sessions/:sessionId/complete",
-    "/api/zero/connectors/:connectorSlug/external-code/sessions/:sessionId/complete",
-  ],
   "/api/connectors/:connectorSlug/manual-grant": [
     "/api/okou/connectors/:connectorSlug/manual-grant",
     "/api/zero/connectors/:connectorSlug/manual-grant",
-  ],
-  "/api/connectors/:connectorSlug/no-auth": [
-    "/api/okou/connectors/:connectorSlug/no-auth",
-    "/api/zero/connectors/:connectorSlug/no-auth",
-  ],
-  "/api/connectors/:connectorSlug/oauth/device/sessions": [
-    "/api/okou/connectors/:connectorSlug/oauth/device/sessions",
-    "/api/zero/connectors/:connectorSlug/oauth/device/sessions",
-  ],
-  "/api/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll": [
-    "/api/okou/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll",
-    "/api/zero/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll",
   ],
   "/api/connectors/:connectorSlug/oauth/start": [
     "/api/okou/connectors/:connectorSlug/oauth/start",
     "/api/zero/connectors/:connectorSlug/oauth/start",
   ],
-  "/api/connectors/:connectorSlug/openid/start": [
-    "/api/okou/connectors/:connectorSlug/openid/start",
-    "/api/zero/connectors/:connectorSlug/openid/start",
-  ],
-  "/api/connectors/:connectorSlug/scope-diff": [
-    "/api/okou/connectors/:connectorSlug/scope-diff",
-    "/api/zero/connectors/:connectorSlug/scope-diff",
-  ],
   "/api/connectors/diagnostics/check": [
     "/api/okou/connectors/diagnostics/check",
     "/api/zero/connectors/diagnostics/check",
-  ],
-  "/api/connectors/search": [
-    "/api/okou/connectors/search",
-    "/api/zero/connectors/search",
-  ],
-  "/api/connectors/steam/player": [
-    "/api/okou/connectors/steam/player",
-    "/api/zero/connectors/steam/player",
   ],
   "/api/custom-connectors": [
     "/api/okou/custom-connectors",
     "/api/zero/custom-connectors",
   ],
-  "/api/custom-connectors/:id": [
-    "/api/okou/custom-connectors/:id",
-    "/api/zero/custom-connectors/:id",
-  ],
-  "/api/custom-connectors/:id/connection": [
-    "/api/okou/custom-connectors/:id/connection",
-    "/api/zero/custom-connectors/:id/connection",
-  ],
-  "/api/custom-connectors/:id/oauth2/start": [
-    "/api/okou/custom-connectors/:id/oauth2/start",
-    "/api/zero/custom-connectors/:id/oauth2/start",
-  ],
-  "/api/custom-connectors/:id/permissions": [
-    "/api/okou/custom-connectors/:id/permissions",
-    "/api/zero/custom-connectors/:id/permissions",
-  ],
-  "/api/custom-connectors/:id/values": [
-    "/api/okou/custom-connectors/:id/values",
-    "/api/zero/custom-connectors/:id/values",
-  ],
-  "/api/custom-connectors/oauth2/callback": [
-    "/api/okou/custom-connectors/oauth2/callback",
-    "/api/zero/custom-connectors/oauth2/callback",
-  ],
-  "/api/custom-connectors/proposals/save": [
-    "/api/okou/custom-connectors/proposals/save",
-    "/api/zero/custom-connectors/proposals/save",
-  ],
   "/api/model-provider-connections": [
     "/api/okou/model-provider-connections",
     "/api/zero/model-provider-connections",
-  ],
-  "/api/model-provider-connections/:id": [
-    "/api/okou/model-provider-connections/:id",
-    "/api/zero/model-provider-connections/:id",
   ],
   "/api/user-permission-grants": [
     "/api/okou/user-permission-grants",
@@ -1141,31 +799,21 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/user-permission-grants/apply",
     "/api/zero/user-permission-grants/apply",
   ],
-  // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes. The
-  // paths a provider console holds were not in this slice; they moved later,
-  // and their rows are at the end of this table.
+  // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes, of
+  // which #28709 kept only the Slack rows — the Teams and Feishu connect and
+  // OAuth-start rows had no request on either branded form in the retained
+  // window. The paths a provider console holds were not in this slice; they
+  // moved later, and their rows are at the end of this table.
   //
   // These rows hold two surfaces open. A released web or app build keeps the
   // branded path it was compiled against until a refresh loads a build that
   // derives the neutral one, the ~2 day window in `docs/fallback.md` section 7.
   // The OAuth-start paths have a second holder that no client version bounds: a
-  // connect or install link the API handed out earlier lives in a Slack, Teams,
-  // or Feishu message a user can still click, and `/api/okou/slack/oauth/install`
-  // is measured traffic listed in `LEGACY_ZERO_PATHS` above, which after this
-  // move only these rows can serve. Removal follows the #26701 evidence gate
-  // like every other row, not either clock.
-  "/api/feishu/connect": [
-    "/api/okou/feishu/connect",
-    "/api/zero/feishu/connect",
-  ],
-  "/api/feishu/connect/status": [
-    "/api/okou/feishu/connect/status",
-    "/api/zero/feishu/connect/status",
-  ],
-  "/api/feishu/oauth/connect": [
-    "/api/okou/feishu/oauth/connect",
-    "/api/zero/feishu/oauth/connect",
-  ],
+  // connect or install link the API handed out earlier lives in a Slack message
+  // a user can still click, and `/api/okou/slack/oauth/install` is measured
+  // traffic listed in `LEGACY_ZERO_PATHS` above, which after this move only
+  // these rows can serve. Removal follows the #26701 evidence gate like every
+  // other row, not either clock.
   "/api/slack/channels": [
     "/api/okou/slack/channels",
     "/api/zero/slack/channels",
@@ -1177,11 +825,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/slack/oauth/install": [
     "/api/okou/slack/oauth/install",
     "/api/zero/slack/oauth/install",
-  ],
-  "/api/teams/connect": ["/api/okou/teams/connect", "/api/zero/teams/connect"],
-  "/api/teams/oauth/connect": [
-    "/api/okou/teams/oauth/connect",
-    "/api/zero/teams/oauth/connect",
   ],
   // #28465: the stable desktop release page and DMG download.
   //
@@ -1243,22 +886,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/model-providers",
     "/api/zero/model-providers",
   ],
-  "/api/model-providers/:type": [
-    "/api/okou/model-providers/:type",
-    "/api/zero/model-providers/:type",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions",
-    "/api/zero/model-providers/claude-code/device-auth/sessions",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions/cancel": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions/cancel",
-    "/api/zero/model-providers/claude-code/device-auth/sessions/cancel",
-  ],
-  "/api/model-providers/claude-code/device-auth/sessions/complete": [
-    "/api/okou/model-providers/claude-code/device-auth/sessions/complete",
-    "/api/zero/model-providers/claude-code/device-auth/sessions/complete",
-  ],
   "/api/model-providers/codex/device-auth/sessions": [
     "/api/okou/model-providers/codex/device-auth/sessions",
     "/api/zero/model-providers/codex/device-auth/sessions",
@@ -1272,7 +899,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/model-providers/codex/device-auth/sessions/complete",
   ],
   "/api/org": ["/api/okou/org", "/api/zero/org"],
-  "/api/org/delete": ["/api/okou/org/delete", "/api/zero/org/delete"],
   "/api/org/invite": ["/api/okou/org/invite", "/api/zero/org/invite"],
   "/api/org/invite/purchase/:purchaseId/confirm": [
     "/api/okou/org/invite/purchase/:purchaseId/confirm",
@@ -1282,17 +908,14 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/org/invite/purchase/preview",
     "/api/zero/org/invite/purchase/preview",
   ],
-  "/api/org/leave": ["/api/okou/org/leave", "/api/zero/org/leave"],
   "/api/org/logo": ["/api/okou/org/logo", "/api/zero/org/logo"],
   "/api/org/members": ["/api/okou/org/members", "/api/zero/org/members"],
-  "/api/org/membership-requests": [
-    "/api/okou/org/membership-requests",
-    "/api/zero/org/membership-requests",
-  ],
   "/api/usage/members": ["/api/okou/usage/members", "/api/zero/usage/members"],
   "/api/usage/record": ["/api/okou/usage/record", "/api/zero/usage/record"],
-  // #28461: the agent reads and writes, the manual Morning Brief trigger, and
-  // the workflow and workflow-automation management routes. Every caller in
+  // #28461: the agent reads and writes and the workflow and
+  // workflow-automation management routes. The slice also covered the manual
+  // Morning Brief trigger; #28709 removed that row on zero-traffic evidence.
+  // Every caller in
   // this repository derives its URL from the contract, so nothing here still
   // asks for a branded form; released builds do. Two surfaces hold these paths,
   // and each has its own window.
@@ -1332,10 +955,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/agents/:id/user-connectors",
     "/api/zero/agents/:id/user-connectors",
   ],
-  "/api/morning-brief/trigger": [
-    "/api/okou/morning-brief/trigger",
-    "/api/zero/morning-brief/trigger",
-  ],
   "/api/workflow-automations": [
     "/api/okou/workflow-automations",
     "/api/zero/workflow-automations",
@@ -1352,14 +971,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflow-automations/:id/enable",
     "/api/zero/workflow-automations/:id/enable",
   ],
-  "/api/workflow-automations/:id/run": [
-    "/api/okou/workflow-automations/:id/run",
-    "/api/zero/workflow-automations/:id/run",
-  ],
-  "/api/workflow-automations/:id/webhook-secret": [
-    "/api/okou/workflow-automations/:id/webhook-secret",
-    "/api/zero/workflow-automations/:id/webhook-secret",
-  ],
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
   "/api/workflows/:workflowId": [
     "/api/okou/workflows/:workflowId",
@@ -1368,26 +979,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/workflows/:workflowId/automations": [
     "/api/okou/workflows/:workflowId/automations",
     "/api/zero/workflows/:workflowId/automations",
-  ],
-  "/api/workflows/:workflowId/chat-thread": [
-    "/api/okou/workflows/:workflowId/chat-thread",
-    "/api/zero/workflows/:workflowId/chat-thread",
-  ],
-  "/api/workflows/:workflowId/connector-readiness": [
-    "/api/okou/workflows/:workflowId/connector-readiness",
-    "/api/zero/workflows/:workflowId/connector-readiness",
-  ],
-  "/api/workflows/:workflowId/copy": [
-    "/api/okou/workflows/:workflowId/copy",
-    "/api/zero/workflows/:workflowId/copy",
-  ],
-  "/api/workflows/:workflowId/demote": [
-    "/api/okou/workflows/:workflowId/demote",
-    "/api/zero/workflows/:workflowId/demote",
-  ],
-  "/api/workflows/:workflowId/publish": [
-    "/api/okou/workflows/:workflowId/publish",
-    "/api/zero/workflows/:workflowId/publish",
   ],
   "/api/workflows/:workflowId/run": [
     "/api/okou/workflows/:workflowId/run",
@@ -1416,46 +1007,31 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/teams/oauth/callback",
   ],
   "/api/webhooks/teams/bot": ["/api/okou/teams/bot", "/api/zero/teams/bot"],
-  // #28463: avatar video, banking, the browser authorization requests, inbound
-  // email, the GitHub user-connect start, mail drafts, people search,
-  // presentation templates, the Strapi webhook, uploads, video-io, voice-io and
-  // the web file reads.
+  // #28463: avatar video, the browser authorization requests, mail drafts,
+  // people search, presentation templates, uploads, voice-io and the web file
+  // reads. The slice also covered banking, inbound email, the GitHub
+  // user-connect start, the Strapi webhook and video-io; #28709 removed those
+  // rows on zero-traffic evidence, which is why `domains/banking.ts` and the
+  // customer-held Strapi console URL no longer appear among the holders below.
   //
-  // Every surface this table protects is represented here at once. Published CLI
-  // builds hold the `okou` form directly: `domains/web.ts` and `domains/banking.ts`
-  // build ten of these URLs by hand rather than from the contract, so the path
-  // they carry shipped independently of this table, and a run execution context
-  // pins its commit-addressed `CLI_PKG_URL` at creation — the queue lifetime plus
+  // Published CLI builds hold the `okou` form directly: `domains/web.ts` builds
+  // its URLs by hand rather than from the contract, so the path it carries
+  // shipped independently of this table, and a run execution context pins its
+  // commit-addressed `CLI_PKG_URL` at creation — the queue lifetime plus
   // claimed execution bounded by the runner's 2h `JOB_TIMEOUT`. A released
   // platform build holds `/api/okou/web/download-file`, `/api/okou/web/file-url`
   // and `/api/okou/voice-io/stt` until a refresh loads a build that derives the
-  // neutral path (~2 days). The Strapi webhook URL sits in a customer's Strapi
-  // console, and every `zero` form was reachable through the blanket expansion
-  // until these contracts moved; neither has a window at all. Removal therefore
-  // follows the #26701 evidence gate above rather than any of those clocks.
+  // neutral path (~2 days). Every `zero` form was reachable through the blanket
+  // expansion until these contracts moved, which has no window at all. Removal
+  // therefore follows the #26701 evidence gate above rather than any of those
+  // clocks.
   "/api/avatar-video/avatars": [
     "/api/okou/avatar-video/avatars",
     "/api/zero/avatar-video/avatars",
   ],
-  "/api/avatar-video/generate": [
-    "/api/okou/avatar-video/generate",
-    "/api/zero/avatar-video/generate",
-  ],
   "/api/avatar-video/voices": [
     "/api/okou/avatar-video/voices",
     "/api/zero/avatar-video/voices",
-  ],
-  "/api/banking/accounts": [
-    "/api/okou/banking/accounts",
-    "/api/zero/banking/accounts",
-  ],
-  "/api/banking/balances": [
-    "/api/okou/banking/balances",
-    "/api/zero/banking/balances",
-  ],
-  "/api/banking/transactions": [
-    "/api/okou/banking/transactions",
-    "/api/zero/banking/transactions",
   ],
   "/api/browser/authorization-requests": [
     "/api/okou/browser/authorization-requests",
@@ -1469,18 +1045,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/browser/authorization-requests/:requestToken/apply",
     "/api/zero/browser/authorization-requests/:requestToken/apply",
   ],
-  "/api/email/inbound": ["/api/okou/email/inbound", "/api/zero/email/inbound"],
-  "/api/github/oauth/connect": [
-    "/api/okou/github/oauth/connect",
-    "/api/zero/github/oauth/connect",
-  ],
   "/api/mail/drafts/:mailDraftId": [
     "/api/okou/mail/drafts/:mailDraftId",
     "/api/zero/mail/drafts/:mailDraftId",
-  ],
-  "/api/mail/drafts/:mailDraftId/attachments/:partId": [
-    "/api/okou/mail/drafts/:mailDraftId/attachments/:partId",
-    "/api/zero/mail/drafts/:mailDraftId/attachments/:partId",
   ],
   "/api/mail/drafts/:mailDraftId/send": [
     "/api/okou/mail/drafts/:mailDraftId/send",
@@ -1499,10 +1066,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/presentation-templates/:templateId",
     "/api/zero/presentation-templates/:templateId",
   ],
-  "/api/strapi/events/:integrationId": [
-    "/api/okou/strapi/events/:integrationId",
-    "/api/zero/strapi/events/:integrationId",
-  ],
   "/api/uploads/complete": [
     "/api/okou/uploads/complete",
     "/api/zero/uploads/complete",
@@ -1519,10 +1082,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/uploads/prepare",
     "/api/zero/uploads/prepare",
   ],
-  "/api/video-io/generate": [
-    "/api/okou/video-io/generate",
-    "/api/zero/video-io/generate",
-  ],
   "/api/voice-io/quota": [
     "/api/okou/voice-io/quota",
     "/api/zero/voice-io/quota",
@@ -1537,76 +1096,53 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/web/download-file",
   ],
   "/api/web/file-url": ["/api/okou/web/file-url", "/api/zero/web/file-url"],
-  // #28544: the two Feishu routes that were classified as console-held without
-  // a Feishu console actually holding them — the console registers the
+  // #28544: the Feishu routes that were classified as console-held without a
+  // Feishu console actually holding them — the console registers the
   // frontend-forwarding OAuth target from `feishuOAuthAppCallbackUrl()` rather
   // than the API callback, and #28338 already moved the events URL shown to
   // operators.
   //
-  // The events row is the load-bearing one. Each Feishu installation registered
+  // The events row is the load-bearing one, and the reason it outlived the
+  // #28709 sweep with no traffic behind it. Each Feishu installation registered
   // its event subscription URL in its own Feishu app console, which we cannot
   // edit, so an installation created before #28338 still posts to the branded
   // form it was given. That holder has no drain window at all — it changes when
-  // its operator edits their own console — so these rows retire under #26701's
-  // evidence rules rather than on any client clock.
+  // its operator edits their own console — so a week without a delivery says
+  // the installation was quiet, not that its console moved, which is the same
+  // reading `slack/commands` and `slack/interactive` get above.
   //
-  // The OAuth callback row covers a time-boxed surface instead. Its caller is
-  // `feishu-oauth-callback-page.ts`, which forwards the code it received from
+  // The slice's other row, the OAuth callback, covered a time-boxed surface
+  // instead: `feishu-oauth-callback-page.ts` forwards the code it received from
   // the Feishu console's `app.vm0.ai` target to whichever path the contract
-  // declared when that bundle was built — so an already-loaded platform tab
-  // keeps posting the branded form for the ~2 day old-web-client window in
-  // `docs/fallback.md` section 7. The `oauthRedirectUri()` branch that this
-  // slice's `feishuOAuthCallbackUrl()` change moves is the other holder, and a
-  // narrower one: it is reached only when `callbackTarget` is absent, which
-  // neither frontend entry point does.
+  // declared when that bundle was built, so an already-loaded platform tab kept
+  // posting the branded form for the ~2 day old-web-client window in
+  // `docs/fallback.md` section 7, and the `oauthRedirectUri()` branch behind it
+  // is reached only when `callbackTarget` is absent, which neither frontend
+  // entry point does. That window closed long before the retained log began, so
+  // #28709 removed it.
   //
   // Each key holds its path parameter verbatim, because the lookup below
   // matches `entry.route.path` exactly rather than an expanded request path.
-  "/api/integrations/feishu/oauth/callback": [
-    "/api/okou/feishu/oauth/callback",
-    "/api/zero/feishu/oauth/callback",
-  ],
   "/api/webhooks/feishu/events/:installationId": [
     "/api/okou/feishu/events/:installationId",
     "/api/zero/feishu/events/:installationId",
   ],
-  // #28565, the closing slice: the connector-account reads and writes and the
-  // managed SocialKit request. Both contracts were added by features that
-  // merged while #28278 was in flight — #28066 and #28519 for the connector
-  // accounts, #28343 for SocialKit — so no earlier slice's inventory contained
-  // them and they declared the branded namespace by default. The guard in
+  // #28565, the closing slice: the managed SocialKit request. The slice also
+  // covered the connector-account reads and writes, whose rows #28709 removed
+  // on zero-traffic evidence — they had no caller in this repository at all, so
+  // nothing but an external holder of a branded form could have reached them.
+  // Both contracts were added by features that merged while #28278 was in
+  // flight — #28066 and #28519 for the connector accounts, #28343 for
+  // SocialKit — so no earlier slice's inventory contained them and they
+  // declared the branded namespace by default. The guard in
   // `contracts/__tests__/api-namespace-declarations.test.ts` lands with this
   // slice so the next late contract is rejected rather than migrated later.
   //
-  // Surfaces: a commit-addressed CLI package pinned by a run execution context
+  // Surface: a commit-addressed CLI package pinned by a run execution context
   // holds `/api/okou/social/request` for that context's queue and
-  // claimed-execution lifetime, bounded by the runner's 2h `JOB_TIMEOUT`. The
-  // connector-account paths have no caller in this repository at all — no
-  // platform, desktop or CLI code references them — so what they owe is the
-  // `zero` form the blanket expansion served until this move, plus any external
-  // holder of either branded form, neither of which has a window. That is a
-  // floor rather than the removal condition either way: these rows retire under
+  // claimed-execution lifetime, bounded by the runner's 2h `JOB_TIMEOUT`. That
+  // is a floor rather than the removal condition: this row retires under
   // #26701's evidence rules like every other row in this file.
-  "/api/connector-accounts": [
-    "/api/okou/connector-accounts",
-    "/api/zero/connector-accounts",
-  ],
-  "/api/connector-accounts/:connectionId": [
-    "/api/okou/connector-accounts/:connectionId",
-    "/api/zero/connector-accounts/:connectionId",
-  ],
-  "/api/connector-accounts/:connectionId/default": [
-    "/api/okou/connector-accounts/:connectionId/default",
-    "/api/zero/connector-accounts/:connectionId/default",
-  ],
-  "/api/connector-accounts/:connectionId/deletion-impact": [
-    "/api/okou/connector-accounts/:connectionId/deletion-impact",
-    "/api/zero/connector-accounts/:connectionId/deletion-impact",
-  ],
-  "/api/connector-accounts/connections": [
-    "/api/okou/connector-accounts/connections",
-    "/api/zero/connector-accounts/connections",
-  ],
   "/api/social/request": [
     "/api/okou/social/request",
     "/api/zero/social/request",

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -214,7 +214,7 @@ async function createSharedThreadSnapshot(
   origin?: string,
 ): Promise<CreatedSharedThreadResult> {
   const response = await sharedThreadTestApp().request(
-    `/api/zero/chat-threads/${threadId}/shared-threads`,
+    `/api/chat-threads/${threadId}/shared-threads`,
     {
       method: "POST",
       headers: {
@@ -237,7 +237,7 @@ async function readSharedThreadSnapshot(
   id: string,
 ): Promise<ReadSharedThreadResult> {
   const response = await sharedThreadTestApp().request(
-    `/api/zero/shared-threads/${id}`,
+    `/api/shared-threads/${id}`,
   );
   expect(response.status).toBe(200);
   const body: unknown = await response.json();
@@ -248,7 +248,7 @@ async function readSharedThreadMeta(
   id: string,
 ): Promise<ReadSharedThreadResult> {
   const response = await sharedThreadTestApp().request(
-    `/api/zero/shared-threads/${id}/meta`,
+    `/api/shared-threads/${id}/meta`,
   );
   expect(response.status).toBe(200);
   const body: unknown = await response.json();
@@ -1297,7 +1297,7 @@ describe("shared thread routes", () => {
     await flushWaitUntilForTest();
 
     const afterOrgDeletionResponse = await sharedThreadTestApp().request(
-      `/api/zero/shared-threads/${first.id}`,
+      `/api/shared-threads/${first.id}`,
     );
     expect(afterOrgDeletionResponse.status).toBe(404);
     const afterOrgDeletion = asRecord(await afterOrgDeletionResponse.json());

--- a/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
@@ -193,7 +193,7 @@ describe("JoggAI built-in avatar video routes", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const response = await createAvatarVideoTestApp(
       fixture.usagePricingResolution,
-    ).request("/api/zero/avatar-video/generate", {
+    ).request("/api/avatar-video/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -463,7 +463,7 @@ describe("JoggAI built-in avatar video routes", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
     const app = createAvatarVideoTestApp(fixture.usagePricingResolution);
-    const response = await app.request("/api/zero/avatar-video/generate", {
+    const response = await app.request("/api/avatar-video/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -646,7 +646,7 @@ describe("JoggAI built-in avatar video routes", () => {
 
     const response = await createAvatarVideoTestApp(
       fixture.usagePricingResolution,
-    ).request("/api/zero/avatar-video/generate", {
+    ).request("/api/avatar-video/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -722,7 +722,7 @@ describe("okou browser route", () => {
       signal: context.signal,
       routes: TEST_APP_ROUTES,
     }).request(
-      `/api/zero/chat-threads/${createdInOtherThread.body.browser.threadId}/browser/resize`,
+      `/api/chat-threads/${createdInOtherThread.body.browser.threadId}/browser/resize`,
       {
         method: "POST",
         headers: {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-image-model.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-image-model.test.ts
@@ -99,7 +99,7 @@ function rawImageModelRequest(
   return setupRawAppRequest({
     context,
     routes: chatThreadImageModelRoutes,
-  })(`/api/okou/chat-threads/${threadId}/image-model`, {
+  })(`/api/chat-threads/${threadId}/image-model`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${token}`,
@@ -125,7 +125,7 @@ async function readImageModelEvents(token: string) {
   });
 }
 
-describe("POST /api/okou/chat-threads/:id/image-model", () => {
+describe("POST /api/chat-threads/:id/image-model", () => {
   it("pins a canonical image model and records one event", async () => {
     const fixture = await seedChatThread("Product launch still");
     const token = zeroToken({

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-video-model.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-video-model.test.ts
@@ -112,7 +112,7 @@ function rawVideoModelRequest(
   return setupRawAppRequest({
     context,
     routes: chatThreadVideoModelRoutes,
-  })(`/api/okou/chat-threads/${threadId}/video-model`, {
+  })(`/api/chat-threads/${threadId}/video-model`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${token}`,
@@ -149,7 +149,7 @@ async function readVideoModelEvents(token: string) {
   });
 }
 
-describe("POST /api/okou/chat-threads/:id/video-model", () => {
+describe("POST /api/chat-threads/:id/video-model", () => {
   it("pins a video model and records one event", async () => {
     const fixture = await seedChatThread("Product launch clip");
     const token = zeroToken({

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -529,7 +529,7 @@ const malformedChatThreadIdRequests = [
   },
   {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/mark-unread",
+    path: "/api/chat-threads/:id/mark-unread",
     paramName: "id",
   },
   {

--- a/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
@@ -191,7 +191,7 @@ describe("low-credit email delivery", () => {
   });
 });
 
-describe("POST /api/zero/email/inbound", () => {
+describe("POST /api/email/inbound", () => {
   it("rejects missing or invalid Svix signatures", async () => {
     const missingHeaders = await webhooks.requestResendInboundWebhook(
       { type: "email.received" },

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -1059,7 +1059,7 @@ describe("Feishu integration", () => {
       signal: context.signal,
       routes: feishuBrowserConnectRoutes,
     });
-    const response = await connectApp.request("/api/zero/feishu/connect", {
+    const response = await connectApp.request("/api/feishu/connect", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -1077,7 +1077,7 @@ describe("Feishu integration", () => {
     );
     const connectBody = feishuConnectBody(connectUrl);
     const statusResponse = await connectApp.request(
-      `/api/zero/feishu/connect/status?${new URLSearchParams(
+      `/api/feishu/connect/status?${new URLSearchParams(
         Object.entries(connectBody).map(([key, value]): [string, string] => {
           return [key, String(value)];
         }),
@@ -2931,17 +2931,14 @@ describe("Feishu integration", () => {
     });
     failedSendTargets.push("ou_feishu_user");
     context.mocks.ably.publish.mockClear();
-    const connectResponse = await connectApp.request(
-      "/api/zero/feishu/connect",
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          cookie: "__session=opaque",
-        },
-        body: JSON.stringify(feishuConnectBody(connectUrl)),
+    const connectResponse = await connectApp.request("/api/feishu/connect", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: "__session=opaque",
       },
-    );
+      body: JSON.stringify(feishuConnectBody(connectUrl)),
+    });
     const authorizationUrl =
       await feishuAuthorizationUrlFromResponse(connectResponse);
     expect(
@@ -3005,7 +3002,7 @@ describe("Feishu integration", () => {
       [200],
     );
     const retryConnectResponse = await connectApp.request(
-      "/api/zero/feishu/connect",
+      "/api/feishu/connect",
       {
         method: "POST",
         headers: {
@@ -3048,17 +3045,14 @@ describe("Feishu integration", () => {
       orgRole: "org:member",
     });
     mocks.clerk.session(otherActor.userId, otherActor.orgId, "org:member");
-    const rebindResponse = await connectApp.request(
-      "/api/zero/feishu/connect",
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          cookie: "__session=opaque",
-        },
-        body: JSON.stringify(feishuConnectBody(connectUrl)),
+    const rebindResponse = await connectApp.request("/api/feishu/connect", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: "__session=opaque",
       },
-    );
+      body: JSON.stringify(feishuConnectBody(connectUrl)),
+    });
     const rebindAuthorizationUrl =
       await feishuAuthorizationUrlFromResponse(rebindResponse);
     const rebindCompletionUrl = await completeFeishuAuthorization(
@@ -3090,7 +3084,7 @@ describe("Feishu integration", () => {
       "Expected replacement Feishu connect URL",
     );
     const legacyReplacementConnectUrl = new URL(
-      "/api/zero/feishu/connect",
+      "/api/feishu/connect",
       "https://www.vm0.test",
     );
     legacyReplacementConnectUrl.search = new URL(replacementConnectUrl).search;
@@ -3521,7 +3515,7 @@ describe("Feishu integration", () => {
       routes: integrationsFeishuFileRoutes,
     });
     const downloadResponse = await app.request(
-      `/api/zero/integrations/feishu/download-file?${new URLSearchParams({
+      `/api/integrations/feishu/download-file?${new URLSearchParams({
         message_id: "om_misquoted_by_model",
         file_key: fileId ?? "",
         type: "image",
@@ -3545,7 +3539,7 @@ describe("Feishu integration", () => {
     ).toBeTruthy();
 
     const wrongRunResponse = await app.request(
-      `/api/zero/integrations/feishu/download-file?${new URLSearchParams({
+      `/api/integrations/feishu/download-file?${new URLSearchParams({
         message_id: "om_file_message",
         file_key: fileId ?? "",
         type: "file",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -372,7 +372,7 @@ export function createAgentPhoneBddApi(context: TestContext) {
         signal: context.signal,
         routes: TEST_APP_ROUTES,
       }).request(
-        `/api/zero/integrations/phone/download-file?file_id=${encodeURIComponent(fileId)}`,
+        `/api/integrations/phone/download-file?file_id=${encodeURIComponent(fileId)}`,
         {
           method: "GET",
           headers: { authorization: `Bearer ${token}` },

--- a/turbo/apps/api/src/signals/routes/__tests__/image-share-x.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-share-x.test.ts
@@ -128,7 +128,7 @@ async function setupAuthenticatedXActor() {
   return { ...actor, orgId: actor.orgId };
 }
 
-describe("POST /api/zero/image-share/x", () => {
+describe("POST /api/image-share/x", () => {
   it("preserves an explicit caption for an Okou request and records connector usage billing", async () => {
     const billing = createBillingMediaApi(context);
     const actor = await setupAuthenticatedXActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -484,7 +484,7 @@ describe("POST /api/integrations/feishu/message", () => {
       type: "file",
     });
     const response = await app.request(
-      `/api/zero/integrations/feishu/download-file?${query.toString()}`,
+      `/api/integrations/feishu/download-file?${query.toString()}`,
       {
         headers: {
           authorization: `Bearer ${okouToken(actor)}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-message.test.ts
@@ -147,7 +147,7 @@ async function seedSendableContext(args: {
   };
 }
 
-describe("POST /api/zero/integrations/telegram/message", () => {
+describe("POST /api/integrations/telegram/message", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
@@ -199,7 +199,7 @@ async function expectTelegramBotConnection(args: {
   );
 }
 
-describe("GET /api/zero/integrations/telegram/bots", () => {
+describe("GET /api/integrations/telegram/bots", () => {
   const fixtures: TelegramFixture[] = [];
 
   beforeEach(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
@@ -33,14 +33,16 @@ interface ResponseSnapshot {
 // on the neutral path from #28278, so the assertion is that all three produce
 // the same response rather than merely that the neutral path is routed.
 //
-// Every endpoint here now declares its neutral path and gains both branded
-// forms from `MIGRATED_BRANDED_PATHS` — the Teams OAuth callback in #28545, the
-// Feishu OAuth callback in #28544, and the four Slack routes in #28600, which
-// emptied and deleted `FINAL_PROVIDER_CONSOLE_PATHS`. Which mechanism produces
-// which registration is deliberately not asserted; what a caller can reach is
-// the same either way, and that is the property this file exists to pin. A
-// dropped row on either side shows up here as one of the three forms answering
-// differently.
+// Every endpoint using this helper declares its neutral path and gains both
+// branded forms from `MIGRATED_BRANDED_PATHS` — the Teams OAuth callback in
+// #28545 and the four Slack routes in #28600, which emptied and deleted
+// `FINAL_PROVIDER_CONSOLE_PATHS`. Which mechanism produces which registration
+// is deliberately not asserted; what a caller can reach is the same either way,
+// and that is the property this file exists to pin. A dropped row on either
+// side shows up here as one of the three forms answering differently.
+//
+// The Feishu OAuth callback is the exception below: #28709 retired its row, so
+// only the neutral path it declares is exercised.
 function namespacePaths(
   brandedSuffix: string,
   finalPath: string,
@@ -219,23 +221,15 @@ describe("provider console paths", () => {
     });
   });
 
-  // The one endpoint in this file whose branded forms are gone. #28544 moved
-  // the contract to the neutral path and gave it a `MIGRATED_BRANDED_PATHS`
-  // row; #28709 removed that row, because the only thing holding the branded
-  // form was an already-loaded platform tab forwarding a code, a window that
-  // closed well before the retained request log begins.
-  //
-  // Kept in this file rather than deleted with the row: the callback is still
-  // reached from a Feishu console flow, so the neutral path answering is worth
-  // pinning here, and the two 404s are what tells a reader the branded forms
-  // were retired deliberately rather than lost.
+  // The one endpoint in this file that no longer has branded forms. #28544
+  // moved the contract to the neutral path and gave it a
+  // `MIGRATED_BRANDED_PATHS` row; #28709 removed that row, because the only
+  // thing holding the branded form was an already-loaded platform tab
+  // forwarding a code, a window that closed well before the retained request
+  // log begins. The case stays because the callback is still reached from a
+  // Feishu console flow, narrowed to the path that serves it.
   describe("GET /api/integrations/feishu/oauth/callback", () => {
-    const brandedPaths = [
-      "/api/okou/feishu/oauth/callback",
-      "/api/zero/feishu/oauth/callback",
-    ];
-
-    it("rejects a callback without connect state on the neutral path", async () => {
+    it("rejects a callback without connect state", async () => {
       const snapshots = await snapshotEachPath(
         ["/api/integrations/feishu/oauth/callback"],
         getRequest(feishuOauthRoutes),
@@ -248,24 +242,6 @@ describe("provider console paths", () => {
           body: jsonBody({ error: "Invalid or expired connect state" }),
         },
       ]);
-    });
-
-    it("no longer answers on either branded path", async () => {
-      const snapshots = await snapshotEachPath(
-        brandedPaths,
-        getRequest(feishuOauthRoutes),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 404,
-            location: null,
-            body: jsonBody({ error: "Not found" }),
-          },
-          brandedPaths,
-        ),
-      );
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
@@ -219,31 +219,51 @@ describe("provider console paths", () => {
     });
   });
 
-  // Like the Teams callback above, this one is no longer console-held: #28544
-  // moved the contract to the neutral path, so the two branded forms below
-  // depend on a `MIGRATED_BRANDED_PATHS` row rather than on a contract
-  // declaration. Kept here because the property being pinned — all three forms
-  // produce the same response — is unchanged.
+  // The one endpoint in this file whose branded forms are gone. #28544 moved
+  // the contract to the neutral path and gave it a `MIGRATED_BRANDED_PATHS`
+  // row; #28709 removed that row, because the only thing holding the branded
+  // form was an already-loaded platform tab forwarding a code, a window that
+  // closed well before the retained request log begins.
+  //
+  // Kept in this file rather than deleted with the row: the callback is still
+  // reached from a Feishu console flow, so the neutral path answering is worth
+  // pinning here, and the two 404s are what tells a reader the branded forms
+  // were retired deliberately rather than lost.
   describe("GET /api/integrations/feishu/oauth/callback", () => {
-    const paths = namespacePaths(
-      "/feishu/oauth/callback",
-      "/api/integrations/feishu/oauth/callback",
-    );
+    const brandedPaths = [
+      "/api/okou/feishu/oauth/callback",
+      "/api/zero/feishu/oauth/callback",
+    ];
 
-    it("rejects a callback without connect state identically", async () => {
+    it("rejects a callback without connect state on the neutral path", async () => {
       const snapshots = await snapshotEachPath(
-        paths,
+        ["/api/integrations/feishu/oauth/callback"],
+        getRequest(feishuOauthRoutes),
+      );
+
+      expect(snapshots).toStrictEqual([
+        {
+          status: 400,
+          location: null,
+          body: jsonBody({ error: "Invalid or expired connect state" }),
+        },
+      ]);
+    });
+
+    it("no longer answers on either branded path", async () => {
+      const snapshots = await snapshotEachPath(
+        brandedPaths,
         getRequest(feishuOauthRoutes),
       );
 
       expect(snapshots).toStrictEqual(
         repeated(
           {
-            status: 400,
+            status: 404,
             location: null,
-            body: jsonBody({ error: "Invalid or expired connect state" }),
+            body: jsonBody({ error: "Not found" }),
           },
-          paths,
+          brandedPaths,
         ),
       );
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -894,10 +894,7 @@ describe("RUN-03: queue position", () => {
     expectApiError(unknown.body);
     expect(unknown.body.error.code).toBe("NOT_FOUND");
 
-    const missingRunId = await reads.rawApiRequest(
-      null,
-      "/api/zero/queue-position",
-    );
+    const missingRunId = await reads.rawApiRequest(null, "/api/queue-position");
     expect(missingRunId.status).toBe(400);
     expect(JSON.stringify(missingRunId.body)).toContain("runId");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
@@ -18,7 +18,7 @@ import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const mocks = createRouteMocks(context);
-const CONNECT_PATH = "http://api.test/api/zero/teams/connect";
+const CONNECT_PATH = "http://api.test/api/teams/connect";
 const APP_ORIGIN = "https://app.vm0.test";
 
 function connectUrl(params: {
@@ -168,7 +168,7 @@ async function expectTeamsConnected(
   });
 }
 
-describe("GET /api/zero/teams/connect", () => {
+describe("GET /api/teams/connect", () => {
   const track = createFixtureTracker<TeamsConnectFixture>((fixture) => {
     return removeTeamsForTest(context.signal, fixture);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -157,7 +157,7 @@ describe("Teams OAuth API routes", () => {
 
   it("redirects to Microsoft OAuth with connect state without a browser session", async () => {
     const response = await appRequest(
-      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      "/api/teams/oauth/connect?orgId=org_1&userId=user_1",
     );
 
     expect(response.status).toBe(307);
@@ -190,7 +190,7 @@ describe("Teams OAuth API routes", () => {
 
   it("keeps API-host connect requests on the API callback origin", async () => {
     const response = await appRequest(
-      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      "/api/teams/oauth/connect?orgId=org_1&userId=user_1",
       { origin: API_ORIGIN },
     );
 
@@ -206,7 +206,7 @@ describe("Teams OAuth API routes", () => {
 
   it("projects the callback origin onto the Okou brand host", async () => {
     const response = await appRequest(
-      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      "/api/teams/oauth/connect?orgId=org_1&userId=user_1",
       { origin: OKOU_API_ORIGIN },
     );
 
@@ -230,7 +230,7 @@ describe("Teams OAuth API routes", () => {
   // a refactor that moves it off this string breaks Microsoft's allowlist.
   it("leaves the VM0 brand authorization URI on the registered legacy value", async () => {
     const response = await appRequest(
-      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      "/api/teams/oauth/connect?orgId=org_1&userId=user_1",
       { origin: API_ORIGIN },
     );
 
@@ -250,7 +250,7 @@ describe("Teams OAuth API routes", () => {
   });
 
   it("rejects connect requests without org and user state", async () => {
-    const response = await appRequest("/api/zero/teams/oauth/connect");
+    const response = await appRequest("/api/teams/oauth/connect");
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -471,7 +471,7 @@ async function orgCredits(fixture: VideoFixture): Promise<number> {
   return body.credits;
 }
 
-describe("POST /api/zero/video-io/generate", () => {
+describe("POST /api/video-io/generate", () => {
   beforeEach(() => {
     mockEnv("VM0_API_BACKEND_URL", WEB_ORIGIN);
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);
@@ -500,7 +500,7 @@ describe("POST /api/zero/video-io/generate", () => {
 
   it("returns 401 when not authenticated", async () => {
     const app = createVideoIoTestApp();
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       body: JSON.stringify({ prompt: "a city at night" }),
     });
@@ -523,7 +523,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city", duration: "3s" }),
@@ -552,7 +552,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -577,7 +577,7 @@ describe("POST /api/zero/video-io/generate", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),
@@ -609,7 +609,7 @@ describe("POST /api/zero/video-io/generate", () => {
       );
 
       const app = createVideoIoTestApp(fixture.pricingResolution);
-      const response = await app.request("/api/zero/video-io/generate", {
+      const response = await app.request("/api/video-io/generate", {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({ prompt: "a city" }),
@@ -646,7 +646,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),
@@ -676,7 +676,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),
@@ -748,7 +748,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -834,7 +834,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -906,7 +906,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -968,7 +968,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1060,7 +1060,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1148,7 +1148,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1205,7 +1205,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1236,7 +1236,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -1267,7 +1267,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),
@@ -1326,7 +1326,7 @@ describe("POST /api/zero/video-io/generate", () => {
       publicBrand: "okou",
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1473,7 +1473,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -1572,7 +1572,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -1669,7 +1669,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -1711,7 +1711,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -1777,7 +1777,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -1873,7 +1873,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -2021,7 +2021,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -2148,7 +2148,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -2208,7 +2208,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -2240,7 +2240,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -2304,7 +2304,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -2417,7 +2417,7 @@ describe("POST /api/zero/video-io/generate", () => {
       runId,
     });
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
       body: JSON.stringify({
@@ -2495,7 +2495,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),
@@ -2558,7 +2558,7 @@ describe("POST /api/zero/video-io/generate", () => {
     );
 
     const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/zero/video-io/generate", {
+    const response = await app.request("/api/video-io/generate", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ prompt: "a city" }),


### PR DESCRIPTION
Closes #28709.

Takes `MIGRATED_BRANDED_PATHS` from **314 rows to 184**. Removing a row makes that route's two branded forms return 404; the neutral path its contract declares is untouched.

`LEGACY_ZERO_PATHS`, `apiNamespaceAliasPaths()`, `withMigratedBrandedPaths` itself, and every neutral contract path are unchanged.

## Re-derived the evidence, and it moved

The issue asked for the check to be re-run per row before deleting. It was, against the same window the issue measured — `vm0-request-log-prod` retains 2026-08-17T01:13Z through 2026-08-23T10:28Z — and it disagreed with the listing on 46 rows.

Two things made the difference:

- **Per-row queries instead of a ranked summary.** The log holds ~6,300 distinct branded path templates over the window, nearly all of it scanner noise. A `summarize … | sort by count desc | limit 500` truncates before reaching rows with single-digit counts — which is exactly the population this gate is deciding. Every row was queried by name instead.
- **Pattern matching instead of literal matching.** A CORS preflight is logged under its request path, not the route template it never matched, so `/api/okou/chat-threads/<uuid>/unpin` never equals `/api/okou/chat-threads/:id/unpin`. Each row's branded forms were matched as patterns.

## Rows held back

**46 rows took measured traffic on a branded form inside the window** and were dropped from the removal list. All of it is from released App (`0.766`–`0.778`) and CLI (`9.279.4`) builds against `api.vm0.ai` and `api.okou.ai`, mostly `200`/`204`. A few examples:

| Row | Branded requests | Last seen | Statuses |
|---|---|---|---|
| `/api/chat-threads/:threadId/browser/open` | 10 | 08-21T20:47 | 200 |
| `/api/chat-threads/:threadId/goal` | 8 | 08-21T04:32 | 200, 403 |
| `/api/runs/:id/context` | 7 | 08-21T05:23 | 200 |
| `/api/billing/portal` | 5 | 08-21T03:16 | 200, 204 |
| `/api/webhooks/teams/bot` | 5 | 08-21T06:52 | 400 |
| `/api/agents` | 3 | 08-21T07:47 | 200, 201, 204 |

The full 46 are listed in a comment on #28709.

**Three rows had zero traffic and stay anyway**, because for them silence is the expected reading rather than evidence:

- `/api/desktop/updates/:channel/:platform/:arch/{dmg,release}` — the comment on these rows already records a gate this table's evidence rules cannot satisfy: the caller is an installed macOS build, `isTrustedZeroMigrationDownloadUrl` in the shipped Zero bridge refuses any path but the one compiled into it, and retiring the branded forms is gated on the Desktop drain tracked by #26364. The request is also a one-shot download a user has to click, so a quiet week says nothing.
- `/api/webhooks/feishu/events/:installationId` — delivered to by a Feishu app console we cannot edit, per installation, with no drain window. That is the same class as `slack/commands` and `slack/interactive`, which the issue kept on identical reasoning despite zero traffic.

## Tests

- **`holds the branded rows this suite has evidence for and no others`** — the remaining count against a literal `184` restated in the test, so a later edit that drops a still-needed row fails rather than passing silently. The two rows the maps and weather cases own are named, so the arithmetic cannot be satisfied by the wrong two.
- The existing per-slice cases still assert that every one of the 184 remaining rows serves both branded forms, and `assertUniqueRouteRegistrations` still holds.
- Tests that happened to drive a retired route through its branded path were moved to the neutral path (67 call sites across 17 files). Those would fail if a removal had taken a neutral registration with it.
- Slice comments that enumerated families no longer in the table were corrected rather than left stale.

The issue asked for a case asserting the removed branded forms return 404. That was written, then removed in `1c7a295`: `docs/fallback.md` section 1 rules out tests that assert removed behavior stays removed, and the review scored it P1. The guard the issue actually wanted — a future edit dropping a still-needed row must fail a test — is carried by the positive assertions above, which fail on an unexplained removal. The 404 cases only restated a deletion the route table already proves, and would have blocked any future reuse of those paths.

## Verification

`migrated-branded-paths.test.ts` (22) and `provider-console-paths.test.ts` (12) pass, along with the non-BDD route tests touched here. The BDD suites (`artifact-catalog`, `browser`, `chat-threads`, `run-reads`, `feishu-integration`) fail identically on `main` and on this branch in the dev container — 41 failed / 38 passed either way — so they are left to CI. `apps/api` lint is clean and `knip` reports the same single pre-existing finding as `main`; the workspace type-check OOMs in the 3.9 GB container regardless of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)