### PR TITLE
fix: log successful stripe reconciliation at debug level

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
@@ -287,6 +287,14 @@ describe("billing entitlement reconciliation", () => {
       [200],
     );
     expect(response.body).toStrictEqual({ success: true, downgraded: 2 });
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.objectContaining({ failed: 0 }),
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.anything(),
+    );
 
     const selected = await readState(selectedMarker);
     expect(statuses(selected)).toStrictEqual(RECONCILED_STATUSES);
@@ -654,6 +662,20 @@ describe("billing entitlement reconciliation", () => {
       [200],
     );
     expect(response.body).toStrictEqual({ success: true, downgraded: 1 });
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.objectContaining({ failed: expect.any(Number) }),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Stripe subscription retrieval failed during discovery",
+      expect.objectContaining({
+        subscriptionId: retrievalPlan.stripeSubscriptionId,
+      }),
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.anything(),
+    );
 
     await expect(readState(retrievalMarker)).resolves.toContainEqual({
       kind: "plan-subscription",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
@@ -287,9 +287,13 @@ describe("billing entitlement reconciliation", () => {
       [200],
     );
     expect(response.body).toStrictEqual({ success: true, downgraded: 2 });
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
       "Stripe subscription snapshots reconciled",
-      expect.objectContaining({ failed: 0 }),
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.anything(),
     );
     expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
       "Stripe subscription snapshots reconciled",
@@ -662,9 +666,13 @@ describe("billing entitlement reconciliation", () => {
       [200],
     );
     expect(response.body).toStrictEqual({ success: true, downgraded: 1 });
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
       "Stripe subscription snapshots reconciled",
-      expect.objectContaining({ failed: expect.any(Number) }),
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
+      "Stripe subscription snapshots reconciled",
+      expect.anything(),
     );
     expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
       "Stripe subscription retrieval failed during discovery",

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -590,7 +590,7 @@ function logStripeSubscriptionSweep(
   sweep: StripeSubscriptionSweepResult,
 ): void {
   if (sweep.attempted > 0) {
-    L.warn("Stripe subscription snapshots reconciled", {
+    L.debug("Stripe subscription snapshots reconciled", {
       attempted: sweep.attempted,
       reconciled: sweep.reconciled,
       failed: sweep.failed,

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -586,20 +586,6 @@ async function disableIneligibleWorkflowWebhooksForOrgs(
   }
 }
 
-function logStripeSubscriptionSweep(
-  sweep: StripeSubscriptionSweepResult,
-): void {
-  if (sweep.attempted > 0) {
-    L.debug("Stripe subscription snapshots reconciled", {
-      attempted: sweep.attempted,
-      reconciled: sweep.reconciled,
-      failed: sweep.failed,
-      paidInvoices: sweep.paidInvoices,
-      orgs: sweep.changedOrgIds.length,
-    });
-  }
-}
-
 function paidInvoiceBelongsToCurrentEnvironment(
   invoice: StripeInvoice,
 ): boolean {
@@ -1823,7 +1809,6 @@ const reconcileBillingEntitlementsForScope$ = command(
     }
     logUsagePackSubscriptionReconciliation(usagePackReconciliation);
     logUsagePackMigrationReconciliation(usagePackMigrationReconciliation);
-    logStripeSubscriptionSweep(stripeSubscriptionSweep);
     if (invitationPurchasesReconciled > 0) {
       L.warn("usage pack invitation purchases reconciled", {
         count: invitationPurchasesReconciled,


### PR DESCRIPTION
## Summary

- Remove the routine `Stripe subscription snapshots reconciled` summary log entirely.
- Preserve warning-level logs for actual subscription discovery and reconciliation failures.
- Keep reconciliation behavior, counts, and API responses unchanged; integration tests verify that the summary is not emitted and failure diagnostics remain actionable.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/cron-billing-entitlements.service.ts apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/cron-billing-entitlements.test.ts --maxWorkers=1`
- `pnpm -F api lint`
- `pnpm -F api check-types`

Closes #28800