### PR TITLE
fix(platform): preserve cooldown diagnostics during refresh

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -917,11 +917,19 @@ describe("settings dialog", () => {
   });
 
   it("shows complete managed model cooldown diagnostics in a collapsed disclosure", async () => {
+    const releaseRefresh = context.mocks.deferred<void>();
     let requestCount = 0;
     context.mocks.api(
       modelProviderCooldownDiagnosticsContract.get,
-      ({ respond }) => {
+      async ({ respond }) => {
         requestCount += 1;
+        if (requestCount > 1) {
+          await releaseRefresh.promise;
+          return respond(200, {
+            fallbackEnabled: true,
+            activeCooldowns: [],
+          });
+        }
         return respond(200, {
           fallbackEnabled: false,
           activeCooldowns: [
@@ -976,7 +984,25 @@ describe("settings dialog", () => {
     click(refreshButton);
     await waitFor(() => {
       expect(requestCount).toBe(2);
+      expect(refreshButton).toBeDisabled();
     });
+    expect(details.open).toBeTruthy();
+    expect(
+      within(diagnostics).getByText("gpt-5.6-luna-2026-08-01"),
+    ).toBeInTheDocument();
+
+    releaseRefresh.resolve();
+    await waitFor(() => {
+      expect(summary).toHaveTextContent("workspace fallback: enabled");
+      expect(summary).toHaveTextContent("global active cooldowns: 0");
+      expect(refreshButton).toBeEnabled();
+    });
+    expect(details.open).toBeTruthy();
+    expect(
+      within(diagnostics).getByText(
+        "No managed model routes are currently in global cooldown.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("refreshes managed model cooldown diagnostics on every Debug entry", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/managed-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/managed-model-cooldown-diagnostics-block.tsx
@@ -1,6 +1,6 @@
 import type { ManagedModelCooldownDiagnostics } from "@okouai/api-contracts/contracts/model-provider-routes";
 import { Button } from "@okouai/ui/components/ui/button";
-import { useLoadable, useSet } from "ccstate-react";
+import { useLastResolved, useLoadableState, useSet } from "ccstate-react";
 import { ChevronDown, ChevronUp, Database, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -71,8 +71,10 @@ function CooldownDiagnosticsSummary({
 
 function CooldownDiagnosticsContent({
   diagnostics,
+  loading,
 }: {
   readonly diagnostics: ManagedModelCooldownDiagnostics;
+  readonly loading: boolean;
 }) {
   const { t } = useTranslation();
   const reloadDiagnostics = useSet(reloadManagedModelCooldownDiagnostics$);
@@ -91,6 +93,7 @@ function CooldownDiagnosticsContent({
           variant="outline"
           size="sm"
           className="h-8 gap-1.5 px-2.5 text-xs"
+          disabled={loading}
           onClick={() => {
             reloadDiagnostics();
           }}
@@ -188,10 +191,9 @@ function CooldownDiagnosticsContent({
 export function ManagedModelCooldownDiagnosticsBlock() {
   const { t } = useTranslation();
   const reloadDiagnostics = useSet(reloadManagedModelCooldownDiagnostics$);
-  const diagnosticsLoadable = useLoadable(managedModelCooldownDiagnostics$);
-  const loading = diagnosticsLoadable.state === "loading";
-  const diagnostics =
-    diagnosticsLoadable.state === "hasData" ? diagnosticsLoadable.data : null;
+  const diagnostics = useLastResolved(managedModelCooldownDiagnostics$);
+  const loading =
+    useLoadableState(managedModelCooldownDiagnostics$) === "loading";
 
   return (
     <section
@@ -202,7 +204,10 @@ export function ManagedModelCooldownDiagnosticsBlock() {
         <details className="group">
           <CooldownDiagnosticsSummary diagnostics={diagnostics} />
           <div className="border-t border-border/60 p-4">
-            <CooldownDiagnosticsContent diagnostics={diagnostics} />
+            <CooldownDiagnosticsContent
+              diagnostics={diagnostics}
+              loading={loading}
+            />
           </div>
         </details>
       ) : (


### PR DESCRIPTION
## Summary

- keep the expanded managed model cooldown diagnostics visible while a manual refresh is pending
- disable the refresh action until the current request completes
- verify that refreshed data replaces the prior result without collapsing the disclosure

## Scope

This is a UI state follow-up to #28733. It does not change the diagnostics API, cooldown data, fallback routing, refresh triggers, or polling behavior.

## Validation

- `cd turbo && pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx` (34 passed)
- `pnpm knip`
- pre-commit full Turbo type checks (14 tasks passed)

Follow-up to #28733
Relates to #28729
