### PR TITLE
refactor(cli): rename the default agent-browser session to okou-browser

### DIFF
--- a/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
@@ -132,7 +132,7 @@ describe("okou browser command", () => {
     expect(authorization).toBe("Bearer test-token");
     expect(spawnSyncMock).toHaveBeenCalledWith(
       "agent-browser",
-      ["--session", "zero-browser", "connect", CDP_URL],
+      ["--session", "okou-browser", "connect", CDP_URL],
       { stdio: "ignore" },
     );
     const output = consoleLog.mock.calls.flat().join("\n");
@@ -163,7 +163,7 @@ describe("okou browser command", () => {
     expect(useRequests).toBe(1);
     expect(spawnSyncMock).toHaveBeenCalledWith(
       "agent-browser",
-      ["--session", "zero-browser", "connect", CDP_URL],
+      ["--session", "okou-browser", "connect", CDP_URL],
       { stdio: "ignore" },
     );
     const output = consoleLog.mock.calls.flat().join("\n");
@@ -219,7 +219,7 @@ describe("okou browser command", () => {
 
     expect(spawnSyncMock).toHaveBeenCalledWith(
       "agent-browser",
-      ["--session", "zero-browser", "connect", CDP_URL],
+      ["--session", "okou-browser", "connect", CDP_URL],
       { stdio: "ignore" },
     );
     const output = consoleLog.mock.calls.flat().join("\n");
@@ -234,7 +234,81 @@ describe("okou browser command", () => {
         threadId: THREAD_ID,
         viewerUrl: `https://app.vm0.ai/browsers/${THREAD_ID}`,
       },
-      agentBrowserSession: "zero-browser",
+      agentBrowserSession: "okou-browser",
     });
+  });
+
+  it("documents the agent-browser session it actually attaches", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/browsers/use", () => {
+        return HttpResponse.json(
+          {
+            browser: browser("active"),
+            cdpUrl: CDP_URL,
+            lifecycleEventId: null,
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    await browserCommand.parseAsync(["node", "cli", "use", "--json"]);
+
+    const { agentBrowserSession } = JSON.parse(
+      consoleLog.mock.calls.flat().join("\n"),
+    ) as { readonly agentBrowserSession: string };
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "agent-browser",
+      ["--session", agentBrowserSession, "connect", CDP_URL],
+      { stdio: "ignore" },
+    );
+
+    // The help text is an instruction agents copy verbatim: a session name that
+    // drifts from the attached one hands them a browser that was never connected.
+    let help = "";
+    browserCommand.configureOutput({
+      writeOut: (text: string) => {
+        help += text;
+      },
+    });
+    browserCommand.outputHelp();
+    browserCommand.configureOutput({
+      writeOut: (text: string) => {
+        process.stdout.write(text);
+      },
+    });
+
+    expect(help).toContain(
+      `agent-browser --session ${agentBrowserSession} open`,
+    );
+  });
+
+  it("attaches to an explicitly named agent-browser session", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/browsers/use", () => {
+        return HttpResponse.json(
+          {
+            browser: browser("active"),
+            cdpUrl: CDP_URL,
+            lifecycleEventId: null,
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    await browserCommand.parseAsync([
+      "node",
+      "cli",
+      "use",
+      "--agent-session",
+      "booking-browser",
+    ]);
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "agent-browser",
+      ["--session", "booking-browser", "connect", CDP_URL],
+      { stdio: "ignore" },
+    );
   });
 });

--- a/turbo/apps/cli/src/commands/browser/index.ts
+++ b/turbo/apps/cli/src/commands/browser/index.ts
@@ -16,7 +16,7 @@ import {
 } from "../../lib/api/domains/browser";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 
-const DEFAULT_AGENT_BROWSER_SESSION = "zero-browser";
+const DEFAULT_AGENT_BROWSER_SESSION = "okou-browser";
 
 interface NewOptions {
   readonly name: string;
@@ -215,7 +215,7 @@ Examples:
   Open this thread's browser: okou browser use
   Keep it alive:              okou browser lease
   Create another browser:     okou browser new --name booking --country us
-  Use the browser:            agent-browser --session zero-browser open https://example.com
+  Use the browser:            agent-browser --session ${DEFAULT_AGENT_BROWSER_SESSION} open https://example.com
   Share live view:            okou browser view
 
 Notes:


### PR DESCRIPTION
Closes #28779. Part of #26873.

## What changed

- `DEFAULT_AGENT_BROWSER_SESSION` is now `okou-browser` instead of `zero-browser`.
- The help-text example at `commands/browser/index.ts:218` is interpolated from the constant instead of repeating the literal, so the documented session name and the attached one cannot diverge.

## Why the rename is safe

The remote browser is owned and resumed by `threadId` on the server. `createBrowser`/`useBrowser`/`leaseBrowser`/`getCurrentBrowser` never send a session name — the request bodies are `{}` or the create payload — and the viewer URL, lease and identity all come from `response.browser`. The session name is only the local `agent-browser --session <name> connect <cdpUrl>` attach label, and every `okou browser use` reconnects with the `cdpUrl` the server just returned. The residue of the rename is at most a stale local session record inside an ephemeral sandbox.

`threadId` ownership, lease handling, viewer URLs, the `--agent-session` flag and the `agent-browser` package itself are untouched.

## Tests

- Four existing assertions updated to `okou-browser`.
- New test asserts the help text documents the session the command actually attaches, deriving the name from the run instead of hardcoding it. Verified by mutation: reverting line 218 to the literal `zero-browser` fails this test.
- New test asserts an explicit `--agent-session` still overrides the default.

## Verification

`vitest` (browser suite), `eslint`, `tsc --noEmit`, `knip`, and `pnpm format` all pass for the CLI workspace.