### PR TITLE
fix: align media model price badge with run model rows

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1042,7 +1042,12 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
       onClick={option.onSelect}
     >
       {option.icon}
-      <span className="min-w-0 flex-1 truncate">{option.label}</span>
+      {/* Not `flex-1`: run-model rows sit inside a shrink-to-fit `SelectItem`
+          text slot, so their price badge trails the model name instead of
+          parking at the row's right edge. These rows are plain buttons that do
+          span the row, so the label must stay shrink-to-fit for the badge to
+          land in the same place. */}
+      <span className="min-w-0 truncate">{option.label}</span>
       <PriceTierBadge
         tier={option.priceTier}
         description={getMediaModelPriceTierLabel(option.priceTier)}


### PR DESCRIPTION
## What

In the model picker, the price indicator (`$` / `$$` / `$$$`) on image and video model rows was right-aligned at the far edge of the popover, while chat (run) model rows show it immediately after the model name. This aligns the two.

## Why the two diverged

Both rows used `min-w-0 flex-1 truncate` on the label span, but they live in different boxes:

- Run-model rows render inside `SelectPrimitive.ItemText`, a shrink-to-fit slot — `flex-1` has no free space to absorb, so the badge trails the name.
- `MediaModelPanelRow` is a plain `<button>` (deliberately, so clicking it does not join the Select's value space) that spans the full row — `flex-1` grew the label and pushed the badge to the right edge.

## Change

Drop `flex-1` from the media row label. `min-w-0 truncate` is kept so long labels still truncate, and `PriceTierBadge` keeps its `shrink-0`. The `pr-8` checkmark column is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)