### PR TITLE
refactor(auth): rename the remaining zero capability helpers

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -58,7 +58,7 @@ const sandboxTokenPayloadSchema = jwtBaseSchema.extend({
   orgId: z.string().min(1),
 });
 
-function isZeroCapability(value: string): value is Capability {
+function isAgentCapability(value: string): value is Capability {
   return CAPABILITIES.some((capability) => {
     return capability === value;
   });
@@ -67,10 +67,10 @@ function isZeroCapability(value: string): value is Capability {
 // Capability names are open-ended at the token boundary so tokens issued by a
 // newer API remain valid on an older API. The validated output remains closed
 // to known capabilities so unknown names cannot grant permissions.
-const zeroCapabilitiesSchema = z
+const agentCapabilitiesSchema = z
   .array(z.string().min(1))
   .transform((capabilities) => {
-    return capabilities.filter(isZeroCapability);
+    return capabilities.filter(isAgentCapability);
   })
   .readonly();
 
@@ -78,7 +78,7 @@ const okouTokenPayloadSchema = jwtBaseSchema.extend({
   scope: z.literal("okou"),
   runId: z.string().min(1),
   orgId: z.string().min(1),
-  capabilities: zeroCapabilitiesSchema,
+  capabilities: agentCapabilitiesSchema,
   // The public brand is presentation-only. Tokens from before this claim and
   // intentionally unbranded callers keep the permanent VM0 presentation.
   publicBrand: publicBrandSchema.optional(),
@@ -141,7 +141,7 @@ function featureSwitchForCapability(
   })?.[1];
 }
 
-function isZeroCapabilityEnabled(
+function isAgentCapabilityEnabled(
   capability: Capability,
   userId: string,
   orgId: string,
@@ -360,7 +360,7 @@ function buildOkouTokenClaims(
     if (!isCapabilityAvailableToAgent(capability, options)) {
       continue;
     }
-    if (isZeroCapabilityEnabled(capability, userId, orgId, overrides)) {
+    if (isAgentCapabilityEnabled(capability, userId, orgId, overrides)) {
       capabilities.push(capability);
     }
   }


### PR DESCRIPTION
Closes #28761. Part of #26873 / #27432.

## What

Three module-private helpers in `apps/api/src/signals/auth/tokens.ts` still carried the `Zero` prefix after the surrounding vocabulary moved on:

| From | To |
|---|---|
| `isZeroCapability` | `isAgentCapability` |
| `zeroCapabilitiesSchema` | `agentCapabilitiesSchema` |
| `isZeroCapabilityEnabled` | `isAgentCapabilityEnabled` |

Six occurrences, all in that one file.

## Why `agent` and not `okou`

These name capabilities carried by the agent token, whose auth-context discriminant #28755 settled as `tokenType: "agent"`. The `Okou` prefix on the sibling symbols (`okouTokenPayloadSchema`, `OkouTokenOptions`, `generateOkouToken`, …) refers to the JWT wire scope that #28695 settled — a different layer, left untouched.

## Out of scope

- `scope: z.literal("okou")` and every `OkouToken*` symbol are unchanged.
- The `Capability` type and the capability string values are unchanged.
- `CONDITIONAL_CAPABILITIES` and the feature-switch lookup behaviour are unchanged.

## Verification

Pure rename, no behaviour change. The issue's acceptance criteria are already covered by existing tests in `apps/api/src/signals/auth/__tests__/tokens.test.ts`:

- capability filtering still drops unknown names at the token boundary — `ignores unknown run capabilities while preserving known capabilities`
- conditional capabilities still resolve through their feature switches — `gates banking capability behind the banking feature switch`, `gates social capability behind the managed SocialKit feature switch`

`grep -rn 'isZeroCapability\|zeroCapabilitiesSchema\|isZeroCapabilityEnabled' turbo/` returns nothing. Formatting checked with the lockfile-pinned prettier 3.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)