### PR TITLE
fix(platform): remove unavailable restored attachments

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1557,6 +1557,9 @@
       "loadingFile": "{{filename}} wird geladen",
       "previewFile": "Vorschau von {{filename}}",
       "title": "Anhänge",
+      "unavailable": "{{filename}} ist nicht mehr verfügbar. Laden Sie die Datei erneut hoch, um sie zu senden.",
+      "unavailableCount_one": "{{count}} Anhang ist nicht mehr verfügbar. Laden Sie ihn erneut hoch, um ihn zu senden.",
+      "unavailableCount_other": "{{count}} Anhänge sind nicht mehr verfügbar. Laden Sie sie erneut hoch, um sie zu senden.",
       "uploadFailed": "Hochladen von {{filename}} fehlgeschlagen",
       "uploadFailedRetry": "Fehler beim Hochladen von {{filename}}. Versuchen Sie es erneut.",
       "uploadsFailed": "Einige Anhänge konnten nicht hochgeladen werden. Versuchen Sie es erneut."

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1557,6 +1557,9 @@
       "loadingFile": "Loading {{filename}}",
       "previewFile": "Preview {{filename}}",
       "title": "Attachments",
+      "unavailable": "{{filename}} is no longer available. Upload it again to send.",
+      "unavailableCount_one": "{{count}} attachment is no longer available. Upload it again to send.",
+      "unavailableCount_other": "{{count}} attachments are no longer available. Upload them again to send.",
       "uploadFailed": "Failed to upload {{filename}}",
       "uploadFailedRetry": "Failed to upload {{filename}}. Try again.",
       "uploadsFailed": "Some attachments failed to upload. Try again."

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1581,6 +1581,10 @@
       "loadingFile": "Cargando {{filename}}",
       "previewFile": "Vista previa de {{filename}}",
       "title": "Archivos adjuntos",
+      "unavailable": "{{filename}} ya no está disponible. Vuelve a subirlo para enviarlo.",
+      "unavailableCount_one": "{{count}} archivo adjunto ya no está disponible. Vuelve a subirlo para enviarlo.",
+      "unavailableCount_many": "{{count}} archivos adjuntos ya no están disponibles. Vuelve a subirlos para enviarlos.",
+      "unavailableCount_other": "{{count}} archivos adjuntos ya no están disponibles. Vuelve a subirlos para enviarlos.",
       "uploadFailed": "No se pudo subir {{filename}}",
       "uploadFailedRetry": "No se pudo subir {{filename}}. Inténtalo de nuevo.",
       "uploadsFailed": "Algunos archivos adjuntos no se han subido. Inténtalo de nuevo."

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1581,6 +1581,10 @@
       "loadingFile": "Chargement de {{filename}}",
       "previewFile": "Aperçu de {{filename}}",
       "title": "Pièces jointes",
+      "unavailable": "{{filename}} n'est plus disponible. Importez-le à nouveau pour l'envoyer.",
+      "unavailableCount_one": "{{count}} pièce jointe n'est plus disponible. Importez-la à nouveau pour l'envoyer.",
+      "unavailableCount_many": "{{count}} pièces jointes ne sont plus disponibles. Importez-les à nouveau pour les envoyer.",
+      "unavailableCount_other": "{{count}} pièces jointes ne sont plus disponibles. Importez-les à nouveau pour les envoyer.",
       "uploadFailed": "Échec du téléchargement de {{filename}}",
       "uploadFailedRetry": "Échec du téléchargement de {{filename}}. Réessayez.",
       "uploadsFailed": "Certaines pièces jointes n'ont pas pu être téléchargées. Réessayez."

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1557,6 +1557,9 @@
       "loadingFile": "{{filename}} लोड हो रहा है",
       "previewFile": "पूर्वावलोकन {{filename}}",
       "title": "संलग्नक",
+      "unavailable": "{{filename}} अब उपलब्ध नहीं है। भेजने के लिए इसे दोबारा अपलोड करें।",
+      "unavailableCount_one": "{{count}} अटैचमेंट अब उपलब्ध नहीं है। भेजने के लिए उसे दोबारा अपलोड करें।",
+      "unavailableCount_other": "{{count}} अटैचमेंट अब उपलब्ध नहीं हैं। भेजने के लिए उन्हें दोबारा अपलोड करें।",
       "uploadFailed": "{{filename}} अपलोड करने में विफल",
       "uploadFailedRetry": "{{filename}} अपलोड करने में विफल. पुनः प्रयास करें।",
       "uploadsFailed": "कुछ अनुलग्नक अपलोड करने में विफल रहे. पुनः प्रयास करें।"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1557,6 +1557,8 @@
       "loadingFile": "Memuat {{filename}}",
       "previewFile": "Pratinjau {{filename}}",
       "title": "Lampiran",
+      "unavailable": "{{filename}} tidak lagi tersedia. Unggah ulang untuk mengirimnya.",
+      "unavailableCount_other": "{{count}} lampiran tidak lagi tersedia. Unggah ulang untuk mengirimnya.",
       "uploadFailed": "Gagal mengunggah {{filename}}",
       "uploadFailedRetry": "Gagal mengunggah {{filename}}. Coba lagi.",
       "uploadsFailed": "Beberapa lampiran gagal diunggah. Coba lagi."

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1581,6 +1581,10 @@
       "loadingFile": "Caricamento in corso {{filename}}",
       "previewFile": "Anteprima {{filename}}",
       "title": "Allegati",
