### PR TITLE
docs(python): clarify model-provider failure shutdown delivery semantics

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -473,7 +473,12 @@ def release_flow(flow: http.HTTPFlow) -> None:
 
 
 def shutdown() -> None:
-    """Stop admitting reports and drain already-submitted best-effort work."""
+    """Stop admitting reports, cancel queued work, and give running deliveries a bounded wait.
+
+    Reports still queued in the executor are cancelled. Reports already running get at most
+    ``_REPORT_TIMEOUT_SECONDS`` to finish; cancellation or timeout may leave a failure report
+    undelivered, so proxy shutdown does not wait indefinitely for it.
+    """
     global _reporter_shut_down
     configure_reporting(api_url="", bearer_credential="")
     with _report_lock:


### PR DESCRIPTION
## Summary

- Clarify that `shutdown()` stops admission and cancels reports still queued in the executor.
- Document that only already-running deliveries receive a bounded wait and may remain undelivered after cancellation or timeout.

## Scope

This is a documentation-only change to the model-provider failure reporter. It does not change executor behavior, timeout values, omission logging, tests, APIs, dependencies, or rollout behavior.

Closes #28833

## Validation

From `crates/runner/mitm-addon`:

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py` (86 passed)
- `uv run --no-sync python -m pytest tests/` (6541 passed, 59 existing warnings)
