### PR TITLE
perf(python): reduce x tld redirect test shutdown latency

### DIFF
--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -347,7 +347,11 @@ def test_fetch_source_rejects_cross_origin_redirect_without_requesting_target(mo
             return None
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+
+    def serve_forever() -> None:
+        server.serve_forever(poll_interval=0.01)
+
+    thread = threading.Thread(target=serve_forever, daemon=True)
     thread.start()
     try:
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- run the X TLD redirect test server with an explicit 10 ms polling interval
- preserve the real loopback redirect request, exact request-path assertion, and existing shutdown/close/join cleanup
- reduce the focused test call from about 510 ms at baseline to about 10 ms locally

## Scope

- test-only change in `test_update_x_tlds.py`
- no production behavior, shared helper API, timing assertion, migration, or deployment compatibility change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_update_x_tlds.py::test_fetch_source_rejects_cross_origin_redirect_without_requesting_target --durations=1` (`1 passed`, `0.01s` call)
- `uv run --no-sync python -m pytest tests/test_update_x_tlds.py` (`41 passed`)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`6542 passed`)
- `git diff --check`

Closes #28857
