### PR TITLE
fix(api): refresh codex tokens before subscription usage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
@@ -5,7 +5,11 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
-import { createBddApi, expectApiError } from "./helpers/api-bdd";
+import {
+  createBddApi,
+  expectApiError,
+  type ApiTestUser,
+} from "./helpers/api-bdd";
 import {
   createAuthDeviceApiActions,
   mockClaudeCodeTokenEndpoint,
@@ -51,6 +55,36 @@ function expectCliApprovalError(
   ) {
     throw new Error("Expected CLI approval error response body");
   }
+}
+
+async function connectPersonalCodexTestAccount(
+  actor: ApiTestUser,
+  args: {
+    readonly accessTokenExpiresAt: number;
+    readonly accountId: string;
+    readonly refreshToken: string;
+    readonly workspaceName: string;
+  },
+): Promise<string> {
+  mockCodexDeviceAuthProvider({
+    tokenScope: "personal",
+    ...args,
+  });
+  const started = await authDevice.requestCodexStart(actor, "personal", [200], {
+    mode: "add",
+  });
+  if (started.status !== 200) {
+    throw new Error(`Expected ${args.accountId} device auth to start`);
+  }
+  const completed = await authDevice.requestCodexComplete(
+    actor,
+    started.body.sessionToken,
+    [200],
+  );
+  if (!("status" in completed.body) || completed.body.status !== "complete") {
+    throw new Error(`Expected ${args.accountId} device auth to complete`);
+  }
+  return completed.body.provider.id;
 }
 
 describe("AUTH-02: CLI device authorization", () => {
@@ -738,6 +772,98 @@ describe("MODEL-PROVIDER: device auth boundaries", () => {
       isActive: true,
     });
 
+    await support.deletePersonalModelProvider(
+      member,
+      "codex-oauth-token",
+      [204],
+    );
+  });
+
+  it("isolates terminal Codex refresh state between concrete accounts", async () => {
+    const member = bdd.user({ orgRole: "org:member" });
+    await support.updateFeatureSwitches(member, {
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+    });
+    const currentSeconds = Math.floor(now() / 1000);
+    const accountAId = await connectPersonalCodexTestAccount(member, {
+      accessTokenExpiresAt: currentSeconds - 60,
+      accountId: "codex-refresh-account-a",
+      refreshToken: "rt_codex_refresh_account_a",
+      workspaceName: "Refresh Account A",
+    });
+    const accountBId = await connectPersonalCodexTestAccount(member, {
+      accessTokenExpiresAt: currentSeconds + 7200,
+      accountId: "codex-refresh-account-b",
+      refreshToken: "rt_codex_refresh_account_b",
+      workspaceName: "Refresh Account B",
+    });
+
+    let refreshCalls = 0;
+    const usageAccountIds: (string | null)[] = [];
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async ({ request }) => {
+        refreshCalls += 1;
+        await expect(request.json()).resolves.toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: "rt_codex_refresh_account_a",
+        });
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_invalidated",
+              message: "refresh token invalidated",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", ({ request }) => {
+        const accountId = request.headers.get("chatgpt-account-id");
+        usageAccountIds.push(accountId);
+        expect(accountId).toBe("codex-refresh-account-b");
+        return HttpResponse.json({
+          plan_type: "plus",
+          rate_limit: {
+            primary_window: {
+              limit_window_seconds: 18_000,
+              reset_at: 1_893_441_600,
+              used_percent: 20,
+            },
+          },
+        });
+      }),
+    );
+
+    for (let requestIndex = 0; requestIndex < 2; requestIndex += 1) {
+      const listed = await support.listPersonalModelProviders(member, [200]);
+      if (!("modelProviders" in listed.body)) {
+        throw new Error("Expected personal model provider list response");
+      }
+      expect(
+        listed.body.modelProviders.find((provider) => {
+          return provider.id === accountAId;
+        }),
+      ).toMatchObject({
+        needsReconnect: true,
+        lastRefreshErrorCode: "refresh_token_invalidated",
+      });
+      expect(
+        listed.body.modelProviders.find((provider) => {
+          return provider.id === accountBId;
+        }),
+      ).toMatchObject({
+        needsReconnect: false,
+        subscriptionUsage: {
+          fiveHour: { usedPercent: 20 },
+        },
+      });
+    }
+
+    expect(refreshCalls).toBe(1);
+    expect(usageAccountIds).toStrictEqual([
+      "codex-refresh-account-b",
+      "codex-refresh-account-b",
+    ]);
     await support.deletePersonalModelProvider(
       member,
       "codex-oauth-token",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -221,17 +221,19 @@ function makeCodexIdToken(opts: {
 function makeCodexTokenResponse(
   scope: "org" | "personal",
   args: {
+    readonly accessTokenExpiresAt?: number;
     readonly accountId?: string;
+    readonly refreshToken?: string;
     readonly workspaceName?: string;
   } = {},
 ) {
   const accountId = args.accountId ?? `ws_acct_from_id_token_${scope}`;
   return {
     access_token: makeCodexJwt({
-      exp: Math.floor(now() / 1000) + 7200,
+      exp: args.accessTokenExpiresAt ?? Math.floor(now() / 1000) + 7200,
       account_id: accountId,
     }),
-    refresh_token: `rt_${scope}_synthetic_high_entropy`,
+    refresh_token: args.refreshToken ?? `rt_${scope}_synthetic_high_entropy`,
     id_token: makeCodexIdToken({
       accountId,
       planType: "plus",
@@ -294,8 +296,10 @@ interface CodexDeviceAuthProviderRecorder {
 
 export function mockCodexDeviceAuthProvider(
   options: {
+    readonly accessTokenExpiresAt?: number;
     readonly tokenScope?: "org" | "personal";
     readonly accountId?: string;
+    readonly refreshToken?: string;
     readonly workspaceName?: string;
   } = {},
 ): CodexDeviceAuthProviderRecorder {

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -774,6 +774,7 @@ describe("POST /api/me/model-providers (upsert)", () => {
       }),
       [201],
     );
+    context.mocks.axiomLogging.warn.mockClear();
     const unauthorized = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
       [200],
@@ -799,6 +800,27 @@ describe("POST /api/me/model-providers (upsert)", () => {
     ).toBeUndefined();
     expect(refreshCalls).toBe(0);
     expect(usageCalls).toBe(3);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(2);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenNthCalledWith(
+      1,
+      "failed to refresh personal model provider subscription usage",
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: "Codex usage request failed with status 401",
+        }),
+        modelProviderAccountId: connected.body.provider.id,
+      }),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenNthCalledWith(
+      2,
+      "failed to refresh personal model provider subscription usage",
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: "Codex usage response shape unrecognized",
+        }),
+        modelProviderAccountId: connected.body.provider.id,
+      }),
+    );
   });
 
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -6,12 +6,14 @@ import {
   personalModelProvidersByTypeContract,
   personalModelProvidersMainContract,
 } from "@okouai/api-contracts/contracts/personal-model-providers";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { now } from "../../../lib/time";
 import { createRouteMocks } from "./helpers/route-test";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { readUserSecrets } from "./helpers/user-config-state";
 import { meModelProvidersDeleteRoutes } from "../me-model-providers-delete";
 import { meModelProvidersListRoutes } from "../me-model-providers-list";
