### PR TITLE
fix(runner): log execution time limit at info

### DIFF
--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -182,7 +182,7 @@ fn log_job_execution_failed(
     match failure.kind {
         ExecutionFailureKind::RunnerJobTimeout { .. } => {
             emit_job_execution_failed!(
-                tracing::Level::ERROR,
+                tracing::Level::INFO,
                 "runner job reached execution time limit"
             );
         }
@@ -1144,7 +1144,7 @@ mod tests {
 
         let event = capture_job_failure_log(&failure);
 
-        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(event.level, Level::INFO);
         assert_eq!(
             event.fields.get("message").map(String::as_str),
             Some("runner job reached execution time limit")
@@ -1192,7 +1192,7 @@ mod tests {
         let timeout_event = capture_job_failure_log(&timeout_failure);
 
         assert_eq!(generic_event.level, Level::INFO);
-        assert_eq!(timeout_event.level, Level::ERROR);
+        assert_eq!(timeout_event.level, Level::INFO);
         assert_eq!(
             generic_event.fields.get("message").map(String::as_str),
             Some("job execution failed")


### PR DESCRIPTION
## Summary

- Log the runner-owned fixed execution time limit at info level instead of error level.
- Preserve the dedicated terminal message and structured timeout metadata for observability.
- Keep generic and unexpected execution failures at error level.

## Exclusions

- No change to the two-hour execution limit, timeout detection, termination behavior, exit status, or completion reporting.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #28743
