### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -24,6 +24,7 @@ const context = testContext();
 const mocks = createRouteMocks(context);
 const store = createStore();
 const API_ORIGIN = "https://api.vm0.ai";
+const CALLBACK_REDIRECT_URI = `${API_ORIGIN}/api/zero/teams/oauth/callback`;
 const OKOU_API_ORIGIN = "https://api.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const APP_ORIGIN = "https://app.vm0.test";
@@ -271,7 +272,11 @@ describe("Teams OAuth API routes", () => {
     const response = await appRequest(
       callbackPath({
         code: "valid-code",
-        state: { orgId: fixture.orgId, userId: fixture.userId },
+        state: {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          redirectUri: CALLBACK_REDIRECT_URI,
+        },
       }),
       { origin: API_ORIGIN },
     );
@@ -330,31 +335,6 @@ describe("Teams OAuth API routes", () => {
     );
   });
 
-  it("falls back to the legacy callback URI for state without a redirect URI", async () => {
-    const fixture = await seedTeamsInstallation(track);
-    await seedMembership(fixture.orgId, fixture.userId, "admin");
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    mockMicrosoftOAuth({
-      tenantId: fixture.teamsTenantId,
-      aadObjectId: fixture.teamsAadObjectId,
-      userPrincipalName: fixture.teamsUserPrincipalName,
-      expectedRedirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
-    });
-
-    const response = await appRequest(
-      callbackPath({
-        code: "valid-code",
-        state: { orgId: fixture.orgId, userId: fixture.userId },
-      }),
-      { origin: API_ORIGIN },
-    );
-
-    expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain(
-      `${APP_ORIGIN}/settings/teams?status=connected`,
-    );
-  });
-
   it("rejects OAuth users when the org is already bound to another Microsoft tenant", async () => {
     const fixture = await seedTeamsInstallation(track);
     await seedMembership(fixture.orgId, fixture.userId, "admin");
@@ -383,7 +363,11 @@ describe("Teams OAuth API routes", () => {
     const response = await appRequest(
       callbackPath({
         code: "valid-code",
-        state: { orgId: fixture.orgId, userId: fixture.userId },
+        state: {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          redirectUri: CALLBACK_REDIRECT_URI,
+        },
       }),
       { origin: API_ORIGIN },
     );
@@ -405,7 +389,11 @@ describe("Teams OAuth API routes", () => {
     const response = await appRequest(
       callbackPath({
         code: "valid-code",
-        state: { orgId: fixture.orgId, userId: fixture.userId },
+        state: {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          redirectUri: CALLBACK_REDIRECT_URI,
+        },
       }),
       { origin: API_ORIGIN },
     );

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -43,7 +43,7 @@ interface OAuthState {
   readonly userId: string | null;
   readonly prompt: string | null;
   readonly publicBrand: PublicBrand;
-  readonly redirectUri: string | null;
+  readonly redirectUri: string;
 }
 
 interface MicrosoftTeamsUserInfo {
@@ -139,27 +139,19 @@ function optionalString(value: unknown): string | null {
 
 function parseOAuthState(state: string | undefined): OAuthState | null {
   if (!state) {
-    return {
-      orgId: null,
-      userId: null,
-      prompt: null,
-      publicBrand: "vm0",
-      redirectUri: null,
-    };
+    return null;
   }
 
   const parsed = safeJsonParse(state);
   if (typeof parsed !== "object" || parsed === null) {
-    return {
-      orgId: null,
-      userId: null,
-      prompt: null,
-      publicBrand: "vm0",
-      redirectUri: null,
-    };
+    return null;
   }
 
   const record = parsed as Record<string, unknown>;
+  const redirectUri = optionalString(record.redirectUri);
+  if (!redirectUri) {
+    return null;
+  }
   return {
     orgId: optionalString(record.orgId),
     userId: optionalString(record.userId),
@@ -167,7 +159,7 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
     // Old web/app OAuth state can omit publicBrand for about two days.
     // Remove this VM0 default in #27660 after legacy states have drained.
     publicBrand: record.publicBrand === "okou" ? "okou" : "vm0",
-    redirectUri: optionalString(record.redirectUri),
+    redirectUri,
   };
 }
 
@@ -185,29 +177,6 @@ function callbackRedirectUri(origin: string, publicBrand: PublicBrand): string {
   return publicBrand === "okou"
     ? `${apiUrlForPublicBrand(origin, "okou")}/api/integrations/teams/oauth/callback`
     : `${apiUrlForPublicBrand(origin, "vm0")}/api/zero/teams/oauth/callback`;
-}
-
-/**
- * Rollout fallback for #28300. State written by the previous API build carries
- * no redirect URI, and that build sent this exact value for both brands: the
- * unprojected origin plus the legacy path. Microsoft rejects a token request
- * whose redirect_uri differs from the authorization request, so an
- * authorization started before this deploy can only be completed against it.
- *
- * Only Okou-brand authorizations actually depend on this. The VM0 brand keeps
- * emitting the legacy path above, so its old and new values are identical.
- *
- * Surface: a browser-held Microsoft consent page, so it is bounded by the old
- * web/app client window of ~2 days rather than by the API deploy gap. The
- * authorization request is not persisted anywhere and carries no expiry of our
- * own, so nothing shortens that window.
- *
- * Removable once no authorization started before this deploy can still be
- * presented, and the previous build is outside the production rollback window.
- * Follow-up: #28303.
- */
-function legacyCallbackRedirectUri(origin: string): string {
-  return `${origin}/api/zero/teams/oauth/callback`;
 }
 
 function microsoftCredentials(): {
@@ -436,9 +405,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
         clientId: credentials.clientId,
         clientSecret: credentials.clientSecret,
         code: query.code,
-        redirectUri:
-          state.redirectUri ??
-          legacyCallbackRedirectUri(getOAuthApiOrigin(request)),
+        redirectUri: state.redirectUri,
       },
       signal,
     ),


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection.

## Cohort — remove the legacy Teams OAuth redirect URI fallback (#28303)

**Old → new boundary.** [PR #28302](https://github.com/vm0-ai/vm0/pull/28302) started carrying the authorization request's `redirectUri` in the Teams OAuth state, so the token exchange repeats the exact value the authorization sent instead of recomputing one that had moved for the Okou brand. State written by the previous build carried no redirect URI, so the callback fell back to `legacyCallbackRedirectUri()` — the unprojected `${origin}/api/zero/teams/oauth/callback` that build sent for **both** brands. Microsoft rejects a token request whose `redirect_uri` differs from the authorization request, so without the fallback an authorization spanning the deploy would have failed with its code already consumed.

**Window.** #28303 states both conditions: no Okou-brand authorization started before #28302 deployed can still be presented (~2 days after that deploy), and the pre-#28302 build is outside the production rollback window. The surface is a **browser-held Microsoft consent page** — the authorization request is not persisted anywhere and carries no expiry of ours, so nothing shortens the ~2-day client window and nothing lengthens it either.

**Rollout evidence.** #28302 merged 2026-08-20T04:42:50Z (`f511cd0cb0`); `api/production` promoted `f71f54850ab2` at **2026-08-20T07:09:44Z**, verified to contain that commit with `git merge-base --is-ancestor`. **Seventeen further `api/production` promotions** have landed since, so the pre-#28302 build is far outside any rollback window. At this run the elapsed time is **86 hours (3.6 days)** against a ~2-day window.

Only Okou-brand authorizations ever depended on the fallback: per #28300's correction the VM0 brand keeps emitting `/api/zero/teams/oauth/callback`, so its pre- and post-#28302 values are identical.

**Removed**, exactly the scope #28303 enumerates: `legacyCallbackRedirectUri()`; the `?? legacyCallbackRedirectUri(...)` branch, leaving `state.redirectUri`; the `redirectUri: null` handling in `parseOAuthState()`, making the field required; and the `falls back to the legacy callback URI for state without a redirect URI` test, which dies with the fallback it covers.

**Kept deliberately.** `/api/zero/teams/oauth/callback` still serves and stays registered in the Microsoft app registration — after #28302 it is the live producer target for the VM0 brand, not merely a drain-window acceptor. #28303 calls this out and it also constrains #26701 Phase C3.

**Producer proof.** `connectOauth$` builds `stateObj` with `redirectUri: string` as a **required** property and always assigns `callbackRedirectUri(origin, publicBrand)`. No current code path can mint a Teams OAuth state without it, so requiring the field on read cannot reject a state this API produced.

**One consequence worth stating plainly.** `parseOAuthState`'s two degenerate branches — absent `state`, and `state` that is not a JSON object — previously returned a synthetic `OAuthState` with `publicBrand: "vm0"` and `redirectUri: null`; they now return `null`. Those branches already produced no `orgId` and no `userId`, so the callback rejected them with `Invalid connect state.` before reaching the token exchange, and that outcome is unchanged. The one observable difference is the brand used for that error redirect: it now comes from `publicBrand$` (the request's own brand) instead of a hardcoded `"vm0"`. On `api.vm0.ai` those are the same value; on `api.okou.ai` an unusable state now redirects to the Okou settings page rather than the VM0 one, which is the correct destination for that caller.

**Test fixtures corrected rather than relaxed.** Three callback fixtures predated #28302 and omitted `redirectUri`. Two of them started failing outright; the third — `rejects callback state when the internal user is not an org member` — still passed but would have passed **for the wrong reason**, short-circuiting on a malformed state before the membership check ran. All three now carry the redirect URI, so they keep exercising the behavior they were written for. That silent-coverage-loss case is the reason the fixtures were fixed instead of the read being loosened.

**Persisted-data reasoning.** None applies: OAuth state is a query parameter round-tripped through Microsoft, never stored.

## Checks

Run once against the combined diff, with a local PostgreSQL 18 cluster created for this run and set to `UTC`:

- `pnpm format`; `pnpm check-types` (all tasks, no errors); `pnpm knip` (exit 0); `pnpm -F api lint` (exit 0)
- `pnpm -F api exec vitest run teams-oauth.test.ts` → **9 passed**
- `pnpm -F api exec vitest run slack-oauth.test.ts` → **44 passed** (the sibling OAuth-state surface, unchanged by this PR)

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

**None.** No open PR touches either changed file.

## Deferred, with exact blockers

The masked production database remains the dominant blocker and is **unchanged since 2026-08-22**: `vm0-prod-ro` still reports 122 tables and still omits `usage_pack_credit_refunds`, `usage_pack_subscriptions`, `connector_catalog_runtime_projections`, and every `browser_*` table. This is not only this workflow's problem — #28449's own status section independently records that "the available read-only production data source does not expose artifact or hosted-site object metadata and masks canonical asset metadata".

- **#28580** legacy credit-note refund fallback — needs a production query proving zero unresolved invoice refund rows with `stripe_credit_note_id IS NOT NULL AND status <> 'succeeded'`. `usage_pack_credit_refunds` is not exposed.
- **#28275** connector catalog projection probe — needs migrations 0963/0964 outside the rollback window *and* the projection table observable; it is not exposed.
- **`memberInviteUsagePackEntitlementSchemaAvailable`** — migration 0899 shipped 2026-08-11 and roughly seventy migrations have followed, but every reader of `member_invite_usage_pack_required` is guarded, so no production request fails observably if it were missing and MaskDB cannot confirm it exists. No positive evidence is obtainable.
- **`browser_*` identity contraction** — still needs `chat_thread_id` uniqueness across retained rows.
- **#28449** three retained items — the issue owner has already recorded that production still holds pre-brand `running` jobs and that object metadata is masked.
- **#27356** zero-agent default-avatar bridge — window long closed, but `apps/api/src/signals/routes/agents.ts:296` still reads `avatarUrl: args.body.avatarUrl ?? null` while only the create path uses `randomPresetAvatar()`. The upsert reaches its INSERT branch from the PUT route for a compose-backed agent with no `zero_agents` row, so the trigger compensates a **live** writer. **Ninth consecutive run reporting this; the unblocking change is one line.**
- **#27786** (and the same pattern on `selectedVideoModel`) — "make it required" is blocked by the producer, not the window: GET and PUT share `userModelPreferenceResponseSchema` and the PUT producer spreads the field conditionally, so requiring it would break the API's own PUT responses.
- **#26842** — closed as completed but its code remains; `supportsInAppPreview` appears at seven contract sites and the current app omits it by design when preview is disabled, so narrowing it is a product change, not compatibility removal.
- **#27660's OAuth half** — unlike this PR's `redirectUri` field, that shim is not separable: its ternary collapses *absent* and *malformed* into one branch.
- **#26938**, **#26672 / #26519** (`LatestWebsiteTemplates` still `enabled: false`), **#26701 / #26364**, **#25620** — multi-stage programs, product gates, or backfill prerequisites.
