### PR TITLE
fix(guest-agent): keep claude appended prompts out of argv

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -20,7 +20,8 @@ pub(super) fn build_claude_command_for_runtime(
         ClaudeArgsConfig {
             model: runtime.anthropic_model.as_ref(),
             resume_id: runtime.resume_session_id.as_ref(),
-            append_system_prompt: runtime.append_system_prompt.as_ref(),
+            append_system_prompt_file: (!runtime.append_system_prompt.is_empty())
+                .then_some(runtime.claude_append_system_prompt_file.as_ref()),
             disallowed_tools: runtime.disallowed_tools.as_ref(),
             tools: runtime.tools.as_ref(),
             settings: runtime.settings.as_ref(),
@@ -49,7 +50,7 @@ fn push_comma_separated_flag_values(args: &mut Vec<String>, flag: &str, values: 
 struct ClaudeArgsConfig<'a> {
     model: &'a str,
     resume_id: &'a str,
-    append_system_prompt: &'a str,
+    append_system_prompt_file: Option<&'a str>,
     disallowed_tools: &'a str,
     tools: &'a str,
     settings: &'a str,
@@ -78,9 +79,9 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
         log_info!(LOG_TAG, "Starting new session");
     }
 
-    if !config.append_system_prompt.is_empty() {
-        args.push("--append-system-prompt".to_string());
-        args.push(config.append_system_prompt.to_string());
+    if let Some(path) = config.append_system_prompt_file {
+        args.push("--append-system-prompt-file".to_string());
+        args.push(path.to_string());
     }
 
     push_comma_separated_flag_values(&mut args, "--disallowed-tools", config.disallowed_tools);
@@ -132,6 +133,8 @@ fn build_claude_command_with_config(
 mod tests {
     use super::*;
 
+    const TEST_APPEND_SYSTEM_PROMPT_FILE: &str = "/tmp/claude-append-system-prompt";
+
     fn disable_system_log() {
         guest_common::log::clear_system_log_file();
     }
@@ -166,7 +169,8 @@ mod tests {
         build_claude_args(ClaudeArgsConfig {
             model: "",
             resume_id,
-            append_system_prompt,
+            append_system_prompt_file: (!append_system_prompt.is_empty())
+                .then_some(TEST_APPEND_SYSTEM_PROMPT_FILE),
             disallowed_tools,
             tools,
             settings,
@@ -187,7 +191,7 @@ mod tests {
             ClaudeArgsConfig {
                 model: "",
                 resume_id: "",
-                append_system_prompt: "",
+                append_system_prompt_file: None,
                 disallowed_tools: "",
                 tools: "",
                 settings: "",
@@ -202,7 +206,7 @@ mod tests {
         build_claude_args(ClaudeArgsConfig {
             model,
             resume_id: "",
-            append_system_prompt: "",
+            append_system_prompt_file: None,
             disallowed_tools: "",
             tools: "",
             settings: "",
@@ -231,6 +235,7 @@ mod tests {
         assert_claude_prompt_is_not_positional(&args, "hello world");
         assert!(args.contains(&"--replay-user-messages".to_string()));
         assert!(!args.contains(&"--append-system-prompt".to_string()));
+        assert!(!args.contains(&"--append-system-prompt-file".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
     }
 
@@ -245,9 +250,10 @@ mod tests {
         let args = build_claude_args_for_test("", "Your name is Aria.", "", "", "");
         let asp_idx = args
             .iter()
-            .position(|a| a == "--append-system-prompt")
+            .position(|a| a == "--append-system-prompt-file")
             .unwrap();
-        assert_eq!(args[asp_idx + 1], "Your name is Aria.");
+        assert_eq!(args[asp_idx + 1], TEST_APPEND_SYSTEM_PROMPT_FILE);
+        assert!(!args.iter().any(|arg| arg == "Your name is Aria."));
         assert_claude_prompt_is_not_positional(&args, "analyze this");
     }
 
@@ -255,6 +261,7 @@ mod tests {
     fn build_claude_args_empty_append_system_prompt_omitted() {
         let args = build_claude_args_for_test("", "", "", "", "");
         assert!(!args.contains(&"--append-system-prompt".to_string()));
+        assert!(!args.contains(&"--append-system-prompt-file".to_string()));
     }
 
     #[test]
@@ -267,7 +274,7 @@ mod tests {
         let args = build_claude_args(ClaudeArgsConfig {
             model: "",
             resume_id: "sess-secret-123",
-            append_system_prompt: "",
+            append_system_prompt_file: None,
             disallowed_tools: "",
             tools: "",
             settings: "",
@@ -286,7 +293,7 @@ mod tests {
     fn build_claude_args_with_resume_and_append() {
         let args = build_claude_args_for_test("sess-123", "Be helpful.", "", "", "");
         assert!(args.contains(&"--resume".to_string()));
-        assert!(args.contains(&"--append-system-prompt".to_string()));
+        assert!(args.contains(&"--append-system-prompt-file".to_string()));
         assert_claude_prompt_is_not_positional(&args, "prompt");
     }
 
@@ -389,8 +396,8 @@ mod tests {
         for expected in [
             "--resume",
             "sess-abc",
-            "--append-system-prompt",
-            "Be concise.",
+            "--append-system-prompt-file",
+            TEST_APPEND_SYSTEM_PROMPT_FILE,
             "--disallowed-tools",
             "CronCreate",
             "CronDelete",

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -342,6 +342,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     agent_log_file: Cow<'a, str>,
     session_id_file: Cow<'a, str>,
     session_history_launch_source: SessionHistoryLaunchSource,
+    claude_append_system_prompt_file: Cow<'a, str>,
     pi_session_id: Cow<'a, str>,
     pi_launch_config: Cow<'a, str>,
     pi_launch_payload_file: Cow<'a, str>,
@@ -420,6 +421,9 @@ impl<'a> CliRuntimeConfig<'a> {
             agent_log_file: Cow::Borrowed(paths.agent_log_file()),
             session_id_file: Cow::Borrowed(paths.session_id_file()),
             session_history_launch_source: SessionHistoryLaunchSource::for_config(config),
+            claude_append_system_prompt_file: Cow::Borrowed(
+                paths.claude_append_system_prompt_file(),
+            ),
             pi_session_id: Cow::Borrowed(&config.pi_session_id),
             pi_launch_config: Cow::Borrowed(&config.pi_launch_config),
             pi_launch_payload_file: Cow::Borrowed(paths.pi_launch_payload_file()),
@@ -528,6 +532,19 @@ fn write_pi_launch_payload_file(runtime: &CliRuntimeConfig<'_>) -> Result<(), Ag
     let path = runtime.pi_launch_payload_file.as_ref();
     paths::ensure_parent_dir(path)?;
     paths::write_private(path, serde_json::to_vec(&payload)?)?;
+    Ok(())
+}
+
+fn write_claude_append_system_prompt_file(
+    runtime: &CliRuntimeConfig<'_>,
+) -> Result<(), AgentError> {
+    if runtime.append_system_prompt.is_empty() {
+        return Ok(());
+    }
+
+    let path = runtime.claude_append_system_prompt_file.as_ref();
+    paths::ensure_parent_dir(path)?;
+    paths::write_private(path, runtime.append_system_prompt.as_bytes())?;
     Ok(())
 }
 
@@ -944,6 +961,10 @@ async fn execute_cli_inner(
         "Starting {} execution...",
         runtime.framework.agent_type()
     );
+
+    if matches!(runtime.framework, env::Framework::ClaudeCode) {
+        write_claude_append_system_prompt_file(runtime)?;
+    }
 
     let cmd = if matches!(runtime.framework, env::Framework::Pi) {
         build_pi_command_for_runtime(runtime)?
@@ -2111,6 +2132,7 @@ mod tests {
                 },
                 env::Framework::Pi => SessionHistoryLaunchSource::Pi,
             },
+            claude_append_system_prompt_file: Cow::Borrowed("/tmp/claude-append-system-prompt"),
             pi_session_id: Cow::Borrowed(""),
             pi_launch_config: Cow::Borrowed(""),
             pi_launch_payload_file: Cow::Borrowed("/tmp/pi-launch-payload/payload.json"),

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -27,6 +27,7 @@ pub struct GuestPaths {
     checkpoint_error_file: String,
     final_session_history_identity_file: String,
     failure_diagnostic_file: String,
+    claude_append_system_prompt_file: String,
     pi_launch_payload_file: String,
     system_log_file: String,
     agent_log_file: String,
@@ -53,6 +54,9 @@ impl GuestPaths {
             ),
             failure_diagnostic_file: path_to_string(
                 guest_contracts::runtime_paths::failure_diagnostic_file(&runtime_dir),
+            ),
+            claude_append_system_prompt_file: path_to_string(
+                guest_contracts::runtime_paths::claude_append_system_prompt_file(&runtime_dir),
             ),
             pi_launch_payload_file: path_to_string(
                 guest_contracts::runtime_paths::pi_launch_payload_file(&runtime_dir),
@@ -130,6 +134,10 @@ impl GuestPaths {
 
     pub fn failure_diagnostic_file(&self) -> &str {
         &self.failure_diagnostic_file
+    }
+
+    pub fn claude_append_system_prompt_file(&self) -> &str {
+        &self.claude_append_system_prompt_file
     }
 
     pub fn pi_launch_payload_file(&self) -> &str {

--- a/crates/guest-agent/tests/claude_append_prompt_transport.rs
+++ b/crates/guest-agent/tests/claude_append_prompt_transport.rs
@@ -1,0 +1,100 @@
+//! Claude appended prompts stay out of process arguments.
+//!
+//! This test lives in its own binary to isolate process env, working directory,
+//! and the broad same-UID `pkill -f` regression scenario.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+const CLEANUP_MARKER: &str = "vm0-pkill-collision-4f83c597e45b";
+
+fn scenario_prompt(expected_prompt: &str, capture_path: &std::path::Path) -> String {
+    format!(
+        "@append-prompt-transport:{}",
+        serde_json::json!({
+            "capturePath": capture_path,
+            "expectedPrompt": expected_prompt,
+        })
+    )
+}
+
+#[tokio::test]
+async fn claude_append_prompt_uses_private_file_and_survives_broad_pkill()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let populated_argv_path = tmp.path().join("populated-argv.json");
+    let initial_prompt = scenario_prompt(CLEANUP_MARKER, &populated_argv_path);
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &initial_prompt, 3, 1)?;
+    }
+
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    runtime.config.append_system_prompt = CLEANUP_MARKER.to_string();
+    let masker = SecretMasker::from_raw("");
+    let populated_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("file-backed append prompt scenario should return promptly")?;
+    assert_eq!(populated_result.exit_code, common::CLEAN_EXIT);
+
+    let populated_argv: Vec<String> =
+        serde_json::from_slice(&std::fs::read(&populated_argv_path)?)?;
+    assert!(
+        !populated_argv
+            .iter()
+            .any(|arg| arg == "--append-system-prompt" || arg.contains(CLEANUP_MARKER)),
+        "raw appended prompt must be absent from Claude argv: {populated_argv:?}"
+    );
+    let file_flag_index = populated_argv
+        .iter()
+        .position(|arg| arg == "--append-system-prompt-file")
+        .ok_or("Claude argv omitted --append-system-prompt-file")?;
+    let prompt_file_arg = populated_argv
+        .get(file_flag_index + 1)
+        .ok_or("Claude append prompt file flag omitted its path")?;
+    assert_eq!(
+        prompt_file_arg,
+        runtime.paths.claude_append_system_prompt_file()
+    );
+
+    let prompt_path = std::path::Path::new(runtime.paths.claude_append_system_prompt_file());
+    assert_eq!(std::fs::read(prompt_path)?, CLEANUP_MARKER.as_bytes());
+    assert_eq!(
+        std::fs::metadata(prompt_path)?.permissions().mode() & 0o777,
+        0o600
+    );
+    assert_eq!(
+        std::fs::metadata(runtime.paths.runtime_dir())?
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+
+    let empty_argv_path = tmp.path().join("empty-argv.json");
+    runtime.config.prompt = scenario_prompt("", &empty_argv_path);
+    runtime.config.append_system_prompt.clear();
+    let empty_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("empty append prompt scenario should return promptly")?;
+    assert_eq!(empty_result.exit_code, common::CLEAN_EXIT);
+
+    let empty_argv: Vec<String> = serde_json::from_slice(&std::fs::read(empty_argv_path)?)?;
+    assert!(
+        !empty_argv
+            .iter()
+            .any(|arg| { arg == "--append-system-prompt" || arg == "--append-system-prompt-file" }),
+        "empty appended prompt must omit both append flags: {empty_argv:?}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -170,6 +170,11 @@ pub fn pi_launch_payload_file(run_dir: impl AsRef<Path>) -> PathBuf {
         .join(crate::env::PI_LAUNCH_PAYLOAD_FILENAME)
 }
 
+/// Return the private Claude appended-system-prompt file.
+pub fn claude_append_system_prompt_file(run_dir: impl AsRef<Path>) -> PathBuf {
+    file(run_dir, "claude-append-system-prompt")
+}
+
 /// Return the run-root `active-input-receipts.json` file.
 pub fn active_input_receipt_journal_file(run_dir: impl AsRef<Path>) -> PathBuf {
     file(run_dir, "active-input-receipts.json")

--- a/crates/guest-mock-claude/src/args.rs
+++ b/crates/guest-mock-claude/src/args.rs
@@ -42,7 +42,7 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
                     i += 1;
                 }
             }
-            "--resume" | "--append-system-prompt" | "--effort" => {
+            "--resume" | "--append-system-prompt" | "--append-system-prompt-file" | "--effort" => {
                 // Parsed for CLI compat but not used by mock-claude
                 skip_flag_value(args, &mut i);
             }

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -44,6 +44,9 @@
 //!                               happy path
 //!   @write-env-json:<path>    - Write current process env as JSON to path,
 //!                               emit result, and exit(0)
+//!   @append-prompt-transport:<json>
+//!                             - Capture argv and verify file-backed appended
+//!                               prompt transport plus broad pkill isolation
 //!   @parallel-shell-tool-oom  - Run two Bash tools concurrently and verify
 //!                               a group OOM leaves the unrelated tool alive
 //!   @ECHO@                    - First-line marker. Validate remaining non-empty

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -136,6 +136,9 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
         MockScenario::WriteEnvJson(path) => {
             fixtures::run_write_env_json_scenario(output_format, path)
         }
+        MockScenario::AppendPromptTransport(payload) => {
+            fixtures::run_append_prompt_transport_scenario(output_format, payload)
+        }
         MockScenario::ParallelShellToolOom => {
             fixtures::run_parallel_shell_tool_oom_scenario(output_format)
         }

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -8,6 +8,7 @@ use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
@@ -410,6 +411,116 @@ pub(super) fn run_write_env_json_scenario(output_format: &str, path: &str) -> Ex
 
     emit_post_result_pair();
     ExitCode::SUCCESS
+}
+
+pub(super) fn run_append_prompt_transport_scenario(output_format: &str, payload: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    match verify_append_prompt_transport(payload) {
+        Ok(summary) => {
+            emit_result_pair(false, &summary);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            let message = format!("append prompt transport fixture failed: {error}");
+            emit_result_pair(true, &message);
+            eprintln!("{message}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn verify_append_prompt_transport(payload: &str) -> Result<String, String> {
+    let payload: serde_json::Value = serde_json::from_str(payload)
+        .map_err(|error| format!("parse scenario payload: {error}"))?;
+    let expected_prompt = payload
+        .get("expectedPrompt")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "scenario payload requires expectedPrompt".to_string())?;
+    let capture_path = payload
+        .get("capturePath")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "scenario payload requires capturePath".to_string())?;
+    if capture_path.is_empty() {
+        return Err("scenario capturePath must not be empty".to_string());
+    }
+
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(parent) = Path::new(capture_path).parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create argv capture parent: {error}"))?;
+    }
+    let capture =
+        serde_json::to_vec(&args).map_err(|error| format!("serialize argv capture: {error}"))?;
+    std::fs::write(capture_path, capture)
+        .map_err(|error| format!("write argv capture: {error}"))?;
+
+    let file_flag_positions: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter_map(|(index, arg)| (arg == "--append-system-prompt-file").then_some(index))
+        .collect();
+    if expected_prompt.is_empty() {
+        if args
+            .iter()
+            .any(|arg| arg == "--append-system-prompt" || arg == "--append-system-prompt-file")
+        {
+            return Err("empty appended prompt emitted an append flag".to_string());
+        }
+        return Ok("empty appended prompt omitted both append flags".to_string());
+    }
+
+    let status = bash_tool_command()
+        .args([
+            "-c",
+            "pkill -9 -f -- \"$1\"; exit 97",
+            "vm0-pkill-f-collision-shell",
+            expected_prompt,
+        ])
+        .status()
+        .map_err(|error| format!("spawn broad pkill shell: {error}"))?;
+    if status.signal() != Some(libc::SIGKILL) {
+        return Err(format!(
+            "broad pkill shell exited with {status}, expected SIGKILL"
+        ));
+    }
+
+    if args.iter().any(|arg| arg == "--append-system-prompt") {
+        return Err("inline --append-system-prompt remained in argv".to_string());
+    }
+    if args.iter().any(|arg| arg.contains(expected_prompt)) {
+        return Err("raw appended prompt remained in argv".to_string());
+    }
+    let [file_flag_index] = file_flag_positions.as_slice() else {
+        return Err(format!(
+            "expected one --append-system-prompt-file flag, found {}",
+            file_flag_positions.len()
+        ));
+    };
+    let prompt_path = args
+        .get(file_flag_index + 1)
+        .ok_or_else(|| "append prompt file flag is missing its path".to_string())?;
+    let prompt_bytes = std::fs::read(prompt_path)
+        .map_err(|error| format!("read append prompt file {prompt_path}: {error}"))?;
+    if prompt_bytes != expected_prompt.as_bytes() {
+        return Err("append prompt file contents did not match".to_string());
+    }
+    let mode = std::fs::metadata(prompt_path)
+        .map_err(|error| format!("stat append prompt file {prompt_path}: {error}"))?
+        .permissions()
+        .mode()
+        & 0o777;
+    if mode != 0o600 {
+        return Err(format!(
+            "append prompt file mode was {mode:o}, expected 600"
+        ));
+    }
+
+    Ok("file-backed appended prompt survived broad pkill".to_string())
 }
 
 pub(super) fn run_parallel_shell_tool_oom_scenario(output_format: &str) -> ExitCode {

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -22,6 +22,7 @@ const HANG_AFTER_RESULT_PERIODIC_EVENTS_MARKER: &str = "@hang-after-result-perio
 const HANG_AFTER_ERROR_RESULT_MARKER: &str = "@hang-after-error-result";
 const EXIT_AFTER_RESULT_MARKER: &str = "@exit-after-result";
 const WRITE_ENV_JSON_MARKER: &str = "@write-env-json:";
+const APPEND_PROMPT_TRANSPORT_MARKER: &str = "@append-prompt-transport:";
 const PARALLEL_SHELL_TOOL_OOM_MARKER: &str = "@parallel-shell-tool-oom";
 const HANG_AFTER_RESULT_MARKER: &str = "@hang-after-result";
 
@@ -48,6 +49,7 @@ pub(crate) enum MockScenario<'a> {
     HangAfterErrorResult,
     ExitAfterResult,
     WriteEnvJson(&'a str),
+    AppendPromptTransport(&'a str),
     ParallelShellToolOom,
     Shell,
 }
@@ -81,6 +83,7 @@ enum ScenarioKind {
     HangAfterErrorResult,
     ExitAfterResult,
     WriteEnvJson,
+    AppendPromptTransport,
     ParallelShellToolOom,
 }
 
@@ -217,6 +220,11 @@ const SCENARIO_RULES: &[ScenarioRule] = &[
         scenario_kind: ScenarioKind::WriteEnvJson,
     },
     ScenarioRule {
+        marker: APPEND_PROMPT_TRANSPORT_MARKER,
+        match_kind: ScenarioMatchKind::PrefixPayload,
+        scenario_kind: ScenarioKind::AppendPromptTransport,
+    },
+    ScenarioRule {
         marker: PARALLEL_SHELL_TOOL_OOM_MARKER,
         match_kind: ScenarioMatchKind::Exact,
         scenario_kind: ScenarioKind::ParallelShellToolOom,
@@ -262,6 +270,9 @@ impl ScenarioKind {
             (Self::FailNoNewline, ScenarioMatch::Payload(msg)) => MockScenario::FailNoNewline(msg),
             (Self::Fail, ScenarioMatch::Payload(msg)) => MockScenario::Fail(msg),
             (Self::WriteEnvJson, ScenarioMatch::Payload(path)) => MockScenario::WriteEnvJson(path),
+            (Self::AppendPromptTransport, ScenarioMatch::Payload(payload)) => {
+                MockScenario::AppendPromptTransport(payload)
+            }
             (Self::FailInvalidUtf8, ScenarioMatch::Marker) => MockScenario::FailInvalidUtf8,
             (Self::FailInvalidUtf8Long, ScenarioMatch::Marker) => MockScenario::FailInvalidUtf8Long,
             (Self::StdoutOverLimit { newline }, ScenarioMatch::Marker) => {
@@ -471,6 +482,10 @@ mod tests {
             (
                 "@write-env-json:/tmp/env.json",
                 MockScenario::WriteEnvJson("/tmp/env.json"),
+            ),
+            (
+                "@append-prompt-transport:{\"expectedPrompt\":\"marker\"}",
+                MockScenario::AppendPromptTransport("{\"expectedPrompt\":\"marker\"}"),
             ),
             (
                 "@parallel-shell-tool-oom",

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -67,6 +67,7 @@ fi
 # test in cmd/build.rs at compile time.
 CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 CLAUDE_TOOL_HOOK_DEST="/etc/claude-code/managed-settings.d/90-tool-containment.json"
+CLAUDE_CLI_DEST="/usr/local/bin/claude"
 CODEX_TOOL_HOOK_DEST="/etc/codex/requirements.toml"
 
 # ---------------------------------------------------------------------------
@@ -330,6 +331,11 @@ check_bin "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf" "Noto Color Emoji"
 check_required_executable "/usr/local/bin/agent-browser" "agent-browser CLI"
 
 # Check CLIs
+check_required_executable "$CLAUDE_CLI_DEST" "Claude Code CLI"
+check_required_file_contains "$CLAUDE_CLI_DEST" \
+  '--append-system-prompt-file' \
+  "Claude Code append-system-prompt-file support"
+
 if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
   echo "  gh CLI: found"
 else


### PR DESCRIPTION
## Summary

- write non-empty Claude appended system prompts to a private run-scoped `0600` file
- launch Claude with `--append-system-prompt-file` so prompt text is absent from process arguments
- add a process-entry regression that proves a broad same-UID `pkill -f` kills its matching shell without killing the mock Claude parent
- require the baked Claude CLI to contain the file-backed prompt flag during rootfs verification

## Scope

This removes the reproducible prompt/argv collision surface behind the strongest supported incident mechanism. It does not claim that the sender of the historical SIGKILLs has been conclusively identified, and it does not add general signal provenance, PID namespaces, command rewriting, or memory-policy changes.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-contracts -p guest-agent -p guest-mock-claude --all-targets -- -D warnings`
- `cd crates && cargo doc -p guest-contracts -p guest-agent -p guest-mock-claude --no-deps`
- `cd crates && cargo test -p guest-contracts`
- `cd crates && cargo test -p guest-agent`
- `cd crates && cargo test -p guest-mock-claude`
- `cd crates && cargo test -p runner cmd::build::scripts::tests`
- `cd crates && bash -n runner/scripts/verify-rootfs.sh`

Closes #28744
