### PR TITLE
fix(runner): treat reuse capacity rejection as informational

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1348,13 +1348,23 @@ async fn rollback_exact_speculation_outcome(
                     destroy_job,
                     reason,
                     error,
+                    expected_capacity_rejection,
                 } => {
-                    warn!(
-                        run_id = %run_id,
-                        reason,
-                        error,
-                        "speculative exact-reuse rollback could not restore idle ownership"
-                    );
+                    if expected_capacity_rejection {
+                        info!(
+                            run_id = %run_id,
+                            reason,
+                            error,
+                            "speculative exact-reuse rollback rejected by idle capacity admission"
+                        );
+                    } else {
+                        warn!(
+                            run_id = %run_id,
+                            reason,
+                            error,
+                            "speculative exact-reuse rollback could not restore idle ownership"
+                        );
+                    }
                     Some(destroy_job)
                 }
             }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -521,16 +521,28 @@ async fn finalize_sandbox_for_completion_inner(
                     rejected,
                     reason,
                     error,
+                    expected_capacity_rejection,
                 } => {
                     telemetry.record_idle_publication(false, Some(reason));
-                    warn!(
-                        run_id = %run_id,
-                        reuse_key_fingerprint = %reuse_key_fingerprint,
-                        reuse_key_kind = reuse_kind,
-                        reason,
-                        error,
-                        "parked sandbox failed idle admission, destroying instead of reusing"
-                    );
+                    if expected_capacity_rejection {
+                        info!(
+                            run_id = %run_id,
+                            reuse_key_fingerprint = %reuse_key_fingerprint,
+                            reuse_key_kind = reuse_kind,
+                            reason,
+                            error,
+                            "parked sandbox rejected by idle capacity admission, destroying instead of reusing"
+                        );
+                    } else {
+                        warn!(
+                            run_id = %run_id,
+                            reuse_key_fingerprint = %reuse_key_fingerprint,
+                            reuse_key_kind = reuse_kind,
+                            reason,
+                            error,
+                            "parked sandbox failed idle admission, destroying instead of reusing"
+                        );
+                    }
                     close_network_log_session(
                         run_id,
                         network_log_session.take(),
@@ -1838,9 +1850,10 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
-        let _finalization_ready =
-            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
-                .await;
+        let (_finalization_ready, events) = capture_async_log_events(
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context),
+        )
+        .await;
 
         assert_eq!(overrides.park_call_count(), 1);
         assert_eq!(overrides.unpark_call_count(), 1);
@@ -1853,6 +1866,14 @@ mod tests {
             cleanup_state.disposition(),
             RunCleanupDisposition::DestroyCompleted
         );
+        let capacity_event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(capacity_event.level, Level::INFO);
+        assert_event_field(capacity_event, "reason", "low_bytes");
+        let lifecycle_event = captured_event(
+            &events,
+            "parked sandbox rejected by idle capacity admission, destroying instead of reusing",
+        );
+        assert_eq!(lifecycle_event.level, Level::INFO);
     }
 
     #[tokio::test]

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -101,6 +101,7 @@ pub(crate) struct IdleParkFailure {
     ownership: IdleParkFailureOwnership,
     reason: &'static str,
     error: String,
+    expected_capacity_rejection: bool,
 }
 
 enum IdleParkFailureOwnership {
@@ -132,6 +133,7 @@ pub(crate) enum IdleParkFailureParts {
         rejected: RejectedParkedIdleCandidate,
         reason: &'static str,
         error: String,
+        expected_capacity_rejection: bool,
     },
 }
 
@@ -152,6 +154,7 @@ pub(crate) enum SpeculativeReparkResult {
         destroy_job: Box<IdleDestroyJob>,
         reason: &'static str,
         error: String,
+        expected_capacity_rejection: bool,
     },
 }
 
@@ -282,6 +285,7 @@ async fn park_idle_transition(
             },
             reason: "promotion_identity_mismatch",
             error: format!("workspace promotion identity mismatch: {mismatch}"),
+            expected_capacity_rejection: false,
         });
     }
 
@@ -304,6 +308,7 @@ async fn park_idle_transition(
                 },
                 reason: "reuse_preparation_failed",
                 error: error.to_string(),