+      "unavailable": "{{filename}} non è più disponibile. Caricalo di nuovo per inviarlo.",
+      "unavailableCount_one": "{{count}} allegato non è più disponibile. Caricalo di nuovo per inviarlo.",
+      "unavailableCount_many": "{{count}} allegati non sono più disponibili. Caricali di nuovo per inviarli.",
+      "unavailableCount_other": "{{count}} allegati non sono più disponibili. Caricali di nuovo per inviarli.",
       "uploadFailed": "Impossibile caricare {{filename}}",
       "uploadFailedRetry": "Impossibile caricare {{filename}}. Riprova.",
       "uploadsFailed": "Impossibile caricare alcuni allegati. Riprova."

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1557,6 +1557,8 @@
       "loadingFile": "{{filename}} をロードしています",
       "previewFile": "{{filename}} のプレビュー",
       "title": "添付ファイル",
+      "unavailable": "{{filename}} は利用できなくなりました。送信するにはもう一度アップロードしてください。",
+      "unavailableCount_other": "{{count}} 件の添付ファイルは利用できなくなりました。送信するにはもう一度アップロードしてください。",
       "uploadFailed": "{{filename}} のアップロードに失敗しました",
       "uploadFailedRetry": "{{filename}} のアップロードに失敗しました。もう一度やり直してください。",
       "uploadsFailed": "一部の添付ファイルのアップロードに失敗しました。もう一度やり直してください。"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1557,6 +1557,8 @@
       "loadingFile": "{{filename}} 불러오는 중",
       "previewFile": "{{filename}} 미리보기",
       "title": "첨부파일",
+      "unavailable": "{{filename}}을(를) 더 이상 사용할 수 없습니다. 보내려면 다시 업로드하세요.",
+      "unavailableCount_other": "첨부파일 {{count}}개를 더 이상 사용할 수 없습니다. 보내려면 다시 업로드하세요.",
       "uploadFailed": "{{filename}} 업로드 실패",
       "uploadFailedRetry": "{{filename}} 업로드 실패. 다시 시도하세요.",
       "uploadsFailed": "일부 첨부파일 업로드에 실패했습니다. 다시 시도하세요."

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1581,6 +1581,10 @@
       "loadingFile": "Carregando {{filename}}",
       "previewFile": "Visualizar {{filename}}",
       "title": "Anexos",
+      "unavailable": "{{filename}} não está mais disponível. Faça o upload novamente para enviar.",
+      "unavailableCount_one": "{{count}} anexo não está mais disponível. Faça o upload novamente para enviar.",
+      "unavailableCount_many": "{{count}} anexos não estão mais disponíveis. Faça o upload novamente para enviar.",
+      "unavailableCount_other": "{{count}} anexos não estão mais disponíveis. Faça o upload novamente para enviar.",
       "uploadFailed": "Falha ao enviar {{filename}}",
       "uploadFailedRetry": "Falha ao enviar {{filename}}. Tente novamente.",
       "uploadsFailed": "Falha ao enviar alguns anexos. Tente novamente."

