### PR TITLE
perf(api): attribute queued promotion lock contention

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6897,6 +6897,35 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(promoted.status).toBe("pending");
     const drained = await waitForRunQueueLength(api, actor, 0);
     expect(drained.body.queue).toHaveLength(0);
+    const promotionTimingEvents = [
+      "api_dispatch_queue_promotion_lock_wait",
+      "api_dispatch_queue_promotion_lock_held",
+    ].flatMap((actionType) => {
+      const events = sandboxOperationEventsForRunByAction(
+        third.runId,
+        actionType,
+      );
+      expect(events).toStrictEqual([
+        expect.objectContaining({
+          source: "api",
+          op_type: actionType,
+          sandbox_type: "runner",
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          dispatch_path: "direct",
+          span_kind: "nested",
+          activation_origin: "promotion",
+        }),
+      ]);
+      expect(Number(events[0]?.duration_ms)).toBeGreaterThanOrEqual(0);
+      return events;
+    });
+    expectApiDispatchTimingEventsNotToLeak(promotionTimingEvents, [
+      "queued run three",
+      agentId,
+    ]);
     const promotedStorageState = await readRunnerJobStorageState(
       context,
       third.runId,

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -206,6 +206,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_check_concurrency_limit"
   | "api_dispatch_concurrency_preflight_lock_wait"
   | "api_dispatch_concurrency_preflight_check"
+  | "api_dispatch_queue_promotion_lock_wait"
+  | "api_dispatch_queue_promotion_lock_held"
   | "api_dispatch_resolve_queue_first_admission"
   | "api_dispatch_claim_queue_first_message"
   | "api_dispatch_resolve_queue_first_claim_snapshot"

--- a/turbo/apps/api/src/signals/services/run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/run-queue.service.ts
@@ -107,12 +107,6 @@ type PromotionResult =
   | PromotedQueuedCandidateTransactionResult
   | PromoteQueuedCandidateNonPromotedResult;
 
-interface PromoteQueuedCandidateArgs {
-  readonly orgId: string;
-  readonly row: QueueCandidate;
-  readonly payload: QueuedRunnerJobPayload | null;
-}
-
 type PromoteQueuedCandidateResult =
   | {
       readonly status: "promoted";
@@ -254,34 +248,33 @@ async function loadDrainCandidates(
     .orderBy(agentRunQueue.createdAt);
 }
 
-async function promoteQueuedCandidate(
-  db: Db,
-  args: PromoteQueuedCandidateArgs,
-): Promise<PromoteQueuedCandidateResult> {
-  // Promotion can happen after the original create-run collector was flushed.
-  // Buffer its lock timings locally and carry them past the durable boundary.
-  const timing = new ApiDispatchTimingCollector();
-  const committed = await db.transaction(async (tx) => {
-    await timing.measure(
-      "api_dispatch_queue_promotion_lock_wait",
-      "nested",
-      async () => {
-        await tx.execute(
-          sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
-        );
-      },
-    );
-    const admissionLockHeldStartedAt = now();
-    return {
-      result: await promoteQueuedCandidateUnderLock(tx, args),
-      admissionLockHeldStartedAt,
-    };
-  });
+async function acquirePromotionAdmissionLock(
+  tx: DbTransaction,
+  orgId: string,
+  timing: ApiDispatchTimingCollector,
+): Promise<number> {
+  await timing.measure(
+    "api_dispatch_queue_promotion_lock_wait",
+    "nested",
+    async () => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+    },
+  );
+  return now();
+}
+
+function finalizePromoteQueuedCandidate(
+  timing: ApiDispatchTimingCollector,
+  committed: {
+    readonly result: PromotionResult;
+    readonly lockHeldAt: number;
+  },
+): PromoteQueuedCandidateResult {
   const transactionReturnedAt = now();
   timing.recordElapsed(
     "api_dispatch_queue_promotion_lock_held",
     "nested",
-    committed.admissionLockHeldStartedAt,
+    committed.lockHeldAt,
     transactionReturnedAt,
   );
   const result = committed.result;
@@ -303,118 +296,137 @@ async function promoteQueuedCandidate(
   };
 }
 
-async function promoteQueuedCandidateUnderLock(
-  tx: DbTransaction,
-  args: PromoteQueuedCandidateArgs,
-): Promise<PromotionResult> {
-  // The caller owns the organization advisory lock for this complete boundary.
-  const concurrency = await effectiveOrgConcurrencyState(tx, args.orgId);
-  if (concurrency.activeRunCount >= concurrency.limit) {
-    return { status: "full" };
-  }
-
-  const [lockedRun] = await tx
-    .select({ status: agentRuns.status })
-    .from(agentRuns)
-    .where(eq(agentRuns.id, args.row.runId))
-    .for("update");
-  if (!lockedRun) {
-    await tx
-      .delete(agentRunQueue)
-      .where(eq(agentRunQueue.runId, args.row.runId));
-    return { status: "removed-stale" };
-  }
-  if (lockedRun.status !== "queued") {
-    await tx
-      .delete(agentRunQueue)
-      .where(eq(agentRunQueue.runId, args.row.runId));
-    return { status: "removed-stale" };
-  }
-  if (args.row.runStatus !== "queued") {
-    return { status: "lost" };
-  }
-
-  const [queueRow] = await tx
-    .select({ runId: agentRunQueue.runId })
-    .from(agentRunQueue)
-    .where(
-      and(
-        eq(agentRunQueue.runId, args.row.runId),
-        eq(agentRunQueue.orgId, args.orgId),
-      ),
-    )
-    .limit(1);
-  if (!queueRow) {
-    return { status: "lost" };
-  }
-
-  if (args.payload === null) {
-    throw new Error(
-      `Queued run "${args.row.runId}" is missing its runner job payload`,
+async function promoteQueuedCandidate(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly row: QueueCandidate;
+    readonly payload: QueuedRunnerJobPayload | null;
+  },
+): Promise<PromoteQueuedCandidateResult> {
+  // Promotion may outlive the create-run collector, so buffer timing until commit.
+  const timing = new ApiDispatchTimingCollector();
+  const committed = await db.transaction(async (tx) => {
+    const lockHeldAt = await acquirePromotionAdmissionLock(
+      tx,
+      args.orgId,
+      timing,
     );
-  }
-  const payload = args.payload;
-  const runValues = {
-    status: "pending",
-    lastHeartbeatAt: nowDate(),
-    runnerGroup: payload.runnerGroup,
-  };
-  const [updated] = await tx
-    .update(agentRuns)
-    .set(runValues)
-    .where(
-      and(eq(agentRuns.id, args.row.runId), eq(agentRuns.status, "queued")),
-    )
-    .returning({ id: agentRuns.id });
-  if (!updated) {
-    return { status: "lost" };
-  }
+    const complete = (result: PromotionResult) => {
+      return { result, lockHeldAt };
+    };
+    const concurrency = await effectiveOrgConcurrencyState(tx, args.orgId);
+    if (concurrency.activeRunCount >= concurrency.limit) {
+      return complete({ status: "full" });
+    }
 
-  await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.row.runId));
+    const [lockedRun] = await tx
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.row.runId))
+      .for("update");
+    if (!lockedRun) {
+      await tx
+        .delete(agentRunQueue)
+        .where(eq(agentRunQueue.runId, args.row.runId));
+      return complete({ status: "removed-stale" });
+    }
+    if (lockedRun.status !== "queued") {
+      await tx
+        .delete(agentRunQueue)
+        .where(eq(agentRunQueue.runId, args.row.runId));
+      return complete({ status: "removed-stale" });
+    }
+    if (args.row.runStatus !== "queued") {
+      return complete({ status: "lost" });
+    }
 
-  const queueMarkerNotification = await revokeQueuedRunAssistantMarkers(tx, {
-    runId: args.row.runId,
-    userId: args.row.userId,
-  });
+    const [queueRow] = await tx
+      .select({ runId: agentRunQueue.runId })
+      .from(agentRunQueue)
+      .where(
+        and(
+          eq(agentRunQueue.runId, args.row.runId),
+          eq(agentRunQueue.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    if (!queueRow) {
+      return complete({ status: "lost" });
+    }
 
-  const runnerJob = await insertPromotedRunnerJob(tx, {
-    orgId: args.orgId,
-    runId: args.row.runId,
-    queuedAt: args.row.createdAt,
-    payload,
-  });
-  return {
-    status: "promoted",
-    queueMarkerNotification,
-    pendingActivation: {
-      apiStartTime: runnerJob.apiStartedAt,
-      chatThreadId: args.row.chatThreadId ?? undefined,
-      runnerNotification: {
-        runId: args.row.runId,
-        runnerGroup: payload.runnerGroup,
-        profile: runnerJob.profile,
-        reuseKey: payload.reuseKey,
-        cliAgentSessionId: payload.cliAgentSessionId,
-        historyGenerationRunId: payload.historyGenerationRunId,
-        createdAt: runnerJob.createdAt,
+    if (args.payload === null) {
+      throw new Error(
+        `Queued run "${args.row.runId}" is missing its runner job payload`,
+      );
+    }
+    const payload = args.payload;
+    const runValues = {
+      status: "pending",
+      lastHeartbeatAt: nowDate(),
+      runnerGroup: payload.runnerGroup,
+    };
+    const [updated] = await tx
+      .update(agentRuns)
+      .set(runValues)
+      .where(
+        and(eq(agentRuns.id, args.row.runId), eq(agentRuns.status, "queued")),
+      )
+      .returning({ id: agentRuns.id });
+    if (!updated) {
+      return complete({ status: "lost" });
+    }
+
+    await tx
+      .delete(agentRunQueue)
+      .where(eq(agentRunQueue.runId, args.row.runId));
+
+    const queueMarkerNotification = await revokeQueuedRunAssistantMarkers(tx, {
+      runId: args.row.runId,
+      userId: args.row.userId,
+    });
+
+    const runnerJob = await insertPromotedRunnerJob(tx, {
+      orgId: args.orgId,
+      runId: args.row.runId,
+      queuedAt: args.row.createdAt,
+      payload,
+    });
+    return complete({
+      status: "promoted",
+      queueMarkerNotification,
+      pendingActivation: {
+        apiStartTime: runnerJob.apiStartedAt,
+        chatThreadId: args.row.chatThreadId ?? undefined,
+        runnerNotification: {
+          runId: args.row.runId,
+          runnerGroup: payload.runnerGroup,
+          profile: runnerJob.profile,
+          reuseKey: payload.reuseKey,
+          cliAgentSessionId: payload.cliAgentSessionId,
+          historyGenerationRunId: payload.historyGenerationRunId,
+          createdAt: runnerJob.createdAt,
+        },
+        ...(runnerJob.executionContext.piLaunchConfig &&
+        args.row.prompt !== null
+          ? {
+              piApiFirstTurn: {
+                runId: args.row.runId,
+                runnerGroup: payload.runnerGroup,
+                userId: args.row.userId,
+                orgId: args.orgId,
+                prompt: args.row.prompt,
+                appendSystemPrompt: args.row.appendSystemPrompt,
+                executionContext: requirePiApiFirstTurnExecutionContext(
+                  runnerJob.executionContext,
+                ),
+              },
+            }
+          : {}),
       },
-      ...(runnerJob.executionContext.piLaunchConfig && args.row.prompt !== null
-        ? {
-            piApiFirstTurn: {
-              runId: args.row.runId,
-              runnerGroup: payload.runnerGroup,
-              userId: args.row.userId,
-              orgId: args.orgId,
-              prompt: args.row.prompt,
-              appendSystemPrompt: args.row.appendSystemPrompt,
-              executionContext: requirePiApiFirstTurnExecutionContext(
-                runnerJob.executionContext,
-              ),
-            },
-          }
-        : {}),
-    },
-  };
+    });
+  });
+  return finalizePromoteQueuedCandidate(timing, committed);
 }
 
 async function publishPromotedQueueSideEffects(args: {
@@ -431,7 +443,11 @@ async function publishPromotedQueueSideEffects(args: {
 
 async function promoteQueuedCandidateWithSideEffects(
   db: Db,
-  args: PromoteQueuedCandidateArgs,
+  args: {
+    readonly orgId: string;
+    readonly row: QueueCandidate;
+    readonly payload: QueuedRunnerJobPayload | null;
+  },
 ): Promise<PromoteQueuedCandidateSideEffectResult> {
   const result = await promoteQueuedCandidate(db, args);
   if (result.status === "removed-stale") {

--- a/turbo/apps/api/src/signals/services/run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/run-queue.service.ts
@@ -41,6 +41,7 @@ import {
   refreshPiApiFirstTurnDeadline,
   requirePiApiFirstTurnExecutionContext,
 } from "./pi-api-first-turn-config";
+import { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 
 const L = logger("RunQueue");
 
@@ -106,12 +107,19 @@ type PromotionResult =
   | PromotedQueuedCandidateTransactionResult
   | PromoteQueuedCandidateNonPromotedResult;
 
+interface PromoteQueuedCandidateArgs {
+  readonly orgId: string;
+  readonly row: QueueCandidate;
+  readonly payload: QueuedRunnerJobPayload | null;
+}
+
 type PromoteQueuedCandidateResult =
   | {
       readonly status: "promoted";
       readonly pendingActivation: PreparedPendingRunActivation;
       readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
       readonly transactionReturnedAt: number;
+      readonly timing: ApiDispatchTimingCollector;
     }
   | PromoteQueuedCandidateNonPromotedResult;
 
@@ -249,135 +257,156 @@ async function loadDrainCandidates(
 
 async function promoteQueuedCandidate(
   db: Db,
-  args: {
-    readonly orgId: string;
-    readonly row: QueueCandidate;
-    readonly payload: QueuedRunnerJobPayload | null;
-  },
+  args: PromoteQueuedCandidateArgs,
 ): Promise<PromoteQueuedCandidateResult> {
-  const result = await db.transaction(async (tx): Promise<PromotionResult> => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
-    );
-
-    const concurrency = await effectiveOrgConcurrencyState(tx, args.orgId);
-    if (concurrency.activeRunCount >= concurrency.limit) {
-      return { status: "full" };
-    }
-
-    const [lockedRun] = await tx
-      .select({ status: agentRuns.status })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, args.row.runId))
-      .for("update");
-    if (!lockedRun) {
-      await tx
-        .delete(agentRunQueue)
-        .where(eq(agentRunQueue.runId, args.row.runId));
-      return { status: "removed-stale" };
-    }
-    if (lockedRun.status !== "queued") {
-      await tx
-        .delete(agentRunQueue)
-        .where(eq(agentRunQueue.runId, args.row.runId));
-      return { status: "removed-stale" };
-    }
-    if (args.row.runStatus !== "queued") {
-      return { status: "lost" };
-    }
-
-    const [queueRow] = await tx
-      .select({ runId: agentRunQueue.runId })
-      .from(agentRunQueue)
-      .where(
-        and(
-          eq(agentRunQueue.runId, args.row.runId),
-          eq(agentRunQueue.orgId, args.orgId),
-        ),
-      )
-      .limit(1);
-    if (!queueRow) {
-      return { status: "lost" };
-    }
-
-    if (args.payload === null) {
-      throw new Error(
-        `Queued run "${args.row.runId}" is missing its runner job payload`,
-      );
-    }
-    const payload = args.payload;
-    const runValues = {
-      status: "pending",
-      lastHeartbeatAt: nowDate(),
-      runnerGroup: payload.runnerGroup,
-    };
-    const [updated] = await tx
-      .update(agentRuns)
-      .set(runValues)
-      .where(
-        and(eq(agentRuns.id, args.row.runId), eq(agentRuns.status, "queued")),
-      )
-      .returning({ id: agentRuns.id });
-    if (!updated) {
-      return { status: "lost" };
-    }
-
-    await tx
-      .delete(agentRunQueue)
-      .where(eq(agentRunQueue.runId, args.row.runId));
-
-    const queueMarkerNotification = await revokeQueuedRunAssistantMarkers(tx, {
-      runId: args.row.runId,
-      userId: args.row.userId,
-    });
-
-    const runnerJob = await insertPromotedRunnerJob(tx, {
-      orgId: args.orgId,
-      runId: args.row.runId,
-      queuedAt: args.row.createdAt,
-      payload,
-    });
-    return {
-      status: "promoted",
-      queueMarkerNotification,
-      pendingActivation: {
-        apiStartTime: runnerJob.apiStartedAt,
-        chatThreadId: args.row.chatThreadId ?? undefined,
-        runnerNotification: {
-          runId: args.row.runId,
-          runnerGroup: payload.runnerGroup,
-          profile: runnerJob.profile,
-          reuseKey: payload.reuseKey,
-          cliAgentSessionId: payload.cliAgentSessionId,
-          historyGenerationRunId: payload.historyGenerationRunId,
-          createdAt: runnerJob.createdAt,
-        },
-        ...(runnerJob.executionContext.piLaunchConfig &&
-        args.row.prompt !== null
-          ? {
-              piApiFirstTurn: {
-                runId: args.row.runId,
-                runnerGroup: payload.runnerGroup,
-                userId: args.row.userId,
-                orgId: args.orgId,
-                prompt: args.row.prompt,
-                appendSystemPrompt: args.row.appendSystemPrompt,
-                executionContext: requirePiApiFirstTurnExecutionContext(
-                  runnerJob.executionContext,
-                ),
-              },
-            }
-          : {}),
+  // Promotion can happen after the original create-run collector was flushed.
+  // Buffer its lock timings locally and carry them past the durable boundary.
+  const timing = new ApiDispatchTimingCollector();
+  const committed = await db.transaction(async (tx) => {
+    await timing.measure(
+      "api_dispatch_queue_promotion_lock_wait",
+      "nested",
+      async () => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
+        );
       },
+    );
+    const admissionLockHeldStartedAt = now();
+    return {
+      result: await promoteQueuedCandidateUnderLock(tx, args),
+      admissionLockHeldStartedAt,
     };
   });
   const transactionReturnedAt = now();
+  timing.recordElapsed(
+    "api_dispatch_queue_promotion_lock_held",
+    "nested",
+    committed.admissionLockHeldStartedAt,
+    transactionReturnedAt,
+  );
+  const result = committed.result;
   if (result.status !== "promoted") {
     return result;
   }
   return {
     ...result,
     transactionReturnedAt,
+    timing,
+  };
+}
+
+async function promoteQueuedCandidateUnderLock(
+  tx: DbTransaction,
+  args: PromoteQueuedCandidateArgs,
+): Promise<PromotionResult> {
+  // The caller owns the organization advisory lock for this complete boundary.
+  const concurrency = await effectiveOrgConcurrencyState(tx, args.orgId);
+  if (concurrency.activeRunCount >= concurrency.limit) {
+    return { status: "full" };
+  }
+
+  const [lockedRun] = await tx
+    .select({ status: agentRuns.status })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.row.runId))
+    .for("update");
+  if (!lockedRun) {
+    await tx
+      .delete(agentRunQueue)
+      .where(eq(agentRunQueue.runId, args.row.runId));
+    return { status: "removed-stale" };
+  }
+  if (lockedRun.status !== "queued") {
+    await tx
+      .delete(agentRunQueue)
+      .where(eq(agentRunQueue.runId, args.row.runId));
+    return { status: "removed-stale" };
+  }
+  if (args.row.runStatus !== "queued") {
+    return { status: "lost" };
+  }
+
+  const [queueRow] = await tx
+    .select({ runId: agentRunQueue.runId })
+    .from(agentRunQueue)
+    .where(
+      and(
+        eq(agentRunQueue.runId, args.row.runId),
+        eq(agentRunQueue.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+  if (!queueRow) {
+    return { status: "lost" };
+  }
+
+  if (args.payload === null) {
+    throw new Error(
+      `Queued run "${args.row.runId}" is missing its runner job payload`,
+    );
+  }
+  const payload = args.payload;
+  const runValues = {
+    status: "pending",
+    lastHeartbeatAt: nowDate(),
+    runnerGroup: payload.runnerGroup,
+  };
+  const [updated] = await tx
+    .update(agentRuns)
+    .set(runValues)
+    .where(
+      and(eq(agentRuns.id, args.row.runId), eq(agentRuns.status, "queued")),
+    )
+    .returning({ id: agentRuns.id });
+  if (!updated) {
+    return { status: "lost" };
+  }
+
+  await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, args.row.runId));
+
+  const queueMarkerNotification = await revokeQueuedRunAssistantMarkers(tx, {
+    runId: args.row.runId,
+    userId: args.row.userId,
+  });
+
+  const runnerJob = await insertPromotedRunnerJob(tx, {
+    orgId: args.orgId,
+    runId: args.row.runId,
+    queuedAt: args.row.createdAt,
+    payload,
+  });
+  return {
+    status: "promoted",
+    queueMarkerNotification,
+    pendingActivation: {
+      apiStartTime: runnerJob.apiStartedAt,
+      chatThreadId: args.row.chatThreadId ?? undefined,
+      runnerNotification: {
+        runId: args.row.runId,
+        runnerGroup: payload.runnerGroup,
+        profile: runnerJob.profile,
+        reuseKey: payload.reuseKey,
+        cliAgentSessionId: payload.cliAgentSessionId,
+        historyGenerationRunId: payload.historyGenerationRunId,
+        createdAt: runnerJob.createdAt,
+      },
+      ...(runnerJob.executionContext.piLaunchConfig && args.row.prompt !== null
+        ? {
+            piApiFirstTurn: {
+              runId: args.row.runId,
+              runnerGroup: payload.runnerGroup,
+              userId: args.row.userId,
+              orgId: args.orgId,
+              prompt: args.row.prompt,
+              appendSystemPrompt: args.row.appendSystemPrompt,
+              executionContext: requirePiApiFirstTurnExecutionContext(
+                runnerJob.executionContext,
+              ),
+            },
+          }
+        : {}),
+    },
   };
 }
 
@@ -395,11 +424,7 @@ async function publishPromotedQueueSideEffects(args: {
 
 async function promoteQueuedCandidateWithSideEffects(
   db: Db,
-  args: {
-    readonly orgId: string;
-    readonly row: QueueCandidate;
-    readonly payload: QueuedRunnerJobPayload | null;
-  },
+  args: PromoteQueuedCandidateArgs,
 ): Promise<PromoteQueuedCandidateSideEffectResult> {
   const result = await promoteQueuedCandidate(db, args);
   if (result.status === "removed-stale") {
@@ -419,6 +444,15 @@ async function promoteQueuedCandidateWithSideEffects(
     queueMarkerNotification: result.queueMarkerNotification,
   });
   const promotionSideEffectsRegisteredAt = now();
+  const runnerNotification = result.pendingActivation.runnerNotification;
+  // Keep optional telemetry submission outside the existing side-effect metric.
+  result.timing.flush({
+    runId: runnerNotification.runId,
+    runnerGroup: runnerNotification.runnerGroup,
+    profile: runnerNotification.profile,
+    dispatchPath: "direct",
+    dimensions: { activation_origin: "promotion" },
+  });
   return {
     status: "drained",
     pendingActivation: {

--- a/turbo/apps/api/src/signals/services/run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/run-queue.service.ts
@@ -119,7 +119,6 @@ type PromoteQueuedCandidateResult =
       readonly pendingActivation: PreparedPendingRunActivation;
       readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
       readonly transactionReturnedAt: number;
-      readonly timing: ApiDispatchTimingCollector;
     }
   | PromoteQueuedCandidateNonPromotedResult;
 
@@ -289,10 +288,18 @@ async function promoteQueuedCandidate(
   if (result.status !== "promoted") {
     return result;
   }
+  const runnerNotification = result.pendingActivation.runnerNotification;
+  // Promotion is durable now; later side-effect failures must not suppress it.
+  timing.flush({
+    runId: runnerNotification.runId,
+    runnerGroup: runnerNotification.runnerGroup,
+    profile: runnerNotification.profile,
+    dispatchPath: "direct",
+    dimensions: { activation_origin: "promotion" },
+  });
   return {
     ...result,
     transactionReturnedAt,
-    timing,
   };
 }
 
@@ -444,15 +451,6 @@ async function promoteQueuedCandidateWithSideEffects(
     queueMarkerNotification: result.queueMarkerNotification,
   });
   const promotionSideEffectsRegisteredAt = now();
-  const runnerNotification = result.pendingActivation.runnerNotification;
-  // Keep optional telemetry submission outside the existing side-effect metric.
-  result.timing.flush({
-    runId: runnerNotification.runId,
-    runnerGroup: runnerNotification.runnerGroup,
-    profile: runnerNotification.profile,
-    dispatchPath: "direct",
-    dimensions: { activation_origin: "promotion" },
-  });
   return {
     status: "drained",
     pendingActivation: {


### PR DESCRIPTION
## Summary

- record queued-promotion organization admission-lock wait and held durations with fixed API dispatch actions
- flush timing immediately after durable promotion so later side-effect failures cannot suppress the attribution
- verify the run-owned rows and bounded dimensions through the existing queue/cancel/promotion API integration scenario

## Problem

Final launch admission already exposes organization-lock wait and held time, but authoritative queued promotion acquires the same lock without either boundary. Production data can show final launch waiting without identifying queued promotion as the holder.

## Solution

Promotion now uses a local API dispatch timing collector. A focused helper measures lock acquisition, and a post-transaction finalizer records held time through transaction return. Both rows are flushed only after a durable promoted result, before later realtime side effects can fail. The existing post-lock queries, state transitions, errors, and ordering remain inline and unchanged.

The new fixed actions are:

- `api_dispatch_queue_promotion_lock_wait`
- `api_dispatch_queue_promotion_lock_held`

## Explicit exclusions

- no lock scope, transaction, query, concurrency, queue, notification, or runner behavior change
- no instrumentation for the test-fixture-only direct-run concurrency preflight
- no schema, migration, API contract, queue payload, runner protocol, or frontend change

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (181 passed)
- `pnpm knip`
- pre-commit full Turbo type checks and file-size checks

Closes #28764

Parent context: #24203
