### PR TITLE
refactor(rust): enforce exec-control payload limit parity

### DIFF
--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -17,11 +17,16 @@ use crate::ids::RunId;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::provider::ApiClient;
 
-/// Exec-control payloads are bounded by the guest-side process-control IPC frame limit.
+/// Shared active-input payload limit across API, vsock, and guest process-control IPC.
 pub(crate) const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: usize =
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES_U64 as usize;
 const _: () = assert!(
-    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES == process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES == vsock_proto::EXEC_CONTROL_MAX_PAYLOAD_BYTES,
+    "API active-input payload limit must match the vsock exec-control limit",
+);
+const _: () = assert!(
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES == process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES,
+    "API active-input payload limit must match the guest process-control IPC limit",
 );
 
 pub(crate) fn identified_active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {

--- a/crates/vsock-guest/src/exec_control/forward.rs
+++ b/crates/vsock-guest/src/exec_control/forward.rs
@@ -20,6 +20,11 @@ use super::{
     request_timeout_error,
 };
 
+const _: () = assert!(
+    vsock_proto::EXEC_CONTROL_MAX_PAYLOAD_BYTES == process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES,
+    "vsock exec-control payload limit must match process-control IPC at the guest bridge",
+);
+
 pub(super) struct OwnedExecControlRequest {
     pub(super) response_seq: u32,
     pub(super) target_seq: u32,

--- a/crates/vsock-guest/src/exec_control/tests/handle.rs
+++ b/crates/vsock-guest/src/exec_control/tests/handle.rs
@@ -48,6 +48,52 @@ fn handle_exec_control_forwards_to_connected_sink() {
 
     client.join().unwrap();
 }
+
+#[test]
+fn handle_exec_control_forwards_maximum_payload_to_connected_sink() {
+    let forward_nonce = unique_test_nonce(22);
+
+    let registry = ExecControlRegistry::default();
+    let registration = registry.register(22, forward_nonce, true).unwrap();
+    let endpoint = registration.bootstrap_endpoint.clone().unwrap();
+    let control_payload = vec![0xA5; vsock_proto::EXEC_CONTROL_MAX_PAYLOAD_BYTES];
+    let payload = vsock_proto::encode_exec_control(
+        22,
+        forward_nonce,
+        "msg-max-payload",
+        &control_payload,
+        5000,
+    )
+    .unwrap();
+    let client = std::thread::spawn(move || {
+        let mut stream = process_control_ipc::connect_abstract(&endpoint).unwrap();
+        process_control_ipc::write_hello(&mut stream).unwrap();
+        let request = process_control_ipc::read_request(&mut stream).unwrap();
+        assert_eq!(request.message_id, "msg-max-payload");
+        assert_eq!(request.payload, control_payload);
+        process_control_ipc::write_response(
+            &mut stream,
+            &process_control_ipc::ControlResponse {
+                message_id: request.message_id,
+                status: process_control_ipc::ControlResponseStatus::Accepted,
+                diagnostic: String::new(),
+            },
+        )
+        .unwrap();
+    });
+
+    let (writer, mut host) = guest_writer_pair();
+    handle_exec_control(44, &payload, &registry, &writer).unwrap();
+
+    let (msg_type, seq, status, message_id, _) = read_exec_control_result(&mut host);
+    assert_eq!(msg_type, MSG_EXEC_CONTROL_RESULT);
+    assert_eq!(seq, 44);
+    assert_eq!(status, ExecControlStatus::Delivered);
+    assert_eq!(message_id, "msg-max-payload");
+
+    client.join().unwrap();
+}
+
 #[test]
 fn handle_exec_control_waits_for_sink_connection() {
     let forward_nonce = unique_test_nonce(9);


### PR DESCRIPTION
## Summary

- enforce compile-time equality between the API, vsock, and guest process-control payload limits
- make the guest bridge fail to compile if its two protocol limits drift apart
- cover forwarding an exact 1 MiB payload through the real guest bridge and IPC codecs

## Compatibility

- no payload limit, wire format, or runtime behavior changes
- no API, database, dependency, or generated artifact changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vsock-guest -p runner --all-features --no-deps`
- `cargo test -p vsock-proto --all-targets --all-features`
- `cargo test -p process-control-ipc --all-targets --all-features`
- `cargo test -p vsock-guest --all-targets --all-features`
- `cargo test -p runner --all-targets --all-features`
- `cargo test -p sandbox-fc process_control_local_validation_failure_keeps_gate_clean --all-features`

Closes #28799
