### PR TITLE
docs(python): distinguish expired firewall auth entries from eviction

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -394,9 +394,11 @@ async def get_firewall_headers(
     Uses a state-owned per-key task so concurrent requests for the same
     auth identity coalesce even if an individual waiter is cancelled.
 
-    Cache state is physically removed when:
-    - The run is removed from the registry (see registry.load_registry)
-    - A 401 response is received (see response handler)
+    Cached headers are physically cleared when:
+    - The run is removed from the registry (see registry.load_registry; its
+      auth state is evicted)
+    - A 401 response is received (see response handler; refresh lifecycle state
+      is preserved)
 
     TTL expiry is different: once the expiresAt timestamp from the auth
     endpoint has passed, the entry is treated as a cache miss and its headers

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -394,10 +394,14 @@ async def get_firewall_headers(
     Uses a state-owned per-key task so concurrent requests for the same
     auth identity coalesce even if an individual waiter is cancelled.
 
-    Cache is evicted when:
+    Cache state is physically removed when:
     - The run is removed from the registry (see registry.load_registry)
     - A 401 response is received (see response handler)
-    - The expiresAt timestamp from the auth endpoint has passed
+
+    TTL expiry is different: once the expiresAt timestamp from the auth
+    endpoint has passed, the entry is treated as a cache miss and its headers
+    are never served. A successful refetch replaces the expired entry, while a
+    failed refetch leaves the expired entry stored for a later retry.
     """
     state = _get_auth_state(cache_key)
 

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -581,8 +581,8 @@ class TestGetFirewallHeaders:
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
-    async def test_cache_evicted_when_ttl_expired(self, headers):
-        """Cached entry with expiresAt in the past should trigger a re-fetch."""
+    async def test_expired_cache_entry_triggers_refetch(self, headers):
+        """An expired entry is a cache miss and is replaced after a successful refetch."""
         cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
@@ -602,6 +602,44 @@ class TestGetFirewallHeaders:
         # Pin the TTL-expiry-to-refetch contract independently of the client transport.
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
+        assert require_cached_headers(cache_key).headers == fresh_headers
+
+    async def test_expired_cache_entry_is_retained_when_refetch_fails(self, headers):
+        """Expired headers are not served, but a failed refetch retains the stored entry."""
+        cache_key = auth_cache_key()
+        stale_headers = {"Authorization": "Bearer stale-token"}
+        expired_at = time.time() - 10
+        set_cached_headers(
+            cache_key,
+            headers=stale_headers,
+            expires_at=expired_at,
+        )
+
+        failed_fetch = AsyncMock(side_effect=ConnectionError("server unreachable"))
+        with (
+            patch.object(auth_cache, "fetch_firewall_headers", failed_fetch),
+            pytest.raises(ConnectionError, match=r"^server unreachable$"),
+        ):
+            await auth_cache.get_firewall_headers(cache_key, firewall_auth_request())
+
+        failed_fetch.assert_awaited_once()
+        retained = require_cached_headers(cache_key)
+        assert retained.headers == stale_headers
+        assert retained.expires_at == expired_at
+
+        fresh_headers = {"Authorization": "Bearer fresh-token"}
+        successful_fetch = AsyncMock(
+            return_value=firewall_auth_success(
+                headers=fresh_headers,
+                expires_at=time.time() + 3600,
+            )
+        )
+        with patch.object(auth_cache, "fetch_firewall_headers", successful_fetch):
+            result = await auth_cache.get_firewall_headers(cache_key, firewall_auth_request())
+
+        assert result["headers"] == fresh_headers
+        assert result["cache_hit"] is False
+        successful_fetch.assert_awaited_once()
         assert require_cached_headers(cache_key).headers == fresh_headers
 
     async def test_cache_with_null_expires_at_never_evicts(self, headers):


### PR DESCRIPTION
## Summary

- Clarify that registry removal evicts firewall auth state while 401 handling clears cached headers and preserves refresh lifecycle state.
- Document that TTL expiry is a cache miss: expired headers are never served, successful refetch replaces the entry, and failed refetch retains the expired entry for a later retry.
- Rename the successful-expiry test and add failed-refetch lifecycle coverage.

## Scope

This PR documents and tests the current behavior. It does not change cache storage, retry, force-refresh, registry, or 401 runtime semantics. No migrations, compatibility paths, dependency updates, or rollout changes are included.

Closes #28853

## Validation

- `uv lock --check`
- `uv run --no-sync python -m pytest tests/test_auth_cache.py tests/test_response_handler_auth_recovery.py` (63 passed)
- `uv run --no-sync python -m pytest tests/` (6,568 passed; 59 existing warnings)
- `uv run --no-sync ruff format --check src/firewall_auth_cache.py tests/test_auth_cache.py`
- `uv run --no-sync ruff check src/firewall_auth_cache.py tests/test_auth_cache.py`
- `uv run --no-sync basedpyright -p .`
