### PR TITLE
test(python): cover protocol failure code normalization

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -757,6 +757,24 @@ def test_media_type_classification_is_shared_by_usage_and_failure_observers(
         ),
         (
             "model-provider:openai-api-key",
+            "/v1/chat/completions",
+            b'{"error":{"code":"rate_limit_error"}}',
+            "rate_limit",
+        ),
+        (
+            "model-provider:openai-api-key",
+            "/v1/chat/completions",
+            b'{"error":{"code":"timeout_error"}}',
+            "timeout",
+        ),
+        (
+            "model-provider:openai-api-key",
+            "/v1/chat/completions",
+            b'{"error":{"code":"connection_error"}}',
+            "connection",
+        ),
+        (
+            "model-provider:openai-api-key",
             "/v1/responses",
             b'{"status":"failed","error":{"code":"server_error"}}',
             "provider_unavailable",


### PR DESCRIPTION
## Summary

- cover payload-driven `rate_limit_error`, `timeout_error`, and `connection_error` normalization through the real HTTP response hooks
- assert the exact normalized failure webhook payload for every newly covered kind
- verify each case fails when its corresponding production mapping is removed

## Scope

This is a test-only change. It does not change model-provider failure classification, reporting behavior, APIs, dependencies, or deployment contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`6528 passed`)
- focused mutation checks for `_RATE_LIMIT_CODES`, `_TIMEOUT_CODES`, and `_CONNECTION_CODES` (each corresponding test failed as expected, then the source was restored)

Closes #28796
