### PR TITLE
refactor(rust): unify runner exec capture limits

### DIFF
--- a/crates/sandbox-fc/src/control/exec_response.rs
+++ b/crates/sandbox-fc/src/control/exec_response.rs
@@ -289,6 +289,8 @@ impl<'a> RawFrameReader<'a> {
 
 #[cfg(test)]
 mod tests {
+    use sandbox::EXEC_OUTPUT_LIMIT_7_MIB;
+
     use super::super::protocol::MAX_FRAME_PAYLOAD_SIZE;
     use super::*;
 
@@ -379,21 +381,21 @@ mod tests {
 
     #[tokio::test]
     async fn maximum_control_capture_avoids_base64_wire_expansion() {
-        const STREAM_LEN: usize = 7 * 1024 * 1024;
+        let stdout_len = EXEC_OUTPUT_LIMIT_7_MIB.stdout_limit_bytes as usize;
+        let stderr_len = EXEC_OUTPUT_LIMIT_7_MIB.stderr_limit_bytes as usize;
         let payload = encoded_payload(ExecResult::Success {
             termination: ExecTermination::Exited { exit_code: 0 },
-            stdout: vec![b'o'; STREAM_LEN],
-            stderr: vec![b'e'; STREAM_LEN],
+            stdout: vec![b'o'; stdout_len],
+            stderr: vec![b'e'; stderr_len],
             stdout_truncated: true,
             stderr_truncated: true,
             diagnostic: String::new(),
         })
         .await;
 
-        assert_eq!(payload.len(), 24 + 2 * STREAM_LEN);
-        let base64_len = 2 * STREAM_LEN.div_ceil(3) * 4;
+        assert_eq!(payload.len(), 24 + stdout_len + stderr_len);
+        let base64_len = stdout_len.div_ceil(3) * 4 + stderr_len.div_ceil(3) * 4;
         assert!(payload.len() < base64_len);
-        assert_eq!(base64_len - payload.len(), 4_893_336);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use sandbox::EXEC_OUTPUT_LIMIT_7_MIB;
 use serde::Serialize;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, oneshot};
@@ -25,7 +26,6 @@ use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate}
 use crate::park_coordinator::{ParkCoordinator, RunControlMismatch, TerminateAdmission};
 use crate::runtime_dirs::set_private_runtime_socket_mode;
 
-const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 const RUN_CONTROL_MISMATCH_ERROR: &str = "run control target is no longer assigned to this sandbox";
@@ -483,8 +483,8 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
                 env,
                 sudo,
                 label: "runner-exec",
-                stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-                stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+                stdout_limit_bytes: EXEC_OUTPUT_LIMIT_7_MIB.stdout_limit_bytes,
+                stderr_limit_bytes: EXEC_OUTPUT_LIMIT_7_MIB.stderr_limit_bytes,
                 expected_exit_codes: &[],
                 stdin_bytes: None,
                 wait_timeout: Duration::from_millis(timeout_ms as u64 + CONTROL_SOCKET_OVERHEAD_MS),

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -4,14 +4,14 @@ use std::future::Future;
 use std::os::unix::fs::PermissionsExt;
 use std::pin::Pin;
 
-use sandbox::ExecTermination;
+use sandbox::{EXEC_OUTPUT_LIMIT_7_MIB, ExecTermination};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::{mpsc, oneshot};
 use vsock_host::{ExecOwnedCapturedOutput, NormalOperationFenceRejection, VsockHost};
 use vsock_proto::{
-    Decoder, ExecCapturedOutput, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY,
-    RawMessage,
+    Decoder, ExecCapturedOutput, ExecOutputPolicy, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG,
+    MSG_READY, RawMessage,
 };
 
 use crate::control::client::send_exec;
@@ -860,9 +860,10 @@ async fn control_server_shutdown_cancels_pending_connection() {
 
 #[tokio::test]
 async fn control_exec_streams_both_capture_limits() {
-    const CAPTURE_LIMIT: usize = 7 * 1024 * 1024;
-    let stdout = vec![0xa5; CAPTURE_LIMIT];
-    let stderr = vec![0x5a; CAPTURE_LIMIT];
+    let stdout_limit = EXEC_OUTPUT_LIMIT_7_MIB.stdout_limit_bytes as usize;
+    let stderr_limit = EXEC_OUTPUT_LIMIT_7_MIB.stderr_limit_bytes as usize;
+    let stdout = vec![0xa5; stdout_limit];
+    let stderr = vec![0x5a; stderr_limit];
     let fixture = VsockExecFixture::connect(move |vsock_base| {
         mock_guest_returns_exec(
             vsock_base,
@@ -896,9 +897,9 @@ async fn control_exec_streams_both_capture_limits() {
         panic!("server should return a raw success response");
     };
     assert_eq!(termination, ExecTermination::Exited { exit_code: 23 });
-    assert_eq!(stdout.len(), CAPTURE_LIMIT);
+    assert_eq!(stdout.len(), stdout_limit);
     assert!(stdout.iter().all(|byte| *byte == 0xa5));
-    assert_eq!(stderr.len(), CAPTURE_LIMIT);
+    assert_eq!(stderr.len(), stderr_limit);
     assert!(stderr.iter().all(|byte| *byte == 0x5a));
     assert!(stdout_truncated);
     assert!(!stderr_truncated);
@@ -1371,6 +1372,19 @@ async fn mock_guest_returns_exec(
     loop {
         let message = read_vsock_message(&mut stream, &mut decoder).await;
         if message.msg_type == MSG_EXEC_START {
+            let request = vsock_proto::decode_exec_start(&message.payload).unwrap();
+            assert_eq!(
+                request.stdout,
+                ExecOutputPolicy::Capture {
+                    limit_bytes: EXEC_OUTPUT_LIMIT_7_MIB.stdout_limit_bytes,
+                }
+            );
+            assert_eq!(
+                request.stderr,
+                ExecOutputPolicy::Capture {
+                    limit_bytes: EXEC_OUTPUT_LIMIT_7_MIB.stderr_limit_bytes,
+                }
+            );
             let mut frame = Vec::new();
             vsock_proto::encode_exec_result_frame_into(
                 &mut frame,


### PR DESCRIPTION
## Summary

- derive runner exec stdout and stderr capture limits directly from `sandbox::EXEC_OUTPUT_LIMIT_7_MIB`
- verify both forwarded capture policies through the control-server-to-vsock integration path
- derive maximum raw-response fixtures and encoding comparisons from the same shared contract

## Compatibility

- preserves the current 7 MiB-per-stream behavior and exec wire format
- adds no API, database, persisted-state, dependency, or rollout-order changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc` (809 unit tests and 1 integration test passed)
- pre-commit workspace Rust formatting, Clippy, documentation, and file-size checks
- `git diff --check`

Closes #28798
