### PR TITLE
docs: drop dead apps/web paths from apps/api provenance comments

### DIFF
--- a/turbo/apps/api/src/lib/telegram-format.ts
+++ b/turbo/apps/api/src/lib/telegram-format.ts
@@ -16,7 +16,8 @@ export function escapeHtml(text: string): string {
 /**
  * Convert standard Markdown to Telegram-supported HTML subset.
  *
- * Supported conversions (mirrors apps/web/src/lib/zero/telegram/format.ts):
+ * Supported conversions (ported from the removed `apps/web` app; no
+ * upstream copy remains, so nothing here needs to be kept in sync):
  * - **bold** -> <b>bold</b>
  * - *italic* -> <i>italic</i>
  * - `code` -> <code>code</code>

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -44,8 +44,9 @@ function uniqueOrgUser(prefix: string): UserModelProviderFixture {
 }
 
 // ===========================================================================
-// JWT helpers ported inline from web's test file (apps/web/app/api/zero/me/
-// model-providers/__tests__/route.test.ts:417-466). Used by codex-oauth tests.
+// JWT helpers ported inline from the model-providers route test in the
+// removed `apps/web` app. That file no longer exists in the tree, so there
+// is nothing left to keep in sync. Used by codex-oauth tests.
 // ===========================================================================
 
 function base64UrlEncode(input: string): string {

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -254,7 +254,8 @@ export const recordHostedSiteArtifact$ = command(
  * run is linked to a thread. No-op when `runId` is undefined (ordinary
  * session callers without a run-scoped token).
  *
- * Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts.
+ * Verbatim port from the removed `apps/web` app; no upstream copy
+ * remains to keep in sync.
  * Idempotency contract is upsert on (runId, source, externalId).
  */
 export const recordWebUploadedFile$ = command(
@@ -355,9 +356,9 @@ interface RecordTelegramUploadedFileArgs {
  * run is linked to a thread. No-op when `runId` is undefined (sandbox
  * callers without a run-scoped token).
  *
- * Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts
- * scoped to the `"telegram"` source. Idempotency contract is upsert on
- * (runId, source, externalId).
+ * Verbatim port from the removed `apps/web` app, scoped to the
+ * `"telegram"` source; no upstream copy remains to keep in sync.
+ * Idempotency contract is upsert on (runId, source, externalId).
  */
 export const recordTelegramUploadedFile$ = command(
   async (


### PR DESCRIPTION
Closes #28772

## What

`turbo/apps/` contains only `api`, `cli`, `desktop`, `host-worker`, and `platform` — the `apps/web` application is gone. Four comments in `apps/api` still cited source files under `apps/web`:

| Location | Old text |
| --- | --- |
| `lib/telegram-format.ts:19` | `mirrors apps/web/src/lib/zero/telegram/format.ts` |
| `signals/services/run-uploaded-files.service.ts:257` | `Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts.` |
| `signals/services/run-uploaded-files.service.ts:358` | `Verbatim port of apps/web/src/lib/zero/uploads/run-uploaded-files.ts` |
| `signals/routes/__tests__/me-model-providers-upsert.test.ts:47` | `ported inline from web's test file (apps/web/app/api/zero/me/model-providers/__tests__/route.test.ts:417-466)` |

Each one asserted a **sync obligation against a tree that no longer exists**. A reader following the path finds nothing, and cannot tell whether the target moved, was renamed, or was deleted. The `zero` segment in those paths also made them look like brand residue to a `ZERO_` sweep, when they were really historical provenance.

## How

Kept the useful half — *this code was ported from somewhere else* — and dropped the unresolvable half, the file path. Each comment now says the source was the removed `apps/web` app and that no upstream copy remains to keep in sync.

Comment-only change. No function names, signatures, or behavior touched.

## ⚠️ Deliberately NOT changed: `turbo/scripts/rebuild-snapshots.ts:64`

```ts
const oldPath = fullPath.replace(
  "/packages/db/src/migrations/",
  "/apps/web/src/db/migrations/",
);
```

**This is live code, not a comment.** It rewrites a path to look up migration files at their *former* location in git history, and `apps/web/src/db/migrations/` genuinely existed there. Editing this string breaks the historical lookup and silently degrades snapshot rebuilds.

Flagging it explicitly so a future `apps/web` sweep does not delete it. The adjacent `/apps/api/src/db/migrations/` fallback on the same function is the same kind of historical literal. `turbo/.prettierignore:14` carries a matching historical path entry and was likewise left alone.

Other `apps/web` mentions under `apps/api` (in `integrations-agentphone.ts`, `one-time-products.ts`, `credit-usage.service.ts`, `billing-customer.service.ts`, `billing-checkout.service.ts`) name the app without citing a file path. They were out of scope per the issue and are untouched.

## Verification

No behavior tests apply.

- `grep -rn "apps/web/" turbo/` returns only `scripts/rebuild-snapshots.ts:64` and `.prettierignore:14` — both intentional historical lookups.
- `prettier --check` passes on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
