### PR TITLE
refactor(api): remove nullable connector authorization state readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -60,7 +60,6 @@ import {
   connectorOAuthRedirectResponse,
 } from "../../lib/connector-oauth-state";
 import { openIdRealmForOrigin } from "./connector-openid-auth-start";
-import { parseStoredConnectorAccountMutationIntent } from "../services/connector-account-mutation.service";
 
 type CallbackIdentity = {
   readonly userId: string;
@@ -79,7 +78,7 @@ type CompleteOAuthCallbackInput = {
   readonly authorizeAgent: boolean;
   readonly origin: string;
   readonly connectorSlug: ConnectorSlug;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: ConnectorAccountMutationIntent;
 };
 
 type CompleteOpenIdCallbackInput = {
@@ -92,7 +91,7 @@ type CompleteOpenIdCallbackInput = {
   readonly authorizeAgent: boolean;
   readonly origin: string;
   readonly connectorSlug: ConnectorSlug;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: ConnectorAccountMutationIntent;
 };
 
 type ResolveCallbackStateInput = {
@@ -119,7 +118,7 @@ type ResolvedCallbackState =
       readonly oauthContext: string | undefined;
       readonly redirectUri: string;
       readonly resolvedMethod: ResolvedConnectorActionMethod;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     }
   | {
       readonly ok: false;
@@ -135,7 +134,7 @@ type ResolvedOpenIdCallbackState =
       readonly expectedReturnTo: string;
       readonly expectedRealm: string;
       readonly resolvedMethod: ResolvedConnectorActionMethod;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     }
   | {
       readonly ok: false;
@@ -727,9 +726,7 @@ async function resolveCallbackState(
     codeVerifier: args.storedState.codeVerifier ?? undefined,
     oauthContext: args.storedState.oauthContext ?? undefined,
     redirectUri: args.storedState.redirectUri,
-    account: parseStoredConnectorAccountMutationIntent(
-      args.storedState.accountMutation,
-    ),
+    account: args.storedState.accountMutation,
   };
 }
 
@@ -781,9 +778,7 @@ async function resolveOpenIdCallbackState(
       args.storedState.oauthContext,
       args.storedState.redirectUri,
     ),
-    account: parseStoredConnectorAccountMutationIntent(
-      args.storedState.accountMutation,
-    ),
+    account: args.storedState.accountMutation,
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import { zeroCustomConnectorOAuth2Contract } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 import type { ConnectorOauthCallbackResult } from "@okouai/api-contracts/contracts/connectors-slug-callback";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
@@ -42,7 +43,6 @@ import {
   clearConnectorOAuthCookies,
 } from "../../lib/connector-oauth-state";
 import { env } from "../../lib/env";
-import { parseStoredConnectorAccountMutationIntent } from "../services/connector-account-mutation.service";
 import { connectorConnectionWriteFailureMessage } from "../services/connector-data.service";
 
 const CUSTOM_CONNECTOR_OAUTH_CALLBACK_PATH = "/connectors/custom/callback";
@@ -218,9 +218,7 @@ async function persistCustomConnectorOAuth2Connection(
     readonly storageVersion: number;
     readonly token: OAuthTokenResult;
     readonly featureContext: FeatureSwitchContext;
-    readonly account?: ReturnType<
-      typeof parseStoredConnectorAccountMutationIntent
-    >;
+    readonly account: ConnectorAccountMutationIntent;
   },
   signal: AbortSignal,
 ): Promise<
@@ -377,9 +375,7 @@ const completeOAuth2Callback$ = command(
             storageVersion: connector.storageVersion,
             token,
             featureContext,
-            account: parseStoredConnectorAccountMutationIntent(
-              claimed.state.accountMutation,
-            ),
+            account: claimed.state.accountMutation,
           },
           signal,
         );

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -1,16 +1,15 @@
 import { command } from "ccstate";
 import { and, eq, isNotNull, ne } from "drizzle-orm";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oauth";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
-import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 import { connectors } from "@okouai/db/schema/connector";
 import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 
 import { env } from "../../lib/env";
-import { parseStoredConnectorAccountMutationIntent } from "../services/connector-account-mutation.service";
 import { logger } from "../../lib/log";
 import { queryOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
@@ -78,7 +77,7 @@ interface FeishuConnectionState {
   readonly installationId: string;
   readonly orgId: string;
   readonly userId: string;
-  readonly accountMutation?: StoredConnectorAccountMutation | null;
+  readonly accountMutation: ConnectorAccountMutationIntent;
 }
 
 interface FeishuInstallationOAuthRow {
@@ -450,9 +449,7 @@ async function persistFeishuOAuthConnection(
               intent: "reconnect",
               connectionId: connection.memberConnectorId,
             }
-          : parseStoredConnectorAccountMutationIntent(
-              args.state.accountMutation ?? null,
-            ),
+          : args.state.accountMutation,
       },
       signal,
     );
