### PR TITLE
fix(api): refresh codex token before reset credit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -771,6 +773,78 @@ describe("MODEL-PROVIDER: device auth boundaries", () => {
       id: completedC.body.provider.id,
       isActive: true,
     });
+
+    await support.deletePersonalModelProvider(
+      member,
+      "codex-oauth-token",
+      [204],
+    );
+  });
+
+  it("refreshes and resets the requested inactive Codex account", async () => {
+    const member = bdd.user({ orgRole: "org:member" });
+    await support.updateFeatureSwitches(member, {
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+    });
+    const currentSeconds = Math.floor(now() / 1000);
+    const requestedAccountId = await connectPersonalCodexTestAccount(member, {
+      accessTokenExpiresAt: currentSeconds - 60,
+      accountId: "codex-reset-requested-account",
+      refreshToken: "rt_codex_reset_requested_account",
+      workspaceName: "Reset Requested Account",
+    });
+    const activeAccountId = await connectPersonalCodexTestAccount(member, {
+      accessTokenExpiresAt: currentSeconds + 7200,
+      accountId: "codex-reset-active-account",
+      refreshToken: "rt_codex_reset_active_account",
+      workspaceName: "Reset Active Account",
+    });
+    await support.activatePersonalModelProviderAccount(member, activeAccountId);
+
+    const idempotencyKey = randomUUID();
+    const refreshedAccessToken = "fresh-requested-reset-access-token";
+    let refreshCalls = 0;
+    let consumeCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async ({ request }) => {
+        refreshCalls += 1;
+        await expect(request.json()).resolves.toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: "rt_codex_reset_requested_account",
+        });
+        return HttpResponse.json({
+          access_token: refreshedAccessToken,
+          refresh_token: "rotated-requested-reset-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+      http.post(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        async ({ request }) => {
+          consumeCalls += 1;
+          expect(request.headers.get("authorization")).toBe(
+            `Bearer ${refreshedAccessToken}`,
+          );
+          expect(request.headers.get("chatgpt-account-id")).toBe(
+            "codex-reset-requested-account",
+          );
+          await expect(request.json()).resolves.toStrictEqual({
+            redeem_request_id: idempotencyKey,
+          });
+          return HttpResponse.json({ code: "reset", windows_reset: 2 });
+        },
+      ),
+    );
+
+    const reset = await support.resetPersonalModelProviderAccount(
+      member,
+      requestedAccountId,
+      idempotencyKey,
+      [200],
+    );
+    expect(reset.body).toStrictEqual({ outcome: "reset" });
+    expect(refreshCalls).toBe(1);
+    expect(consumeCalls).toBe(1);
 
     await support.deletePersonalModelProvider(
       member,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
@@ -128,6 +128,24 @@ export function createAuthDeviceSupportApi(context: TestContext) {
       );
     },
 
