### PR TITLE
test(python): cover malformed registry routing metadata

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -395,10 +395,6 @@ def _validate_connector_routing_variables(vm: dict) -> None:
     if not isinstance(routing_variables, dict):
         raise TypeError("proxy registry VM entry connectorRoutingVariables must be an object")
     for identity, values in routing_variables.items():
-        if not isinstance(identity, str):
-            raise TypeError(
-                "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
-            )
         if not identity.startswith(("builtin:", "custom:")):
             raise ValueError(
                 "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
@@ -409,7 +405,7 @@ def _validate_connector_routing_variables(vm: dict) -> None:
                 "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
             )
         if not isinstance(values, dict) or any(
-            not isinstance(key, str) or not isinstance(value, str) for key, value in values.items()
+            not isinstance(value, str) for value in values.values()
         ):
             raise TypeError(
                 "proxy registry VM entry connectorRoutingVariables values must be string maps"

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -67,6 +67,166 @@ class TestLoadRegistry:
         assert state.invalid_vms["10.200.0.6"].reason == "empty_run_id"
         assert state.invalid_vms["10.200.0.7"].reason == "invalid_run_id"
 
+    @pytest.mark.parametrize(
+        ("vm_fields", "expected_reason", "expected_message"),
+        [
+            pytest.param(
+                {"omittedBuiltinFirewalls": "github"},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedBuiltinFirewalls must be a string list",
+                id="builtin-omissions-not-list",
+            ),
+            pytest.param(
+                {"omittedBuiltinFirewalls": [""]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedBuiltinFirewalls must be a string list",
+                id="builtin-omissions-empty-member",
+            ),
+            pytest.param(
+                {"omittedBuiltinFirewalls": [1]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedBuiltinFirewalls must be a string list",
+                id="builtin-omissions-non-string-member",
+            ),
+            pytest.param(
+                {"omittedBuiltinFirewalls": ["github", "github"]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedBuiltinFirewalls must be unique",
+                id="builtin-omissions-duplicate",
+            ),
+            pytest.param(
+                {"omittedCustomConnectorIds": "connector-1"},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedCustomConnectorIds must be a string list",
+                id="custom-omissions-not-list",
+            ),
+            pytest.param(
+                {"omittedCustomConnectorIds": [""]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedCustomConnectorIds must be a string list",
+                id="custom-omissions-empty-member",
+            ),
+            pytest.param(
+                {"omittedCustomConnectorIds": [1]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedCustomConnectorIds must be a string list",
+                id="custom-omissions-non-string-member",
+            ),
+            pytest.param(
+                {"omittedCustomConnectorIds": ["connector-1", "connector-1"]},
+                "invalid_omitted_intents",
+                "proxy registry VM entry omittedCustomConnectorIds must be unique",
+                id="custom-omissions-duplicate",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": []},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables must be an object",
+                id="routing-variables-not-object",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"github": {}}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector",
+                id="routing-identity-unsupported",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"builtin:": {}}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector",
+                id="builtin-routing-identity-empty",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"custom:": {}}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector",
+                id="custom-routing-identity-empty",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"builtin:github": []}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables values must be string maps",
+                id="routing-variable-map-not-object",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"builtin:github": {"HOST": 1}}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables values must be string maps",
+                id="routing-variable-value-not-string",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"builtin:github": {"": "example.test"}}},
+                "invalid_connector_routing_variables",
+                "proxy registry VM entry connectorRoutingVariables values must be string maps",
+                id="routing-variable-key-empty",
+            ),
+        ],
+    )
+    def test_rejects_invalid_routing_metadata(
+        self,
+        tmp_path,
+        vm_fields,
+        expected_reason,
+        expected_message,
+    ):
+        path = tmp_path / "registry.json"
+        vm = {
+            "runId": "run-active",
+            "billableFirewalls": [],
+            "cliAgentType": "claude-code",
+            **vm_fields,
+        }
+        path.write_text(json.dumps({"vms": {"10.200.0.1": vm}, "updatedAt": 0}))
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            state = registry.load_registry_state(str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert state.vms == {}
+        assert set(state.invalid_vms) == {"10.200.0.1"}
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == expected_reason
+        assert invalid_vm.message == expected_message
+
+    @pytest.mark.parametrize(
+        "vm_fields",
+        [
+            pytest.param({}, id="metadata-absent"),
+            pytest.param(
+                {
+                    "omittedBuiltinFirewalls": [],
+                    "omittedCustomConnectorIds": [],
+                    "connectorRoutingVariables": {},
+                },
+                id="metadata-empty",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"builtin:github": {"HOST": "example.test"}}},
+                id="builtin-routing-identity",
+            ),
+            pytest.param(
+                {"connectorRoutingVariables": {"custom:connector-1": {"HOST": "example.test"}}},
+                id="custom-routing-identity",
+            ),
+        ],
+    )
+    def test_accepts_valid_routing_metadata(self, tmp_path, vm_fields):
+        path = tmp_path / "registry.json"
+        vm = {
+            "runId": "run-active",
+            "billableFirewalls": [],
+            "cliAgentType": "claude-code",
+            **vm_fields,
+        }
+        path.write_text(json.dumps({"vms": {"10.200.0.1": vm}, "updatedAt": 0}))
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            state = registry.load_registry_state(str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.vms) == {"10.200.0.1"}
+        assert state.invalid_vms == {}
+
     def test_missing_file_returns_empty(self, tmp_path):
         missing = str(tmp_path / "nonexistent.json")
         with patch.object(registry.ctx, "log", MagicMock(), create=True):

