### PR TITLE
perf(python): share model http response parsing

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -4,14 +4,13 @@ import json
 import threading
 import urllib.error
 import urllib.parse
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from mitmproxy import http
 
-import body_decoding
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_response_classification
@@ -19,14 +18,13 @@ import openai_responses_events
 import platform_api
 import runtime_url_parsing
 from logging_utils import log_proxy_entry
-from usage.json_selective import (
-    FIRST_ARRAY_ELEMENT,
-    JsonExtractionResult,
-    JsonSelectiveExtractor,
-    ScalarField,
+from usage.json_selective import JsonSelectiveExtractor
+from usage.model_http import (
+    FAILURE_SCALAR_FIELDS,
+    FAILURE_VALUE_PRESENCE_PATHS,
+    ModelHttpFailureEvidence,
+    failure_evidence_from_result,
 )
-from usage.json_selective import Path as JsonPath
-from usage.sse import SseUsageScanner
 
 if TYPE_CHECKING:
     from usage.openai_responses import OpenAIResponsesServerFailureEvidence
@@ -51,12 +49,10 @@ _OutcomeKind = Literal["failure", "success", "unknown"]
 _FLOW_STATE = "_model_provider_failure_flow_state"
 _RESPONSE_FINISH = "_model_provider_failure_response_finish"
 _MAX_JSON_WORK_UNITS = 65_536
-_MAX_SELECTED_STRING_BYTES = 128
 _MAX_RETRY_AFTER_SECONDS = 300
 _REPORT_TIMEOUT_SECONDS = 3
 _REPORT_WORKERS = 4
 _MAX_PENDING_REPORTS = _REPORT_WORKERS * 4
-_DONE_SENTINEL = b"[DONE]"
 RUNNER_AUTH_ENV = "VM0_MITM_RUNNER_TOKEN"
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
@@ -89,47 +85,18 @@ _UNAVAILABLE_CODES = frozenset(
 )
 _TIMEOUT_CODES = frozenset(("timeout", "timeout_error"))
 _CONNECTION_CODES = frozenset(("connection", "connection_error"))
-
-_SCALAR_FIELDS: Mapping[JsonPath, ScalarField] = {
-    ("type",): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("code",): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("status",): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("error_type",): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("error", "type"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("error", "code"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("error", "error_type"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("error", "metadata", "error_type"): ScalarField(
-        "string", max_bytes=_MAX_SELECTED_STRING_BYTES
-    ),
-    ("response", "id"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("response", "status"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("response", "error_type"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("response", "error", "type"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("response", "error", "code"): ScalarField("string", max_bytes=_MAX_SELECTED_STRING_BYTES),
-    ("response", "error", "error_type"): ScalarField(
-        "string", max_bytes=_MAX_SELECTED_STRING_BYTES
-    ),
-    ("choices", FIRST_ARRAY_ELEMENT, "error", "metadata", "error_type"): ScalarField(
-        "string", max_bytes=_MAX_SELECTED_STRING_BYTES
-    ),
+_OPENAI_RESPONSES_IGNORED_HTTP_EVENTS = openai_responses_events.KNOWN_NON_USAGE_EVENTS - {
+    openai_responses_events.SERVER_ERROR_EVENT
 }
-_VALUE_PRESENCE_PATHS = (
-    ("error",),
-    ("response", "error"),
-    ("choices", FIRST_ARRAY_ELEMENT, "error"),
-    ("choices",),
-)
-_FAILURE_CODE_PATHS = (
-    ("error", "metadata", "error_type"),
-    ("choices", FIRST_ARRAY_ELEMENT, "error", "metadata", "error_type"),
-    ("error", "error_type"),
-    ("response", "error_type"),
-    ("response", "error", "error_type"),
-    ("error_type",),
-    ("response", "error", "code"),
-    ("error", "code"),
-    ("response", "error", "type"),
-    ("error", "type"),
+_ANTHROPIC_IGNORED_HTTP_EVENTS = frozenset(
+    (
+        "message_start",
+        "message_delta",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "ping",
+    )
 )
 
 
@@ -226,8 +193,96 @@ def admit_flow(flow: http.HTTPFlow) -> None:
     flow.metadata[_FLOW_STATE] = flow_state
 
 
-def configure_response_parser(flow: http.HTTPFlow) -> Callable[[bytes], None] | None:
-    """Install bounded body classification for an admitted HTTP flow."""
+class HttpResponseFailureObserver:
+    """Reduce shared HTTP parse evidence without owning transport or parsing."""
+
+    def __init__(self, flow: http.HTTPFlow, flow_state: _FlowState) -> None:
+        self._flow = flow
+        self._flow_state = flow_state
+        self._terminal: _Outcome | None = None
+        self._parse_ambiguous = False
+
+    def needs_sse_event(self, event_name: str | None) -> bool:
+        if event_name is None:
+            return True
+        if self._flow_state.protocol == "openai_responses":
+            return event_name not in _OPENAI_RESPONSES_IGNORED_HTTP_EVENTS
+        if self._flow_state.protocol == "anthropic_messages":
+            return event_name not in _ANTHROPIC_IGNORED_HTTP_EVENTS
+        return True
+
+    def observe(self, evidence: ModelHttpFailureEvidence) -> None:
+        if not evidence.is_valid:
+            self._mark_parse_ambiguous()
+            return
+        if (
+            evidence.event_name is not None
+            and evidence.payload_type is not None
+            and evidence.event_name != evidence.payload_type
+        ):
+            self._mark_parse_ambiguous()
+            return
+
+        event_type = evidence.event_name or evidence.payload_type
+        if self._flow_state.protocol == "anthropic_messages":
+            if event_type == "message_stop":
+                self._record_terminal(_success_outcome())
+            elif event_type == "error":
+                self._record_terminal(_failure_or_unknown_from_codes(evidence.failure_codes))
+            return
+        if self._flow_state.protocol == "openai_responses":
+            if event_type in ("response.completed", "response.done"):
+                self._record_terminal(_success_outcome())
+            elif event_type in (
+                "response.failed",
+                "response.error",
+                openai_responses_events.SERVER_ERROR_EVENT,
+            ):
+                self._record_terminal(_failure_or_unknown_from_codes(evidence.failure_codes))
+            elif event_type == "response.incomplete":
+                self._record_terminal(_unknown_outcome())
+            return
+        if evidence.is_done:
+            self._record_terminal(_success_outcome())
+        elif evidence.has_error:
+            self._record_terminal(_failure_or_unknown_from_codes(evidence.failure_codes))
+
+    def observe_json(self, evidence: ModelHttpFailureEvidence) -> None:
+        self._store_terminal(_outcome_from_evidence(self._flow_state.protocol, evidence))
+
+    def finish(self) -> _Outcome:
+        if self._terminal is not None and self._terminal.kind == "failure":
+            outcome = self._terminal
+        elif self._parse_ambiguous:
+            outcome = _unknown_outcome()
+        else:
+            outcome = self._terminal or _unknown_outcome()
+        return outcome
+
+    def settle(self) -> _Outcome:
+        """Finish evidence reduction and settle a completed response stream."""
+
+        outcome = self.finish()
+        _settle_http_flow(self._flow, self._flow_state, outcome)
+        return outcome
+
+    def _record_terminal(self, outcome: _Outcome) -> None:
+        self._store_terminal(outcome)
+        self.settle()
+
+    def _store_terminal(self, outcome: _Outcome) -> None:
+        if self._terminal is None:
+            self._terminal = outcome
+        elif self._terminal != outcome:
+            self._terminal = _unknown_outcome()
+
+    def _mark_parse_ambiguous(self) -> None:
+        self._parse_ambiguous = True
+        self.settle()
+
+
+def configure_response_observer(flow: http.HTTPFlow) -> HttpResponseFailureObserver | None:
+    """Configure parser-free body classification for an admitted HTTP flow."""
     flow_state = _flow_state(flow)
     response = flow.response
     if (
@@ -255,40 +310,13 @@ def configure_response_parser(flow: http.HTTPFlow) -> Callable[[bytes], None] | 
             ),
         )
         return None
+    return HttpResponseFailureObserver(flow, flow_state)
 
-    parser: _JsonResponseParser | _SseResponseParser
-    if http_response_classification.has_event_stream_media_type(response):
-        parser = _SseResponseParser(
-            flow_state.protocol,
-            lambda outcome: _settle_http_flow(flow, flow_state, outcome),
-        )
-    else:
-        parser = _JsonResponseParser(flow_state.protocol)
-    decode_session = body_decoding.create_stream_decode_session(response.headers, parser.feed)
-    if decode_session is None:
-        flow.metadata[_RESPONSE_FINISH] = _unknown_outcome
-        return None
 
-    final_outcome: _Outcome | None = None
-
-    def finish() -> _Outcome:
-        nonlocal final_outcome
-        if final_outcome is None:
-            final_outcome = (
-                _unknown_outcome() if decode_session.finish_error() is not None else parser.finish()
-            )
-        return final_outcome
-
-    def observe(chunk: bytes) -> None:
-        if chunk:
-            decode_session.feed(chunk)
-            return
-        # mitmproxy calls streaming transformations with an empty chunk at EOM,
-        # before it forwards the downstream end-of-message marker.
-        _settle_http_flow(flow, flow_state, finish())
+def register_response_finish(flow: http.HTTPFlow, finish: Callable[[], object]) -> None:
+    """Register the shared response finalizer consumed by failure hook ordering."""
 
     flow.metadata[_RESPONSE_FINISH] = finish
-    return observe
 
 
 def finish_http_response(flow: http.HTTPFlow) -> None:
@@ -353,6 +381,8 @@ def finish_connection_error(flow: http.HTTPFlow) -> None:
             outcome = _failure_outcome("connection")
         else:
             parsed_outcome = _finish_response_body(flow, flow_state.protocol)
+            if flow_state.terminal_observed:
+                return
             if parsed_outcome.kind != "unknown":
                 outcome = parsed_outcome
             elif (
@@ -464,136 +494,8 @@ class _JsonResponseParser:
         self._extractor.feed(chunk)
 
     def finish(self) -> _Outcome:
-        return _outcome_from_json(self._protocol, self._extractor.finish())
-
-
-class _SseResponseParser:
-    def __init__(
-        self,
-        protocol: _Protocol,
-        settle: Callable[[_Outcome], None],
-    ) -> None:
-        self._handler: _SseEventHandler = _SseEventHandler(protocol, settle)
-        self._scanner = SseUsageScanner(
-            self._handler,
-            capture_data_without_event=True,
-        )
-
-    def feed(self, chunk: bytes) -> None:
-        self._scanner.feed(chunk)
-
-    def finish(self) -> _Outcome:
-        self._scanner.finish()
-        return self._handler.outcome()
-
-
-class _SseEventHandler:
-    def __init__(
-        self,
-        protocol: _Protocol,
-        settle: Callable[[_Outcome], None],
-    ) -> None:
-        self._protocol: _Protocol = protocol
-        self._settle = settle
-        self._extractor: JsonSelectiveExtractor | None = None
-        self._done_candidate = bytearray()
-        self._done_overflow = False
-        self._terminal: _Outcome | None = None
-        self._parse_ambiguous = False
-
-    def should_capture_event(self, event_name: str | None) -> bool:
-        del event_name
-        return True
-
-    def on_event_start(self, event_name: str | None) -> None:
-        del event_name
-        self._extractor = _new_json_extractor()
-        self._done_candidate.clear()
-        self._done_overflow = False
-
-    def on_data(self, chunk: bytes) -> None:
-        if self._extractor is not None:
-            self._extractor.feed(chunk)
-        if not self._done_overflow:
-            remaining = len(_DONE_SENTINEL) - len(self._done_candidate)
-            self._done_candidate.extend(chunk[:remaining])
-            if len(chunk) > remaining:
-                self._done_overflow = True
-
-    def on_data_separator(self) -> None:
-        if self._extractor is not None:
-            self._extractor.feed(b"\n")
-        self._done_overflow = True
-
-    def on_event_end(self, event_name: str | None) -> None:
-        extractor = self._extractor
-        self._extractor = None
-        if (
-            not self._done_overflow
-            and bytes(self._done_candidate) == _DONE_SENTINEL
-            and self._protocol == "openai_chat_completions"
-        ):
-            self._record_terminal(_success_outcome())
-            return
-        if extractor is None:
-            self._mark_parse_ambiguous()
-            return
-        result = extractor.finish()
-        payload_event_type = _string_value(result.values, ("type",))
-        if (
-            event_name is not None
-            and payload_event_type is not None
-            and event_name != payload_event_type
-        ):
-            self._mark_parse_ambiguous()
-            return
-        event_type = event_name or payload_event_type
-        if not result.complete:
-            self._mark_parse_ambiguous()
-            return
-        if self._protocol == "anthropic_messages":
-            if event_type == "message_stop":
-                self._record_terminal(_success_outcome())
-            elif event_type == "error":
-                self._record_terminal(_failure_or_unknown(result))
-            return
-        if self._protocol == "openai_responses":
-            if event_type in ("response.completed", "response.done"):
-                self._record_terminal(_success_outcome())
-            elif event_type in (
-                "response.failed",
-                "response.error",
-                openai_responses_events.SERVER_ERROR_EVENT,
-            ):
-                self._record_terminal(_failure_or_unknown(result))
-            elif event_type == "response.incomplete":
-                self._record_terminal(_unknown_outcome())
-            return
-        if _has_error_value(result):
-            self._record_terminal(_failure_or_unknown(result))
-
-    def on_event_discard(self, event_name: str | None) -> None:
-        del event_name
-        self._extractor = None
-        self._mark_parse_ambiguous()
-
-    def outcome(self) -> _Outcome:
-        if self._terminal is not None and self._terminal.kind == "failure":
-            return self._terminal
-        if self._parse_ambiguous:
-            return _unknown_outcome()
-        return self._terminal or _unknown_outcome()
-
-    def _record_terminal(self, outcome: _Outcome) -> None:
-        if self._terminal is None:
-            self._terminal = outcome
-        elif self._terminal != outcome:
-            self._terminal = _unknown_outcome()
-        self._settle(self.outcome())
-
-    def _mark_parse_ambiguous(self) -> None:
-        self._parse_ambiguous = True
-        self._settle(self.outcome())
+        evidence = failure_evidence_from_result(self._extractor.finish())
+        return _outcome_from_evidence(self._protocol, evidence)
 
 
 def _protocol_for_flow(flow: http.HTTPFlow) -> _Protocol | None:
@@ -637,16 +539,10 @@ def _upstream_connection_failed(flow: http.HTTPFlow) -> bool:
 
 def _new_json_extractor() -> JsonSelectiveExtractor:
     return JsonSelectiveExtractor(
-        scalar_fields=_SCALAR_FIELDS,
-        value_presence_paths=_VALUE_PRESENCE_PATHS,
+        scalar_fields=FAILURE_SCALAR_FIELDS,
+        value_presence_paths=FAILURE_VALUE_PRESENCE_PATHS,
         max_work_units=_MAX_JSON_WORK_UNITS,
     )
-
-
-def _extract_json(body: bytes) -> JsonExtractionResult:
-    extractor = _new_json_extractor()
-    extractor.feed(body)
-    return extractor.finish()
 
 
 def _finish_response_body(flow: http.HTTPFlow, protocol: _Protocol) -> _Outcome:
@@ -664,41 +560,25 @@ def _finish_response_body(flow: http.HTTPFlow, protocol: _Protocol) -> _Outcome:
     return _unknown_outcome()
 
 
-def _outcome_from_json(protocol: _Protocol, result: JsonExtractionResult) -> _Outcome:
-    if not result.complete:
+def _outcome_from_evidence(
+    protocol: _Protocol,
+    evidence: ModelHttpFailureEvidence,
+) -> _Outcome:
+    if not evidence.is_valid:
         return _unknown_outcome()
-    failure = _failure_from_result(result)
+    failure = _failure_from_codes(evidence.failure_codes)
     if failure is not None:
         return _Outcome("failure", failure)
-    if _has_error_value(result):
+    if evidence.has_error:
         return _unknown_outcome()
     if protocol == "openai_responses":
-        status = _string_value(result.values, ("status",)) or _string_value(
-            result.values, ("response", "status")
-        )
+        status = evidence.status or evidence.response_status
         return _success_outcome() if status == "completed" else _unknown_outcome()
     if protocol == "anthropic_messages":
-        return (
-            _success_outcome()
-            if _string_value(result.values, ("type",)) == "message"
-            else _unknown_outcome()
-        )
-    if protocol == "openai_chat_completions" and ("choices",) in result.value_present:
+        return _success_outcome() if evidence.payload_type == "message" else _unknown_outcome()
+    if protocol == "openai_chat_completions" and evidence.has_choices:
         return _success_outcome()
     return _unknown_outcome()
-
-
-def _failure_from_result(result: JsonExtractionResult) -> Failure | None:
-    codes = tuple(
-        code
-        for path in _FAILURE_CODE_PATHS
-        if (code := _string_value(result.values, path)) is not None
-    )
-    if _string_value(result.values, ("type",)) == "error":
-        code = _string_value(result.values, ("code",))
-        if code is not None:
-            codes = (*codes, code)
-    return _failure_from_codes(codes)
 
 
 def _failure_from_codes(codes: tuple[str, ...]) -> Failure | None:
@@ -707,11 +587,6 @@ def _failure_from_codes(codes: tuple[str, ...]) -> Failure | None:
         if failure_kind is not None:
             return Failure(failure_kind)
     return None
-
-
-def _failure_or_unknown(result: JsonExtractionResult) -> _Outcome:
-    failure = _failure_from_result(result)
-    return _Outcome("failure", failure) if failure is not None else _unknown_outcome()
 
 
 def _failure_or_unknown_from_codes(codes: tuple[str, ...]) -> _Outcome:
@@ -775,22 +650,6 @@ def _retry_after_seconds(status: int, headers: http.Headers) -> int | None:
     if len(digits) > len(maximum) or (len(digits) == len(maximum) and digits > maximum):
         return _MAX_RETRY_AFTER_SECONDS
     return int(digits)
-
-
-def _has_error_value(result: JsonExtractionResult) -> bool:
-    return any(
-        path in result.value_present
-        for path in (
-            ("error",),
-            ("response", "error"),
-            ("choices", FIRST_ARRAY_ELEMENT, "error"),
-        )
-    )
-
-
-def _string_value(values: Mapping[JsonPath, object], path: JsonPath) -> str | None:
-    value = values.get(path)
-    return value if isinstance(value, str) else None
 
 
 def _failure_outcome(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -70,9 +70,10 @@ def _anthropic_incomplete_accounting_status(
     return "recovered_partial"
 
 
-class _ResponseUsageStreamSetup(NamedTuple):
+class _ResponseStreamSetup(NamedTuple):
     parser: _ResponseChunkParser | None
     needs_buffered_fallback: bool
+    finish_stream: Callable[[], object] | None = None
 
 
 def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
@@ -173,12 +174,15 @@ def _maybe_log_response_encoding_inspection_risk(
     )
 
 
-def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStreamSetup:
-    # Set up usage extraction for response classes that need body inspection.
-    # Usage parsers consume chunks separately from the optional capped buffer.
+def _configure_response_inspection_stream(
+    flow: http.HTTPFlow,
+    failure_observer: model_provider_failure.HttpResponseFailureObserver | None,
+) -> _ResponseStreamSetup:
+    # Set up model inspection or connector usage extraction for response classes
+    # that need it. Parsers consume chunks separately from the optional buffer.
     response = flow.response
     if response is None:
-        return _ResponseUsageStreamSetup(None, False)
+        return _ResponseStreamSetup(None, False)
 
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
@@ -186,16 +190,20 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     # extraction. Model-provider usage reporting is gated separately.
     is_billable_flow = flow_metadata.is_firewall_billable(flow.metadata)
     is_observable_model_provider = usage.is_model_provider_usage_observable(flow)
-    model_protocol = model_usage_protocol(flow) if is_observable_model_provider else None
+    model_protocol = (
+        model_usage_protocol(flow)
+        if is_observable_model_provider or failure_observer is not None
+        else None
+    )
     if (
         is_observable_model_provider
         and model_protocol == "openai_responses"
         and is_confirmed_websocket_upgrade_response(flow)
     ):
         model_websocket_usage.activate(flow)
-        return _ResponseUsageStreamSetup(None, False)
+        return _ResponseStreamSetup(None, False)
     if not http_response_classification.can_have_body(flow, response):
-        return _ResponseUsageStreamSetup(None, False)
+        return _ResponseStreamSetup(None, False)
     if model_protocol is not None:
         if http_response_classification.has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
@@ -216,7 +224,11 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
 
                 parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor(
                     on_parse_error=log_parse_error,
-                    on_terminal_usage=record_openai_terminal_usage,
+                    on_terminal_usage=(
+                        record_openai_terminal_usage if is_observable_model_provider else None
+                    ),
+                    include_usage=is_observable_model_provider,
+                    failure_observer=failure_observer,
                 )
             elif model_protocol == "openai_chat_completions":
                 usage_protocol = _OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL
@@ -226,6 +238,8 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                 )
                 parser_fn, usage_dict = usage.create_openai_chat_completions_sse_usage_extractor(
                     on_parse_error=log_parse_error,
+                    include_usage=is_observable_model_provider,
+                    failure_observer=failure_observer,
                 )
             else:
                 usage_protocol = _ANTHROPIC_MESSAGES_SSE_PROTOCOL
@@ -233,78 +247,146 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                     flow,
                     usage_protocol=usage_protocol,
                 )
-                lifecycle_observer = _anthropic_lifecycle_observer(flow)
+                lifecycle_observer = (
+                    _anthropic_lifecycle_observer(flow) if is_observable_model_provider else None
+                )
                 parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
                     on_parse_error=log_parse_error,
                     on_lifecycle_event=lifecycle_observer,
-                    on_accounting_event=anthropic_accounting_events.add,
+                    on_accounting_event=(
+                        anthropic_accounting_events.add if is_observable_model_provider else None
+                    ),
+                    include_usage=is_observable_model_provider,
+                    failure_observer=failure_observer,
                 )
             decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
-                _maybe_log_response_encoding_inspection_risk(flow, response)
-                return _ResponseUsageStreamSetup(None, False)
-            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
+                if is_observable_model_provider:
+                    _maybe_log_response_encoding_inspection_risk(flow, response)
+                if failure_observer is not None:
+                    model_provider_failure.register_response_finish(
+                        flow,
+                        failure_observer.finish,
+                    )
+                return _ResponseStreamSetup(None, False)
 
-            def finish_sse_usage() -> None:
-                decode_error = decode_session.finish_error()
-                if decode_error is not None:
-                    log_parse_error("compressed_body", decode_error)
-                    if (
-                        usage_protocol == _ANTHROPIC_MESSAGES_SSE_PROTOCOL
-                        and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
-                    ):
-                        accounting_status = _anthropic_incomplete_accounting_status(
-                            usage_dict,
-                            anthropic_accounting_events,
-                        )
-                        anthropic_accounting.report_incomplete(
-                            flow,
-                            accounting_status,
-                        )
-                    elif (
-                        usage_protocol == _OPENAI_RESPONSES_SSE_PROTOCOL
-                        and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
-                    ):
-                        usage_dict.clear()
-                        usage.merge_openai_responses_usage_result(
-                            usage_dict,
-                            openai_recoverable_usage,
-                        )
-                    else:
-                        usage_dict.clear()
-                else:
-                    parser_fn.finish()
-                if lifecycle_observer is not None:
-                    claude_output_timing.retry_pending(flow)
+            finished = False
 
-            flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
-            return _ResponseUsageStreamSetup(decode_session.feed, False)
+            def finish_sse_response() -> object:
+                nonlocal finished
+                if not finished:
+                    decode_error = decode_session.finish_error()
+                    if decode_error is None:
+                        parser_fn.finish()
+                    elif is_observable_model_provider:
+                        log_parse_error("compressed_body", decode_error)
+                        if (
+                            usage_protocol == _ANTHROPIC_MESSAGES_SSE_PROTOCOL
+                            and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
+                        ):
+                            accounting_status = _anthropic_incomplete_accounting_status(
+                                usage_dict,
+                                anthropic_accounting_events,
+                            )
+                            anthropic_accounting.report_incomplete(
+                                flow,
+                                accounting_status,
+                            )
+                        elif (
+                            usage_protocol == _OPENAI_RESPONSES_SSE_PROTOCOL
+                            and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
+                        ):
+                            usage_dict.clear()
+                            usage.merge_openai_responses_usage_result(
+                                usage_dict,
+                                openai_recoverable_usage,
+                            )
+                        else:
+                            usage_dict.clear()
+                    if lifecycle_observer is not None:
+                        claude_output_timing.retry_pending(flow)
+                    finished = True
+                return failure_observer.finish() if failure_observer is not None else None
 
-        extractor = usage.create_model_json_usage_extractor(model_protocol)
+            def finish_sse_stream() -> object:
+                finish_sse_response()
+                return failure_observer.settle() if failure_observer is not None else None
+
+            if is_observable_model_provider:
+                flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
+                flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_response
+            if failure_observer is not None:
+                model_provider_failure.register_response_finish(flow, finish_sse_response)
+            return _ResponseStreamSetup(
+                decode_session.feed,
+                False,
+                finish_sse_stream if failure_observer is not None else None,
+            )
+
+        extractor = usage.create_model_json_response_inspector(
+            model_protocol,
+            include_usage=is_observable_model_provider,
+            include_failure=failure_observer is not None,
+        )
         decode_session = _make_response_decode_session(
             extractor.feed,
             response.headers,
             should_continue=extractor.accepts_more_input,
         )
         if decode_session is None:
-            _maybe_log_response_encoding_inspection_risk(flow, response)
-            return _ResponseUsageStreamSetup(
+            if is_observable_model_provider:
+                _maybe_log_response_encoding_inspection_risk(flow, response)
+            if failure_observer is not None:
+                model_provider_failure.register_response_finish(
+                    flow,
+                    failure_observer.finish,
+                )
+            return _ResponseStreamSetup(
                 None,
-                uses_model_json_fallback(flow)
+                is_observable_model_provider
+                and uses_model_json_fallback(flow)
                 and body_decoding.can_decode_json_usage_body(response.headers),
             )
 
+        inspection: usage.ModelJsonResponseInspection | None = None
+        decode_error: str | None = None
+        finished = False
+
+        def finish_json_response() -> object:
+            nonlocal decode_error, finished, inspection
+            if not finished:
+                decode_error = decode_session.finish_error()
+                if decode_error is None:
+                    inspection = extractor.finish()
+                    if failure_observer is not None:
+                        failure_observer.observe_json(inspection.failure)
+                finished = True
+            return failure_observer.finish() if failure_observer is not None else None
+
         def finish_json_usage() -> tuple[dict | None, str | None]:
-            decode_error = decode_session.finish_error()
+            finish_json_response()
             if decode_error is not None:
                 return None, decode_error
-            return extractor.finish()
+            if inspection is None:
+                return None, None
+            return inspection.usage, inspection.usage_error
 
-        flow.metadata[_MODEL_JSON_USAGE_FINISH] = finish_json_usage
-        return _ResponseUsageStreamSetup(decode_session.feed, False)
+        def finish_json_stream() -> object:
+            finish_json_response()
+            return failure_observer.settle() if failure_observer is not None else None
+
+        if is_observable_model_provider:
+            flow.metadata[_MODEL_JSON_USAGE_FINISH] = finish_json_usage
+        if failure_observer is not None:
+            model_provider_failure.register_response_finish(flow, finish_json_response)
+        return _ResponseStreamSetup(
+            decode_session.feed,
+            False,
+            finish_json_stream if failure_observer is not None else None,
+        )
 
     if not is_billable_flow:
-        return _ResponseUsageStreamSetup(None, False)
+        return _ResponseStreamSetup(None, False)
     if not body_decoding.can_stream_decode_usage(response.headers):
         firewall_name = flow_metadata.firewall_name(flow.metadata)
         if (
@@ -312,7 +394,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             and usage.has_connector_response_parser(firewall_name)
         ):
             _maybe_log_response_encoding_inspection_risk(flow, response)
-        return _ResponseUsageStreamSetup(
+        return _ResponseStreamSetup(
             None,
             http_response_classification.can_have_body(flow, response)
             and body_decoding.can_decode_json_usage_body(response.headers)
@@ -341,9 +423,9 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                     connector_parser.finish()
 
             flow.metadata[_CONNECTOR_RESPONSE_FINISH] = finish_connector_response
-        return _ResponseUsageStreamSetup(decode_session.feed, False)
+        return _ResponseStreamSetup(decode_session.feed, False)
 
-    return _ResponseUsageStreamSetup(None, False)
+    return _ResponseStreamSetup(None, False)
 
 
 def is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
@@ -389,8 +471,11 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
         return
 
     metrics = {"total_bytes": 0}
-    usage_parser, needs_buffered_fallback = _configure_response_usage_stream(flow)
-    failure_parser = model_provider_failure.configure_response_parser(flow)
+    failure_observer = model_provider_failure.configure_response_observer(flow)
+    response_parser, needs_buffered_fallback, finish_stream = _configure_response_inspection_stream(
+        flow,
+        failure_observer,
+    )
     retain_body = flow_metadata.should_capture_body(flow.metadata) or needs_buffered_fallback
     buf = bytearray() if retain_body else None
     buffer_state = {"truncated": False} if retain_body else None
@@ -404,10 +489,10 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
             else:
                 buf.extend(chunk[:remaining])
                 buffer_state["truncated"] = True
-        if usage_parser is not None:
-            usage_parser(chunk)
-        if failure_parser is not None:
-            failure_parser(chunk)
+        if response_parser is not None:
+            response_parser(chunk)
+        if not chunk and finish_stream is not None:
+            finish_stream()
         return chunk
 
     flow.response.stream = stream_and_observe

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -56,7 +56,9 @@ from .counters import (
     write_pending_snapshot,
 )
 from .model_json import (
+    ModelJsonResponseInspection,
     ModelUsageProtocol,
+    create_model_json_response_inspector,
     create_model_json_usage_extractor,
     extract_model_usage_with_error_from_json,
 )
@@ -102,6 +104,7 @@ __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
     "OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR",
     "BufferedReportLease",
+    "ModelJsonResponseInspection",
     "ModelUsageProtocol",
     "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
@@ -117,6 +120,7 @@ __all__ = [
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
     "create_connector_response_parser",
+    "create_model_json_response_inspector",
     "create_model_json_usage_extractor",
     "create_openai_chat_completions_json_usage_extractor",
     "create_openai_chat_completions_sse_usage_extractor",

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -9,7 +9,14 @@ from collections.abc import Callable
 import body_decoding
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
-from .json_selective import JsonSelectiveExtractor, ScalarField
+from .json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
+from .model_http import (
+    ModelHttpFailureEvidence,
+    ModelHttpFailureObserver,
+    combined_scalar_fields,
+    combined_value_presence_paths,
+    failure_evidence_from_result,
+)
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
 from .quantities import MAX_USAGE_QUANTITY, is_usage_quantity
 from .sse import SseUsageScanner
@@ -79,6 +86,9 @@ def create_anthropic_messages_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
     on_lifecycle_event: AnthropicMessagesLifecycleCallback | None = None,
     on_accounting_event: AnthropicMessagesAccountingEventCallback | None = None,
+    *,
+    include_usage: bool = True,
+    failure_observer: ModelHttpFailureObserver | None = None,
 ) -> tuple[SseUsageScanner, dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
@@ -132,6 +142,8 @@ def create_anthropic_messages_sse_usage_extractor(
             on_parse_error=on_parse_error,
             on_lifecycle_event=on_lifecycle_event,
             on_accounting_event=on_accounting_event,
+            include_usage=include_usage,
+            failure_observer=failure_observer,
         ),
         # Anthropic-shaped streams can omit SSE event names and rely on JSON
         # "type" fields to classify message_start/message_delta payloads.
@@ -148,23 +160,40 @@ class _AnthropicMessagesSseUsageHandler:
         on_parse_error: _SseUsageParseErrorCallback | None = None,
         on_lifecycle_event: AnthropicMessagesLifecycleCallback | None = None,
         on_accounting_event: AnthropicMessagesAccountingEventCallback | None = None,
+        include_usage: bool = True,
+        failure_observer: ModelHttpFailureObserver | None = None,
     ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
         self._on_parse_error = on_parse_error
         self._on_lifecycle_event = on_lifecycle_event
         self._on_accounting_event = on_accounting_event
+        self._include_usage = include_usage
+        self._failure_observer = failure_observer
 
     def should_capture_event(self, event_name: str | None) -> bool:
-        return (
+        usage_needs_event = self._include_usage and (
             event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
             or (event_name == "message_stop" and self._on_accounting_event is not None)
             or (event_name == "content_block_start" and self._on_lifecycle_event is not None)
         )
+        return usage_needs_event or (
+            self._failure_observer is not None
+            and self._failure_observer.needs_sse_event(event_name)
+        )
 
     def on_event_start(self, event_name: str | None) -> None:
         self._extractor = JsonSelectiveExtractor(
-            scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS,
+            scalar_fields=combined_scalar_fields(
+                _ANTHROPIC_SSE_SCALAR_FIELDS,
+                include_usage=self._include_usage,
+                include_failure=self._failure_observer is not None,
+            ),
+            value_presence_paths=combined_value_presence_paths(
+                (),
+                include_usage=self._include_usage,
+                include_failure=self._failure_observer is not None,
+            ),
             max_work_units=_ANTHROPIC_MESSAGES_MAX_WORK_UNITS,
         )
 
@@ -182,6 +211,12 @@ class _AnthropicMessagesSseUsageHandler:
             return
 
         result = extractor.finish()
+        if self._failure_observer is not None:
+            self._failure_observer.observe(
+                failure_evidence_from_result(result, event_name=event_name)
+            )
+        if not self._include_usage:
+            return
         if not result.complete:
             event_type = event_name
             if event_type is None:
@@ -233,6 +268,10 @@ class _AnthropicMessagesSseUsageHandler:
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._extractor = None
+        if self._failure_observer is not None and self._failure_observer.needs_sse_event(
+            event_name
+        ):
+            self._failure_observer.observe(ModelHttpFailureEvidence(event_name=event_name))
 
 
 class AnthropicMessagesJsonUsageExtractor:
@@ -263,25 +302,39 @@ class AnthropicMessagesJsonUsageExtractor:
 
     def finish(self) -> tuple[dict | None, str | None]:
         result = self._extractor.finish()
-        if not result.complete:
-            return None, result.error
-        usage: dict = {}
-        model = result.values.get(("model",))
-        if isinstance(model, str) and model:
-            usage["model"] = model
-        _store_selected_usage_values(result.values, usage, ("usage",))
-        if not usage:
-            return None, None
-        message_id = result.values.get(("id",))
-        if isinstance(message_id, str) and message_id:
-            usage["message_id"] = message_id
-        return usage, None
+        return model_json_usage_from_result(result)
 
 
 def create_anthropic_messages_json_usage_extractor() -> AnthropicMessagesJsonUsageExtractor:
     """Create an incremental parser for non-SSE Anthropic Messages JSON chunks."""
 
     return AnthropicMessagesJsonUsageExtractor()
+
+
+def model_json_scalar_fields() -> dict:
+    """Return Anthropic JSON fields selected for usage inspection."""
+
+    return dict(_MODEL_JSON_SCALAR_FIELDS)
+
+
+def model_json_usage_from_result(
+    result: JsonExtractionResult,
+) -> tuple[dict | None, str | None]:
+    """Map one complete shared JSON extraction into Anthropic usage."""
+
+    if not result.complete:
+        return None, result.error
+    usage: dict = {}
+    model = result.values.get(("model",))
+    if isinstance(model, str) and model:
+        usage["model"] = model
+    _store_selected_usage_values(result.values, usage, ("usage",))
+    if not usage:
+        return None, None
+    message_id = result.values.get(("id",))
+    if isinstance(message_id, str) and message_id:
+        usage["message_id"] = message_id
+    return usage, None
 
 
 def _extract_anthropic_messages_usage_from_decoded_json_body(

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -151,6 +151,10 @@ class JsonExtractionResult:
     array path lengths, ``wildcard_array_counts`` contains per-wildcard-key array
     lengths, ``object_present`` contains observed object paths, and
     ``value_present`` contains paths where any JSON value appeared.
+    ``discarded_scalar_paths`` identifies selected strings discarded by their
+    configured overflow policy.
+    ``selected_string_max_raw_bytes`` retains the maximum encoded JSON string
+    length observed at each selected path, including duplicate occurrences.
 
     When ``complete`` is false, all observation containers are empty and
     ``error`` describes the parse or bound failure. This prevents callers from
@@ -163,6 +167,8 @@ class JsonExtractionResult:
     wildcard_array_counts: dict[WildcardPath, dict[str, int]] = field(default_factory=dict)
     object_present: set[Path] = field(default_factory=set)
     value_present: set[Path] = field(default_factory=set)
+    discarded_scalar_paths: set[Path] = field(default_factory=set)
+    selected_string_max_raw_bytes: dict[Path, int] = field(default_factory=dict)
     error: str | None = None
 
 
@@ -327,6 +333,8 @@ class JsonSelectiveExtractor:
         self.wildcard_array_counts: dict[WildcardPath, dict[str, int]] = {}
         self.object_present: set[Path] = set()
         self.value_present: set[Path] = set()
+        self.discarded_scalar_paths: set[Path] = set()
+        self.selected_string_max_raw_bytes: dict[Path, int] = {}
         self._scalar_consistency: dict[Path, _ScalarConsistency] = {}
 
         self._stack: list[_Frame] = []
@@ -346,6 +354,8 @@ class JsonSelectiveExtractor:
         self.wildcard_array_counts.clear()
         self.object_present.clear()
         self.value_present.clear()
+        self.discarded_scalar_paths.clear()
+        self.selected_string_max_raw_bytes.clear()
         self._scalar_consistency.clear()
 
         self._stack.clear()
@@ -456,6 +466,10 @@ class JsonSelectiveExtractor:
             else {},
             object_present=set(self.object_present) if complete else set(),
             value_present=set(self.value_present) if complete else set(),
+            discarded_scalar_paths=(set(self.discarded_scalar_paths) if complete else set()),
+            selected_string_max_raw_bytes=(
+                dict(self.selected_string_max_raw_bytes) if complete else {}
+            ),
             error=self._error,
         )
 
@@ -868,6 +882,8 @@ class JsonSelectiveExtractor:
         state.raw.append(b)
         if len(state.raw) > state.max_bytes:
             if state.role == "key" or state.overflow_policy == "discard":
+                if state.role == "selected" and state.path is not None:
+                    self.discarded_scalar_paths.add(state.path)
                 state.raw = None
                 return
             self._error = "string limit exceeded"
@@ -901,6 +917,10 @@ class JsonSelectiveExtractor:
         if state.raw is None:
             self._value_complete()
             return
+        self.selected_string_max_raw_bytes[state.path] = max(
+            len(state.raw),
+            self.selected_string_max_raw_bytes.get(state.path, 0),
+        )
         if _contains_surrogate(value):
             self._value_complete()
             return

--- a/crates/runner/mitm-addon/src/usage/model_http.py
+++ b/crates/runner/mitm-addon/src/usage/model_http.py
@@ -1,0 +1,168 @@
+"""Shared bounded failure evidence for model-provider HTTP body inspection."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import Protocol
+
+from .json_selective import (
+    FIRST_ARRAY_ELEMENT,
+    JsonExtractionResult,
+    ScalarField,
+)
+from .json_selective import Path as JsonPath
+
+_MAX_FAILURE_STRING_BYTES = 128
+
+FAILURE_SCALAR_FIELDS: Mapping[JsonPath, ScalarField] = {
+    ("type",): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("code",): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("status",): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("error_type",): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("error", "type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("error", "code"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("error", "error_type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("error", "metadata", "error_type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "id"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "status"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "error_type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "error", "type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "error", "code"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("response", "error", "error_type"): ScalarField("string", max_bytes=_MAX_FAILURE_STRING_BYTES),
+    ("choices", FIRST_ARRAY_ELEMENT, "error", "metadata", "error_type"): ScalarField(
+        "string", max_bytes=_MAX_FAILURE_STRING_BYTES
+    ),
+}
+
+FAILURE_VALUE_PRESENCE_PATHS = (
+    ("error",),
+    ("response", "error"),
+    ("choices", FIRST_ARRAY_ELEMENT, "error"),
+    ("choices",),
+)
+
+_FAILURE_CODE_PATHS = (
+    ("error", "metadata", "error_type"),
+    ("choices", FIRST_ARRAY_ELEMENT, "error", "metadata", "error_type"),
+    ("error", "error_type"),
+    ("response", "error_type"),
+    ("response", "error", "error_type"),
+    ("error_type",),
+    ("response", "error", "code"),
+    ("error", "code"),
+    ("response", "error", "type"),
+    ("error", "type"),
+)
+
+
+@dataclass(frozen=True)
+class ModelHttpFailureEvidence:
+    """Immutable failure-classification evidence from one JSON document or SSE event."""
+
+    event_name: str | None = None
+    payload_type: str | None = None
+    status: str | None = None
+    response_status: str | None = None
+    response_id: str | None = None
+    failure_codes: tuple[str, ...] = ()
+    has_error: bool = False
+    has_choices: bool = False
+    is_done: bool = False
+    is_valid: bool = False
+
+
+class ModelHttpFailureObserver(Protocol):
+    """Parser-free consumer of shared model HTTP failure evidence."""
+
+    def needs_sse_event(self, event_name: str | None) -> bool:
+        raise NotImplementedError
+
+    def observe(self, evidence: ModelHttpFailureEvidence) -> None:
+        raise NotImplementedError
+
+    def observe_json(self, evidence: ModelHttpFailureEvidence) -> None:
+        raise NotImplementedError
+
+    def finish(self) -> object:
+        raise NotImplementedError
+
+
+def combined_scalar_fields(
+    usage_fields: Mapping[JsonPath, ScalarField],
+    *,
+    include_usage: bool,
+    include_failure: bool,
+) -> dict[JsonPath, ScalarField]:
+    """Return the exact selected-field union for the active consumers."""
+
+    fields = dict(usage_fields) if include_usage else {}
+    if include_failure:
+        for path, field in FAILURE_SCALAR_FIELDS.items():
+            if path not in fields:
+                fields[path] = replace(field, overflow_policy="discard") if include_usage else field
+    return fields
+
+
+def combined_value_presence_paths(
+    usage_paths: tuple[JsonPath, ...],
+    *,
+    include_usage: bool,
+    include_failure: bool,
+) -> set[JsonPath]:
+    paths = set(usage_paths) if include_usage else set()
+    if include_failure:
+        paths.update(FAILURE_VALUE_PRESENCE_PATHS)
+    return paths
+
+
+def failure_evidence_from_result(
+    result: JsonExtractionResult,
+    *,
+    event_name: str | None = None,
+    is_done: bool = False,
+) -> ModelHttpFailureEvidence:
+    """Project one shared extraction result into the strict failure evidence contract."""
+
+    if not result.complete or _failure_fields_overflowed(result):
+        return ModelHttpFailureEvidence(event_name=event_name, is_done=is_done)
+
+    payload_type = _string_value(result, ("type",))
+    failure_codes = tuple(
+        value for path in _FAILURE_CODE_PATHS if (value := _string_value(result, path)) is not None
+    )
+    top_level_code = _string_value(result, ("code",))
+    if payload_type == "error" and top_level_code is not None:
+        failure_codes = (*failure_codes, top_level_code)
+    return ModelHttpFailureEvidence(
+        event_name=event_name,
+        payload_type=payload_type,
+        status=_string_value(result, ("status",)),
+        response_status=_string_value(result, ("response", "status")),
+        response_id=_string_value(result, ("response", "id")),
+        failure_codes=failure_codes,
+        has_error=any(
+            path in result.value_present
+            for path in (
+                ("error",),
+                ("response", "error"),
+                ("choices", FIRST_ARRAY_ELEMENT, "error"),
+            )
+        ),
+        has_choices=("choices",) in result.value_present,
+        is_done=is_done,
+        is_valid=True,
+    )
+
+
+def _failure_fields_overflowed(result: JsonExtractionResult) -> bool:
+    if result.discarded_scalar_paths.intersection(FAILURE_SCALAR_FIELDS):
+        return True
+    return any(
+        raw_bytes > _MAX_FAILURE_STRING_BYTES
+        for path, raw_bytes in result.selected_string_max_raw_bytes.items()
+        if path in FAILURE_SCALAR_FIELDS
+    )
+
+
+def _string_value(result: JsonExtractionResult, path: JsonPath) -> str | None:
+    value = result.values.get(path)
+    return value if isinstance(value, str) else None

--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -5,12 +5,21 @@ extractor factory and bounded complete-body extractor. Cross-provider callers
 must dispatch through this module so the two JSON paths cannot drift.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Literal, NamedTuple, Protocol, assert_never
 
 from mitmproxy import http
 
 from . import anthropic_messages, openai_chat_completions, openai_responses
+from .json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
+from .json_selective import Path as JsonPath
+from .model_http import (
+    ModelHttpFailureEvidence,
+    combined_scalar_fields,
+    combined_value_presence_paths,
+    failure_evidence_from_result,
+)
 
 ModelUsageProtocol = Literal[
     "anthropic_messages",
@@ -44,6 +53,10 @@ _ModelJsonUsageCompleteBodyExtractor = Callable[
 class _ModelJsonUsageRegistration(NamedTuple):
     create_extractor: _ModelJsonUsageExtractorFactory
     extract_from_complete_body: _ModelJsonUsageCompleteBodyExtractor
+    scalar_fields: Callable[[], Mapping[JsonPath, ScalarField]]
+    object_presence_paths: Callable[[], set[JsonPath]]
+    value_presence_paths: Callable[[], set[JsonPath]]
+    usage_from_result: Callable[[JsonExtractionResult], ModelJsonUsageResult]
 
 
 _ANTHROPIC_MESSAGES_REGISTRATION = _ModelJsonUsageRegistration(
@@ -51,19 +64,100 @@ _ANTHROPIC_MESSAGES_REGISTRATION = _ModelJsonUsageRegistration(
     extract_from_complete_body=(
         anthropic_messages.extract_anthropic_messages_usage_with_error_from_json
     ),
+    scalar_fields=anthropic_messages.model_json_scalar_fields,
+    object_presence_paths=set,
+    value_presence_paths=set,
+    usage_from_result=anthropic_messages.model_json_usage_from_result,
 )
 _OPENAI_CHAT_COMPLETIONS_REGISTRATION = _ModelJsonUsageRegistration(
     create_extractor=(openai_chat_completions.create_openai_chat_completions_json_usage_extractor),
     extract_from_complete_body=(
         openai_chat_completions.extract_openai_chat_completions_usage_with_error_from_json
     ),
+    scalar_fields=openai_chat_completions.model_json_scalar_fields,
+    object_presence_paths=openai_chat_completions.model_json_object_presence_paths,
+    value_presence_paths=openai_chat_completions.model_json_value_presence_paths,
+    usage_from_result=openai_chat_completions.model_json_usage_from_result,
 )
 _OPENAI_RESPONSES_REGISTRATION = _ModelJsonUsageRegistration(
     create_extractor=openai_responses.create_openai_responses_json_usage_extractor,
     extract_from_complete_body=(
         openai_responses.extract_openai_responses_usage_with_error_from_json
     ),
+    scalar_fields=openai_responses.model_json_scalar_fields,
+    object_presence_paths=set,
+    value_presence_paths=set,
+    usage_from_result=openai_responses.model_json_usage_from_result,
 )
+
+
+@dataclass(frozen=True)
+class ModelJsonResponseInspection:
+    usage: dict | None
+    usage_error: str | None
+    failure: ModelHttpFailureEvidence
+
+
+class ModelJsonResponseInspector:
+    """One bounded JSON extractor shared by active model HTTP consumers."""
+
+    def __init__(
+        self,
+        protocol: ModelUsageProtocol,
+        *,
+        include_usage: bool,
+        include_failure: bool,
+    ) -> None:
+        self._registration = _model_json_usage_registration(protocol)
+        self._include_usage = include_usage
+        self._include_failure = include_failure
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=combined_scalar_fields(
+                self._registration.scalar_fields(),
+                include_usage=include_usage,
+                include_failure=include_failure,
+            ),
+            object_presence_paths=(
+                self._registration.object_presence_paths() if include_usage else set()
+            ),
+            value_presence_paths=combined_value_presence_paths(
+                tuple(self._registration.value_presence_paths()),
+                include_usage=include_usage,
+                include_failure=include_failure,
+            ),
+            max_work_units=65_536,
+        )
+
+    def feed(self, chunk: bytes) -> None:
+        self._extractor.feed(chunk)
+
+    def accepts_more_input(self) -> bool:
+        return self._extractor.accepts_more_input()
+
+    def finish(self) -> ModelJsonResponseInspection:
+        result = self._extractor.finish()
+        usage, usage_error = (
+            self._registration.usage_from_result(result) if self._include_usage else (None, None)
+        )
+        failure = (
+            failure_evidence_from_result(result)
+            if self._include_failure
+            else ModelHttpFailureEvidence()
+        )
+        return ModelJsonResponseInspection(usage, usage_error, failure)
+
+
+def create_model_json_response_inspector(
+    protocol: ModelUsageProtocol,
+    *,
+    include_usage: bool,
+    include_failure: bool,
+) -> ModelJsonResponseInspector:
+    return ModelJsonResponseInspector(
+        protocol,
+        include_usage=include_usage,
+        include_failure=include_failure,
+    )
 
 
 def _model_json_usage_registration(

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -14,6 +14,13 @@ from .json_selective import (
     Path,
     ScalarField,
 )
+from .model_http import (
+    ModelHttpFailureEvidence,
+    ModelHttpFailureObserver,
+    combined_scalar_fields,
+    combined_value_presence_paths,
+    failure_evidence_from_result,
+)
 from .model_tokens import (
     MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
@@ -68,11 +75,23 @@ _USAGE_VALUE_PRESENCE_PATHS = {
 }
 
 
-def _new_extractor() -> JsonSelectiveExtractor:
+def _new_extractor(
+    *,
+    include_usage: bool = True,
+    include_failure: bool = False,
+) -> JsonSelectiveExtractor:
     return JsonSelectiveExtractor(
-        scalar_fields=_CHAT_COMPLETIONS_SCALAR_FIELDS,
-        object_presence_paths=set(_USAGE_PATHS),
-        value_presence_paths=_USAGE_VALUE_PRESENCE_PATHS,
+        scalar_fields=combined_scalar_fields(
+            _CHAT_COMPLETIONS_SCALAR_FIELDS,
+            include_usage=include_usage,
+            include_failure=include_failure,
+        ),
+        object_presence_paths=set(_USAGE_PATHS) if include_usage else set(),
+        value_presence_paths=combined_value_presence_paths(
+            tuple(_USAGE_VALUE_PRESENCE_PATHS),
+            include_usage=include_usage,
+            include_failure=include_failure,
+        ),
         max_work_units=_CHAT_COMPLETIONS_MAX_WORK_UNITS,
     )
 
@@ -144,10 +163,17 @@ class _OpenAIChatCompletionsSseUsageHandler:
         usage: dict,
         *,
         on_parse_error: _SseUsageParseErrorCallback | None = None,
+        include_usage: bool = True,
+        failure_observer: ModelHttpFailureObserver | None = None,
     ) -> None:
         self._usage = usage
         self._on_parse_error = on_parse_error
-        self._extractor = _new_extractor()
+        self._include_usage = include_usage
+        self._failure_observer = failure_observer
+        self._extractor = _new_extractor(
+            include_usage=include_usage,
+            include_failure=failure_observer is not None,
+        )
         self._data_prefix = bytearray()
         self._data_prefix_complete = True
 
@@ -180,10 +206,34 @@ class _OpenAIChatCompletionsSseUsageHandler:
         self._extractor.reset()
         if not result.complete:
             if data_prefix_complete and data_prefix.strip() == _DONE_SENTINEL:
+                if self._failure_observer is not None:
+                    self._failure_observer.observe(
+                        ModelHttpFailureEvidence(
+                            event_name=event_name,
+                            is_done=True,
+                            is_valid=True,
+                        )
+                    )
                 return
-            self._usage.clear()
-            if result.error is not None and self._on_parse_error is not None:
+            if self._failure_observer is not None:
+                self._failure_observer.observe(
+                    failure_evidence_from_result(result, event_name=event_name)
+                )
+            if self._include_usage:
+                self._usage.clear()
+            if (
+                self._include_usage
+                and result.error is not None
+                and self._on_parse_error is not None
+            ):
                 self._on_parse_error(event_name or "eventless", result.error)
+            return
+
+        if self._failure_observer is not None:
+            self._failure_observer.observe(
+                failure_evidence_from_result(result, event_name=event_name)
+            )
+        if not self._include_usage:
             return
 
         snapshot = _usage_snapshot(result)
@@ -196,10 +246,15 @@ class _OpenAIChatCompletionsSseUsageHandler:
         self._extractor.reset()
         self._data_prefix.clear()
         self._data_prefix_complete = True
+        if self._failure_observer is not None:
+            self._failure_observer.observe(ModelHttpFailureEvidence(event_name=event_name))
 
 
 def create_openai_chat_completions_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
+    *,
+    include_usage: bool = True,
+    failure_observer: ModelHttpFailureObserver | None = None,
 ) -> tuple[SseUsageScanner, dict]:
     """Create an incremental usage parser for Chat Completions SSE bytes."""
     usage: dict = {}
@@ -207,6 +262,8 @@ def create_openai_chat_completions_sse_usage_extractor(
         _OpenAIChatCompletionsSseUsageHandler(
             usage,
             on_parse_error=on_parse_error,
+            include_usage=include_usage,
+            failure_observer=failure_observer,
         ),
         capture_data_without_event=True,
     )
@@ -227,12 +284,7 @@ class OpenAIChatCompletionsJsonUsageExtractor:
 
     def finish(self) -> tuple[dict | None, str | None]:
         result = self._extractor.finish()
-        if not result.complete:
-            return None, result.error
-        usage = _usage_snapshot(result)
-        if usage is None or not any(category in usage for category in MODEL_USAGE_CATEGORIES):
-            return None, None
-        return usage, None
+        return model_json_usage_from_result(result)
 
 
 def create_openai_chat_completions_json_usage_extractor() -> (
@@ -240,6 +292,33 @@ def create_openai_chat_completions_json_usage_extractor() -> (
 ):
     """Create an incremental parser for a Chat Completions JSON response."""
     return OpenAIChatCompletionsJsonUsageExtractor()
+
+
+def model_json_scalar_fields() -> dict:
+    """Return Chat Completions JSON fields selected for usage inspection."""
+
+    return dict(_CHAT_COMPLETIONS_SCALAR_FIELDS)
+
+
+def model_json_object_presence_paths() -> set[Path]:
+    return set(_USAGE_PATHS)
+
+
+def model_json_value_presence_paths() -> set[Path]:
+    return set(_USAGE_VALUE_PRESENCE_PATHS)
+
+
+def model_json_usage_from_result(
+    result: JsonExtractionResult,
+) -> tuple[dict | None, str | None]:
+    """Map one complete shared JSON extraction into Chat Completions usage."""
+
+    if not result.complete:
+        return None, result.error
+    usage = _usage_snapshot(result)
+    if usage is None or not any(category in usage for category in MODEL_USAGE_CATEGORIES):
+        return None, None
+    return usage, None
 
 
 def extract_openai_chat_completions_usage_with_error_from_json(

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -42,6 +42,13 @@ from .json_selective import (
     ScalarField,
 )
 from .json_selective import Path as JsonPath
+from .model_http import (
+    ModelHttpFailureEvidence,
+    ModelHttpFailureObserver,
+    combined_scalar_fields,
+    combined_value_presence_paths,
+    failure_evidence_from_result,
+)
 from .model_tokens import (
     MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
@@ -711,6 +718,9 @@ def _store_sse_result_values(
 def create_openai_responses_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
     on_terminal_usage: _SseTerminalUsageCallback | None = None,
+    *,
+    include_usage: bool = True,
+    failure_observer: ModelHttpFailureObserver | None = None,
 ) -> tuple[SseUsageScanner, dict]:
     """Create an incremental usage parser for content-decoded Responses SSE bytes.
 
@@ -741,6 +751,8 @@ def create_openai_responses_sse_usage_extractor(
             usage,
             on_parse_error=on_parse_error,
             on_terminal_usage=on_terminal_usage,
+            include_usage=include_usage,
+            failure_observer=failure_observer,
         ),
         # Some compatible streams omit SSE event names and carry the terminal
         # response type in the JSON payload.
@@ -756,6 +768,8 @@ class _OpenAIResponsesSseUsageHandler:
         *,
         on_parse_error: _SseUsageParseErrorCallback | None = None,
         on_terminal_usage: _SseTerminalUsageCallback | None = None,
+        include_usage: bool = True,
+        failure_observer: ModelHttpFailureObserver | None = None,
     ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
@@ -766,9 +780,18 @@ class _OpenAIResponsesSseUsageHandler:
         self._discard_named_event = False
         self._on_parse_error = on_parse_error
         self._on_terminal_usage = on_terminal_usage
+        self._include_usage = include_usage
+        self._failure_observer = failure_observer
 
     def should_capture_event(self, event_name: str | None) -> bool:
-        return event_name is None or not _is_known_non_usage_event(event_name)
+        return (
+            event_name is None
+            or (self._include_usage and not _is_known_non_usage_event(event_name))
+            or (
+                self._failure_observer is not None
+                and self._failure_observer.needs_sse_event(event_name)
+            )
+        )
 
     def on_event_start(self, event_name: str | None) -> None:
         self._reset_event_state()
@@ -797,13 +820,25 @@ class _OpenAIResponsesSseUsageHandler:
             prefix = bytes(self._eventless_prefix)
             self._eventless_prefix = None
             event_type = _classify_responses_event_type(prefix)
-            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
+            observed_event_name = (
+                _observed_responses_event_type(_probe_responses_event_type(prefix))
+                if self._failure_observer is not None
+                and event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE
+                else None
+            )
+            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE or (
+                self._failure_observer is not None
+                and self._failure_observer.needs_sse_event(observed_event_name)
+            ):
                 self._start_full_extractor_from_prefix(prefix, event_type)
         if self._named_event_prefix is not None and self._data_event_type is None:
             prefix = bytes(self._named_event_prefix)
             self._named_event_prefix = None
             event_type = _classify_responses_event_type(prefix)
-            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
+            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE or (
+                self._failure_observer is not None
+                and self._failure_observer.needs_sse_event(event_name)
+            ):
                 self._start_full_extractor_from_prefix(prefix, event_type)
         extractor = self._extractor
         data_event_type = self._data_event_type
@@ -811,6 +846,12 @@ class _OpenAIResponsesSseUsageHandler:
         if extractor is None:
             return
         result = extractor.finish()
+        if self._failure_observer is not None:
+            self._failure_observer.observe(
+                failure_evidence_from_result(result, event_name=event_name)
+            )
+        if not self._include_usage:
+            return
         if result.complete:
             terminal_usage = _store_sse_result_values(
                 result.values,
@@ -840,6 +881,10 @@ class _OpenAIResponsesSseUsageHandler:
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._reset_event_state()
+        if self._failure_observer is not None and self._failure_observer.needs_sse_event(
+            event_name
+        ):
+            self._failure_observer.observe(ModelHttpFailureEvidence(event_name=event_name))
 
     def _reset_event_state(self) -> None:
         self._extractor = None
@@ -850,12 +895,23 @@ class _OpenAIResponsesSseUsageHandler:
         self._discard_named_event = False
 
     def _start_full_extractor(self, *, include_type: bool = True) -> JsonSelectiveExtractor:
-        scalar_fields = (
+        usage_fields = (
             _RESPONSES_SSE_SCALAR_FIELDS if include_type else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
         )
         self._extractor = JsonSelectiveExtractor(
-            scalar_fields=scalar_fields,
-            scalar_consistency_paths={("type",)} if self._on_terminal_usage is not None else None,
+            scalar_fields=combined_scalar_fields(
+                usage_fields,
+                include_usage=self._include_usage,
+                include_failure=self._failure_observer is not None,
+            ),
+            value_presence_paths=combined_value_presence_paths(
+                (),
+                include_usage=self._include_usage,
+                include_failure=self._failure_observer is not None,
+            ),
+            scalar_consistency_paths=(
+                {("type",)} if self._include_usage and self._on_terminal_usage is not None else None
+            ),
             max_work_units=_RESPONSES_MAX_WORK_UNITS,
         )
         return self._extractor
@@ -863,8 +919,9 @@ class _OpenAIResponsesSseUsageHandler:
     def _should_include_type_scalar(self) -> bool:
         return (
             self._data_event_type is None
-            or self._on_parse_error is not None
-            or self._on_terminal_usage is not None
+            or (self._include_usage and self._on_parse_error is not None)
+            or (self._include_usage and self._on_terminal_usage is not None)
+            or self._failure_observer is not None
         )
 
     def _start_full_extractor_from_prefix(
@@ -891,8 +948,13 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._eventless_prefix = None
-        event_type = _classify_responses_event_type(prefix_bytes)
-        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
+        probe = _probe_responses_event_type(prefix_bytes)
+        event_type = _classify_responses_event_type_result(probe)
+        observed_event_name = _observed_responses_event_type(probe)
+        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE and not (
+            self._failure_observer is not None
+            and self._failure_observer.needs_sse_event(observed_event_name)
+        ):
             self._discard_eventless_event = True
             return
 
@@ -916,8 +978,12 @@ class _OpenAIResponsesSseUsageHandler:
         prefix_bytes = bytes(prefix)
         self._named_event_prefix = None
         event_type = _classify_responses_event_type(prefix_bytes)
-        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
-            self._extractor = None
+        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE and not (
+            self._failure_observer is not None
+            and self._failure_observer.needs_sse_event(
+                _observed_responses_event_type(_probe_responses_event_type(prefix_bytes))
+            )
+        ):
             self._discard_named_event = True
             return
 
@@ -957,15 +1023,7 @@ class OpenAIResponsesJsonUsageExtractor:
 
     def finish(self) -> tuple[dict | None, str | None]:
         result = self._extractor.finish()
-        if not result.complete:
-            return None, result.error
-
-        usage: dict = {}
-        _store_response_values(result.values, usage)
-
-        if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
-            return None, None
-        return usage, None
+        return model_json_usage_from_result(result)
 
 
 def create_openai_responses_json_usage_extractor() -> OpenAIResponsesJsonUsageExtractor:
@@ -976,6 +1034,26 @@ def create_openai_responses_json_usage_extractor() -> OpenAIResponsesJsonUsageEx
     """
 
     return OpenAIResponsesJsonUsageExtractor()
+
+
+def model_json_scalar_fields() -> dict:
+    """Return Responses JSON fields selected for usage inspection."""
+
+    return dict(_RESPONSES_RESPONSE_SCALAR_FIELDS)
+
+
+def model_json_usage_from_result(
+    result: JsonExtractionResult,
+) -> tuple[dict | None, str | None]:
+    """Map one complete shared JSON extraction into Responses usage."""
+
+    if not result.complete:
+        return None, result.error
+    usage: dict = {}
+    _store_response_values(result.values, usage)
+    if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
+        return None, None
+    return usage, None
 
 
 def _extract_openai_responses_usage_from_decoded_json_body(

--- a/crates/runner/mitm-addon/tests/test_json_selective_numbers.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_numbers.py
@@ -157,6 +157,8 @@ def _assert_no_observations(result: JsonExtractionResult) -> None:
     assert result.wildcard_array_counts == {}
     assert result.object_present == set()
     assert result.value_present == set()
+    assert result.discarded_scalar_paths == set()
+    assert result.selected_string_max_raw_bytes == {}
 
 
 @pytest.mark.parametrize(("number", "number_splits"), _NUMBER_CASES)

--- a/crates/runner/mitm-addon/tests/test_json_selective_strings.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_strings.py
@@ -314,6 +314,7 @@ def test_accepts_selected_string_at_exact_limit():
 
     assert result.complete is True
     assert result.values == {("model",): "abc"}
+    assert result.selected_string_max_raw_bytes == {("model",): 3}
 
 
 def test_rejects_oversized_selected_string():
@@ -343,6 +344,7 @@ def test_discards_oversized_optional_selected_string_across_chunks():
 
     assert result.complete is True
     assert result.values == {("usage", "output_tokens"): 7}
+    assert result.discarded_scalar_paths == {("type",)}
     assert extractor.observed_scalar_for_diagnostics(("type",)) is None
 
 
@@ -364,6 +366,8 @@ def test_discarded_oversized_selected_string_still_validates_json(payload, error
     assert result.complete is False
     assert result.error == error
     assert result.values == {}
+    assert result.discarded_scalar_paths == set()
+    assert result.selected_string_max_raw_bytes == {}
 
 
 @pytest.mark.parametrize(
@@ -384,7 +388,37 @@ def test_discarded_oversized_duplicate_selected_string_uses_last_value(payload, 
     assert result.complete is True
     expected_values = {} if expected_type is None else {("type",): expected_type}
     assert result.values == expected_values
+    assert result.discarded_scalar_paths == {("type",)}
+    assert result.selected_string_max_raw_bytes == {("type",): 2}
     assert extractor.observed_scalar_for_diagnostics(("type",)) == expected_type
+
+
+def test_reset_clears_discarded_selected_string_paths():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("type",): ScalarField("string", max_bytes=3, overflow_policy="discard")}
+    )
+    extractor.feed(b'{"type":"long"}')
+
+    assert extractor.finish().discarded_scalar_paths == {("type",)}
+
+    extractor.reset()
+    extractor.feed(b'{"type":"ok"}')
+
+    reset_result = extractor.finish()
+    assert reset_result.discarded_scalar_paths == set()
+    assert reset_result.selected_string_max_raw_bytes == {("type",): 2}
+
+
+def test_selected_string_max_raw_bytes_includes_escaped_duplicate_occurrences():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard")}
+    )
+    extractor.feed(b'{"type":"' + rb"\u0061" * 22 + b'","type":"ok"}')
+
+    result = extractor.finish()
+
+    assert result.values == {("type",): "ok"}
+    assert result.selected_string_max_raw_bytes == {("type",): 132}
 
 
 def test_selected_string_limit_counts_escape_bytes():

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1,7 +1,9 @@
 """Integration tests for trusted model-provider failure reduction."""
 
+import gzip
 import json
 import threading
+import zlib
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Literal
@@ -12,11 +14,15 @@ from mitmproxy import http
 from mitmproxy.connection import ConnectionState
 from mitmproxy.flow import Error
 
+import body_decoding
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import model_provider_failure
 import model_websocket_usage
 import platform_api
+import usage.anthropic_messages as anthropic_messages
+import usage.model_json as model_json
+import usage.openai_responses as openai_responses
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
@@ -740,6 +746,317 @@ def test_media_type_classification_is_shared_by_usage_and_failure_observers(
     ]
 
 
+@pytest.mark.parametrize("content_encoding", ["", "gzip", "deflate"])
+def test_combined_sse_response_uses_one_decoder_and_one_dense_event_parse(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    content_encoding: str,
+    model_provider_failure_api,
+):
+    dense_values = b",".join([b"0"] * 2_000)
+    plaintext = (
+        b"event: response.failed\n"
+        b'data: {"type":"response.failed","response":{"id":"resp-shared",'
+        b'"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":3},'
+        b'"error":{"code":"server_error"}},"padding":[' + dense_values + b"]}\n\n"
+    )
+    if content_encoding == "gzip":
+        body = gzip.compress(plaintext)
+    elif content_encoding == "deflate":
+        body = zlib.compress(plaintext)
+    else:
+        body = plaintext
+    headers = {"content-type": "text/event-stream"}
+    if content_encoding:
+        headers["content-encoding"] = content_encoding
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map(headers),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    model_provider_failure.admit_flow(flow)
+
+    with (
+        patch.object(
+            body_decoding,
+            "create_stream_decode_session",
+            wraps=body_decoding.create_stream_decode_session,
+        ) as create_decoder,
+        patch.object(
+            openai_responses,
+            "JsonSelectiveExtractor",
+            wraps=openai_responses.JsonSelectiveExtractor,
+        ) as create_extractor,
+    ):
+        mitm_addon.responseheaders(flow)
+        stream = response_stream(flow)
+        stream(body)
+        stream(b"")
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert create_decoder.call_count == 1
+        assert create_extractor.call_count == 1
+
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+        "message_id": "resp-shared",
+        "model": "gpt-5.5",
+        "tokens.input": 12,
+        "tokens.output": 3,
+    }
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+
+
+def test_combined_json_response_uses_one_decoder_and_one_parse(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = (
+        b'{"id":"resp-json","model":"gpt-5.5","status":"failed",'
+        b'"usage":{"input_tokens":9,"output_tokens":4},'
+        b'"error":{"code":"server_error"}}'
+    )
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "application/json"}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    model_provider_failure.admit_flow(flow)
+
+    with (
+        patch.object(
+            body_decoding,
+            "create_stream_decode_session",
+            wraps=body_decoding.create_stream_decode_session,
+        ) as create_decoder,
+        patch.object(
+            model_json,
+            "JsonSelectiveExtractor",
+            wraps=model_json.JsonSelectiveExtractor,
+        ) as create_extractor,
+        patch.object(
+            model_provider_failure,
+            "JsonSelectiveExtractor",
+            wraps=model_provider_failure.JsonSelectiveExtractor,
+        ) as create_legacy_extractor,
+    ):
+        mitm_addon.responseheaders(flow)
+        stream = response_stream(flow)
+        stream(body)
+        stream(b"")
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert create_decoder.call_count == 1
+        assert create_extractor.call_count == 1
+        assert create_legacy_extractor.call_count == 0
+
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+        "message_id": "resp-json",
+        "model": "gpt-5.5",
+        "tokens.input": 9,
+        "tokens.output": 4,
+    }
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+
+
+def test_combined_sse_known_ordinary_deltas_skip_full_json_parse(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    cases = (
+        (
+            "model-provider:openai-api-key",
+            "/v1/responses",
+            b"event: response.output_text.delta\n"
+            b'data: {"type":"response.output_text.delta","delta":"hello"}\n\n',
+            openai_responses,
+        ),
+        (
+            "model-provider:anthropic-api-key",
+            "/v1/messages",
+            b"event: content_block_delta\n"
+            b'data: {"type":"content_block_delta","delta":{"text":"hello"}}\n\n',
+            anthropic_messages,
+        ),
+    )
+
+    for index, (firewall_name, request_path, body, provider_module) in enumerate(cases):
+        flow = _make_flow(
+            real_flow,
+            tmp_path / f"proxy-{index}.jsonl",
+            firewall_name=firewall_name,
+            request_path=request_path,
+            response_body=body,
+            response_headers=header_map({"content-type": "text/event-stream"}),
+        )
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "test-model"
+        model_provider_failure.admit_flow(flow)
+        with patch.object(
+            provider_module,
+            "JsonSelectiveExtractor",
+            wraps=provider_module.JsonSelectiveExtractor,
+        ) as create_extractor:
+            mitm_addon.responseheaders(flow)
+            stream = response_stream(flow)
+            stream(body)
+            stream(b"")
+            with mitm_ctx():
+                mitm_addon.response(flow)
+
+            assert create_extractor.call_count == 0
+
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
+def test_combined_sse_work_limit_does_not_retry_full_parse(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    dense_values = b",".join([b"0"] * 40_000)
+    body = (
+        b"event: response.completed\n"
+        b'data: {"type":"response.completed","response":{"id":"resp-limited",'
+        b'"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":3}},'
+        b'"padding":[' + dense_values + b"]}\n\n"
+    )
+    flow = _make_flow(
+        real_flow,
+        proxy_log_path,
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "text/event-stream"}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    model_provider_failure.admit_flow(flow)
+
+    with (
+        patch.object(
+            openai_responses,
+            "JsonSelectiveExtractor",
+            wraps=openai_responses.JsonSelectiveExtractor,
+        ) as create_extractor,
+        patch.object(
+            model_provider_failure,
+            "JsonSelectiveExtractor",
+            wraps=model_provider_failure.JsonSelectiveExtractor,
+        ) as create_legacy_extractor,
+        mitm_ctx(),
+    ):
+        mitm_addon.responseheaders(flow)
+        stream = response_stream(flow)
+        stream(body)
+        stream(b"")
+        mitm_addon.response(flow)
+
+        assert create_extractor.call_count == 1
+        assert create_legacy_extractor.call_count == 0
+
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+    warnings = [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log_path)
+        if entry.get("message") == "Model provider SSE usage extraction failed"
+    ]
+    assert [warning["error"] for warning in warnings] == ["work limit exceeded"]
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
+def test_combined_sse_failure_field_overflow_preserves_usage_and_fails_closed(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = (
+        b"event: response.failed\n"
+        b'data: {"type":"response.failed","response":{"id":"resp-overflow",'
+        b'"model":"gpt-5.5","usage":{"input_tokens":8,"output_tokens":2},'
+        b'"error":{"code":"' + b"x" * 129 + b'"}}}\n\n'
+    )
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "text/event-stream"}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+    stream = response_stream(flow)
+    stream(body)
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+        "message_id": "resp-overflow",
+        "model": "gpt-5.5",
+        "tokens.input": 8,
+        "tokens.output": 2,
+    }
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
+def test_combined_sse_overlapping_escaped_field_keeps_failure_byte_limit(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = (
+        b"event: response.failed\n"
+        b'data: {"type":"'
+        + rb"\u0061"
+        * 22
+        + b'","type":"response.failed","response":{"id":"resp-escaped",'
+        b'"model":"gpt-5.5","usage":{"input_tokens":5,"output_tokens":1},'
+        b'"error":{"code":"server_error"}}}\n\n'
+    )
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "text/event-stream"}),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+    stream = response_stream(flow)
+    stream(body)
+    stream(b"")
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+        "message_id": "resp-escaped",
+        "model": "gpt-5.5",
+        "tokens.input": 5,
+        "tokens.output": 1,
+    }
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
 @pytest.mark.parametrize(
     ("firewall_name", "request_path", "body", "expected_kind"),
     [
@@ -1130,6 +1447,37 @@ def test_openrouter_stable_failure_survives_response_interruption(
     mitm_addon.responseheaders(flow)
     response_stream(flow)(body)
     flow.error = Error("connection reset after error body")
+
+    with mitm_ctx():
+        mitm_addon.error(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+
+
+def test_trailing_sse_failure_is_settled_once_during_response_interruption(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = (
+        b"event: response.failed\n"
+        b'data: {"type":"response.failed","response":{'
+        b'"error":{"code":"server_error"}}}'
+    )
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "text/event-stream"}),
+    )
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+    response_stream(flow)(body)
+    flow.error = Error("connection reset after trailing failure event")
 
     with mitm_ctx():
         mitm_addon.error(flow)


### PR DESCRIPTION
## Summary

- share one response-scoped identity/gzip/deflate decoder and one protocol parser between model usage extraction and HTTP failure reporting
- dispatch bounded failure evidence from the existing Anthropic Messages, Chat Completions, and Responses JSON/SSE parsers while keeping reporting and accounting state machines separate
- preserve failure-only 128-byte limits, usage data when combined-only failure fields overflow, and framing-only handling for known ordinary Responses and Anthropic SSE events
- add deterministic integration coverage for decoder/parser counts, compressed and dense events, work exhaustion, field overflow, and interruption finalization

## Exclusions

- no changes to connector response parsing or model-provider WebSocket inspection
- no API, database, persisted-state, queue, runner protocol, or failure report schema changes
- no Grafana or deployment configuration changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6536 passed)

Closes #28793
