### PR TITLE
perf(runner): specialize guest storage manifest invocation

### DIFF
--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -3,7 +3,9 @@
 use std::time::Duration;
 
 use guest_contracts::storage_manifest::Manifest;
-use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox, StorageManifestRequest,
+};
 use tracing::{info, warn};
 
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir};
@@ -15,10 +17,6 @@ const STORAGE_MANIFEST_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) fn guest_download_command() -> String {
     format!("{} {}", guest::DOWNLOAD_BIN, guest::STORAGE_MANIFEST)
-}
-
-pub(super) fn guest_download_stdin_command() -> String {
-    format!("{} --manifest-stdin", guest::DOWNLOAD_BIN)
 }
 
 pub(super) fn guest_storage_manifest_cleanup_command() -> String {
@@ -47,10 +45,23 @@ pub(super) async fn download_storages(
         .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
     let run_id = context.run_id.to_string();
     let runtime_dir = guest_runtime_dir(context.run_id)?;
-    let download_env = guest_download_env(&run_id, &runtime_dir);
-    let use_stdin = manifest_json.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES;
-    let download_cmd = if use_stdin {
-        guest_download_stdin_command()
+    let use_dedicated = manifest_json.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES;
+    let transport = if use_dedicated {
+        "dedicated"
+    } else {
+        "fallback"
+    };
+
+    info!(run_id = %context.run_id, transport, "downloading storages");
+    let result = if use_dedicated {
+        sandbox
+            .apply_storage_manifest(&StorageManifestRequest {
+                manifest_json: &manifest_json,
+                run_id: &run_id,
+                runtime_dir: &runtime_dir,
+                timeout: DEFAULT_EXEC_TIMEOUT,
+            })
+            .await
     } else {
         remove_fallback_storage_manifest(sandbox).await?;
         if let Err(error) = sandbox
@@ -60,29 +71,27 @@ pub(super) async fn download_storages(
             cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
             return Err(error.into());
         }
-        guest_download_command()
+        let download_cmd = guest_download_command();
+        let download_env = guest_download_env(&run_id, &runtime_dir);
+        sandbox
+            .exec_with_diagnostic_label(
+                &ExecRequest {
+                    cmd: &download_cmd,
+                    timeout: DEFAULT_EXEC_TIMEOUT,
+                    env: &download_env,
+                    sudo: false,
+                    expected_exit_codes: &[],
+                    stdin_bytes: None,
+                    output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
+                },
+                "storage-download",
+            )
+            .await
     };
-    let stdin_bytes = use_stdin.then_some(manifest_json.as_slice());
-
-    info!(run_id = %context.run_id, "downloading storages");
-    let result = match sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &download_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &download_env,
-                sudo: false,
-                expected_exit_codes: &[],
-                stdin_bytes,
-                output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
-            },
-            "storage-download",
-        )
-        .await
-    {
+    let result = match result {
         Ok(result) => result,
         Err(e) => {
-            if !use_stdin {
+            if !use_dedicated {
                 cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
             }
             return Err(e.into());
@@ -90,7 +99,7 @@ pub(super) async fn download_storages(
     };
 
     if !helper_exec_succeeded(&result) {
-        if !use_stdin {
+        if !use_dedicated {
             cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
         }
         return Err(RunnerError::Internal(format_guest_download_failure(

--- a/crates/runner/src/executor/tests/agent_run_tests/storage.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/storage.rs
@@ -12,7 +12,6 @@ use super::support::{
     assert_failed_action_error_once, assert_no_action, assert_successful_action_once,
 };
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
-use crate::executor::storage::guest_download_stdin_command;
 use crate::executor::telemetry::RunnerSpawnTiming;
 use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, api_artifact, api_storage, create_overridden_sandbox,
@@ -100,13 +99,7 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
     .await
     .unwrap();
 
-    let exec_calls = sandbox.exec_calls();
-    assert!(
-        exec_calls
-            .iter()
-            .any(|call| call.cmd == guest_download_stdin_command()),
-        "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
-    );
+    assert_eq!(sandbox.storage_manifest_calls().len(), 1);
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action_once(&ops, "runner_storage_manifest_fingerprint_reuse");
     assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
@@ -173,13 +166,7 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
             archive_request.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
         ));
-        let exec_calls = overrides.exec_calls();
-        assert!(
-            exec_calls
-                .iter()
-                .any(|call| call.cmd == guest_download_stdin_command()),
-            "cache miss passthrough should reach guest-download before process spawn; calls: {exec_calls:?}"
-        );
+        assert_eq!(overrides.storage_manifest_calls().len(), 1);
 
         start_process_gate.release_one();
         tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
@@ -387,13 +374,7 @@ async fn run_in_sandbox_records_storage_manifest_no_work_timing_without_guest_do
     .await
     .unwrap();
 
-    let exec_calls = sandbox.exec_calls();
-    assert!(
-        exec_calls
-            .iter()
-            .all(|call| call.cmd != guest_download_stdin_command()),
-        "fully cached storage without cleanup or instruction normalization should skip guest-download; calls: {exec_calls:?}"
-    );
+    assert!(sandbox.storage_manifest_calls().is_empty());
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action_once(&ops, "runner_storage_manifest_fingerprint_reuse");
     assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
@@ -512,13 +493,7 @@ async fn run_in_sandbox_rejects_non_empty_artifact_without_archive_url() {
             .contains("storage manifest artifact memory version version-2 is missing archiveUrl"),
         "got: {error}"
     );
-    let exec_calls = sandbox.exec_calls();
-    assert!(
-        exec_calls
-            .iter()
-            .all(|call| call.cmd != guest_download_stdin_command()),
-        "invalid storage manifest should fail before guest-download; calls: {exec_calls:?}"
-    );
+    assert!(sandbox.storage_manifest_calls().is_empty());
     let ops = telemetry.pending_ops_snapshot();
     assert_failed_action_error_once(
         &ops,

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -1,11 +1,9 @@
-use std::collections::HashSet;
-
 use guest_contracts::storage_manifest::{Manifest, StorageEntry};
-use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, ExecResult, ExecTermination};
+use sandbox::{ExecResult, ExecTermination};
 use sandbox_mock::MockSandbox;
 
 use super::super::storage::{
-    download_storages, guest_download_command, guest_download_env, guest_download_stdin_command,
+    download_storages, guest_download_command, guest_download_env,
     guest_storage_manifest_cleanup_command,
 };
 use super::super::{DEFAULT_EXEC_TIMEOUT, guest_runtime_dir};
@@ -49,7 +47,7 @@ fn manifest_with_serialized_len(len: usize) -> Manifest {
 }
 
 #[tokio::test]
-async fn download_storages_sends_manifest_over_stdin() {
+async fn download_storages_uses_fixed_manifest_operation() {
     let sandbox = MockSandbox::new("test");
     let context = minimal_context();
     let manifest = storage_manifest();
@@ -60,27 +58,16 @@ async fn download_storages_sends_manifest_over_stdin() {
         .unwrap();
 
     assert!(sandbox.write_file_calls().is_empty());
-    let calls = sandbox.exec_calls();
+    assert!(sandbox.exec_calls().is_empty());
+    let calls = sandbox.storage_manifest_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].cmd, guest_download_stdin_command());
+    assert_eq!(calls[0].manifest_json, manifest_json);
+    assert_eq!(calls[0].run_id, context.run_id.to_string());
     assert_eq!(
-        calls[0]
-            .env_keys
-            .iter()
-            .map(String::as_str)
-            .collect::<HashSet<_>>(),
-        HashSet::from([
-            guest_contracts::env::RUN_ID_ENV,
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-        ])
+        calls[0].runtime_dir,
+        guest_runtime_dir(context.run_id).unwrap()
     );
     assert_eq!(calls[0].timeout, DEFAULT_EXEC_TIMEOUT);
-    assert_eq!(calls[0].output_limits, EXEC_OUTPUT_LIMIT_1_MIB);
-    assert!(!calls[0].sudo);
-    assert_eq!(
-        calls[0].stdin_bytes.as_deref(),
-        Some(manifest_json.as_slice())
-    );
 }
 
 #[test]
@@ -102,7 +89,7 @@ fn guest_download_env_contains_run_identity_values() {
 }
 
 #[tokio::test]
-async fn exact_stdin_limit_uses_stdin_transport() {
+async fn exact_manifest_limit_uses_dedicated_transport() {
     let sandbox = MockSandbox::new("test");
     let context = minimal_context();
     let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES);
@@ -112,7 +99,8 @@ async fn exact_stdin_limit_uses_stdin_transport() {
         .unwrap();
 
     assert!(sandbox.write_file_calls().is_empty());
-    assert_eq!(sandbox.exec_calls()[0].cmd, guest_download_stdin_command());
+    assert!(sandbox.exec_calls().is_empty());
+    assert_eq!(sandbox.storage_manifest_calls().len(), 1);
 }
 
 #[tokio::test]
@@ -162,6 +150,7 @@ async fn stale_fallback_cleanup_failure_prevents_write() {
     );
     assert!(sandbox.write_file_calls().is_empty());
     assert_eq!(sandbox.exec_calls().len(), 1);
+    assert!(sandbox.storage_manifest_calls().is_empty());
 }
 
 #[tokio::test]
@@ -185,7 +174,7 @@ async fn fallback_exec_error_triggers_cleanup() {
 }
 
 #[tokio::test]
-async fn stdin_exec_error_does_not_run_fallback_cleanup() {
+async fn dedicated_operation_error_does_not_run_fallback_cleanup() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
     let context = minimal_context();
@@ -196,7 +185,8 @@ async fn stdin_exec_error_does_not_run_fallback_cleanup() {
         .unwrap_err();
 
     assert!(error.to_string().contains("vsock exec failed"));
-    assert_eq!(sandbox.exec_calls().len(), 1);
+    assert!(sandbox.exec_calls().is_empty());
+    assert_eq!(sandbox.storage_manifest_calls().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -259,6 +259,13 @@ impl Sandbox for ObservedStartSandbox {
         Ok(result)
     }
 
+    async fn apply_storage_manifest(
+        &self,
+        request: &sandbox::StorageManifestRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.apply_storage_manifest(request).await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         self.inner.read_file(path, max_bytes).await
     }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3814,6 +3814,13 @@ mod tests {
             self.inner.exec_with_diagnostic_label(request, label).await
         }
 
+        async fn apply_storage_manifest(
+            &self,
+            request: &sandbox::StorageManifestRequest<'_>,
+        ) -> sandbox::Result<sandbox::ExecResult> {
+            self.inner.apply_storage_manifest(request).await
+        }
+
         async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
             self.inner.read_file(path, max_bytes).await
         }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -146,6 +146,13 @@ impl Sandbox for PostCopyGateSandbox {
         self.inner.exec(request).await
     }
 
+    async fn apply_storage_manifest(
+        &self,
+        request: &sandbox::StorageManifestRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.apply_storage_manifest(request).await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         self.inner.read_file(path, max_bytes).await
     }
@@ -228,6 +235,13 @@ impl Sandbox for PanicExecSandbox {
 
     async fn exec(&self, _request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
         panic!("simulated exec panic");
+    }
+
+    async fn apply_storage_manifest(
+        &self,
+        _request: &sandbox::StorageManifestRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        panic!("unused apply_storage_manifest");
     }
 
     async fn read_file(&self, _path: &str, _max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -17,7 +17,7 @@ use sandbox::{
     SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
     SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
-    SevereMemoryRetentionDiagnostics, StartProcessRequest, WriteFileEntry,
+    SevereMemoryRetentionDiagnostics, StartProcessRequest, StorageManifestRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -25,8 +25,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use vsock_host::{
     ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, FrameWriteObserver,
-    NormalOperationFence, NormalOperationFenceRejection, SupervisedExecControl,
-    SupervisedExecRequest, VsockHost,
+    GuestStorageManifestResult, NormalOperationFence, NormalOperationFenceRejection,
+    SupervisedExecControl, SupervisedExecRequest, VsockHost,
 };
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
 
@@ -2407,6 +2407,29 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
+    async fn apply_storage_manifest(
+        &self,
+        request: &StorageManifestRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        let operation = SandboxOperation::Exec;
+        let timeout_ms = request.timeout_ms();
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            validate_exec_capture_timeout(timeout_ms)?;
+            guest
+                .guest_storage_manifest(
+                    request.manifest_json,
+                    request.run_id,
+                    request.runtime_dir,
+                    timeout_ms,
+                    Duration::from_millis(u64::from(timeout_ms) + 5_000),
+                )
+                .await
+                .map(storage_manifest_exec_result)
+        })
+        .await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         let operation = SandboxOperation::ReadFile;
 
@@ -2611,6 +2634,18 @@ impl Sandbox for FirecrackerSandbox {
                 Err(Self::backend_crashed_error(operation))
             }
         }
+    }
+}
+
+fn storage_manifest_exec_result(result: GuestStorageManifestResult) -> ExecResult {
+    ExecResult {
+        termination: exec_termination_from_vsock_termination(result.termination),
+        guest_duration_ms: Some(result.duration_ms),
+        stdout: result.stdout,
+        stderr: result.stderr,
+        diagnostic: result.diagnostic,
+        stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
     }
 }
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2460,17 +2460,51 @@ fn exec_result_from_operation_result_preserves_terminal_metadata() {
     assert!(!result.stderr_truncated);
 }
 
-#[test]
-fn storage_manifest_exec_result_preserves_terminal_metadata() {
-    let result = storage_manifest_exec_result(GuestStorageManifestResult {
-        termination: vsock_proto::ExecTermination::WaitFailed,
-        duration_ms: 19,
-        stdout: b"out".to_vec(),
-        stderr: b"err".to_vec(),
-        stdout_truncated: true,
-        stderr_truncated: false,
-        diagnostic: "containment cleanup failed".to_string(),
-    });
+#[tokio::test]
+async fn apply_storage_manifest_preserves_terminal_metadata() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let request = StorageManifestRequest {
+        manifest_json: b"{\"storages\":[]}",
+        run_id: "run-1",
+        runtime_dir: "/run/vm0/runs/run-1",
+        timeout: Duration::from_secs(5),
+    };
+
+    let apply = sandbox.apply_storage_manifest(&request);
+    let respond = async {
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, vsock_proto::MSG_GUEST_STORAGE_MANIFEST);
+        let decoded = vsock_proto::decode_guest_storage_manifest_request(&request.payload).unwrap();
+        assert_eq!(decoded.timeout_ms, 5_000);
+        assert_eq!(decoded.run_id, "run-1");
+        assert_eq!(decoded.runtime_dir, "/run/vm0/runs/run-1");
+        assert_eq!(decoded.manifest_json, b"{\"storages\":[]}");
+
+        let payload = vsock_proto::encode_guest_storage_manifest_result(
+            vsock_proto::ExecTermination::WaitFailed,
+            19,
+            vsock_proto::ExecCapturedOutput::Captured {
+                bytes: b"out",
+                truncated: true,
+            },
+            vsock_proto::ExecCapturedOutput::Captured {
+                bytes: b"err",
+                truncated: false,
+            },
+            "containment cleanup failed",
+        )
+        .unwrap();
+        let response = vsock_proto::encode(
+            vsock_proto::MSG_GUEST_STORAGE_MANIFEST_RESULT,
+            request.seq,
+            &payload,
+        )
+        .unwrap();
+        guest.write_all(&response).await.unwrap();
+    };
+    let (result, ()) = tokio::join!(apply, respond);
+    let result = result.unwrap();
 
     assert_eq!(result.termination, ExecTermination::WaitFailed);
     assert_eq!(result.guest_duration_ms, Some(19));

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2461,6 +2461,27 @@ fn exec_result_from_operation_result_preserves_terminal_metadata() {
 }
 
 #[test]
+fn storage_manifest_exec_result_preserves_terminal_metadata() {
+    let result = storage_manifest_exec_result(GuestStorageManifestResult {
+        termination: vsock_proto::ExecTermination::WaitFailed,
+        duration_ms: 19,
+        stdout: b"out".to_vec(),
+        stderr: b"err".to_vec(),
+        stdout_truncated: true,
+        stderr_truncated: false,
+        diagnostic: "containment cleanup failed".to_string(),
+    });
+
+    assert_eq!(result.termination, ExecTermination::WaitFailed);
+    assert_eq!(result.guest_duration_ms, Some(19));
+    assert_eq!(result.stdout, b"out");
+    assert_eq!(result.stderr, b"err");
+    assert!(result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+    assert_eq!(result.diagnostic, "containment cleanup failed");
+}
+
+#[test]
 fn exec_result_from_operation_result_maps_terminal_edge_states() {
     for (termination, diagnostic, input_stderr, expected_termination) in [
         (

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -57,6 +57,19 @@ pub struct ExecCall {
     pub output_limits: ExecOutputLimits,
 }
 
+/// Captured fixed storage-manifest request fields recorded for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageManifestCall {
+    /// Canonical manifest JSON supplied to the provider operation.
+    pub manifest_json: Vec<u8>,
+    /// Run identity supplied to the fixed guest helper.
+    pub run_id: String,
+    /// Absolute guest runtime directory supplied to the fixed helper.
+    pub runtime_dir: String,
+    /// Helper timeout supplied by the caller.
+    pub timeout: Duration,
+}
+
 /// Captured `start_process` request fields recorded for test assertions.
 ///
 /// Unlike [`ExecCall`], this record captures environment values as well as

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -31,7 +31,8 @@ mod support;
 
 pub use call_records::{
     CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, ReadFileCall,
-    RemoteExecCall, StartProcessCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
+    RemoteExecCall, StartProcessCall, StorageManifestCall, WaitProcessCall, WriteFileCall,
+    WriteFilesCall,
 };
 pub use control::MockSandboxControl;
 pub use factory_runtime::{MockRuntimeProvider, MockSandboxFactory, MockSandboxRuntime};

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::call_records::{
     CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, StartProcessCall,
-    WaitProcessCall, WriteFileCall, WriteFilesCall,
+    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{DestroyBehavior, LifecycleBehaviors, MockLifecycleGate};
 use crate::support::LockIgnoringPoison;
@@ -38,6 +38,8 @@ pub(crate) struct ExecOverrideState {
     pub(crate) persistent_matchers: Mutex<Vec<ExecMatcherResult>>,
     /// Recorded exec calls across all sandboxes built from this override set.
     pub(crate) calls: Mutex<Vec<ExecCall>>,
+    /// Recorded fixed storage-manifest calls across all attached sandboxes.
+    pub(crate) storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
     /// Wakes tests after an exec call is recorded.
     pub(crate) call_notify: tokio::sync::Notify,
     /// Optional gate entered after every exec call is recorded but before its
@@ -450,6 +452,14 @@ impl MockSandboxOverrides {
     /// is captured before exec matchers or queued exec results are consumed.
     pub fn exec_calls(&self) -> Vec<ExecCall> {
         self.exec.calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return fixed storage-manifest calls across all attached sandboxes.
+    pub fn storage_manifest_calls(&self) -> Vec<StorageManifestCall> {
+        self.exec
+            .storage_manifest_calls
+            .lock_ignoring_poison()
+            .clone()
     }
 
     /// Wait until at least `expected` exec calls have been recorded.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 
 use crate::call_records::{
     CopyFileCall, ExecCall, ProcessCancelCall, ProcessControlCall, ReadFileCall, StartProcessCall,
-    WaitProcessCall, WriteFileCall, WriteFilesCall,
+    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
 use crate::overrides::{ExecMatcherOutcome, MockSandboxOverrides};
@@ -35,6 +35,7 @@ pub struct MockSandbox {
     run_control_id: Option<String>,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     exec_calls: Mutex<Vec<ExecCall>>,
+    storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     read_file_calls: Mutex<Vec<ReadFileCall>>,
     copy_file_results: Mutex<VecDeque<Result<Vec<u8>>>>,
@@ -76,6 +77,7 @@ impl MockSandbox {
             run_control_id: None,
             exec_results: Mutex::new(VecDeque::new()),
             exec_calls: Mutex::new(Vec::new()),
+            storage_manifest_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             read_file_calls: Mutex::new(Vec::new()),
             copy_file_results: Mutex::new(VecDeque::new()),
@@ -222,6 +224,11 @@ impl MockSandbox {
     /// [`MockSandboxOverrides::exec_calls`].
     pub fn exec_calls(&self) -> Vec<ExecCall> {
         self.exec_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return this sandbox's recorded fixed storage-manifest calls.
+    pub fn storage_manifest_calls(&self) -> Vec<StorageManifestCall> {
+        self.storage_manifest_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a small file read result. Results are consumed in FIFO order.
@@ -575,6 +582,34 @@ impl Sandbox for MockSandbox {
                 .unwrap_or_else(|| Ok(default_exec_result()))
         }?;
         Ok(apply_exec_output_limits(result, request.output_limits))
+    }
+
+    async fn apply_storage_manifest(
+        &self,
+        request: &StorageManifestRequest<'_>,
+    ) -> Result<ExecResult> {
+        let call = StorageManifestCall {
+            manifest_json: request.manifest_json.to_vec(),
+            run_id: request.run_id.to_string(),
+            runtime_dir: request.runtime_dir.to_string(),
+            timeout: request.timeout,
+        };
+        self.storage_manifest_calls
+            .lock_ignoring_poison()
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .exec
+                .storage_manifest_calls
+                .lock_ignoring_poison()
+                .push(call);
+        }
+        let result = self
+            .exec_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or_else(|| Ok(default_exec_result()))?;
+        Ok(apply_exec_output_limits(result, EXEC_OUTPUT_LIMIT_1_MIB))
     }
 
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>> {

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -61,5 +61,5 @@ pub use types::{
     GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlFailureKind,
     ProcessControlGuestStatus, ProcessControlMode, ProcessControlOutcome, ProcessControlWriteState,
     ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest,
-    WriteFileEntry,
+    StorageManifestRequest, WriteFileEntry,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -10,7 +10,7 @@ use tokio::sync::Notify;
 use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
-    StartProcessRequest, WriteFileEntry,
+    StartProcessRequest, StorageManifestRequest, WriteFileEntry,
 };
 
 /// Eligibility result after a sandbox successfully reaches the parked state.
@@ -723,6 +723,17 @@ pub trait Sandbox: Send + Sync + Any {
     ) -> Result<ExecResult> {
         self.exec(request).await
     }
+
+    /// Apply a bounded canonical storage manifest through the provider's fixed
+    /// guest helper operation.
+    ///
+    /// Implementations must preserve helper timeout and cancellation, bounded
+    /// stdout/stderr capture, structured termination, and backend-crash
+    /// classification. The caller owns any oversized-manifest fallback.
+    async fn apply_storage_manifest(
+        &self,
+        request: &StorageManifestRequest<'_>,
+    ) -> Result<ExecResult>;
 
     /// Read a small file from the guest.
     ///

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -76,6 +76,33 @@ pub struct ExecRequest<'a> {
     pub output_limits: ExecOutputLimits,
 }
 
+/// Request to apply one bounded storage manifest inside the guest.
+///
+/// The provider selects the fixed guest helper and argument contract. Callers
+/// supply only the canonical manifest bytes and the run-scoped context needed
+/// by that helper. Manifests outside the provider's bounded transport belong
+/// on the caller's established fallback path.
+pub struct StorageManifestRequest<'a> {
+    /// Canonical storage-manifest JSON passed to the fixed guest helper.
+    pub manifest_json: &'a [u8],
+    /// Run identity exposed to the helper through the guest run-id contract.
+    pub run_id: &'a str,
+    /// Absolute guest runtime directory exposed to the helper.
+    pub runtime_dir: &'a str,
+    /// Guest-side helper timeout.
+    pub timeout: Duration,
+}
+
+impl StorageManifestRequest<'_> {
+    /// Return the timeout as milliseconds, saturating at `u32::MAX`.
+    ///
+    /// Non-zero sub-millisecond durations round up to 1ms so callers do not
+    /// accidentally turn a bounded operation into a zero-timeout request.
+    pub fn timeout_ms(&self) -> u32 {
+        duration_ms(self.timeout)
+    }
+}
+
 impl ExecRequest<'_> {
     /// Return the timeout as milliseconds, saturating at `u32::MAX`.
     ///

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -8,9 +8,9 @@ use std::time::{Duration, Instant};
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, BorrowedRawMessage, DecodeWithError, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START,
-    MSG_GUEST_DNS_READINESS, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
-    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY,
-    MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
+    MSG_GUEST_DNS_READINESS, MSG_GUEST_STORAGE_MANIFEST, MSG_MEMORY_SNAPSHOT,
+    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
+    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
 };
 
 use crate::error::to_io_error;
@@ -22,6 +22,10 @@ use crate::exec_operation::{
 use crate::file_write_worker::{FileWriteKind, FileWriteSubmitError, FileWriteWorker};
 use crate::guest_dns_readiness::{
     GuestDnsReadinessProgram, GuestDnsReadinessSubmitError, GuestDnsReadinessWorker,
+};
+use crate::guest_storage_manifest::{
+    GuestStorageManifestProgram, GuestStorageManifestSubmission, GuestStorageManifestSubmitError,
+    GuestStorageManifestWorker,
 };
 use crate::handlers::{MessageOutcome, handle_basic_message};
 use crate::log::log;
@@ -130,6 +134,7 @@ fn is_real_host_work_message(msg_type: u8) -> bool {
             | MSG_WRITE_FILE
             | MSG_WRITE_FILES
             | MSG_GUEST_DNS_READINESS
+            | MSG_GUEST_STORAGE_MANIFEST
             | MSG_QUIESCE_OPERATIONS
             | MSG_RESUME_OPERATIONS
             | MSG_MEMORY_SNAPSHOT
@@ -293,6 +298,7 @@ struct ConnectionDispatcher {
     connection_cancel: Arc<AtomicBool>,
     file_write_worker: FileWriteWorker,
     guest_dns_readiness_worker: GuestDnsReadinessWorker,
+    guest_storage_manifest_worker: GuestStorageManifestWorker,
     exec_operation_registry: ExecOperationRegistry,
     exec_control_registry: ExecControlRegistry,
     operation_state: OperationState,
@@ -307,6 +313,7 @@ impl ConnectionDispatcher {
         process_containment_mode: ProcessContainmentMode,
         exec_drain_deadline: Duration,
         guest_dns_readiness_program: GuestDnsReadinessProgram,
+        guest_storage_manifest_program: GuestStorageManifestProgram,
     ) -> io::Result<Self> {
         let file_write_worker =
             FileWriteWorker::start(writer.clone(), Arc::clone(&connection_cancel))?;
@@ -315,11 +322,19 @@ impl ConnectionDispatcher {
             Arc::clone(&connection_cancel),
             guest_dns_readiness_program,
         );
+        let guest_storage_manifest_worker = GuestStorageManifestWorker::start(
+            writer.clone(),
+            Arc::clone(&connection_cancel),
+            guest_storage_manifest_program,
+            process_containment_mode,
+            exec_drain_deadline,
+        );
         Ok(Self {
             writer,
             connection_cancel,
             file_write_worker,
             guest_dns_readiness_worker,
+            guest_storage_manifest_worker,
             exec_operation_registry: ExecOperationRegistry::default(),
             exec_control_registry: ExecControlRegistry::default(),
             operation_state: OperationState::default(),
@@ -336,6 +351,7 @@ impl ConnectionDispatcher {
             MSG_WRITE_FILE => self.handle_file_write(msg, FileWriteKind::File)?,
             MSG_WRITE_FILES => self.handle_file_write(msg, FileWriteKind::Files)?,
             MSG_GUEST_DNS_READINESS => self.handle_guest_dns_readiness(msg)?,
+            MSG_GUEST_STORAGE_MANIFEST => self.handle_guest_storage_manifest(msg)?,
             MSG_QUIESCE_OPERATIONS => self.handle_quiesce_operations(msg)?,
             MSG_RESUME_OPERATIONS => self.handle_resume_operations(msg)?,
             MSG_MEMORY_SNAPSHOT => self.handle_memory_snapshot(msg)?,
@@ -535,6 +551,62 @@ impl ConnectionDispatcher {
         }
     }
 
+    fn handle_guest_storage_manifest(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "guest storage manifest", &self.writer)? {
+            return Ok(());
+        }
+        if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
+            return Ok(());
+        }
+        let decoded = match vsock_proto::decode_guest_storage_manifest_request(msg.payload) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
+        let Some(admission) = self.guest_storage_manifest_worker.try_admit() else {
+            send_error_response(
+                msg.seq,
+                "guest storage manifest operation already active",
+                &self.writer,
+            )?;
+            return Ok(());
+        };
+        let Some(operation_guard) =
+            acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
+        else {
+            return Ok(());
+        };
+        match self.guest_storage_manifest_worker.submit(
+            GuestStorageManifestSubmission {
+                seq: msg.seq,
+                timeout_ms: decoded.timeout_ms,
+                run_id: decoded.run_id,
+                runtime_dir: decoded.runtime_dir,
+                manifest_json: decoded.manifest_json,
+            },
+            operation_guard,
+            admission,
+        ) {
+            Ok(()) => Ok(()),
+            Err(GuestStorageManifestSubmitError::Busy) => send_error_response(
+                msg.seq,
+                "guest storage manifest operation already active",
+                &self.writer,
+            ),
+            Err(GuestStorageManifestSubmitError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "guest storage manifest worker stopped",
+            )),
+            Err(GuestStorageManifestSubmitError::Start(error)) => send_error_response(
+                msg.seq,
+                &format!("failed to start guest storage manifest worker: {error}"),
+                &self.writer,
+            ),
+        }
+    }
+
     fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         handle_quiesce_operations(
             msg.seq,
@@ -669,6 +741,22 @@ pub fn handle_connection_with_test_dns_readiness_program(
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
         GuestDnsReadinessProgram::for_test(program),
+        GuestStorageManifestProgram::production(),
+    )
+}
+
+/// Handles a host-side test connection with a test storage helper executable.
+#[doc(hidden)]
+pub fn handle_connection_with_test_storage_manifest_program(
+    stream: UnixStream,
+    program: std::path::PathBuf,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_program(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
+        GuestDnsReadinessProgram::production(),
+        GuestStorageManifestProgram::for_test(program),
     )
 }
 
@@ -693,6 +781,7 @@ fn handle_connection_with_mode_and_exec_drain_deadline(
         process_containment_mode,
         exec_drain_deadline,
         GuestDnsReadinessProgram::production(),
+        GuestStorageManifestProgram::production(),
     )
 }
 
@@ -701,12 +790,14 @@ fn handle_connection_with_mode_and_program(
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
     guest_dns_readiness_program: GuestDnsReadinessProgram,
+    guest_storage_manifest_program: GuestStorageManifestProgram,
 ) -> io::Result<()> {
     match handle_connection_with_outcome(
         stream,
         process_containment_mode,
         exec_drain_deadline,
         guest_dns_readiness_program,
+        guest_storage_manifest_program,
     ) {
         Ok(_) => Ok(()),
         Err(failure) => Err(failure.error),
@@ -718,6 +809,7 @@ fn handle_connection_with_outcome(
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
     guest_dns_readiness_program: GuestDnsReadinessProgram,
+    guest_storage_manifest_program: GuestStorageManifestProgram,
 ) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
@@ -746,6 +838,7 @@ fn handle_connection_with_outcome(
         process_containment_mode,
         exec_drain_deadline,
         guest_dns_readiness_program,
+        guest_storage_manifest_program,
     )
     .map_err(|error| session.failure(error))?;
     let mut buf = [0u8; READ_BUFFER_SIZE];
@@ -894,6 +987,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
                         GuestDnsReadinessProgram::production(),
+                        GuestStorageManifestProgram::production(),
                     )
                 })
         } else {
@@ -907,6 +1001,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
                         GuestDnsReadinessProgram::production(),
+                        GuestStorageManifestProgram::production(),
                     )
                 })
         };
@@ -983,6 +1078,7 @@ mod tests {
             MSG_WRITE_FILE,
             MSG_WRITE_FILES,
             MSG_GUEST_DNS_READINESS,
+            MSG_GUEST_STORAGE_MANIFEST,
             MSG_QUIESCE_OPERATIONS,
             MSG_RESUME_OPERATIONS,
         ] {

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -1,0 +1,655 @@
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use vsock_proto::{ExecCapturedOutput, ExecTermination, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES};
+
+use crate::drain::{BoundedDrainResult, drain_bounded_cancellable};
+use crate::error::to_io_error;
+use crate::log::log;
+use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
+use crate::process_containment::{
+    ExecProcessContainment, ProcessContainmentCleanupMode, ProcessContainmentError,
+    ProcessContainmentMode,
+};
+use crate::quiesce::OperationGuard;
+use crate::wait::{
+    WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
+};
+use crate::worker_ownership::{
+    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
+};
+use crate::writer::GuestWriter;
+
+const PRODUCTION_PROGRAM: &str = "/usr/local/bin/guest-download";
+const THREAD_WORKER: &str = "vsock-guest-storage-manifest";
+const THREAD_STDIN: &str = "vsock-guest-storage-stdin";
+const THREAD_STDOUT: &str = "vsock-guest-storage-stdout";
+const THREAD_STDERR: &str = "vsock-guest-storage-stderr";
+const MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
+
+#[derive(Clone)]
+pub(crate) enum GuestStorageManifestProgram {
+    Production,
+    Test(PathBuf),
+}
+
+impl GuestStorageManifestProgram {
+    pub(crate) fn production() -> Self {
+        Self::Production
+    }
+
+    pub(crate) fn for_test(path: PathBuf) -> Self {
+        Self::Test(path)
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Self::Production => Path::new(PRODUCTION_PROGRAM),
+            Self::Test(path) => path,
+        }
+    }
+}
+
+pub(crate) enum GuestStorageManifestSubmitError {
+    Busy,
+    Disconnected,
+    Start(io::Error),
+}
+
+struct GuestStorageManifestRequest {
+    seq: u32,
+    timeout_ms: u32,
+    run_id: String,
+    runtime_dir: String,
+    manifest_json: Vec<u8>,
+    operation_guard: OperationGuard,
+    admission: SingleActivePermit,
+}
+
+pub(crate) struct GuestStorageManifestWorker {
+    state: Mutex<GuestStorageManifestWorkerState>,
+    writer: GuestWriter,
+    program: GuestStorageManifestProgram,
+    admission: SingleActiveAdmission,
+    connection_cancel: Arc<AtomicBool>,
+    process_containment_mode: ProcessContainmentMode,
+    drain_deadline: Duration,
+}
+
+struct GuestStorageManifestWorkerState {
+    sender: Option<SyncSender<GuestStorageManifestRequest>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl GuestStorageManifestWorker {
+    pub(crate) fn start(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+        program: GuestStorageManifestProgram,
+        process_containment_mode: ProcessContainmentMode,
+        drain_deadline: Duration,
+    ) -> Self {
+        Self {
+            state: Mutex::new(GuestStorageManifestWorkerState {
+                sender: None,
+                handle: None,
+            }),
+            writer,
+            program,
+            admission: SingleActiveAdmission::new(),
+            connection_cancel,
+            process_containment_mode,
+            drain_deadline,
+        }
+    }
+
+    pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
+        self.admission.try_acquire()
+    }
+
+    pub(crate) fn submit(
+        &self,
+        submission: GuestStorageManifestSubmission<'_>,
+        operation_guard: OperationGuard,
+        admission: SingleActivePermit,
+    ) -> Result<(), GuestStorageManifestSubmitError> {
+        let sender = self.sender()?;
+        let request = GuestStorageManifestRequest {
+            seq: submission.seq,
+            timeout_ms: submission.timeout_ms,
+            run_id: submission.run_id.to_owned(),
+            runtime_dir: submission.runtime_dir.to_owned(),
+            manifest_json: submission.manifest_json.to_vec(),
+            operation_guard,
+            admission,
+        };
+        match sender.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(GuestStorageManifestSubmitError::Busy),
+            Err(TrySendError::Disconnected(_)) => {
+                Err(GuestStorageManifestSubmitError::Disconnected)
+            }
+        }
+    }
+
+    fn sender(
+        &self,
+    ) -> Result<SyncSender<GuestStorageManifestRequest>, GuestStorageManifestSubmitError> {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        if let Some(sender) = &state.sender {
+            return Ok(sender.clone());
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let writer = self.writer.clone();
+        let worker_cancel = Arc::clone(&self.connection_cancel);
+        let program = self.program.clone();
+        let process_containment_mode = self.process_containment_mode;
+        let drain_deadline = self.drain_deadline;
+        let handle = thread::Builder::new()
+            .name(THREAD_WORKER.to_string())
+            .spawn(move || {
+                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
+                while let Ok(request) = receiver.recv() {
+                    if let Err(error) = handle_request(
+                        request,
+                        &writer,
+                        &worker_cancel,
+                        &program,
+                        process_containment_mode,
+                        drain_deadline,
+                    ) {
+                        log(
+                            "ERROR",
+                            &format!("guest storage manifest worker failed: {error}"),
+                        );
+                        break;
+                    }
+                }
+            })
+            .map_err(GuestStorageManifestSubmitError::Start)?;
+        state.sender = Some(sender.clone());
+        state.handle = Some(handle);
+        Ok(sender)
+    }
+}
+
+pub(crate) struct GuestStorageManifestSubmission<'a> {
+    pub(crate) seq: u32,
+    pub(crate) timeout_ms: u32,
+    pub(crate) run_id: &'a str,
+    pub(crate) runtime_dir: &'a str,
+    pub(crate) manifest_json: &'a [u8],
+}
+
+impl Drop for GuestStorageManifestWorker {
+    fn drop(&mut self) {
+        self.connection_cancel.store(true, Ordering::Release);
+        let state = self
+            .state
+            .get_mut()
+            .unwrap_or_else(|error| error.into_inner());
+        drop(state.sender.take());
+        if let Some(handle) = state.handle.take()
+            && handle.join().is_err()
+        {
+            log("ERROR", "guest storage manifest worker panicked");
+        }
+    }
+}
+
+struct GuestStorageManifestOutput {
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: BoundedDrainResult,
+    stderr: BoundedDrainResult,
+    diagnostic: String,
+}
+
+fn handle_request(
+    request: GuestStorageManifestRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+    program: &GuestStorageManifestProgram,
+    process_containment_mode: ProcessContainmentMode,
+    drain_deadline: Duration,
+) -> io::Result<()> {
+    let GuestStorageManifestRequest {
+        seq,
+        timeout_ms,
+        run_id,
+        runtime_dir,
+        manifest_json,
+        operation_guard,
+        admission,
+    } = request;
+    let output = run_manifest(RunManifestInput {
+        seq,
+        program: program.path(),
+        timeout_ms,
+        run_id: &run_id,
+        runtime_dir: &runtime_dir,
+        manifest_json,
+        connection_cancel,
+        process_containment_mode,
+        drain_deadline,
+    });
+    let stdout = captured_output(&output.stdout);
+    let stderr = captured_output(&output.stderr);
+    let mut frame = Vec::new();
+    vsock_proto::encode_guest_storage_manifest_result_frame_into(
+        &mut frame,
+        seq,
+        output.termination,
+        output.duration_ms,
+        stdout,
+        stderr,
+        &output.diagnostic,
+    )
+    .map_err(to_io_error)?;
+
+    writer
+        .write_frame_after_lock_unless_cancelled(&frame, connection_cancel, || {
+            operation_guard.release();
+            drop(admission);
+        })
+        .map(|_| ())
+}
+
+struct RunManifestInput<'a> {
+    seq: u32,
+    program: &'a Path,
+    timeout_ms: u32,
+    run_id: &'a str,
+    runtime_dir: &'a str,
+    manifest_json: Vec<u8>,
+    connection_cancel: &'a AtomicBool,
+    process_containment_mode: ProcessContainmentMode,
+    drain_deadline: Duration,
+}
+
+fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+    let RunManifestInput {
+        seq,
+        program,
+        timeout_ms,
+        run_id,
+        runtime_dir,
+        manifest_json,
+        connection_cancel,
+        process_containment_mode,
+        drain_deadline,
+    } = input;
+    let started = Instant::now();
+    let process_containment =
+        match ExecProcessContainment::create(seq, process_containment_mode, false) {
+            Ok(process_containment) => process_containment,
+            Err(error) => {
+                return failed_output(
+                    ExecTermination::StartFailed,
+                    started,
+                    format!("Failed to initialize storage helper process containment: {error}"),
+                );
+            }
+        };
+    let mut prepared_containment = match process_containment.prepare_command() {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("Failed to prepare storage helper process containment: {error}"),
+            );
+        }
+    };
+    let mut command = Command::new(program);
+    command
+        .arg("--manifest-stdin")
+        .env(guest_contracts::env::RUN_ID_ENV, run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            runtime_dir,
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    prepared_containment.configure_placement(&mut command);
+    if let Err(error) = crate::user::apply_command_identity(&mut command, false) {
+        let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+        return failed_output(
+            ExecTermination::StartFailed,
+            started,
+            format!("Failed to select sandbox user for storage helper: {error}"),
+        );
+    }
+    prepared_containment.configure_process_inspection(&mut command);
+    let mut child = match spawn_in_own_process_group(&mut command) {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("Failed to start storage helper: {error}"),
+            );
+        }
+    };
+
+    let Some(stdin) = child.stdin.take() else {
+        return abort_spawned(
+            child,
+            process_containment,
+            started,
+            "storage helper stdin pipe missing",
+        );
+    };
+    let Some(stdout) = child.stdout.take() else {
+        drop(stdin);
+        return abort_spawned(
+            child,
+            process_containment,
+            started,
+            "storage helper stdout pipe missing",
+        );
+    };
+    let Some(stderr) = child.stderr.take() else {
+        drop(stdin);
+        drop(stdout);
+        return abort_spawned(
+            child,
+            process_containment,
+            started,
+            "storage helper stderr pipe missing",
+        );
+    };
+
+    let drain_cancel = Arc::new(AtomicBool::new(false));
+    let (drain_done_tx, drain_done_rx) = mpsc::channel();
+    let stdout_drain = match spawn_drain(
+        stdout,
+        Arc::clone(&drain_cancel),
+        drain_done_tx.clone(),
+        THREAD_STDOUT,
+    ) {
+        Ok(drain) => drain,
+        Err(error) => {
+            drop(stdin);
+            drop(stderr);
+            kill_and_reap_child(child);
+            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            return failed_output(
+                ExecTermination::WaitFailed,
+                started,
+                append_cleanup_failure(
+                    format!("Failed to start storage helper stdout drain: {error}"),
+                    cleanup.err().as_ref(),
+                ),
+            );
+        }
+    };
+    let stderr_drain = match spawn_drain(
+        stderr,
+        Arc::clone(&drain_cancel),
+        drain_done_tx.clone(),
+        THREAD_STDERR,
+    ) {
+        Ok(drain) => drain,
+        Err(error) => {
+            drain_cancel.store(true, Ordering::Release);
+            drop(stdin);
+            kill_and_reap_child(child);
+            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            drop(drain_done_tx);
+            let _ = stdout_drain.join();
+            return failed_output(
+                ExecTermination::WaitFailed,
+                started,
+                append_cleanup_failure(
+                    format!("Failed to start storage helper stderr drain: {error}"),
+                    cleanup.err().as_ref(),
+                ),
+            );
+        }
+    };
+    let stdin_writer = match spawn_stdin(stdin, manifest_json) {
+        Ok(writer) => writer,
+        Err(error) => {
+            drain_cancel.store(true, Ordering::Release);
+            kill_and_reap_child(child);
+            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            drop(drain_done_tx);
+            let _ = stdout_drain.join();
+            let _ = stderr_drain.join();
+            return failed_output(
+                ExecTermination::WaitFailed,
+                started,
+                append_cleanup_failure(
+                    format!("Failed to start storage helper stdin writer: {error}"),
+                    cleanup.err().as_ref(),
+                ),
+            );
+        }
+    };
+    drop(drain_done_tx);
+
+    let outcome = wait_with_kill_timeout_or_connection_cancelled(
+        child,
+        timeout_ms,
+        connection_cancel,
+        // Reap the group before the exited leader can release its process-group
+        // identity, so helper descendants cannot outlive this fixed operation.
+        || true,
+    );
+    let cancellation_observed = connection_cancel.load(Ordering::Acquire);
+    let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome, cancellation_observed);
+    let containment_result = process_containment.cleanup(cleanup_mode);
+    let stdin_result = stdin_writer.join();
+    if !matches!(outcome, WaitOutcome::Exited(_))
+        || cancellation_observed
+        || containment_result.is_err()
+    {
+        drain_cancel.store(true, Ordering::Release);
+    }
+    let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel, drain_deadline);
+    let stdout_result = stdout_drain.join();
+    let stderr_result = stderr_drain.join();
+    let drains_incomplete = completed < 2 || stdout_result.is_err() || stderr_result.is_err();
+    let mut stdout = stdout_result.unwrap_or_default();
+    let mut stderr = stderr_result.unwrap_or_default();
+    if drains_incomplete {
+        stdout.capture_truncated = true;
+        stderr.capture_truncated = true;
+    }
+    if stdout.captured.is_none() {
+        stdout.captured = Some(Vec::new());
+    }
+    if stderr.captured.is_none() {
+        stderr.captured = Some(Vec::new());
+    }
+
+    let (mut termination, mut diagnostic) = match outcome {
+        WaitOutcome::Exited(status) => (
+            ExecTermination::Exited {
+                exit_code: extract_exit_code(status),
+            },
+            String::new(),
+        ),
+        WaitOutcome::TimedOut => (ExecTermination::TimedOut, String::new()),
+        WaitOutcome::Cancelled => (ExecTermination::Cancelled, String::new()),
+        WaitOutcome::WaitFailed(message) => (
+            ExecTermination::WaitFailed,
+            format!("Failed to wait for storage helper: {message}"),
+        ),
+    };
+    if let Err(error) = stdin_result
+        && matches!(termination, ExecTermination::Exited { .. })
+    {
+        log(
+            "WARN",
+            &format!("storage helper stdin writer finished with error: {error}"),
+        );
+    }
+    if let Err(error) = containment_result {
+        termination = ExecTermination::WaitFailed;
+        diagnostic = append_cleanup_failure(diagnostic, Some(&error));
+    }
+
+    GuestStorageManifestOutput {
+        termination,
+        duration_ms: elapsed_ms(started),
+        stdout,
+        stderr,
+        diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
+    }
+}
+
+fn abort_spawned(
+    child: Child,
+    process_containment: ExecProcessContainment,
+    started: Instant,
+    diagnostic: &str,
+) -> GuestStorageManifestOutput {
+    kill_and_reap_child(child);
+    let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+    failed_output(
+        ExecTermination::WaitFailed,
+        started,
+        append_cleanup_failure(diagnostic.to_string(), cleanup.err().as_ref()),
+    )
+}
+
+fn cleanup_mode_for_wait_outcome(
+    outcome: &WaitOutcome,
+    cancellation_observed: bool,
+) -> ProcessContainmentCleanupMode {
+    if cancellation_observed {
+        return ProcessContainmentCleanupMode::Forced;
+    }
+    match outcome {
+        WaitOutcome::Exited(_) => ProcessContainmentCleanupMode::Graceful,
+        WaitOutcome::TimedOut | WaitOutcome::Cancelled | WaitOutcome::WaitFailed(_) => {
+            ProcessContainmentCleanupMode::Forced
+        }
+    }
+}
+
+fn append_cleanup_failure(diagnostic: String, error: Option<&ProcessContainmentError>) -> String {
+    let Some(error) = error else {
+        return diagnostic;
+    };
+    if diagnostic.is_empty() {
+        format!("Failed to clean storage helper process containment: {error}")
+    } else {
+        format!("{diagnostic}; failed to clean storage helper process containment: {error}")
+    }
+}
+
+struct DrainHandle {
+    handle: JoinHandle<()>,
+    result_rx: mpsc::Receiver<BoundedDrainResult>,
+}
+
+impl DrainHandle {
+    fn join(self) -> Result<BoundedDrainResult, ()> {
+        if self.handle.join().is_err() {
+            return Err(());
+        }
+        self.result_rx.recv().map_err(|_| ())
+    }
+}
+
+fn spawn_drain(
+    pipe: impl Into<std::os::fd::OwnedFd> + Send + 'static,
+    cancel: Arc<AtomicBool>,
+    done_tx: mpsc::Sender<()>,
+    thread_name: &'static str,
+) -> io::Result<DrainHandle> {
+    let (result_tx, result_rx) = mpsc::channel();
+    let handle = thread::Builder::new()
+        .name(thread_name.to_string())
+        .spawn(move || {
+            let result = drain_bounded_cancellable(
+                pipe,
+                &cancel,
+                Some(GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES),
+                None,
+                |_, _| true,
+            );
+            let _ = result_tx.send(result);
+            let _ = done_tx.send(());
+        })?;
+    Ok(DrainHandle { handle, result_rx })
+}
+
+struct StdinWriter {
+    handle: JoinHandle<io::Result<()>>,
+}
+
+impl StdinWriter {
+    fn join(self) -> io::Result<()> {
+        self.handle
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+    }
+}
+
+fn spawn_stdin(mut stdin: ChildStdin, manifest_json: Vec<u8>) -> io::Result<StdinWriter> {
+    let handle = thread::Builder::new()
+        .name(THREAD_STDIN.to_string())
+        .spawn(move || {
+            let result = stdin.write_all(&manifest_json);
+            drop(stdin);
+            result
+        })?;
+    Ok(StdinWriter { handle })
+}
+
+fn failed_output(
+    termination: ExecTermination,
+    started: Instant,
+    diagnostic: String,
+) -> GuestStorageManifestOutput {
+    GuestStorageManifestOutput {
+        termination,
+        duration_ms: elapsed_ms(started),
+        stdout: BoundedDrainResult {
+            captured: Some(Vec::new()),
+            capture_truncated: false,
+        },
+        stderr: BoundedDrainResult {
+            captured: Some(Vec::new()),
+            capture_truncated: false,
+        },
+        diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
+    }
+}
+
+fn captured_output(result: &BoundedDrainResult) -> ExecCapturedOutput<'_> {
+    ExecCapturedOutput::Captured {
+        bytes: result.captured.as_deref().unwrap_or_default(),
+        truncated: result.capture_truncated,
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u32 {
+    u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
+}
+
+fn truncate_utf8(mut value: String, limit: usize) -> String {
+    if value.len() <= limit {
+        return value;
+    }
+    let mut end = limit;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    value
+}

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -13,6 +13,7 @@ mod exec_control;
 mod exec_operation;
 mod file_write_worker;
 mod guest_dns_readiness;
+mod guest_storage_manifest;
 mod handlers;
 mod log;
 mod memory_snapshot;
@@ -30,6 +31,7 @@ mod worker_ownership;
 mod writer;
 
 pub use connection::handle_connection_with_test_dns_readiness_program;
+pub use connection::handle_connection_with_test_storage_manifest_program;
 pub use connection::{
     connect_unix, connect_vsock, handle_connection,
     handle_connection_with_test_process_containment,

--- a/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
+++ b/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
@@ -1,0 +1,253 @@
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
+    MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_OPERATIONS_QUIESCED,
+};
+
+use super::support::*;
+
+fn create_program(body: &str) -> (tempfile::TempDir, PathBuf) {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("guest-download-test");
+    std::fs::write(&path, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+    (directory, path)
+}
+
+fn send_request(
+    stream: &mut impl Write,
+    seq: u32,
+    timeout_ms: u32,
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+) {
+    let payload = vsock_proto::encode_guest_storage_manifest_request(
+        timeout_ms,
+        run_id,
+        runtime_dir,
+        manifest_json,
+    )
+    .unwrap();
+    let frame = vsock_proto::encode(MSG_GUEST_STORAGE_MANIFEST, seq, &payload).unwrap();
+    stream.write_all(&frame).unwrap();
+}
+
+struct TestResult {
+    termination: ExecTermination,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    diagnostic: String,
+}
+
+fn read_result(stream: &mut impl std::io::Read, seq: u32) -> TestResult {
+    let message = read_message(stream);
+    assert_eq!(message.msg_type, MSG_GUEST_STORAGE_MANIFEST_RESULT);
+    assert_eq!(message.seq, seq);
+    let decoded = vsock_proto::decode_guest_storage_manifest_result(&message.payload).unwrap();
+    let (stdout, stdout_truncated) = captured(decoded.stdout);
+    let (stderr, stderr_truncated) = captured(decoded.stderr);
+    TestResult {
+        termination: decoded.termination,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+        diagnostic: decoded.diagnostic.to_owned(),
+    }
+}
+
+fn captured(output: ExecCapturedOutput<'_>) -> (Vec<u8>, bool) {
+    match output {
+        ExecCapturedOutput::Captured { bytes, truncated } => (bytes.to_vec(), truncated),
+        ExecCapturedOutput::Discarded => panic!("storage helper output must be captured"),
+    }
+}
+
+fn slow_program(pid_path: &Path) -> String {
+    format!(
+        "printf '%s' \"$$\" > '{}'; cat >/dev/null; sleep 60",
+        pid_path.display()
+    )
+}
+
+#[test]
+fn guest_storage_manifest_runs_fixed_argv_env_and_stdin() {
+    let (_directory, program) = create_program(
+        r#"
+[ "$1" = "--manifest-stdin" ]
+[ "$OKOU_RUN_ID" = "run-1" ]
+[ "$VM0_GUEST_RUNTIME_DIR" = "/run/vm0/runs/run-1" ]
+[ "$(cat)" = '{"storages":[]}' ]
+printf 'applied\n'
+printf 'helper stderr\n' >&2
+"#,
+    );
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(
+        &mut host_stream,
+        401,
+        1_000,
+        "run-1",
+        "/run/vm0/runs/run-1",
+        br#"{"storages":[]}"#,
+    );
+    let result = read_result(&mut host_stream, 401);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.stdout, b"applied\n");
+    assert_eq!(result.stderr, b"helper stderr\n");
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+    assert!(result.diagnostic.is_empty());
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_returns_nonzero_exit_and_captured_diagnostic_output() {
+    let (_directory, program) = create_program(
+        r#"
+cat >/dev/null
+printf 'manifest failed\n' >&2
+exit 7
+"#,
+    );
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 411, 1_000, "run", "/run", b"{}");
+    let result = read_result(&mut host_stream, 411);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 7 });
+    assert!(result.stdout.is_empty());
+    assert_eq!(result.stderr, b"manifest failed\n");
+    assert!(!result.stdout_truncated);
+    assert!(!result.stderr_truncated);
+    assert!(result.diagnostic.is_empty());
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_bounds_both_output_streams() {
+    let output_bytes = GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES + 1_024;
+    let (_directory, program) = create_program(&format!(
+        "cat >/dev/null; head -c {output_bytes} /dev/zero | tr '\\000' x; head -c {output_bytes} /dev/zero | tr '\\000' y >&2"
+    ));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 402, 5_000, "run", "/run", b"{}");
+    let result = read_result(&mut host_stream, 402);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        result.stdout.len(),
+        GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES
+    );
+    assert_eq!(
+        result.stderr.len(),
+        GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES
+    );
+    assert!(result.stdout_truncated);
+    assert!(result.stderr_truncated);
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_timeout_kills_and_reaps_process_group() {
+    let pid_path = unique_pid_path("storage-manifest-timeout");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 403, 20, "run", "/run", b"{}");
+    let pid = process_guard.read_pid();
+    let result = read_result(&mut host_stream, 403);
+
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    wait_for_pid_exit(pid, "guest storage manifest timeout");
+    process_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_natural_exit_cleans_remaining_process_group() {
+    let pid_path = unique_pid_path("storage-manifest-natural-exit");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&format!(
+        "cat >/dev/null; sleep 60 & printf '%s' \"$!\" > '{}'; printf 'applied\\n'",
+        pid_path.as_str()
+    ));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 408, 1_000, "run", "/run", b"{}");
+    let pid = process_guard.read_pid();
+    let result = read_result(&mut host_stream, 408);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.stdout, b"applied\n");
+    wait_for_pid_exit(pid, "guest storage manifest natural exit");
+    process_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_connection_close_kills_and_reaps_process_group() {
+    let pid_path = unique_pid_path("storage-manifest-disconnect");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 404, 60_000, "run", "/run", b"{}");
+    let pid = process_guard.read_pid();
+    drop(host_stream);
+    join_guest_connection(handle);
+
+    wait_for_pid_exit(pid, "guest storage manifest connection close");
+    process_guard.disarm();
+}
+
+#[test]
+fn guest_storage_manifest_rejects_concurrent_request_and_cleans_active_process() {
+    let pid_path = unique_pid_path("storage-manifest-busy");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    send_request(&mut host_stream, 409, 60_000, "run", "/run", b"{}");
+    let pid = process_guard.read_pid();
+    send_request(&mut host_stream, 410, 1_000, "run", "/run", b"{}");
+    let error = read_error_response(&mut host_stream, 410);
+    assert!(error.contains("already active"));
+
+    drop(host_stream);
+    join_guest_connection(handle);
+    wait_for_pid_exit(pid, "guest storage manifest busy connection close");
+    process_guard.disarm();
+}
+
+#[test]
+fn guest_storage_manifest_validates_request_and_obeys_quiesce_gate() {
+    let marker = unique_tmp_path("storage-manifest-quiesce", ".marker");
+    let (_directory, program) = create_program(&format!("touch '{}'; exit 0", marker.as_str()));
+    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+
+    let malformed = vsock_proto::encode(MSG_GUEST_STORAGE_MANIFEST, 405, b"bad").unwrap();
+    host_stream.write_all(&malformed).unwrap();
+    let malformed_error = read_error_response(&mut host_stream, 405);
+    assert!(malformed_error.contains("timeout_ms truncated"));
+
+    send_quiesce_operations(&mut host_stream, 406);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    send_request(&mut host_stream, 407, 1_000, "run", "/run", b"{}");
+    let quiesce_error = read_error_response(&mut host_stream, 407);
+    assert!(quiesce_error.contains("operations are quiescing"));
+    assert!(!Path::new(marker.as_str()).exists());
+
+    finish_guest_connection(handle, host_stream);
+}

--- a/crates/vsock-guest/tests/connection/main.rs
+++ b/crates/vsock-guest/tests/connection/main.rs
@@ -16,6 +16,7 @@ mod exec_output;
 mod exec_stdin;
 mod exec_validation;
 mod guest_dns_readiness;
+mod guest_storage_manifest;
 mod quiesce;
 mod reconnect;
 mod shutdown;

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -10,6 +10,7 @@ use vsock_guest::{
     handle_connection_with_test_dns_readiness_program,
     handle_connection_with_test_process_containment,
     handle_connection_with_test_process_containment_and_exec_drain_deadline,
+    handle_connection_with_test_storage_manifest_program,
 };
 
 use super::protocol::read_message_with_context;
@@ -45,6 +46,14 @@ pub(crate) fn start_guest_connection_with_dns_readiness_program(
 ) -> (GuestConnectionHandle, UnixStream) {
     start_guest_connection_with_handler(move |stream| {
         handle_connection_with_test_dns_readiness_program(stream, program)
+    })
+}
+
+pub(crate) fn start_guest_connection_with_storage_manifest_program(
+    program: std::path::PathBuf,
+) -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler(move |stream| {
+        handle_connection_with_test_storage_manifest_program(stream, program)
     })
 }
 

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -8,7 +8,8 @@ pub(crate) use connection::{
     accept_guest_connection, finish_guest_connection, guest_connection_completion_diagnostic,
     join_guest_connection, listener_has_pending_connection, read_guest_ready,
     start_guest_connection, start_guest_connection_with_dns_readiness_program,
-    start_guest_connection_with_exec_drain_deadline, wait_for_guest_connection,
+    start_guest_connection_with_exec_drain_deadline,
+    start_guest_connection_with_storage_manifest_program, wait_for_guest_connection,
 };
 pub(crate) use exec::{
     LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout, large_env_entries,

--- a/crates/vsock-host/src/guest_storage_manifest.rs
+++ b/crates/vsock-host/src/guest_storage_manifest.rs
@@ -1,0 +1,115 @@
+use std::io;
+use std::time::Duration;
+
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, MSG_ERROR, MSG_GUEST_STORAGE_MANIFEST_RESULT,
+    decode_guest_storage_manifest_result, encode_guest_storage_manifest_request_frame_into,
+};
+
+use crate::{
+    FrameWriteObserver, VsockHost, normal_request_on_shared_with_write_observer_frame_builder,
+};
+
+const TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_GUEST_STORAGE_MANIFEST_RESULT];
+
+/// Owned result of the fixed guest storage-manifest helper.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuestStorageManifestResult {
+    /// Terminal process state.
+    pub termination: ExecTermination,
+    /// Guest-observed helper duration in milliseconds.
+    pub duration_ms: u32,
+    /// Retained helper stdout bytes.
+    pub stdout: Vec<u8>,
+    /// Retained helper stderr bytes.
+    pub stderr: Vec<u8>,
+    /// Whether stdout exceeded its fixed capture bound.
+    pub stdout_truncated: bool,
+    /// Whether stderr exceeded its fixed capture bound.
+    pub stderr_truncated: bool,
+    /// Bounded process or internal diagnostic.
+    pub diagnostic: String,
+}
+
+impl VsockHost {
+    /// Apply canonical manifest bytes through the fixed guest storage helper.
+    ///
+    /// The guest chooses the executable, argument, identity, containment, and
+    /// output bounds. `request_timeout` covers request encoding/write and the
+    /// terminal-result wait. This is a tracked normal operation; abandoning it
+    /// after the write boundary makes the connection non-parkable.
+    pub async fn guest_storage_manifest(
+        &self,
+        manifest_json: &[u8],
+        run_id: &str,
+        runtime_dir: &str,
+        process_timeout_ms: u32,
+        request_timeout: Duration,
+    ) -> io::Result<GuestStorageManifestResult> {
+        let response = normal_request_on_shared_with_write_observer_frame_builder(
+            &self.shared,
+            TERMINAL_MSG_TYPES,
+            request_timeout,
+            FrameWriteObserver::noop(),
+            |seq, frame| {
+                encode_guest_storage_manifest_request_frame_into(
+                    frame,
+                    seq,
+                    process_timeout_ms,
+                    run_id,
+                    runtime_dir,
+                    manifest_json,
+                )
+                .map_err(protocol_invalid_input)
+            },
+        )
+        .await?;
+
+        if response.msg_type == MSG_ERROR {
+            let message =
+                vsock_proto::decode_error(&response.payload).map_err(protocol_invalid_data)?;
+            return Err(io::Error::other(message.to_owned()));
+        }
+        if response.msg_type != MSG_GUEST_STORAGE_MANIFEST_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unexpected guest storage manifest response type: 0x{:02X}",
+                    response.msg_type
+                ),
+            ));
+        }
+
+        let decoded = decode_guest_storage_manifest_result(&response.payload)
+            .map_err(protocol_invalid_data)?;
+        let (stdout, stdout_truncated) = owned_capture(decoded.stdout, "stdout")?;
+        let (stderr, stderr_truncated) = owned_capture(decoded.stderr, "stderr")?;
+        Ok(GuestStorageManifestResult {
+            termination: decoded.termination,
+            duration_ms: decoded.duration_ms,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic: decoded.diagnostic.to_owned(),
+        })
+    }
+}
+
+fn owned_capture(output: ExecCapturedOutput<'_>, name: &str) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        ExecCapturedOutput::Captured { bytes, truncated } => Ok((bytes.to_vec(), truncated)),
+        ExecCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("guest storage manifest result discarded {name}"),
+        )),
+    }
+}
+
+fn protocol_invalid_input(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+}
+
+fn protocol_invalid_data(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -71,6 +71,7 @@ mod connection;
 mod exec_operation;
 mod file;
 mod guest_dns_readiness;
+mod guest_storage_manifest;
 mod operation_tracker;
 #[cfg(test)]
 mod tests;
@@ -99,6 +100,7 @@ pub use exec_operation::{
 };
 pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
 pub use guest_dns_readiness::GuestDnsReadinessResult;
+pub use guest_storage_manifest::GuestStorageManifestResult;
 
 /// Observer called when a request frame reaches the guest-write boundary.
 ///

--- a/crates/vsock-host/src/tests/guest_storage_manifest.rs
+++ b/crates/vsock-host/src/tests/guest_storage_manifest.rs
@@ -1,0 +1,214 @@
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, MSG_GUEST_STORAGE_MANIFEST,
+    MSG_GUEST_STORAGE_MANIFEST_RESULT,
+};
+
+use crate::operation_tracker::NormalOperationReadiness;
+use crate::tests::support::{
+    MockGuest, host_from_stream, make_pair, normal_operation_readiness, pending_request_count,
+};
+
+fn success_payload() -> Vec<u8> {
+    vsock_proto::encode_guest_storage_manifest_result(
+        ExecTermination::Exited { exit_code: 0 },
+        17,
+        ExecCapturedOutput::Captured {
+            bytes: b"out",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: b"err",
+            truncated: true,
+        },
+        "",
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn guest_storage_manifest_sends_request_and_decodes_result() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+        let decoded = vsock_proto::decode_guest_storage_manifest_request(&request.payload).unwrap();
+        assert_eq!(decoded.timeout_ms, 300_000);
+        assert_eq!(decoded.run_id, "run-1");
+        assert_eq!(decoded.runtime_dir, "/run/vm0/runs/run-1");
+        assert_eq!(decoded.manifest_json, b"{}");
+        guest
+            .send_response(
+                MSG_GUEST_STORAGE_MANIFEST_RESULT,
+                request.seq,
+                &success_payload(),
+            )
+            .await;
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let result = host
+        .guest_storage_manifest(
+            b"{}",
+            "run-1",
+            "/run/vm0/runs/run-1",
+            300_000,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.duration_ms, 17);
+    assert_eq!(result.stdout, b"out");
+    assert_eq!(result.stderr, b"err");
+    assert!(!result.stdout_truncated);
+    assert!(result.stderr_truncated);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_storage_manifest_surfaces_guest_error_and_completes_operation() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+        guest
+            .send_error_response(request.seq, "guest operations are quiescing")
+            .await;
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let error = host
+        .guest_storage_manifest(b"{}", "run", "/run", 1, Duration::from_secs(1))
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("guest operations are quiescing"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_storage_manifest_rejects_malformed_terminal_payload_after_completion() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+        guest
+            .send_response(MSG_GUEST_STORAGE_MANIFEST_RESULT, request.seq, &[0xFF])
+            .await;
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let error = host
+        .guest_storage_manifest(b"{}", "run", "/run", 1, Duration::from_secs(1))
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_storage_manifest_timeout_abandons_connection_and_ignores_late_result() {
+    let (host_stream, guest_stream) = make_pair();
+    let (request_tx, request_rx) = oneshot::channel();
+    let (late_tx, late_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+        request_tx.send(request.seq).unwrap();
+        late_rx.await.unwrap();
+        guest
+            .send_response(
+                MSG_GUEST_STORAGE_MANIFEST_RESULT,
+                request.seq,
+                &success_payload(),
+            )
+            .await;
+        tokio::task::yield_now().await;
+    });
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let request_host = Arc::clone(&host);
+    let request = tokio::spawn(async move {
+        request_host
+            .guest_storage_manifest(b"{}", "run", "/run", 1, Duration::from_millis(20))
+            .await
+    });
+    request_rx.await.unwrap();
+
+    let error = request.await.unwrap().unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    late_tx.send(()).unwrap();
+    guest.await.unwrap();
+    assert_eq!(pending_request_count(&host), 0);
+}
+
+#[tokio::test]
+async fn dropping_guest_storage_manifest_after_write_abandons_connection_for_parking() {
+    let (host_stream, guest_stream) = make_pair();
+    let (request_tx, request_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let _request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+        request_tx.send(()).unwrap();
+        release_rx.await.unwrap();
+    });
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let request_host = Arc::clone(&host);
+    let request = tokio::spawn(async move {
+        request_host
+            .guest_storage_manifest(b"{}", "run", "/run", 1, Duration::from_secs(1))
+            .await
+    });
+    request_rx.await.unwrap();
+
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    tokio::task::yield_now().await;
+
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}

--- a/crates/vsock-host/src/tests/mod.rs
+++ b/crates/vsock-host/src/tests/mod.rs
@@ -4,3 +4,4 @@ mod connection;
 mod exec_operation;
 mod file;
 mod guest_dns_readiness;
+mod guest_storage_manifest;

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types currently occupy the contiguous range `0x00..=0x17`
+//! Non-error message types currently occupy the contiguous range `0x00..=0x19`
 //! in allocation order. Existing values are stable wire assignments: do not
 //! renumber or reuse them. Allocate new non-error messages at the next unused
 //! value below `0xFF`, even when related operations are not adjacent. `0xFF` is
@@ -53,11 +53,14 @@
 //! | 0x15 | G→H       | memory_snapshot_result | eighteen big-endian `[8B counter_bytes]` fields; see [`MemorySnapshot`] |
 //! | 0x16 | H→G       | guest_dns_readiness | `[4B positive timeout_ms][2B hostname_len][hostname]` |
 //! | 0x17 | G→H       | guest_dns_readiness_result | `[termination][4B duration_ms][1B flags][2B answer_len][answer][2B diagnostic_len][diagnostic]` |
+//! | 0x18 | H→G       | guest_storage_manifest | `[4B positive timeout_ms][2B run_id_len][run_id][2B runtime_dir_len][runtime_dir][4B manifest_len][manifest]` |
+//! | 0x19 | G→H       | guest_storage_manifest_result | same payload as `exec_result`, with both streams captured and bounded to 1 MiB each |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
 //! covers `write_file`, `write_files`, `exec_start`, `exec_cancel`,
-//! `exec_control`, and `guest_dns_readiness`; operation replies reuse the
+//! `exec_control`, `guest_dns_readiness`, and `guest_storage_manifest`;
+//! operation replies reuse the
 //! original non-zero request sequence. `exec_output.output_seq` is per exec
 //! operation and starts at 0, incrementing by 1 for each output frame across
 //! stdout and stderr.
@@ -211,6 +214,13 @@ pub use payloads::guest_dns_readiness::{
     encode_guest_dns_readiness_request, encode_guest_dns_readiness_request_frame_into,
     encode_guest_dns_readiness_result,
 };
+pub use payloads::guest_storage_manifest::{
+    DecodedGuestStorageManifestRequest, GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES,
+    GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
+    decode_guest_storage_manifest_request, decode_guest_storage_manifest_result,
+    encode_guest_storage_manifest_request, encode_guest_storage_manifest_request_frame_into,
+    encode_guest_storage_manifest_result, encode_guest_storage_manifest_result_frame_into,
+};
 pub use payloads::memory_snapshot::{
     MEMORY_SNAPSHOT_PAYLOAD_SIZE, MemorySnapshot, decode_memory_snapshot,
 };
@@ -225,10 +235,10 @@ pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
     MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
     MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_MEMORY_SNAPSHOT,
-    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING,
-    MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
-    MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
-    MSG_WRITE_FILES_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
-    WRITE_FILE_FLAG_SUDO,
+    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_GUEST_STORAGE_MANIFEST,
+    MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT,
+    WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
+++ b/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
@@ -1,0 +1,380 @@
+use std::path::Path;
+
+use crate::ProtocolError;
+use crate::frame::encode_into;
+use crate::read::{
+    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
+    expect_consumed, read_slice, read_str, read_u16, read_u32,
+};
+use crate::wire::{MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT};
+use crate::{DecodedExecResult, ExecCapturedOutput, ExecTermination, MAX_EXEC_STDIN_BYTES};
+
+/// Maximum encoded run-id length accepted by the fixed storage operation.
+pub const GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES: usize = 256;
+
+/// Maximum encoded guest runtime-directory length accepted by the operation.
+pub const GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES: usize = 4 * 1024;
+
+/// Fixed stdout/stderr capture bound for the storage helper.
+pub const GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Decoded fixed guest storage-manifest request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DecodedGuestStorageManifestRequest<'a> {
+    /// Positive child-process timeout in milliseconds.
+    pub timeout_ms: u32,
+    /// Run identity exposed to the fixed helper.
+    pub run_id: &'a str,
+    /// Absolute guest runtime directory exposed to the fixed helper.
+    pub runtime_dir: &'a str,
+    /// Canonical manifest JSON written to helper stdin.
+    pub manifest_json: &'a [u8],
+}
+
+/// Encode a fixed guest storage-manifest request payload.
+pub fn encode_guest_storage_manifest_request(
+    timeout_ms: u32,
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+) -> Result<Vec<u8>, ProtocolError> {
+    let lengths = validate_request(timeout_ms, run_id, runtime_dir, manifest_json)?;
+    let payload_len = request_payload_len(run_id, runtime_dir, manifest_json)?;
+    let mut payload = Vec::with_capacity(payload_len);
+    append_request_payload(
+        &mut payload,
+        timeout_ms,
+        run_id,
+        runtime_dir,
+        manifest_json,
+        lengths,
+    );
+    Ok(payload)
+}
+
+/// Encode a full fixed guest storage-manifest request frame into `frame`.
+pub fn encode_guest_storage_manifest_request_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    timeout_ms: u32,
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+) -> Result<(), ProtocolError> {
+    let lengths = validate_request(timeout_ms, run_id, runtime_dir, manifest_json)?;
+    let payload_len = request_payload_len(run_id, runtime_dir, manifest_json)?;
+    encode_into(
+        frame,
+        MSG_GUEST_STORAGE_MANIFEST,
+        seq,
+        payload_len,
+        |frame| {
+            append_request_payload(
+                frame,
+                timeout_ms,
+                run_id,
+                runtime_dir,
+                manifest_json,
+                lengths,
+            )
+        },
+    )
+}
+
+/// Decode a fixed guest storage-manifest request payload.
+pub fn decode_guest_storage_manifest_request(
+    payload: &[u8],
+) -> Result<DecodedGuestStorageManifestRequest<'_>, ProtocolError> {
+    let mut offset = 0;
+    let timeout_ms = read_u32(
+        payload,
+        &mut offset,
+        "guest_storage_manifest timeout_ms truncated",
+    )?;
+    let run_id_len = usize::from(read_u16(
+        payload,
+        &mut offset,
+        "guest_storage_manifest run_id_len truncated",
+    )?);
+    let run_id = read_str(
+        payload,
+        &mut offset,
+        run_id_len,
+        "guest_storage_manifest run_id truncated",
+        "guest_storage_manifest run_id invalid UTF-8",
+    )?;
+    let runtime_dir_len = usize::from(read_u16(
+        payload,
+        &mut offset,
+        "guest_storage_manifest runtime_dir_len truncated",
+    )?);
+    let runtime_dir = read_str(
+        payload,
+        &mut offset,
+        runtime_dir_len,
+        "guest_storage_manifest runtime_dir truncated",
+        "guest_storage_manifest runtime_dir invalid UTF-8",
+    )?;
+    let manifest_len = read_u32(
+        payload,
+        &mut offset,
+        "guest_storage_manifest manifest_len truncated",
+    )? as usize;
+    let manifest_json = read_slice(
+        payload,
+        &mut offset,
+        manifest_len,
+        "guest_storage_manifest manifest truncated",
+    )?;
+    expect_consumed(payload, offset, "guest_storage_manifest trailing bytes")?;
+    validate_request(timeout_ms, run_id, runtime_dir, manifest_json)?;
+    Ok(DecodedGuestStorageManifestRequest {
+        timeout_ms,
+        run_id,
+        runtime_dir,
+        manifest_json,
+    })
+}
+
+/// Encode a fixed guest storage-manifest terminal result payload.
+pub fn encode_guest_storage_manifest_result(
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<Vec<u8>, ProtocolError> {
+    validate_result_output(stdout, "stdout")?;
+    validate_result_output(stderr, "stderr")?;
+    crate::encode_exec_result(termination, duration_ms, stdout, stderr, diagnostic)
+}
+
+/// Encode a full fixed guest storage-manifest terminal result frame.
+pub fn encode_guest_storage_manifest_result_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<(), ProtocolError> {
+    let payload =
+        encode_guest_storage_manifest_result(termination, duration_ms, stdout, stderr, diagnostic)?;
+    encode_into(
+        frame,
+        MSG_GUEST_STORAGE_MANIFEST_RESULT,
+        seq,
+        payload.len(),
+        |frame| frame.extend_from_slice(&payload),
+    )
+}
+
+/// Decode a fixed guest storage-manifest terminal result payload.
+pub fn decode_guest_storage_manifest_result(
+    payload: &[u8],
+) -> Result<DecodedExecResult<'_>, ProtocolError> {
+    let decoded = crate::decode_exec_result(payload)?;
+    validate_result_output(decoded.stdout, "stdout")?;
+    validate_result_output(decoded.stderr, "stderr")?;
+    Ok(decoded)
+}
+
+#[derive(Clone, Copy)]
+struct RequestLengths {
+    run_id: u16,
+    runtime_dir: u16,
+    manifest: u32,
+}
+
+fn validate_request(
+    timeout_ms: u32,
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+) -> Result<RequestLengths, ProtocolError> {
+    if timeout_ms == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest timeout_ms must be positive",
+        ));
+    }
+    if run_id.is_empty() {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest run_id must not be empty",
+        ));
+    }
+    if run_id.len() > GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES {
+        return Err(ProtocolError::PayloadTooLarge("run_id", run_id.len()));
+    }
+    if run_id.as_bytes().contains(&0) {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest run_id contains NUL",
+        ));
+    }
+    if runtime_dir.is_empty() || !Path::new(runtime_dir).is_absolute() {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest runtime_dir must be absolute",
+        ));
+    }
+    if runtime_dir.len() > GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "runtime_dir",
+            runtime_dir.len(),
+        ));
+    }
+    if runtime_dir.as_bytes().contains(&0) {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest runtime_dir contains NUL",
+        ));
+    }
+    if manifest_json.len() > MAX_EXEC_STDIN_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "manifest_json",
+            manifest_json.len(),
+        ));
+    }
+
+    let lengths = RequestLengths {
+        run_id: ensure_u16_len("run_id", run_id.len())?,
+        runtime_dir: ensure_u16_len("runtime_dir", runtime_dir.len())?,
+        manifest: ensure_u32_len("manifest_json", manifest_json.len())?,
+    };
+    ensure_payload_fits_message(request_payload_len(run_id, runtime_dir, manifest_json)?)?;
+    Ok(lengths)
+}
+
+fn request_payload_len(
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+) -> Result<usize, ProtocolError> {
+    let mut len = 4usize;
+    len = checked_payload_len_add(len, 2 + run_id.len())?;
+    len = checked_payload_len_add(len, 2 + runtime_dir.len())?;
+    checked_payload_len_add(len, 4 + manifest_json.len())
+}
+
+fn append_request_payload(
+    payload: &mut Vec<u8>,
+    timeout_ms: u32,
+    run_id: &str,
+    runtime_dir: &str,
+    manifest_json: &[u8],
+    lengths: RequestLengths,
+) {
+    payload.extend_from_slice(&timeout_ms.to_be_bytes());
+    payload.extend_from_slice(&lengths.run_id.to_be_bytes());
+    payload.extend_from_slice(run_id.as_bytes());
+    payload.extend_from_slice(&lengths.runtime_dir.to_be_bytes());
+    payload.extend_from_slice(runtime_dir.as_bytes());
+    payload.extend_from_slice(&lengths.manifest.to_be_bytes());
+    payload.extend_from_slice(manifest_json);
+}
+
+fn validate_result_output(
+    output: ExecCapturedOutput<'_>,
+    field: &'static str,
+) -> Result<(), ProtocolError> {
+    match output {
+        ExecCapturedOutput::Captured { bytes, .. }
+            if bytes.len() <= GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES =>
+        {
+            Ok(())
+        }
+        ExecCapturedOutput::Captured { bytes, .. } => {
+            Err(ProtocolError::PayloadTooLarge(field, bytes.len()))
+        }
+        ExecCapturedOutput::Discarded => Err(ProtocolError::InvalidPayload(
+            "guest_storage_manifest_result output must be captured",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trip_preserves_exact_boundary_bytes() {
+        let manifest = vec![b'x'; MAX_EXEC_STDIN_BYTES];
+        let payload = encode_guest_storage_manifest_request(
+            300_000,
+            "run-1",
+            "/run/vm0/runs/run-1",
+            &manifest,
+        )
+        .unwrap();
+
+        let decoded = decode_guest_storage_manifest_request(&payload).unwrap();
+
+        assert_eq!(decoded.timeout_ms, 300_000);
+        assert_eq!(decoded.run_id, "run-1");
+        assert_eq!(decoded.runtime_dir, "/run/vm0/runs/run-1");
+        assert_eq!(decoded.manifest_json, manifest);
+    }
+
+    #[test]
+    fn request_rejects_invalid_context_and_oversized_manifest() {
+        assert!(encode_guest_storage_manifest_request(0, "run", "/run", b"{}").is_err());
+        assert!(encode_guest_storage_manifest_request(1, "", "/run", b"{}").is_err());
+        assert!(encode_guest_storage_manifest_request(1, "run", "relative", b"{}").is_err());
+        assert!(
+            encode_guest_storage_manifest_request(
+                1,
+                "run",
+                "/run",
+                &vec![0; MAX_EXEC_STDIN_BYTES + 1],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn result_round_trip_requires_bounded_capture_for_both_streams() {
+        let stdout = ExecCapturedOutput::Captured {
+            bytes: b"out",
+            truncated: false,
+        };
+        let stderr = ExecCapturedOutput::Captured {
+            bytes: b"err",
+            truncated: true,
+        };
+        let payload = encode_guest_storage_manifest_result(
+            ExecTermination::Exited { exit_code: 7 },
+            42,
+            stdout,
+            stderr,
+            "diagnostic",
+        )
+        .unwrap();
+
+        let decoded = decode_guest_storage_manifest_result(&payload).unwrap();
+
+        assert_eq!(
+            decoded.termination,
+            ExecTermination::Exited { exit_code: 7 }
+        );
+        assert_eq!(decoded.duration_ms, 42);
+        assert_eq!(decoded.stdout, stdout);
+        assert_eq!(decoded.stderr, stderr);
+        assert_eq!(decoded.diagnostic, "diagnostic");
+        assert!(
+            encode_guest_storage_manifest_result(
+                ExecTermination::WaitFailed,
+                0,
+                ExecCapturedOutput::Discarded,
+                stderr,
+                "",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn request_decoder_rejects_trailing_bytes() {
+        let mut payload = encode_guest_storage_manifest_request(1, "run", "/run", b"{}").unwrap();
+        payload.push(0);
+
+        assert!(decode_guest_storage_manifest_request(&payload).is_err());
+    }
+}

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod exec_operation;
 pub(crate) mod guest_dns_readiness;
+pub(crate) mod guest_storage_manifest;
 pub(crate) mod memory_snapshot;
 pub(crate) mod write_file;
 

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -89,6 +89,12 @@ pub const MSG_GUEST_DNS_READINESS: u8 = 0x16;
 /// Guest-to-host result of the fixed guest DNS readiness operation.
 pub const MSG_GUEST_DNS_READINESS_RESULT: u8 = 0x17;
 
+/// Host-to-guest request to apply a bounded storage manifest.
+pub const MSG_GUEST_STORAGE_MANIFEST: u8 = 0x18;
+
+/// Guest-to-host result of applying a bounded storage manifest.
+pub const MSG_GUEST_STORAGE_MANIFEST_RESULT: u8 = 0x19;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -153,6 +159,16 @@ mod tests {
                 "MSG_GUEST_DNS_READINESS_RESULT",
                 MSG_GUEST_DNS_READINESS_RESULT,
                 0x17,
+            ),
+            (
+                "MSG_GUEST_STORAGE_MANIFEST",
+                MSG_GUEST_STORAGE_MANIFEST,
+                0x18,
+            ),
+            (
+                "MSG_GUEST_STORAGE_MANIFEST_RESULT",
+                MSG_GUEST_STORAGE_MANIFEST_RESULT,
+                0x19,
             ),
             ("MSG_ERROR", MSG_ERROR, 0xFF),
         ];


### PR DESCRIPTION
## Summary

- add a dedicated, bounded vsock operation for the canonical guest storage manifest path
- preserve helper identity, containment, cancellation, structured termination, and 1 MiB output bounds while retaining the established fallback for manifests over 64 KiB
- record a low-cardinality dedicated/fallback transport field for rollout observability

## Performance evidence

A controlled alternating benchmark ran on `local-1.aws.vm3.ai` with the production Firecracker containment path and the same empty-artifact manifest (`n=50` successful samples per transport):

- generic invocation p90: `65.064 ms`
- dedicated invocation p90: `21.250 ms`
- p90 improvement: `43.814 ms`
- failures: `0 / 50` for each transport

This clears the issue's `>=25 ms` p90 evidence gate. Full measurements are recorded on #28732.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-mock -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox -p sandbox-mock -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc -p runner --no-deps --all-features`
- `cargo check --release -p vsock-guest -p vsock-host -p sandbox-fc -p runner`
- `cargo check --release -p vsock-guest --no-default-features`
- `cargo test -p sandbox -p sandbox-mock -p vsock-proto -p vsock-host -p vsock-guest -p sandbox-fc -p runner --quiet`

Closes #28732
Parent: #24203