+                expected_capacity_rejection: false,
             });
         }
     };
@@ -356,12 +361,14 @@ async fn park_idle_transition(
             let preparation_report = match preparation.validate_result(exec_result) {
                 Ok(report) => report,
                 Err(error) => {
+                    let expected_capacity_rejection = error.is_expected_capacity_rejection();
                     return Err(IdleParkFailure {
                         ownership: IdleParkFailureOwnership::Parked {
                             rejected: candidate.into_rejected(),
                         },
                         reason: "reuse_preparation_failed",
                         error: error.to_string(),
+                        expected_capacity_rejection,
                     });
                 }
             };
@@ -390,6 +397,7 @@ async fn park_idle_transition(
             },
             reason: "park_failed",
             error: error.to_string(),
+            expected_capacity_rejection: false,
         }),
         Err(_) => {
             // A panic leaves the park transition state uncertain; destroy
@@ -406,6 +414,7 @@ async fn park_idle_transition(
                 },
                 reason: "park_panicked",
                 error: "sandbox park panicked".into(),
+                expected_capacity_rejection: false,
             })
         }
     }
@@ -423,6 +432,7 @@ impl SpeculativeIdleSandbox {
                 destroy_job: Box::new(self.into_destroy_job(REASON)),
                 reason: REASON,
                 error: "speculative exact-reuse entry is missing a history generation".into(),
+                expected_capacity_rejection: false,
             };
         };
         let Self { entry } = self;
@@ -464,6 +474,7 @@ impl SpeculativeIdleSandbox {
                     }),
                     reason: "speculative_repark_unexpected_handoff",
                     error: "speculative re-park unexpectedly produced an immediate handoff".into(),
+                    expected_capacity_rejection: false,
                 }
             }
             Ok(IdleParkOutcome::NonReusable {
@@ -479,15 +490,17 @@ impl SpeculativeIdleSandbox {
                     }),
                     reason: "speculative_repark_non_reusable",
                     error: format!("re-parked sandbox is not reusable: {}", reason.as_str()),
+                    expected_capacity_rejection: false,
                 }
             }
             Err(failure) => {
-                let (destroy_job, reason, error) =
+                let (destroy_job, reason, error, expected_capacity_rejection) =
                     failure.into_speculative_destroy_job(reuse_key, profile_name);
                 SpeculativeReparkResult::Destroy {
                     destroy_job: Box::new(destroy_job),
                     reason,
                     error,
+                    expected_capacity_rejection,
                 }
             }
         }