--- a/turbo/apps/platform/src/mocks/handlers/api-web-files.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-web-files.ts
@@ -1,0 +1,17 @@
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
+
+import { mockApi } from "../msw-contract.ts";
+
+/**
+ * Restored composer attachments resolve their artifact id against this route,
+ * so every test that opens a saved draft would otherwise need its own handler.
+ * The default says "still resolves"; tests covering an unreadable artifact
+ * override it with a 404.
+ */
+export const apiWebFilesHandlers = [
+  mockApi(webFilesContract.fileUrl, ({ query, respond }) => {
+    return respond(200, {
+      url: `https://cdn.vm0.io/artifacts/${query.file_id}`,
+    });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -94,6 +94,7 @@ import {
 } from "./api-user-permission-grants.ts";
 import { apiVoiceIoHandlers } from "./api-voice-io.ts";
 import { apiBuildInfoHandlers } from "./api-build-info.ts";
+import { apiWebFilesHandlers } from "./api-web-files.ts";
 
 export const handlers = [
   ...apiBuildInfoHandlers,
@@ -128,6 +129,7 @@ export const handlers = [
   ...apiUserPermissionGrantsHandlers,
   ...apiQueuePositionHandlers,
   ...apiVoiceIoHandlers,
+  ...apiWebFilesHandlers,
 ];
 
 export function resetAllMockHandlers(): void {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -152,12 +152,19 @@ const loadDraft$ = command(
       const restoredAttachments = restoredDraft.attachments.map(
         createRestoredAttachment,
       );
-      set(thread.composer.draft.seed$, {
-        content: restoredDraft.content,
-        userMessage: restoredDraft.userMessage,
-        generationTemplate: undefined,
-        attachments: restoredAttachments,
-      });
+      const removedUnavailableAttachments = await set(
+        thread.composer.draft.seed$,
+        {
+          content: restoredDraft.content,
+          userMessage: restoredDraft.userMessage,
+          generationTemplate: undefined,
+          attachments: restoredAttachments,
+        },
+        signal,
+      );
+      if (removedUnavailableAttachments) {
+        await set(thread.composer.draft.save$, signal);
+      }
     }
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3150,15 +3150,19 @@ function createRecallMessage(deps: RecallMessageDeps) {
     const templatePart = userMessage.parts.find((part) => {
       return part.type === "template";
     });
-    set(draft.seed$, {
-      content: messageDocumentToPrompt(userMessage) ?? "",
-      userMessage,
-      generationTemplate:
-        templatePart?.type === "template" ? templatePart.template : undefined,
-      attachments: userMessageFileAttachments(userMessage).map(
-        createRestoredAttachment,
-      ),
-    });
+    await set(
+      draft.seed$,
+      {
+        content: messageDocumentToPrompt(userMessage) ?? "",
+        userMessage,
+        generationTemplate:
+          templatePart?.type === "template" ? templatePart.template : undefined,
+        attachments: userMessageFileAttachments(userMessage).map(
+          createRestoredAttachment,
+        ),
+      },
+      signal,
+    );
 
     await set(
       sendEvent$,

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -73,6 +73,16 @@ export const composerSubmitDomReconcileEnabled$ = computed((get): boolean => {
   );
 });
 
+export const composerRestoredAttachmentValidationEnabled$ = computed(
+  (get): boolean => {
+    return (
+      get(featureSwitch$)[
+        FeatureSwitchKey.ComposerRestoredAttachmentValidation
+      ] ?? false
+    );
+  },
+);
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
@@ -100,13 +100,7 @@ export const setupAgentChatPage$ = command(
     const prompt = params.get("prompt");
     const queue = params.get("queue");
     if (agentDraft && !prompt) {
-      await set(
-        loadAgentDraft$,
-        agentId,
-        agentDraft.draft,
-        agentDraft.isNew,
-        signal,
-      );
+      await set(loadAgentDraft$, agentId, agentDraft, signal);
     }
     if (prompt) {
       const targetDraft = agentDraft?.draft ?? get(talkDraft$);

--- a/turbo/apps/platform/src/signals/okou-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-draft.ts
@@ -192,10 +192,10 @@ export const loadAgentDraft$ = command(
   async (
     { get, set },
     agentId: string,
-    draft: DraftSignals,
-    isNew: boolean,
+    agentDraft: EnsuredAgentDraft,
     signal: AbortSignal,
   ) => {
+    const { draft, isNew } = agentDraft;
     if (!isNew) {
       return;
     }
@@ -241,12 +241,19 @@ export const loadAgentDraft$ = command(
       return;
     }
 
-    set(draft.seed$, {
-      content: restoredDraft.content,
-      userMessage: restoredDraft.userMessage,
-      generationTemplate: undefined,
-      attachments: restoredDraft.attachments.map(createRestoredAttachment),
-    });
+    const removedUnavailableAttachments = await set(
+      draft.seed$,
+      {
+        content: restoredDraft.content,
+        userMessage: restoredDraft.userMessage,
+        generationTemplate: undefined,
+        attachments: restoredDraft.attachments.map(createRestoredAttachment),
+      },
+      signal,
+    );
+    if (removedUnavailableAttachments) {
+      await set(agentDraft.queueDraftSync$, signal);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -26,6 +26,7 @@ import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
 import { i18n } from "../../i18n/index.ts";
+import { composerRestoredAttachmentValidationEnabled$ } from "../external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)
@@ -405,8 +406,9 @@ export interface DraftSignals {
   attachmentUploadsReady$: Computed<boolean>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
   /**
-   * Adds persisted attachments to the draft, then drops the ones whose
-   * artifact no longer resolves for this account.
+   * Adds persisted attachments to the draft. When restored-attachment
+   * validation is enabled, drops the ones whose artifact no longer resolves
+   * for this account.
    */
   restoreAttachments$: Command<
     Promise<boolean>,
@@ -419,8 +421,8 @@ export interface DraftSignals {
   clear$: Command<void, []>;
   /**
    * Seed draft from persisted server data. Only called when local cache was
-   * empty. The draft is visible immediately; the returned promise settles once
-   * unresolvable attachments have been dropped.
+   * empty. The draft is visible immediately; when validation is enabled, the
+   * returned promise settles once unresolvable attachments have been dropped.
    */
   seed$: Command<Promise<boolean>, [DraftSeed, AbortSignal]>;
 }
@@ -442,9 +444,10 @@ export interface DraftInputSyncTarget {
  *
  * The persisted id is an externally managed reference: the artifact is stored
  * per user, so a saved draft, a forwarded message, or a pasted chat payload can
- * carry an id the current account cannot read. `fileInfo$` resolves it once
- * against the current account and reports `null` when it no longer resolves,
- * instead of asserting the file is still reachable.
+ * carry an id the current account cannot read. With restored-attachment
+ * validation enabled, `fileInfo$` resolves it once against the current account
+ * and reports `null` when it no longer resolves, instead of asserting the file
+ * is still reachable. The disabled path preserves the persisted file info.
  *
  * A probe that cannot run at all (offline, transient failure) keeps the
  * persisted info so a flaky network never blocks a send; the server performs
@@ -459,6 +462,9 @@ export function createRestoredAttachment(
     contentType: persisted.contentType,
   };
   const fileInfo$ = computed(async (get): Promise<FileInfo | null> => {
+    if (!get(composerRestoredAttachmentValidationEnabled$)) {
+      return persistedInfo;
+    }
     const signal = get(rootSignal$);
     const client = get(apiClient$)(webFilesContract);
     const resolved = await tapError(

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -449,9 +449,6 @@ export interface DraftInputSyncTarget {
  * and reports `null` when it no longer resolves, instead of asserting the file
  * is still reachable. The disabled path preserves the persisted file info.
  *
- * A probe that cannot run at all (offline, transient failure) keeps the
- * persisted info so a flaky network never blocks a send; the server performs
- * the authoritative check.
  */
 export function createRestoredAttachment(
   persisted: PersistedAttachment,
@@ -467,20 +464,14 @@ export function createRestoredAttachment(
     }
     const signal = get(rootSignal$);
     const client = get(apiClient$)(webFilesContract);
-    const resolved = await tapError(
-      accept(
-        client.fileUrl({
-          query: { file_id: persisted.id },
-          fetchOptions: { signal },
-        }),
-        [200, 404],
-        signal,
-        { showErrorToast: false },
-      ),
+    const resolved = await accept(
+      client.fileUrl({
+        query: { file_id: persisted.id },
+        fetchOptions: { signal },
+      }),
+      [200, 404],
+      signal,
     );
-    if (!resolved) {
-      return persistedInfo;
-    }
     return resolved.status === 404 ? null : persistedInfo;
   });
 

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -13,6 +13,7 @@ import {
   type ImageLoadSignals,
 } from "../image-load.ts";
 import { apiClient$ } from "../api-client.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { accept } from "../../lib/accept.ts";
 import { IN_VITEST } from "../../env.ts";
 import type {
@@ -21,6 +22,7 @@ import type {
   UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
 import { i18n } from "../../i18n/index.ts";
@@ -402,14 +404,25 @@ export interface DraftSignals {
   attachments$: Computed<ZeroChatAttachment[]>;
   attachmentUploadsReady$: Computed<boolean>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
-  restoreAttachments$: Command<void, [PersistedAttachment[]]>;
+  /**
+   * Adds persisted attachments to the draft, then drops the ones whose
+   * artifact no longer resolves for this account.
+   */
+  restoreAttachments$: Command<
+    Promise<boolean>,
+    [PersistedAttachment[], AbortSignal]
+  >;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
   dragOver$: Computed<boolean>;
   setDragOver$: Command<void, [boolean]>;
   /** Reset all draft state (input, template, attachments). Called after send. */
   clear$: Command<void, []>;
-  /** Seed draft from persisted server data. Only called when local cache was empty. */
-  seed$: Command<void, [DraftSeed]>;
+  /**
+   * Seed draft from persisted server data. Only called when local cache was
+   * empty. The draft is visible immediately; the returned promise settles once
+   * unresolvable attachments have been dropped.
+   */
+  seed$: Command<Promise<boolean>, [DraftSeed, AbortSignal]>;
 }
 
 interface DraftSeed {
@@ -426,17 +439,43 @@ export interface DraftInputSyncTarget {
 
 /**
  * Reconstructs a ZeroChatAttachment from persisted attachment metadata.
- * The fileInfo$ resolves immediately since the file was already uploaded.
+ *
+ * The persisted id is an externally managed reference: the artifact is stored
+ * per user, so a saved draft, a forwarded message, or a pasted chat payload can
+ * carry an id the current account cannot read. `fileInfo$` resolves it once
+ * against the current account and reports `null` when it no longer resolves,
+ * instead of asserting the file is still reachable.
+ *
+ * A probe that cannot run at all (offline, transient failure) keeps the
+ * persisted info so a flaky network never blocks a send; the server performs
+ * the authoritative check.
  */
 export function createRestoredAttachment(
   persisted: PersistedAttachment,
 ): ZeroChatAttachment {
-  const fileInfo$ = computed((): Promise<FileInfo | null> => {
-    return Promise.resolve({
-      id: persisted.id,
-      url: persisted.url,
-      contentType: persisted.contentType,
-    });
+  const persistedInfo: FileInfo = {
+    id: persisted.id,
+    url: persisted.url,
+    contentType: persisted.contentType,
+  };
+  const fileInfo$ = computed(async (get): Promise<FileInfo | null> => {
+    const signal = get(rootSignal$);
+    const client = get(apiClient$)(webFilesContract);
+    const resolved = await tapError(
+      accept(
+        client.fileUrl({
+          query: { file_id: persisted.id },
+          fetchOptions: { signal },
+        }),
+        [200, 404],
+        signal,
+        { showErrorToast: false },
+      ),
+    );
+    if (!resolved) {
+      return persistedInfo;
+    }
+    return resolved.status === 404 ? null : persistedInfo;
   });
 
   const cancel$ = command(() => {
@@ -458,6 +497,33 @@ export function createRestoredAttachment(
     cancel$,
     upload$,
   };
+}
+
+/** Fixed id so repeated restores replace the toast instead of stacking. */
+const UNAVAILABLE_ATTACHMENT_TOAST_ID = "chat-attachment-unavailable";
+
+/**
+ * Tells the user which attachments no longer resolve and returns the message so
+ * a caller can reuse it to abort. Re-uploading is the only fix, so the copy
+ * says that rather than offering a retry.
+ */
+function reportUnavailableAttachments(filenames: readonly string[]): string {
+  const message =
+    filenames.length === 1
+      ? i18n.t(
+          ($) => {
+            return $.chat.attachments.unavailable;
+          },
+          { filename: filenames[0] },
+        )
+      : i18n.t(
+          ($) => {
+            return $.chat.attachments.unavailableCount;
+          },
+          { count: filenames.length },
+        );
+  toast.warning(message, { id: UNAVAILABLE_ATTACHMENT_TOAST_ID });
+  return message;
 }
 
 function createDraftInputSignals() {
@@ -541,18 +607,69 @@ function createDraftDocumentSignals() {
   };
 }
 
+/**
+ * Drops restored attachments whose artifact no longer resolves for this
+ * account. Leaving them in place strands the composer: the chip waits on a file
+ * it can never load and every send is rejected, so removing them and saying so
+ * is the only state the user can act on.
+ */
+function createPruneUnavailableAttachments(
+  internalAttachments$: State<ZeroChatAttachment[]>,
+): Command<Promise<boolean>, [readonly ZeroChatAttachment[], AbortSignal]> {
+  return command(
+    async (
+      { get, set },
+      candidates: readonly ZeroChatAttachment[],
+      signal: AbortSignal,
+    ): Promise<boolean> => {
+      if (candidates.length === 0) {
+        return false;
+      }
+      const infos = await Promise.all(
+        candidates.map((attachment) => {
+          return get(attachment.fileInfo$);
+        }),
+      );
+      signal.throwIfAborted();
+      const currentAttachments = get(internalAttachments$);
+      const unavailable = candidates.filter((attachment, index) => {
+        return infos[index] === null && currentAttachments.includes(attachment);
+      });
+      if (unavailable.length === 0) {
+        return false;
+      }
+      set(internalAttachments$, (prev) => {
+        return prev.filter((attachment) => {
+          return !unavailable.includes(attachment);
+        });
+      });
+      reportUnavailableAttachments(
+        unavailable.map((attachment) => {
+          return attachment.filename;
+        }),
+      );
+      return true;
+    },
+  );
+}
+
 function createDraftLifecycleSignals({
   draftInput,
   draftDocument,
   internalGenerationTemplate$,
   internalAttachments$,
   internalDragOver$,
+  pruneUnavailableAttachments$,
 }: {
   draftInput: ReturnType<typeof createDraftInputSignals>;
   draftDocument: ReturnType<typeof createDraftDocumentSignals>;
   internalGenerationTemplate$: State<GenerationTemplateRequest | undefined>;
   internalAttachments$: State<ZeroChatAttachment[]>;
   internalDragOver$: State<boolean>;
+  pruneUnavailableAttachments$: Command<
+    Promise<boolean>,
+    [readonly ZeroChatAttachment[], AbortSignal]
+  >;
 }) {
   const clear$ = command(({ get, set }) => {
     set(draftInput.setInput$, "");
@@ -569,19 +686,26 @@ function createDraftLifecycleSignals({
     set(internalDragOver$, false);
   });
 
-  const seed$ = command(({ set }, value: DraftSeed) => {
-    set(draftDocument.setEditorDocument$, null);
-    set(draftDocument.setRestoredUserMessage$, value.userMessage);
-    set(internalGenerationTemplate$, value.generationTemplate);
-    set(internalAttachments$, value.attachments);
-    set(draftInput.setInput$, value.content);
-    if (
-      value.userMessage &&
-      set(draftInput.syncUserMessage$, value.userMessage)
-    ) {
-      set(draftDocument.takeRestoredUserMessage$);
-    }
-  });
+  const seed$ = command(
+    async (
+      { set },
+      value: DraftSeed,
+      signal: AbortSignal,
+    ): Promise<boolean> => {
+      set(draftDocument.setEditorDocument$, null);
+      set(draftDocument.setRestoredUserMessage$, value.userMessage);
+      set(internalGenerationTemplate$, value.generationTemplate);
+      set(internalAttachments$, value.attachments);
+      set(draftInput.setInput$, value.content);
+      if (
+        value.userMessage &&
+        set(draftInput.syncUserMessage$, value.userMessage)
+      ) {
+        set(draftDocument.takeRestoredUserMessage$);
+      }
+      return await set(pruneUnavailableAttachments$, value.attachments, signal);
+    },
+  );
 
   return { clear$, seed$ };
 }
@@ -640,15 +764,23 @@ export function createDraftSignals(): DraftSignals {
     },
   );
 
+  const pruneUnavailableAttachments$ =
+    createPruneUnavailableAttachments(internalAttachments$);
+
   const restoreAttachments$ = command(
-    ({ set }, persisted: PersistedAttachment[]) => {
+    async (
+      { set },
+      persisted: PersistedAttachment[],
+      signal: AbortSignal,
+    ): Promise<boolean> => {
       if (persisted.length === 0) {
-        return;
+        return false;
       }
       const restored = persisted.map(createRestoredAttachment);
       set(internalAttachments$, (prev) => {
         return [...prev, ...restored];
       });
+      return await set(pruneUnavailableAttachments$, restored, signal);
     },
   );
 
@@ -676,6 +808,7 @@ export function createDraftSignals(): DraftSignals {
     internalGenerationTemplate$,
     internalAttachments$,
     internalDragOver$,
+    pruneUnavailableAttachments$,
   });
 
   return {

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -1,7 +1,6 @@
 import type {
   ChatRunVideoOptionsRequest,
   GenerationTemplateRequest,
-  PersistedAttachment,
   UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { foldActiveChatGoalObjective } from "@okouai/api-contracts/contracts/chat-events";
@@ -137,7 +136,7 @@ interface ComposerDraftSignals {
   readonly attachments$: Computed<ZeroChatAttachment[]>;
   readonly attachmentUploadsReady$: Computed<boolean>;
   readonly uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
-  readonly restoreAttachments$: Command<void, [PersistedAttachment[]]>;
+  readonly restoreAttachments$: DraftSignals["restoreAttachments$"];
   readonly removeAttachment$: Command<void, [ZeroChatAttachment]>;
   readonly dragOver$: Computed<boolean>;
   readonly setDragOver$: Command<void, [boolean]>;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
@@ -575,7 +575,6 @@ describe("chat drafts", () => {
 
   it("keeps restored attachments untouched when validation is disabled", async () => {
     let validationRequests = 0;
-    const toastWarning = vi.spyOn(toast, "warning");
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
       serviceTier: null,
@@ -627,12 +626,16 @@ describe("chat drafts", () => {
       expect(screen.getByLabelText("Remove brief.md")).toBeInTheDocument();
     });
     expect(validationRequests).toBe(0);
-    expect(toastWarning).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText(
+        "brief.md is no longer available. Upload it again to send.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("drops and clears a saved attachment whose artifact no longer resolves", async () => {
     const draftPatches: Record<string, unknown>[] = [];
-    const toastWarning = vi.spyOn(toast, "warning");
+    const warningIconColor = "#f59e0b";
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
       serviceTier: null,
@@ -693,10 +696,19 @@ describe("chat drafts", () => {
     await waitFor(() => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
     });
-    expect(toastWarning).toHaveBeenCalledWith(
+    const warningMessage = await screen.findByText(
       "brief.md is no longer available. Upload it again to send.",
-      { id: "chat-attachment-unavailable" },
     );
+    const warningToast = warningMessage.closest("[data-sonner-toast]");
+    if (!(warningToast instanceof HTMLElement)) {
+      throw new Error("Warning toast was not rendered");
+    }
+    expect(warningToast).toHaveAttribute("data-type", "warning");
+    const warningIcon = warningToast.querySelector("[data-icon] svg");
+    if (!(warningIcon instanceof SVGElement)) {
+      throw new Error("Warning toast icon was not rendered");
+    }
+    expect(getComputedStyle(warningIcon).color).toBe(warningIconColor);
     expect(screen.queryByLabelText("Remove brief.md")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(draftPatches).toContainEqual({
@@ -707,6 +719,66 @@ describe("chat drafts", () => {
         draftAttachments: null,
       });
     });
+  });
+
+  it("surfaces restored attachment validation failures", async () => {
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftUserMessage: {
+          version: 1,
+          parts: [
+            {
+              type: "file",
+              fileId: "draft-brief",
+              filenameSnapshot: "brief.md",
+              contentType: "text/markdown",
+            },
+            { type: "text", text: "Review the saved launch brief" },
+          ],
+        },
+        draftAttachments: [
+          {
+            id: "draft-brief",
+            filename: "brief.md",
+            contentType: "text/markdown",
+            size: 64,
+            url: "https://cdn.vm7.io/artifacts/test/drafts/brief.md",
+          },
+        ],
+      });
+    });
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      return respond(403, {
+        error: {
+          message: "Attachment validation is unavailable",
+          code: "FORBIDDEN",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ONE_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerRestoredAttachmentValidation]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText("Attachment validation is unavailable"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Remove brief.md")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "brief.md is no longer available. Upload it again to send.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("restores and persists feedback as a userMessage draft", async () => {
@@ -1843,7 +1915,6 @@ describe("chat drafts", () => {
     const pastedText = "Please use the copied brief";
     const filename = "foreign-brief.md";
     const draftPatches: Record<string, unknown>[] = [];
-    const toastWarning = vi.spyOn(toast, "warning");
 
     mockChatLifecycle(context, { threadId });
     context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
@@ -1898,10 +1969,11 @@ describe("chat drafts", () => {
         screen.queryByLabelText(`Remove ${filename}`),
       ).not.toBeInTheDocument();
     });
-    expect(toastWarning).toHaveBeenCalledWith(
-      `${filename} is no longer available. Upload it again to send.`,
-      { id: "chat-attachment-unavailable" },
-    );
+    await expect(
+      screen.findByText(
+        `${filename} is no longer available. Upload it again to send.`,
+      ),
+    ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(draftPatches).toContainEqual({
         draftUserMessage: {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
@@ -10,6 +10,7 @@ import {
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { agentDraftContract } from "@okouai/api-contracts/contracts/agent-draft";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { agentsByIdContract } from "@okouai/api-contracts/contracts/agents";
 import { runsQueueContract } from "@okouai/api-contracts/contracts/run-routes";
 import { teamContract } from "@okouai/api-contracts/contracts/team";
@@ -615,6 +616,79 @@ describe("chat drafts", () => {
     await waitFor(() => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
       expect(screen.getByLabelText("Remove brief.md")).toBeInTheDocument();
+    });
+  });
+
+  it("drops and clears a saved attachment whose artifact no longer resolves", async () => {
+    const draftPatches: Record<string, unknown>[] = [];
+    const toastWarning = vi.spyOn(toast, "warning");
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        lastReadAt: null,
+        cancellationRecoveryPending: false,
+      });
+    });
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftUserMessage: {
+          version: 1,
+          parts: [
+            {
+              type: "file",
+              fileId: "draft-brief",
+              filenameSnapshot: "brief.md",
+              contentType: "text/markdown",
+            },
+            { type: "text", text: "Review the saved launch brief" },
+          ],
+        },
+        draftAttachments: [
+          {
+            id: "draft-brief",
+            filename: "brief.md",
+            contentType: "text/markdown",
+            size: 64,
+            url: "https://cdn.vm7.io/artifacts/test/drafts/brief.md",
+          },
+        ],
+      });
+    });
+    // The artifact is stored per user, so a draft carried over from another
+    // account resolves to nothing here.
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      return respond(404, {
+        error: { message: "File not found", code: "NOT_FOUND" },
+      });
+    });
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ONE_ID}` });
+
+    await waitFor(() => {
+      expect(textarea()).toHaveTextContent("Review the saved launch brief");
+    });
+    expect(toastWarning).toHaveBeenCalledWith(
+      "brief.md is no longer available. Upload it again to send.",
+      { id: "chat-attachment-unavailable" },
+    );
+    expect(screen.queryByLabelText("Remove brief.md")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual({
+        draftUserMessage: {
+          version: 1,
+          parts: [{ type: "text", text: "Review the saved launch brief" }],
+        },
+        draftAttachments: null,
+      });
     });
   });
 
@@ -1743,6 +1817,76 @@ describe("chat drafts", () => {
     await waitFor(() => {
       expect(input).toHaveTextContent(pastedText);
       expect(screen.getByLabelText(`Remove ${filename}`)).toBeInTheDocument();
+    });
+  });
+
+  it("drops a copied attachment that is unavailable in the current account", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e3000000-0000-4000-a000-000000000006";
+    const pastedText = "Please use the copied brief";
+    const filename = "foreign-brief.md";
+    const draftPatches: Record<string, unknown>[] = [];
+    const toastWarning = vi.spyOn(toast, "warning");
+
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      return respond(404, {
+        error: { message: "File not found", code: "NOT_FOUND" },
+      });
+    });
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const input = await waitFor(() => {
+      return textarea();
+    });
+    await user.click(input);
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return chatClipboardHtml({
+              text: pastedText,
+              attachments: [
+                {
+                  id: "foreign-brief",
+                  url: "https://cdn.vm7.io/artifacts/another-user/foreign-brief.md",
+                  filename,
+                  contentType: "text/markdown",
+                  size: 42,
+                },
+              ],
+            });
+          }
+          return "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(input).toHaveTextContent(pastedText);
+      expect(
+        screen.queryByLabelText(`Remove ${filename}`),
+      ).not.toBeInTheDocument();
+    });
+    expect(toastWarning).toHaveBeenCalledWith(
+      `${filename} is no longer available. Upload it again to send.`,
+      { id: "chat-attachment-unavailable" },
+    );
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual({
+        draftUserMessage: {
+          version: 1,
+          parts: [{ type: "text", text: pastedText }],
+        },
+        draftAttachments: null,
+      });
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@okouai/core";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -572,7 +573,9 @@ describe("chat drafts", () => {
     );
   });
 
-  it("restores a saved server draft with attachments on first thread open", async () => {
+  it("keeps restored attachments untouched when validation is disabled", async () => {
+    let validationRequests = 0;
+    const toastWarning = vi.spyOn(toast, "warning");
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
       serviceTier: null,
@@ -610,6 +613,12 @@ describe("chat drafts", () => {
         ],
       });
     });
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      validationRequests += 1;
+      return respond(404, {
+        error: { message: "File not found", code: "NOT_FOUND" },
+      });
+    });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ONE_ID}` });
 
@@ -617,6 +626,8 @@ describe("chat drafts", () => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
       expect(screen.getByLabelText("Remove brief.md")).toBeInTheDocument();
     });
+    expect(validationRequests).toBe(0);
+    expect(toastWarning).not.toHaveBeenCalled();
   });
 
   it("drops and clears a saved attachment whose artifact no longer resolves", async () => {
@@ -671,7 +682,13 @@ describe("chat drafts", () => {
       return respond(204);
     });
 
-    detachedSetupPage({ context, path: `/chats/${THREAD_ONE_ID}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ONE_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerRestoredAttachmentValidation]: true,
+      },
+    });
 
     await waitFor(() => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
@@ -1839,7 +1856,13 @@ describe("chat drafts", () => {
       return respond(204);
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerRestoredAttachmentValidation]: true,
+      },
+    });
 
     const input = await waitFor(() => {
       return textarea();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8493,6 +8493,7 @@ function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
   const visualAttachmentUnsupported =
     useComposerVisualAttachmentUnsupported(signals);
   const restoreAttachments = useSet(signals.draft.restoreAttachments$);
+  const pageSignal = useGet(pageSignal$);
   const insertPromptMarkdown = useSet(signals.editor.insertPromptMarkdown$);
   const insertUserMessage = useSet(signals.editor.insertUserMessage$);
   const uploadFile = useComposerFileUpload(signals);
@@ -8512,7 +8513,20 @@ function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
         visualAttachmentUnsupported,
         insertPromptMarkdown,
         insertUserMessage,
-        restoreAttachments,
+        restoreAttachments: (attachments) => {
+          detach(
+            (async () => {
+              const removedUnavailableAttachments = await restoreAttachments(
+                attachments,
+                pageSignal,
+              );
+              if (removedUnavailableAttachments) {
+                notifyDraftChanged();
+              }
+            })(),
+            Reason.DomCallback,
+          );
+        },
         onDraftChange: notifyDraftChanged,
       })
     ) {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -104,6 +104,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
       false,
     );
+    expect(
+      staffOrgStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
+    ).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
@@ -139,6 +142,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
       false,
     );
+    expect(
+      otherOrgStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
+    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatForward]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
@@ -167,13 +173,16 @@ describe("getAllFeatureStates", () => {
     );
   });
 
-  it("should enable composer submit DOM reconciliation only for Bingjie", () => {
+  it("should enable Bingjie-only composer switches only for Bingjie", () => {
     const bingjieStates = getAllFeatureStates({
       email: "bingjie@vm0.ai",
     });
     expect(bingjieStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
       true,
     );
+    expect(
+      bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
+    ).toBe(true);
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -182,6 +191,9 @@ describe("getAllFeatureStates", () => {
     expect(otherStaffStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
       false,
     );
+    expect(
+      otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
+    ).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -86,4 +86,5 @@ export enum FeatureSwitchKey {
   ChatConversationLocator = "chatConversationLocator",
   SharedChatDatabase = "sharedChatDatabase",
   ComposerSubmitDomReconcile = "composerSubmitDomReconcile",
+  ComposerRestoredAttachmentValidation = "composerRestoredAttachmentValidation",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -392,6 +392,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
+  [FeatureSwitchKey.ComposerRestoredAttachmentValidation]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Validate restored composer attachments against the current account, remove unavailable references, and show a warning.",
+    enabled: false,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
@@ -42,17 +42,6 @@ describe("Toaster", () => {
     ).toBe("calc(var(--sab, 0px) + 16px)");
   });
 
-  it("uses the warning color for warning toast icons", async () => {
-    render(<Toaster />);
-
-    toast.warning("Attachment unavailable");
-
-    const message = await screen.findByText("Attachment unavailable");
-    expect(message.closest("[data-sonner-toast]")).toHaveClass(
-      "[&[data-type=warning]_[data-icon]]:text-amber-500",
-    );
-  });
-
   it("calls onReady only once when its callback identity changes", async () => {
     const firstOnReady = vi.fn<() => void>();
     const secondOnReady = vi.fn<() => void>();

--- a/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
@@ -42,6 +42,17 @@ describe("Toaster", () => {
     ).toBe("calc(var(--sab, 0px) + 16px)");
   });
 
+  it("uses the warning color for warning toast icons", async () => {
+    render(<Toaster />);
+
+    toast.warning("Attachment unavailable");
+
+    const message = await screen.findByText("Attachment unavailable");
+    expect(message.closest("[data-sonner-toast]")).toHaveClass(
+      "[&[data-type=warning]_[data-icon]]:text-amber-500",
+    );
+  });
+
   it("calls onReady only once when its callback identity changes", async () => {
     const firstOnReady = vi.fn<() => void>();
     const secondOnReady = vi.fn<() => void>();

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -49,7 +49,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
         toastOptions={{
           classNames: {
             toast:
-              "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
+              "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=warning]_[data-icon]]:text-amber-500 [&[data-type=error]_[data-icon]]:text-red-500",
             description: "group-[.toast]:text-muted-foreground",
             actionButton:
               "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -18,6 +18,23 @@ const DEFAULT_TOASTER_MOBILE_OFFSET = {
   left: "0px",
 } satisfies ToasterProps["mobileOffset"];
 
+const DEFAULT_WARNING_ICON = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    height="20"
+    width="20"
+    style={{ color: "#f59e0b" }}
+  >
+    <path
+      fillRule="evenodd"
+      d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
 function ToasterReady({ onReady }: { readonly onReady: () => void }) {
   const initialOnReadyRef = useRef(onReady);
 
@@ -30,6 +47,7 @@ function ToasterReady({ onReady }: { readonly onReady: () => void }) {
 
 function Toaster({ onReady, ...props }: ToasterProps) {
   const {
+    icons,
     mobileOffset = DEFAULT_TOASTER_MOBILE_OFFSET,
     offset = DEFAULT_TOASTER_OFFSET,
     style,
@@ -40,6 +58,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
       <Sonner
         className="toaster group !flex !flex-col !items-center"
         duration={3000}
+        icons={{ warning: DEFAULT_WARNING_ICON, ...icons }}
         mobileOffset={mobileOffset}
         offset={offset}
         style={{
@@ -49,7 +68,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
         toastOptions={{
           classNames: {
             toast:
-              "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=warning]_[data-icon]]:text-amber-500 [&[data-type=error]_[data-icon]]:text-red-500",
+              "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
             description: "group-[.toast]:text-muted-foreground",
             actionButton:
               "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
## Summary

- gate restored-attachment validation behind `composerRestoredAttachmentValidation`, disabled by default and statically enabled only for `bingjie@vm0.ai`
- validate restored attachment references against the current account before they are reused
- remove unavailable chips automatically, show a localized re-upload warning, and persist the cleaned draft
- render warning toast icons with the shared amber warning color instead of the generic green success color

## Testing

- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-draft.test.tsx --silent=passed-only`
- `pnpm -F @okouai/ui lint`
- `pnpm -F @okouai/ui check-types`
- `pnpm -F @okouai/ui exec vitest run src/components/ui/__tests__/sonner.test.tsx --silent=passed-only`
- `pnpm knip --workspace @okouai/app`
- `pnpm exec prettier --check` on all changed files

Closes #28769
