### PR TITLE
refactor(python): centralize buffered auth body framing

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -484,10 +484,12 @@ def _has_current_direct_connector_auth_binding(
     )
 
 
-def _auth_base_body_header_check(
+def _buffered_auth_body_header_check(
     flow: http.HTTPFlow,
     *,
     request_end_stream: bool | None,
+    max_body_bytes: int,
+    method_allows_missing_content_length: bool,
 ) -> _BufferedRequestBodyCheck:
     if flow.request.headers.get_all("Transfer-Encoding"):
         return _BufferedRequestBodyCheck(
@@ -497,10 +499,10 @@ def _auth_base_body_header_check(
 
     parsed_content_length = content_length.parse(
         flow.request.headers.get_all("Content-Length"),
-        max_value=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+        max_value=max_body_bytes,
     )
     if parsed_content_length.kind == "missing":
-        if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
+        if not method_allows_missing_content_length:
             return _BufferedRequestBodyCheck(
                 kind="length_required",
                 reason="missing_content_length",
@@ -514,11 +516,6 @@ def _auth_base_body_header_check(
             return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
         return _BufferedRequestBodyCheck(kind="ok")
 
-    if parsed_content_length.kind == "invalid":
-        return _BufferedRequestBodyCheck(
-            kind="length_required",
-            reason="invalid_content_length",
-        )
     if parsed_content_length.kind == "conflicting":
         return _BufferedRequestBodyCheck(
             kind="length_required",
@@ -529,7 +526,27 @@ def _auth_base_body_header_check(
             kind="too_large",
             observed_size=parsed_content_length.value,
         )
-    return _BufferedRequestBodyCheck(kind="ok", observed_size=parsed_content_length.value)
+    if parsed_content_length.kind == "valid":
+        return _BufferedRequestBodyCheck(kind="ok", observed_size=parsed_content_length.value)
+    return _BufferedRequestBodyCheck(
+        kind="length_required",
+        reason="invalid_content_length",
+    )
+
+
+def _auth_base_body_header_check(
+    flow: http.HTTPFlow,
+    *,
+    request_end_stream: bool | None,
+) -> _BufferedRequestBodyCheck:
+    return _buffered_auth_body_header_check(
+        flow,
+        request_end_stream=request_end_stream,
+        max_body_bytes=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+        method_allows_missing_content_length=(
+            flow.request.method.upper() in _AUTH_BASE_BODYLESS_METHODS
+        ),
+    )
 
 
 def _aws_sigv4_body_header_check(
@@ -537,42 +554,12 @@ def _aws_sigv4_body_header_check(
     *,
     request_end_stream: bool | None,
 ) -> _BufferedRequestBodyCheck:
-    if flow.request.headers.get_all("Transfer-Encoding"):
-        return _BufferedRequestBodyCheck(
-            kind="length_required",
-            reason="transfer_encoding",
-        )
-
-    parsed_content_length = content_length.parse(
-        flow.request.headers.get_all("Content-Length"),
-        max_value=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+    return _buffered_auth_body_header_check(
+        flow,
+        request_end_stream=request_end_stream,
+        max_body_bytes=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+        method_allows_missing_content_length=True,
     )
-    if parsed_content_length.kind == "missing":
-        if request_end_stream is True:
-            return _BufferedRequestBodyCheck(kind="ok")
-        reason = (
-            "request_stream_open"
-            if request_end_stream is False
-            else "request_end_stream_unavailable"
-        )
-        return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
-
-    if parsed_content_length.kind == "invalid":
-        return _BufferedRequestBodyCheck(
-            kind="length_required",
-            reason="invalid_content_length",
-        )
-    if parsed_content_length.kind == "conflicting":
-        return _BufferedRequestBodyCheck(
-            kind="length_required",
-            reason="conflicting_content_length",
-        )
-    if parsed_content_length.kind == "over_limit":
-        return _BufferedRequestBodyCheck(
-            kind="too_large",
-            observed_size=parsed_content_length.value,
-        )
-    return _BufferedRequestBodyCheck(kind="ok", observed_size=parsed_content_length.value)
 
 
 def _request_body_fits_stream_buffer(flow: http.HTTPFlow) -> bool:

--- a/crates/runner/mitm-addon/tests/buffered_auth_body_framing_cases.py
+++ b/crates/runner/mitm-addon/tests/buffered_auth_body_framing_cases.py
@@ -1,0 +1,52 @@
+"""Shared rejected body-framing cases for buffered auth request integration tests."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+BufferedAuthBodyFramingRejectionKind = Literal["length_required", "too_large"]
+
+
+@dataclass(frozen=True, slots=True)
+class BufferedAuthBodyFramingRejectionCase:
+    id: str
+    header_pairs: tuple[tuple[str, str], ...]
+    kind: BufferedAuthBodyFramingRejectionKind
+
+
+def buffered_auth_body_framing_rejection_cases(
+    *,
+    max_body_bytes: int,
+) -> tuple[BufferedAuthBodyFramingRejectionCase, ...]:
+    return (
+        BufferedAuthBodyFramingRejectionCase(
+            id="transfer-encoding",
+            header_pairs=(("Transfer-Encoding", "chunked"),),
+            kind="length_required",
+        ),
+        BufferedAuthBodyFramingRejectionCase(
+            id="invalid-nondigit",
+            header_pairs=(("Content-Length", "not-a-number"),),
+            kind="length_required",
+        ),
+        BufferedAuthBodyFramingRejectionCase(
+            id="invalid-negative",
+            header_pairs=(("Content-Length", "-1"),),
+            kind="length_required",
+        ),
+        BufferedAuthBodyFramingRejectionCase(
+            id="conflicting",
+            header_pairs=(("Content-Length", "4"), ("Content-Length", "5")),
+            kind="length_required",
+        ),
+        BufferedAuthBodyFramingRejectionCase(
+            id="over-limit",
+            header_pairs=(("Content-Length", str(max_body_bytes + 1)),),
+            kind="too_large",
+        ),
+    )
+
+
+def buffered_auth_body_framing_case_id(
+    framing_case: BufferedAuthBodyFramingRejectionCase,
+) -> str:
+    return framing_case.id

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -14,6 +14,11 @@ import mitm_addon
 import request_classification
 import upstream_destination_binding
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.buffered_auth_body_framing_cases import (
+    BufferedAuthBodyFramingRejectionCase,
+    buffered_auth_body_framing_case_id,
+    buffered_auth_body_framing_rejection_cases,
+)
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
@@ -254,23 +259,11 @@ def test_auth_base_requestheaders_releases_new_admission_after_attach_failure(
 
 
 @pytest.mark.parametrize(
-    ("method", "request_header_pairs"),
-    [
-        ("GET", []),
-        ("HEAD", []),
-        ("POST", []),
-        ("PUT", []),
-        ("PATCH", []),
-        ("OPTIONS", []),
-        ("TRACE", []),
-        ("POST", [("Transfer-Encoding", "chunked")]),
-        ("POST", [("Content-Length", "not-a-number")]),
-        ("POST", [("Content-Length", "-1")]),
-        ("POST", [("Content-Length", "4"), ("Content-Length", "5")]),
-    ],
+    "method",
+    ["GET", "HEAD", "POST", "PUT", "PATCH", "OPTIONS", "TRACE"],
 )
-async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
-    tmp_path, real_flow, mitm_ctx, headers, method, request_header_pairs
+async def test_auth_base_requestheaders_rejects_missing_content_length(
+    tmp_path, real_flow, mitm_ctx, headers, method
 ):
     reg_path = _write_auth_base_firewall_registry(tmp_path)
     flow = real_flow(
@@ -281,7 +274,6 @@ async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
         path="/",
         request_headers=headers(
             ("Host", "placeholder.example.com"),
-            *request_header_pairs,
         ),
     )
     get_headers = AsyncMock()
@@ -299,6 +291,54 @@ async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
     assert flow.error.msg == Error.KILLED_MESSAGE
     assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == ("auth_base_request_body_length_required")
+
+
+@pytest.mark.parametrize(
+    "framing_case",
+    buffered_auth_body_framing_rejection_cases(
+        max_body_bytes=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES
+    ),
+    ids=buffered_auth_body_framing_case_id,
+)
+async def test_auth_base_requestheaders_rejects_shared_body_framing(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    framing_case: BufferedAuthBodyFramingRejectionCase,
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            *framing_case.header_pairs,
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    expected_error = (
+        "auth_base_request_body_too_large"
+        if framing_case.kind == "too_large"
+        else "auth_base_request_body_length_required"
+    )
+    get_headers.assert_not_called()
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_error
 
 
 async def test_browser_auth_base_requestheaders_skips_body_framing_rejection(

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -29,6 +29,11 @@ from tests.aws_sigv4_helpers import (
     aws_sigv4_presigned_query_path,
     resolved_aws_sigv4_credentials,
 )
+from tests.buffered_auth_body_framing_cases import (
+    BufferedAuthBodyFramingRejectionCase,
+    buffered_auth_body_framing_case_id,
+    buffered_auth_body_framing_rejection_cases,
+)
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
@@ -877,43 +882,25 @@ async def test_payload_dependent_sigv4_holds_admission_until_websocket_end(
 
 
 @pytest.mark.parametrize(
-    ("extra_headers", "expected_error"),
+    "framing_case",
     [
-        (
-            [
-                (
-                    "Content-Length",
-                    str(aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES + 1),
-                )
-            ],
-            auth.AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR,
+        *buffered_auth_body_framing_rejection_cases(
+            max_body_bytes=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES
         ),
-        (
-            [("Content-Length", "not-a-number")],
-            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
-        ),
-        (
-            [("Content-Length", "4"), ("Content-Length", "5")],
-            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
-        ),
-        (
-            [("Transfer-Encoding", "chunked")],
-            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
-        ),
-        (
-            [],
-            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+        BufferedAuthBodyFramingRejectionCase(
+            id="indeterminate",
+            header_pairs=(),
+            kind="length_required",
         ),
     ],
-    ids=["oversized", "invalid", "conflicting", "chunked", "indeterminate"],
+    ids=buffered_auth_body_framing_case_id,
 )
 def test_payload_dependent_sigv4_rejects_unbounded_framing_before_auth(
     tmp_path,
     real_flow,
     headers,
     mitm_ctx,
-    extra_headers: list[tuple[str, str]],
-    expected_error: str,
+    framing_case: BufferedAuthBodyFramingRejectionCase,
 ) -> None:
     registry_path = _write_aws_registry(tmp_path)
     flow = real_flow(
@@ -922,7 +909,9 @@ def test_payload_dependent_sigv4_rejects_unbounded_framing_before_auth(
         host=STS_HOST,
         method="POST",
         path="/",
-        request_headers=headers(*aws_sigv4_header_auth_headers(extra_headers=extra_headers)),
+        request_headers=headers(
+            *aws_sigv4_header_auth_headers(extra_headers=framing_case.header_pairs)
+        ),
     )
     get_headers = AsyncMock()
 
@@ -932,6 +921,11 @@ def test_payload_dependent_sigv4_rejects_unbounded_framing_before_auth(
     ):
         assert mitm_addon.requestheaders(flow) is None
 
+    expected_error = (
+        auth.AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR
+        if framing_case.kind == "too_large"
+        else auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR
+    )
     get_headers.assert_not_called()
     assert flow.error is not None
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_error

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -111,6 +111,7 @@ suites before committing the upgrade.
 | `test_builtin_host_policy_contract.py`                  | Cross-stage malformed built-in host policy contracts                                                                 |
 | `test_connection_endpoints.py`                          | Connection endpoint shape validation and IPv6 tuple normalization                                                    |
 | `test_content_length.py`                                | Shared bounded Content-Length field parsing contract                                                                 |
+| `buffered_auth_body_framing_cases.py`                   | Shared rejected framing cases for auth.base and AWS SigV4 request integration tests                                  |
 | `codex_model_catalog_cache_helpers.py`                  | Shared Codex catalog flow, response, and cache lifecycle test builders                                               |
 | `test_codex_model_catalog_cache_coordination.py`        | Codex catalog prefetch, single-flight, wait, cancellation, and active-request capacity behavior                      |
 | `test_codex_model_catalog_cache_hooks.py`               | Codex catalog request admission, firewall hook integration, telemetry, and cleanup                                   |


### PR DESCRIPTION
## Summary

- centralize Transfer-Encoding and Content-Length classification for buffered auth.base and AWS SigV4 requests
- preserve each protocol's body limit and missing-length policy while allowing only an explicit valid length to succeed
- share rejected framing cases across both requestheaders integration suites

## Scope

The change keeps existing domain error codes, reason strings, logging, and admission accounting unchanged. It intentionally does not alter the general Content-Length parser, stream-buffer classification, response-size accounting, or other parser consumers.

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_auth_base_body.py tests/test_request_handler_aws_sigv4_body.py tests/test_mitmproxy_request_body_admission_framing.py`
- `uv run --no-sync python -m pytest tests/` (6519 passed)

Closes #28687