@@ -533,11 +546,12 @@ impl IdleParkFailure {
         self,
         reuse_key: String,
         profile_name: String,
-    ) -> (IdleDestroyJob, &'static str, String) {
+    ) -> (IdleDestroyJob, &'static str, String, bool) {
         let Self {
             ownership,
             reason,
             error,
+            expected_capacity_rejection,
         } = self;
         let (payload, budget_lease) = match ownership {
             IdleParkFailureOwnership::Active {
@@ -559,6 +573,7 @@ impl IdleParkFailure {
             },
             reason,
             error,
+            expected_capacity_rejection,
         )
     }
 
@@ -567,6 +582,7 @@ impl IdleParkFailure {
             ownership,
             reason,
             error,
+            expected_capacity_rejection,
         } = self;
         match ownership {
             IdleParkFailureOwnership::Active {
@@ -593,6 +609,7 @@ impl IdleParkFailure {
                 rejected,
                 reason,
                 error,
+                expected_capacity_rejection,
             },
         }
     }

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use guest_contracts::reuse_preparation::ReusePreparationRequest;
+use guest_contracts::reuse_preparation::{
+    ReusePreparationReport, ReusePreparationRequest, RootFilesystemCapacity,
+};
 use guest_contracts::session_history_identity::{
     SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySourceRef,
 };
@@ -111,6 +113,7 @@ async fn idle_park_request_semantic_rejection_returns_parked_ownership() {
         rejected,
         reason,
         error,
+        expected_capacity_rejection,
     } = failure.into_parts()
     else {
         panic!("semantic rejection after park must retain parked ownership");
@@ -118,11 +121,69 @@ async fn idle_park_request_semantic_rejection_returns_parked_ownership() {
 
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(reason, "reuse_preparation_failed");
+    assert!(!expected_capacity_rejection);
     assert!(error.contains("invalid report"));
     let (payload, budget_lease) = rejected.into_active_destroy_parts();
     assert_eq!(budget_lease.vcpu(), 2);
     assert_eq!(budget_lease.memory_mb(), 2048);
     assert_eq!(payload.stop_and_destroy().await, DestroyOutcome::Completed);
+    assert_eq!(overrides.destroy_call_count(), 1);
+}
+
+#[tokio::test]
+async fn speculative_repark_preserves_expected_capacity_rejection() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let mut request = make_idle_park_request(
+        Arc::clone(&overrides),
+        "session-speculative-capacity-rejection",
+        make_budget_lease(2, 2048),
+    )
+    .await;
+    request.parts.history_generation_run_id = Some(request.parts.run_id);
+    let candidate = match request.park_for_idle().await {
+        Ok(outcome) => outcome.expect_reusable(),
+        Err(_) => panic!("initial park should succeed"),
+    };
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "prepare-for-reuse".into(),
+        exit_code: 0,
+        stdout: serde_json::to_vec(&ReusePreparationReport {
+            before: RootFilesystemCapacity {
+                available_bytes: 64 * 1024 * 1024,
+                available_inodes: 4096,
+            },
+            after: RootFilesystemCapacity {
+                available_bytes: 64 * 1024 * 1024,
+                available_inodes: 4096,
+            },
+            removed_entries: 0,
+        })
+        .unwrap(),
+        stderr: Vec::new(),
+    });
+    let reservation = ReservedIdleSandbox {
+        entry: candidate.into_idle_entry(Instant::now()),
+    };
+    let SpeculativeIdleUnparkResult::Ready(speculative) = reservation
+        .try_unpark_for_speculation(RunId::new_v4())
+        .await
+    else {
+        panic!("speculative unpark should succeed");
+    };
+
+    let SpeculativeReparkResult::Destroy {
+        destroy_job,
+        expected_capacity_rejection,
+        ..
+    } = speculative
+        .repark_for_claim_rollback(RunId::new_v4(), 0)
+        .await
+    else {
+        panic!("low-capacity speculative repark should return destroy ownership");
+    };
+
+    assert!(expected_capacity_rejection);
+    destroy_job.run().await;
     assert_eq!(overrides.destroy_call_count(), 1);
 }
 
@@ -418,6 +479,7 @@ async fn speculative_repark_without_history_generation_returns_owned_destroy_job
         destroy_job,
         reason,
         error,
+        expected_capacity_rejection,
     } = speculative
         .repark_for_claim_rollback(RunId::new_v4(), 0)
         .await
@@ -426,6 +488,7 @@ async fn speculative_repark_without_history_generation_returns_owned_destroy_job
     };
 
     assert_eq!(reason, "speculative_repark_missing_history_generation");
+    assert!(!expected_capacity_rejection);
     assert_eq!(
         error,
         "speculative exact-reuse entry is missing a history generation"

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -56,11 +56,18 @@ impl ReuseRejectionReason {
 #[derive(Debug)]
 pub(crate) struct IdleReusePreparationFailure {
     error: String,
+    expected_capacity_rejection: bool,
 }
 
 impl std::fmt::Display for IdleReusePreparationFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.error)
+    }
+}
+
+impl IdleReusePreparationFailure {
+    pub(crate) fn is_expected_capacity_rejection(&self) -> bool {
+        self.expected_capacity_rejection
     }
 }
 
@@ -175,6 +182,7 @@ impl IdleReusePreparation {
                     "guest rootfs below reuse reserve: {} bytes and {} inodes available",
                     report.after.available_bytes, report.after.available_inodes
                 ),
+                expected_capacity_rejection: true,
             });
         }
 
@@ -272,7 +280,10 @@ fn reject_without_exec(
         error = %error,
         "sandbox rejected from idle reuse"
     );
