### PR TITLE
perf(runner): attribute pre-spawn concurrency

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -138,8 +138,11 @@ async fn run_finalizing_claim(
         factory,
     } = request;
     let run_id = claimed.context().run_id;
-    let mut pre_spawn_timing =
-        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_timing());
+    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_at(
+        claim_returned_at,
+        claimed.api_claim_timing(),
+        &ctx.pre_spawn_concurrency,
+    );
     pre_spawn_timing.mark_task_enqueued();
     let started_at = Instant::now();
     let mut reserved_exact = None;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -318,8 +318,11 @@ pub(super) async fn handle_discovered_job(
         .await;
         return DiscoveredJobResult::completed(true);
     }
-    let mut pre_spawn_timing =
-        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_timing());
+    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_at(
+        claim_returned_at,
+        claimed.api_claim_timing(),
+        &ctx.spawn_ctx.pre_spawn_concurrency,
+    );
     let started_at = Instant::now();
     let resume_session_error = validate_resume_session_id(claimed.context()).err();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -30,7 +30,8 @@ use super::sandbox_finalization::{
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{
-    self, ExecutorConfig, RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryRestorePlan,
+    self, ExecutorConfig, RunnerPreSpawnConcurrency, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
+    SessionHistoryRestorePlan,
 };
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
@@ -82,6 +83,7 @@ pub(super) struct SpawnContext {
     /// Best-effort signal for the main loop to ask mitmproxy to flush usage.
     pub(super) usage_flush_tx: mpsc::Sender<()>,
     pub(super) active_runs: ActiveRuns,
+    pub(super) pre_spawn_concurrency: RunnerPreSpawnConcurrency,
     pub(super) budget: Arc<ResourceBudget>,
     pub(super) workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -57,7 +57,9 @@ use crate::config::{self, ProfileConfig};
 use crate::deps;
 use crate::dns;
 use crate::error::{RunnerError, RunnerResult};
-use crate::executor::{ExecutorConfig, SessionHistoryCpuPool, SessionHistoryProbe};
+use crate::executor::{
+    ExecutorConfig, RunnerPreSpawnConcurrency, SessionHistoryCpuPool, SessionHistoryProbe,
+};
 use crate::host;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
@@ -1734,6 +1736,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         reuse_state_notify: Arc::clone(&reuse_state_notify),
         usage_flush_tx,
         active_runs: active_runs.clone(),
+        pre_spawn_concurrency: RunnerPreSpawnConcurrency::default(),
         budget: Arc::clone(&capacity.budget),
         workspace_cache_snapshot,
         device_rate_limits: capacity.device_rate_limits.clone(),

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -25,6 +25,7 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
                 .body_includes("runner_claim_active_status_publish")
                 .body_includes("runner_claim_spawn_job_setup")
                 .body_includes("runner_claim_task_schedule_wait")
+                .body_includes(r#""runner_pre_spawn_concurrency_bucket":"1""#)
                 .body_includes("runner_host_finalization_started")
                 .body_includes("runner_host_reuse_preparation")
                 .body_includes("runner_host_physical_park")

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -64,8 +64,8 @@ use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
 pub(crate) use telemetry::{
-    ExactReuseSpeculationTiming, FinalizingHandoffOutcome, RunnerPreSpawnOperationTiming,
-    RunnerPreSpawnPhase, RunnerPreSpawnTiming,
+    ExactReuseSpeculationTiming, FinalizingHandoffOutcome, RunnerPreSpawnConcurrency,
+    RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
 };
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -1,6 +1,9 @@
 //! Executor telemetry marker helpers.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use guest_contracts::epoch_milliseconds::{
@@ -10,11 +13,64 @@ use tracing::warn;
 
 use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::provider::ApiClaimTiming;
-use crate::telemetry::{JobTelemetry, RunnerStartupPath};
+use crate::telemetry::{
+    JobTelemetry, RunnerPreSpawnAttribution, RunnerPreSpawnConcurrencyBucket, RunnerStartupPath,
+};
 use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
 
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Tracks only post-claim jobs that have not yet spawned a guest process.
+#[derive(Clone, Default)]
+pub(crate) struct RunnerPreSpawnConcurrency {
+    active: Arc<AtomicUsize>,
+}
+
+struct RunnerPreSpawnConcurrencyGuard {
+    active: Arc<AtomicUsize>,
+    attribution: RunnerPreSpawnAttribution,
+    preserve_attribution_on_drop: bool,
+}
+
+impl RunnerPreSpawnConcurrency {
+    fn enter(&self) -> RunnerPreSpawnConcurrencyGuard {
+        let existing = self.active.fetch_add(1, Ordering::Relaxed);
+        let bucket = match existing {
+            0 => RunnerPreSpawnConcurrencyBucket::One,
+            1 => RunnerPreSpawnConcurrencyBucket::Two,
+            2..=3 => RunnerPreSpawnConcurrencyBucket::ThreeToFour,
+            4..=7 => RunnerPreSpawnConcurrencyBucket::FiveToEight,
+            _ => RunnerPreSpawnConcurrencyBucket::NinePlus,
+        };
+        RunnerPreSpawnConcurrencyGuard {
+            active: Arc::clone(&self.active),
+            attribution: RunnerPreSpawnAttribution::new(bucket),
+            preserve_attribution_on_drop: false,
+        }
+    }
+}
+
+impl RunnerPreSpawnConcurrencyGuard {
+    fn attribution(&self) -> RunnerPreSpawnAttribution {
+        self.attribution.clone()
+    }
+
+    fn preserve_attribution_after_spawn(&mut self) {
+        // Live membership ends when this guard drops at spawn. The immutable
+        // cohort remains valid for the immediately following api_to_spawn row.
+        self.preserve_attribution_on_drop = true;
+    }
+}
+
+impl Drop for RunnerPreSpawnConcurrencyGuard {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::Relaxed);
+        if !self.preserve_attribution_on_drop {
+            self.attribution.deactivate();
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 pub(crate) enum RunnerPreSpawnPhase {
@@ -158,6 +214,7 @@ impl RunnerPreSpawnPhaseDurations {
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
     api_claim_timing: Option<ApiClaimTiming>,
+    concurrency: RunnerPreSpawnConcurrencyGuard,
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
     exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
@@ -188,16 +245,18 @@ pub(super) struct RunnerSpawnTiming {
 impl RunnerPreSpawnTiming {
     #[cfg(test)]
     pub(crate) fn start_after_claim() -> Self {
-        Self::start_at(Instant::now(), None)
+        Self::start_at(Instant::now(), None, &RunnerPreSpawnConcurrency::default())
     }
 
     pub(crate) fn start_at(
         claim_returned_at: Instant,
         api_claim_timing: Option<ApiClaimTiming>,
+        concurrency: &RunnerPreSpawnConcurrency,
     ) -> Self {
         Self {
             claim_returned_at,
             api_claim_timing,
+            concurrency: concurrency.enter(),
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
             exact_reuse_speculation: None,
@@ -231,6 +290,14 @@ impl RunnerPreSpawnTiming {
 
     fn elapsed_at(&self, at: Instant) -> Duration {
         at.saturating_duration_since(self.claim_returned_at)
+    }
+
+    fn concurrency_attribution(&self) -> RunnerPreSpawnAttribution {
+        self.concurrency.attribution()
+    }
+
+    fn preserve_concurrency_attribution_after_spawn(&mut self) {
+        self.concurrency.preserve_attribution_after_spawn();
     }
 
     fn record_collected_phases(&self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
@@ -333,6 +400,8 @@ impl RunnerSpawnTiming {
 
     pub(super) fn record_claim_to_executor_start(&self, telemetry: &mut JobTelemetry) {
         if let Some(pre_spawn_timing) = self.pre_spawn_timing.as_ref() {
+            telemetry
+                .start_runner_pre_spawn_attribution(pre_spawn_timing.concurrency_attribution());
             telemetry.record(
                 "runner_claim_to_executor_start",
                 pre_spawn_timing.elapsed_at(self.executor_started_at),
@@ -344,7 +413,7 @@ impl RunnerSpawnTiming {
     }
 
     pub(super) fn record_spawn_success_at(
-        &self,
+        mut self,
         telemetry: &mut JobTelemetry,
         spawned_at: Instant,
     ) {
@@ -361,6 +430,9 @@ impl RunnerSpawnTiming {
                 true,
                 None,
             );
+        }
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing.as_mut() {
+            pre_spawn_timing.preserve_concurrency_attribution_after_spawn();
         }
     }
 }
@@ -421,6 +493,7 @@ pub(super) fn record_api_to_spawn(
     if let Some(duration) = api_latency_duration("api_to_spawn", context) {
         telemetry.record_api_to_spawn(duration, runner_startup_path, sandbox_reuse_result);
     }
+    telemetry.finish_runner_pre_spawn_attribution();
 }
 
 fn api_latency_duration(action_type: &str, context: &ExecutionContext) -> Option<Duration> {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -828,45 +828,58 @@ async fn execute_job_attributes_overlapping_pre_spawn_work_and_releases_membersh
     let config = test_executor_config(dir.path()).await;
     let factory = ObservedMockSandboxFactory::new();
     let concurrency = RunnerPreSpawnConcurrency::default();
-    let held_timing = RunnerPreSpawnTiming::start_at(Instant::now(), None, &concurrency);
+    let mut held_timings = Vec::new();
 
-    let mut overlapping_context = minimal_context();
-    overlapping_context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
-    let cancel = tokio_util::sync::CancellationToken::new();
-    let (_outcome, overlapping_telemetry) = execute_job_with_prepared_notifier(
-        &factory,
-        overlapping_context,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        RunCancellationSignals::hard_only(cancel),
-        ExecutionHooks {
-            sandbox_prepared: None,
-            active_input_source: None,
-            pre_spawn_timing: Some(pre_spawn_timing_with_phases_and_concurrency(&concurrency)),
-            session_history_restore_plan: SessionHistoryRestorePlan::Default,
-        },
-    )
-    .await;
-
-    for action in [
-        "runner_claim_to_executor_start",
-        "runner_fresh_sandbox_prepare",
-        "runner_agent_start_process",
-        "api_to_spawn",
+    for (held_count, expected_bucket) in [
+        (0, RunnerPreSpawnConcurrencyBucket::One),
+        (1, RunnerPreSpawnConcurrencyBucket::Two),
+        (2, RunnerPreSpawnConcurrencyBucket::ThreeToFour),
+        (3, RunnerPreSpawnConcurrencyBucket::ThreeToFour),
+        (4, RunnerPreSpawnConcurrencyBucket::FiveToEight),
+        (7, RunnerPreSpawnConcurrencyBucket::FiveToEight),
+        (8, RunnerPreSpawnConcurrencyBucket::NinePlus),
     ] {
-        assert_pre_spawn_concurrency_bucket(
-            &overlapping_telemetry,
-            action,
-            Some(RunnerPreSpawnConcurrencyBucket::Two),
-        );
-    }
-    assert_pre_spawn_concurrency_bucket(&overlapping_telemetry, "agent_execute", None);
+        while held_timings.len() < held_count {
+            held_timings.push(RunnerPreSpawnTiming::start_at(
+                Instant::now(),
+                None,
+                &concurrency,
+            ));
+        }
+        let mut context = minimal_context();
+        context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (_outcome, telemetry) = execute_job_with_prepared_notifier(
+            &factory,
+            context,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            RunCancellationSignals::hard_only(cancel),
+            ExecutionHooks {
+                sandbox_prepared: None,
+                active_input_source: None,
+                pre_spawn_timing: Some(pre_spawn_timing_with_phases_and_concurrency(&concurrency)),
+                session_history_restore_plan: SessionHistoryRestorePlan::Default,
+            },
+        )
+        .await;
 
-    drop(held_timing);
+        for action in [
+            "runner_claim_to_executor_start",
+            "runner_fresh_sandbox_prepare",
+            "runner_agent_start_process",
+            "api_to_spawn",
+        ] {
+            assert_pre_spawn_concurrency_bucket(&telemetry, action, Some(expected_bucket));
+        }
+        assert_pre_spawn_concurrency_bucket(&telemetry, "agent_execute", None);
+    }
+
+    drop(held_timings);
 
     let mut baseline_context = minimal_context();
     baseline_context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -16,8 +16,9 @@ use super::super::telemetry::{
 };
 use super::super::{
     ExactReuseSpeculationTiming, ExecutionHooks, FinalizingHandoffOutcome, NewSandboxDispatch,
-    RunnerPreSpawnOperationTiming, RunnerPreSpawnTiming, SessionHistoryRestorePlan, execute_job,
-    execute_job_reuse, execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
+    RunnerPreSpawnConcurrency, RunnerPreSpawnOperationTiming, RunnerPreSpawnTiming,
+    SessionHistoryRestorePlan, execute_job, execute_job_reuse, execute_job_reuse_with_hooks,
+    execute_job_with_prepared_notifier,
 };
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
@@ -27,7 +28,7 @@ use crate::http::{HttpClient, HttpClientConfig};
 use crate::ids::RunId;
 use crate::provider::ApiClaimTiming;
 use crate::run_cancellation::RunCancellationSignals;
-use crate::telemetry::{JobTelemetry, RunnerStartupPath};
+use crate::telemetry::{JobTelemetry, RunnerPreSpawnConcurrencyBucket, RunnerStartupPath};
 use crate::types::{SandboxReuseResult, WorkspaceReuseResult};
 
 #[test]
@@ -542,6 +543,13 @@ fn assert_pre_spawn_phase_actions_succeeded(telemetry: &JobTelemetry) {
 }
 
 fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
+    let concurrency = RunnerPreSpawnConcurrency::default();
+    pre_spawn_timing_with_phases_and_concurrency(&concurrency)
+}
+
+fn pre_spawn_timing_with_phases_and_concurrency(
+    concurrency: &RunnerPreSpawnConcurrency,
+) -> RunnerPreSpawnTiming {
     let mut timing = RunnerPreSpawnTiming::start_at(
         Instant::now(),
         Some(ApiClaimTiming::new(
@@ -549,6 +557,7 @@ fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
             Duration::from_millis(7),
             Duration::from_millis(3),
         )),
+        concurrency,
     );
     for (phase, duration_ms) in [
         (RunnerPreSpawnPhase::ResumeSessionValidation, 1),
@@ -566,6 +575,22 @@ fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
     timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Accepted);
     timing.mark_task_enqueued();
     timing
+}
+
+fn assert_pre_spawn_concurrency_bucket(
+    telemetry: &JobTelemetry,
+    action: &str,
+    expected: Option<RunnerPreSpawnConcurrencyBucket>,
+) {
+    let operations = telemetry.pending_ops_with_runner_startup_snapshot();
+    let matching: Vec<_> = operations
+        .iter()
+        .filter(|operation| operation.action_type == action)
+        .collect();
+    let [operation] = matching.as_slice() else {
+        panic!("expected one {action} operation, got {operations:?}");
+    };
+    assert_eq!(operation.runner_pre_spawn_concurrency_bucket, expected);
 }
 
 fn pre_spawn_timing_with_exact_reuse_speculation() -> RunnerPreSpawnTiming {
@@ -795,6 +820,81 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
+}
+
+#[tokio::test]
+async fn execute_job_attributes_overlapping_pre_spawn_work_and_releases_membership() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::new();
+    let concurrency = RunnerPreSpawnConcurrency::default();
+    let held_timing = RunnerPreSpawnTiming::start_at(Instant::now(), None, &concurrency);
+
+    let mut overlapping_context = minimal_context();
+    overlapping_context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, overlapping_telemetry) = execute_job_with_prepared_notifier(
+        &factory,
+        overlapping_context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases_and_concurrency(&concurrency)),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+
+    for action in [
+        "runner_claim_to_executor_start",
+        "runner_fresh_sandbox_prepare",
+        "runner_agent_start_process",
+        "api_to_spawn",
+    ] {
+        assert_pre_spawn_concurrency_bucket(
+            &overlapping_telemetry,
+            action,
+            Some(RunnerPreSpawnConcurrencyBucket::Two),
+        );
+    }
+    assert_pre_spawn_concurrency_bucket(&overlapping_telemetry, "agent_execute", None);
+
+    drop(held_timing);
+
+    let mut baseline_context = minimal_context();
+    baseline_context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, baseline_telemetry) = execute_job_with_prepared_notifier(
+        &factory,
+        baseline_context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases_and_concurrency(&concurrency)),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+
+    assert_pre_spawn_concurrency_bucket(
+        &baseline_telemetry,
+        "api_to_spawn",
+        Some(RunnerPreSpawnConcurrencyBucket::One),
+    );
 }
 
 #[tokio::test]
@@ -1128,6 +1228,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 async fn start_process_failure_records_phase_failure_without_spawn_completion() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
+    let concurrency = RunnerPreSpawnConcurrency::default();
     let overrides = std::sync::Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_start_process_stdout_chunks(vec![
         ProcessOutputChunk {
@@ -1152,7 +1253,11 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
-            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_at(
+                Instant::now(),
+                None,
+                &concurrency,
+            )),
             session_history_restore_plan: SessionHistoryRestorePlan::Default,
         },
     )
@@ -1163,4 +1268,37 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
     assert_lacks_api_claim_timing(&telemetry);
     assert_lacks_action(&telemetry, "runner_executor_start_to_spawn");
     assert_lacks_action(&telemetry, "runner_claim_to_spawn");
+    assert_pre_spawn_concurrency_bucket(
+        &telemetry,
+        "runner_agent_start_process",
+        Some(RunnerPreSpawnConcurrencyBucket::One),
+    );
+
+    let mut recovery_context = minimal_context();
+    recovery_context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+    let recovery_factory = MockSandboxFactory::new();
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, recovery_telemetry) = execute_job_with_prepared_notifier(
+        &recovery_factory,
+        recovery_context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases_and_concurrency(&concurrency)),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+    assert_pre_spawn_concurrency_bucket(
+        &recovery_telemetry,
+        "api_to_spawn",
+        Some(RunnerPreSpawnConcurrencyBucket::One),
+    );
 }

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -1,3 +1,7 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use api_contracts::generated::routes;
@@ -34,6 +38,45 @@ pub(crate) enum RunnerStartupPath {
     Cold,
 }
 
+/// Inclusive number of Runner jobs in post-claim work before guest process spawn.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) enum RunnerPreSpawnConcurrencyBucket {
+    #[serde(rename = "1")]
+    One,
+    #[serde(rename = "2")]
+    Two,
+    #[serde(rename = "3_4")]
+    ThreeToFour,
+    #[serde(rename = "5_8")]
+    FiveToEight,
+    #[serde(rename = "9_plus")]
+    NinePlus,
+}
+
+/// Shared cohort label that becomes inactive when startup terminates before spawn.
+#[derive(Clone)]
+pub(crate) struct RunnerPreSpawnAttribution {
+    bucket: RunnerPreSpawnConcurrencyBucket,
+    active: Arc<AtomicBool>,
+}
+
+impl RunnerPreSpawnAttribution {
+    pub(crate) fn new(bucket: RunnerPreSpawnConcurrencyBucket) -> Self {
+        Self {
+            bucket,
+            active: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    pub(crate) fn deactivate(&self) {
+        self.active.store(false, Ordering::Relaxed);
+    }
+
+    fn active_bucket(&self) -> Option<RunnerPreSpawnConcurrencyBucket> {
+        self.active.load(Ordering::Relaxed).then_some(self.bucket)
+    }
+}
+
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
 ///
@@ -44,6 +87,7 @@ pub struct JobTelemetry {
     run_id: RunId,
     sandbox_token: String,
     runner_name: String,
+    runner_pre_spawn_attribution: Option<RunnerPreSpawnAttribution>,
     pending_ops: Vec<SandboxOp>,
     oldest_pending: Option<Instant>,
     in_flight_flushes: Vec<JoinHandle<()>>,
@@ -65,6 +109,8 @@ struct SandboxOp {
     runner_startup_path: Option<RunnerStartupPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox_reuse_result: Option<SandboxReuseResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_pre_spawn_concurrency_bucket: Option<RunnerPreSpawnConcurrencyBucket>,
     #[serde(flatten)]
     session_history: Option<SessionHistoryTelemetryFields>,
 }
@@ -92,10 +138,23 @@ impl JobTelemetry {
             run_id,
             sandbox_token,
             runner_name,
+            runner_pre_spawn_attribution: None,
             pending_ops: Vec::new(),
             oldest_pending: None,
             in_flight_flushes: Vec::new(),
         }
+    }
+
+    pub(crate) fn start_runner_pre_spawn_attribution(
+        &mut self,
+        attribution: RunnerPreSpawnAttribution,
+    ) {
+        self.runner_pre_spawn_attribution = Some(attribution);
+    }
+
+    /// Stop decorating operations after the success-only `api_to_spawn` boundary.
+    pub(crate) fn finish_runner_pre_spawn_attribution(&mut self) {
+        self.runner_pre_spawn_attribution = None;
     }
 
     /// Record a timed operation. Starts an owned auto-flush if the oldest
@@ -212,7 +271,11 @@ impl JobTelemetry {
         ));
     }
 
-    fn push_operation(&mut self, operation: SandboxOp) {
+    fn push_operation(&mut self, mut operation: SandboxOp) {
+        operation.runner_pre_spawn_concurrency_bucket = self
+            .runner_pre_spawn_attribution
+            .as_ref()
+            .and_then(RunnerPreSpawnAttribution::active_bucket);
         self.pending_ops.push(operation);
         if self.oldest_pending.is_none() {
             self.oldest_pending = Some(Instant::now());
@@ -313,6 +376,7 @@ impl JobTelemetry {
                 action_type: op.action_type.clone(),
                 runner_startup_path: op.runner_startup_path,
                 sandbox_reuse_result: op.sandbox_reuse_result,
+                runner_pre_spawn_concurrency_bucket: op.runner_pre_spawn_concurrency_bucket,
             })
             .collect()
     }
@@ -417,6 +481,7 @@ pub(crate) struct RunnerStartupTelemetrySnapshot {
     pub(crate) action_type: String,
     pub(crate) runner_startup_path: Option<RunnerStartupPath>,
     pub(crate) sandbox_reuse_result: Option<SandboxReuseResult>,
+    pub(crate) runner_pre_spawn_concurrency_bucket: Option<RunnerPreSpawnConcurrencyBucket>,
 }
 
 fn sandbox_op(
@@ -457,6 +522,7 @@ fn sandbox_op_at(
         reason: None,
         runner_startup_path: None,
         sandbox_reuse_result: None,
+        runner_pre_spawn_concurrency_bucket: None,
         session_history: metadata.map(SessionHistoryTelemetryFields::from),
     }
 }
@@ -549,6 +615,7 @@ mod tests {
             reason: None,
             runner_startup_path: None,
             sandbox_reuse_result: None,
+            runner_pre_spawn_concurrency_bucket: None,
             session_history: None,
         };
         let json = serde_json::to_value(&op).unwrap();
@@ -635,6 +702,9 @@ mod tests {
             "tok".to_string(),
             "test-runner".to_string(),
         );
+        telemetry.start_runner_pre_spawn_attribution(RunnerPreSpawnAttribution::new(
+            RunnerPreSpawnConcurrencyBucket::ThreeToFour,
+        ));
         telemetry.record_api_to_spawn(
             Duration::from_millis(125),
             RunnerStartupPath::Workspace,
@@ -650,6 +720,7 @@ mod tests {
                 "success": true,
                 "runner_startup_path": "workspace",
                 "sandbox_reuse_result": "poolMiss",
+                "runner_pre_spawn_concurrency_bucket": "3_4",
             })
         );
     }
@@ -676,6 +747,7 @@ mod tests {
                 reason: None,
                 runner_startup_path: None,
                 sandbox_reuse_result: None,
+                runner_pre_spawn_concurrency_bucket: None,
                 session_history: Some(metadata.into()),
             }],
         };

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2077,7 +2077,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     ).toBeFalsy();
   });
 
-  it("attributes sandbox operation telemetry to the optional runner name", async () => {
+  it("attributes sandbox operation telemetry to optional runner dimensions", async () => {
     const { runId, headers } = await createEventWebhookRun(
       `runner-name telemetry ${randomUUID()}`,
     );
@@ -2093,6 +2093,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
             action_type: "runner_name_attribution",
             duration_ms: 12,
             success: true,
+            runner_pre_spawn_concurrency_bucket: "3_4",
           },
         ],
       },
@@ -2108,6 +2109,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
           run_id: runId,
           op_type: "runner_name_attribution",
           runner_name: "v0.168.14",
+          runner_pre_spawn_concurrency_bucket: "3_4",
         }),
       ],
     );
