### PR TITLE
perf(guest-agent): buffer transcript writes

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -459,8 +459,8 @@ async fn run_codex_app_server(
     }
     let active_input_delivery_ids = active_input_controller.finalize_receipts().await;
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
-    // Complete the final event-log write after the child is stopped and
-    // before callers observe the finished app-server execution.
+    // Publish buffered event-log bytes after the child is stopped and before
+    // callers observe the finished app-server execution.
     agent_log.flush().await;
     let active_input_delivery_ids = match active_input_delivery_ids {
         Ok(delivery_ids) => delivery_ids,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -71,12 +71,13 @@ use std::time::{Duration, Instant};
 use termination::{
     CliTerminationRuntime, ControlTerminationLog, PostResultCleanupPolicy, TerminationReason,
 };
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::oneshot;
 use tokio::time::Sleep;
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const AGENT_LOG_BUFFER_BYTES: usize = 8 * 1024;
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 const OKOU_AGENT_ID_ENV_KEY: &str = "OKOU_AGENT_ID";
 const CLI_PACKAGE_URL_ENV_KEY: &str = "CLI_PKG_URL";
@@ -616,14 +617,17 @@ enum ParsedEventAction {
 }
 
 struct BestEffortAgentLog {
-    file: Option<tokio::fs::File>,
+    file: Option<BufWriter<tokio::fs::File>>,
 }
 
 impl BestEffortAgentLog {
     fn open(path: &str) -> Self {
         match guest_contracts::runtime_paths::create_private(path) {
             Ok(file) => Self {
-                file: Some(tokio::fs::File::from_std(file)),
+                file: Some(BufWriter::with_capacity(
+                    AGENT_LOG_BUFFER_BYTES,
+                    tokio::fs::File::from_std(file),
+                )),
             },
             Err(error) => {
                 Self::warn_failure("open", &error);

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1702,9 +1702,8 @@ async fn execute_cli_inner(
         }
     };
 
-    // `tokio::fs::File` may still own an in-flight blocking write after
-    // `write_all` returns. Wait for it before callers observe the completed
-    // execution and read the run log.
+    // Publish buffered transcript bytes and finish any in-flight file write
+    // before callers observe the completed execution and read the run log.
     agent_log.flush().await;
 
     active_input_controller.close_terminal();

--- a/crates/guest-agent/tests/claude_task_notification_result.rs
+++ b/crates/guest-agent/tests/claude_task_notification_result.rs
@@ -7,6 +7,8 @@ use guest_contracts::diagnostics::CliTerminationReason;
 use serde_json::json;
 use std::time::Duration;
 
+const TRANSCRIPT_CHECKPOINT_PADDING_BYTES: usize = 16 * 1024;
+
 #[tokio::test]
 async fn task_notification_result_does_not_end_the_user_command()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -64,7 +66,10 @@ async fn task_notification_result_does_not_end_the_user_command()
             "message": {
                 "role": "assistant",
                 "content": [{ "type": "text", "text": continued_activity }]
-            }
+            },
+            // Keep this checkpoint larger than the transcript buffer. Its
+            // persisted marker proves the earlier task result was consumed.
+            "checkpoint_padding": "x".repeat(TRANSCRIPT_CHECKPOINT_PADDING_BYTES)
         })
         .to_string(),
     ]

--- a/crates/guest-agent/tests/cli_agent_log_buffering.rs
+++ b/crates/guest-agent/tests/cli_agent_log_buffering.rs
@@ -1,0 +1,45 @@
+//! Buffered Claude agent-log writes preserve exact JSONL bytes at completion.
+
+mod common;
+
+use guest_agent::cli::ClaudeResultStatus;
+use std::time::Duration;
+
+const INIT_RECORD: &str = r#"{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"00000000-0000-4000-8000-000000000001","tools":["Bash"],"model":"mock-claude"}"#;
+const ASSISTANT_RECORD: &str = r#"{"type":"assistant","session_id":"00000000-0000-4000-8000-000000000001","message":{"role":"assistant","content":[{"type":"text","text":"buffered response"}]}}"#;
+const RESULT_RECORD: &str = r#"{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000001","is_error":false,"duration_ms":1,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}"#;
+
+#[tokio::test]
+async fn agent_log_flushes_exact_buffered_records_before_claude_run_returns()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let payload = [INIT_RECORD, ASSISTANT_RECORD, RESULT_RECORD].join("\n");
+    let prompt = format!("@ECHO@\n{payload}");
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("buffered Claude run should complete promptly")?;
+
+    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
+    assert_eq!(
+        execution.claude_result.map(|result| result.status),
+        Some(ClaudeResultStatus::Success)
+    );
+    let expected = format!("{payload}\n");
+    assert_eq!(
+        std::fs::read(runtime.paths.agent_log_file())?,
+        expected.as_bytes()
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
@@ -5,6 +5,8 @@ mod common;
 use guest_agent::cli::ClaudeResultStatus;
 use std::time::Duration;
 
+const AGENT_LOG_WARNING: &str = "Agent log flush failed; continuing without local transcript";
+const FILE_SIZE_LIMIT: usize = 4 * 1024;
 const RESULT_RECORD: &str = r#"{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000001","is_error":false,"duration_ms":1,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}"#;
 
 #[tokio::test]
@@ -13,9 +15,13 @@ async fn agent_log_flush_failure_keeps_claude_run_successful()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let (mut gate, gated_mock) = common::PostOpenMockGate::create(tmp.path(), &mock)?;
-    // The raw record reaches the file while Tokio buffers the delimiter. The
-    // final flush surfaces EFBIG after the result has already been processed.
-    let prompt = format!("@ECHO@\n{RESULT_RECORD}");
+    let record = format!(
+        "{RESULT_RECORD}{}",
+        " ".repeat(FILE_SIZE_LIMIT - RESULT_RECORD.len())
+    );
+    // The padded record reaches the file while the delimiter crosses the
+    // process file-size limit during the final buffer flush.
+    let prompt = format!("@ECHO@\n{record}");
     unsafe {
         common::setup_env(&gated_mock, tmp.path(), &prompt, 3, 1)?;
     }
@@ -34,7 +40,9 @@ async fn agent_log_flush_failure_keeps_claude_run_successful()
         ready = gate.wait_until_ready(Duration::from_secs(5)) => ready?,
     }
 
