### PR TITLE
refactor(auth): rename the zero token type to agent

### DIFF
--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -10,7 +10,7 @@ import {
 } from "./tokens";
 import { clerkSessionAuth$ } from "./clerk-session";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
-import { AuthContext, CliAuth, ZeroAuthContext } from "../../types/auth";
+import { AgentAuthContext, AuthContext, CliAuth } from "../../types/auth";
 import {
   cliTokenRecord,
   getMemberRoleAndUpdateCache$,
@@ -116,15 +116,15 @@ function resolveSandboxAuth(
   return null;
 }
 
-const zeroAuth$ = command(
+const agentAuth$ = command(
   async (
     { set },
     token: string,
     options: AuthOptions,
     signal: AbortSignal,
   ): Promise<AuthContext | null> => {
-    const zeroAuth = verifyOkouToken(token);
-    if (!zeroAuth) {
+    const agentAuth = verifyOkouToken(token);
+    if (!agentAuth) {
       return null;
     }
 
@@ -132,7 +132,7 @@ const zeroAuth$ = command(
       if (!options.requiredCapability) {
         return null;
       }
-      const hasCapability = zeroAuth.capabilities.some((capability) => {
+      const hasCapability = agentAuth.capabilities.some((capability) => {
         return capability === options.requiredCapability;
       });
       if (!hasCapability) {
@@ -140,27 +140,27 @@ const zeroAuth$ = command(
       }
     }
 
-    const result: ZeroAuthContext = {
-      tokenType: "zero",
-      userId: zeroAuth.userId,
-      orgId: zeroAuth.orgId,
-      runId: zeroAuth.runId,
-      capabilities: [...zeroAuth.capabilities],
-      publicBrand: zeroAuth.publicBrand,
-      ...(zeroAuth.computerUseHostId
-        ? { computerUseHostId: zeroAuth.computerUseHostId }
+    const result: AgentAuthContext = {
+      tokenType: "agent",
+      userId: agentAuth.userId,
+      orgId: agentAuth.orgId,
+      runId: agentAuth.runId,
+      capabilities: [...agentAuth.capabilities],
+      publicBrand: agentAuth.publicBrand,
+      ...(agentAuth.computerUseHostId
+        ? { computerUseHostId: agentAuth.computerUseHostId }
         : {}),
     };
 
     const membership = await set(
       getMemberRoleAndUpdateCache$,
-      zeroAuth.orgId,
-      zeroAuth.userId,
+      agentAuth.orgId,
+      agentAuth.userId,
       signal,
     );
     if (!membership) {
       return {
-        tokenType: "zero" as const,
+        tokenType: "agent" as const,
         userId: result.userId,
         runId: result.runId,
         publicBrand: result.publicBrand,
@@ -178,9 +178,9 @@ const sandboxTokenAuth$ = command(
     options: AuthOptions,
     signal: AbortSignal,
   ): Promise<AuthContext | null> => {
-    const zeroResult = await set(zeroAuth$, token, options, signal);
-    if (zeroResult) {
-      return zeroResult;
+    const agentResult = await set(agentAuth$, token, options, signal);
+    if (agentResult) {
+      return agentResult;
     }
 
     if (!options.requiredCapability && !options.acceptAnySandboxCapability) {
@@ -282,8 +282,8 @@ function sandboxTokenAuthError(
   }
 
   const sandboxAuth = verifySandboxToken(token);
-  const zeroAuth = sandboxAuth ? null : verifyOkouToken(token);
-  if (!sandboxAuth && !zeroAuth) {
+  const agentAuth = sandboxAuth ? null : verifyOkouToken(token);
+  if (!sandboxAuth && !agentAuth) {
     return null;
   }
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -16,10 +16,10 @@ import { env } from "../../lib/env";
 import { now } from "../../lib/time";
 import { safeJsonParse } from "../utils";
 import {
+  AgentAuth,
   CliAuth,
   ComposeJobAuth,
   SandboxAuth,
-  ZeroAuth,
 } from "../../types/auth";
 import { singleton } from "../../lib/singleton";
 
@@ -262,7 +262,7 @@ export function verifySandboxToken(token: string): SandboxAuth | null {
   };
 }
 
-export function verifyOkouToken(token: string): ZeroAuth | null {
+export function verifyOkouToken(token: string): AgentAuth | null {
   const parsed = okouTokenPayloadSchema.safeParse(
     verifyPrefixedToken(token, SANDBOX_TOKEN_PREFIX),
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -639,7 +639,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       [200],
     );
     expect(memberProbe.body).toStrictEqual({
-      tokenType: "zero",
+      tokenType: "agent",
       userId: zeroMember.userId,
       orgId: zeroMember.orgId,
       orgRole: "member",
@@ -656,7 +656,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       [200],
     );
     expect(adminProbe.body).toStrictEqual({
-      tokenType: "zero",
+      tokenType: "agent",
       userId: zeroAdmin.userId,
       orgId: zeroAdmin.orgId,
       orgRole: "admin",
@@ -673,7 +673,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       [200],
     );
     expect(orphanProbe.body).toStrictEqual({
-      tokenType: "zero",
+      tokenType: "agent",
       userId: zeroOrphan.userId,
       runId: orphanZero.runId,
       publicBrand: "vm0",

--- a/turbo/apps/api/src/signals/routes/avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/avatar-video.ts
@@ -192,11 +192,11 @@ const postGenerateInner$ = command(
     );
     signal.throwIfAborted();
     const runId =
-      auth.tokenType === "zero" || auth.tokenType === "sandbox"
+      auth.tokenType === "agent" || auth.tokenType === "sandbox"
         ? auth.runId
         : undefined;
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const admission = await set(
       startRunBuiltInAdmission$,
       { runId, kind: "video" },

--- a/turbo/apps/api/src/signals/routes/banking.ts
+++ b/turbo/apps/api/src/signals/routes/banking.ts
@@ -54,7 +54,7 @@ const transactionsBody$ = bodyResultOf(bankingContract.transactions);
 
 const accountsInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "zero") {
+  if (auth.tokenType !== "agent") {
     return okouTokenRequired();
   }
   if (!(await set(bankingEnabled$))) {
@@ -73,7 +73,7 @@ const accountsInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const balancesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "zero") {
+  if (auth.tokenType !== "agent") {
     return okouTokenRequired();
   }
   if (!(await set(bankingEnabled$))) {
@@ -93,7 +93,7 @@ const balancesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const transactionsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    if (auth.tokenType !== "zero") {
+    if (auth.tokenType !== "agent") {
       return okouTokenRequired();
     }
     if (!(await set(bankingEnabled$))) {
@@ -119,7 +119,7 @@ const bankingAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "banking:read",
-  accept: ["zero"],
+  accept: ["agent"],
 } as const;
 
 export const bankingRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/browser-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/browser-authorization.ts
@@ -41,7 +41,7 @@ const browserAuthorizationAuthOptions = {
 const browserAuthorizationCreateAuthOptions = {
   ...browserAuthorizationAuthOptions,
   acceptAnySandboxCapability: true,
-  accept: ["zero", "sandbox"],
+  accept: ["agent", "sandbox"],
 } as const;
 
 const createAuthorizationRequestInner$ = command(
@@ -52,13 +52,13 @@ const createAuthorizationRequestInner$ = command(
     if (!body.ok) {
       return body.response;
     }
-    if (auth.tokenType !== "zero" && auth.tokenType !== "sandbox") {
+    if (auth.tokenType !== "agent" && auth.tokenType !== "sandbox") {
       return badRequestMessage(
         "Cloud browser authorization requires a run token",
       );
     }
     // Legacy sandbox tokens do not carry presentation context and remain VM0.
-    const publicBrand = auth.tokenType === "zero" ? auth.publicBrand : "vm0";
+    const publicBrand = auth.tokenType === "agent" ? auth.publicBrand : "vm0";
 
     const result = await set(
       createBrowserAuthorizationRequest$,

--- a/turbo/apps/api/src/signals/routes/browser.ts
+++ b/turbo/apps/api/src/signals/routes/browser.ts
@@ -41,7 +41,7 @@ const createBrowserInner$ = command(
     }
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       createBrowser$,
       {
@@ -70,7 +70,7 @@ const useBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     useBrowser$,
     {
@@ -96,7 +96,7 @@ const leaseBrowserInner$ = command(
     }
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       leaseCurrentBrowser$,
       {
@@ -124,7 +124,7 @@ const leaseBrowserByThreadInner$ = command(
     }
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       leaseBrowserByThread$,
       {
@@ -152,7 +152,7 @@ const openBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     openBrowserForThread$,
     {
@@ -181,7 +181,7 @@ const closeBrowserInner$ = command(
     }
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       closeBrowserForThread$,
       {
@@ -211,7 +211,7 @@ const resizeBrowserByThreadInner$ = command(
     }
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       resizeBrowserByThread$,
       {
@@ -234,7 +234,7 @@ const currentBrowserInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       getCurrentBrowser$,
       {
@@ -255,7 +255,7 @@ const getParams$ = pathParamsOf(browserContract.get);
 const getBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     getBrowser$,
     {
@@ -276,14 +276,14 @@ const browserReadAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "browser:read" as const,
-  accept: Object.freeze(["session", "zero"] as const),
+  accept: Object.freeze(["session", "agent"] as const),
 });
 
 const browserWriteAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "browser:write" as const,
-  accept: Object.freeze(["zero"] as const),
+  accept: Object.freeze(["agent"] as const),
 });
 
 // Keeping a browser alive and restarting a suspended one are viewer actions, so
@@ -292,14 +292,14 @@ const browserViewerWriteAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "browser:write" as const,
-  accept: Object.freeze(["session", "zero"] as const),
+  accept: Object.freeze(["session", "agent"] as const),
 });
 
 const browserCurrentAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "browser:read" as const,
-  accept: Object.freeze(["zero"] as const),
+  accept: Object.freeze(["agent"] as const),
 });
 
 export const browserRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
@@ -30,7 +30,7 @@ const syncInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       runId: bodyResult.data.runId,
       fileId: bodyResult.data.fileId,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );
@@ -53,7 +53,7 @@ export const chatThreadsArtifactsSyncRoutes: readonly RouteEntry[] = [
         requireOrganization: true,
         missingOrganizationStatus: 401,
         requiredCapability: "file:write",
-        accept: ["session", "pat", "zero"],
+        accept: ["session", "pat", "agent"],
       },
       syncInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -121,7 +121,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     }
   }
   const callerRunId =
-    auth.tokenType === "sandbox" || auth.tokenType === "zero"
+    auth.tokenType === "sandbox" || auth.tokenType === "agent"
       ? auth.runId
       : undefined;
   const inherited = await inheritedRunChatSettings(writeDb, callerRunId);

--- a/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
@@ -45,7 +45,7 @@ const computerUseAuthorizationAuthOptions = {
 const computerUseAuthorizationCreateAuthOptions = {
   ...computerUseAuthorizationAuthOptions,
   acceptAnySandboxCapability: true,
-  accept: ["zero", "sandbox"],
+  accept: ["agent", "sandbox"],
 } as const;
 
 const createAuthorizationRequestInner$ = command(
@@ -57,13 +57,13 @@ const createAuthorizationRequestInner$ = command(
       return body.response;
     }
 
-    if (auth.tokenType !== "zero" && auth.tokenType !== "sandbox") {
+    if (auth.tokenType !== "agent" && auth.tokenType !== "sandbox") {
       return badRequestMessage(
         "Computer Use authorization requires a run token",
       );
     }
     // Legacy sandbox tokens do not carry presentation context and remain VM0.
-    const publicBrand = auth.tokenType === "zero" ? auth.publicBrand : "vm0";
+    const publicBrand = auth.tokenType === "agent" ? auth.publicBrand : "vm0";
 
     const result = await set(
       createComputerUseAuthorizationRequest$,

--- a/turbo/apps/api/src/signals/routes/computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/computer-use.ts
@@ -188,7 +188,7 @@ const hostsListInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
 
-  if (auth.tokenType === "zero") {
+  if (auth.tokenType === "agent") {
     const hostId = auth.computerUseHostId;
     if (!hostId) {
       return computerUseHostNotAuthorized;
@@ -217,8 +217,8 @@ const commandCreateInner$ = command(
     }
 
     const targetHostId =
-      auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-    if (auth.tokenType === "zero" && !targetHostId) {
+      auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+    if (auth.tokenType === "agent" && !targetHostId) {
       return computerUseHostNotAuthorized;
     }
 
@@ -230,7 +230,7 @@ const commandCreateInner$ = command(
         kind: bodyResult.data.kind,
         payload: bodyResult.data,
         timeoutMs: bodyResult.data.timeoutMs,
-        ...(auth.tokenType === "zero"
+        ...(auth.tokenType === "agent"
           ? { runId: auth.runId, targetHostId }
           : {}),
       },
@@ -271,8 +271,8 @@ const writeCommandCreateInner$ = command(
     }
 
     const targetHostId =
-      auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-    if (auth.tokenType === "zero" && !targetHostId) {
+      auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+    if (auth.tokenType === "agent" && !targetHostId) {
       return computerUseHostNotAuthorized;
     }
 
@@ -284,7 +284,7 @@ const writeCommandCreateInner$ = command(
         kind: bodyResult.data.kind,
         payload: bodyResult.data,
         timeoutMs: bodyResult.data.timeoutMs,
-        ...(auth.tokenType === "zero"
+        ...(auth.tokenType === "agent"
           ? { runId: auth.runId, targetHostId }
           : {}),
       },
@@ -338,8 +338,8 @@ const pluginCommandCreateInner$ = command(
     }
 
     const targetHostId =
-      auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-    if (auth.tokenType === "zero" && !targetHostId) {
+      auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+    if (auth.tokenType === "agent" && !targetHostId) {
       return computerUseHostNotAuthorized;
     }
 
@@ -363,7 +363,7 @@ const pluginCommandCreateInner$ = command(
                 arguments: bodyResult.data.arguments,
               },
         timeoutMs: bodyResult.data.timeoutMs,
-        ...(auth.tokenType === "zero"
+        ...(auth.tokenType === "agent"
           ? { runId: auth.runId, targetHostId }
           : {}),
       },
@@ -395,8 +395,9 @@ const commandGetParams$ = pathParamsOf(computerUseCommandContract.get);
 const commandGetInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const params = get(commandGetParams$);
-  const hostId = auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-  if (auth.tokenType === "zero" && !hostId) {
+  const hostId =
+    auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+  if (auth.tokenType === "agent" && !hostId) {
     return computerUseHostNotAuthorized;
   }
   const result = await set(
@@ -425,8 +426,8 @@ const screenshotGetInner$ = command(
     const auth = get(organizationAuthContext$);
     const params = get(screenshotGetParams$);
     const hostId =
-      auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-    if (auth.tokenType === "zero" && !hostId) {
+      auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+    if (auth.tokenType === "agent" && !hostId) {
       return computerUseHostNotAuthorized;
     }
     const screenshot = await set(
@@ -464,8 +465,8 @@ const pluginContentGetInner$ = command(
     const auth = get(organizationAuthContext$);
     const params = get(pluginContentGetParams$);
     const hostId =
-      auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
-    if (auth.tokenType === "zero" && !hostId) {
+      auth.tokenType === "agent" ? auth.computerUseHostId : undefined;
+    if (auth.tokenType === "agent" && !hostId) {
       return computerUseHostNotAuthorized;
     }
     const content = await set(

--- a/turbo/apps/api/src/signals/routes/connector-check.ts
+++ b/turbo/apps/api/src/signals/routes/connector-check.ts
@@ -31,7 +31,7 @@ const checkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
   if (
-    auth.tokenType === "zero" &&
+    auth.tokenType === "agent" &&
     !auth.capabilities.includes("agent-run:read")
   ) {
     return missingAgentRunReadCapability();
@@ -44,7 +44,7 @@ const checkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       orgId: auth.orgId,
       userId: auth.userId,
       stateSource:
-        auth.tokenType === "zero"
+        auth.tokenType === "agent"
           ? { kind: "run", runId: auth.runId }
           : { kind: "stored" },
     },

--- a/turbo/apps/api/src/signals/routes/feishu-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-connect.ts
@@ -86,7 +86,7 @@ const checkAppId$ = computed(async (get) => {
   }
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
@@ -107,7 +107,7 @@ const setup$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }

--- a/turbo/apps/api/src/signals/routes/goals.ts
+++ b/turbo/apps/api/src/signals/routes/goals.ts
@@ -38,21 +38,21 @@ const goalReadAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "goal:read",
-  accept: ["zero"],
+  accept: ["agent"],
 } as const;
 
 const goalAgentResultWriteAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "goal:agent-result:write",
-  accept: ["zero"],
+  accept: ["agent"],
 } as const;
 
 const goalUserControlWriteAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "goal:user-control:write",
-  accept: ["zero"],
+  accept: ["agent"],
 } as const;
 
 const sessionGoalUserControlWriteAuth = {
@@ -82,8 +82,8 @@ interface SessionGoalAuth {
 }
 
 function goalAuth(auth: AuthContext & { readonly orgId: string }): GoalAuth {
-  if (auth.tokenType !== "zero") {
-    throw new Error("Goal routes require zero token auth");
+  if (auth.tokenType !== "agent") {
+    throw new Error("Goal routes require agent token auth");
   }
   return {
     orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/routes/host.ts
+++ b/turbo/apps/api/src/signals/routes/host.ts
@@ -28,7 +28,7 @@ const prepareBody$ = bodyResultOf(hostContract.prepare);
 const prepareInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
 
   const bodyResult = await get(prepareBody$);
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -374,11 +374,11 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const runId =
-    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+    auth.tokenType === "agent" || auth.tokenType === "sandbox"
       ? auth.runId
       : undefined;
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const runImageModelDefault = await loadRunImageModelDefault(
     db,
     auth.orgId,

--- a/turbo/apps/api/src/signals/routes/image-recognition.ts
+++ b/turbo/apps/api/src/signals/routes/image-recognition.ts
@@ -11,7 +11,7 @@ const recognitionBody$ = bodyResultOf(imageRecognitionContract.recognize);
 
 const recognizeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "zero") {
+  if (auth.tokenType !== "agent") {
     throw new Error("Image recognition route requires run authentication");
   }
   const bodyResult = await get(recognitionBody$);
@@ -27,7 +27,7 @@ export const imageRecognitionRoutes: readonly RouteEntry[] = [
     route: imageRecognitionContract.recognize,
     handler: authRoute(
       {
-        accept: ["zero"],
+        accept: ["agent"],
         requireOrganization: true,
         missingOrganizationStatus: 401,
         requiredCapability: "image-recognition:write",

--- a/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
@@ -343,7 +343,7 @@ const sendAgentPhoneVerificationText$ = command(
 const startLink$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
 
   const bodyResult = await get(startLinkBody$);
   signal.throwIfAborted();
@@ -478,7 +478,7 @@ const connectAgentPhone$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const publicBrand =
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const bodyResult = await get(connectBody$);
     signal.throwIfAborted();
     if (!bodyResult.ok) {

--- a/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
@@ -408,7 +408,7 @@ const initUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       filename: bodyResult.data.filename,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
@@ -31,7 +31,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       filename: body.filename,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
@@ -31,7 +31,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       filename: body.filename,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/integrations-slack-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-upload-complete.ts
@@ -198,7 +198,7 @@ const completeDirectUpload$ = command(
 const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const runId =
     "runId" in auth && typeof auth.runId === "string" ? auth.runId : undefined;
 

--- a/turbo/apps/api/src/signals/routes/integrations-slack-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-upload-init.ts
@@ -66,7 +66,7 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         size: body.length,
         checksumSha256: body.canonical.checksumSha256,
         publicBrand:
-          auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+          auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
         destination: {
           channelId: body.canonical.channel,
           ...(body.canonical.threadTs

--- a/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
@@ -31,7 +31,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       filename: body.filename,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
@@ -311,7 +311,7 @@ const linkOfficialInner$ = command(
     signal: AbortSignal,
   ) => {
     const publicBrand =
-      args.auth.tokenType === "zero"
+      args.auth.tokenType === "agent"
         ? args.auth.publicBrand
         : get(publicBrand$);
     const config = getOfficialTelegramBotConfig();
@@ -427,7 +427,7 @@ const linkCustomWithTelegramAuth$ = command(
     signal: AbortSignal,
   ) => {
     const publicBrand =
-      args.auth.tokenType === "zero"
+      args.auth.tokenType === "agent"
         ? args.auth.publicBrand
         : get(publicBrand$);
     const telegramAuth = args.body.telegramAuth;
@@ -475,7 +475,7 @@ const linkCustomWithConnectSignature$ = command(
     signal: AbortSignal,
   ) => {
     const publicBrand =
-      args.auth.tokenType === "zero"
+      args.auth.tokenType === "agent"
         ? args.auth.publicBrand
         : get(publicBrand$);
     const connectSignature = args.body.connectSignature;

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
@@ -32,7 +32,7 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       filename,
       publicBrand:
-        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+        auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/mail.ts
+++ b/turbo/apps/api/src/signals/routes/mail.ts
@@ -75,7 +75,7 @@ const linkDraftBody$ = bodyResultOf(mailContract.linkDraft);
 const linkDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const bodyResult = await get(linkDraftBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -206,7 +206,7 @@ const mailDraftLinkAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "connector:read" as const,
-  accept: Object.freeze(["session", "zero"] as const),
+  accept: Object.freeze(["session", "agent"] as const),
 });
 
 const mailDraftHumanAuth = Object.freeze({

--- a/turbo/apps/api/src/signals/routes/mcp-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/mcp-connectors.ts
@@ -8,8 +8,8 @@ import { runMcpConnectorList } from "../services/run-mcp-connectors.service";
 
 const listRunMcpConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "zero") {
-    throw new Error("Run MCP connector route requires Zero authentication");
+  if (auth.tokenType !== "agent") {
+    throw new Error("Run MCP connector route requires agent authentication");
   }
   const connectors = await get(
     runMcpConnectorList({
@@ -26,7 +26,7 @@ export const mcpConnectorsRoutes: readonly RouteEntry[] = [
     route: mcpConnectorsContract.list,
     handler: authRoute(
       {
-        accept: ["zero"],
+        accept: ["agent"],
         requireOrganization: true,
         missingOrganizationStatus: 401,
         requiredCapability: "connector:read",

--- a/turbo/apps/api/src/signals/routes/strapi-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/strapi-integrations.ts
@@ -68,7 +68,7 @@ const list$ = computed(async (get) => {
       ...(await listStrapiIntegrations(get(db$), {
         orgId: auth.orgId,
         publicBrand:
-          auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+          auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
       })),
     ],
   };
@@ -94,7 +94,7 @@ const create$ = command(async ({ get, set }, signal: AbortSignal) => {
     name: bodyResult.data.name,
     baseUrl: bodyResult.data.baseUrl,
     publicBrand:
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
   });
   signal.throwIfAborted();
   if (result.kind === "bad_request") {
@@ -121,7 +121,7 @@ const revealSecret$ = computed(async (get) => {
     orgId: auth.orgId,
     integrationId: params.integrationId,
     publicBrand:
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
   });
   return secret
     ? { status: 200 as const, body: secret }

--- a/turbo/apps/api/src/signals/routes/translation.ts
+++ b/turbo/apps/api/src/signals/routes/translation.ts
@@ -11,7 +11,7 @@ const translationBody$ = bodyResultOf(translationContract.translate);
 
 const translateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "zero") {
+  if (auth.tokenType !== "agent") {
     throw new Error("Translation route requires run authentication");
   }
   const bodyResult = await get(translationBody$);
@@ -27,7 +27,7 @@ export const translationRoutes: readonly RouteEntry[] = [
     route: translationContract.translate,
     handler: authRoute(
       {
-        accept: ["zero"],
+        accept: ["agent"],
         requireOrganization: true,
         missingOrganizationStatus: 401,
         requiredCapability: "translation:write",

--- a/turbo/apps/api/src/signals/routes/uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-prepare.ts
@@ -59,7 +59,7 @@ const prepareUploadInner$ = command(
         userId: auth.userId,
         filename,
         publicBrand:
-          auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+          auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -67,7 +67,7 @@ function resolveGenerationPublicBrand(
   auth: AuthContext,
   requestPublicBrand: PublicBrand,
 ): PublicBrand {
-  return auth.tokenType === "zero" ? auth.publicBrand : requestPublicBrand;
+  return auth.tokenType === "agent" ? auth.publicBrand : requestPublicBrand;
 }
 
 async function loadRunVideoModel(
@@ -430,7 +430,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const runId =
-    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+    auth.tokenType === "agent" || auth.tokenType === "sandbox"
       ? auth.runId
       : undefined;
   const publicBrand = resolveGenerationPublicBrand(auth, get(publicBrand$));

--- a/turbo/apps/api/src/signals/routes/voice-io-speech.ts
+++ b/turbo/apps/api/src/signals/routes/voice-io-speech.ts
@@ -176,11 +176,11 @@ const postSpeechInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const runId =
-    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+    auth.tokenType === "agent" || auth.tokenType === "sandbox"
       ? auth.runId
       : undefined;
   const publicBrand =
-    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
+    auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const admission = await set(
     startRunBuiltInAdmission$,
     { runId, kind: "voice" },

--- a/turbo/apps/api/src/signals/routes/workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/workflow-automations.ts
@@ -156,7 +156,7 @@ const createAutomationInner$ = command(
 
     let autonomyBudget: number | undefined;
     const db = get(db$);
-    if (auth.tokenType === "zero") {
+    if (auth.tokenType === "agent") {
       const sourceAutonomyBudget = await loadOwnedRunAutonomyBudget(db, {
         runId: auth.runId,
         orgId: auth.orgId,
@@ -183,7 +183,7 @@ const createAutomationInner$ = command(
     const result = await set(
       createWorkflowAutomation$,
       { ...bodyResult.data, ...automationInputBase },
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
       signal,
     );
     signal.throwIfAborted();
@@ -223,7 +223,7 @@ const revealWebhookSecretInner$ = computed(async (get) => {
     member: memberFromAuth(auth),
     automationId: params.id,
     publicBrand:
-      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
+      auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$),
   });
   if (!secret) {
     return notFound("Workflow webhook automation not found");
@@ -293,7 +293,7 @@ const enableAutomationInner$ = command(
     const params = get(pathParamsOf(workflowAutomationsContract.enable));
     let inheritedAutonomyBudget: number | undefined;
     const db = get(db$);
-    if (auth.tokenType === "zero") {
+    if (auth.tokenType === "agent") {
       const sourceAutonomyBudget = await loadOwnedRunAutonomyBudget(db, {
         runId: auth.runId,
         orgId: auth.orgId,
@@ -360,7 +360,7 @@ const runAutomationInner$ = command(
         orgId: auth.orgId,
         member: memberFromAuth(auth),
         automationId: params.id,
-        ...(auth.tokenType === "zero" ? { sourceRunId: auth.runId } : {}),
+        ...(auth.tokenType === "agent" ? { sourceRunId: auth.runId } : {}),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -918,7 +918,7 @@ const copyWorkflowInner$ = command(
 
     const writeDb = set(writeDb$);
     let inheritedAutonomyBudget: number | undefined;
-    if (auth.tokenType === "zero") {
+    if (auth.tokenType === "agent") {
       const sourceAutonomyBudget = await loadOwnedRunAutonomyBudget(writeDb, {
         runId: auth.runId,
         orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/services/air-quality.service.ts
+++ b/turbo/apps/api/src/signals/services/air-quality.service.ts
@@ -88,7 +88,7 @@ function googleAirQualityErrorMessage(body: unknown): string {
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/banking.service.ts
+++ b/turbo/apps/api/src/signals/services/banking.service.ts
@@ -31,7 +31,7 @@ import {
 import { env } from "../../lib/env";
 import { singleton } from "../../lib/singleton";
 import { now, nowDate } from "../../lib/time";
-import type { ZeroAuthContext } from "../../types/auth";
+import type { AgentAuthContext } from "../../types/auth";
 import { type Db, writeDb$ } from "../external/db";
 import { safeJsonParse } from "../utils";
 
@@ -39,7 +39,7 @@ const APP_TOKEN_REFRESH_MS = 90 * 60 * 1000;
 const FINICITY_BASE_URL = "https://api.finicity.com";
 const PROVIDER = "finicity";
 
-type BankingAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
+type BankingAuth = Extract<AgentAuthContext, { readonly orgId: string }>;
 type BankingAccountRow = InferSelectModel<typeof bankingAccounts>;
 
 interface CachedFinicityAppToken {

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -270,7 +270,7 @@ interface PreparedNormalSend {
 function normalSendTriggerSource(
   auth: OrganizationAuthContext,
 ): "web" | "agent" {
-  return auth.tokenType === "zero" ? "agent" : "web";
+  return auth.tokenType === "agent" ? "agent" : "web";
 }
 
 async function resolveChatAgentRunSourceById(
@@ -331,7 +331,7 @@ async function resolveChatAgentRunSource(
   readonly annotation: ChatAgentRunSourceAnnotation | null;
   readonly autonomyBudget: number;
 } | null> {
-  if (auth.tokenType !== "zero") {
+  if (auth.tokenType !== "agent") {
     return null;
   }
   return await resolveChatAgentRunSourceById(db, auth, auth.runId);
@@ -361,7 +361,7 @@ async function resolveNormalSendAgentRunSource(params: {
   }
   if (params.sourceRunId !== undefined) {
     if (
-      params.auth.tokenType === "zero" ||
+      params.auth.tokenType === "agent" ||
       params.auth.tokenType === "sandbox"
     ) {
       return {
@@ -389,7 +389,7 @@ async function resolveNormalSendAgentRunSource(params: {
   }
   const resolved = await resolveChatAgentRunSource(params.db, params.auth);
   if (resolved === null) {
-    return params.auth.tokenType === "zero"
+    return params.auth.tokenType === "agent"
       ? { response: badRequestMessage("Agent source run not found") }
       : { source: null };
   }
@@ -2519,7 +2519,7 @@ function resolveTimedNormalSendAgentRunSource(
       normal_send_agent_run_source_kind:
         args.body.sourceRunId !== undefined
           ? "forward"
-          : args.auth.tokenType === "zero"
+          : args.auth.tokenType === "agent"
             ? "agent"
             : "none",
     },

--- a/turbo/apps/api/src/signals/services/finance.service.ts
+++ b/turbo/apps/api/src/signals/services/finance.service.ts
@@ -194,7 +194,7 @@ async function fetchApidojo(
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/image-recognition.service.ts
+++ b/turbo/apps/api/src/signals/services/image-recognition.service.ts
@@ -10,7 +10,7 @@ import {
 import { command } from "ccstate";
 
 import { insufficientCredits, notConfigured, notFound } from "../../lib/error";
-import type { ZeroAuthContext } from "../../types/auth";
+import type { AgentAuthContext } from "../../types/auth";
 import { requestSignal$ } from "../context/hono";
 import {
   generateTextWithUsage,
@@ -34,7 +34,7 @@ const IMAGE_RECOGNITION_MODEL = "xiaomi/mimo-v2.5";
 const IMAGE_RECOGNITION_OPERATION = "image-recognition";
 const IMAGE_RECOGNITION_MAX_TOKENS = 8192;
 
-type RecognitionAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
+type RecognitionAuth = Extract<AgentAuthContext, { readonly orgId: string }>;
 
 interface RecognitionArgs {
   readonly auth: RecognitionAuth;

--- a/turbo/apps/api/src/signals/services/maps-osm.service.ts
+++ b/turbo/apps/api/src/signals/services/maps-osm.service.ts
@@ -365,7 +365,7 @@ function toGeoJson(features: readonly OsmFeature[]): GeoJsonFeatureCollection {
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/maps.service.ts
+++ b/turbo/apps/api/src/signals/services/maps.service.ts
@@ -287,7 +287,7 @@ function placeDetailsBillingCategory(fields: PlaceDetailFieldset): string {
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/people-search.service.ts
+++ b/turbo/apps/api/src/signals/services/people-search.service.ts
@@ -649,7 +649,7 @@ function normalizeProfiles(
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/scrape.service.ts
+++ b/turbo/apps/api/src/signals/services/scrape.service.ts
@@ -182,7 +182,7 @@ function boundedFirecrawlErrorMessage(message: string): string {
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/seo.service.ts
+++ b/turbo/apps/api/src/signals/services/seo.service.ts
@@ -570,7 +570,7 @@ async function fetchDataForSeo(
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -294,7 +294,7 @@ function providerResult(
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/translation.service.ts
+++ b/turbo/apps/api/src/signals/services/translation.service.ts
@@ -8,7 +8,7 @@ import {
 import { command } from "ccstate";
 
 import { insufficientCredits, notConfigured } from "../../lib/error";
-import type { ZeroAuthContext } from "../../types/auth";
+import type { AgentAuthContext } from "../../types/auth";
 import { requestSignal$ } from "../context/hono";
 import {
   generateTextWithUsage,
@@ -35,7 +35,7 @@ const TRANSLATION_SYSTEM_PROMPT = [
   "Return only the translated text with no explanation, labels, quotation marks, or commentary.",
 ].join("\n");
 
-type TranslationAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
+type TranslationAuth = Extract<AgentAuthContext, { readonly orgId: string }>;
 
 interface TranslationArgs {
   readonly auth: TranslationAuth;

--- a/turbo/apps/api/src/signals/services/weather.service.ts
+++ b/turbo/apps/api/src/signals/services/weather.service.ts
@@ -169,7 +169,7 @@ function googleWeatherUrl(
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/web-search.service.ts
+++ b/turbo/apps/api/src/signals/services/web-search.service.ts
@@ -156,7 +156,7 @@ function perplexityErrorMessage(body: unknown): string {
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
-  return auth.tokenType === "zero" || auth.tokenType === "sandbox"
+  return auth.tokenType === "agent" || auth.tokenType === "sandbox"
     ? auth.runId
     : undefined;
 }

--- a/turbo/apps/api/src/types/auth.ts
+++ b/turbo/apps/api/src/types/auth.ts
@@ -39,9 +39,9 @@ interface SandboxAuthContext {
   readonly runId: string;
 }
 
-export type ZeroAuthContext =
+export type AgentAuthContext =
   | {
-      readonly tokenType: "zero";
+      readonly tokenType: "agent";
       readonly userId: string;
       readonly orgId: string;
       readonly orgRole?: ApiOrgRole;
@@ -51,7 +51,7 @@ export type ZeroAuthContext =
       readonly computerUseHostId?: string;
     }
   | {
-      readonly tokenType: "zero";
+      readonly tokenType: "agent";
       readonly userId: string;
       readonly runId: string;
       readonly publicBrand: PublicBrand;
@@ -64,7 +64,7 @@ export type AuthContext =
   | SessionAuthContext
   | PatAuthContext
   | SandboxAuthContext
-  | ZeroAuthContext;
+  | AgentAuthContext;
 
 export type AuthTokenType = AuthContext["tokenType"];
 
@@ -79,7 +79,7 @@ export interface SandboxAuth {
   readonly orgId: string;
 }
 
-export interface ZeroAuth {
+export interface AgentAuth {
   readonly userId: string;
   readonly runId: string;
   readonly orgId: string;


### PR DESCRIPTION
Closes #28746. Part of #26873 / #27432.

## What

`tokenType: "zero"` was the only value in the auth-context union named after a brand rather than after the principal the token represents. `session` is a signed-in person, `pat` is a person on the command line, `sandbox` is the infrastructure itself — and the fourth value is the agent inside a run. This renames it to `"agent"` along with the types it travels with.

| From | To |
|---|---|
| `tokenType: "zero"` | `tokenType: "agent"` |
| `tokenType === / !== "zero"` | `=== / !== "agent"` |
| `accept: ["zero", …]` | `accept: ["agent", …]` |
| `ZeroAuthContext` | `AgentAuthContext` |
| `ZeroAuth` | `AgentAuth` |
| `zeroAuth` / `zeroAuth$` | `agentAuth` / `agentAuth$` |

Two internal guard messages that named the token type were updated with it (`goals.ts`, `mcp-connectors.ts`).

The codebase was already translating the value to express its meaning:

```ts
// services/chat-events.command.ts
function normalSendTriggerSource(auth): "web" | "agent" {
  return auth.tokenType === "zero" ? "agent" : "web";
}
```

That line now reads `auth.tokenType === "agent" ? "agent" : "web"` and the translation is gone.

## Scope

50 files, all under `apps/api`. Nothing outside that app references these symbols, so the change does not cross a package boundary.

## Not touched

- The JWT `scope: "okou"` in `auth/tokens.ts` — a wire value on a different layer, settled by #28695
- `verifyOkouToken` / `generateOkouToken` / the `OkouToken*` types — settled by #28695
- The retired `zero` JWT scope (`RetiredZeroScopePayload`), which exists only so verification tests can prove a legacy token is rejected
- `sandbox`, `pat`, `session`
- `zeroAgents` / `zero_agents` — owned by a separate EPIC

## Persistence check

Verified independently rather than taken from the issue: `tokenType` is a pure in-memory discriminant. Every reference in `turbo/` is either a construction in `auth-context.ts`, a comparison, an `accept` list on route auth options, or the `/health/auth` probe response. It is never written to the database, never logged, and never emitted as a telemetry dimension. The `token_type` field in `vm0-sandbox-op-log-prod` is the unrelated OAuth `"Bearer"` literal.

The one place the value reaches a response body is the `/health/auth` probe, whose only consumers in the repo are API tests — no CLI, runner, or frontend client reads it, so there is no cross-version deployment concern.

## Verification

- `pnpm -F api check-types` — clean. The union type makes the type checker the proof that no `"zero"` token-type literal survives anywhere in `apps/api`.
- `pnpm -F api lint` — clean (warnings are pre-existing and in untouched files)
- `pnpm format` — clean
- `pnpm knip --workspace apps/api` — the single reported unused export is pre-existing on `main` (confirmed by stashing this branch)
- `grep` over `turbo/` finds no remaining `tokenType: "zero"`, `ZeroAuth`, `ZeroAuthContext` or `zeroAuth` identifier

Behaviour is unchanged: every endpoint that accepted a `zero`-typed context accepts an `agent`-typed one with the same capability checks, and `normalSendTriggerSource` still returns `"agent"` for an agent token and `"web"` otherwise. Test suites run in the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)