+    async resetPersonalModelProviderAccount(
+      actor: ApiTestUser,
+      id: string,
+      idempotencyKey: string,
+      statuses: readonly (200 | 400 | 401 | 404 | 500)[],
+    ) {
+      return await accept(
+        authDeviceSupportApp(context)(
+          personalModelProviderAccountsByIdContract,
+        ).resetSubscriptionUsage({
+          headers: authenticate(context, actor),
+          params: { id },
+          body: { idempotencyKey },
+        }),
+        statuses,
+      );
+    },
+
     async deletePersonalModelProviderAccount(
       actor: ApiTestUser,
       id: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 
 import {
+  personalModelProviderAccountsByIdContract,
   personalModelProvidersByTypeContract,
   personalModelProvidersMainContract,
 } from "@okouai/api-contracts/contracts/personal-model-providers";
@@ -11,10 +12,11 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
-import { now } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import { createRouteMocks } from "./helpers/route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { readUserSecrets } from "./helpers/user-config-state";
+import { meModelProviderAccountRoutes } from "../me-model-provider-accounts";
 import { meModelProvidersDeleteRoutes } from "../me-model-providers-delete";
 import { meModelProvidersListRoutes } from "../me-model-providers-list";
 import { meModelProvidersResetSubscriptionRoutes } from "../me-model-providers-reset-subscription";
@@ -28,6 +30,10 @@ const personalModelProvidersMainTestRoutes = Object.freeze([
 const personalModelProvidersByTypeTestRoutes = Object.freeze([
   ...meModelProvidersDeleteRoutes,
   ...meModelProvidersResetSubscriptionRoutes,
+]);
+
+const personalModelProviderAccountsByIdTestRoutes = Object.freeze([
+  ...meModelProviderAccountRoutes,
 ]);
 
 const context = testContext();
@@ -498,6 +504,236 @@ describe("POST /api/me/model-providers (upsert)", () => {
     );
 
     expect(response.body).toStrictEqual({ outcome: "reset" });
+  });
+
+  it("refreshes an expired Codex token before consuming a reset credit", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-reset-refresh");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const connectedAt = now();
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: 3600 });
+    const idempotencyKey = randomUUID();
+    const refreshedAccessToken = "fresh-reset-chatgpt-access-token";
+    let refreshCalls = 0;
+    let consumeCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", async ({ request }) => {
+        refreshCalls += 1;
+        await expect(request.json()).resolves.toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: authJson.refreshToken,
+        });
+        return HttpResponse.json({
+          access_token: refreshedAccessToken,
+          refresh_token: "rotated-reset-chatgpt-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        return HttpResponse.json(codexUsageResponse());
+      }),
+      http.post(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        async ({ request }) => {
+          consumeCalls += 1;
+          expect(request.headers.get("authorization")).toBe(
+            `Bearer ${refreshedAccessToken}`,
+          );
+          expect(request.headers.get("chatgpt-account-id")).toBe(
+            authJson.accountId,
+          );
+          await expect(request.json()).resolves.toStrictEqual({
+            redeem_request_id: idempotencyKey,
+          });
+          return HttpResponse.json({ code: "reset", windows_reset: 2 });
+        },
+      ),
+    );
+
+    const mainClient = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    await accept(
+      mainClient.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    mockNow(connectedAt + 2 * 3_600_000);
+
+    const byTypeClient = setupApp({
+      context,
+      routes: personalModelProvidersByTypeTestRoutes,
+    })(personalModelProvidersByTypeContract);
+    const response = await accept(
+      byTypeClient.resetSubscriptionUsage({
+        params: { type: "codex-oauth-token" },
+        body: { idempotencyKey },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ outcome: "reset" });
+    expect(refreshCalls).toBe(1);
+    expect(consumeCalls).toBe(1);
+  });
+
+  it("does not consume a reset credit after terminal Codex refresh failure", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-reset-terminal");
+    await enablePersonalModelProviderAccounts(fixture);
+    const connectedAt = now();
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: 3600 });
+    let refreshCalls = 0;
+    let consumeCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCalls += 1;
+        return HttpResponse.json(
+          {
+            error: {
+              code: "refresh_token_expired",
+              message: "refresh token expired",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        return HttpResponse.json(codexUsageResponse());
+      }),
+      http.post(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        () => {
+          consumeCalls += 1;
+          return HttpResponse.json({ code: "reset", windows_reset: 2 });
+        },
+      ),
+    );
+
+    const mainClient = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    const connected = await accept(
+      mainClient.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    mockNow(connectedAt + 2 * 3_600_000);
+
+    const accountClient = setupApp({
+      context,
+      routes: personalModelProviderAccountsByIdTestRoutes,
+    })(personalModelProviderAccountsByIdContract);
+    const failed = await accept(
+      accountClient.resetSubscriptionUsage({
+        params: { id: connected.body.provider.id },
+        body: { idempotencyKey: randomUUID() },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+    expect(failed.status).toBe(500);
+
+    const listed = await accept(
+      mainClient.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(listed.body.modelProviders[0]).toMatchObject({
+      id: connected.body.provider.id,
+      needsReconnect: true,
+      lastRefreshErrorCode: "refresh_token_expired",
+    });
+    expect(refreshCalls).toBe(1);
+    expect(consumeCalls).toBe(0);
+  });
+
+  it("retries reset after transient Codex refresh failure", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-reset-transient");
+    await enablePersonalModelProviderAccounts(fixture);
+    const connectedAt = now();
+    const authJson = makeAuthJsonFixture({ accessExpiresInSeconds: 3600 });
+    const idempotencyKey = randomUUID();
+    const refreshedAccessToken = "recovered-reset-chatgpt-access-token";
+    let refreshCalls = 0;
+    let consumeCalls = 0;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        refreshCalls += 1;
+        if (refreshCalls === 1) {
+          return HttpResponse.json(
+            { error: "temporarily_unavailable" },
+            { status: 503 },
+          );
+        }
+        return HttpResponse.json({
+          access_token: refreshedAccessToken,
+          refresh_token: "recovered-reset-chatgpt-refresh-token",
+          expires_in: 3600,
+        });
+      }),
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        return HttpResponse.json(codexUsageResponse());
+      }),
+      http.post(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        ({ request }) => {
+          consumeCalls += 1;
+          expect(request.headers.get("authorization")).toBe(
+            `Bearer ${refreshedAccessToken}`,
+          );
+          return HttpResponse.json({ code: "reset", windows_reset: 2 });
+        },
+      ),
+    );
+
+    const mainClient = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    const connected = await accept(
+      mainClient.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: authJson.raw },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+    mockNow(connectedAt + 2 * 3_600_000);
+
+    const accountClient = setupApp({
+      context,
+      routes: personalModelProviderAccountsByIdTestRoutes,
+    })(personalModelProviderAccountsByIdContract);
+    const reset = () => {
+      return accountClient.resetSubscriptionUsage({
+        params: { id: connected.body.provider.id },
+        body: { idempotencyKey },
+        headers: { authorization: "Bearer clerk-session" },
+      });
+    };
+    const unavailable = await accept(reset(), [500]);
+    expect(unavailable.status).toBe(500);
+
+    const recovered = await accept(reset(), [200]);
+    expect(recovered.body).toStrictEqual({ outcome: "reset" });
+    expect(refreshCalls).toBe(2);
+    expect(consumeCalls).toBe(1);
   });
 
   it("coalesces concurrent refreshes for an expired Codex account", async () => {

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -49,37 +49,6 @@ type SerializedSubscriptionUsage = NonNullable<
   ModelProviderResponse["subscriptionUsage"]
 >;
 
-async function resolveCurrentCodexAccessToken(
-  args: {
-    readonly db: Db;
-    readonly orgId: string;
-    readonly userId: string;
-    readonly modelProviderAccountId?: string;
-    readonly featureSwitchContext: FeatureSwitchContext;
-  },
-  signal: AbortSignal,
-) {
-  return await resolveCurrentModelProviderRuntimeSecretForApi(
-    {
-      db: args.db,
-      orgId: args.orgId,
-      userId: args.userId,
-      key: "CHATGPT_ACCESS_TOKEN",
-      providerKey: "codex-oauth-token",
-      metadata: {
-        sourceType: "model-provider",
-        sourceUserId: args.userId,
-        ...(args.modelProviderAccountId
-          ? { sourceId: args.modelProviderAccountId }
-          : {}),
-        metadataKey: "codex-oauth-token",
-      },
-      featureSwitchContext: args.featureSwitchContext,
-    },
-    signal,
-  );
-}
-
 async function modelProviderSecretValues(
   args: {
     readonly db: ReadonlyDb;
@@ -204,15 +173,21 @@ async function refreshCodexProvider(
   },
   signal: AbortSignal,
 ): Promise<ModelProviderResponse> {
+  const accountMetadata = {
+    sourceType: "model-provider" as const,
+    sourceUserId: args.userId,
+    ...(args.provider.modelProviderId ? { sourceId: args.provider.id } : {}),
+    metadataKey: args.provider.type,
+  };
   const [accessTokenResult, secretValues] = await Promise.all([
-    resolveCurrentCodexAccessToken(
+    resolveCurrentModelProviderRuntimeSecretForApi(
       {
         db: args.db,
         orgId: args.orgId,
         userId: args.userId,
-        ...(args.provider.modelProviderId
-          ? { modelProviderAccountId: args.provider.id }
-          : {}),
+        key: "CHATGPT_ACCESS_TOKEN",
+        providerKey: args.provider.type,
+        metadata: accountMetadata,
         featureSwitchContext: args.featureSwitchContext,
       },
       signal,
@@ -421,18 +396,26 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
       return notFound("Resource not found");
     }
 
-    const accessTokenResult = await resolveCurrentCodexAccessToken(
-      {
-        db: database,
-        orgId: args.orgId,
-        userId: args.userId,
-        ...(args.modelProviderAccountId
-          ? { modelProviderAccountId: args.modelProviderAccountId }
-          : {}),
-        featureSwitchContext,
-      },
-      signal,
-    );
+    const accessTokenResult =
+      await resolveCurrentModelProviderRuntimeSecretForApi(
+        {
+          db: database,
+          orgId: args.orgId,
+          userId: args.userId,
+          key: "CHATGPT_ACCESS_TOKEN",
+          providerKey: "codex-oauth-token",
+          metadata: {
+            sourceType: "model-provider",
+            sourceUserId: args.userId,
+            ...(args.modelProviderAccountId
+              ? { sourceId: args.modelProviderAccountId }
+              : {}),
+            metadataKey: "codex-oauth-token",
+          },
+          featureSwitchContext,
+        },
+        signal,
+      );
     signal.throwIfAborted();
     if (accessTokenResult.status === "unavailable") {
       if (!accessTokenResult.reconnectState) {

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -9,7 +9,7 @@ import { modelProviderAccountSecrets } from "@okouai/db/schema/model-provider-ac
 import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
-import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
+import { type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
 import { tapError } from "../utils";
 import { resolveCurrentModelProviderRuntimeSecretForApi } from "./agent-webhook-firewall-auth.service";
@@ -32,10 +32,7 @@ const CODEX_USAGE_METADATA_SECRET_NAMES = [
   "CHATGPT_ACCOUNT_ID",
   "CHATGPT_ID_TOKEN",
 ] as const;
-const CODEX_RESET_SECRET_NAMES = [
-  "CHATGPT_ACCESS_TOKEN",
-  "CHATGPT_ACCOUNT_ID",
-] as const;
+const CODEX_RESET_METADATA_SECRET_NAMES = ["CHATGPT_ACCOUNT_ID"] as const;
 const CLAUDE_CODE_OAUTH_TOKEN_SECRET_NAME = "CLAUDE_CODE_OAUTH_TOKEN";
 
 interface SubscriptionMetadata {
@@ -51,6 +48,37 @@ interface SubscriptionMetadata {
 type SerializedSubscriptionUsage = NonNullable<
   ModelProviderResponse["subscriptionUsage"]
 >;
+
+async function resolveCurrentCodexAccessToken(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly modelProviderAccountId?: string;
+    readonly featureSwitchContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+) {
+  return await resolveCurrentModelProviderRuntimeSecretForApi(
+    {
+      db: args.db,
+      orgId: args.orgId,
+      userId: args.userId,
+      key: "CHATGPT_ACCESS_TOKEN",
+      providerKey: "codex-oauth-token",
+      metadata: {
+        sourceType: "model-provider",
+        sourceUserId: args.userId,
+        ...(args.modelProviderAccountId
+          ? { sourceId: args.modelProviderAccountId }
+          : {}),
+        metadataKey: "codex-oauth-token",
+      },
+      featureSwitchContext: args.featureSwitchContext,
+    },
+    signal,
+  );
+}
 
 async function modelProviderSecretValues(
   args: {
@@ -176,21 +204,15 @@ async function refreshCodexProvider(
   },
   signal: AbortSignal,
 ): Promise<ModelProviderResponse> {
-  const accountMetadata = {
-    sourceType: "model-provider" as const,
-    sourceUserId: args.userId,
-    ...(args.provider.modelProviderId ? { sourceId: args.provider.id } : {}),
-    metadataKey: args.provider.type,
-  };
   const [accessTokenResult, secretValues] = await Promise.all([
-    resolveCurrentModelProviderRuntimeSecretForApi(
+    resolveCurrentCodexAccessToken(
       {
         db: args.db,
         orgId: args.orgId,
         userId: args.userId,
-        key: "CHATGPT_ACCESS_TOKEN",
-        providerKey: args.provider.type,
-        metadata: accountMetadata,
+        ...(args.provider.modelProviderId
+          ? { modelProviderAccountId: args.provider.id }
+          : {}),
         featureSwitchContext: args.featureSwitchContext,
       },
       signal,
@@ -363,7 +385,7 @@ type NotFoundResponse = ReturnType<typeof notFound>;
 
 export const consumePersonalCodexRateLimitResetCredit$ = command(
   async (
-    { get },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -377,7 +399,7 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
       }
     | NotFoundResponse
   > => {
-    const database = get(db$);
+    const database = set(writeDb$);
     const featureSwitchContext = await get(
       userFeatureSwitchContext(args.orgId, args.userId),
     );
@@ -388,21 +410,42 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
         db: database,
         orgId: args.orgId,
         userId: args.userId,
-        names: CODEX_RESET_SECRET_NAMES,
+        names: CODEX_RESET_METADATA_SECRET_NAMES,
         modelProviderAccountId: args.modelProviderAccountId,
         featureSwitchContext,
       },
       signal,
     );
-    const accessToken = secretValues.get("CHATGPT_ACCESS_TOKEN");
     const accountId = secretValues.get("CHATGPT_ACCOUNT_ID");
-    if (!accessToken || !accountId) {
+    if (!accountId) {
       return notFound("Resource not found");
+    }
+
+    const accessTokenResult = await resolveCurrentCodexAccessToken(
+      {
+        db: database,
+        orgId: args.orgId,
+        userId: args.userId,
+        ...(args.modelProviderAccountId
+          ? { modelProviderAccountId: args.modelProviderAccountId }
+          : {}),
+        featureSwitchContext,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (accessTokenResult.status === "unavailable") {
+      if (!accessTokenResult.reconnectState) {
+        return notFound("Resource not found");
+      }
+      throw new Error(
+        "Codex access token unavailable for reset-credit request",
+      );
     }
 
     return await consumeCodexRateLimitResetCredit(
       {
-        accessToken,
+        accessToken: accessTokenResult.value,
         accountId,
         idempotencyKey: args.idempotencyKey,
       },


### PR DESCRIPTION
## Summary

- resolve a current Codex OAuth access token at the shared reset-credit mutation boundary
- reuse the existing exact-account refresh coordinator, rotated-token persistence, and reconnect-state handling
- preserve one downstream consume attempt with the caller's original idempotency key
- cover legacy reset, inactive exact-account reset, terminal failure, and transient recovery through API-route integration tests

## Behavior

Missing account metadata or a missing source still returns not found. Refresh failure for an existing source reaches the existing internal-error boundary; terminal failures persist reconnect state, while transient failures remain retryable. The reset-credit consume endpoint is never called unless a current token is available.

This PR does not change the public API schema and does not refresh or retry solely because the downstream consume endpoint rejects a request.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/me-model-providers-upsert.test.ts src/signals/routes/__tests__/auth-device.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit repository Prettier, Knip, type checks, and file-size checks

Closes #28844
