### PR TITLE
perf(python): avoid duplicate responses sse type probes

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -819,9 +819,10 @@ class _OpenAIResponsesSseUsageHandler:
         if self._eventless_prefix is not None:
             prefix = bytes(self._eventless_prefix)
             self._eventless_prefix = None
-            event_type = _classify_responses_event_type(prefix)
+            probe = _probe_responses_event_type(prefix)
+            event_type = _classify_responses_event_type_result(probe)
             observed_event_name = (
-                _observed_responses_event_type(_probe_responses_event_type(prefix))
+                _observed_responses_event_type(probe)
                 if self._failure_observer is not None
                 and event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE
                 else None
@@ -977,12 +978,11 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._named_event_prefix = None
-        event_type = _classify_responses_event_type(prefix_bytes)
+        probe = _probe_responses_event_type(prefix_bytes)
+        event_type = _classify_responses_event_type_result(probe)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE and not (
             self._failure_observer is not None
-            and self._failure_observer.needs_sse_event(
-                _observed_responses_event_type(_probe_responses_event_type(prefix_bytes))
-            )
+            and self._failure_observer.needs_sse_event(_observed_responses_event_type(probe))
         ):
             self._discard_named_event = True
             return

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -6,6 +6,24 @@ import usage.openai_responses as openai_responses
 from usage import (
     create_openai_responses_sse_usage_extractor,
 )
+from usage.model_http import ModelHttpFailureEvidence
+
+
+class _IgnoringDeltaFailureObserver:
+    def __init__(self) -> None:
+        self.observed: list[ModelHttpFailureEvidence] = []
+
+    def needs_sse_event(self, event_name: str | None) -> bool:
+        return event_name != "response.output_text.delta"
+
+    def observe(self, evidence: ModelHttpFailureEvidence) -> None:
+        self.observed.append(evidence)
+
+    def observe_json(self, evidence: ModelHttpFailureEvidence) -> None:
+        self.observed.append(evidence)
+
+    def finish(self) -> None:
+        return None
 
 
 class TestOpenAIResponsesSseUsageExtractor:
@@ -615,7 +633,7 @@ class TestOpenAIResponsesSseUsageExtractor:
             pytest.param(b"event: response.completed\n", id="named"),
         ],
     )
-    def test_tiny_chunks_classify_late_terminal_type_once(self, event_prefix, monkeypatch):
+    def test_tiny_chunks_probe_late_terminal_type_once(self, event_prefix, monkeypatch):
         metadata = b",".join(f'"key_{index}":{index}'.encode() for index in range(250))
         payload = (
             b"{"
@@ -625,17 +643,17 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert len(payload) < openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES
 
-        real_classify = openai_responses._classify_responses_event_type
-        classified_prefixes: list[bytes] = []
+        real_probe = openai_responses._probe_responses_event_type
+        probed_prefixes: list[bytes] = []
 
-        def track_classification(body: bytes):
-            classified_prefixes.append(body)
-            return real_classify(body)
+        def track_probe(body: bytes):
+            probed_prefixes.append(body)
+            return real_probe(body)
 
         monkeypatch.setattr(
             openai_responses,
-            "_classify_responses_event_type",
-            track_classification,
+            "_probe_responses_event_type",
+            track_probe,
         )
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(event_prefix + b"data: ")
@@ -644,7 +662,45 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse(b"\n\n")
 
         assert usage == {"model": "gpt-5.6", "tokens.output": 17}
-        assert classified_prefixes == [payload]
+        assert probed_prefixes == [payload]
+
+    @pytest.mark.parametrize(
+        ("event_prefix", "payload"),
+        [
+            pytest.param(
+                b"",
+                b'{"type":"response.output_text.delta","delta":"hello"}',
+                id="eventless-event-end",
+            ),
+            pytest.param(
+                b"event: vendor.delta\n",
+                b'{"type":"response.output_text.delta","padding":"'
+                + b"x" * openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES
+                + b'"}',
+                id="named-prefix-cap",
+            ),
+        ],
+    )
+    def test_failure_filter_probes_known_non_usage_prefix_once(
+        self, event_prefix, payload, monkeypatch
+    ):
+        real_probe = openai_responses._probe_responses_event_type
+        probed_prefixes: list[bytes] = []
+
+        def track_probe(body: bytes):
+            probed_prefixes.append(body)
+            return real_probe(body)
+
+        monkeypatch.setattr(openai_responses, "_probe_responses_event_type", track_probe)
+        failure_observer = _IgnoringDeltaFailureObserver()
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            failure_observer=failure_observer
+        )
+        parse(event_prefix + b"data: " + payload + b"\n\n")
+
+        assert probed_prefixes == [payload[: openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES]]
+        assert usage == {}
+        assert failure_observer.observed == []
 
     def test_eventless_incomplete_terminal_reports_parse_error(self):
         parse_errors: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary

- retain each bounded OpenAI Responses SSE `type` probe result long enough to derive both classification and the observed body event name
- remove duplicate prefix scans from small eventless known non-usage events and prefix-capped named events when failure reporting is active
- count the production prefilter at parser entry points for both regression paths while preserving ordinary-delta discard behavior

## Exclusions

- no changes to usage or failure-classification state machines
- no changes to the 4 KiB prefilter bound or JSON probe grammar
- no API, database, persisted-state, queue-payload, runner-protocol, or deployment-order changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_openai_responses_sse.py tests/test_model_provider_failure_reporting.py` (159 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6543 passed)

Closes #28837