@@ -771,7 +768,10 @@ const completeLegacyFeishuOAuth$ = command(
     const completed = await finishFeishuOAuthConnection(
       {
         db,
-        state,
+        state: {
+          ...state,
+          accountMutation: { intent: "single-account" },
+        },
         installation,
         connector,
         ...exchanged,

--- a/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
@@ -2,7 +2,6 @@ import {
   connectorAccountMutationIntentSchema,
   type ConnectorAccountMutationIntent,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 import {
   isFeatureEnabled,
   type FeatureSwitchContext,
@@ -13,7 +12,7 @@ import { sql, type SQLWrapper } from "drizzle-orm";
 import { zodDriverValueDecoder } from "../../lib/db-structured-result";
 
 const storedConnectorAccountMutationDecoder = zodDriverValueDecoder(
-  connectorAccountMutationIntentSchema.nullable(),
+  connectorAccountMutationIntentSchema,
 );
 
 export type ConnectorAccountMutation =
@@ -32,22 +31,8 @@ export function normalizeConnectorAccountMutation(
   return intent ?? { intent: "target-only-client-singleton" };
 }
 
-export function parseStoredConnectorAccountMutationIntent(
-  value: StoredConnectorAccountMutation | null,
-): ConnectorAccountMutationIntent | undefined {
-  const mutation: ConnectorAccountMutation =
-    value === null
-      ? { intent: "target-only-client-singleton" }
-      : connectorAccountMutationIntentSchema.parse(value);
-  return mutation.intent === "target-only-client-singleton"
-    ? undefined
-    : mutation;
-}
-
-export function storedConnectorAccountMutationSelection(relation: SQLWrapper) {
-  // Keep old authorization state readable through the #28726 rollout.
-  // #28727 removes this projection after the rollback window drains.
-  return sql`
-    to_jsonb(${relation}) -> 'account_mutation'
-  `.mapWith(storedConnectorAccountMutationDecoder);
+export function storedConnectorAccountMutationSelection(
+  accountMutation: SQLWrapper,
+) {
+  return sql`${accountMutation}`.mapWith(storedConnectorAccountMutationDecoder);
 }

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -22,7 +22,6 @@ import {
   type ConnectorAuthProviderGrantResult,
 } from "@okouai/connectors/auth-providers";
 import { isOAuthProviderHttpError } from "@okouai/connectors/auth-providers/oauth/error";
-import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 import { connectorExternalCodeSessions } from "@okouai/db/schema/connector-external-code-session";
 import { command } from "ccstate";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
@@ -58,7 +57,6 @@ import {
 } from "./connected-connector-authorization.service";
 import {
   connectorAccountSiblingWritesEnabled,
-  parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
 } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
@@ -83,7 +81,7 @@ const externalCodeSessionSelection = Object.freeze({
   sessionTokenHash: connectorExternalCodeSessions.sessionTokenHash,
   encryptedProviderState: connectorExternalCodeSessions.encryptedProviderState,
   accountMutation: storedConnectorAccountMutationSelection(
-    connectorExternalCodeSessions,
+    connectorExternalCodeSessions.accountMutation,
   ),
   authorizationUrl: connectorExternalCodeSessions.authorizationUrl,
   errorCode: connectorExternalCodeSessions.errorCode,
@@ -94,12 +92,7 @@ const externalCodeSessionSelection = Object.freeze({
   completedAt: connectorExternalCodeSessions.completedAt,
 });
 
-type ExternalCodeSessionRow = Omit<
-  typeof connectorExternalCodeSessions.$inferSelect,
-  "accountMutation"
-> & {
-  readonly accountMutation: StoredConnectorAccountMutation | null;
-};
+type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
 
 type ExternalCodeSessionOwner = {
   readonly connectorSlug: ConnectorSlug;
@@ -1119,9 +1112,7 @@ export const completeConnectorExternalCodeSession$ = command(
               oauthScopes: token.scopes,
               expiresIn: token.expiresIn,
               extraConnectorSecrets: token.extraConnectorSecrets,
-              account: parseStoredConnectorAccountMutationIntent(
-                claimedSession.accountMutation,
-              ),
+              account: claimedSession.accountMutation,
             },
             persistSignal,
           );

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -24,7 +24,6 @@ import type {
   OAuthDeviceAuthCompleteResultBase,
   OAuthDeviceAuthPollResultBase,
 } from "@okouai/connectors/auth-providers/provider-flow-types";
-import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 import { connectorOauthDeviceAuthorizationSessions } from "@okouai/db/schema/connector-oauth-device-authorization-session";
 import { command } from "ccstate";
 import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
@@ -61,7 +60,6 @@ import {
 } from "./connected-connector-authorization.service";
 import {
   connectorAccountSiblingWritesEnabled,
-  parseStoredConnectorAccountMutationIntent,
   storedConnectorAccountMutationSelection,
 } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
@@ -91,7 +89,7 @@ const deviceAuthSessionSelection = Object.freeze({
   encryptedProviderState:
     connectorOauthDeviceAuthorizationSessions.encryptedProviderState,
   accountMutation: storedConnectorAccountMutationSelection(
-    connectorOauthDeviceAuthorizationSessions,
+    connectorOauthDeviceAuthorizationSessions.accountMutation,
   ),
   userCode: connectorOauthDeviceAuthorizationSessions.userCode,
   verificationUri: connectorOauthDeviceAuthorizationSessions.verificationUri,
@@ -106,12 +104,8 @@ const deviceAuthSessionSelection = Object.freeze({
   completedAt: connectorOauthDeviceAuthorizationSessions.completedAt,
 });
 
-type DeviceAuthSessionRow = Omit<
-  typeof connectorOauthDeviceAuthorizationSessions.$inferSelect,
-  "accountMutation"
-> & {
-  readonly accountMutation: StoredConnectorAccountMutation | null;
-};
+type DeviceAuthSessionRow =
+  typeof connectorOauthDeviceAuthorizationSessions.$inferSelect;
 
 type PendingPollBody = Extract<
   ConnectorOauthDeviceAuthSessionPollResponse,
@@ -1311,9 +1305,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
               oauthScopes: result.token.scopes,
               expiresIn: result.token.expiresIn,
               extraConnectorSecrets: result.token.extraConnectorSecrets,
-              account: parseStoredConnectorAccountMutationIntent(
-                claimedSession.accountMutation,
-              ),
+              account: claimedSession.accountMutation,
             },
             signal,
           );

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,6 +1,5 @@
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
-import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
 import { and, eq, gt, isNotNull, isNull, type SQL } from "drizzle-orm";
 
@@ -24,22 +23,18 @@ const storedOAuthStateSelection = Object.freeze({
   authorizationUrl: connectorOauthStates.authorizationUrl,
   codeVerifier: connectorOauthStates.codeVerifier,
   oauthContext: connectorOauthStates.oauthContext,
-  accountMutation:
-    storedConnectorAccountMutationSelection(connectorOauthStates),
+  accountMutation: storedConnectorAccountMutationSelection(
+    connectorOauthStates.accountMutation,
+  ),
   createdAt: connectorOauthStates.createdAt,
   expiresAt: connectorOauthStates.expiresAt,
   consumedAt: connectorOauthStates.consumedAt,
 });
 
-type StoredOAuthStateRow = Omit<
-  Pick<
-    typeof connectorOauthStates.$inferSelect,
-    keyof typeof storedOAuthStateSelection
-  >,
-  "accountMutation"
-> & {
-  readonly accountMutation: StoredConnectorAccountMutation | null;
-};
+type StoredOAuthStateRow = Pick<
+  typeof connectorOauthStates.$inferSelect,
+  keyof typeof storedOAuthStateSelection
+>;
 
 export type StoredBuiltinOAuthState = Omit<
   StoredOAuthStateRow,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -66,10 +66,7 @@ import {
   replaceConnectorConnection,
   resolveConnectorConnectionMutation,
 } from "./connector-connection-write.service";
-import {
-  connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
-} from "./connector-account-mutation.service";
+import { connectorAccountSiblingWritesEnabled } from "./connector-account-mutation.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
@@ -836,7 +833,7 @@ export async function storeCustomConnectorOAuth2Connection(
     readonly storageVersion: number;
     readonly token: OAuthTokenResult;
     readonly featureContext: FeatureSwitchContext;
-    readonly account?: ConnectorAccountMutationIntent;
+    readonly account: ConnectorAccountMutationIntent;
   },
   signal: AbortSignal,
 ): Promise<
@@ -857,7 +854,7 @@ export async function storeCustomConnectorOAuth2Connection(
       orgId: args.orgId,
       userId: args.userId,
       target: { kind: "custom", customConnectorId: args.connectorId },
-      mutation: normalizeConnectorAccountMutation(args.account),
+      mutation: args.account,
       allowSiblings:
         !isIntegrationManagedCustomConnectorProviderAdapter(
           contract.providerAdapter,


### PR DESCRIPTION
## Summary

- read connector OAuth, device-auth, and external-code account mutation state through the required non-null JSONB contract
- propagate persisted mutation intent directly through built-in, custom, and Feishu completion paths
- remove the rollout-only missing-column projection, nullable row overrides, and null-to-singleton parser

## Compatibility

- preserves installed CLI request normalization and target-only singleton behavior at the request boundary
- preserves Feishu Integration ownership and exact member-connector reconnect behavior
- does not change connector UI, account selection, permissions, migrations, or feature rollout

## Merge blocker

Do not merge until all of the following production conditions are recorded as complete:

- the database contraction from #28726 is deployed successfully
- the DB/API rollback window has drained
- every production database instance exposes non-null `account_mutation` columns

PR #28735 is deployed, but preparing and making this PR CI-clean is not evidence that the rollback drain and all-instance verification have completed.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run --maxWorkers=1 --no-file-parallelism src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/connectors-openid.bdd.test.ts src/signals/routes/__tests__/connectors-oauth-start.test.ts src/signals/routes/__tests__/feishu-integration.test.ts src/signals/routes/__tests__/integrations.bdd.test.ts` (204 tests passed on a fresh fully migrated disposable PostgreSQL database)

Closes #28727

Parent: #28698
