### PR TITLE
test(python): cover failure reporter shutdown timeout

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -139,6 +139,23 @@ def _report_omissions(proxy_log_path: Path) -> list[dict[str, object]]:
     ]
 
 
+def _assert_queued_reports_cancelled(
+    proxy_log_path: Path,
+    flows: list[http.HTTPFlow],
+) -> None:
+    shutdown_entries = [
+        entry for entry in _report_omissions(proxy_log_path) if entry.get("reason") == "shutdown"
+    ]
+    assert len(shutdown_entries) == _REPORT_CAPACITY - _REPORT_WORKERS
+    assert len({entry["flow_id"] for entry in shutdown_entries}) == len(shutdown_entries)
+    flow_ids = {flow.id for flow in flows}
+    for entry in shutdown_entries:
+        flow_id = entry["flow_id"]
+        assert isinstance(flow_id, str)
+        assert flow_id in flow_ids
+        _assert_report_omission_entry(entry, flow_id=flow_id, reason="shutdown")
+
+
 def _assert_report_omission_entry(
     entry: dict[str, object],
     *,
@@ -528,22 +545,58 @@ def test_shutdown_cancels_queued_reports(
         shutdown_thread.join(timeout=3)
 
     assert model_provider_failure_api.request_count == _REPORT_WORKERS
-    shutdown_entries = [
-        entry for entry in _report_omissions(proxy_log_path) if entry.get("reason") == "shutdown"
-    ]
-    assert len(shutdown_entries) == _REPORT_CAPACITY - _REPORT_WORKERS
-    assert len({entry["flow_id"] for entry in shutdown_entries}) == len(shutdown_entries)
-    flow_ids = {flow.id for flow in flows}
-    for entry in shutdown_entries:
-        flow_id = entry["flow_id"]
-        assert isinstance(flow_id, str)
-        assert flow_id in flow_ids
-        _assert_report_omission_entry(entry, flow_id=flow_id, reason="shutdown")
+    _assert_queued_reports_cancelled(proxy_log_path, flows)
 
     _restart_reporter_after_callbacks(model_provider_failure_api)
     _assert_full_report_capacity(
         real_flow,
         tmp_path / "shutdown-recovery.jsonl",
+        model_provider_failure_api,
+    )
+
+
+def test_shutdown_timeout_returns_with_running_reports_blocked(
+    tmp_path,
+    real_flow,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "shutdown-timeout.jsonl"
+    rejected_log_path = tmp_path / "shutdown-timeout-rejected.jsonl"
+    release_delivery = threading.Event()
+    for _ in range(_REPORT_WORKERS):
+        model_provider_failure_api.queue_response(204, release_event=release_delivery)
+    flows = [
+        _enqueue_provider_unavailable(real_flow, proxy_log_path) for _ in range(_REPORT_CAPACITY)
+    ]
+
+    assert model_provider_failure_api.wait_for_request_count(_REPORT_WORKERS)
+
+    shutdown_thread = ThreadUnderTest(target=model_provider_failure.shutdown)
+    try:
+        with patch.object(model_provider_failure, "_REPORT_TIMEOUT_SECONDS", 0.01):
+            shutdown_thread.start()
+            shutdown_thread.join_and_raise(timeout=1)
+
+        assert not release_delivery.is_set()
+        rejected_flow = _enqueue_provider_unavailable(real_flow, rejected_log_path)
+        assert model_provider_failure_api.request_count == _REPORT_WORKERS
+        _assert_single_report_omission(
+            rejected_log_path,
+            flow_id=rejected_flow.id,
+            reason="reporting_not_configured",
+        )
+    finally:
+        release_delivery.set()
+        shutdown_thread.join(timeout=1)
+        model_provider_failure.drain_reports_for_tests()
+
+    assert model_provider_failure_api.request_count == _REPORT_WORKERS
+    _assert_queued_reports_cancelled(proxy_log_path, flows)
+
+    _restart_reporter_after_callbacks(model_provider_failure_api)
+    _assert_full_report_capacity(
+        real_flow,
+        tmp_path / "shutdown-timeout-recovery.jsonl",
         model_provider_failure_api,
     )
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -563,6 +563,8 @@ def test_shutdown_timeout_returns_with_running_reports_blocked(
     proxy_log_path = tmp_path / "shutdown-timeout.jsonl"
     rejected_log_path = tmp_path / "shutdown-timeout-rejected.jsonl"
     release_delivery = threading.Event()
+    executor_shutdown_started = threading.Event()
+    continue_shutdown = threading.Event()
     for _ in range(_REPORT_WORKERS):
         model_provider_failure_api.queue_response(204, release_event=release_delivery)
     flows = [
@@ -571,21 +573,48 @@ def test_shutdown_timeout_returns_with_running_reports_blocked(
 
     assert model_provider_failure_api.wait_for_request_count(_REPORT_WORKERS)
 
+    original_shutdown = ThreadPoolExecutor.shutdown
+
+    def pause_after_executor_shutdown(
+        executor: ThreadPoolExecutor,
+        wait: bool = True,
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        original_shutdown(executor, wait=wait, cancel_futures=cancel_futures)
+        executor_shutdown_started.set()
+        if not continue_shutdown.wait(timeout=1):
+            raise AssertionError("failure reporter shutdown test did not release executor shutdown")
+
     shutdown_thread = ThreadUnderTest(target=model_provider_failure.shutdown)
     try:
-        with patch.object(model_provider_failure, "_REPORT_TIMEOUT_SECONDS", 0.01):
+        with (
+            patch.object(model_provider_failure, "_REPORT_TIMEOUT_SECONDS", 0.01),
+            patch.object(ThreadPoolExecutor, "shutdown", pause_after_executor_shutdown),
+        ):
             shutdown_thread.start()
+            wait_for_event(
+                executor_shutdown_started,
+                timeout=1,
+                threads=(shutdown_thread,),
+                message="failure reporter did not begin executor shutdown",
+            )
+            assert shutdown_thread.is_alive()
+
+            rejected_flow = _enqueue_provider_unavailable(real_flow, rejected_log_path)
+            assert model_provider_failure_api.request_count == _REPORT_WORKERS
+            _assert_single_report_omission(
+                rejected_log_path,
+                flow_id=rejected_flow.id,
+                reason="reporting_not_configured",
+            )
+
+            continue_shutdown.set()
             shutdown_thread.join_and_raise(timeout=1)
 
         assert not release_delivery.is_set()
-        rejected_flow = _enqueue_provider_unavailable(real_flow, rejected_log_path)
-        assert model_provider_failure_api.request_count == _REPORT_WORKERS
-        _assert_single_report_omission(
-            rejected_log_path,
-            flow_id=rejected_flow.id,
-            reason="reporting_not_configured",
-        )
     finally:
+        continue_shutdown.set()
         release_delivery.set()
         shutdown_thread.join(timeout=1)
         model_provider_failure.drain_reports_for_tests()


### PR DESCRIPTION
## Summary

- add deterministic integration coverage for the model-provider failure reporter's bounded shutdown timeout
- keep four real loopback HTTP deliveries blocked while proving shutdown returns and queued reports are cancelled
- synchronize inside real executor shutdown to prove new reports are rejected while shutdown is actively in progress
- verify callback cleanup restores the reporter's full capacity

## Scope

- test-only change in the mitm-addon model-provider failure reporting suite
- no production behavior, protocol, dependency, migration, or deployment change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_model_provider_failure_reporting.py::test_shutdown_timeout_returns_with_running_reports_blocked` (1 passed in 0.21s)
- `uv run --no-sync python -m pytest -q tests/test_model_provider_failure_reporting.py -k 'shutdown_cancels_queued_reports or shutdown_timeout_returns_with_running_reports_blocked'` (2 passed)
- `uv run --no-sync python -m pytest -q tests/test_model_provider_failure_reporting.py` (87 passed in 1.45s)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/ --quiet` (6,568 passed in 31.07s)

Closes #28861
