### PR TITLE
refactor(python): centralize client peer validation

### DIFF
--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -19,7 +19,7 @@ class ConnectedIpEndpoint:
 
 
 def client_peername(client: object) -> tuple[str, int] | None:
-    """Return the shape-validated client peer endpoint."""
+    """Return the client peer address pair after shape validation without parsing its host."""
     return address_pair(getattr(client, "peername", None))
 
 

--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -18,6 +18,11 @@ class ConnectedIpEndpoint:
     parsed_ip: ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
+def client_peername(client: object) -> tuple[str, int] | None:
+    """Return the shape-validated client peer endpoint."""
+    return address_pair(getattr(client, "peername", None))
+
+
 def server_address(server: object) -> tuple[str, int] | None:
     return address_pair(getattr(server, "address", None))
 

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -367,7 +367,8 @@ def _classify_request(
     trusted_authority: TrustedAuthority | None,
     defer_unresolved_public_destination: bool,
 ) -> RequestClassification:
-    client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+    client_peername = connection_endpoints.client_peername(flow.client_conn)
+    client_ip = client_peername[0] if client_peername is not None else None
 
     if not client_ip:
         if tls_admission is not None:

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -4,6 +4,7 @@ import time
 
 from mitmproxy import tcp
 
+import connection_endpoints
 import deferred_callbacks
 import flow_metadata
 import flow_metadata_keys as metadata_keys
@@ -30,7 +31,8 @@ def start(flow: tcp.TCPFlow, *, registry_path: str) -> None:
     - A valid registered VM installs the run ID, network and proxy log paths, and
       ``TCP_START_MONOTONIC``.
     """
-    client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+    client_peername = connection_endpoints.client_peername(flow.client_conn)
+    client_ip = client_peername[0] if client_peername is not None else None
     if not client_ip:
         return
 

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -345,7 +345,8 @@ def handle_server_connect(
     if client is None or server is None:
         return
 
-    client_ip = client.peername[0] if getattr(client, "peername", None) else None
+    client_peername = connection_endpoints.client_peername(client)
+    client_ip = client_peername[0] if client_peername is not None else None
     if not client_ip:
         return
 
@@ -392,7 +393,8 @@ def handle_tls_clienthello(
     classification, not cached authorization; current request-time registry state remains
     authoritative for enforcement.
     """
-    client_ip = data.context.client.peername[0] if data.context.client.peername else None
+    client_peername = connection_endpoints.client_peername(data.context.client)
+    client_ip = client_peername[0] if client_peername is not None else None
     if not client_ip:
         return
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -204,7 +204,7 @@ class _StubTLSClient:
         client_id: str | None,
     ) -> None:
         self.id = client_id or str(uuid.uuid4())
-        self.peername: object = peername
+        self.peername = peername
         self.sni = sni
         self.timestamp_end: float | None = None
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -204,7 +204,7 @@ class _StubTLSClient:
         client_id: str | None,
     ) -> None:
         self.id = client_id or str(uuid.uuid4())
-        self.peername = peername
+        self.peername: object = peername
         self.sni = sni
         self.timestamp_end: float | None = None
 

--- a/crates/runner/mitm-addon/tests/test_connection_endpoints.py
+++ b/crates/runner/mitm-addon/tests/test_connection_endpoints.py
@@ -7,6 +7,51 @@ import pytest
 import connection_endpoints
 
 
