### PR TITLE
refactor(api): make connector authorization state writers explicit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -60,6 +60,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readProjectedChatEvents } from "./helpers/chat-event-test-reader";
 import {
   clearFeishuConnectorOwnership,
+  readConnectorOAuthAccountMutation,
   readCustomConnectorCredentialStorageParent,
   readFeishuMemberConnectorState,
   seedConnectorStorageRow,
@@ -1003,6 +1004,11 @@ describe("Feishu integration", () => {
       authorizationUrl.searchParams.get("state"),
       "Expected Feishu OAuth state",
     );
+    await expect(
+      readConnectorOAuthAccountMutation(context, state),
+    ).resolves.toMatchObject({
+      account_mutation: { intent: "single-account" },
+    });
     oauthUserOpenId = openId;
     const oauthApp = createAppWithRoutes({
       signal: context.signal,
@@ -2355,6 +2361,11 @@ describe("Feishu integration", () => {
     if (!state) {
       throw new Error("Expected Feishu authorization URL to include state");
     }
+    await expect(
+      readConnectorOAuthAccountMutation(context, state),
+    ).resolves.toMatchObject({
+      account_mutation: { intent: "single-account" },
+    });
 
     const handoffResponse = await oauthApp.request(
       `${feishuOauthContract.callback.path}?${new URLSearchParams({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -85,6 +85,16 @@ export async function readCustomConnectorOAuthStorageState(
   });
 }
 
+export async function readConnectorOAuthAccountMutation(
+  context: TestContext,
+  state: string,
+): Promise<TestConnectorCredentialStorageStateActionResponse> {
+  return await postAction(context, {
+    action: "read-oauth-state-account-mutation",
+    state,
+  });
+}
+
 export async function deleteCustomConnectorCredentialValues(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -30,6 +30,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { readThreadSessionBinding } from "./helpers/runtime-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { readConnectorOAuthAccountMutation } from "./helpers/connector-credential-storage-state";
 
 /*
 helper gap:
@@ -5747,9 +5748,16 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
       "https://www.vm0.test/api/connectors/github/callback",
     );
-    expect(authorizationUrl.searchParams.get("state")).toMatch(
-      /^[0-9a-f]{64}$/u,
-    );
+    const state = authorizationUrl.searchParams.get("state");
+    expect(state).toMatch(/^[0-9a-f]{64}$/u);
+    if (!state) {
+      throw new Error("Expected GitHub authorization state");
+    }
+    await expect(
+      readConnectorOAuthAccountMutation(context, state),
+    ).resolves.toMatchObject({
+      account_mutation: { intent: "single-account" },
+    });
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -57,10 +57,7 @@ import {
   buildConnectorOpenIdAuthUrlWithMethod,
   prepareConnectorOpenIdAuthStartWithMethod,
 } from "./connector-openid-auth-start";
-import {
-  connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
-} from "../services/connector-account-mutation.service";
+import { connectorAccountSiblingWritesEnabled } from "../services/connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "../services/connector-connection-write.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 
@@ -515,7 +512,7 @@ const startConnectorOauthInner$ = command(
         orgId: auth.orgId,
         userId: auth.userId,
         target: { kind: "builtin", connectorSlug: resolved.connectorSlug },
-        mutation: normalizeConnectorAccountMutation(bodyResult.data.account),
+        mutation: bodyResult.data.account,
         allowSiblings:
           connectorAccountSiblingWritesEnabled(featureSwitchContext),
       });
@@ -638,7 +635,7 @@ const startConnectorOpenIdInner$ = command(
         orgId: auth.orgId,
         userId: auth.userId,
         target: { kind: "builtin", connectorSlug: resolved.connectorSlug },
-        mutation: normalizeConnectorAccountMutation(bodyResult.data.account),
+        mutation: bodyResult.data.account,
         allowSiblings:
           connectorAccountSiblingWritesEnabled(featureSwitchContext),
       });

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -60,7 +60,6 @@ import {
 import {
   connectorAccountSiblingWritesEnabled,
   normalizeConnectorAccountMutation,
-  storedConnectorAccountMutationWrite,
 } from "../services/connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "../services/connector-connection-write.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
@@ -535,7 +534,7 @@ const startConnectorOauthInner$ = command(
         authorizationUrl: authResult.url,
         codeVerifier: authResult.codeVerifier,
         oauthContext: authResult.oauthContext,
-        ...storedConnectorAccountMutationWrite(bodyResult.data.account),
+        accountMutation: bodyResult.data.account,
         expiresAt: connectorOAuthStateExpiresAt(),
       });
       return resolution;
@@ -657,7 +656,7 @@ const startConnectorOpenIdInner$ = command(
         redirectUri: prepared.expectedReturnTo,
         codeVerifier: authResult.codeVerifier,
         oauthContext: JSON.stringify({ realm: prepared.realm }),
-        ...storedConnectorAccountMutationWrite(bodyResult.data.account),
+        accountMutation: bodyResult.data.account,
         expiresAt: connectorOAuthStateExpiresAt(),
       });
       return resolution;

--- a/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
@@ -128,6 +128,7 @@ const startFeishuAccountOAuth$ = command(
         connectorId,
         redirectUri: feishuOAuthAppCallbackUrl(),
         publicBrand: args.publicBrand,
+        account: { intent: "single-account" },
         feishuContext: {
           installationId: args.installationId,
           expectedOpenId: args.openId,

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -653,6 +653,7 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
       connectorId,
       redirectUri: oauthRedirectUri(query.callbackTarget),
       publicBrand: state.publicBrand,
+      account: { intent: "single-account" },
       feishuContext: {
         installationId: state.installationId,
       },

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -234,6 +234,23 @@ async function readCustomOAuthState(
   });
 }
 
+async function readOAuthStateAccountMutation(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"read-oauth-state-account-mutation">,
+  signal: AbortSignal,
+) {
+  const [state] = await db
+    .select({ accountMutation: connectorOauthStates.accountMutation })
+    .from(connectorOauthStates)
+    .where(eq(connectorOauthStates.state, body.state))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!state) {
+    throw new Error("Expected connector OAuth state");
+  }
+  return actionOk({ account_mutation: state.accountMutation });
+}
+
 async function deleteCustomCredentialValues(
   db: Db,
   body: ConnectorCredentialStorageAction<"delete-custom-credential-values">,
@@ -830,6 +847,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "read-custom-oauth-state": {
         return await readCustomOAuthState(db, body, signal);
+      }
+      case "read-oauth-state-account-mutation": {
+        return await readOAuthStateAccountMutation(db, body, signal);
       }
       case "delete-custom-credential-values": {
         return await deleteCustomCredentialValues(db, body, signal);

--- a/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
@@ -51,13 +51,3 @@ export function storedConnectorAccountMutationSelection(relation: SQLWrapper) {
     to_jsonb(${relation}) -> 'account_mutation'
   `.mapWith(storedConnectorAccountMutationDecoder);
 }
-
-export function storedConnectorAccountMutationWrite(
-  intent: ConnectorAccountMutationIntent | null | undefined,
-): { readonly accountMutation?: StoredConnectorAccountMutation } {
-  // Omitted client intent remains a supported compatibility boundary until
-  // #28589 contracts each applicable route and persisted state authority.
-  return intent === null || intent === undefined
-    ? {}
-    : { accountMutation: intent };
-}

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -60,7 +60,6 @@ import {
   normalizeConnectorAccountMutation,
   parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
-  storedConnectorAccountMutationWrite,
 } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
@@ -824,7 +823,7 @@ async function createExternalCodeSession(
     readonly authorizeAgent: true | undefined;
     readonly connectorSlug: ConnectorSlug;
     readonly authMethod: ConnectorAuthMethodId;
-    readonly account?: ConnectorAccountMutationIntent;
+    readonly account: ConnectorAccountMutationIntent;
     readonly allowSiblings: boolean;
     readonly sessionToken: string;
     readonly encryptedProviderState: string;
@@ -873,7 +872,7 @@ async function createExternalCodeSession(
         status: "pending",
         sessionTokenHash: sessionTokenHash(args.sessionToken),
         encryptedProviderState: args.encryptedProviderState,
-        ...storedConnectorAccountMutationWrite(args.account),
+        accountMutation: args.account,
         authorizationUrl: args.authorizationUrl,
         createdAt: args.now,
         updatedAt: args.now,
@@ -897,7 +896,7 @@ export const startConnectorExternalCodeSession$ = command(
       readonly authorizeAgent: true | undefined;
       readonly connectorSlug: ConnectorSlug;
       readonly authMethod: ConnectorAuthMethodId;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ) => {

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -57,7 +57,6 @@ import {
 } from "./connected-connector-authorization.service";
 import {
   connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
   parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
 } from "./connector-account-mutation.service";
@@ -845,7 +844,7 @@ async function createExternalCodeSession(
       orgId: args.orgId,
       userId: args.userId,
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
-      mutation: normalizeConnectorAccountMutation(args.account),
+      mutation: args.account,
       allowSiblings: args.allowSiblings,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -60,7 +60,6 @@ import {
 } from "./connected-connector-authorization.service";
 import {
   connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
   parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
 } from "./connector-account-mutation.service";
@@ -1026,7 +1025,7 @@ async function createDeviceAuthSession(
       orgId: args.orgId,
       userId: args.userId,
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
-      mutation: normalizeConnectorAccountMutation(args.account),
+      mutation: args.account,
       allowSiblings: args.allowSiblings,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -63,7 +63,6 @@ import {
   normalizeConnectorAccountMutation,
   parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
-  storedConnectorAccountMutationWrite,
 } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
@@ -1002,7 +1001,7 @@ async function createDeviceAuthSession(
     readonly authorizeAgent: true | undefined;
     readonly connectorSlug: ConnectorSlug;
     readonly authMethod: ConnectorAuthMethodId;
-    readonly account?: ConnectorAccountMutationIntent;
+    readonly account: ConnectorAccountMutationIntent;
     readonly allowSiblings: boolean;
     readonly sessionToken: string;
     readonly encryptedProviderState: string;
@@ -1054,7 +1053,7 @@ async function createDeviceAuthSession(
         status: "awaiting_user_authorization",
         sessionTokenHash: sessionTokenHash(args.sessionToken),
         encryptedProviderState: args.encryptedProviderState,
-        ...storedConnectorAccountMutationWrite(args.account),
+        accountMutation: args.account,
         userCode: args.userCode,
         verificationUri: args.verificationUri,
         verificationUriComplete: args.verificationUriComplete,
@@ -1082,7 +1081,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       readonly connectorSlug: ConnectorSlug;
       readonly authMethod: ConnectorAuthMethodId;
       readonly options?: Readonly<Record<string, string>>;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ) => {

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -69,7 +69,6 @@ import {
 import {
   connectorAccountSiblingWritesEnabled,
   normalizeConnectorAccountMutation,
-  storedConnectorAccountMutationWrite,
 } from "./connector-account-mutation.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 
@@ -503,7 +502,7 @@ export const startCustomConnectorOAuth2$ = command(
       readonly redirectUri: string;
       readonly publicBrand: PublicBrand;
       readonly agentId?: string;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
       readonly feishuContext?: {
         readonly installationId?: string;
         readonly expectedOpenId?: string;
@@ -605,7 +604,7 @@ export const startCustomConnectorOAuth2$ = command(
         authorizationUrl,
         codeVerifier,
         oauthContext: JSON.stringify(context),
-        ...storedConnectorAccountMutationWrite(args.account),
+        accountMutation: args.account,
         expiresAt: connectorOAuthStateExpiresAt(),
       });
       return resolution;

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -583,7 +583,7 @@ export const startCustomConnectorOAuth2$ = command(
         orgId: args.orgId,
         userId: args.userId,
         target: { kind: "custom", customConnectorId: connector.id },
-        mutation: normalizeConnectorAccountMutation(args.account),
+        mutation: args.account,
         allowSiblings:
           !isIntegrationManagedCustomConnector(connector) &&
           connectorAccountSiblingWritesEnabled(featureContext),

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -469,6 +469,7 @@ export async function buildGithubUserConnectAuthorizationUrl(
     redirectUri,
     codeVerifier: authResult.codeVerifier,
     oauthContext: authResult.oauthContext,
+    accountMutation: { intent: "single-account" },
     expiresAt: connectorOAuthStateExpiresAt(),
   });
   signal.throwIfAborted();

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
+import { connectorAccountMutationIntentSchema } from "./connector-accounts";
 
 const c = initContract();
 
@@ -51,6 +52,10 @@ export const testConnectorCredentialStorageStateActionBodySchema =
     }),
     z.object({
       action: z.literal("read-custom-oauth-state"),
+      state: z.string(),
+    }),
+    z.object({
+      action: z.literal("read-oauth-state-account-mutation"),
       state: z.string(),
     }),
     z.object({
@@ -197,6 +202,9 @@ export const testConnectorCredentialStorageStateActionResponseSchema = z.object(
     ok: z.literal(true),
     connector: connectorStateSchema.nullable().optional(),
     connector_id: z.uuid().optional(),
+    account_mutation: connectorAccountMutationIntentSchema
+      .nullable()
+      .optional(),
     custom_oauth_state: customOauthStateSchema.nullable().optional(),
     feishu_member_connection: feishuMemberConnectionStateSchema
       .nullable()


### PR DESCRIPTION
## Summary

- require explicit connector account mutation intent at every shared authorization-state writer and persist it directly
- persist fixed `single-account` intent for specialized GitHub user-connect OAuth and both Feishu Integration start paths while preserving exact Feishu reconnect at completion
- remove the optional state-write helper and add integration assertions that inspect persisted OAuth state before callback

## Deployment compatibility

This is the writer-only rollback-floor release. The three database columns remain nullable, and `to_jsonb` selection, nullable decoding, and null-to-target-only parsing remain in place so pre-deployment authorization state can still complete and the API can roll back safely.

Data cleanup and `NOT NULL` enforcement remain in #28726. Strict-reader cleanup remains in #28727. After this PR deploys, those issues require the production state and rollback drains recorded in parent #28698.

## Validation

- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/connectors-openid.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/connectors-oauth-start.test.ts --maxWorkers=4 --silent=passed-only` (160 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t 'starts configured GitHub user OAuth with connector state' --maxWorkers=1 --silent=passed-only`
- pre-commit staged checks, including full Turbo `check-types` (14/14 tasks)

An unrelated pre-existing repeat-run collision in the full integrations file is tracked separately in #28730.

Closes #28725

Parent context: #28698
