### PR TITLE
feat(platform): collapse connector catalog diagnostics

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -85,6 +85,22 @@ function createPreferences(
   };
 }
 
+function connectorCatalogDisclosure(region: HTMLElement): {
+  readonly details: HTMLDetailsElement;
+  readonly summary: HTMLElement;
+} {
+  const title = within(region).getByText("Connector catalog");
+  const summary = title.closest("summary");
+  const details = summary?.closest("details");
+  if (!(summary instanceof HTMLElement)) {
+    throw new Error("Connector catalog summary not found");
+  }
+  if (!(details instanceof HTMLDetailsElement)) {
+    throw new Error("Connector catalog disclosure not found");
+  }
+  return { details, summary };
+}
+
 describe("settings dialog", () => {
   it("keeps every available locale in the language menu", async () => {
     context.mocks.data.userPreferences(
@@ -889,9 +905,15 @@ describe("settings dialog", () => {
     const diagnostics = await screen.findByRole("region", {
       name: "Connector catalog",
     });
-    expect(within(diagnostics).getByText("Stale")).toBeInTheDocument();
-    expect(within(diagnostics).getByText("Current")).toBeInTheDocument();
-    expect(within(diagnostics).getByText("2026-07-25.1")).toBeInTheDocument();
+    const { details, summary } = connectorCatalogDisclosure(diagnostics);
+    expect(details.open).toBeFalsy();
+    expect(summary).toHaveTextContent("Sync state: Stale");
+    expect(summary).toHaveTextContent("Active version: 2026-07-25.1");
+    expect(summary).toHaveTextContent("Last attempt: Rejected");
+    expect(summary).toHaveTextContent("Evaluation: Current");
+
+    click(summary);
+    expect(details.open).toBeTruthy();
     expect(within(diagnostics).getByText("2026-07-25.2")).toBeInTheDocument();
     expect(within(diagnostics).getByText("1.319.0")).toBeInTheDocument();
     expect(within(diagnostics).getByText("Reused")).toBeInTheDocument();
@@ -914,6 +936,9 @@ describe("settings dialog", () => {
     expect(
       within(diagnostics).getByText("Unresolved bridge credentials"),
     ).toBeInTheDocument();
+
+    click(summary);
+    expect(details.open).toBeFalsy();
   });
 
   it("refreshes connector catalog diagnostics on every Debug entry", async () => {
@@ -953,10 +978,15 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "debug");
 
-    await expect(
-      screen.findByText("2026-08-19.1"),
-    ).resolves.toBeInTheDocument();
+    let diagnostics = await screen.findByRole("region", {
+      name: "Connector catalog",
+    });
+    let { details, summary } = connectorCatalogDisclosure(diagnostics);
+    expect(summary).toHaveTextContent("Active version: 2026-08-19.1");
     expect(requestCount).toBe(1);
+
+    click(summary);
+    expect(details.open).toBeTruthy();
 
     click(screen.getByRole("switch"));
     await expect(
@@ -984,9 +1014,14 @@ describe("settings dialog", () => {
     ).resolves.toBeInTheDocument();
 
     click(dialogButton("Debug"));
-    await expect(
-      screen.findByText("2026-08-19.2"),
-    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      diagnostics = screen.getByRole("region", {
+        name: "Connector catalog",
+      });
+      ({ details, summary } = connectorCatalogDisclosure(diagnostics));
+      expect(summary).toHaveTextContent("Active version: 2026-08-19.2");
+      expect(details.open).toBeFalsy();
+    });
     expect(requestCount).toBe(2);
 
     click(dialogButton("Close"));
@@ -996,9 +1031,14 @@ describe("settings dialog", () => {
 
     await context.store.set(openSettingsDialogAt$, "debug", context.signal);
 
-    await expect(
-      screen.findByText("2026-08-19.3"),
-    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      diagnostics = screen.getByRole("region", {
+        name: "Connector catalog",
+      });
+      ({ details, summary } = connectorCatalogDisclosure(diagnostics));
+      expect(summary).toHaveTextContent("Active version: 2026-08-19.3");
+      expect(details.open).toBeFalsy();
+    });
     expect(requestCount).toBe(3);
   });
 
@@ -1039,29 +1079,43 @@ describe("settings dialog", () => {
     const diagnostics = await screen.findByRole("region", {
       name: "Connector catalog",
     });
+    const { summary } = connectorCatalogDisclosure(diagnostics);
+    click(summary);
     expect(within(diagnostics).getByText("Not reused")).toBeInTheDocument();
     expect(
       within(diagnostics).queryByText("Fresh evaluation"),
     ).not.toBeInTheDocument();
   });
 
-  it("keeps Debug settings usable when diagnostics are unavailable", async () => {
-    context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {
-      return respond(404, {
-        error: {
-          message: "Connector catalog diagnostics are unavailable",
-          code: "NOT_FOUND",
-        },
-      });
-    });
+  it("keeps Debug settings usable while diagnostics load or are unavailable", async () => {
+    const releaseDiagnostics = context.mocks.deferred<void>();
+    context.mocks.api(
+      connectorCatalogContract.diagnostics,
+      async ({ respond }) => {
+        await releaseDiagnostics.promise;
+        return respond(404, {
+          error: {
+            message: "Connector catalog diagnostics are unavailable",
+            code: "NOT_FOUND",
+          },
+        });
+      },
+    );
 
     await openDialog("admin", "debug");
 
     const diagnostics = await screen.findByRole("region", {
       name: "Connector catalog",
     });
-    expect(within(diagnostics).getByText("Unavailable")).toBeInTheDocument();
+    expect(within(diagnostics).getByText("Loading")).toBeInTheDocument();
+    expect(diagnostics.querySelector("summary")).toBeNull();
     expect(screen.getByText("Build information")).toBeInTheDocument();
     expect(screen.getByText("Capture network bodies")).toBeInTheDocument();
+
+    releaseDiagnostics.resolve();
+    await expect(
+      within(diagnostics).findByText("Unavailable"),
+    ).resolves.toBeInTheDocument();
+    expect(diagnostics.querySelector("summary")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -941,6 +941,42 @@ describe("settings dialog", () => {
     expect(details.open).toBeFalsy();
   });
 
+  it("summarizes a never-synced connector catalog", async () => {
+    context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {
+      return respond(200, {
+        state: "never-synced",
+        active: null,
+        lastAttempt: null,
+        lastSuccessAt: null,
+        rejectedCandidate: null,
+        filtering: {
+          capabilityDigest: `sha256:${"a".repeat(64)}`,
+          evaluatedAt: null,
+          stale: true,
+          filteredAuthMethods: [],
+        },
+        credentialStorage: {
+          missingConnectorVersions: 0,
+          unownedConnectorSecrets: 0,
+          unownedConnectorVariables: 0,
+          unresolvedBridgeCredentials: 0,
+        },
+      });
+    });
+
+    await openDialog("admin", "debug");
+
+    const diagnostics = await screen.findByRole("region", {
+      name: "Connector catalog",
+    });
+    const { details, summary } = connectorCatalogDisclosure(diagnostics);
+    expect(details.open).toBeFalsy();
+    expect(summary).toHaveTextContent("Sync state: Never synced");
+    expect(summary).toHaveTextContent("Active version: None");
+    expect(summary).toHaveTextContent("Last attempt: None");
+    expect(summary).toHaveTextContent("Evaluation: Stale");
+  });
+
   it("refreshes connector catalog diagnostics on every Debug entry", async () => {
     let requestCount = 0;
     context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -3,7 +3,7 @@ import type {
   ConnectorCatalogDiagnostics,
   ConnectorCatalogSyncFailureCode,
 } from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
-import { Database } from "lucide-react";
+import { ChevronDown, ChevronUp, Database } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -211,6 +211,70 @@ function DiagnosticField({
         {value}
       </Value>
     </div>
+  );
+}
+
+function CatalogDiagnosticsSummary({
+  diagnostics,
+}: {
+  readonly diagnostics: ConnectorCatalogDiagnostics;
+}) {
+  const activeVersion = diagnostics.active?.catalogVersion ?? emptyValue();
+  const lastAttempt = diagnostics.lastAttempt
+    ? formatEnumValue(diagnostics.lastAttempt.outcome)
+    : emptyValue();
+  const evaluation = formatEnumValue(
+    diagnostics.filtering.stale ? "stale" : "current",
+  );
+
+  return (
+    <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+        <Database size={22} className="text-muted-foreground" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-2">
+        <span
+          id="connector-catalog-diagnostics-title"
+          className="text-sm font-medium text-foreground"
+        >
+          {i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.title;
+          })}
+        </span>
+        <span className="flex min-w-0 flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
+          <span className="zero-badge max-w-full rounded-md px-2 py-0.5 break-all">
+            {i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .syncState;
+            })}
+            : {formatEnumValue(diagnostics.state)}
+          </span>
+          <span className="zero-badge max-w-full rounded-md px-2 py-0.5 break-all">
+            {i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .activeVersion;
+            })}
+            : {activeVersion}
+          </span>
+          <span className="zero-badge max-w-full rounded-md px-2 py-0.5 break-all">
+            {i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .lastAttempt;
+            })}
+            : {lastAttempt}
+          </span>
+          <span className="zero-badge max-w-full rounded-md px-2 py-0.5 break-all">
+            {i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .evaluation;
+            })}
+            : {evaluation}
+          </span>
+        </span>
+      </span>
+      <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground group-open:hidden" />
+      <ChevronUp className="mt-1 hidden h-4 w-4 shrink-0 text-muted-foreground group-open:block" />
+    </summary>
   );
 }
 
@@ -500,38 +564,45 @@ export function ConnectorCatalogDiagnosticsBlock() {
   return (
     <section
       aria-labelledby="connector-catalog-diagnostics-title"
-      className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border"
+      className="overflow-hidden rounded-xl bg-card zero-border"
     >
-      <div className="shrink-0">
-        <div className="flex h-7 w-7 items-center justify-center">
-          <Database size={22} className="text-muted-foreground" />
-        </div>
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-3">
-        <div
-          id="connector-catalog-diagnostics-title"
-          className="text-sm font-medium text-foreground"
-        >
-          {t(($) => {
-            return $.connectors.providerSettings.catalogDiagnostics.title;
-          })}
-        </div>
-        {diagnostics ? (
-          <DiagnosticsContent diagnostics={diagnostics} />
-        ) : (
-          <div className="text-sm text-muted-foreground">
-            {loading
-              ? t(($) => {
-                  return $.connectors.providerSettings.catalogDiagnostics
-                    .loading;
-                })
-              : t(($) => {
-                  return $.connectors.providerSettings.catalogDiagnostics
-                    .unavailable;
-                })}
+      {diagnostics ? (
+        <details className="group">
+          <CatalogDiagnosticsSummary diagnostics={diagnostics} />
+          <div className="border-t border-border/60 p-4">
+            <DiagnosticsContent diagnostics={diagnostics} />
           </div>
-        )}
-      </div>
+        </details>
+      ) : (
+        <div className="flex items-start gap-4 p-4">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <Database size={22} className="text-muted-foreground" />
+            </div>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-3">
+            <div
+              id="connector-catalog-diagnostics-title"
+              className="text-sm font-medium text-foreground"
+            >
+              {t(($) => {
+                return $.connectors.providerSettings.catalogDiagnostics.title;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {loading
+                ? t(($) => {
+                    return $.connectors.providerSettings.catalogDiagnostics
+                      .loading;
+                  })
+                : t(($) => {
+                    return $.connectors.providerSettings.catalogDiagnostics
+                      .unavailable;
+                  })}
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- collapse loaded Connector catalog diagnostics by default with the native disclosure pattern used by Realtime diagnostics
- keep sync state, active version, latest attempt, and compatibility evaluation visible in the summary while retaining every existing detail after expansion
- keep Loading and Unavailable non-interactive and preserve the existing named region, data loading, and refresh lifecycle
- update the Settings page-level test for populated and never-synced summaries, default closed state, expansion/collapse, Debug remount reset, and loading/unavailable behavior

## Scope

This PR changes platform presentation only. It does not change the diagnostics API or contract, ccstate signals, synchronization behavior, localization resources, or persisted state.

## Validation

- `pnpm exec prettier --write apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx --maxWorkers=4 --silent=passed-only` (31 tests)
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: repository formatting, full Knip, and full Turbo type checks

Closes #28720
