### PR TITLE
feat(api): lengthen managed provider cooldowns

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -352,72 +352,137 @@ describe("POST /api/test/runtime-state/action", () => {
 });
 
 describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
-  it("records a bounded cooldown for only the persisted managed route", async () => {
-    const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
-    await withMockNowForTest(startedAt, async () => {
-      const claimed = await createClaimedVm0Run();
-      const primary = await resolveVm0ManagedModelRouteFixture(
-        context,
-        claimed.selectedModel,
-        true,
-      );
-      if (!primary) {
-        throw new Error("Expected a managed model primary route");
-      }
-      registerVm0ManagedCandidateCooldownCleanup(
-        context,
-        claimed.selectedModel,
-        primary,
-      );
-
-      await expect(
-        runs.reportRunnerModelProviderFailure(claimed.runId, {
-          failureKind: "authentication",
-        }),
-      ).resolves.toStrictEqual({ outcome: "recorded" });
-      await expect(
-        runs.readRun(claimed.actor, claimed.runId),
-      ).resolves.toMatchObject({ status: "running" });
-      await expect(
-        resolveVm0ManagedModelRouteFixture(
-          context,
-          claimed.selectedModel,
-          false,
-        ),
-      ).resolves.toMatchObject({
-        provider_type: primary.provider_type,
-        upstream_model: primary.upstream_model,
-      });
-      await expect(
-        resolveVm0ManagedModelRouteFixture(
+  it.each([
+    {
+      caseName: "authentication intervention",
+      failureKind: "authentication",
+      retryAfterSeconds: 1,
+      cooldownSeconds: 30 * 60,
+    },
+    {
+      caseName: "billing intervention",
+      failureKind: "billing",
+      retryAfterSeconds: 1,
+      cooldownSeconds: 30 * 60,
+    },
+    {
+      caseName: "rate limit default",
+      failureKind: "rate_limit",
+      retryAfterSeconds: undefined,
+      cooldownSeconds: 5 * 60,
+    },
+    {
+      caseName: "provider unavailable default",
+      failureKind: "provider_unavailable",
+      retryAfterSeconds: undefined,
+      cooldownSeconds: 5 * 60,
+    },
+    {
+      caseName: "timeout default",
+      failureKind: "timeout",
+      retryAfterSeconds: undefined,
+      cooldownSeconds: 5 * 60,
+    },
+    {
+      caseName: "connection default",
+      failureKind: "connection",
+      retryAfterSeconds: undefined,
+      cooldownSeconds: 5 * 60,
+    },
+    {
+      caseName: "bounded provider retry delay",
+      failureKind: "rate_limit",
+      retryAfterSeconds: 120,
+      cooldownSeconds: 120,
+    },
+  ] as const)(
+    "records the $caseName cooldown for only the persisted managed route",
+    async ({ failureKind, retryAfterSeconds, cooldownSeconds }) => {
+      const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
+      await withMockNowForTest(startedAt, async () => {
+        const claimed = await createClaimedVm0Run();
+        const primary = await resolveVm0ManagedModelRouteFixture(
           context,
           claimed.selectedModel,
           true,
-        ),
-      ).resolves.not.toMatchObject({
-        provider_type: primary.provider_type,
-        upstream_model: primary.upstream_model,
-      });
+        );
+        if (!primary) {
+          throw new Error("Expected a managed model primary route");
+        }
+        registerVm0ManagedCandidateCooldownCleanup(
+          context,
+          claimed.selectedModel,
+          primary,
+        );
 
-      await seedVm0ManagedModelCandidateKeys(context, "deepseek-v4-pro");
-      await expect(
-        resolveVm0ManagedModelRouteFixture(context, "deepseek-v4-pro", true),
-      ).resolves.toMatchObject({ provider_type: "deepseek" });
-
-      await withMockNowForTest(startedAt + 60_000, async () => {
+        await expect(
+          runs.reportRunnerModelProviderFailure(claimed.runId, {
+            failureKind,
+            ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+          }),
+        ).resolves.toStrictEqual({ outcome: "recorded" });
+        await expect(
+          runs.readRun(claimed.actor, claimed.runId),
+        ).resolves.toMatchObject({ status: "running" });
+        await expect(
+          resolveVm0ManagedModelRouteFixture(
+            context,
+            claimed.selectedModel,
+            false,
+          ),
+        ).resolves.toMatchObject({
+          provider_type: primary.provider_type,
+          upstream_model: primary.upstream_model,
+        });
         await expect(
           resolveVm0ManagedModelRouteFixture(
             context,
             claimed.selectedModel,
             true,
           ),
-        ).resolves.toMatchObject({
+        ).resolves.not.toMatchObject({
           provider_type: primary.provider_type,
           upstream_model: primary.upstream_model,
         });
+
+        await seedVm0ManagedModelCandidateKeys(context, "deepseek-v4-pro");
+        await expect(
+          resolveVm0ManagedModelRouteFixture(context, "deepseek-v4-pro", true),
+        ).resolves.toMatchObject({ provider_type: "deepseek" });
+
+        await withMockNowForTest(
+          startedAt + cooldownSeconds * 1000 - 1,
+          async () => {
+            await expect(
+              resolveVm0ManagedModelRouteFixture(
+                context,
+                claimed.selectedModel,
+                true,
+              ),
+            ).resolves.not.toMatchObject({
+              provider_type: primary.provider_type,
+              upstream_model: primary.upstream_model,
+            });
+          },
+        );
+        await withMockNowForTest(
+          startedAt + cooldownSeconds * 1000,
+          async () => {
+            await expect(
+              resolveVm0ManagedModelRouteFixture(
+                context,
+                claimed.selectedModel,
+                true,
+              ),
+            ).resolves.toMatchObject({
+              provider_type: primary.provider_type,
+              upstream_model: primary.upstream_model,
+            });
+          },
+        );
       });
-    });
-  });
+    },
+  );
 
   it("monotonically extends concurrent bounded reports from receipt time", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 1, 0, 0);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -134,7 +134,8 @@ const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
 const RESUME_SESSION_HISTORY_URL_TTL_SECONDS = 60 * 60;
-const DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS = 60;
+const DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS = 5 * 60;
+const MANAGED_MODEL_PROVIDER_INTERVENTION_COOLDOWN_SECONDS = 30 * 60;
 const RESUME_SESSION_HISTORY_LOAD_ERROR =
   "Runner job missing resume session history";
 const RESUME_SESSION_HISTORY_INVALID_ERROR =
@@ -2613,14 +2614,17 @@ const modelProviderFailureInner$ = command(
       return { status: 200 as const, body: { outcome: "ignored" as const } };
     }
 
-    const retryAfterSeconds =
-      body.data.retryAfterSeconds ??
-      DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS;
+    const cooldownSeconds =
+      body.data.failureKind === "authentication" ||
+      body.data.failureKind === "billing"
+        ? MANAGED_MODEL_PROVIDER_INTERVENTION_COOLDOWN_SECONDS
+        : (body.data.retryAfterSeconds ??
+          DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS);
     const unavailableUntil = await extendManagedModelCandidateCooldown(db, {
       selectedModel: run.selectedModel,
       providerType: run.modelRuntimeProvider,
       upstreamModel: run.modelRuntimeModel,
-      retryAfterSeconds,
+      retryAfterSeconds: cooldownSeconds,
     });
     signal.throwIfAborted();
     L.debug("Managed model provider failure report recorded", {
@@ -2629,7 +2633,7 @@ const modelProviderFailureInner$ = command(
       providerType: run.modelRuntimeProvider,
       upstreamModel: run.modelRuntimeModel,
       failureKind: body.data.failureKind,
-      retryAfterSeconds,
+      retryAfterSeconds: cooldownSeconds,
       unavailableUntil: unavailableUntil.toISOString(),
     });
     return { status: 200 as const, body: { outcome: "recorded" as const } };


### PR DESCRIPTION
## Summary

- increase the default exact-route cooldown for transient managed-provider failures from 60 seconds to 5 minutes
- apply a 30-minute cooldown to authentication and billing failures, ignoring shorter reported retry delays
- preserve bounded 1–300 second retry delays for non-intervention failures and monotonic deadline extension
- cover all six accepted failure kinds and provider retry timing through the official-runner API integration path

## Compatibility

- no API contract, runner protocol, database schema, or feature-switch changes
- existing cooldown rows retain their absolute deadlines
- current runs and fallback-disabled primary selection remain unchanged

## Out of scope

- credential-wide cooldowns
- same-run replay, half-open probes, or success-based early recovery
- changes to runner-side failure classification

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit formatting, repository type checks, Knip, file-size, and commitlint hooks

Closes #28807

Parent: #28148
