### PR TITLE
fix(platform): label unmatched endpoints as other endpoints

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "Berechtigungen aktualisiert"
       },
       "saving": "Speichern...",
-      "unknownEndpoints": "Unbekannte Endpunkte",
       "userFallback": "Dort",
       "wouldLike": "Würde gerne"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "Läuft in {{count}} Stunde ab",
       "expiresInHours_other": "Läuft in {{count}} Stunden ab",
       "loadFailed": "Berechtigungsstatus konnte nicht geladen werden",
+      "otherEndpoints": "andere Endpunkte",
       "unknown": "Unbekannte Berechtigung",
       "updated": "Berechtigungen aktualisiert",
       "updateFailed": "Berechtigungen konnten nicht aktualisiert werden"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "Permissions updated"
       },
       "saving": "Saving...",
-      "unknownEndpoints": "Unknown endpoints",
       "userFallback": "there",
       "wouldLike": "Would like to"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "Expires in {{count}} hour",
       "expiresInHours_other": "Expires in {{count}} hours",
       "loadFailed": "Couldn't load permission status",
+      "otherEndpoints": "other endpoints",
       "unknown": "Unknown permission",
       "updated": "Permissions updated",
       "updateFailed": "Couldn't update permissions"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1108,7 +1108,6 @@
         "updatedTitle": "Permisos actualizados"
       },
       "saving": "Guardando...",
-      "unknownEndpoints": "Endpoints desconocidos",
       "userFallback": "Ahí",
       "wouldLike": "Me gustaría"
     }
@@ -1883,6 +1882,7 @@
       "expiresInHours_many": "Caduca en {{count}} horas",
       "expiresInHours_other": "Caduca en {{count}} horas",
       "loadFailed": "No se pudo cargar el estado de los permisos",
+      "otherEndpoints": "otros endpoints",
       "unknown": "Permiso desconocido",
       "updated": "Permisos actualizados",
       "updateFailed": "No se pudieron actualizar los permisos"

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1108,7 +1108,6 @@
         "updatedTitle": "Autorisations mises à jour"
       },
       "saving": "Enregistrement...",
-      "unknownEndpoints": "Points de terminaison inconnus",
       "userFallback": "là",
       "wouldLike": "Souhaite"
     }
@@ -1883,6 +1882,7 @@
       "expiresInHours_many": "Expire dans {{count}} heures",
       "expiresInHours_other": "Expire dans {{count}} heures",
       "loadFailed": "Impossible de charger le statut de la permission",
+      "otherEndpoints": "autres points de terminaison",
       "unknown": "Permission inconnue",
       "updated": "Permissions mises à jour",
       "updateFailed": "Impossible de mettre à jour les permissions"

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "अनुमतियाँ अद्यतन की गईं"
       },
       "saving": "सहेजा जा रहा है...",
-      "unknownEndpoints": "अज्ञात समापनबिंदु",
       "userFallback": "वहाँ",
       "wouldLike": "करना चाहेंगे"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "{{count}} घंटे में समाप्त होता है",
       "expiresInHours_other": "{{count}} घंटे में समाप्त होता है",
       "loadFailed": "अनुमति स्थिति लोड नहीं की जा सकी",
+      "otherEndpoints": "अन्य समापन बिंदु",
       "unknown": "अज्ञात अनुमति",
       "updated": "अनुमतियाँ अद्यतन की गईं",
       "updateFailed": "अनुमतियाँ अपडेट नहीं की जा सकीं"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "Izin diperbarui"
       },
       "saving": "Menyimpan...",
-      "unknownEndpoints": "Endpoint tidak dikenal",
       "userFallback": "di sana",
       "wouldLike": "Ingin"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "Kedaluwarsa dalam {{count}} jam",
       "expiresInHours_other": "Kedaluwarsa dalam {{count}} jam",
       "loadFailed": "Tidak dapat memuat status izin",
+      "otherEndpoints": "endpoint lainnya",
       "unknown": "Izin tidak dikenal",
       "updated": "Izin diperbarui",
       "updateFailed": "Tidak dapat memperbarui izin"

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1108,7 +1108,6 @@
         "updatedTitle": "Autorizzazioni aggiornate"
       },
       "saving": "Salvataggio...",
-      "unknownEndpoints": "Endpoint sconosciuti",
       "userFallback": "lì",
       "wouldLike": "Mi piacerebbe"
     }
@@ -1883,6 +1882,7 @@
       "expiresInHours_many": "Scade tra {{count}} ore",
       "expiresInHours_other": "Scade tra {{count}} ore",
       "loadFailed": "Impossibile caricare lo stato dell'autorizzazione",
+      "otherEndpoints": "altri endpoint",
       "unknown": "Autorizzazione sconosciuta",
       "updated": "Autorizzazioni aggiornate",
       "updateFailed": "Impossibile aggiornare le autorizzazioni"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "権限が更新されました"
       },
       "saving": "保存中...",
-      "unknownEndpoints": "不明なエンドポイント",
       "userFallback": "そこに",
       "wouldLike": "したいです"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "{{count}} 時間後に期限切れになります",
       "expiresInHours_other": "{{count}} 時間で期限切れになります",
       "loadFailed": "権限ステータスを読み込めませんでした",
+      "otherEndpoints": "その他のエンドポイント",
       "unknown": "不明な権限",
       "updated": "権限が更新されました",
       "updateFailed": "権限を更新できませんでした"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1088,7 +1088,6 @@
         "updatedTitle": "권한이 업데이트되었습니다"
       },
       "saving": "저장 중...",
-      "unknownEndpoints": "알 수 없는 엔드포인트",
       "userFallback": "거기",
       "wouldLike": "원합니다"
     }