@@ -2135,6 +2137,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
       [
         expect.not.objectContaining({
           runner_name: expect.anything(),
+          runner_pre_spawn_concurrency_bucket: expect.anything(),
         }),
       ],
     );

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -4,6 +4,7 @@ import {
   webhookModelUsageObservationContract,
   webhookTelemetryContract,
   webhookUsageEventContract,
+  type RunnerPreSpawnConcurrencyBucket,
   type RunnerStartupPath,
   type SandboxReuseResult,
 } from "@okouai/api-contracts/contracts/webhooks";
@@ -50,6 +51,7 @@ interface SandboxOperationDimensionInput {
   readonly reason?: string;
   readonly runner_startup_path?: RunnerStartupPath;
   readonly sandbox_reuse_result?: SandboxReuseResult;
+  readonly runner_pre_spawn_concurrency_bucket?: RunnerPreSpawnConcurrencyBucket;
   readonly encoding?: string;
   readonly session_history_raw_size_bucket?: string;
   readonly session_history_encoded_size_bucket?: string;
@@ -77,6 +79,12 @@ function sandboxOperationDimensions(
       : {}),
     ...(op.sandbox_reuse_result
       ? { sandbox_reuse_result: op.sandbox_reuse_result }
+      : {}),
+    ...(op.runner_pre_spawn_concurrency_bucket
+      ? {
+          runner_pre_spawn_concurrency_bucket:
+            op.runner_pre_spawn_concurrency_bucket,
+        }
       : {}),
     ...(op.encoding ? { encoding: op.encoding } : {}),
     ...(op.session_history_raw_size_bucket

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -369,6 +369,53 @@ describe("webhook telemetry contract", () => {
     ).toBe(false);
   });
 
+  it("accepts bounded runner pre-spawn concurrency and keeps it optional", () => {
+    const buckets = ["1", "2", "3_4", "5_8", "9_plus"] as const;
+    const result = webhookTelemetryContract.send.body.parse({
+      runId: "00000000-0000-4000-8000-000000000000",
+      sandboxOperations: [
+        ...buckets.map((bucket) => {
+          return {
+            ts: "2026-01-15T10:00:00.000Z",
+            action_type: "runner_claim_to_spawn",
+            duration_ms: 10,
+            success: true,
+            runner_pre_spawn_concurrency_bucket: bucket,
+          };
+        }),
+        {
+          ts: "2026-01-15T10:00:00.000Z",
+          action_type: "agent_execute",
+          duration_ms: 20,
+          success: true,
+        },
+      ],
+    });
+
+    expect(
+      result.sandboxOperations?.slice(0, buckets.length).map((operation) => {
+        return operation.runner_pre_spawn_concurrency_bucket;
+      }),
+    ).toStrictEqual(buckets);
+    expect(result.sandboxOperations?.at(-1)).not.toHaveProperty(
+      "runner_pre_spawn_concurrency_bucket",
+    );
+    expect(
+      webhookTelemetryContract.send.body.safeParse({
+        runId: "00000000-0000-4000-8000-000000000000",
+        sandboxOperations: [
+          {
+            ts: "2026-01-15T10:00:00.000Z",
+            action_type: "runner_claim_to_spawn",
+            duration_ms: 10,
+            success: true,
+            runner_pre_spawn_concurrency_bucket: "10_plus",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts known session history download sources", () => {
     const result = webhookTelemetryContract.send.body.safeParse({
       runId: "00000000-0000-4000-8000-000000000000",

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -847,6 +847,18 @@ export const runnerStartupPathSchema = z.enum(["sandbox", "workspace", "cold"]);
 
 export type RunnerStartupPath = z.infer<typeof runnerStartupPathSchema>;
 
+const runnerPreSpawnConcurrencyBucketSchema = z.enum([
+  "1",
+  "2",
+  "3_4",
+  "5_8",
+  "9_plus",
+]);
+
+export type RunnerPreSpawnConcurrencyBucket = z.infer<
+  typeof runnerPreSpawnConcurrencyBucketSchema
+>;
+
 /**
  * Sandbox operation schema for internal sandbox operations (init, storage, cli, checkpoint, cleanup)
  */
@@ -860,6 +872,8 @@ const sandboxOperationSchema = z.object({
   reason: z.string().max(64).optional(),
   runner_startup_path: runnerStartupPathSchema.optional(),
   sandbox_reuse_result: sandboxReuseResultSchema.optional(),
+  runner_pre_spawn_concurrency_bucket:
+    runnerPreSpawnConcurrencyBucketSchema.optional(),
   encoding: sessionHistoryEncodingSchema.optional(),
   session_history_raw_size_bucket: sessionHistorySizeBucketSchema.optional(),
   session_history_encoded_size_bucket:


### PR DESCRIPTION
## Summary

- measure each claimed job's inclusive Runner-local pre-spawn concurrency cohort with bounded buckets
- attach the cohort to startup telemetry through `api_to_spawn`, while releasing live membership at guest process spawn or any earlier failure
- accept and forward the optional low-cardinality dimension through the webhook contract into Axiom

## Compatibility and scope

- the webhook field is optional, so existing runners remain compatible
- the change does not alter scheduling, admission, queueing, concurrency limits, or persisted database state
- API-first deployment avoids temporarily dropping the new field from newer Runner payloads

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner --quiet` (3236 passed, 20 ignored; integration test passed)
- `cargo test -p runner executor::tests::telemetry_tests::execute_job_attributes_overlapping_pre_spawn_work_and_releases_membership -- --exact`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/webhooks.ts packages/api-contracts/src/contracts/__tests__/webhooks.test.ts apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm knip --workspace @okouai/api-contracts --workspace api`
- pre-commit hooks: full Turbo Knip and type checks, Rust fmt, docs, and Clippy

Closes #28824

Parent context: #24203