@@ -83,20 +85,75 @@ function makeIdToken(opts: {
   });
 }
 
-function makeAuthJson(overrides?: { planType?: string }): string {
-  const accessExp = Math.floor(now() / 1000) + 7200;
-  return JSON.stringify({
-    OPENAI_API_KEY: null,
-    tokens: {
-      access_token: makeJwt({ exp: accessExp }),
-      refresh_token: "rt_personal_synthetic_high_entropy",
-      account_id: "ws_acct_plain",
-      id_token: makeIdToken({
-        accountId: "ws_acct_from_id_token_personal",
-        planType: overrides?.planType ?? "plus",
-        workspaceName: "Personal Acme",
-      }),
+function makeAuthJsonFixture(
+  overrides: {
+    readonly accessExpiresInSeconds?: number;
+    readonly accountId?: string;
+    readonly planType?: string;
+    readonly refreshToken?: string;
+  } = {},
+): {
+  readonly accessToken: string;
+  readonly accountId: string;
+  readonly raw: string;
+  readonly refreshToken: string;
+} {
+  const accountId = overrides.accountId ?? "ws_acct_from_id_token_personal";
+  const accessToken = makeJwt({
+    exp: Math.floor(now() / 1000) + (overrides.accessExpiresInSeconds ?? 7200),
+  });
+  const refreshToken =
+    overrides.refreshToken ?? "rt_personal_synthetic_high_entropy";
+  return {
+    accessToken,
+    accountId,
+    refreshToken,
+    raw: JSON.stringify({
+      OPENAI_API_KEY: null,
+      tokens: {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        account_id: "ws_acct_plain",
+        id_token: makeIdToken({
+          accountId,
+          planType: overrides.planType ?? "plus",
+          workspaceName: "Personal Acme",
+        }),
+      },
+    }),
+  };
+}
+
+function makeAuthJson(overrides?: { readonly planType?: string }): string {
+  return makeAuthJsonFixture(overrides).raw;
+}
+
+function codexUsageResponse() {
+  return {
+    plan_type: "pro",
+    rate_limit: {
+      primary_window: {
+        limit_window_seconds: 18_000,
+        reset_at: 1_893_441_600,
+        used_percent: 25,
+      },
+      secondary_window: {
+        limit_window_seconds: 604_800,
+        reset_at: 1_893_456_000,
+        used_percent: 40,
+      },
     },
+    rate_limit_reset_credits: {
+      available_count: 3,
+    },
+  };
+}
+
+async function enablePersonalModelProviderAccounts(
+  fixture: UserModelProviderFixture,
+): Promise<void> {
+  await updateFeatureSwitchesForUser(context, fixture, {
+    [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
   });
 }
 
@@ -441,6 +498,307 @@ describe("POST /api/me/model-providers (upsert)", () => {
     );
 
     expect(response.body).toStrictEqual({ outcome: "reset" });
+  });
+
+  it("coalesces concurrent refreshes for an expired Codex account", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-refresh");
+    await enablePersonalModelProviderAccounts(fixture);
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: -60 });
+    const refreshedAccessToken = "fresh-chatgpt-access-token";
+    const refreshedRefreshToken = "rotated-chatgpt-refresh-token";
+    const usageAuthorizations: (string | null)[] = [];
+    let refreshCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async ({ request }) => {
+        refreshCalls += 1;
+        await expect(request.json()).resolves.toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: authJson.refreshToken,
+        });
+        return HttpResponse.json({
+          access_token: refreshedAccessToken,
+          refresh_token: refreshedRefreshToken,
+          expires_in: 3600,
+        });
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", ({ request }) => {
+        const authorization = request.headers.get("authorization");
+        usageAuthorizations.push(authorization);
+        if (authorization === `Bearer ${authJson.accessToken}`) {
+          return HttpResponse.json({ error: "expired" }, { status: 401 });
+        }
+        expect(authorization).toBe(`Bearer ${refreshedAccessToken}`);
+        expect(request.headers.get("chatgpt-account-id")).toBe(
+          authJson.accountId,
+        );
+        return HttpResponse.json(codexUsageResponse());
+      }),
+    );
+
+    const client = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    const connected = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    expect(connected.body.provider).toMatchObject({
+      modelProviderId: expect.any(String),
+      needsReconnect: false,
+    });
+    const [first, second] = await Promise.all([
+      accept(
+        client.list({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      ),
+      accept(
+        client.list({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      ),
+    ]);
+    for (const response of [first, second]) {
+      expect(response.body.modelProviders[0]).toMatchObject({
+        id: connected.body.provider.id,
+        needsReconnect: false,
+        subscriptionUsage: {
+          fiveHour: { usedPercent: 25 },
+          weekly: { usedPercent: 40 },
+        },
+      });
+    }
+    expect(refreshCalls).toBe(1);
+    expect(usageAuthorizations).toStrictEqual([
+      `Bearer ${authJson.accessToken}`,
+      `Bearer ${refreshedAccessToken}`,
+      `Bearer ${refreshedAccessToken}`,
+    ]);
+
+    await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(refreshCalls).toBe(1);
+  });
+
+  it("returns and short-circuits terminal Codex reconnect state", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-terminal");
+    await enablePersonalModelProviderAccounts(fixture);
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: -60 });
+    let refreshCalls = 0;
+    let usageCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_expired",
+              message: "refresh token expired",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        usageCalls += 1;
+        return HttpResponse.json({ error: "expired" }, { status: 401 });
+      }),
+    );
+
+    const client = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    const connected = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    context.mocks.axiomLogging.warn.mockClear();
+
+    for (let requestIndex = 0; requestIndex < 2; requestIndex += 1) {
+      const listed = await accept(
+        client.list({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+      expect(listed.body.modelProviders[0]).toMatchObject({
+        id: connected.body.provider.id,
+        needsReconnect: true,
+        lastRefreshErrorCode: "refresh_token_expired",
+      });
+    }
+
+    expect(refreshCalls).toBe(1);
+    expect(usageCalls).toBe(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex-oauth-token token refresh failed"),
+      expect.objectContaining({
+        modelProviderAccountId: connected.body.provider.id,
+        errorCode: "refresh_token_expired",
+        failureReason: "reconnect_required",
+      }),
+    );
+  });
+
+  it("retries transient Codex refresh failure without false reconnect", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-transient");
+    await enablePersonalModelProviderAccounts(fixture);
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: -60 });
+    let refreshCalls = 0;
+    let usageCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCalls += 1;
+        if (refreshCalls === 1) {
+          return HttpResponse.json(
+            { error: "temporarily_unavailable" },
+            { status: 503 },
+          );
+        }
+        return HttpResponse.json({
+          access_token: "recovered-chatgpt-access-token",
+          refresh_token: "recovered-chatgpt-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", ({ request }) => {
+        usageCalls += 1;
+        if (
+          request.headers.get("authorization") ===
+          `Bearer ${authJson.accessToken}`
+        ) {
+          return HttpResponse.json({ error: "expired" }, { status: 401 });
+        }
+        return HttpResponse.json(codexUsageResponse());
+      }),
+    );
+
+    const client = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    const unavailable = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(unavailable.body.modelProviders[0]).toMatchObject({
+      needsReconnect: false,
+      lastRefreshErrorCode: null,
+    });
+    expect(
+      unavailable.body.modelProviders[0]?.subscriptionUsage,
+    ).toBeUndefined();
+
+    const recovered = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(recovered.body.modelProviders[0]).toMatchObject({
+      needsReconnect: false,
+      subscriptionUsage: {
+        fiveHour: { usedPercent: 25 },
+        weekly: { usedPercent: 40 },
+      },
+    });
+    expect(refreshCalls).toBe(2);
+    expect(usageCalls).toBe(2);
+  });
+
+  it("isolates Codex usage response failures to account enrichment", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-usage-errors");
+    await enablePersonalModelProviderAccounts(fixture);
+    let usageCalls = 0;
+    let refreshCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.error();
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        usageCalls += 1;
+        if (usageCalls === 1) {
+          return HttpResponse.json(codexUsageResponse());
+        }
+        if (usageCalls === 2) {
+          return HttpResponse.json({ error: "unauthorized" }, { status: 401 });
+        }
+        return HttpResponse.json({ plan_type: 123 });
+      }),
+    );
+
+    const client = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    const connected = await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: makeAuthJson() },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    const unauthorized = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(unauthorized.body.modelProviders[0]).toMatchObject({
+      id: connected.body.provider.id,
+      needsReconnect: false,
+    });
+    expect(
+      unauthorized.body.modelProviders[0]?.subscriptionUsage,
+    ).toBeUndefined();
+
+    const unrecognized = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(unrecognized.body.modelProviders[0]).toMatchObject({
+      id: connected.body.provider.id,
+      needsReconnect: false,
+    });
+    expect(
+      unrecognized.body.modelProviders[0]?.subscriptionUsage,
+    ).toBeUndefined();
+    expect(refreshCalls).toBe(0);
+    expect(usageCalls).toBe(3);
   });
 
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2441,6 +2441,9 @@ async function markAndReturnRefreshFailure(
     accessSourceKey: args.accessSourceKey,
     orgId: args.orgId,
     userId: args.userId,
+    ...(args.sourceType === "model-provider" && args.sourceId
+      ? { modelProviderAccountId: args.sourceId }
+      : {}),
     errorCode,
     failureReason,
     ...oauthRefreshFailureLogFields(error),
@@ -3260,7 +3263,7 @@ async function getModelProviderRuntimeSecretValue(args: {
   });
 }
 
