### PR TITLE
refactor: remove joggai built-in feature switch

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1832,14 +1832,6 @@ test("image lightbox centers and pans across the full viewer", async ({
 test("avatar catalog surfaces stay stable while scrolling and selecting", async ({
   page,
 }) => {
-  await page.route("**/api/feature-switches", async (route) => {
-    await route.fulfill({
-      json: {
-        switches: {},
-        effectiveSwitches: { joggAiBuiltIn: true },
-      },
-    });
-  });
   await page.route("**/api/avatar-video/avatars**", async (route) => {
     await route.fulfill({
       json: {

--- a/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
@@ -3,7 +3,6 @@ import { createHmac, randomUUID } from "node:crypto";
 
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
@@ -26,7 +25,6 @@ import { artifactCatalogRoutes } from "../artifact-catalog";
 import { avatarVideoRoutes } from "../avatar-video";
 import { billingStatusRoutes } from "../billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createRouteMocks } from "./helpers/route-test";
 import { seedCompose$, seedRun$ } from "./helpers/usage-state";
@@ -97,7 +95,6 @@ function okouToken(args: {
 }
 
 async function seedAvatarVideoFixture(options?: {
-  readonly featureEnabled?: boolean;
   readonly withPricing?: boolean;
 }): Promise<AvatarVideoFixture> {
   const pricing = await createUsagePricingFixture(
@@ -121,11 +118,6 @@ async function seedAvatarVideoFixture(options?: {
     { ...fixture, role: "admin" },
     context.signal,
   );
-  if (options?.featureEnabled !== undefined) {
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.JoggAiBuiltIn]: options.featureEnabled,
-    });
-  }
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return fixture;
 }
@@ -185,31 +177,6 @@ describe("JoggAI built-in avatar video routes", () => {
       clientId: "test-user",
       nonce: "test-nonce",
       mac: "test-mac",
-    });
-  });
-
-  it("keeps the built-in capability behind its feature switch", async () => {
-    const fixture = await seedAvatarVideoFixture({ featureEnabled: false });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-    const response = await createAvatarVideoTestApp(
-      fixture.usagePricingResolution,
-    ).request("/api/avatar-video/generate", {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({
-        avatarId: 81,
-        voiceId: "en-US-ChristopherNeural",
-        script: "Hello",
-      }),
-    });
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message:
-          "Built-in JoggAI avatar video generation is not enabled for this workspace.",
-        code: "FEATURE_DISABLED",
-      },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/avatar-video.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import { command, computed } from "ccstate";
+import { command } from "ccstate";
 import { avatarVideoContract } from "@okouai/api-contracts/contracts/avatar-video";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { env } from "../../lib/env";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -14,10 +12,8 @@ import { bodyResultOf, queryOf } from "../context/request";
 import { db$ } from "../external/db";
 import { createBuiltInGenerationRealtimeSubscription } from "../external/realtime";
 import type { RouteEntry } from "../route-entry";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import {
-  avatarVideoFeatureDisabled,
   avatarVideoInsufficientCredits,
   avatarVideoPricing$,
   avatarVideoRequiresPaidPlan,
@@ -46,18 +42,6 @@ import {
 const generateBody$ = bodyResultOf(avatarVideoContract.generate);
 const avatarsQuery$ = queryOf(avatarVideoContract.avatars);
 const voicesQuery$ = queryOf(avatarVideoContract.voices);
-
-const avatarVideoEnabled$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-});
 
 function avatarVideoRequestRecord(
   options: AvatarVideoOptions,
@@ -140,11 +124,6 @@ const submitAvatarVideoJob$ = command(
 
 const postGenerateInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(avatarVideoEnabled$))) {
-      return avatarVideoFeatureDisabled();
-    }
-    signal.throwIfAborted();
-
     const auth = get(organizationAuthContext$);
     const db = get(db$);
     const capabilities = await loadOrgPlanCapabilities(db, auth.orgId);
@@ -241,10 +220,6 @@ const postGenerateInner$ = command(
 );
 
 const getAvatarsInner$ = command(async ({ get }, signal: AbortSignal) => {
-  if (!(await get(avatarVideoEnabled$))) {
-    return avatarVideoFeatureDisabled();
-  }
-  signal.throwIfAborted();
   const apiKey = env("JOGGAI_API_KEY");
   if (!apiKey) {
     return avatarVideoServiceUnavailable(
@@ -263,10 +238,6 @@ const getAvatarsInner$ = command(async ({ get }, signal: AbortSignal) => {
 });
 
 const getVoicesInner$ = command(async ({ get }, signal: AbortSignal) => {
-  if (!(await get(avatarVideoEnabled$))) {
-    return avatarVideoFeatureDisabled();
-  }
-  signal.throwIfAborted();
   const apiKey = env("JOGGAI_API_KEY");
   if (!apiKey) {
     return avatarVideoServiceUnavailable(

--- a/turbo/apps/api/src/signals/services/avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/avatar-video.service.ts
@@ -38,7 +38,7 @@ const JOGGAI_PUBLIC_AVATARS_URL = `${JOGGAI_API_BASE_URL}/avatars/public`;
 const JOGGAI_PUBLIC_VOICES_URL = `${JOGGAI_API_BASE_URL}/voices`;
 const JOGGAI_CREDIT_DURATION_SECONDS = 120;
 
-type ErrorStatus = 400 | 402 | 403 | 502 | 503;
+type ErrorStatus = 400 | 402 | 502 | 503;
 
 interface ErrorBody {
   readonly error: {
@@ -182,16 +182,6 @@ export function avatarVideoRequiresPaidPlan(): AvatarVideoErrorResponse {
     body: errorBody(
       "Built-in avatar video generation requires Pro, Team, or Custom workspace access.",
       "PRO_REQUIRED",
-    ),
-  };
-}
-
-export function avatarVideoFeatureDisabled(): AvatarVideoErrorResponse {
-  return {
-    status: 403,
-    body: errorBody(
-      "Built-in JoggAI avatar video generation is not enabled for this workspace.",
-      "FEATURE_DISABLED",
     ),
   };
 }

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 
 import { setupPage } from "../../__tests__/page-helper.ts";
 import {
-  avatarTemplatesEnabled$,
   featureSwitch$,
   imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
@@ -47,23 +46,6 @@ describe("bootstrap feature switch hydration", () => {
     });
 
     expect(context.store.get(imageRecognitionAvailable$)).toBeTruthy();
-  });
-
-  it("enables avatar templates from the feature switch alone", async () => {
-    context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
-      return respond(200, {
-        switches: { [FeatureSwitchKey.JoggAiBuiltIn]: true },
-        effectiveSwitches: { [FeatureSwitchKey.JoggAiBuiltIn]: true },
-      });
-    });
-
-    await setupPage({
-      context,
-      path: "/error",
-      withoutRender: true,
-    });
-
-    expect(context.store.get(avatarTemplatesEnabled$)).toBeTruthy();
   });
 
   it("skips feature switch hydration without an authenticated organization", async () => {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -51,10 +51,6 @@ export const imageRecognitionAvailable$ = computed((): boolean => {
   return true;
 });
 
-export const avatarTemplatesEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.JoggAiBuiltIn] ?? false;
-});
-
 export const homeStartCardsEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.HomeStartCards] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/start-cards.ts
+++ b/turbo/apps/platform/src/signals/okou-page/start-cards.ts
@@ -5,7 +5,6 @@ import {
 } from "@okouai/core/workflow-template-items";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
-import { avatarTemplatesEnabled$ } from "../external/feature-switch.ts";
 import { connectorCatalogItemBySlug } from "../external/connectors.ts";
 
 /**
@@ -81,13 +80,9 @@ export const startCardWorkflowConnectorIcons$ = computed(
 );
 
 export const startCardKinds$ = computed((get): readonly StartCardKind[] => {
-  const avatarEnabled = get(avatarTemplatesEnabled$);
   const workflowTemplate = get(startCardWorkflowTemplate$);
   return get(internalStartCardOrder$)
     .filter((kind) => {
-      if (kind === "avatar") {
-        return avatarEnabled;
-      }
       if (kind === "workflow") {
         return workflowTemplate !== undefined;
       }

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -34,7 +34,6 @@ function artifact(overrides: Partial<ArtifactSummary> = {}): ArtifactSummary {
 
 function setupArtifactCatalogPage(
   featureSwitches: Partial<Record<FeatureSwitchKey, boolean>> = {
-    [FeatureSwitchKey.JoggAiBuiltIn]: true,
     [FeatureSwitchKey.SharedThreadSharing]: true,
   },
 ): void {
@@ -272,26 +271,6 @@ describe("artifact catalog page", () => {
     await findCard("launch-deck");
   });
 
-  it("hides avatars when the JoggAI switch is disabled", async () => {
-    context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
-      return respond(200, {
-        artifacts: [artifact({ kind: "presentation", title: "launch-deck" })],
-        nextCursor: null,
-      });
-    });
-
-    setupArtifactCatalogPage({
-      [FeatureSwitchKey.JoggAiBuiltIn]: false,
-      [FeatureSwitchKey.SharedThreadSharing]: true,
-    });
-    await findCard("launch-deck");
-
-    expect(buttonByLabel("Show avatar artifacts")).toBeUndefined();
-    expect(
-      buttonByLabel("Show shared conversation artifacts"),
-    ).toBeInTheDocument();
-  });
-
   it("hides shared conversations when sharing is disabled", async () => {
     context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
       return respond(200, {
@@ -301,7 +280,6 @@ describe("artifact catalog page", () => {
     });
 
     setupArtifactCatalogPage({
-      [FeatureSwitchKey.JoggAiBuiltIn]: true,
       [FeatureSwitchKey.SharedThreadSharing]: false,
     });
     await findCard("launch-deck");

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -375,21 +375,16 @@ export function ArtifactCatalogEmpty() {
 
 function ArtifactCatalogKindFilter({
   selectedKind,
-  avatarEnabled,
   sharedConversationEnabled,
   onKindChange,
 }: {
   readonly selectedKind: ArtifactCatalogKind | null;
-  readonly avatarEnabled: boolean;
   readonly sharedConversationEnabled: boolean;
   readonly onKindChange: (value: ArtifactCatalogKind | null) => void;
 }) {
   const { t } = useTranslation();
   const options = ARTIFACT_KIND_OPTIONS.filter((kind) => {
-    return (
-      (kind !== "avatar" || avatarEnabled) &&
-      (kind !== "shared-thread" || sharedConversationEnabled)
-    );
+    return kind !== "shared-thread" || sharedConversationEnabled;
   });
   return (
     <div
@@ -532,9 +527,6 @@ export function ArtifactCatalogPage() {
           </div>
           <ArtifactCatalogKindFilter
             selectedKind={selectedKind}
-            avatarEnabled={
-              featureSwitches[FeatureSwitchKey.JoggAiBuiltIn] ?? false
-            }
             sharedConversationEnabled={
               featureSwitches[FeatureSwitchKey.SharedThreadSharing] ?? false
             }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -253,7 +253,6 @@ async function openAvatarPicker(
 ): Promise<HTMLElement> {
   detachedSetupPage({
     context,
-    featureSwitches: { [FeatureSwitchKey.JoggAiBuiltIn]: true },
     path: `/chats/${THREAD_ID}`,
   });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -186,7 +186,6 @@ import {
 import {
   codexFastModeEnabled$,
   customConnectorMcpEnabled$,
-  avatarTemplatesEnabled$,
   imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
   videoModelSelectionEnabled$,
@@ -7090,7 +7089,7 @@ function ComposerTemplatePickerSlot({ signals }: { signals: ComposerSignals }) {
   const hasPptTab = true;
   const hasIllustrationTab = true;
   const hasVideoTab = true;
-  const hasAvatarTab = useGet(avatarTemplatesEnabled$);
+  const hasAvatarTab = true;
   const hasWorkflowTab = true;
   const presentationItems = PRESENTATION_TEMPLATE_PICKER_ITEMS;
   const prepareTemplateInsertion = useSet(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -13,7 +13,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.BoxConnector, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -18,7 +18,6 @@ export enum FeatureSwitchKey {
   DropboxConnector = "dropboxConnector",
   FigmaConnector = "figmaConnector",
   ExpensifyConnector = "expensifyConnector",
-  JoggAiBuiltIn = "joggAiBuiltIn",
   ManagedSocialKit = "managedSocialKit",
   MercuryConnector = "mercuryConnector",
   NeonConnector = "neonConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -108,11 +108,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Expensify accounting connector",
     enabled: false,
   },
-  [FeatureSwitchKey.JoggAiBuiltIn]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Enable vm0-managed JoggAI talking-avatar video generation",
-    enabled: true,
-  },
   [FeatureSwitchKey.ManagedSocialKit]: {
     maintainer: "lancy@vm0.ai",
     description: "Enable vm0-managed SocialKit data and analysis operations",


### PR DESCRIPTION
## Summary

- make vm0-managed JoggAI avatar generation permanently available
- remove `joggAiBuiltIn` / `JoggAiBuiltIn` from the feature-switch enum, API authorization path, Platform surfaces, E2E mocks, and test fixtures
- preserve plan, pricing, credit, provider-availability, and webhook validation behavior

## Switch history

- introduced in `a0e8cf62fbbd85245195d173e8a934109a85a2e6` (`feat: add built-in joggai avatar videos`)
- rolled out globally in `f801aebd94efb1587b030795aa68e9dace3ea796` (`feat: roll out avatar to all users`), which changed the switch to `enabled: true`

## Scope

- removed API feature authorization for generation, avatar listing, and voice listing
- removed the feature-disabled response and its negative route test
- permanently exposed avatar templates, start cards, and artifact filters
- removed switch hydration coverage, Platform switch fixtures, and the E2E feature-switch route mock
- removed the registry/key entry and core assertion

Search keywords reviewed: `joggAiBuiltIn`, `JoggAiBuiltIn`, `avatarTemplatesEnabled`, `avatarVideoFeatureDisabled`.

JoggAI names in route descriptions, webhook handlers, logs, and API contract summaries intentionally remain because they identify the built-in provider integration, not a rollout switch.

## Verification

- Prettier and `git diff --check`: passed
- core, API, Platform, and E2E type checks: passed; E2E type checking was repeated after rebasing onto latest `main`
- core feature-switch tests after rebasing: 25 passed
- targeted Platform tests after rebasing: 64 passed across 3 files
- core, API, and Platform lint checks: passed (repository-baseline warnings only)
- Knip: post-cleanup output matches the pre-cleanup baseline (48 existing configuration hints, no new unused findings)
- exact switch-identifier search: no remaining matches

## Local environment caveat

The API avatar-video route test requires the local PostgreSQL-backed route-test fixture. PostgreSQL is unavailable in this environment (`ECONNREFUSED` was confirmed by the billing route suite), so that database-backed test is left to CI. The Playwright scenario was type-checked but not executed because no local dev server was started. This PR is therefore opened as a draft.
