### PR TITLE
fix(rust): make payload-too-large diagnostics unit-accurate

### DIFF
--- a/crates/vsock-proto/src/error.rs
+++ b/crates/vsock-proto/src/error.rs
@@ -7,8 +7,10 @@ pub enum ProtocolError {
     MessageTooSmall(usize),
     /// Payload contents were structurally invalid.
     InvalidPayload(&'static str),
-    /// Named payload field exceeded its encoded size or count limit.
+    /// Named payload field exceeded its encoded byte-length limit.
     PayloadTooLarge(&'static str, usize),
+    /// Named payload field exceeded its element-count limit.
+    PayloadCountTooLarge(&'static str, usize),
 }
 
 impl std::fmt::Display for ProtocolError {
@@ -19,6 +21,9 @@ impl std::fmt::Display for ProtocolError {
             Self::InvalidPayload(msg) => write!(f, "invalid payload: {msg}"),
             Self::PayloadTooLarge(field, size) => {
                 write!(f, "payload field too large: {field} ({size} bytes)")
+            }
+            Self::PayloadCountTooLarge(field, count) => {
+                write!(f, "payload field too large: {field} ({count} elements)")
             }
         }
     }

--- a/crates/vsock-proto/src/payloads/exec_operation/start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/start.rs
@@ -1,7 +1,8 @@
 use crate::error::ProtocolError;
 use crate::read::{
-    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
-    expect_consumed, read_i32, read_slice, read_str, read_u8, read_u16, read_u32,
+    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_count, ensure_u16_len,
+    ensure_u32_count, ensure_u32_len, expect_consumed, read_i32, read_slice, read_str, read_u8,
+    read_u16, read_u32,
 };
 use crate::wire::EXEC_FLAG_SUDO;
 
@@ -335,18 +336,18 @@ pub fn encode_exec_start_with_expected_exit_codes(
     let cmd = request.command.as_bytes();
     let label_bytes = request.label.as_bytes();
     let cmd_len = ensure_u32_len("command", cmd.len())?;
-    let env_count = ensure_u32_len("env_count", request.env.len())?;
+    let env_count = ensure_u32_count("env_count", request.env.len())?;
     if request.env.len() > MAX_EXEC_ENV_VARS {
-        return Err(ProtocolError::PayloadTooLarge(
+        return Err(ProtocolError::PayloadCountTooLarge(
             "env_count",
             request.env.len(),
         ));
     }
     let label_len = ensure_u16_len("label", label_bytes.len())?;
     let expected_exit_count =
-        ensure_u16_len("expected_exit_count", request.expected_exit_codes.len())?;
+        ensure_u16_count("expected_exit_count", request.expected_exit_codes.len())?;
     if request.expected_exit_codes.len() > MAX_EXEC_EXPECTED_EXIT_CODES {
-        return Err(ProtocolError::PayloadTooLarge(
+        return Err(ProtocolError::PayloadCountTooLarge(
             "expected_exit_count",
             request.expected_exit_codes.len(),
         ));

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
@@ -458,7 +458,7 @@ fn exec_start_rejects_env_count_above_limit() {
     .unwrap_err();
     assert!(matches!(
         err,
-        ProtocolError::PayloadTooLarge("env_count", size) if size == MAX_EXEC_ENV_VARS + 1
+        ProtocolError::PayloadCountTooLarge("env_count", size) if size == MAX_EXEC_ENV_VARS + 1
     ));
 
     let mut payload = exec_start_payload("", &[], "");
@@ -709,7 +709,7 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
     .unwrap_err();
     assert!(matches!(
         err,
-        ProtocolError::PayloadTooLarge("expected_exit_count", _)
+        ProtocolError::PayloadCountTooLarge("expected_exit_count", _)
     ));
 
     let mut payload = default_exec_start_payload();

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -2,8 +2,8 @@ use super::truncate_utf8_to_u16_bytes;
 use crate::error::ProtocolError;
 use crate::frame::encode_into;
 use crate::read::{
-    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
-    expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
+    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_count, ensure_u16_len,
+    ensure_u32_len, expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
 use crate::wire::{
     MSG_WRITE_FILE, MSG_WRITE_FILES, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
@@ -196,7 +196,7 @@ fn validate_write_files_payload<'a>(
             "write_files file count must be positive",
         ));
     }
-    let file_count = ensure_u16_len("files", files.len())?;
+    let file_count = ensure_u16_count("file_count", files.len())?;
     let mut payload_len = 2;
     let mut encoded_entries = Vec::with_capacity(files.len());
     for file in files {
@@ -573,6 +573,24 @@ mod tests {
 
         assert_invalid_payload(err, "write_files file count must be positive");
         assert!(frame.is_empty());
+    }
+
+    #[test]
+    fn write_files_rejects_count_above_wire_limit() {
+        let files = vec![
+            WriteFileBatchEntry {
+                path: "/tmp/f",
+                content: b"",
+            };
+            usize::from(u16::MAX) + 1
+        ];
+        let err = encode_write_files(&files).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProtocolError::PayloadCountTooLarge("file_count", count)
+                if count == usize::from(u16::MAX) + 1
+        ));
     }
 
     #[test]

--- a/crates/vsock-proto/src/read.rs
+++ b/crates/vsock-proto/src/read.rs
@@ -148,3 +148,21 @@ pub(crate) fn expect_consumed(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_u32_count;
+    use crate::error::ProtocolError;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn ensure_u32_count_rejects_overflow() {
+        let count = usize::MAX;
+
+        assert!(matches!(
+            ensure_u32_count("env_count", count),
+            Err(ProtocolError::PayloadCountTooLarge("env_count", value))
+                if value == count
+        ));
+    }
+}

--- a/crates/vsock-proto/src/read.rs
+++ b/crates/vsock-proto/src/read.rs
@@ -57,6 +57,20 @@ pub(crate) fn ensure_u32_len(field: &'static str, len: usize) -> Result<u32, Pro
     Ok(len as u32)
 }
 
+pub(crate) fn ensure_u16_count(field: &'static str, count: usize) -> Result<u16, ProtocolError> {
+    if count > u16::MAX as usize {
+        return Err(ProtocolError::PayloadCountTooLarge(field, count));
+    }
+    Ok(count as u16)
+}
+
+pub(crate) fn ensure_u32_count(field: &'static str, count: usize) -> Result<u32, ProtocolError> {
+    if count > u32::MAX as usize {
+        return Err(ProtocolError::PayloadCountTooLarge(field, count));
+    }
+    Ok(count as u32)
+}
+
 pub(crate) fn read_u8(
     payload: &[u8],
     offset: &mut usize,

--- a/crates/vsock-proto/tests/error.rs
+++ b/crates/vsock-proto/tests/error.rs
@@ -1,0 +1,21 @@
+use vsock_proto::ProtocolError;
+
+#[test]
+fn payload_too_large_display_identifies_byte_lengths() {
+    let error = ProtocolError::PayloadTooLarge("payload", 123);
+
+    assert_eq!(
+        error.to_string(),
+        "payload field too large: payload (123 bytes)"
+    );
+}
+
+#[test]
+fn payload_count_too_large_display_identifies_element_counts() {
+    let error = ProtocolError::PayloadCountTooLarge("env_count", 4097);
+
+    assert_eq!(
+        error.to_string(),
+        "payload field too large: env_count (4097 elements)"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `ProtocolError::PayloadCountTooLarge` so element-count limits are distinct from byte-length limits.
- Route `env_count`, `expected_exit_count`, and `file_count` through count-aware validation and diagnostics.
- Add public display coverage for byte and element units plus regression coverage for oversized file batches and count-overflow validation.

## Compatibility And Scope

- `ProtocolError::PayloadTooLarge` keeps its existing two-field shape and `bytes` rendering for byte-oriented values.
- Adding the public count-specific enum variant may require exhaustive downstream matches to handle it.
- This change does not alter protocol frames, wire field widths, message assignments, or persisted data.

Closes #28788

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto` (151 unit tests, 2 new display tests, and all crate integration/property tests passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets -- -D warnings -A clippy::chunks_exact_to_as_chunks`
- The same Clippy command without the lint allowance remains blocked by two pre-existing warnings in `vsock-proto/src/payloads/memory_snapshot.rs`.
