### PR TITLE
fix(platform): use semantic icons for debug diagnostics

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -3,7 +3,7 @@ import type {
   ConnectorCatalogDiagnostics,
   ConnectorCatalogSyncFailureCode,
 } from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
-import { ChevronDown, ChevronUp, Database } from "lucide-react";
+import { ChevronDown, ChevronUp, Plug } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -230,7 +230,7 @@ function CatalogDiagnosticsSummary({
   return (
     <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-        <Database size={22} className="text-muted-foreground" />
+        <Plug size={22} className="text-muted-foreground" />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-2">
         <span
@@ -577,7 +577,7 @@ export function ConnectorCatalogDiagnosticsBlock() {
         <div className="flex items-start gap-4 p-4">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Database size={22} className="text-muted-foreground" />
+              <Plug size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/managed-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/managed-model-cooldown-diagnostics-block.tsx
@@ -1,7 +1,7 @@
 import type { ManagedModelCooldownDiagnostics } from "@okouai/api-contracts/contracts/model-provider-routes";
 import { Button } from "@okouai/ui/components/ui/button";
 import { useLastResolved, useLoadableState, useSet } from "ccstate-react";
-import { ChevronDown, ChevronUp, Database, RefreshCw } from "lucide-react";
+import { ChevronDown, ChevronUp, Cpu, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
@@ -20,7 +20,7 @@ function CooldownDiagnosticsSummary({
   return (
     <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-        <Database size={22} className="text-muted-foreground" />
+        <Cpu size={22} className="text-muted-foreground" />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-2">
         <span
@@ -214,7 +214,7 @@ export function ManagedModelCooldownDiagnosticsBlock() {
         <div className="flex items-start gap-4 p-4">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Database size={22} className="text-muted-foreground" />
+              <Cpu size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-3">


### PR DESCRIPTION
## Summary

- use the existing connector `Plug` icon for Connector catalog diagnostics
- use the existing model `Cpu` icon for Managed model fallback diagnostics
- keep icons consistent across loaded, loading, and unavailable states

## Scope

This is a visual-only change. It does not change diagnostics behavior, data, or fallback routing.

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx`
