### PR TITLE
feat: roll out chat quote-only feedback to all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,6 +15,9 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ChatQuoteOnlyFeedback, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -106,7 +109,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -142,7 +144,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatForward]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -409,8 +409,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Allow quoted assistant passages to be sent without an added user comment.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",


### PR DESCRIPTION
## Summary

Roll `chatQuoteOnlyFeedback` out to 100%. The switch was introduced in #27888 (`fix: allow quote-only feedback messages`) as `enabled: false` + `STAFF_ORG_ID_HASHES`; it has been staff-only since. This flips it to `enabled: true` and drops the staff org gate, so every user can send a quoted assistant passage without typing an accompanying comment.

## Changes

- `turbo/packages/core/src/feature-switch.ts` — `ChatQuoteOnlyFeedback` becomes `enabled: true`, `enabledOrgIdHashes` removed.
- `turbo/packages/core/src/__tests__/feature-switch.test.ts` — moved the key out of the staff-org rollout matrix (both the staff and non-staff halves) and into the globally-enabled assertion, matching how previous rollouts were recorded (#25320, #25586).

No product code changes. The server side (`chat-user-message.service.ts`, the `note` array schema in `api-contracts`) was never gated, so this only removes the client-side gate.

## Verification

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed.
- Because `page-helper.ts` resolves platform test switches through the real `getAllFeatureStates` registry, this flip changes the default for platform tests too. Re-ran the affected suites:
  - `chat-inline-feedback.test.tsx` — 32 passed
  - `user-message-document-codec.test.ts` — 11 passed
  - `chat-draft.test.tsx`, `chat-user-messages.test.tsx`, `chat-event-action-cards.test.tsx` — 80 passed
- `pnpm exec prettier --write` on the changed files (unchanged), `pnpm -F @okouai/core run lint`, `pnpm -F @okouai/core run check-types` — all clean.
- `git diff --check` — clean.
- Full suite left to the PR pipeline.

## Follow-up

The switch removal is stacked on this branch as a separate PR; merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)