### PR TITLE
test(api): isolate telegram identity across reruns

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4811,7 +4811,7 @@ describe("INT-02: Telegram integration", () => {
       throw new Error("Expected Telegram onboarding to configure an agent");
     }
 
-    const telegramUserId = 91_234_567;
+    const telegramUserId = randomInt(100_000_000, 999_999_999);
     await integrations.requestLinkTelegram(
       actor,
       {


### PR DESCRIPTION
## Summary

- allocate a fresh Telegram user identity whenever the missing-agent official-bot integration test runs
- preserve the real official-link persistence and uniqueness behavior while keeping unrelated provider fixtures deterministic
- leave production Telegram routes, schemas, cleanup behavior, and deployment boundaries unchanged

## Why

The test previously persisted the fixed Telegram user ID `91_234_567`. Re-running the file against the same PostgreSQL database created a different organization, so the real official-bot link route correctly returned `409 CONFLICT` for the already-owned identity.

The new identity allocation matches adjacent persisted Telegram scenarios and establishes test ownership before the database write. Public unlink teardown is intentionally not added because cleanup cannot guarantee isolation for concurrent, failed, or interrupted runs.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts --maxWorkers=4 --silent=passed-only` (44 passed)
- repeated the same Vitest command against the unchanged database (44 passed)
- pre-commit hooks: Prettier, Knip, full Turbo type checks (14/14), file-size check, and commitlint

## Deployment compatibility

Test data allocation only; no runtime contract, persisted production state, or independently deployed component changes.

Closes #28730
