### PR TITLE
refactor(api): switch agent run model key reads to canonical column

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7055,8 +7055,8 @@ describe("CHAT-02: run-level model overrides", () => {
       selectedModel,
       modelRuntimeProvider: "anthropic-api-key",
       modelRuntimeModel: selectedModel,
-      vm0ModelKeyId: expect.any(String),
-      modelKeyVendor: "anthropic",
+      builtInModelKeyId: expect.any(String),
+      builtInModelKeyVendor: "anthropic",
     });
 
     const reused = await sendChatRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -643,7 +643,7 @@ async function seedVm0ManagedModelKey(selectedModel: string): Promise<string> {
   return fixture.selectedModel;
 }
 
-async function expectVm0RunRuntimeRoute(
+async function expectBuiltInModelRunRuntimeRoute(
   runId: string,
   selectedModel: string,
 ): Promise<void> {
@@ -652,8 +652,8 @@ async function expectVm0RunRuntimeRoute(
     selectedModel,
     modelRuntimeProvider: getVm0ConcreteProviderType(selectedModel),
     modelRuntimeModel: getProviderRuntimeModel("vm0", selectedModel),
-    vm0ModelKeyId: expect.any(String),
-    modelKeyVendor: getVm0Vendor(selectedModel),
+    builtInModelKeyId: expect.any(String),
+    builtInModelKeyVendor: getVm0Vendor(selectedModel),
   });
 }
 
@@ -5018,8 +5018,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
       modelRuntimeProvider: null,
       modelRuntimeModel: null,
-      vm0ModelKeyId: null,
-      modelKeyVendor: null,
+      builtInModelKeyId: null,
+      builtInModelKeyVendor: null,
     });
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: randomUUID(),
@@ -5151,7 +5151,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(resumedStorageManifest.storageMounts).toStrictEqual(
       initialStorageMounts,
     );
-    await expectVm0RunRuntimeRoute(resumed.runId, selectedModel);
+    await expectBuiltInModelRunRuntimeRoute(resumed.runId, selectedModel);
 
     const resumedHistory = `managed resumed history ${resumed.runId}`;
     const resumedHistoryHash = createHash("sha256")
@@ -5202,7 +5202,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(rotatedStorageManifest.storageMounts).toStrictEqual(
       initialStorageMounts,
     );
-    await expectVm0RunRuntimeRoute(rotated.runId, selectedModel);
+    await expectBuiltInModelRunRuntimeRoute(rotated.runId, selectedModel);
     await api.requestCancelRun(actor, rotated.runId, [200]);
   });
 
