### PR TITLE
docs: align database rollout guidance with release workflow

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -255,11 +255,28 @@ Schema changes have two independent compatibility directions:
   visible to it. New readers and writers must not require the new column, enum
   value, relation, constraint, or function until the migration is complete.
 
-The production workflow must continue to order required migrations before API
-traffic promotion, but intended ordering is not a substitute for compatibility.
-Promotion drift, rollback, draining instances, and other environments can expose
-either direction. A compatibility object that protects old code after migration
-does not by itself protect new code before migration.
+The normal production release enforces migration-before-promotion in
+`promote-api-production`: it builds one API artifact, smoke-tests the migration
+on an expiring branch cloned from production, runs the migration against the
+Neon `production` database, and deploys that exact artifact only after the
+migration succeeds. A failed migration stops the job before API promotion. The
+rollback dashboard is updated only after all applicable production promotions
+succeed.
+
+This ordering is direct evidence that a successful normal release closed the
+new-code-before-migration gate for its release target. It is not a reason to
+write incompatible migrations: promotion drift, draining instances,
+nonstandard deployment paths, and old code after migration remain reachable
+conditions. The production rollback workflow promotes App, Runner, and API
+artifacts and requires an explicit compatibility confirmation; it does not
+restore an older database schema. Retained rollback API targets must therefore
+remain compatible with the current schema.
+
+Do not replace these event-based gates with a fixed wait. Verify the release
+run, current schema, and retained target compatibility directly. A compatibility
+object that protects old code after migration does not by itself protect new
+code before migration, and migration-before-promotion does not protect an
+outgoing API whose statements become invalid after the migration.
 
 The ChatEvent schema-contraction releases from July 27-29, 2026 provide concrete
 examples:
@@ -268,7 +285,9 @@ examples:
   added `event_type`. From about 09:11 to 10:52 UTC on July 27 (102 minutes),
   new App reads, crons, and the automation poller queried it before the migration
   ran and received PostgreSQL error `42703` (`column does not exist`). An
