### PR TITLE
fix(api): remove redundant axiom reduction log

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1534,12 +1534,17 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     );
     expect(resultDeliveredBytes).toBeLessThanOrEqual(900_000);
 
-    const reductionLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
+    const reductionLogs = context.mocks.axiomLogging.debug.mock.calls.filter(
       ([message]) => {
         return message === "Reduced oversized agent event for Axiom";
       },
     );
     expect(reductionLogs).toHaveLength(2);
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.some(([message]) => {
+        return message === "Reduced oversized agent event for Axiom";
+      }),
+    ).toBeFalsy();
     const assistantFields = reductionLogs[0]?.[1];
     expect(assistantFields).toStrictEqual(
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1534,49 +1534,18 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     );
     expect(resultDeliveredBytes).toBeLessThanOrEqual(900_000);
 
-    const reductionLogs = context.mocks.axiomLogging.debug.mock.calls.filter(
-      ([message]) => {
-        return message === "Reduced oversized agent event for Axiom";
-      },
-    );
-    expect(reductionLogs).toHaveLength(2);
-    expect(
-      context.mocks.axiomLogging.warn.mock.calls.some(([message]) => {
-        return message === "Reduced oversized agent event for Axiom";
-      }),
-    ).toBeFalsy();
-    const assistantFields = reductionLogs[0]?.[1];
-    expect(assistantFields).toStrictEqual(
-      expect.objectContaining({
-        context: "agent-event-consumer:axiom",
-        runId,
-        sequenceNumber: assistantEvent.sequenceNumber,
-        eventType: assistantEvent.type,
-        originalBytes: assistantOriginalBytes,
-        deliveredBytes: assistantDeliveredBytes,
-        budgetBytes: 900_000,
-      }),
-    );
-    const resultFields = reductionLogs[1]?.[1];
-    expect(resultFields).toStrictEqual(
-      expect.objectContaining({
-        context: "agent-event-consumer:axiom",
-        runId,
-        sequenceNumber: resultEvent.sequenceNumber,
-        eventType: resultEvent.type,
-        originalBytes: resultOriginalBytes,
-        deliveredBytes: resultDeliveredBytes,
-        budgetBytes: 900_000,
-      }),
-    );
-    for (const fields of [assistantFields, resultFields]) {
-      expect(fields).not.toHaveProperty("eventData");
-      expect(JSON.stringify(fields)).not.toContain(
-        oversizedAssistantContent.slice(0, 64),
-      );
-      expect(JSON.stringify(fields)).not.toContain(
-        oversizedResultContent.slice(0, 64),
-      );
+    const reductionMessage = "Reduced oversized agent event for Axiom";
+    for (const calls of [
+      context.mocks.axiomLogging.debug.mock.calls,
+      context.mocks.axiomLogging.info.mock.calls,
+      context.mocks.axiomLogging.warn.mock.calls,
+      context.mocks.axiomLogging.error.mock.calls,
+    ]) {
+      expect(
+        calls.some(([message]) => {
+          return message === reductionMessage;
+        }),
+      ).toBeFalsy();
     }
   });
 

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -2,7 +2,6 @@ import type {
   AgentEvent,
   EventConsumerPayload,
 } from "../../lib/event-consumer/verify";
-import { logger } from "../../lib/log";
 import { getDatasetName, ingestAxiomDirect } from "../external/axiom";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -10,8 +9,6 @@ const AXIOM_EVENT_INGEST_TIMEOUT_MS = 10_000;
 const AXIOM_EVENT_DATA_MAX_BYTES = 900_000;
 const AXIOM_TRUNCATED_STRING_VALUE = "[truncated]";
 const AXIOM_TRUNCATED_STRING_SUFFIX = `\n\n${AXIOM_TRUNCATED_STRING_VALUE}`;
-
-const L = logger("agent-event-consumer:axiom");
 
 function serializedUtf8Bytes(
   value: unknown,
@@ -209,7 +206,6 @@ function reducedEventData(
 }
 
 function eventDataForAxiom(
-  runId: string,
   event: AgentEvent,
   encoder: InstanceType<typeof TextEncoder>,
 ): AgentEvent {
@@ -222,22 +218,7 @@ function eventDataForAxiom(
     return event;
   }
 
-  const reducedEvent = reducedEventData(
-    event,
-    serialized,
-    originalBytes,
-    encoder,
-  );
-  const deliveredBytes = serializedUtf8Bytes(reducedEvent, encoder);
-  L.debug("Reduced oversized agent event for Axiom", {
-    runId,
-    sequenceNumber: event.sequenceNumber,
-    eventType: event.type,
-    originalBytes,
-    deliveredBytes,
-    budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
-  });
-  return reducedEvent;
+  return reducedEventData(event, serialized, originalBytes, encoder);
 }
 
 export async function ingestAxiomEvents(
@@ -252,7 +233,7 @@ export async function ingestAxiomEvents(
       userId: payload.context.userId,
       sequenceNumber: event.sequenceNumber,
       eventType: event.type,
-      eventData: eventDataForAxiom(payload.runId, event, encoder),
+      eventData: eventDataForAxiom(event, encoder),
     };
   });
   const result = await ingestAxiomDirect(

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -229,7 +229,7 @@ function eventDataForAxiom(
     encoder,
   );
   const deliveredBytes = serializedUtf8Bytes(reducedEvent, encoder);
-  L.warn("Reduced oversized agent event for Axiom", {
+  L.debug("Reduced oversized agent event for Axiom", {
     runId,
     sequenceNumber: event.sequenceNumber,
     eventType: event.type,


### PR DESCRIPTION
## Summary

- stop emitting a separate application log when oversized agent events are successfully reduced for Axiom
- keep reduction evidence on the reduced `agent-run-events` record through its correlation fields and `axiomReduction` metadata
- remove the second serialization and log-only `deliveredBytes` calculation
- verify through the webhook integration path that reduced events are delivered within budget without the message at any application-log level

## Scope and compatibility

- the reduction algorithm, 900,000-byte budget, Axiom HTTP ingest, webhook acknowledgement, and run behavior are unchanged
- actual serialization and Axiom delivery failures remain unchanged error paths
- no API, protocol, queue, database, persisted-state, runner, or deployment compatibility changes
- exact-message application-log queries and the log-only `deliveredBytes` field intentionally stop receiving new data

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --silent=passed-only` (56 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit full Turbo type checking (14 tasks passed)

Closes #28765