-    let limit = u64::try_from(RESULT_RECORD.len())?;
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log = common::SystemLogOverrideGuard::set(&system_log_path);
+    let limit = u64::try_from(FILE_SIZE_LIMIT)?;
     let limit_guard = common::set_soft_file_size_limit(limit)?;
     gate.release()?;
     let outcome = match tokio::time::timeout(Duration::from_secs(5), &mut execution).await {
@@ -62,8 +70,10 @@ async fn agent_log_flush_failure_keeps_claude_run_successful()
     assert_eq!(execution.last_event_sequence, None);
     assert_eq!(
         std::fs::read(runtime.paths.agent_log_file())?,
-        RESULT_RECORD.as_bytes()
+        record.as_bytes()
     );
+    let system_log = std::fs::read_to_string(system_log_path)?;
+    assert_eq!(system_log.matches(AGENT_LOG_WARNING).count(), 1);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
@@ -5,8 +5,11 @@ mod common;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
+const AGENT_LOG_WARNING: &str = "Agent log write failed; continuing without local transcript";
+const FILE_SIZE_LIMIT: usize = 4 * 1024;
+
 #[tokio::test]
-async fn first_agent_log_write_failure_keeps_codex_run_successful()
+async fn buffered_agent_log_write_failure_keeps_codex_run_successful()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
@@ -18,7 +21,7 @@ async fn first_agent_log_write_failure_keeps_codex_run_successful()
             common::CodexAppServerEnvConfig {
                 run_id: "codex-agent-log-persistence-failure-test",
                 prompt: "fail the first local event write",
-                scenario: Some("runtime-turn-complete-without-thread-started"),
+                scenario: Some("runtime-event-flood"),
                 resume_session_id: None,
             },
         )?;
@@ -38,7 +41,9 @@ async fn first_agent_log_write_failure_keeps_codex_run_successful()
         ready = gate.wait_until_ready(Duration::from_secs(5)) => ready?,
     }
 
-    let limit_guard = common::set_soft_file_size_limit(0)?;
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log = common::SystemLogOverrideGuard::set(&system_log_path);
+    let limit_guard = common::set_soft_file_size_limit(u64::try_from(FILE_SIZE_LIMIT)?)?;
     gate.release()?;
     let outcome = tokio::time::timeout(Duration::from_secs(5), &mut execution)
         .await
@@ -49,7 +54,12 @@ async fn first_agent_log_write_failure_keeps_codex_run_successful()
     assert_eq!(execution.exit_code, common::CLEAN_EXIT);
     assert!(execution.control_error.is_none());
     assert!(execution.cli_termination.is_none());
-    assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
+    assert_eq!(
+        std::fs::metadata(runtime.paths.agent_log_file())?.len(),
+        u64::try_from(FILE_SIZE_LIMIT)?
+    );
+    let system_log = std::fs::read_to_string(system_log_path)?;
+    assert_eq!(system_log.matches(AGENT_LOG_WARNING).count(), 1);
 
     Ok(())
 }

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -25,6 +25,7 @@ const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_re
 const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
 const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
 const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
+const TRANSCRIPT_FENCE_PADDING_BYTES: usize = 16 * 1024;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const TOOL_OOM_PARENT_HEADROOM_BYTES: u64 = 192 * 1024 * 1024;
 const TOOL_OOM_READY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -165,9 +166,18 @@ fn emit_termination_ready_fence() {
 }
 
 fn emit_stream_event_fence(event_type: &str) {
+    // These mock-only events are consumption fences for integration tests.
+    // Keep each record larger than guest-agent's transcript buffer so seeing
+    // the marker on disk proves that all preceding events were ingested.
     println!(
         "{}",
-        json!({"type": "stream_event", "event": {"type": event_type}})
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": event_type,
+                "padding": "x".repeat(TRANSCRIPT_FENCE_PADDING_BYTES),
+            }
+        })
     );
     let _ = std::io::stdout().flush();
 }


### PR DESCRIPTION
## Summary

- buffer guest-agent transcript output with a fixed 8 KiB Tokio buffer shared by the Claude and Codex execution paths
- preserve exact JSONL output and best-effort failure handling across capacity-pressure writes and final flushes
- keep virtual-time integration fences deterministic without restoring per-record production flushes

## Scope

- no API, protocol, schema, environment variable, or transcript format changes
- no background writer, unbounded queue, periodic flush, or configurable buffer size

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- repository pre-commit hooks (`cargo-fmt`, workspace `cargo-doc`, workspace `cargo-clippy`, file-size check)

Closes #28858
