### PR TITLE
fix(api): restrict connector resolution warnings

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -125,6 +125,7 @@ function resolvedSlug(args: {
   ) {
     log.warn("Connector runtime capability is unavailable", {
       connectorSlug: args.connectorSlug,
+      reason: "missing_executable_capability",
     });
     return { ok: false, reason: "missing_executable_capability" };
   }
@@ -155,6 +156,7 @@ function executableMethod(args: {
     log.warn("Connector auth method runtime capability is unavailable", {
       connectorSlug: args.resolvedSlug.connectorSlug,
       authMethodId: args.authMethodId,
+      reason: "missing_executable_capability",
     });
     return { ok: false, reason: "missing_executable_capability" };
   }
@@ -186,9 +188,7 @@ function createConnectorActionResolver(
     });
   };
 
-  const resolveMethodCore: ConnectorActionResolver["resolveMethod"] = (
-    input,
-  ) => {
+  const resolveMethod: ConnectorActionResolver["resolveMethod"] = (input) => {
     const runtimeConnector = getConnectorRuntimeConnector(
       snapshot,
       input.connectorSlug,
@@ -232,21 +232,6 @@ function createConnectorActionResolver(
     });
   };
 
-  const resolveMethod: ConnectorActionResolver["resolveMethod"] = (input) => {
-    const resolution = resolveMethodCore(input);
-    if (
-      !resolution.ok &&
-      resolution.reason !== "missing_executable_capability"
-    ) {
-      log.warn("Connector action runtime method is unavailable", {
-        connectorSlug: input.connectorSlug,
-        authMethodId: input.authMethodId,
-        reason: resolution.reason,
-      });
-    }
-    return resolution;
-  };
-
   return {
     resolveSlug,
     resolveMethod,
@@ -269,7 +254,7 @@ function createConnectorActionResolver(
         }
       }
 
-      return resolveMethodCore(input);
+      return resolveMethod(input);
     },
 
     resolveSlugs(input) {

--- a/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
@@ -20,6 +20,7 @@ import { alias } from "drizzle-orm/pg-core";
 import { logger } from "../../lib/log";
 import type { ReadonlyDb } from "../external/db";
 import {
+  getConnectorRuntimeConnector,
   getConnectorRuntimeMethod,
   type ConnectorRuntimeMethod,
   type ConnectorRuntimeSelection,
@@ -87,18 +88,32 @@ export function resolveStoredConnectorRuntimeMethod(args: {
     readonly connectorSlug: string;
   };
 }): ConnectorRuntimeMethod | undefined {
+  const runtimeConnector = getConnectorRuntimeConnector(
+    args.snapshot,
+    args.stored.connectorSlug,
+  );
+  if (
+    runtimeConnector === undefined ||
+    !runtimeConnector.catalogConnector.authMethods.some((method) => {
+      return method.id === args.stored.authMethodId;
+    })
+  ) {
+    return undefined;
+  }
+
   const runtimeMethod = getConnectorRuntimeMethod({
     snapshot: args.snapshot,
     connectorSlug: args.stored.connectorSlug,
     authMethodId: args.stored.authMethodId,
-    requireExecutable: true,
   });
-  if (runtimeMethod === undefined) {
+  if (runtimeMethod?.executable !== true) {
     log.warn("Stored connector runtime method is unavailable", {
       connectorId: args.stored.connectorId,
       connectorSlug: args.stored.connectorSlug,
       authMethodId: args.stored.authMethodId,
+      reason: "missing_executable_capability",
     });
+    return undefined;
   }
   return runtimeMethod;
 }


### PR DESCRIPTION
## Summary

- treat removed connectors and auth methods as expected external catalog misses without per-read warnings
- keep warnings for known catalog entries that cannot provide the executable runtime capability required by the operation
- classify the remaining warnings with `reason: "missing_executable_capability"`

## Behavior

- stored credentials for a connector or auth method no longer present in the current catalog remain unavailable and are skipped silently
- connector action resolution still returns its existing typed unavailable results for unknown connectors, unknown auth methods, and incompatible grant kinds, but does not warn for those expected request/domain outcomes
- known catalog connector or auth-method entries that lack executable runtime support still warn because they indicate a catalog/runtime capability mismatch

## Exclusions

- does not restore the removed npm connector
- does not delete stored connector records or require users to reconnect
- does not change API responses, persisted data, or connector selection behavior
- does not suppress operational warnings for catalog loading, synchronization, provider refresh, or runtime lifecycle failures

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/connector-credential-access.service.ts apps/api/src/signals/services/connector-action-resolver.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-list.test.ts src/signals/routes/__tests__/connectors-by-slug-get.test.ts src/signals/routes/__tests__/connectors-scope-diff.test.ts src/signals/routes/__tests__/connectors-oauth-start.test.ts --maxWorkers=4 --silent=passed-only` (58 tests)
- pre-commit hook: repository-wide Knip and sequential TypeScript checks (14/14 tasks)

Closes #28777
