### PR TITLE
docs(api): align test descriptions with the agent vocabulary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
@@ -235,7 +235,7 @@ describe("GET /api/agents/:id/custom-connectors", () => {
     });
   });
 
-  it("returns 403 for a zero token without agent:read capability", async () => {
+  it("returns 403 for an agent token without agent:read capability", async () => {
     const actor = bdd.user();
     const token = okouTokenFor(actor, ["file:read"]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
@@ -6,7 +6,7 @@ import { createBddApi, expectApiError } from "./helpers/api-bdd";
 const context = testContext();
 const api = createBddApi(context);
 
-describe("AGENT-01: zero agent lifecycle through public API", () => {
+describe("AGENT-01: agent lifecycle through public API", () => {
   it("creates, reads, lists, updates, deletes, and verifies removal through API-visible state", async () => {
     const admin = api.user();
     api.acceptAgentStorageWrites();

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -1210,7 +1210,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsBeforeCompletion);
   });
 
-  it("uploads and streams phone media with a real run-scoped zero token", async () => {
+  it("uploads and streams phone media with a real run-scoped agent token", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const integrations = createBddIntegrationApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
@@ -300,7 +300,7 @@ describe("GET /api/agents/:id", () => {
     });
   });
 
-  it("returns 403 for a zero token without agent:read capability", async () => {
+  it("returns 403 for an agent token without agent:read capability", async () => {
     const actor = bdd.user();
     const token = okouTokenFor(actor, ["file:read"]);
 
@@ -320,7 +320,7 @@ describe("GET /api/agents/:id", () => {
     });
   });
 
-  it("returns the agent for a zero token with agent:read capability", async () => {
+  it("returns the agent for an agent token with agent:read capability", async () => {
     const actor = bdd.user();
     const agent = await createAgent(actor, {
       displayName: "Zero Token Agent",
@@ -354,7 +354,7 @@ describe("DELETE /api/agents/:id", () => {
     });
   });
 
-  it("returns 403 for a zero token without agent:delete capability", async () => {
+  it("returns 403 for an agent token without agent:delete capability", async () => {
     const actor = bdd.user();
     const token = okouTokenFor(actor, ["file:read"]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
@@ -77,7 +77,7 @@ describe("POST /api/agents", () => {
     });
   });
 
-  it("returns 403 for a zero token without agent:write capability", async () => {
+  it("returns 403 for an agent token without agent:write capability", async () => {
     const seconds = currentSecond();
     const token = signSandboxJwtForTests({
       scope: "okou",

--- a/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
@@ -399,7 +399,7 @@ describe("POST /api/zero/banking/*", () => {
     ]);
   });
 
-  it("rejects zero tokens without banking capability before provider access", async () => {
+  it("rejects agent tokens without banking capability before provider access", async () => {
     const fixture = await seedBankingFixture();
     let authRequestCount = 0;
     server.use(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -18911,7 +18911,7 @@ describe("POST /api/billing/concurrency-checkout", () => {
     ]);
   });
 
-  it("adds concurrency to the Plan subscription for a zero token with billing write capability", async () => {
+  it("adds concurrency to the Plan subscription for an agent token with billing write capability", async () => {
     context.mocks.stripe.subscriptions.list.mockResolvedValueOnce({
       data: [],
       has_more: false,
@@ -20147,7 +20147,7 @@ describe("POST /api/billing/credit-checkout", () => {
     });
   });
 
-  it("returns 403 for zero tokens without billing write capability", async () => {
+  it("returns 403 for agent tokens without billing write capability", async () => {
     const token = okouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
@@ -21027,7 +21027,7 @@ describe("POST /api/billing/credit-checkout", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("creates credit checkout for zero tokens with billing write capability", async () => {
+  it("creates credit checkout for agent tokens with billing write capability", async () => {
     const fixture = await trackedSeed();
     await seedMemberRole({
       orgId: fixture.orgId,

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-status.test.ts
@@ -137,7 +137,7 @@ describe("GET /api/billing/status", () => {
     expect(response.body.currentPeriodEnd).toBeNull();
   });
 
-  it("returns billing status for zero tokens with billing read capability", async () => {
+  it("returns billing status for agent tokens with billing read capability", async () => {
     const fixture = await track(
       store.set(seedBillingStatusOrg$, { credits: 100_000 }, context.signal),
     );
@@ -160,7 +160,7 @@ describe("GET /api/billing/status", () => {
     expect(response.body.credits).toBe(100_000);
   });
 
-  it("returns 403 for zero tokens without billing read capability", async () => {
+  it("returns 403 for agent tokens without billing read capability", async () => {
     const token = okouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events-auth.test.ts
@@ -16,7 +16,7 @@ function client() {
 }
 
 describe("POST /api/zero/chat/events authorization", () => {
-  it("rejects a zero token without chat-event:write", async () => {
+  it("rejects an agent token without chat-event:write", async () => {
     const seconds = Math.floor(now() / 1000);
     const token = signSandboxJwtForTests({
       scope: "okou",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4041,7 +4041,7 @@ describe("CHAT-02: admission without spendable credits", () => {
   }, 60_000);
 });
 
-describe("CHAT-02: Zero Mail link delivery", () => {
+describe("CHAT-02: Okou Mail link delivery", () => {
   it("delivers a linked Gmail draft exactly once through the agent reply", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     mockGmailConnectorOAuth({
@@ -11096,7 +11096,7 @@ describe("CHAT-02: public-brand default assistant identity", () => {
   }, 90_000);
 });
 
-describe("CHAT-02: run-scoped Zero-token chat launches", () => {
+describe("CHAT-02: run-scoped agent-token chat launches", () => {
   it("keeps immediate and queued runs agent-scoped without retired provenance", async () => {
     const { actor, agentId } = await entitledChatActor();
     if (!actor.orgId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -602,7 +602,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     expect(unauthenticatedBody.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("allows chat-thread read zero tokens to sync snapshots and events", async () => {
+  it("allows chat-thread read agent tokens to sync snapshots and events", async () => {
     const actor = bdd.user();
     if (!actor.orgId) {
       throw new Error("Expected an org-scoped actor");

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -637,7 +637,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
     ]);
   });
 
-  it("scopes host discovery to the bound host for zero run tokens", async () => {
+  it("scopes host discovery to the bound host for agent run tokens", async () => {
     const actor = bdd.user();
     await api.startComputerUseHost(actor, {
       hostName: "Other Desktop",

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -193,7 +193,7 @@ beforeEach(() => {
 });
 
 describe("POST /api/connectors/diagnostics/check", () => {
-  it("requires organization auth and both Zero capabilities", async () => {
+  it("requires organization auth and both agent capabilities", async () => {
     const body = {
       mode: "url" as const,
       method: "POST",
@@ -695,7 +695,7 @@ describe("POST /api/connectors/diagnostics/check", () => {
     }
   });
 
-  it("uses only an owned Zero snapshot, including dynamic bases and final policies", async () => {
+  it("uses only an owned agent run snapshot, including dynamic bases and final policies", async () => {
     const owner = bdd.user();
     const runId = await createOwnedRun(owner);
     await seedZeroMembership(owner);

--- a/turbo/apps/api/src/signals/routes/__tests__/finance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/finance.test.ts
@@ -59,7 +59,7 @@ function configureProvider(): void {
 }
 
 describe("okou finance routes", () => {
-  it("rejects zero tokens without finance:read capability", async () => {
+  it("rejects agent tokens without finance:read capability", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("Finance test actor must belong to an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -162,7 +162,7 @@ async function readGoalMarkerSummaries(fixture: GoalApiFixture) {
     });
 }
 
-describe("zero goals", () => {
+describe("agent goals", () => {
   beforeEach(() => {
     mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -962,8 +962,8 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
   });
 });
 
-describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped zero-token attribution", () => {
-  it("attributes maps usage and hosted-site artifacts to a claimed run through its real zero token [HOST-B/MAPS-B]", async () => {
+describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped agent-token attribution", () => {
+  it("attributes maps usage and hosted-site artifacts to a claimed run through its real agent token [HOST-B/MAPS-B]", async () => {
     const bdd = createBddApi(context);
     const api = createHostMapsBddApi(context);
     const billing = createMapsBillingApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -603,7 +603,7 @@ describe("POST /api/image-io/generate", () => {
     });
   });
 
-  it("returns 403 when a zero token lacks file write capability", async () => {
+  it("returns 403 when an agent token lacks file write capability", async () => {
     const token = okouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
@@ -1057,7 +1057,7 @@ describe("POST /api/image-io/generate", () => {
     await expect(orgCredits(fixture)).resolves.toBe(1000);
   });
 
-  it("limits run-scoped zero token image generations after three active built-ins", async () => {
+  it("limits run-scoped agent token image generations after three active built-ins", async () => {
     const fixture = await seedImageFixture({});
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,
@@ -1143,7 +1143,7 @@ describe("POST /api/image-io/generate", () => {
     await expect(orgCredits(fixture)).resolves.toBe(10_000);
   });
 
-  it("generates image files on the Okou CDN for Okou run-scoped zero tokens", async () => {
+  it("generates image files on the Okou CDN for Okou run-scoped agent tokens", async () => {
     const fixture = await seedImageFixture({});
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,

--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -300,7 +300,7 @@ describe("POST /api/recognize", () => {
     ]);
   });
 
-  it("enforces Zero-only capability authorization before object access", async () => {
+  it("enforces agent-only capability authorization before object access", async () => {
     const actor = await seedActor();
     const fileId = randomUUID();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -428,7 +428,7 @@ describe("POST /api/integrations/slack/upload-file/complete", () => {
     expect(files).toStrictEqual([]);
   });
 
-  it("records a Slack upload for a run-scoped zero token", async () => {
+  it("records a Slack upload for a run-scoped agent token", async () => {
     const { orgId, userId, runId, threadId } = await seedRunScoped();
     const fileId = `F-${randomUUID().slice(0, 8)}`;
     mockSlackFileInfo(fileId);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
@@ -813,7 +813,7 @@ describe("GET /api/okou/integrations/slack/download-file", () => {
     await expectErrorResponse(response, 401, "UNAUTHORIZED");
   });
 
-  it("rejects a zero token without slack:write capability", async () => {
+  it("rejects an agent token without slack:write capability", async () => {
     const token = okouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -1158,7 +1158,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await expect(badJson.text()).resolves.toBe("Bad Request");
   });
 
-  it("creates a Zero run for a linked custom-bot private message", async () => {
+  it("creates an agent run for a linked custom-bot private message", async () => {
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
     );
@@ -2044,7 +2044,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(messages[0]?.text).toBe("following up");
   });
 
-  it("creates a Zero run for a linked custom-bot supergroup mention", async () => {
+  it("creates an agent run for a linked custom-bot supergroup mention", async () => {
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
     );
@@ -2112,7 +2112,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     });
   });
 
-  it("creates a Zero run for a linked official-bot private message", async () => {
+  it("creates an agent run for a linked official-bot private message", async () => {
     configureOfficialBotEnv();
     const fixture = await trackFixture(
       seedTelegramPostFixture({ installBot: false, seedOfficialLink: true }),
@@ -2186,7 +2186,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     });
   });
 
-  it("creates a Zero run for a linked official-bot group mention", async () => {
+  it("creates an agent run for a linked official-bot group mention", async () => {
     configureOfficialBotEnv();
     const fixture = await trackFixture(
       seedTelegramPostFixture({ installBot: false, seedOfficialLink: true }),
@@ -2665,7 +2665,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     );
   });
 
-  it("does not prompt unlinked official group replies to another bot but prompts replies to Zero", async () => {
+  it("does not prompt unlinked official group replies to another bot but prompts replies to the official bot", async () => {
     configureOfficialBotEnv();
     const telegramMocks = telegramApiMocks(OFFICIAL_BOT_TOKEN);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
@@ -232,7 +232,7 @@ describe("GET /api/mcp-connectors", () => {
     expect(response.body).toStrictEqual({ connectors: [] });
   });
 
-  it("requires Zero authentication with connector read capability", async () => {
+  it("requires agent authentication with connector read capability", async () => {
     const actor = bdd.user();
     mockClerkMembership(context, actor, "org:admin");
     const runId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -317,7 +317,7 @@ describe("GET/PUT /api/model-policies", () => {
     );
   });
 
-  it("allows zero tokens to read policy controls without a model-provider capability", async () => {
+  it("allows agent tokens to read policy controls without a model-provider capability", async () => {
     const fixture = await seedFixture();
     authOrgApi.mockClerkOrg(fixture);
     const seconds = currentSecond();

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -1038,8 +1038,8 @@ describe("ORG-01/AGENT-02: team listing and default-agent recovery", () => {
   });
 });
 
-describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
-  it("serves the org read to a claimed run's zero token and rejects member reads and org writes [ORG-TOKEN-G]", async () => {
+describe("AUTH-02/ORG-01: run-scoped agent tokens on org routes", () => {
+  it("serves the org read to a claimed run's agent token and rejects member reads and org writes [ORG-TOKEN-G]", async () => {
     const runs = createRunsApi(context);
     const admin = api.user();
     api.acceptAgentStorageWrites();

--- a/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
@@ -275,7 +275,7 @@ async function successfulRequest(
 }
 
 describe("okou people-search route", () => {
-  it("rejects zero tokens without people-search capability", async () => {
+  it("rejects agent tokens without people-search capability", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("People Search test actor must have an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
@@ -338,7 +338,7 @@ describe("POST /api/presentation/images/resolve", () => {
     });
   });
 
-  it("requires file write capability for zero tokens", async () => {
+  it("requires file write capability for agent tokens", async () => {
     const fixture = createFixture();
     mockEnv("UNSPLASH_ACCESS_KEY", "test-unsplash-key");
     const client = setupApp({ context, routes: presentationImagesRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7201,7 +7201,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
   });
 });
 
-describe("RUN-01: zero run authorization and session boundaries", () => {
+describe("RUN-01: agent run authorization and session boundaries", () => {
   it("does not expose the removed Zero run creation route", async () => {
     const actor = createBddApi(context).user();
     await expect(
@@ -8376,7 +8376,7 @@ describe("RUN-02: persisted run environment resolution", () => {
 });
 
 describe("RUN-02: stored connector injection into claimed runs", () => {
-  it("omits connected stored connectors when the Zero run allowlist is empty", async () => {
+  it("omits connected stored connectors when the agent run allowlist is empty", async () => {
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -13921,7 +13921,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
   });
 });
 
-describe("RUN-01: zero runner context, queue promotion, and skills", () => {
+describe("RUN-01: agent runner context, queue promotion, and skills", () => {
   it("uses the application plan for a valid legacy head", async () => {
     const appUrl = "https://app.environment-shadow.example.test";
     mockEnv("APP_URL", appUrl);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -744,8 +744,8 @@ describe("RUN-03/RUN-04: direct run list, detail, and queue reads", () => {
   });
 });
 
-describe("RUN-03: cancel through the Zero route", () => {
-  it("cancels runs through the Zero cancel route across states", async () => {
+describe("RUN-03: cancel through the run cancel route", () => {
+  it("cancels runs through the run cancel route across states", async () => {
     const actor = await entitledActor();
     const compose = await createClaudeCompose(actor, "bdd-cancel");
 
@@ -2112,7 +2112,7 @@ describe("RUN-04: agent run telemetry families", () => {
     expect(eventQueries[0]?.[1]).toStrictEqual({ noCache: true });
   });
 
-  it("hardens network log rows in the zero read API", async () => {
+  it("hardens network log rows in the agent read API", async () => {
     const actor = await entitledActor();
     const compose = await createClaudeCompose(actor, "bdd-network-hardening");
     const agentRun = await api.createDirectRun(actor, {
@@ -2597,7 +2597,7 @@ describe("RUN-04: agent run telemetry families", () => {
     });
   });
 
-  it("maps zero run context, network, and runner metadata from axiom snapshots", async () => {
+  it("maps agent run context, network, and runner metadata from axiom snapshots", async () => {
     const actor = await entitledActor();
     const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
     await api.ensureOrgModelProvider(actor);
@@ -3181,8 +3181,8 @@ describe("RUN-04: agent run telemetry families", () => {
   });
 });
 
-describe("RUN-04/OPS-01: zero run logs", () => {
-  it("lists run logs with filters, paging, zero tokens, and detail residue", async () => {
+describe("RUN-04/OPS-01: agent run logs", () => {
+  it("lists run logs with filters, paging, agent tokens, and detail residue", async () => {
     const actor = await entitledActor();
     const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
     await api.ensureOrgModelProvider(actor);
@@ -3524,7 +3524,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     });
   });
 
-  it("resolves zero log agent identity from the run session when compose versions are shared", async () => {
+  it("resolves run log agent identity from the run session when compose versions are shared", async () => {
     const actor = await entitledActor();
     const foreignActor = bdd.user();
     await api.ensureOrgModelProvider(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
@@ -178,7 +178,7 @@ async function createScrapePricingFixture(): Promise<UsagePricingFixture> {
 }
 
 describe("okou scrape route", () => {
-  it("rejects zero tokens without scrape:read capability", async () => {
+  it("rejects agent tokens without scrape:read capability", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("Scrape test actor must belong to an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
@@ -143,7 +143,7 @@ function emptyDataForSeoResponse() {
 }
 
 describe("SEO routes", () => {
-  it("rejects zero tokens without the seo capability", async () => {
+  it("rejects agent tokens without the seo capability", async () => {
     const actor = await seedActor();
     if (!actor.orgId) {
       throw new Error("SEO test actor must belong to an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -432,7 +432,7 @@ describe("managed SocialKit route", () => {
     }
   });
 
-  it("rejects zero tokens without social:read capability", async () => {
+  it("rejects agent tokens without social:read capability", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("Social test actor must belong to an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -3190,7 +3190,7 @@ describe("POST /api/zero/teams/bot", () => {
     await runsApi.requestCancelRun(actor, runId, [200]);
   });
 
-  it("includes Teams thread computer use host bindings in queued zero tokens", async () => {
+  it("includes Teams thread computer use host bindings in queued agent tokens", async () => {
     const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
     const host = await computerUseApi.startComputerUseHost(actor, {
       hostName: "Teams authorized host",

--- a/turbo/apps/api/src/signals/routes/__tests__/translation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/translation.test.ts
@@ -285,7 +285,7 @@ describe("POST /api/translate", () => {
     });
   });
 
-  it("enforces Zero-only capability authorization before provider work", async () => {
+  it("enforces agent-only capability authorization before provider work", async () => {
     const actor = await seedActor();
 
     const unauthenticated = await requestTranslation({});

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
@@ -439,7 +439,7 @@ describe("POST /api/uploads/complete", () => {
     });
   });
 
-  it("returns 403 for a zero token without file:write capability", async () => {
+  it("returns 403 for an agent token without file:write capability", async () => {
     const response = await chat.completeUploadWithBearer(
       zeroBearer(["file:read"]),
       { id: randomUUID() },

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -94,7 +94,7 @@ describe("POST /api/zero/uploads/prepare", () => {
     expect(response.body.id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  it("uses the zero token brand instead of the request origin", async () => {
+  it("uses the agent token brand instead of the request origin", async () => {
     const userId = `user_${randomUUID().slice(0, 8)}`;
     const orgId = `org_${randomUUID().slice(0, 8)}`;
     const runId = `run_${randomUUID()}`;
@@ -131,7 +131,7 @@ describe("POST /api/zero/uploads/prepare", () => {
     });
   });
 
-  it("uses the trusted request brand when no zero token is present", async () => {
+  it("uses the trusted request brand when no agent token is present", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -597,8 +597,8 @@ describe("AUTH-02 auth probe CLI PAT bearers", () => {
   });
 });
 
-describe("AUTH-01 sandbox and zero bearers", () => {
-  it("resolves sandbox and zero bearers on the auth probe by capability opt-in", async () => {
+describe("AUTH-01 sandbox and agent bearers", () => {
+  it("resolves sandbox and agent bearers on the auth probe by capability opt-in", async () => {
     const sandboxActor = api.user();
     const zeroMember = api.user();
     const zeroAdmin = api.user();
@@ -688,7 +688,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
     expect(badSignature.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("enforces zero capabilities on real user-config routes", async () => {
+  it("enforces agent capabilities on real user-config routes", async () => {
     const admin = api.user();
     api.acceptAgentStorageWrites();
     const agent = await api.createAgent(admin, {
@@ -738,7 +738,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
     });
   });
 
-  it("accepts sandbox and zero bearers on auth me", async () => {
+  it("accepts sandbox and agent bearers on auth me", async () => {
     const sandboxActor = api.user();
     const writeActor = api.user();
     const bareActor = api.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
@@ -1178,7 +1178,7 @@ describe("POST /api/zero/voice-io/*", () => {
     expect(calledOpenAi).toBeFalsy();
   });
 
-  it("generates /speech WAV files for run-scoped zero tokens", async () => {
+  it("generates /speech WAV files for run-scoped agent tokens", async () => {
     const fixture = await seedVoiceFixture({});
     const usagePricingResolution =
       await createSpeechPricingResolution("configured");

--- a/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
@@ -161,7 +161,7 @@ describe("GET /api/web/download-file", () => {
     await expectErrorResponse(response, 401, "UNAUTHORIZED");
   });
 
-  it("returns 403 for a zero token without file:read capability", async () => {
+  it("returns 403 for an agent token without file:read capability", async () => {
     const token = mintOkouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
@@ -133,7 +133,7 @@ describe("GET /api/web/file-url", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("returns 403 for a zero token without file:read capability", async () => {
+  it("returns 403 for an agent token without file:read capability", async () => {
     const token = mintOkouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
@@ -207,7 +207,7 @@ function providerResponse() {
 }
 
 describe("okou web-search route", () => {
-  it("rejects zero tokens without web-search:read capability", async () => {
+  it("rejects agent tokens without web-search:read capability", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("Web Search test actor must belong to an organization");

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -4417,7 +4417,7 @@ describe("okou workflow automations", () => {
     await runs.requestCancelRun(actor, exhaustedRun.body.runId, [200]);
   });
 
-  it("derives manual run budgets from the source and rejects exhausted Zero callers", async () => {
+  it("derives manual run budgets from the source and rejects exhausted agent callers", async () => {
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const { actor, workflowId } = await setupFixture();
     const automation = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -1530,7 +1530,7 @@ describe("workflows", () => {
     ).toBeTruthy();
   });
 
-  it("inherits copied automation budgets from Zero callers and rejects exhausted runs", async () => {
+  it("inherits copied automation budgets from agent callers and rejects exhausted runs", async () => {
     const actor = user({ orgRole: "org:admin" });
     await enableWorkflowRuns(actor);
     const sourceAgent = await createAgent(actor, {


### PR DESCRIPTION
Closes #28785. Part of #26873.

Renames brand residue in `apps/api` test `describe`/`it` strings where the code they describe is now called *agent*. **Description strings only** — no test behaviour, assertion, or fixture is touched, and nothing under `packages/db` or any `zeroAgents` / `zero_agents` / feature-switch symbol is modified.

## What changed

**69 descriptions across 42 files.**

- **`zero token` → `agent token`** — #28755 renamed the auth-context discriminant to `tokenType: "agent"` (verified: `auth.tokenType === "agent"` throughout `apps/api/src/signals/services/`), so a description saying "run-scoped zero token" now names something the code calls an agent token.
- **Prose residue** — `Zero callers` → `agent callers`, `Zero-only capability authorization` → `agent-only capability authorization`, `zero run authorization` → `agent run authorization`, `sandbox and zero bearers` → `sandbox and agent bearers`, and similar.
- **`CHAT-02: Zero Mail link delivery` → `CHAT-02: Okou Mail link delivery`** — the feature is `okou mail link` today.
- **`cancel through the Zero route` → `cancel through the run cancel route`** — checked `runsCancelContract`: its path is the neutral `/api/runs/:id/cancel`, not a `/api/zero/` path, so "Zero route" was pure residue rather than a path reference.
- **`prompts replies to Zero` → `prompts replies to the official bot`** — the test asserts on `OFFICIAL_BOT_USERNAME`.

## Deliberately retained (45 strings)

Each is left at its original wording so a later sweep can tell deliberate retention from an oversight.

| Category | Count | Why |
| --- | --- | --- |
| `describe("… /api/zero/…")` route paths | 20 | Those paths still resolve through the compatibility table; the description names the endpoint actually exercised. |
| `ZeroDebug` feature-switch key | 3 | `connector-catalog.test.ts:423,443` and `model-providers.test.ts:514` — literal switch key. |
| Numeric `zero` | 13 | `budget zero`, `zero-amount`, `zero-quantity`, `zero credits`, `zero rows`, `reports zero …` — the number, not the brand. |
| Literal legacy identifiers asserted in the test body | 9 | See below. |

The nine literal-identifier retentions, each verified against the code the test asserts on:

- `run-lifecycle.bdd.test.ts:7205` — **`does not expose the removed Zero run creation route`**. Kept as a historical statement, per the issue. The helper `requestRemovedAgentRunCreation` posts to the literal `/api/zero/runs`, and the removed route was called that; renaming would rewrite history.
- `user-permission-grants.test.ts:152` — **`zero user permission grants`**. **Left alone: PR #28200 (`refactor(contracts): neutralize permission grant and connector contract naming`) is still open**, so `zeroUserPermissionGrantsContract` has not been renamed yet. A description that disagrees with its symbol is worse than one that is merely dated. Worth a follow-up once #28200 lands.
- `run-lifecycle.bdd.test.ts:15320` — **`mounts workflows for claude-code zero agents`**. Checked as the issue asks: this test creates its subject with `bdd.createAgent` (a `zero_agents`-backed agent), in contrast to sibling tests that run against composes via `createClaudeCompose`/`composeId`. The distinction it draws is load-bearing, and that entity belongs to #26938's consolidation, which #28368 asks not to pre-empt with a competing rename. Left untouched.
- `tokens.test.ts:90` — `retired zero scope`: the test literally mints `scope: "zero"`.
- `api-namespace-compatibility.test.ts:226` — `legacy Zero path`: the test literally builds `/api/zero/`.
- `app-factory.test.ts:1248` — `classifies … as Zero`: asserts `x_client_product: DESKTOP_PRODUCT_ZERO`.
- `auth-device.bdd.test.ts:134` — `legacy Zero callback URL`: asserts the `ai.vm0.zero.desktop.dev:` scheme.
- `desktop-updates.test.ts:495,524` — the two tests exist precisely to contrast the literal `Zero-*` artifact/feed against the `Okou-*` one; renaming would erase what they check.

`ZERO_TOKEN` in descriptions (17 strings) is the literal test fixture constant and is outside this issue's 114.

## Note on the issue's arithmetic

The issue predicted an 88/26 split; the actual split is 69/45. The gap is almost entirely the numeric-`zero` bucket, which the issue estimated at 3 but is 13 in the tree, plus the literal-identifier cases enumerated above that the issue described by principle rather than by count. The rules were applied as written; only the counts differ.

## Concurrent work

PRs #28200 and #28206 touch `apps/api/src/signals/routes/__tests__/`. Conflicts there should be resolved by keeping both sides: those PRs change symbol names, this one changes description text.

## Tests

The suite is unchanged — no assertion reads a description string. `prettier --write` reports every touched file unchanged, so no line reflowed.
