### PR TITLE
fix(platform): keep debug diagnostic icons stationary

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1303,15 +1303,6 @@ details > summary {
   transition: color 0.15s ease;
 }
 
-details > summary > span:first-child {
-  display: inline-block;
-  transition: transform 0.15s ease;
-}
-
-details[open] > summary > span:first-child {
-  transform: rotate(90deg);
-}
-
 /* Zero workspace: soft texture + gentle gradient — documents, records, thinking, meeting notes.
    Grid is on ::before with z-index: -1; container has z-index: 0 so the texture stays behind content only. */
 /* Document card body: serif for reading */


### PR DESCRIPTION
## Summary

- remove the unused global rule that rotated the first direct `span` in every open native summary
- keep Debug feature icons stationary while preserving their explicit right-side disclosure indicators
- retain the independent summary color transition and all component-owned chevron animations

## Scope

This PR only removes the obsolete positional CSS. It does not change diagnostic data, component state, APIs, or other disclosure markup.

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx` (34 tests)

Closes #28790