@@ -1851,6 +1850,7 @@
       "expiresInHours_one": "{{count}}시간 후 만료",
       "expiresInHours_other": "{{count}}시간 후 만료",
       "loadFailed": "권한 상태를 불러올 수 없습니다",
+      "otherEndpoints": "기타 엔드포인트",
       "unknown": "알 수 없는 권한",
       "updated": "권한이 업데이트되었습니다",
       "updateFailed": "권한을 업데이트할 수 없습니다"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1108,7 +1108,6 @@
         "updatedTitle": "Permissões atualizadas"
       },
       "saving": "Salvando...",
-      "unknownEndpoints": "Endpoints desconhecidos",
       "userFallback": "você",
       "wouldLike": "Gostaria de"
     }
@@ -1883,6 +1882,7 @@
       "expiresInHours_many": "Expira em {{count}} horas",
       "expiresInHours_other": "Expira em {{count}} horas",
       "loadFailed": "Não foi possível carregar o status da permissão",
+      "otherEndpoints": "outros endpoints",
       "unknown": "Permissão desconhecida",
       "updated": "Permissões atualizadas",
       "updateFailed": "Não foi possível atualizar as permissões"

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -88,7 +88,7 @@ export function findPermissionInMetadata(
     return {
       name: UNKNOWN_PERMISSION_GRANT,
       description: i18n.t(($) => {
-        return $.authorization.permission.unknownEndpoints;
+        return $.connectors.permissions.otherEndpoints;
       }),
     };
   }

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -666,8 +666,10 @@ describe("permission allow page", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Cloudflare")).toBeInTheDocument();
-    expect(screen.getByText("Unknown endpoints")).toBeInTheDocument();
-    expect(screen.getByText(UNKNOWN_PERMISSION_GRANT)).toBeInTheDocument();
+    expect(screen.getByText("Other endpoints")).toBeInTheDocument();
+    expect(
+      screen.queryByText(UNKNOWN_PERMISSION_GRANT),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByText("Confirm"));
 

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@okouai/ui";
 import { AlertTriangle, Ban, Check, Loader2 } from "lucide-react";
 import type { UserPermissionGrantExpiresIn } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
+import { UNKNOWN_PERMISSION_GRANT } from "@okouai/connectors/firewall-types";
 import type {
   PlatformConnectorPermissionMetadata,
   PlatformUserPermissionGrant,
@@ -131,9 +132,11 @@ function ConnectorPermissionCard({
           <span className="min-w-0 flex-1 text-sm text-foreground truncate">
             {permission.description ?? permission.name}
           </span>
-          <code className="shrink-0 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-sky-700">
-            {permission.name}
-          </code>
+          {permission.name !== UNKNOWN_PERMISSION_GRANT && (
+            <code className="shrink-0 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-sky-700">
+              {permission.name}
+            </code>
+          )}
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -4312,7 +4312,7 @@ describe("chat event action cards", () => {
         within(permissionCard).getByText("Cloudflare permissions"),
       ).toBeInTheDocument();
       expect(
-        within(permissionCard).getByText(`Allow ${UNKNOWN_PERMISSION_GRANT}`),
+        within(permissionCard).getByText("Allow other endpoints"),
       ).toBeInTheDocument();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
@@ -39,7 +39,10 @@ import { ArtifactThumbnailImage } from "./zero-artifact-thumbnail.tsx";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { publicAttachmentUrl } from "./zero-attachment-url";
 import type { UserPermissionGrantExpiresIn } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
-import type { FirewallPolicyValue } from "@okouai/connectors/firewall-types";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicyValue,
+} from "@okouai/connectors/firewall-types";
 import { r2ImageTransformUrl } from "@okouai/core";
 import { Skeleton, cn } from "@okouai/ui";
 import {
@@ -663,6 +666,19 @@ function permissionActionVerb(action: PermissionAction): string {
     : i18n.t(($) => {
         return $.chat.permissions.deny;
       });
+}
+
+function permissionActionPermissionLabel(
+  permission: { name: string } | undefined,
+  fallback: string,
+): string {
+  const permissionName = permission?.name ?? fallback;
+  if (permissionName === UNKNOWN_PERMISSION_GRANT) {
+    return i18n.t(($) => {
+      return $.chat.permissions.otherEndpoints;
+    });
+  }
+  return permissionName;
 }
 
 function permissionActionStatusText(
@@ -1314,7 +1330,10 @@ function PermissionActionCardForTarget({
       icon={permissionMetadata?.icon}
       connectorLabel={permissionMetadata?.label ?? signals.connectorSlug}
       actionLabel={actionState.actionLabel}
-      permissionName={actionState.focusedPermission?.name ?? signals.permission}
+      permissionName={permissionActionPermissionLabel(
+        actionState.focusedPermission,
+        signals.permission,
+      )}
       status={actionState.status}
       expirationAvailable={expirationAvailable}
       expiresIn={expiresIn}


### PR DESCRIPTION
## Summary

- Render the unknown-endpoint grant sentinel as localized `other endpoints` copy in permission action cards, including before permission metadata is available.
- Reuse the existing `Other endpoints` label on the dedicated permission confirmation page and hide the internal `__unknown__` badge there.
- Preserve the internal grant value and update targeted tests for both user-facing surfaces.

## Exclusions

- No changes to firewall matching, `unknownPolicy` behavior, authentication injection, or persisted grant values.
- Named permission labels and grant behavior are unchanged.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/permission-allow/__tests__/permission-allow-page.test.tsx` (13 tests)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx` (47 tests)

Closes #28756