@@ -7551,7 +7551,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
-    await expectVm0RunRuntimeRoute(run.runId, selectedModel);
+    await expectBuiltInModelRunRuntimeRoute(run.runId, selectedModel);
 
     expect(
       claim.firewalls?.map((firewall) => {
@@ -7601,7 +7601,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       experimentalProfile: DEFAULT_PROFILE,
     });
     const claim = await api.claimRunnerJob(sent.body.runId);
-    await expectVm0RunRuntimeRoute(sent.body.runId, selectedModel);
+    await expectBuiltInModelRunRuntimeRoute(sent.body.runId, selectedModel);
 
     expect(claim.cliAgentType).toBe("codex");
     await expect(
@@ -7726,7 +7726,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 
       await api.heartbeatRunner(runnerGroup);
       const claim = await api.claimRunnerJob(sent.body.runId);
-      await expectVm0RunRuntimeRoute(sent.body.runId, selectedModel);
+      await expectBuiltInModelRunRuntimeRoute(sent.body.runId, selectedModel);
 
       expect(claim.cliAgentType).toBe("codex");
       expect(claim.environment).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2594,7 +2594,7 @@ const modelProviderFailureInner$ = command(
         selectedModel: agentRuns.selectedModel,
         modelRuntimeProvider: agentRuns.modelRuntimeProvider,
         modelRuntimeModel: agentRuns.modelRuntimeModel,
-        vm0ModelKeyId: agentRuns.vm0ModelKeyId,
+        builtInModelKeyId: agentRuns.builtInModelKeyId,
       })
       .from(agentRuns)
       .where(eq(agentRuns.id, runId))
@@ -2607,7 +2607,7 @@ const modelProviderFailureInner$ = command(
       !run.selectedModel ||
       !run.modelRuntimeProvider ||
       !run.modelRuntimeModel ||
-      !run.vm0ModelKeyId
+      !run.builtInModelKeyId
     ) {
       L.debug("Managed model provider failure report ignored", { runId });
       return { status: 200 as const, body: { outcome: "ignored" as const } };

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6184,26 +6184,26 @@ function launchRunValues(
   };
 }
 
-type Vm0LaunchMetadataValues = Pick<
+type BuiltInModelLaunchMetadataValues = Pick<
   RunMetadataValues,
-  "modelRuntimeProvider" | "modelRuntimeModel" | "vm0ModelKeyId"
+  "modelRuntimeProvider" | "modelRuntimeModel" | "builtInModelKeyId"
 >;
 
-function vm0LaunchMetadataValues(
+function builtInModelLaunchMetadataValues(
   modelProvider: ResolvedModelProviderEnvironment | null,
-): Vm0LaunchMetadataValues {
+): BuiltInModelLaunchMetadataValues {
   const runtimeRoute = modelProvider?.builtInModelRuntimeRoute;
   if (!runtimeRoute) {
     return {
       modelRuntimeProvider: null,
       modelRuntimeModel: null,
-      vm0ModelKeyId: null,
+      builtInModelKeyId: null,
     };
   }
   return {
     modelRuntimeProvider: runtimeRoute.providerType,
     modelRuntimeModel: runtimeRoute.upstreamModel,
-    vm0ModelKeyId: runtimeRoute.modelKeyId,
+    builtInModelKeyId: runtimeRoute.modelKeyId,
   };
 }
 
@@ -6234,7 +6234,7 @@ function launchRunMetadataValues(args: LaunchRunRowsArgs): RunMetadataValues {
     modelProviderId: modelPin.modelProviderId,
     modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
     selectedModel: modelPin.selectedModel,
-    ...vm0LaunchMetadataValues(args.modelProvider),
+    ...builtInModelLaunchMetadataValues(args.modelProvider),
     selectedVideoModel: args.selectedVideoModel,
     selectedImageModel: args.selectedImageModel,
     chatThreadId: args.chatThreadId ?? null,

--- a/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
@@ -16,7 +16,7 @@ type StoredRunMetadataValues = Pick<
   | "selectedModel"
   | "modelRuntimeProvider"
   | "modelRuntimeModel"
-  | "vm0ModelKeyId"
+  | "builtInModelKeyId"
   | "codexServiceTier"
   | "selectedVideoModel"
   | "selectedImageModel"
@@ -73,7 +73,7 @@ export function normalizeRunMetadata(
     selectedModel: input.selectedModel ?? null,
     modelRuntimeProvider: input.modelRuntimeProvider ?? null,
     modelRuntimeModel: input.modelRuntimeModel ?? null,
-    vm0ModelKeyId: input.vm0ModelKeyId ?? null,
+    builtInModelKeyId: input.builtInModelKeyId ?? null,
     codexServiceTier: input.codexServiceTier ?? null,
     selectedVideoModel: input.selectedVideoModel ?? null,
     selectedImageModel: input.selectedImageModel ?? null,

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -539,13 +539,13 @@ export async function readRunModelRuntimeRouteFixture(runId: string) {
       selectedModel: agentRuns.selectedModel,
       modelRuntimeProvider: agentRuns.modelRuntimeProvider,
       modelRuntimeModel: agentRuns.modelRuntimeModel,
-      vm0ModelKeyId: agentRuns.vm0ModelKeyId,
-      modelKeyVendor: builtInModelKeys.vendor,
+      builtInModelKeyId: agentRuns.builtInModelKeyId,
+      builtInModelKeyVendor: builtInModelKeys.vendor,
     })
     .from(agentRuns)
     .leftJoin(
       builtInModelKeys,
-      eq(builtInModelKeys.id, agentRuns.vm0ModelKeyId),
+      eq(builtInModelKeys.id, agentRuns.builtInModelKeyId),
     )
     .where(eq(agentRuns.id, runId))
     .limit(1);

--- a/turbo/packages/db/scripts/test-agent-run-built-in-model-key-bridge.ts
+++ b/turbo/packages/db/scripts/test-agent-run-built-in-model-key-bridge.ts
@@ -245,10 +245,6 @@ async function validateRuntimeCallerIsolation(): Promise<void> {
       "builtInModelKeyId|built_in_model_key_id",
       runtimePathspecs,
     ),
-    [],
-  );
-  assert.deepEqual(
-    trackedFilesWithPattern("vm0ModelKeyId|vm0_model_key_id", runtimePathspecs),
     [
       "turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts",
       "turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts",
@@ -257,6 +253,10 @@ async function validateRuntimeCallerIsolation(): Promise<void> {
       "turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts",
       "turbo/apps/api/src/test-fixtures/agent-runs.ts",
     ],
+  );
+  assert.deepEqual(
+    trackedFilesWithPattern("vm0ModelKeyId|vm0_model_key_id", runtimePathspecs),
+    [],
   );
   assert.deepEqual(
     trackedFilesWithPattern(
@@ -279,6 +279,8 @@ async function validateRuntimeCallerIsolation(): Promise<void> {
   const statementEnd = selectionSource.length;
   assert.ok(statementStart >= 0 && statementEnd > statementStart);
   const statementSource = selectionSource.slice(statementStart, statementEnd);
+  assert.equal(statementSource.includes("vm0ModelKeyId"), false);
+  assert.equal(statementSource.includes("vm0_model_key_id"), false);
   assert.equal(statementSource.includes("builtInModelKeyId"), false);
   assert.equal(statementSource.includes("built_in_model_key_id"), false);
 


### PR DESCRIPTION
## Summary

- switch every active Agent Run built-in model key writer and reader to the canonical `builtInModelKeyId` field
- rename directly associated launch and fixture vocabulary to built-in-model terminology while retaining the `"vm0"` provider discriminator
- flip the permanent runtime inventory to the exact canonical caller set, reject legacy runtime callers, retain the whole-row guard, and keep both compatibility fields out of log-detail selection

## Compatibility and rollback

- keep `agent_runs.vm0_model_key_id`, its `agentRuns.vm0ModelKeyId` schema mapping, `built_in_model_key_id`, migration 0971's bidirectional bridge, and migration 0973's backfill unchanged
- do not add application fallback reads, `COALESCE`, or dual writes; migration 0971 remains the only mixed-version bridge
- rollback is the previous API release, which continues writing the legacy column while migration 0971 mirrors it into the canonical column

## Verification

- `pnpm format`
- `pnpm turbo run lint --filter=api --filter=@okouai/db --concurrency=1 --log-order=grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --log-order=grouped`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=... pnpm --filter @okouai/db exec tsx scripts/test-agent-run-built-in-model-key-bridge.ts`
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (181 passed)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` (125 passed)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts` (7 passed)

Refs #28739