+class _Client:
+    def __init__(self, peername: object) -> None:
+        self.peername = peername
+
+
+@pytest.mark.parametrize(
+    "peername",
+    [
+        pytest.param((), id="empty-tuple"),
+        pytest.param(("10.200.0.5",), id="one-element-tuple"),
+        pytest.param((int(ipaddress.IPv4Address("10.200.0.5")), 12345), id="integer-host"),
+        pytest.param(("10.200.0.5", "12345"), id="string-port"),
+        pytest.param(["10.200.0.5", 12345], id="list"),
+    ],
+)
+def test_client_peername_rejects_malformed_endpoint(peername: object) -> None:
+    assert connection_endpoints.client_peername(_Client(peername)) is None
+
+
+def test_client_peername_rejects_missing_peername() -> None:
+    assert connection_endpoints.client_peername(object()) is None
+
+
+@pytest.mark.parametrize(
+    ("peername", "expected"),
+    [
+        pytest.param(
+            ("10.200.0.5", 12345),
+            ("10.200.0.5", 12345),
+            id="ipv4-pair",
+        ),
+        pytest.param(
+            ("2001:db8::5", 12345, 0, 2),
+            ("2001:db8::5", 12345),
+            id="ipv6-extra-fields",
+        ),
+    ],
+)
+def test_client_peername_returns_host_port_pair(
+    peername: tuple[object, ...],
+    expected: tuple[str, int],
+) -> None:
+    assert connection_endpoints.client_peername(_Client(peername)) == expected
+
+
 @pytest.mark.parametrize(
     "address",
     [

--- a/crates/runner/mitm-addon/tests/test_request_handler_tls_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_tls_admission.py
@@ -1,6 +1,7 @@
 """Connection-scoped TLS admission request hook integration tests."""
 
 import json
+from typing import cast
 
 import pytest
 
@@ -131,11 +132,22 @@ async def test_valid_tls_admission_blocks_when_run_id_changes(
     _assert_stale_tls_admission_block(flow, reason="run_id_mismatch")
 
 
-async def test_valid_tls_admission_blocks_when_request_client_ip_is_missing(
+@pytest.mark.parametrize(
+    "request_peername",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(
+            cast(tuple[str, int], ("10.200.0.5",)),
+            id="one-element-tuple",
+        ),
+    ],
+)
+async def test_valid_tls_admission_blocks_when_request_client_ip_is_unavailable(
     tmp_path,
     real_flow,
     make_tls_data,
     mitm_ctx,
+    request_peername: tuple[str, int] | None,
 ):
     client_ip = "10.200.0.5"
     reg_path = _write_registry(
@@ -160,7 +172,7 @@ async def test_valid_tls_admission_blocks_when_request_client_ip_is_missing(
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         mitm_addon.tls_clienthello(tls_data)
-        flow.client_conn.peername = None
+        flow.client_conn.peername = request_peername
 
         await mitm_addon.request(flow)
 

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -1,6 +1,7 @@
 """Tests for upstream destination binding in server_connect()."""
 
 import uuid
+from typing import cast
 
 import pytest
 from mitmproxy import connection
@@ -64,7 +65,7 @@ class _Client:
         sockname: tuple[str, int] = ("127.0.0.1", 8080),
     ) -> None:
         self.id = str(uuid.uuid4())
-        self.peername: object = (client_ip, 12345)
+        self.peername: tuple[str, int] = (client_ip, 12345)
         self.sockname = sockname
         self.sni = sni
 
@@ -482,7 +483,7 @@ def test_server_connect_ignores_unregistered_vm(registry_file, mitm_ctx):
 def test_server_connect_ignores_non_string_client_peer_host(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     client = _Client()
-    client.peername = (10, 12345)
+    client.peername = cast(tuple[str, int], (10, 12345))
     data = _ServerConnectData(client=client, server=_Server())
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -64,7 +64,7 @@ class _Client:
         sockname: tuple[str, int] = ("127.0.0.1", 8080),
     ) -> None:
         self.id = str(uuid.uuid4())
-        self.peername = (client_ip, 12345)
+        self.peername: object = (client_ip, 12345)
         self.sockname = sockname
         self.sni = sni
 
@@ -473,6 +473,19 @@ def test_server_connect_ignores_unregistered_vm(registry_file, mitm_ctx):
     data = _data(client_ip="192.168.99.99")
 
     with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+        mitm_addon.server_connect(data)
+
+    assert data.server.address == ("203.0.113.10", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+def test_server_connect_ignores_non_string_client_peer_host(tmp_path, mitm_ctx):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    client = _Client()
+    client.peername = (10, 12345)
+    data = _ServerConnectData(client=client, server=_Server())
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         mitm_addon.server_connect(data)
 
     assert data.server.address == ("203.0.113.10", 443)

--- a/crates/runner/mitm-addon/tests/test_tcp_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_hooks.py
@@ -4,6 +4,7 @@ import json
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import pytest
 from mitmproxy import tcp
@@ -50,9 +51,25 @@ class TestTcpStart:
         assert metadata_keys.VM_NETWORK_LOG_PATH in flow.metadata
         assert metadata_keys.TCP_START_MONOTONIC in flow.metadata
 
-    def test_skips_when_no_client_ip(self, registry_file, mitm_ctx, real_tcp_flow):
+    @pytest.mark.parametrize(
+        "client_peername",
+        [
+            pytest.param(None, id="missing"),
+            pytest.param(
+                cast(tuple[str, int], ("10.200.0.1", "12345")),
+                id="string-port",
+            ),
+        ],
+    )
+    def test_skips_when_client_ip_is_unavailable(
+        self,
+        registry_file,
+        mitm_ctx,
+        real_tcp_flow,
+        client_peername: tuple[str, int] | None,
+    ):
         flow = real_tcp_flow()
-        flow.client_conn.peername = None
+        flow.client_conn.peername = client_peername
 
         with (
             mitm_ctx(registry_path=str(registry_file)),

--- a/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
+++ b/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
@@ -1,6 +1,7 @@
 """Tests for TLS clienthello connection hooks."""
 
 import json
+from typing import cast
 
 import mitm_addon
 import registry
@@ -51,7 +52,7 @@ class TestTlsClienthello:
             sni="pr-test-api.vm6.ai",
             client_sni="",
         )
-        data.context.client.peername = ["10.200.0.1", 12345]
+        data.context.client.peername = cast(tuple[str, int], ["10.200.0.1", 12345])
 
         with mitm_ctx(
             registry_path=str(registry_file),

--- a/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
+++ b/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
@@ -43,6 +43,26 @@ class TestTlsClienthello:
         # All registered VMs use MITM — should NOT set ignore_connection
         assert data.ignore_connection is False
 
+    def test_non_tuple_client_peer_does_not_supply_registry_identity(
+        self, registry_file, make_tls_data, mitm_ctx
+    ):
+        data = make_tls_data(
+            client_ip="10.200.0.1",
+            sni="pr-test-api.vm6.ai",
+            client_sni="",
+        )
+        data.context.client.peername = ["10.200.0.1", 12345]
+
+        with mitm_ctx(
+            registry_path=str(registry_file),
+            api_url="https://pr-test-api.vm6.ai",
+        ):
+            mitm_addon.tls_clienthello(data)
+
+        assert data.ignore_connection is False
+        assert data.context.server.address == ("203.0.113.10", 443)
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
     def test_registered_vm_retargets_api_host_from_clienthello_sni(
         self, registry_file, make_tls_data, mitm_ctx
     ):


### PR DESCRIPTION
## Summary

- add a shared, shape-validated client peer endpoint projection
- route request, TCP, server-connect, and ClientHello registry identity through that projection
- cover malformed peer shapes and preserve valid IPv4 and longer IPv6 tuples

## Scope

This change only centralizes client endpoint-shape validation. It does not apply upstream destination IP-category policy to clients or change registry lookup, destination binding, API, persistence, or protocol contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_connection_endpoints.py tests/test_request_handler_tls_admission.py tests/test_tcp_hooks.py tests/test_server_connect_hook.py tests/test_tls_clienthello_hook.py` (74 passed)
- `uv run --no-sync python -m pytest tests/` (6554 passed)

Closes #28854
