### PR TITLE
feat(core): roll out usage pack plans

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -11,6 +12,7 @@ import {
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { manualHttpCustomConnectorCreateBody } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 
 /*
 helper gap:
@@ -37,6 +39,17 @@ function shortId(): string {
 
 function slug(prefix: string): string {
   return `${prefix}-${shortId()}`;
+}
+
+async function disableUsagePackPlans(actor: ApiTestUser): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped actor");
+  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...actor, orgId: actor.orgId },
+    { [FeatureSwitchKey.UsagePackPlans]: false },
+  );
 }
 
 async function onboardAdmin(
@@ -233,6 +246,7 @@ describe("ORG-01 and ORG-02", () => {
   it("projects direct invitation redirects by request brand", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const admin = api.user();
+    await disableUsagePackPlans(admin);
 
     const vm0Email = `vm0-invite-${shortId()}@example.test`;
     context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
@@ -267,6 +281,7 @@ describe("ORG-01 and ORG-02", () => {
 
   it("reads, updates, lists, invites, changes membership, handles requests, and leaves orgs through APIs", async () => {
     const admin = api.user();
+    await disableUsagePackPlans(admin);
     const member = api.user({
       orgId: admin.orgId,
       orgRole: "org:member",

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -345,6 +345,14 @@ function authenticateOrg(
   mocks.clerk.session(fixture.userId, fixture.orgId, role);
 }
 
+async function disableUsagePackPlans(
+  fixture: BillingOrgFixture,
+): Promise<void> {
+  await updateFeatureSwitchesForUser(context, fixture, {
+    [FeatureSwitchKey.UsagePackPlans]: false,
+  });
+}
+
 function mockClerkOrganization(fixture: BillingOrgFixture): void {
   context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
     id: fixture.orgId,
@@ -2286,6 +2294,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
   it("keeps the usage pack catalog behind the same feature switch", async () => {
     const fixture = createOrgFixture();
     authenticateOrg(fixture);
+    await disableUsagePackPlans(fixture);
 
     const response = await accept(
       setupApp({ context, routes: billingCheckoutRoutes })(
@@ -2358,6 +2367,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
   it("keeps usage pack checkout behind its feature switch", async () => {
     const fixture = createOrgFixture();
     authenticateOrg(fixture);
+    await disableUsagePackPlans(fixture);
     const before = await readUsagePackState(fixture.orgId);
 
     const response = await accept(
@@ -5080,6 +5090,7 @@ describe("legacy subscription usage pack migration", () => {
       orgId: `org_non_staff_${randomUUID()}`,
     });
     expect(isStaffOrg(fixture.orgId)).toBeFalsy();
+    await disableUsagePackPlans(fixture);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       legacyMigrationSubscription(fixture),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
@@ -153,6 +153,10 @@ function registerCleanup(
 describe("GET /api/billing/usage-pack-credits", () => {
   it("keeps member usage pack credits behind UsagePackPlans", async () => {
     const actor = fixture();
+    registerCleanup(actor);
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.UsagePackPlans]: false,
+    });
     authenticate(actor);
 
     const response = await accept(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -1968,7 +1968,11 @@ describe("chat composer models", () => {
     ]);
     mockAgent();
 
-    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: false },
+    });
 
     await expectComposerModel("DeepSeek V4 Flash");
     await user.click(await findComposerModel("DeepSeek V4 Flash"));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fill } from "../../../__tests__/page-helper.ts";
 import {
   mockChatLifecycle,
@@ -27,6 +28,8 @@ import {
   chatComposerTextarea,
 } from "./chat-lifecycle-test-helpers.ts";
 import { billingStatus } from "./chat-composer-test-helpers.ts";
+
+const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function computerUseRow(switchName: string): HTMLElement {
   const row = screen
@@ -1444,7 +1447,11 @@ describe("chat lifecycle", () => {
       );
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: LEGACY_PRICING,
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
@@ -1494,7 +1501,11 @@ describe("chat lifecycle", () => {
       });
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: LEGACY_PRICING,
+    });
 
     const voiceInput = await screen.findByLabelText("Voice input");
     expect(voiceInput).toBeEnabled();
@@ -1555,7 +1566,11 @@ describe("chat lifecycle", () => {
     });
     mockChatLifecycle(context, { threadId });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: LEGACY_PRICING,
+    });
 
     await user.click(await screen.findByLabelText("Voice input"));
 
@@ -1653,7 +1668,11 @@ describe("chat lifecycle", () => {
       );
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: LEGACY_PRICING,
+    });
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -33,6 +33,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
+const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function queryButtonByText(
   text: string,
@@ -271,7 +272,11 @@ async function openBillingTab(
   path = "/?settings=billing",
   featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
 ): Promise<void> {
-  detachedSetupPage({ context, path, featureSwitches });
+  detachedSetupPage({
+    context,
+    path,
+    featureSwitches: { ...LEGACY_PRICING, ...featureSwitches },
+  });
   await waitFor(() => {
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
@@ -347,6 +352,7 @@ describe("organization billing settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=billing",
+      featureSwitches: LEGACY_PRICING,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -24,6 +24,7 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function buttonByText(
   text: string,
@@ -347,10 +348,11 @@ function mockUsagePackCatalog(): void {
   });
 }
 
-async function openMembersTab(heading = "People"): Promise<void> {
+async function openLegacyMembersTab(heading = "People"): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=people",
+    featureSwitches: LEGACY_PRICING,
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -369,7 +371,7 @@ function rowByEmail(email: string): HTMLElement {
 describe("organization members settings", () => {
   it("filters members and sends an invitation", async () => {
     mockMembersStory();
-    await openMembersTab();
+    await openLegacyMembersTab();
 
     expect(screen.getByText("Alice Admin")).toBeInTheDocument();
     expect(screen.getByText("bob@example.com")).toBeInTheDocument();
@@ -869,7 +871,7 @@ describe("organization members settings", () => {
 
   it("accepts and rejects membership requests", async () => {
     mockMembersStory();
-    await openMembersTab();
+    await openLegacyMembersTab();
 
     await fill(screen.getByPlaceholderText("Search"), "carol");
     await waitFor(() => {
@@ -911,7 +913,7 @@ describe("organization members settings", () => {
 
   it("changes roles, removes a member, and lets an admin self-demote", async () => {
     mockMembersStory();
-    await openMembersTab();
+    await openLegacyMembersTab();
 
     click(screen.getByLabelText("Actions for bob@example.com"));
     click(menuItemByText("Make admin"));
@@ -1015,7 +1017,7 @@ describe("organization members settings", () => {
 
   it("cancels and confirms invitation revoke", async () => {
     mockMembersStory();
-    await openMembersTab();
+    await openLegacyMembersTab();
 
     await fill(screen.getByPlaceholderText("Search"), "pending");
     await waitFor(() => {
@@ -1059,7 +1061,7 @@ describe("organization members settings", () => {
       locale: "pt-BR",
       supportedLocales: ["en-US", "pt-BR"],
     });
-    await openMembersTab("Pessoas");
+    await openLegacyMembersTab("Pessoas");
 
     const settingsDialog = screen.getByRole("dialog", {
       name: "Configurações",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -15,6 +15,7 @@ import {
   type CreateModelProviderConnectionRequest,
   type ModelProviderConnectionResponse,
 } from "@okouai/api-contracts/contracts/model-provider-gateways";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -325,8 +326,16 @@ async function openProvidersTab(): Promise<void> {
   });
 }
 
-async function openModelSettings(): Promise<void> {
-  detachedSetupPage({ context, path: "/?settings=model" });
+async function openModelSettings(
+  usagePackPlansEnabled: boolean,
+): Promise<void> {
+  detachedSetupPage({
+    context,
+    path: "/?settings=model",
+    featureSwitches: {
+      [FeatureSwitchKey.UsagePackPlans]: usagePackPlansEnabled,
+    },
+  });
   await waitFor(() => {
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
@@ -917,7 +926,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openProvidersTab();
+    await openModelSettings(false);
 
     const defaultRow = screen.getByTestId("default-model-row");
     click(within(defaultRow).getByRole("combobox"));
@@ -941,7 +950,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings();
+    await openModelSettings(true);
 
     click(buttonByText("Add model"));
     const dialog = screen.getByRole("dialog", { name: "Add model" });
@@ -975,7 +984,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings();
+    await openModelSettings(false);
 
     click(buttonByText("Add model"));
     await selectDialogModel("Claude Opus 4.8");
@@ -1004,7 +1013,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings();
+    await openModelSettings(false);
 
     click(buttonByText("Add model"));
     const dialog = screen.getByRole("dialog", { name: "Add model" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-usage-tab.test.tsx
@@ -176,6 +176,7 @@ function mockUsageStory(): void {
 }
 
 const NEW_PRICING = { [FeatureSwitchKey.UsagePackPlans]: true } as const;
+const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 async function openCreditBalance(): Promise<void> {
   detachedSetupPage({
@@ -346,7 +347,11 @@ describe("organization usage settings", () => {
 
   it("keeps the usage records inside credit balance without the new pricing", async () => {
     mockUsageStory();
-    detachedSetupPage({ context, path: "/?settings=usage" });
+    detachedSetupPage({
+      context,
+      path: "/?settings=usage",
+      featureSwitches: LEGACY_PRICING,
+    });
 
     await waitFor(() => {
       expect(screen.getByText("3,750 / 5,000 credits")).toBeInTheDocument();
@@ -370,7 +375,11 @@ describe("organization usage settings", () => {
 
   it("falls back from the usage records deep link without the new pricing", async () => {
     mockUsageStory();
-    detachedSetupPage({ context, path: "/?settings=usage-records" });
+    detachedSetupPage({
+      context,
+      path: "/?settings=usage-records",
+      featureSwitches: LEGACY_PRICING,
+    });
 
     const heading = await screen.findByRole("heading", { name: "Preference" });
     expect(heading).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
@@ -385,7 +385,9 @@ describe("personal model providers settings", () => {
     context.mocks.data.personalModelProviders([]);
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: false });
 
-    await openModelSettings();
+    await openModelSettings("Models", {
+      [FeatureSwitchKey.UsagePackPlans]: false,
+    });
 
     const claudeCodeRow = await screen.findByTestId(
       "oauth-card-claude-code-oauth-token",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -272,9 +272,9 @@ async function openUsageSettings(
   detachedSetupPage({
     context,
     path: `/?settings=${section}`,
-    featureSwitches: usagePackPlansEnabled
-      ? { [FeatureSwitchKey.UsagePackPlans]: true }
-      : undefined,
+    featureSwitches: {
+      [FeatureSwitchKey.UsagePackPlans]: usagePackPlansEnabled,
+    },
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-deep-link-handoff.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-deep-link-handoff.test.tsx
@@ -2,6 +2,7 @@ import {
   teamContract,
   type TeamComposeItem,
 } from "@okouai/api-contracts/contracts/team";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -39,14 +40,12 @@ describe("settings deep-link handoff", () => {
     detachedSetupPage({
       context,
       path: "/?settings=billing&billingView=plans",
+      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await teamRequestStarted.promise;
     expect(
-      screen.queryByRole("dialog", { name: "Settings" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("heading", { name: "Compare plans" }),
+      screen.queryByRole("dialog", { name: "Choose a plan" }),
     ).not.toBeInTheDocument();
 
     releaseTeamRequest.resolve(undefined);
@@ -55,10 +54,7 @@ describe("settings deep-link handoff", () => {
       expect(pathname()).toBe(`/agents/${DEFAULT_AGENT.id}/chat`);
     });
     await expect(
-      screen.findByRole("dialog", { name: "Settings" }),
-    ).resolves.toBeInTheDocument();
-    await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("dialog", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -455,6 +455,7 @@ describe("zero sidebar account menu", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
       },
+      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: false },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -182,9 +182,11 @@ function mockCatalogItem({
   });
 }
 
-async function openMakePage(): Promise<void> {
+async function openMakePage(
+  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
+): Promise<void> {
   mockOnboardingNeeded();
-  detachedSetupPage({ context, path: "/onboarding" });
+  detachedSetupPage({ context, path: "/onboarding", featureSwitches });
   await expect(
     screen.findByRole("heading", {
       name: "What do you want to make first",
@@ -1168,7 +1170,7 @@ describe("onboarding flow", () => {
       return respond(200, { completed: true });
     });
 
-    await openMakePage();
+    await openMakePage({ [FeatureSwitchKey.UsagePackPlans]: false });
     chooseMakeOption("Video production");
 
     await expect(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -155,7 +155,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
   });
 
   it("should enable composer submit DOM reconciliation only for Bingjie", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -339,8 +339,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Show the new Pro and Team plan UI with required monthly usage packs.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `UsagePackPlans` for every organization
- remove the staff-only rollout restriction
- update the feature-switch rollout matrix for non-staff organizations

## Verification

- `corepack pnpm@10.33.4 exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `corepack pnpm@10.33.4 -F @okouai/core lint`
- `corepack pnpm@10.33.4 -F @okouai/core check-types`
- `corepack pnpm@10.33.4 -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (25 tests passed)
- `corepack pnpm@10.33.4 exec knip --workspace packages/core`
- `git diff --check`
