### PR TITLE
fix(platform): flatten the model picker category switch and tighten its header

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1206,6 +1206,22 @@ async function cardEdgeAppearance(locator: Locator) {
   });
 }
 
+async function segmentFill(locator: Locator) {
+  return locator.evaluate(async (element) => {
+    // Segments cross-fade when the selection moves, so read them settled.
+    await Promise.all(
+      element.getAnimations().map((animation) => {
+        return animation.finished;
+      }),
+    );
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      boxShadow: style.boxShadow,
+    };
+  });
+}
+
 test("chat page displays tagline after onboarding", async ({ page }) => {
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
@@ -1270,6 +1286,33 @@ test("model picker fits seven rows and scrolls one row for eight", async ({
   expect(eightModels.scrollHeight - eightModels.clientHeight).toBe(
     eightModels.rowStep,
   );
+});
+
+test("model picker category switch marks its selection without a raised shadow", async ({
+  page,
+}) => {
+  await mockModelPickerBoundary(page);
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+  await page
+    .getByRole("combobox", { name: "Claude Fable 5", exact: true })
+    .click();
+  const categorySwitch = page.getByRole("radiogroup", { name: "Models" });
+  const chatCategory = categorySwitch.getByRole("radio", { name: "Chat" });
+  const imageCategory = categorySwitch.getByRole("radio", { name: "Image" });
+  await imageCategory.click();
+  await expect(imageCategory).toBeChecked();
+
+  // The switch sits straight on the popover surface with no track to lift off,
+  // so the selection is a flat state layer: readable against its neighbours,
+  // and carrying none of the raised segment's shadow.
+  const [selected, unselected] = await Promise.all([
+    segmentFill(imageCategory),
+    segmentFill(chatCategory),
+  ]);
+  expect(selected.boxShadow).toBe("none");
+  expect(selected.backgroundColor).not.toBe(unselected.backgroundColor);
 });
 
 test("chat composer keeps the model icon unclipped on narrow screens", async ({

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1251,10 +1251,10 @@ test("model picker fits seven rows and scrolls one row for eight", async ({
 
   const sevenModels = await openModelPickerAndReadGeometry(page);
   expect(sevenModels).toStrictEqual({
-    clientHeight: 300,
+    clientHeight: 288,
     optionCount: 7,
     rowStep: 36,
-    scrollHeight: 300,
+    scrollHeight: 288,
   });
 
   boundary.showEightModels();
@@ -1262,10 +1262,10 @@ test("model picker fits seven rows and scrolls one row for eight", async ({
 
   const eightModels = await openModelPickerAndReadGeometry(page);
   expect(eightModels).toStrictEqual({
-    clientHeight: 300,
+    clientHeight: 288,
     optionCount: 8,
     rowStep: 36,
-    scrollHeight: 336,
+    scrollHeight: 324,
   });
   expect(eightModels.scrollHeight - eightModels.clientHeight).toBe(
     eightModels.rowStep,

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -1086,15 +1086,18 @@ function ModelPickerListHeader({
 }) {
   return (
     // Pinned so switching category never means scrolling back up for the
-    // switch. The negative margins bleed the row over the list's own `p-1`
-    // inset so rows scroll under an opaque surface rather than beside it.
+    // switch. The negative side and top margins bleed the row over the list's
+    // own `p-1` inset so rows scroll under an opaque surface rather than
+    // beside it.
     //
-    // `py-2` matches `pr-2`: the switch is a 28px control tucked into the
-    // popover's top-right corner, and 4px above it against 8px beside it read
-    // as a mistake rather than as a tighter grid.
+    // The 28px switch is what sets this row's height, so its padding is what
+    // sets the label's distance from the first option: `py-2` left the label
+    // floating in a band nearly four times its own ink. `py-1` seats the
+    // switch on the same 4px inset the rows sit on, and `-mb-1` takes back the
+    // list's `gap-1` so the header's own padding is the whole distance.
     <div
       data-model-picker-header
-      className="sticky top-0 z-10 -mx-1 -mt-1 flex items-center gap-2 bg-card py-2 pl-3 pr-2"
+      className="sticky top-0 z-10 -mx-1 -mt-1 -mb-1 flex items-center gap-2 bg-card py-1 pl-3 pr-2"
     >
       <span className="min-w-0 flex-1 truncate text-xs font-medium text-muted-foreground">
         {label}
@@ -1111,13 +1114,12 @@ const MEDIA_MODEL_CATEGORY_ICONS = {
 
 const CHAT_CATEGORY_VALUE = "chat";
 
-// Icon-only, and trackless: three glyphs sitting straight on the popover
-// surface. A filled track was the darkest thing in a popover otherwise made of
-// quiet rows, and the labels it carried repeated the group label beside it.
-// The selected glyph takes the shared selected layer, which reads on any
-// surface and reverses in dark, in place of the raised segment fill.
-const MEDIA_MODEL_CATEGORY_SEGMENT_CLASS =
-  "w-7 px-0 data-checked:bg-state-selected data-checked:shadow-none";
+// Icon-only: three glyphs sitting straight on the popover surface. A filled
+// track was the darkest thing in a popover otherwise made of quiet rows, and
+// the labels it carried repeated the group label beside it. The `plain`
+// variant is what drops the track and, with it, the raised fill and shadow the
+// selected glyph used to carry; only the square footprint is set here.
+const MEDIA_MODEL_CATEGORY_SEGMENT_CLASS = "w-7 px-0";
 
 /**
  * Category switch for the popover. It used to live in the composer as a filled
@@ -1132,7 +1134,8 @@ function MediaModelCategorySwitch({ panel }: { panel: MediaModelPanelState }) {
   return (
     <SegmentControl
       size="xs"
-      className="shrink-0 gap-0.5 bg-transparent p-0"
+      variant="plain"
+      className="shrink-0"
       aria-label={t(($) => {
         return $.settings.models.picker.models;
       })}
@@ -1211,13 +1214,14 @@ function ModelFirstModelPickerContentLayout({
         // a name beside a badge again.
         "min-w-[260px]",
         mediaModelPanel
-          ? // The 302px bordered cap leaves a 300px scroll viewport: enough for
+          ? // The 290px bordered cap leaves a 288px scroll viewport: enough for
             // the header and seven model rows, while an eighth adds one 32px
             // row plus its 4px gap. The image category is the one that runs
-            // past it today, and scrolls by that single row. The cap grew with
-            // the header when it went from `py-1` to `py-2`; both numbers move
-            // together or seven rows stop fitting.
-            "max-h-[302px]"
+            // past it today, and scrolls by that single row. The cap tracks the
+            // header's height -- it lost 12px when the header went to `py-1`
+            // and dropped the gap beneath it; both numbers move together or
+            // seven rows stop fitting.
+            "max-h-[290px]"
           : "max-h-[280px]",
       )}
     >

--- a/turbo/packages/ui/src/components/ui/__tests__/segment-control.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/segment-control.test.tsx
@@ -51,18 +51,6 @@ describe("SegmentControl", () => {
     expect(screen.getByRole("radio", { name: "16:9" })).toBeChecked();
   });
 
-  it("drops the raised selected fill and its shadow in the plain variant", () => {
-    renderAspectRatioControl({ variant: "plain" });
-
-    const selected = screen.getByRole("radio", { name: "9:16" });
-
-    // The raised fill and the shadow are separate utilities, so a consumer
-    // cannot take the shadow back through `className` on its own.
-    expect(selected.className).not.toContain("bg-segment-selected");
-    expect(selected.className).not.toContain("shadow-segment-selected");
-    expect(selected.className).toContain("data-checked:bg-state-selected");
-  });
-
   it("skips a disabled segment", async () => {
     const user = userEvent.setup();
     render(

--- a/turbo/packages/ui/src/components/ui/__tests__/segment-control.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/segment-control.test.tsx
@@ -51,6 +51,18 @@ describe("SegmentControl", () => {
     expect(screen.getByRole("radio", { name: "16:9" })).toBeChecked();
   });
 
+  it("drops the raised selected fill and its shadow in the plain variant", () => {
+    renderAspectRatioControl({ variant: "plain" });
+
+    const selected = screen.getByRole("radio", { name: "9:16" });
+
+    // The raised fill and the shadow are separate utilities, so a consumer
+    // cannot take the shadow back through `className` on its own.
+    expect(selected.className).not.toContain("bg-segment-selected");
+    expect(selected.className).not.toContain("shadow-segment-selected");
+    expect(selected.className).toContain("data-checked:bg-state-selected");
+  });
+
   it("skips a disabled segment", async () => {
     const user = userEvent.setup();
     render(

--- a/turbo/packages/ui/src/components/ui/segment-control.tsx
+++ b/turbo/packages/ui/src/components/ui/segment-control.tsx
@@ -9,8 +9,28 @@ import { cn } from "../../lib/utils";
 
 type SegmentControlSize = "xs" | "sm" | "default" | "lg";
 
-const SegmentControlSizeContext =
-  React.createContext<SegmentControlSize>("default");
+/**
+ * `default` is the tracked control: a recessed track with the selected segment
+ * raised out of it. `plain` is the same control without the track -- segments
+ * sit straight on whatever surface holds them, and the selection is marked
+ * with the shared selected layer instead of a raised fill. The raised fill
+ * needs a track to lift off; on a bare surface it reads as a stray card.
+ *
+ * The two treatments are variants rather than class overrides because the
+ * selected fill and its shadow are separate utilities that a consumer's
+ * `className` cannot reliably take back.
+ */
+type SegmentControlVariant = "default" | "plain";
+
+interface SegmentControlContextValue {
+  size: SegmentControlSize;
+  variant: SegmentControlVariant;
+}
+
+const SegmentControlContext = React.createContext<SegmentControlContextValue>({
+  size: "default",
+  variant: "default",
+});
 
 /**
  * The track carries the same heights and radius as the rest of the control
@@ -23,7 +43,7 @@ const SegmentControlSizeContext =
  * step under the selected segment in both themes.
  */
 const segmentControlVariants = cva(
-  "inline-flex items-center gap-0.5 rounded-lg bg-muted p-0.5",
+  "inline-flex items-center gap-0.5 rounded-lg",
   {
     variants: {
       size: {
@@ -32,9 +52,16 @@ const segmentControlVariants = cva(
         default: "h-9",
         lg: "h-10",
       },
+      variant: {
+        default: "bg-muted p-0.5",
+        // No track means nothing to inset the segments from, so the track
+        // padding goes with it and a segment is the full control height.
+        plain: "p-0",
+      },
     },
     defaultVariants: {
       size: "default",
+      variant: "default",
     },
   },
 );
@@ -43,12 +70,14 @@ const segmentControlVariants = cva(
  * `rounded-md` keeps the segment concentric with the track: the 8px outer
  * radius minus the 2px of track padding it sits inside.
  *
- * The selected segment carries an opaque fill, so it must not take the
+ * A selected `default` segment carries an opaque fill, so it must not take the
  * translucent `state-hover` layer -- the layer replaces a fill instead of
- * sitting on it, which would drop the segment back to the track colour.
+ * sitting on it, which would drop the segment back to the track colour. The
+ * hover rule stays scoped to the unselected segments for `plain` too, where
+ * the selection is itself a state layer.
  */
 const segmentControlItemVariants = cva(
-  "inline-flex h-full shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap text-muted-foreground outline-none transition-colors select-none not-data-checked:hover:bg-state-hover not-data-checked:hover:text-foreground data-checked:bg-segment-selected data-checked:text-foreground data-checked:shadow-segment-selected data-disabled:pointer-events-none data-disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex h-full shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap text-muted-foreground outline-none transition-colors select-none not-data-checked:hover:bg-state-hover not-data-checked:hover:text-foreground data-checked:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     // Segment padding runs one step tighter than the matching button size,
     // because the segment already sits inside the track's 2px inset -- that
@@ -63,9 +92,17 @@ const segmentControlItemVariants = cva(
         default: "px-3 text-sm",
         lg: "px-5 text-sm",
       },
+      variant: {
+        default:
+          "data-checked:bg-segment-selected data-checked:shadow-segment-selected",
+        // The selected layer reads on any surface and reverses in dark, so a
+        // trackless segment needs no raised fill -- and no shadow with it.
+        plain: "data-checked:bg-state-selected",
+      },
     },
     defaultVariants: {
       size: "default",
+      variant: "default",
     },
   },
 );
@@ -76,21 +113,23 @@ interface SegmentControlProps<Value> extends Omit<
 > {
   className?: string;
   size?: SegmentControlSize;
+  variant?: SegmentControlVariant;
 }
 
 function SegmentControl<Value>({
   className,
   size = "default",
+  variant = "default",
   ...props
 }: SegmentControlProps<Value>) {
   return (
-    <SegmentControlSizeContext value={size}>
+    <SegmentControlContext value={{ size, variant }}>
       <RadioGroupPrimitive
         data-slot="segment-control"
-        className={cn(segmentControlVariants({ size }), className)}
+        className={cn(segmentControlVariants({ size, variant }), className)}
         {...props}
       />
-    </SegmentControlSizeContext>
+    </SegmentControlContext>
   );
 }
 SegmentControl.displayName = "SegmentControl";
@@ -106,12 +145,12 @@ function SegmentControlItem<Value>({
   className,
   ...props
 }: SegmentControlItemProps<Value>) {
-  const size = React.useContext(SegmentControlSizeContext);
+  const { size, variant } = React.useContext(SegmentControlContext);
 
   return (
     <RadioPrimitive.Root
       data-slot="segment-control-item"
-      className={cn(segmentControlItemVariants({ size }), className)}
+      className={cn(segmentControlItemVariants({ size, variant }), className)}
       {...props}
     />
   );


### PR DESCRIPTION
## What

Two fixes to the model picker popover, from feedback on the image-model panel.

### 1. The selected category glyph no longer carries a shadow

The trackless switch already tried to opt out with `data-checked:shadow-none`, but tailwind-merge sorts `shadow-segment-selected` into its `shadow-color` group and `shadow-none` into its `shadow` group — the two never conflict, so both classes survived into the DOM and the raised shadow won.

Rather than fight the merge, the raised treatment now lives in a `plain` variant of `SegmentControl`: no track, no opaque fill, no shadow — just the shared selected layer. The picker asks for the variant instead of patching classes.

### 2. Less air between the group label and the first option

The 28px switch is what sets the header row's height, so its `py-2` left the label floating in a 44px band around 12px of ink — 19px of clear space above the first row. `py-1` seats the switch on the same 4px inset the rows sit on, and `-mb-1` takes back the list's `gap-1`, so the header's own padding is the whole distance: 19px → 12px.

The popover's `max-h` tracks the header height (it is sized to show the header plus seven rows), so it moves with it: 302px → 290px.

## Test plan

- [x] Added a regression test asserting the `plain` variant renders neither the raised fill nor its shadow
- [ ] CI: lint, types, tests
- [ ] Visual check on the preview: open the model picker, switch between chat / image / video

🤖 Generated with [Claude Code](https://claude.com/claude-code)