### PR TITLE
fix(api): stop logging expected unknown connector misses

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -170,7 +170,7 @@ function executableMethod(args: {
 function createConnectorActionResolver(
   snapshot: ConnectorRuntimeSnapshot,
 ): ConnectorActionResolver {
-  const resolveSlugCore: ConnectorActionResolver["resolveSlug"] = (input) => {
+  const resolveSlug: ConnectorActionResolver["resolveSlug"] = (input) => {
     const runtimeConnector = getConnectorRuntimeConnector(
       snapshot,
       input.connectorSlug,
@@ -248,7 +248,7 @@ function createConnectorActionResolver(
   };
 
   return {
-    resolveSlug: resolveSlugCore,
+    resolveSlug,
     resolveMethod,
 
     resolveNewActionMethod(input) {
@@ -275,7 +275,7 @@ function createConnectorActionResolver(
     resolveSlugs(input) {
       const connectors: ResolvedConnectorSlug[] = [];
       for (const connectorSlug of input.connectorSlugs) {
-        const resolved = resolveSlugCore({
+        const resolved = resolveSlug({
           connectorSlug,
           requireExecutable: input.requireExecutable,
         });

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -186,17 +186,6 @@ function createConnectorActionResolver(
     });
   };
 
-  const resolveSlug: ConnectorActionResolver["resolveSlug"] = (input) => {
-    const resolution = resolveSlugCore(input);
-    if (!resolution.ok && resolution.reason === "unknown_connector") {
-      log.warn("Connector runtime is unavailable", {
-        connectorSlug: input.connectorSlug,
-        reason: resolution.reason,
-      });
-    }
-    return resolution;
-  };
-
   const resolveMethodCore: ConnectorActionResolver["resolveMethod"] = (
     input,
   ) => {
@@ -259,7 +248,7 @@ function createConnectorActionResolver(
   };
 
   return {
-    resolveSlug,
+    resolveSlug: resolveSlugCore,
     resolveMethod,
 
     resolveNewActionMethod(input) {


### PR DESCRIPTION
## Summary

- remove the `resolveSlug()` wrapper that warned for expected `unknown_connector` results
- expose the unchanged core resolver directly so fail-closed API behavior is preserved
- keep known-connector executable capability warnings unchanged

## Exclusions

- no connector selection or credential cleanup
- no replacement info/debug event or logging-policy exception
- no API, schema, migration, or connector catalog changes

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/connector-action-resolver.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agents.test.ts --maxWorkers=4 --silent=passed-only` (2 passed)
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, full Turbo type checking (14 tasks), file-size check, and commitlint
- `git diff --check`

Closes #28770