--- a/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
@@ -318,11 +318,49 @@ async def test_invalid_billable_firewalls_blocks_before_auth_injection(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
-async def test_invalid_connector_routing_variables_block_before_auth_injection(
+@pytest.mark.parametrize(
+    ("vm_fields", "expected_reason", "expected_message"),
+    [
+        pytest.param(
+            {"omittedBuiltinFirewalls": [1]},
+            "invalid_omitted_intents",
+            "proxy registry VM entry omittedBuiltinFirewalls must be a string list",
+            id="omitted-intent-string-list",
+        ),
+        pytest.param(
+            {"omittedCustomConnectorIds": ["connector-1", "connector-1"]},
+            "invalid_omitted_intents",
+            "proxy registry VM entry omittedCustomConnectorIds must be unique",
+            id="omitted-intent-unique",
+        ),
+        pytest.param(
+            {"connectorRoutingVariables": []},
+            "invalid_connector_routing_variables",
+            "proxy registry VM entry connectorRoutingVariables must be an object",
+            id="routing-variables-object",
+        ),
+        pytest.param(
+            {"connectorRoutingVariables": {"github": {}}},
+            "invalid_connector_routing_variables",
+            "proxy registry VM entry connectorRoutingVariables keys must identify a connector",
+            id="routing-identity",
+        ),
+        pytest.param(
+            {"connectorRoutingVariables": {"builtin:github": {"HOST": 1}}},
+            "invalid_connector_routing_variables",
+            "proxy registry VM entry connectorRoutingVariables values must be string maps",
+            id="routing-variable-map",
+        ),
+    ],
+)
+async def test_invalid_routing_metadata_blocks_before_auth_injection(
     tmp_path,
     real_flow,
     mitm_ctx,
     fake_firewall_headers,
+    vm_fields,
+    expected_reason,
+    expected_message,
 ):
     vm_info = _single_firewall_vm(
         tmp_path,
@@ -337,7 +375,7 @@ async def test_invalid_connector_routing_variables_block_before_auth_injection(
             "ask": [],
             "unknownPolicy": "allow",
         },
-        vm_fields={"connectorRoutingVariables": {"github": {"HOST": "example.test"}}},
+        vm_fields=vm_fields,
     )
     reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
     flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
@@ -352,12 +390,17 @@ async def test_invalid_connector_routing_variables_block_before_auth_injection(
     assert flow.response.status_code == 503
     assert json.loads(flow.response.content) == {
         "error": "invalid_registry_vm",
-        "message": (
-            "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
-        ),
-        "reason": "invalid_connector_routing_variables",
+        "message": expected_message,
+        "reason": expected_reason,
     }
     auth_fetch.assert_not_called()
+    assert flow.request.headers.get("Authorization") is None
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.CLI_AGENT_TYPE not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_AUTH_CACHE_KEY not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- remove connector-routing key type guards that cannot be reached through JSON-decoded registry input
- cover every externally representable malformed omitted-intent and routing-variable shape through `load_registry_state()`
- verify representative malformed entries return fail-closed `503 invalid_registry_vm` responses before auth or cache metadata is attached
- retain accepted controls for absent, empty, built-in, and custom routing metadata

## Scope

This preserves the existing registry wire fields, response shape, and downstream auth/classification behavior. It does not introduce a registry schema abstraction or test private validator functions.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_registry_loading.py tests/test_request_handler_registry_admission.py -v` (75 passed)
- `uv run --no-sync python -m pytest tests/` (6564 passed)

Closes #28836