-  additive column still breaks a new reader when code wins the race.
+  additive column still breaks a new reader when code wins the race. This is a
+  historical failure duration from before the current release ordering was
+  hardened, not a mandatory wait after a successful release.
 - The [PR #23252](https://github.com/vm0-ai/vm0/pull/23252)-era migration
   `0700` added the `teams_user_message` enum value. From about 00:38 to 00:47 UTC
   on July 28 (10 minutes), new code used the value before the migration ran and

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -13,8 +13,8 @@ Other release artifacts, such as the desktop app and host-worker deployments,
 have their own release paths and are outside this compatibility model unless
 they interact with these frontend, backend, or runner boundaries.
 
-New versions are normally deployed together, but they do not become active at the
-same instant. Code and tests must account for short periods where different
+New versions are normally deployed together, but they do not become active at
+the same instant. Code and tests must account for periods where different
 surfaces are on different versions.
 
 ## Deployment Model
@@ -242,7 +242,7 @@ capabilities in their client version. The API projects a stored locale to
 writes that the client did not advertise. Keep this compatibility layer until
 stale browser clients and API rollback windows have closed.
 
-### Treat Deploy-before-migrate Windows as a First-class Risk
+### Treat Database/API Transitions as a First-class Boundary
 
 Schema changes have two independent compatibility directions:
 
@@ -256,27 +256,15 @@ Schema changes have two independent compatibility directions:
   value, relation, constraint, or function until the migration is complete.
 
 The normal production release enforces migration-before-promotion in
-`promote-api-production`: it builds one API artifact, smoke-tests the migration
-on an expiring branch cloned from production, runs the migration against the
-Neon `production` database, and deploys that exact artifact only after the
-migration succeeds. A failed migration stops the job before API promotion. The
-rollback dashboard is updated only after all applicable production promotions
-succeed.
+`promote-api-production`: it builds one API artifact, migrates the Neon
+`production` database, and deploys that exact artifact only after the migration
+succeeds. A failed migration stops the job before API promotion.
 
-This ordering is direct evidence that a successful normal release closed the
-new-code-before-migration gate for its release target. It is not a reason to
-write incompatible migrations: promotion drift, draining instances,
-nonstandard deployment paths, and old code after migration remain reachable
-conditions. The production rollback workflow promotes App, Runner, and API
-artifacts and requires an explicit compatibility confirmation; it does not
-restore an older database schema. Retained rollback API targets must therefore
-remain compatible with the current schema.
-
-Do not replace these event-based gates with a fixed wait. Verify the release
-run, current schema, and retained target compatibility directly. A compatibility
-object that protects old code after migration does not by itself protect new
-code before migration, and migration-before-promotion does not protect an
-outgoing API whose statements become invalid after the migration.
+For a successful normal release, this closes the new-code-before-migration gate
+for its release target. Old code after migration remains a separate boundary:
+outgoing, draining, and retained rollback API targets must stay compatible with
+the current schema. The production rollback workflow promotes application
+artifacts; it does not restore an older database schema.
 
 The ChatEvent schema-contraction releases from July 27-29, 2026 provide concrete
 examples:
@@ -285,9 +273,7 @@ examples:
   added `event_type`. From about 09:11 to 10:52 UTC on July 27 (102 minutes),
   new App reads, crons, and the automation poller queried it before the migration
   ran and received PostgreSQL error `42703` (`column does not exist`). An
-  additive column still breaks a new reader when code wins the race. This is a
-  historical failure duration from before the current release ordering was
-  hardened, not a mandatory wait after a successful release.
+  additive column still breaks a new reader when code wins the race.
 - The [PR #23252](https://github.com/vm0-ai/vm0/pull/23252)-era migration
   `0700` added the `teams_user_message` enum value. From about 00:38 to 00:47 UTC
   on July 28 (10 minutes), new code used the value before the migration ran and

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -256,15 +256,16 @@ Schema changes have two independent compatibility directions:
   value, relation, constraint, or function until the migration is complete.
 
 The normal production release enforces migration-before-promotion in
-`promote-api-production`: it builds one API artifact, migrates the Neon
-`production` database, and deploys that exact artifact only after the migration
-succeeds. A failed migration stops the job before API promotion.
+`promote-api-production`: it builds one API artifact, runs required migrations
+against the Neon `production` database, and deploys that exact artifact only
+after the migrations succeed. A failed migration stops the job before API
+promotion.
 
 For a successful normal release, this closes the new-code-before-migration gate
 for its release target. Old code after migration remains a separate boundary:
 outgoing, draining, and retained rollback API targets must stay compatible with
-the current schema. The production rollback workflow promotes application
-artifacts; it does not restore an older database schema.
+the current schema. The production rollback workflow promotes App, Runner, and
+API artifacts; it does not restore an older database schema.
 
 The ChatEvent schema-contraction releases from July 27-29, 2026 provide concrete
 examples:

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -170,38 +170,24 @@ Keep a fallback only when it belongs to one of these:
 
 Everything else is slop.
 
-## 7. Rolling Update Windows And Gates
+## 7. Rollout Removal Gates
 
 A rollout fallback is justified only while the incompatible state it protects
-is reachable. The removal gate must match the owning surface: some consumers
-have a bounded lifetime, while DB/API convergence is proven by release and
-schema events rather than by waiting for a fixed interval.
+is reachable. Use the removal gate for the owning surface.
 
-Do not turn a historical incident duration into a mandatory wait. Elapsed time
-cannot prove that a migration ran, that API promotion succeeded, or that a
-retained rollback target is compatible.
-
-| Surface                   | Typical bound        | What resolves it                                                                                                      |
-| ------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| DB vs API                 | Event-gated          | The production migration and API promotion succeed for the same release target, and retained API targets remain safe. |
-| Existing runner / sandbox | Up to 2 hours        | Old instances drain; newly created ones match immediately.                                                            |
-| Old web / app clients     | Approximately 2 days | A refresh loads the current version; a `426` response can force the prompt earlier.                                   |
+| Surface                   | Removal gate                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| DB vs API                 | Release and schema state; see `docs/deployment-compatibility.md`.                |
+| Existing runner / sandbox | Old instances drain, up to 2 hours.                                              |
+| Old web/app -> API        | The replacement app is live and the client-version floor excludes the old build. |
+| New web/app -> old API    | The old API is no longer serving or retained as a rollback target.               |
 
 How to use them:
 
-- **DB vs API.** `docs/deployment-compatibility.md` is the source of truth for
-  this surface; treat the numbers above as a summary of it, not a replacement.
-  The normal production release builds one API artifact, smoke-tests and runs
-  migrations against the production database, and promotes that artifact only
-  after the migration succeeds. A successful release run is direct evidence
-  for the new-code-before-migration gate; a failed, cancelled, or incomplete run
-  blocks cleanup regardless of elapsed time.
-
-  Before this ordering was hardened, migration `0697` exposed new readers for
-  **102 minutes**, `0723` for **12 minutes**, `0700` for **10 minutes**, and
-  `0722` for **2 minutes**. These are historical failure durations and design
-  evidence for preserving cross-version compatibility. They are not minimum
-  waits after a successful current release.
+- **DB vs API.** The normal production release migrates the production database
+  before promoting the corresponding API artifact. A successful release closes
+  the new-code-before-migration gate; a failed, cancelled, or incomplete run
+  does not.
 
   This surface also has **two independent directions**, and a fallback that
   covers one does not cover the other:
@@ -213,12 +199,10 @@ How to use them:
     `42P01` in production. New readers and writers must not require the new
     column, enum value, relation, or constraint until the migration lands.
 
-  Remove a DB/API fallback only after direct evidence shows that its protected
-  mismatch is unreachable: the expected production migration and API promotion
-  succeeded for the release target, the current schema satisfies the new code,
-  and the outgoing API plus retained rollback targets remain compatible with
-  that schema. The production rollback workflow promotes application artifacts;
-  it does not restore an older database schema.
+  Remove a fallback only after its direction is safe. New-code fallbacks require
+  a successful release and the expected schema. Old-code fallbacks require the
+  outgoing API to finish draining and retained rollback targets to remain
+  compatible without the fallback; rollback does not restore the database.
 
 - **Old runner or sandbox (up to 2h).** The backend must accept the old runner
   protocol for the full drain. The bound is the guest runtime budget,
@@ -228,19 +212,16 @@ How to use them:
   event shapes cannot be deleted in the same PR that stops emitting them; the
   removal is a follow-up after the window closes. Newly created runners and
   sandboxes are already on the new version, so no fallback is needed for them.
-- **Old web or app clients (~2 days).** Frontend-to-API compatibility branches
-  are sized by this window. It is the longest one, so a client-facing rollout
-  fallback is the one most worth writing — and the one most often left behind.
-  A raised client-version floor can end it earlier by returning `426 Upgrade
-Required`, but only once an open page makes a handled API request; an idle
-  page never discovers it.
+- **Old web or app clients.** Keep their API contract until the replacement app
+  is live and the client-version floor excludes the old build. An open page
+  discovers the floor on its next handled API request and receives `426 Upgrade
+Required`; an idle page makes no request that needs compatibility.
+- **Old API targets.** A new app may need a fallback while an older API remains
+  reachable. Remove it after that API is no longer serving or retained for
+  rollback.
 
-State the applicable surface and its concrete removal evidence in the code
-comment and in the PR summary, so the removal condition is a verifiable fact
-rather than a judgment call. For time-bounded consumers, include the observed
-maximum exposure. For event-gated DB/API changes, name the release, schema, and
-rollback evidence instead. If a fallback protects more than one surface, every
-gate must pass before removal.
+State the surface and removal gate in the code comment and PR summary. If a
+fallback protects more than one surface, every gate must pass before removal.
 
 These gates apply only to GA behavior. A feature still behind a non-GA feature
 switch has no old external client to protect, so none of these gates create an
@@ -312,9 +293,8 @@ switch`),
 ## Fallbacks
 
 - `sidebar-unread-threads.ts:allUnreadThreadIds$` — accepts `404` from an API
-  that predates the additive `unreadIds` route. Surface: old app clients,
-  ~2 days. Remove after the API is outside the rollback window; follow-up
-  #25694.
+  that predates the additive `unreadIds` route. Surface: new app -> old API.
+  Remove after that API is outside the rollback window; follow-up #25694.
 ```
 
 PRs that do not introduce a fallback need no `Fallbacks` section. This includes
@@ -340,10 +320,7 @@ must show why the removed branch is unreachable:
 - **Production evidence** — a read-only query against the masked production
   branch showing zero rows in the old shape. PR #24888 removed an unreachable
   claim-time fallback only after confirming `pending_automation = 0`.
-- **Rollout evidence** — the applicable gate in section 7 has passed: for a
-  time-bounded consumer, the old version is outside its supported lifetime; for
-  DB/API, the release, schema, and retained rollback targets satisfy the stated
-  compatibility condition.
+- **Rollout evidence** — the applicable gate in section 7 has passed.
 
 The evidence can come from the diff, tests, or linked production or rollout
 data. Removing a fallback does not require a `Fallbacks` section or a separate
@@ -359,10 +336,10 @@ surfaces a violation if the assumption ever breaks.
   cutover is acceptable.
 - Does the PR add a test that asserts removed behavior stays removed? Request
   removal unless it is a fail-closed security boundary.
-- Does a new rollout fallback name its surface, its window from section 7, a
+- Does a new rollout fallback name its surface, its gate from section 7, a
   removal condition, and a follow-up?
-- Is the window the right one? A runner-protocol branch sized to the ~4 second
-  DB window, or a client branch sized to the ~2 hour runner window, is wrong.
+- Is it the right gate? Check release and schema state, runner drain, client
+  floor, or retained API targets as applicable.
 - If the PR adds a fallback, does its summary contain a `Fallbacks` section
   listing every new fallback? Every introduced fallback that the summary omits
   is a P1 finding and blocks the verdict: ask the author to record it there and

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -178,7 +178,7 @@ is reachable. Use the removal gate for the owning surface.
 | Surface                   | Removal gate                                                                     |
 | ------------------------- | -------------------------------------------------------------------------------- |
 | DB vs API                 | Release and schema state; see `docs/deployment-compatibility.md`.                |
-| Existing runner / sandbox | Old instances drain, up to 2 hours.                                              |
+| Existing runner / sandbox | Old instances finish draining.                                                   |
 | Old web/app -> API        | The replacement app is live and the client-version floor excludes the old build. |
 | New web/app -> old API    | The old API is no longer serving or retained as a rollback target.               |
 
@@ -202,16 +202,13 @@ How to use them:
   Remove a fallback only after its direction is safe. New-code fallbacks require
   a successful release and the expected schema. Old-code fallbacks require the
   outgoing API to finish draining and retained rollback targets to remain
-  compatible without the fallback; rollback does not restore the database.
+  compatible without the fallback; rollback does not restore the database
+  schema.
 
-- **Old runner or sandbox (up to 2h).** The backend must accept the old runner
-  protocol for the full drain. The bound is the guest runtime budget,
-  `JOB_TIMEOUT = Duration::from_secs(7200)` in
-  `crates/runner/src/executor/mod.rs`: a draining runner can still be finishing
-  a claimed run for that long. Runner-facing endpoints, payload variants, and
-  event shapes cannot be deleted in the same PR that stops emitting them; the
-  removal is a follow-up after the window closes. Newly created runners and
-  sandboxes are already on the new version, so no fallback is needed for them.
+- **Old runner or sandbox.** The backend must accept the old runner protocol
+  until old instances finish draining. A claimed run has a two-hour guest
+  runtime budget plus bounded finalization. Remove runner-facing endpoints,
+  payload variants, and event shapes only after the drain completes.
 - **Old web or app clients.** Keep their API contract until the replacement app
   is live and the client-version floor excludes the old build. An open page
   discovers the floor on its next handled API request and receives `426 Upgrade

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -144,7 +144,7 @@ to be nullable.
 
 Once a producer is gone, its reader is dead weight. Delete the reader in the
 same PR that retires the producer, or in an explicit follow-up PR that names
-the rollout window it waited for.
+the rollout gate it waited for.
 
 This includes retired runner event shapes, superseded API routes, old storage
 prefixes, previous OAuth callback metadata, obsolete IndexedDB cache versions,
@@ -156,10 +156,10 @@ teaching the reader to accept both.
 
 Keep a fallback only when it belongs to one of these:
 
-1. **Time-boxed cross-version rollout compatibility.** Frontend, backend, and
+1. **Bounded cross-version rollout compatibility.** Frontend, backend, and
    runner deploy independently, so a briefly-mixed fleet is a real reachable
-   state. See `docs/deployment-compatibility.md`. This fallback must be
-   time-boxed to a known rollout window (see sections 7 and 8).
+   state. See `docs/deployment-compatibility.md`. This fallback must have a
+   verifiable removal gate (see sections 7 and 8).
 2. **Genuinely optional external data.** Third-party API fields that the
    provider documents as optional, or that runtime inspection proves absent
    despite the TypeScript declaration.
@@ -170,37 +170,38 @@ Keep a fallback only when it belongs to one of these:
 
 Everything else is slop.
 
-## 7. Rolling Update Windows
+## 7. Rolling Update Windows And Gates
 
-A rollout fallback is only justified for the duration that an old version can
-still be live. Size every compatibility branch against the surface it protects.
+A rollout fallback is justified only while the incompatible state it protects
+is reachable. The removal gate must match the owning surface: some consumers
+have a bounded lifetime, while DB/API convergence is proven by release and
+schema events rather than by waiting for a fixed interval.
 
-Two different numbers matter, and confusing them is how compatibility code gets
-deleted too early:
+Do not turn a historical incident duration into a mandatory wait. Elapsed time
+cannot prove that a migration ran, that API promotion succeeded, or that a
+retained rollback target is compatible.
 
-- the **nominal deploy gap**, how far apart the pipeline intends to promote two
-  surfaces, and
-- the **observed maximum exposure**, how long the two versions have actually
-  overlapped in production, including promotion drift, rollback, and draining
-  instances.
-
-Only the second number bounds a fallback.
-
-| Surface                   | Nominal deploy gap | Observed maximum exposure | What resolves it                                                                    |
-| ------------------------- | ------------------ | ------------------------- | ----------------------------------------------------------------------------------- |
-| DB vs API                 | ~4 seconds         | ~102 minutes              | API and DB converge only after promotion completes without drift or rollback.       |
-| Existing runner / sandbox | none               | up to 2 hours             | Old instances drain; newly created ones match immediately.                          |
-| Old web / app clients     | none               | ~2 days                   | A refresh loads the current version; a `426` response can force the prompt earlier. |
+| Surface                   | Typical bound        | What resolves it                                                                                                      |
+| ------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| DB vs API                 | Event-gated          | The production migration and API promotion succeed for the same release target, and retained API targets remain safe. |
+| Existing runner / sandbox | Up to 2 hours        | Old instances drain; newly created ones match immediately.                                                            |
+| Old web / app clients     | Approximately 2 days | A refresh loads the current version; a `426` response can force the prompt earlier.                                   |
 
 How to use them:
 
 - **DB vs API.** `docs/deployment-compatibility.md` is the source of truth for
   this surface; treat the numbers above as a summary of it, not a replacement.
-  The pipeline promotes migrations before API traffic, nominally within a few
-  seconds, but intended ordering is not compatibility. Recorded incidents ran
-  far longer: migration `0697` exposed new readers for **102 minutes**, `0723`
-  for **12 minutes**, `0700` for **10 minutes**, and `0722` for **2 minutes**.
-  Never size a DB/API compatibility branch by the nominal gap.
+  The normal production release builds one API artifact, smoke-tests and runs
+  migrations against the production database, and promotes that artifact only
+  after the migration succeeds. A successful release run is direct evidence
+  for the new-code-before-migration gate; a failed, cancelled, or incomplete run
+  blocks cleanup regardless of elapsed time.
+
+  Before this ordering was hardened, migration `0697` exposed new readers for
+  **102 minutes**, `0723` for **12 minutes**, `0700` for **10 minutes**, and
+  `0722` for **2 minutes**. These are historical failure durations and design
+  evidence for preserving cross-version compatibility. They are not minimum
+  waits after a successful current release.
 
   This surface also has **two independent directions**, and a fallback that
   covers one does not cover the other:
@@ -211,6 +212,13 @@ How to use them:
     is visible to it. This is the direction that produced `42703`, `22P02`, and
     `42P01` in production. New readers and writers must not require the new
     column, enum value, relation, or constraint until the migration lands.
+
+  Remove a DB/API fallback only after direct evidence shows that its protected
+  mismatch is unreachable: the expected production migration and API promotion
+  succeeded for the release target, the current schema satisfies the new code,
+  and the outgoing API plus retained rollback targets remain compatible with
+  that schema. The production rollback workflow promotes application artifacts;
+  it does not restore an older database schema.
 
 - **Old runner or sandbox (up to 2h).** The backend must accept the old runner
   protocol for the full drain. The bound is the guest runtime budget,
@@ -227,16 +235,18 @@ How to use them:
 Required`, but only once an open page makes a handled API request; an idle
   page never discovers it.
 
-State the applicable surface and its observed maximum exposure in the code
-comment and in the PR summary, so the removal condition is a bounded fact rather
-than a judgment call. If a fallback protects more than one surface, state every
-relevant window; the removal waits for the longest one.
+State the applicable surface and its concrete removal evidence in the code
+comment and in the PR summary, so the removal condition is a verifiable fact
+rather than a judgment call. For time-bounded consumers, include the observed
+maximum exposure. For event-gated DB/API changes, name the release, schema, and
+rollback evidence instead. If a fallback protects more than one surface, every
+gate must pass before removal.
 
-These windows apply only to GA behavior. A feature still behind a non-GA
-feature switch has no old external client to protect, so none of these windows
-create an obligation (see section 2).
+These gates apply only to GA behavior. A feature still behind a non-GA feature
+switch has no old external client to protect, so none of these gates create an
+obligation (see section 2).
 
-## 8. Writing a Time-Boxed Rollout Fallback
+## 8. Writing a Bounded Rollout Fallback
 
 A legitimate rollout fallback is introduced with its removal already planned.
 
@@ -267,7 +277,7 @@ so it dies with the fallback rather than becoming a tombstone.
 
 Requirements for this pattern:
 
-- a comment naming the surface, its window from section 7, and the condition
+- a comment naming the surface, its gate from section 7, and the condition
   that makes the branch removable,
 - an entry in the PR summary (see section 9),
 - a follow-up issue or PR that removes it,
@@ -294,7 +304,7 @@ in the diff. For each fallback give:
 
 - the file and symbol,
 - what old/new interaction it protects,
-- the surface and its window from section 7 (or `none — non-GA feature
+- the surface and its gate from section 7 (or `none — non-GA feature
 switch`),
 - the removal condition and the follow-up issue or PR.
 
@@ -313,7 +323,7 @@ PRs that only keep or remove existing fallbacks; do not require
 
 **Reviewer — in the review comment.** The review must list every fallback the
 diff introduces, in the same shape, and state whether each one is justified
-under section 6, correctly time-boxed under section 7, and declared in the PR
+under section 6, correctly bounded under section 7, and declared in the PR
 summary. Raise each undeclared one as a P1 finding asking the author to record
 it in the summary, and request changes until it is recorded. A review that says
 nothing about fallbacks in a PR that adds one is not a completed review.
@@ -330,8 +340,10 @@ must show why the removed branch is unreachable:
 - **Production evidence** — a read-only query against the masked production
   branch showing zero rows in the old shape. PR #24888 removed an unreachable
   claim-time fallback only after confirming `pending_automation = 0`.
-- **Rollout evidence** — the deploy that made the old version unreachable is
-  past its rollback window.
+- **Rollout evidence** — the applicable gate in section 7 has passed: for a
+  time-bounded consumer, the old version is outside its supported lifetime; for
+  DB/API, the release, schema, and retained rollback targets satisfy the stated
+  compatibility condition.
 
 The evidence can come from the diff, tests, or linked production or rollout
 data. Removing a fallback does not require a `Fallbacks` section or a separate


### PR DESCRIPTION
## Summary

- replace elapsed-time rollout assumptions with concrete removal gates
- document the current database migration and API promotion ordering
- distinguish database/API and frontend/API compatibility directions

## Validation

- `pnpm exec prettier --check ../docs/fallback.md ../docs/deployment-compatibility.md`
- `scripts/check-file-size.sh docs/fallback.md docs/deployment-compatibility.md`
- `git diff --check`

Closes #28808
