### PR TITLE
test(mitm-addon): verify log timestamps use current utc clock

### DIFF
--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -1,6 +1,7 @@
 """Tests for mitm addon logging utilities."""
 
 import json
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,19 +17,25 @@ def _read_jsonl_entries_without_flush(path):
 
 
 class TestLogNetworkEntry:
-    def test_writes_jsonl(self, tmp_path):
+    def test_writes_jsonl_with_current_utc_timestamp(self, tmp_path):
         log_path = str(tmp_path / "net.jsonl")
         entry = {"action": "ALLOW", "host": "example.com"}
+        current_time = datetime(2026, 8, 24, 2, 16, 45, 678_901, tzinfo=UTC)
 
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
+        with (
+            patch.object(logging_utils, "datetime") as clock,
+            patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+        ):
+            clock.now.return_value = current_time
             logging_utils.log_network_entry(log_path, entry)
 
         entries = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert len(entries) == 1
         parsed = entries[0]
+        clock.now.assert_called_once_with(UTC)
         assert parsed["action"] == "ALLOW"
         assert parsed["host"] == "example.com"
-        assert_utc_millisecond_timestamp(parsed["timestamp"])
+        assert parsed["timestamp"] == "2026-08-24T02:16:45.678Z"
         assert "timestamp" not in entry
 
     def test_timestamp_is_authoritative(self, tmp_path):


### PR DESCRIPTION
## Summary

- strengthen the existing public network-log integration test with a controlled UTC clock
- verify the persisted timestamp uses the controlled current instant and preserves millisecond `Z` formatting
- prove the reported well-formed stale timestamp mutation is rejected without adding sleeps or another filesystem test

## Exclusions

- no production logging behavior, dependency, API, protocol, persisted state, or deployment compatibility changes
- the shared shape-only assertion remains for broad format coverage in other logging paths

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_logging_utils.py::TestLogNetworkEntry::test_writes_jsonl_with_current_utc_timestamp` (1 passed)
- in-memory stale timestamp mutation check (expected test failure observed)
- `uv run --no-sync python -m pytest tests/` (6517 passed)

Closes #28685
