### PR TITLE
test(runner): verify fresh fallback execution

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1,6 +1,6 @@
 use super::super::super::*;
 use super::super::support::{
-    SpeculativeIdleSeedSpec, context_with_session, mock_run_config,
+    SpeculativeIdleSeedSpec, context_with_session, mock_run_config, mock_run_config_with_overrides,
     seed_idle_pool_with_speculative_timezone, shutdown, status_idle_reuse_keys_and_active_runs,
     test_profiles, test_runner_identity, wait_budget_count, wait_cancel_handle,
     wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
@@ -1117,11 +1117,11 @@ async fn assert_speculation_failure_falls_back_to_fresh(
     claimed: Option<&str>,
     configure_failure: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
 ) {
-    let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);
-    let budget = Arc::clone(&config.capacity.budget);
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     configure_failure(&overrides);
-    add_healthy_reuse_preparation_matcher(&overrides);
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
     let reuse_key = RunId::new_v4().to_string();
     let generation_run_id = RunId::new_v4();
     let idle_sandbox_id = seed_idle_pool_with_speculative_timezone(
@@ -1158,11 +1158,17 @@ async fn assert_speculation_failure_falls_back_to_fresh(
         .wait_completion(run_id, Duration::from_secs(30))
         .await
         .expect("valid claim should use fresh fallback after speculation failure");
+    assert_eq!(completion.exit_code, 0);
+    assert!(completion.error.is_none());
+    let fresh_sandbox_id = completion
+        .sandbox_id
+        .expect("fresh fallback should complete with a sandbox");
+    assert_ne!(fresh_sandbox_id, idle_sandbox_id);
     assert_eq!(
         completion.reuse_result,
         Some(SandboxReuseResult::UnparkFailed)
     );
-    assert_ne!(completion.sandbox_id, Some(idle_sandbox_id));
+    assert_eq!(overrides.start_process_calls().len(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;


### PR DESCRIPTION
## Summary

- share one sandbox mock override between the seeded speculative sandbox and fresh runner runtime
- require successful completion with no error and a replacement sandbox ID
- verify the fresh fallback starts exactly one agent process while preserving the reuse and cleanup assertions across all five failure cases

## Scope

- test-only change; production behavior and deployment contracts are unchanged
- does not add post-completion parking waits or new mock infrastructure

## Validation

- `cd crates && cargo test -p runner exact_reuse_speculation`
- `cd crates && cargo fmt --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p runner --no-deps`
- `cd crates && cargo test -p runner`
- pre-commit workspace Cargo format, documentation, Clippy, file-size, and commitlint hooks

Closes #28801