-    IdleReusePreparationFailure { error }
+    IdleReusePreparationFailure {
+        error,
+        expected_capacity_rejection: false,
+    }
 }
 
 fn reject_with_result(
@@ -294,7 +305,10 @@ fn reject_with_result(
         error = %error,
         "sandbox rejected from idle reuse"
     );
-    IdleReusePreparationFailure { error }
+    IdleReusePreparationFailure {
+        error,
+        expected_capacity_rejection: false,
+    }
 }
 
 fn log_report(
@@ -329,7 +343,7 @@ fn log_report(
             "sandbox prepared for idle reuse"
         );
     } else {
-        warn!(
+        info!(
             run_id = %run_id,
             sandbox_id,
             reason,
@@ -353,6 +367,7 @@ mod tests {
     use guest_contracts::reuse_preparation::REUSE_PREPARATION_EXIT_SUCCESS;
     use sandbox::{Sandbox, SandboxError, SandboxOperation, SandboxOperationReason};
     use sandbox_mock::MockSandbox;
+    use tracing::Level;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
@@ -488,6 +503,7 @@ mod tests {
 
         assert!(result.is_err());
         let event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(event.level, Level::INFO);
         assert_eq!(
             event.fields.get("reason").map(String::as_str),
             Some("low_bytes")
@@ -525,6 +541,7 @@ mod tests {
 
         assert!(result.is_err());
         let event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(event.level, Level::INFO);
         assert_eq!(
             event.fields.get("reason").map(String::as_str),
             Some("low_inodes")
@@ -539,6 +556,26 @@ mod tests {
         assert_eq!(
             event.fields.get("reclaimed_inodes").map(String::as_str),
             Some("100")
+        );
+    }
+
+    #[tokio::test]
+    async fn preparation_rejects_low_bytes_and_inodes_at_info() {
+        let sandbox = MockSandbox::new("low-bytes-and-inodes");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            serde_json::to_vec(&report(64, 96, 500, 600)).unwrap(),
+            Vec::new(),
+        )));
+
+        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+        assert!(result.is_err());
+        let event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(event.level, Level::INFO);
+        assert_eq!(
+            event.fields.get("reason").map(String::as_str),
+            Some("low_bytes_and_inodes")
         );
     }
 
@@ -567,6 +604,7 @@ mod tests {
 
             assert!(result.is_err());
             let event = captured_event(&events, "sandbox rejected from idle reuse");
+            assert_eq!(event.level, Level::WARN);
             assert_eq!(
                 event.fields.get("reason").map(String::as_str),
                 Some(expected_reason)
@@ -648,6 +686,10 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse").level,
+            Level::WARN
+        );
+        assert_eq!(
             captured_event(&events, "sandbox rejected from idle reuse")
                 .fields
                 .get("reason")
@@ -662,6 +704,10 @@ mod tests {
         malformed.push_exec_result(Ok(ExecResult::new(0, b"not-json".to_vec(), Vec::new())));
         let (result, events) = capture_preparation(&malformed, RunId::new_v4()).await;
         assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse").level,
+            Level::WARN
+        );
         assert_eq!(
             captured_event(&events, "sandbox rejected from idle reuse")
                 .fields
@@ -678,6 +724,10 @@ mod tests {
         }));
         let (result, events) = capture_preparation(&transport, RunId::new_v4()).await;
         assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse").level,
+            Level::WARN
+        );
         assert_eq!(
             captured_event(&events, "sandbox rejected from idle reuse")
                 .fields


### PR DESCRIPTION
## Summary

- classify valid low-rootfs capacity as an expected idle reuse rejection
- log expected capacity rejection at info across preparation, finalization, and speculative rollback
- preserve warning severity for malformed reports and operational failures, and preserve terminal errors for failed executions

## Observability

- detailed capacity fields remain available in local runner info logs
- expected capacity rejection is intentionally excluded from WARN+ Axiom ingestion
- no telemetry schema or runner protocol changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner idle_reuse_preparation::tests`
- `cargo test -p runner --bin runner idle_pool::park_transition_tests`
- `cargo test -p runner --bin runner finalizer_preserves_success_when_reuse_preparation_rejects_guest`
- `cargo test -p runner --bin runner classified_resource_failure_logs_resource_fields`
- `cargo test -p runner --bin runner` (3235 passed, 20 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`

Closes #28751