-export async function resolveModelProviderRuntimeSecretForApi(args: {
+interface ModelProviderRuntimeSecretForApiArgs {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
@@ -3268,7 +3271,50 @@ export async function resolveModelProviderRuntimeSecretForApi(args: {
   readonly providerKey: string;
   readonly metadata: SecretConnectorMetadata;
   readonly featureSwitchContext: FeatureSwitchContext;
-}): Promise<string | null> {
+}
+
+interface ResolvedModelProviderRuntimeSecretLookup {
+  readonly metadata: SecretConnectorMetadata;
+  readonly providerType: ModelProviderType;
+  readonly secretName: string;
+  readonly userId: string;
+}
+
+interface ModelProviderRuntimeRefreshState {
+  readonly tokenExpiresAt: Date | null;
+  readonly needsReconnect: boolean;
+  readonly lastRefreshErrorCode: string | null;
+}
+
+interface ModelProviderRuntimeReconnectState {
+  readonly needsReconnect: boolean;
+  readonly lastRefreshErrorCode: string | null;
+}
+
+type CurrentModelProviderRuntimeSecretForApiResult =
+  | {
+      readonly status: "available";
+      readonly value: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly reconnectState: ModelProviderRuntimeReconnectState | null;
+    };
+
+function modelProviderRuntimeReconnectState(
+  state: ModelProviderRuntimeRefreshState | null,
+): ModelProviderRuntimeReconnectState | null {
+  return state
+    ? {
+        needsReconnect: state.needsReconnect,
+        lastRefreshErrorCode: state.lastRefreshErrorCode,
+      }
+    : null;
+}
+
+function resolveModelProviderRuntimeSecretLookup(
+  args: ModelProviderRuntimeSecretForApiArgs,
+): ResolvedModelProviderRuntimeSecretLookup | null {
   const metadata = resolveRefreshMetadata(args.providerKey, args.metadata);
   if (metadata.sourceType !== "model-provider") {
     return null;
@@ -3282,19 +3328,184 @@ export async function resolveModelProviderRuntimeSecretForApi(args: {
   if (!providerType || !secretName) {
     return null;
   }
-  return await getModelProviderRuntimeSecretValue({
-    db: args.db,
-    orgId: args.orgId,
+
+  return {
+    metadata,
+    providerType,
+    secretName,
     userId: resolveSecretUserId(
       "model-provider",
       args.userId,
       metadata.sourceUserId,
     ),
-    providerType,
-    secretName,
-    sourceId: metadata.sourceId,
+  };
+}
+
+async function loadModelProviderRuntimeRefreshState(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly lookup: ResolvedModelProviderRuntimeSecretLookup;
+}): Promise<ModelProviderRuntimeRefreshState | null> {
+  if (args.lookup.metadata.sourceId) {
+    const [row] = await args.db
+      .select({
+        tokenExpiresAt: modelProviderAccounts.tokenExpiresAt,
+        needsReconnect: modelProviderAccounts.needsReconnect,
+        lastRefreshErrorCode: modelProviderAccounts.lastRefreshErrorCode,
+      })
+      .from(modelProviderAccounts)
+      .where(
+        and(
+          eq(modelProviderAccounts.id, args.lookup.metadata.sourceId),
+          eq(modelProviderAccounts.orgId, args.orgId),
+          eq(modelProviderAccounts.userId, args.lookup.userId),
+          eq(modelProviderAccounts.type, args.lookup.providerType),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
+  const [row] = await args.db
+    .select({
+      tokenExpiresAt: modelProviders.tokenExpiresAt,
+      needsReconnect: modelProviders.needsReconnect,
+      lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
+    })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, args.orgId),
+        eq(modelProviders.userId, args.lookup.userId),
+        eq(modelProviders.type, args.lookup.providerType),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function readModelProviderRuntimeSecretForApi(
+  args: ModelProviderRuntimeSecretForApiArgs,
+  lookup: ResolvedModelProviderRuntimeSecretLookup,
+): Promise<string | null> {
+  return await getModelProviderRuntimeSecretValue({
+    db: args.db,
+    orgId: args.orgId,
+    userId: lookup.userId,
+    providerType: lookup.providerType,
+    secretName: lookup.secretName,
+    sourceId: lookup.metadata.sourceId,
     featureSwitchContext: args.featureSwitchContext,
   });
+}
+
+async function unavailableModelProviderRuntimeSecretForApi(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly lookup: ResolvedModelProviderRuntimeSecretLookup;
+  },
+  signal: AbortSignal,
+): Promise<CurrentModelProviderRuntimeSecretForApiResult> {
+  const state = await loadModelProviderRuntimeRefreshState(args);
+  signal.throwIfAborted();
+  return {
+    status: "unavailable",
+    reconnectState: modelProviderRuntimeReconnectState(state),
+  };
+}
+
+export async function resolveModelProviderRuntimeSecretForApi(
+  args: ModelProviderRuntimeSecretForApiArgs,
+): Promise<string | null> {
+  const lookup = resolveModelProviderRuntimeSecretLookup(args);
+  return lookup
+    ? await readModelProviderRuntimeSecretForApi(args, lookup)
+    : null;
+}
+
+export async function resolveCurrentModelProviderRuntimeSecretForApi(
+  args: ModelProviderRuntimeSecretForApiArgs,
+  signal: AbortSignal,
+): Promise<CurrentModelProviderRuntimeSecretForApiResult> {
+  const lookup = resolveModelProviderRuntimeSecretLookup(args);
+  if (!lookup) {
+    return { status: "unavailable", reconnectState: null };
+  }
+
+  const refreshMetadata = getModelProviderRefreshMetadata(args.providerKey);
+  if (!refreshMetadata?.refreshableSecrets.includes(lookup.secretName)) {
+    const value = await readModelProviderRuntimeSecretForApi(args, lookup);
+    signal.throwIfAborted();
+    return value === null
+      ? await unavailableModelProviderRuntimeSecretForApi(
+          { db: args.db, orgId: args.orgId, lookup },
+          signal,
+        )
+      : { status: "available", value };
+  }
+
+  const initialState = await loadModelProviderRuntimeRefreshState({
+    db: args.db,
+    orgId: args.orgId,
+    lookup,
+  });
+  signal.throwIfAborted();
+  if (!initialState) {
+    return { status: "unavailable", reconnectState: null };
+  }
+  if (
+    args.providerKey === "codex-oauth-token" &&
+    initialState.needsReconnect &&
+    isTerminalChatgptRefreshErrorCode(initialState.lastRefreshErrorCode)
+  ) {
+    return {
+      status: "unavailable",
+      reconnectState: modelProviderRuntimeReconnectState(initialState),
+    };
+  }
+  if (
+    !initialState.needsReconnect &&
+    !tokenExpiresAtNeedsRefresh(initialState.tokenExpiresAt)
+  ) {
+    const value = await readModelProviderRuntimeSecretForApi(args, lookup);
+    signal.throwIfAborted();
+    if (value !== null) {
+      return { status: "available", value };
+    }
+  }
+
+  const refreshResult = await refreshAccessTokenForSource({
+    db: args.db,
+    accessSourceKey: args.providerKey,
+    orgId: args.orgId,
+    userId: args.userId,
+    sourceType: "model-provider",
+    sourceUserId: lookup.metadata.sourceUserId,
+    sourceId: lookup.metadata.sourceId,
+    metadataKey: lookup.metadata.metadataKey,
+    connectorSecrets: {},
+    accessEnvVars: [args.key],
+    forceRefresh: false,
+    forceRefreshStartedAtMicros: null,
+    connectorAccessBySlug: new Map<string, ConnectorAccessState>(),
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  signal.throwIfAborted();
+  if (refreshResult.ok) {
+    const value = refreshResult.secrets[args.key];
+    if (value === undefined) {
+      throw new Error(
+        `${args.providerKey} refresh did not resolve API runtime secret ${args.key}`,
+      );
+    }
+    return { status: "available", value };
+  }
+
+  return await unavailableModelProviderRuntimeSecretForApi(
+    { db: args.db, orgId: args.orgId, lookup },
+    signal,
+  );
 }
 
 async function syncModelProviderRuntimeSecrets(args: {

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -9,9 +9,10 @@ import { modelProviderAccountSecrets } from "@okouai/db/schema/model-provider-ac
 import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
-import { db$, type ReadonlyDb } from "../external/db";
+import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
 import { tapError } from "../utils";
+import { resolveCurrentModelProviderRuntimeSecretForApi } from "./agent-webhook-firewall-auth.service";
 import { fetchClaudeCodeSubscriptionMetadata } from "./claude-code-usage.service";
 import {
   consumeCodexRateLimitResetCredit,
@@ -27,10 +28,13 @@ import type {
 
 const L = logger("model-provider-subscription-usage.service");
 
-const CODEX_USAGE_SECRET_NAMES = [
-  "CHATGPT_ACCESS_TOKEN",
+const CODEX_USAGE_METADATA_SECRET_NAMES = [
   "CHATGPT_ACCOUNT_ID",
   "CHATGPT_ID_TOKEN",
+] as const;
+const CODEX_RESET_SECRET_NAMES = [
+  "CHATGPT_ACCESS_TOKEN",
+  "CHATGPT_ACCOUNT_ID",
 ] as const;
 const CLAUDE_CODE_OAUTH_TOKEN_SECRET_NAME = "CLAUDE_CODE_OAUTH_TOKEN";
 
@@ -164,7 +168,7 @@ function withSubscriptionMetadata(
 
 async function refreshCodexProvider(
   args: {
-    readonly db: ReadonlyDb;
+    readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
     readonly provider: ModelProviderResponse;
@@ -172,29 +176,60 @@ async function refreshCodexProvider(
   },
   signal: AbortSignal,
 ): Promise<ModelProviderResponse> {
-  const secretValues = await modelProviderSecretValues(
-    {
-      db: args.db,
-      orgId: args.orgId,
-      userId: args.userId,
-      names: CODEX_USAGE_SECRET_NAMES,
-      ...(args.provider.modelProviderId
-        ? { modelProviderAccountId: args.provider.id }
-        : {}),
-      featureSwitchContext: args.featureSwitchContext,
-    },
-    signal,
-  );
-  const accessToken = secretValues.get("CHATGPT_ACCESS_TOKEN");
+  const accountMetadata = {
+    sourceType: "model-provider" as const,
+    sourceUserId: args.userId,
+    ...(args.provider.modelProviderId ? { sourceId: args.provider.id } : {}),
+    metadataKey: args.provider.type,
+  };
+  const [accessTokenResult, secretValues] = await Promise.all([
+    resolveCurrentModelProviderRuntimeSecretForApi(
+      {
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        key: "CHATGPT_ACCESS_TOKEN",
+        providerKey: args.provider.type,
+        metadata: accountMetadata,
+        featureSwitchContext: args.featureSwitchContext,
+      },
+      signal,
+    ),
+    modelProviderSecretValues(
+      {
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        names: CODEX_USAGE_METADATA_SECRET_NAMES,
+        ...(args.provider.modelProviderId
+          ? { modelProviderAccountId: args.provider.id }
+          : {}),
+        featureSwitchContext: args.featureSwitchContext,
+      },
+      signal,
+    ),
+  ]);
+  signal.throwIfAborted();
+  if (accessTokenResult.status === "unavailable") {
+    return accessTokenResult.reconnectState
+      ? {
+          ...args.provider,
+          needsReconnect: accessTokenResult.reconnectState.needsReconnect,
+          lastRefreshErrorCode:
+            accessTokenResult.reconnectState.lastRefreshErrorCode,
+        }
+      : args.provider;
+  }
+
   const accountId = secretValues.get("CHATGPT_ACCOUNT_ID");
   const idToken = secretValues.get("CHATGPT_ID_TOKEN");
-  if (!accessToken || !accountId) {
+  if (!accountId) {
     return args.provider;
   }
 
   const metadata = await fetchCodexUsageMetadata(
     {
-      accessToken,
+      accessToken: accessTokenResult.value,
       accountId,
       idToken,
     },
@@ -244,7 +279,7 @@ async function refreshClaudeCodeProvider(
 
 async function refreshProvider(
   args: {
-    readonly db: ReadonlyDb;
+    readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
     readonly provider: ModelProviderResponse;
@@ -252,12 +287,11 @@ async function refreshProvider(
   },
   signal: AbortSignal,
 ): Promise<ModelProviderResponse> {
-  if (args.provider.needsReconnect) {
-    return args.provider;
-  }
-
   if (args.provider.type === "codex-oauth-token") {
     return await refreshCodexProvider(args, signal);
+  }
+  if (args.provider.needsReconnect) {
+    return args.provider;
   }
   if (args.provider.type === "claude-code-oauth-token") {
     return await refreshClaudeCodeProvider(args, signal);
@@ -267,7 +301,7 @@ async function refreshProvider(
 
 export const refreshPersonalModelProviderSubscriptionUsage$ = command(
   async (
-    { get },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -279,7 +313,7 @@ export const refreshPersonalModelProviderSubscriptionUsage$ = command(
       return args.result;
     }
 
-    const database = get(db$);
+    const database = set(writeDb$);
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
     );
@@ -304,6 +338,9 @@ export const refreshPersonalModelProviderSubscriptionUsage$ = command(
                 "failed to refresh personal model provider subscription usage",
                 {
                   error,
+                  ...(provider.modelProviderId
+                    ? { modelProviderAccountId: provider.id }
+                    : {}),
                   orgId: args.orgId,
                   providerType: provider.type,
                   userId: args.userId,
@@ -351,7 +388,7 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
         db: database,
         orgId: args.orgId,
         userId: args.userId,
-        names: CODEX_USAGE_SECRET_NAMES,
+        names: CODEX_RESET_SECRET_NAMES,
         modelProviderAccountId: args.modelProviderAccountId,
         featureSwitchContext,
       },


### PR DESCRIPTION
## Summary

- resolve each personal Codex account's current access token through the existing locked OAuth refresh authority before fetching subscription usage
- preserve exact-account isolation, refresh-token rotation, terminal reconnect state, and transient per-account fallback
- add sanitized account identifiers to refresh and usage diagnostics
- cover concurrent refresh coalescing, terminal and transient failures, malformed usage responses, and multi-account isolation at API route entry points

## Explicit exclusions

- no API contract, database schema, migration, frontend, or runner changes
- no forced refresh or reconnect transition based only on an unexpected usage-endpoint 401
- no broad extraction of the existing firewall credential lifecycle service

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/me-model-providers-upsert.test.ts src/signals/routes/__tests__/auth-device.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=4 --silent=passed-only` (90 passed)
- `pnpm knip`

Closes #28773
