### PR TITLE
refactor: remove saved billing credit purchase switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -345,14 +345,6 @@ function authenticateOrg(
   mocks.clerk.session(fixture.userId, fixture.orgId, role);
 }
 
-async function enableSavedBillingPurchasePreview(
-  fixture: BillingOrgFixture,
-): Promise<void> {
-  await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-  });
-}
-
 function mockClerkOrganization(fixture: BillingOrgFixture): void {
   context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
     id: fixture.orgId,
@@ -1108,7 +1100,6 @@ describe("POST /api/billing/checkout", () => {
   it("pays a saved-card Plan preview through the rollout-safe checkout route", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
@@ -1274,7 +1265,6 @@ describe("POST /api/billing/checkout", () => {
       tier: "pro",
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
 
     const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     const periodStart = currentSecond();
@@ -1454,7 +1444,6 @@ describe("POST /api/billing/checkout", () => {
       tier: "pro",
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
 
     const previewPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     const replacementPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
@@ -1580,7 +1569,6 @@ describe("POST /api/billing/checkout", () => {
   it("refreshes an invalid Plan preview through the rollout-safe checkout route", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const initialPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     const currentPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
@@ -1659,7 +1647,6 @@ describe("POST /api/billing/checkout", () => {
   it("allows only one of two Plan previews to create a subscription", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
@@ -1767,7 +1754,6 @@ describe("POST /api/billing/checkout", () => {
   it("uses hosted Checkout when an opted-in plan purchase has no saved card", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
     context.mocks.stripe.customers.retrieve.mockResolvedValue({
@@ -2596,7 +2582,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     authenticateOrg(fixture);
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -3344,7 +3329,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     authenticateOrg(fixture);
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -3787,7 +3771,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const paymentMethodId = `pm_${randomUUID()}`;
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -3879,7 +3862,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
       "https://invoice.stripe.com/usage-pack-authentication";
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -3993,7 +3975,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const paymentMethodId = `pm_${randomUUID()}`;
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -4145,7 +4126,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const checkoutUrl = "https://checkout.stripe.com/session/usage-pack-retry";
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.UsagePackPlans]: true,
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -8581,7 +8561,6 @@ describe("usage pack allocation management", () => {
   it("retries a grouped subscription change after a Stripe failure", async () => {
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    await enableSavedBillingPurchasePreview(fixture);
     const sourceSubscription = managedUsagePackSubscription(
       fixture,
       new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
@@ -8681,7 +8660,6 @@ describe("usage pack allocation management", () => {
     });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_${randomUUID()}`;
     const oldSubscription = {
       ...managedUsagePackSubscription(
@@ -10767,7 +10745,6 @@ describe("usage pack allocation management", () => {
     });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_${randomUUID()}`;
     const oldSubscription = {
       ...managedUsagePackSubscription(
@@ -10869,7 +10846,6 @@ describe("usage pack allocation management", () => {
     });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_${randomUUID()}`;
     const oldSubscription = {
       ...managedUsagePackSubscription(
@@ -13187,7 +13163,6 @@ describe("usage pack allocation management", () => {
     const paymentMethodId = `pm_invite_${randomUUID()}`;
     const invoiceId = `in_invite_${randomUUID()}`;
     const hostedInvoiceUrl = `https://invoice.stripe.test/${invoiceId}`;
-    await enableSavedBillingPurchasePreview(fixture);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       ...managedUsagePackSubscription(
         fixture,
@@ -13310,7 +13285,6 @@ describe("usage pack allocation management", () => {
     const fixture = await seedManagedUsagePack([
       { userId: existingMemberUserId, usagePackUsd: 20 },
     ]);
-    await enableSavedBillingPurchasePreview(fixture);
     const email = `setup-invite-${randomUUID()}@example.test`;
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -15222,7 +15196,6 @@ describe("POST /api/billing/concurrency-checkout", () => {
       expiresAt: periodEnd,
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_${randomUUID()}`;
     const allowanceItem = {
       id: `si_${TEST_PRICE_USAGE_ALLOWANCE}`,
@@ -15419,7 +15392,6 @@ describe("POST /api/billing/concurrency-checkout", () => {
       expiresAt: allowanceEnd,
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
 
     const periodStartUnix = Math.floor(periodStart.getTime() / 1000);
     const allowanceEndUnix = Math.floor(allowanceEnd.getTime() / 1000);
@@ -17392,7 +17364,6 @@ describe("POST /api/billing/concurrency-checkout", () => {
       tier: "team",
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_${randomUUID()}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: subscriptionId,
@@ -20293,7 +20264,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("applies a customer coupon without including subscription renewal", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const couponId = `coupon_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
@@ -20458,7 +20428,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("uses a legacy subscription source when no higher-priority card exists", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const subscriptionSourceId = `card_${randomUUID().slice(0, 8)}`;
     const customerSourceId = `card_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
@@ -20569,7 +20538,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("rejects payment when the finalized invoice amount differs from the preview", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -20677,7 +20645,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("returns completed when customer balance pays the invoice during finalization", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -20776,7 +20743,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("returns the hosted invoice when saved-billing payment requires authentication", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -20894,7 +20860,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("falls back to Stripe checkout when saved billing is unavailable", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: fixture.subscriptionId,
       default_payment_method: null,
@@ -20931,7 +20896,6 @@ describe("POST /api/billing/credit-checkout", () => {
 
   it("returns Checkout when all saved cards are removed after preview", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
-    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: fixture.subscriptionId,

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -59,7 +59,6 @@ import {
 } from "../services/usage-pack-subscription.service";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
-  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
   type BillingPurchasePaymentMethod,
@@ -534,15 +533,7 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     trialDays,
     adAttribution,
   } = bodyResult.data;
-  const previewEnabled = await set(
-    billingPurchasePreviewEnabled$,
-    {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      requested: supportsInAppPreview === true,
-    },
-    signal,
-  );
+  const previewEnabled = supportsInAppPreview === true;
   const clerk = get(clerk$);
   const resolvedAttribution = await checkoutAttribution(
     clerk,
@@ -751,15 +742,7 @@ const usagePackCheckoutAuthed$ = command(
     signal.throwIfAborted();
 
     const body = bodyResult.data;
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        requested: body.supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = body.supportsInAppPreview === true;
     const clerk = get(clerk$);
     const resolvedAttribution = await checkoutAttribution(
       clerk,
@@ -1005,15 +988,7 @@ const usagePackChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: access.auth.orgId,
-        userId: access.auth.userId,
-        requested: bodyResult.data.supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = bodyResult.data.supportsInAppPreview === true;
     if (
       previewEnabled &&
       (!bodyResult.data.returnUrl ||
@@ -1518,15 +1493,7 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: access.auth.orgId,
-        userId: access.auth.userId,
-        requested: bodyResult.data.supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = bodyResult.data.supportsInAppPreview === true;
     if (
       previewEnabled &&
       (!bodyResult.data.returnUrl ||

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
@@ -26,7 +26,6 @@ import {
 import { previewConcurrencySubscriptionChange$ } from "../services/billing-concurrency-subscription.service";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
-  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
   type BillingPurchasePaymentMethod,
@@ -222,15 +221,7 @@ const concurrencyCheckoutPreviewAuthed$ = command(
       return bodyResult.response;
     }
     const { supportsInAppPreview, returnUrl } = bodyResult.data;
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        requested: supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = supportsInAppPreview === true;
     if (previewEnabled && (!returnUrl || !billingRedirectAllowed(returnUrl))) {
       return badRequestMessage(
         "returnUrl must match the platform origin for in-app billing",

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
@@ -22,7 +22,6 @@ import {
 import { getStripeClient } from "../external/stripe-client";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
-  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
   type BillingPurchasePaymentMethod,
@@ -54,15 +53,7 @@ const previewConcurrencySubscriptionChangeAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        requested: bodyResult.data.supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = bodyResult.data.supportsInAppPreview === true;
     if (
       previewEnabled &&
       (!bodyResult.data.returnUrl ||

--- a/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
@@ -22,7 +22,6 @@ import {
 } from "../services/billing-checkout.service";
 import { updateAutoRechargeConfig$ } from "../services/billing.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
-import { billingPurchasePreviewEnabled$ } from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -111,19 +110,9 @@ const creditCheckoutAuthed$ = command(
     }
 
     // This shared route also serves the commit-addressed CLI, which requires
-    // hosted Checkout, while old app builds can omit this opt-in for about two
-    // days during rollout. Remove the rollout compatibility after #26842; keep
-    // an explicit hosted-checkout contract for CLI before narrowing this field.
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        requested:
-          supportsInAppPreview === true || previewExistingBilling === true,
-      },
-      signal,
-    );
+    // hosted Checkout, so in-app preview remains an explicit client opt-in.
+    const previewEnabled =
+      supportsInAppPreview === true || previewExistingBilling === true;
     if (previewEnabled) {
       const preview = await set(
         previewExistingBillingCreditPurchase$,

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -34,7 +34,6 @@ import {
 } from "../services/usage-pack-invitation-purchase.service";
 import { activeUsagePackBillingContext } from "../services/usage-pack-subscription.service";
 import {
-  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
   type BillingPurchasePaymentMethod,
@@ -350,15 +349,7 @@ const purchasePreviewInner$ = command(
     if (!body.ok) {
       return body.response;
     }
-    const previewEnabled = await set(
-      billingPurchasePreviewEnabled$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        requested: body.data.supportsInAppPreview === true,
-      },
-      signal,
-    );
+    const previewEnabled = body.data.supportsInAppPreview === true;
     if (
       previewEnabled &&
       (!body.data.returnUrl || !billingRedirectAllowed(body.data.returnUrl))

--- a/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
@@ -1,9 +1,4 @@
-import { command } from "ccstate";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-
 import { getStripeClient } from "../external/stripe-client";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import {
   billingPreviewExpiresAt,
   createBillingPaymentMethodPreviewToken,
@@ -142,31 +137,6 @@ export async function setStripeSubscriptionPaymentMethod(
   );
   signal.throwIfAborted();
 }
-
-export const billingPurchasePreviewEnabled$ = command(
-  async (
-    { get },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly requested: boolean;
-    },
-    signal: AbortSignal,
-  ): Promise<boolean> => {
-    if (!args.requested) {
-      return false;
-    }
-    const overrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
-    );
-    signal.throwIfAborted();
-    return isFeatureEnabled(FeatureSwitchKey.SavedBillingCreditPurchase, {
-      orgId: args.orgId,
-      userId: args.userId,
-      overrides,
-    });
-  },
-);
 
 type BillingPurchasePreviewRoute = {
   readonly kind: "preview";

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -795,14 +795,11 @@ export const startCheckout$ = command(
     cancelUrl.searchParams.set("billing", "canceled");
     set(applyStoredAdAttribution$, cancelUrl);
     const adAttribution = set(readStoredAdAttributionMetadata$);
-    const supportsInAppPreview =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
-
     const createClient = get(apiClient$);
     const client = createClient(billingCheckoutContract);
     const request: CheckoutRequest = {
       tier,
-      ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
+      supportsInAppPreview: true,
       successUrl: stripeSuccessUrl,
       cancelUrl: cancelUrl.toString(),
       ...(options?.trialDays === undefined
@@ -866,14 +863,11 @@ export const startUsagePackCheckout$ = command(
     cancelUrl.searchParams.set("billing", "canceled");
     set(applyStoredAdAttribution$, cancelUrl);
     const adAttribution = set(readStoredAdAttributionMetadata$);
-    const supportsInAppPreview =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
-
     const createClient = get(apiClient$);
     const client = createClient(billingUsagePackCheckoutContract);
     const request: UsagePackCheckoutRequest = {
       tier: args.tier,
-      ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
+      supportsInAppPreview: true,
       memberUsagePacks: [...args.memberUsagePacks],
       successUrl: stripeSuccessUrl,
       cancelUrl: cancelUrl.toString(),
@@ -1164,19 +1158,13 @@ export const previewUsagePackSubscriptionChange$ = command(
   ) => {
     const createClient = get(apiClient$);
     const client = createClient(billingUsagePackManagementContract);
-    const supportsInAppPreview =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const preview = await accept(
       client.previewSubscriptionChange({
         body: {
           targetTier: args.targetTier,
           memberUsagePacks: [...args.memberUsagePacks],
-          ...(supportsInAppPreview
-            ? {
-                supportsInAppPreview: true,
-                returnUrl: checkoutReturnUrl().toString(),
-              }
-            : {}),
+          supportsInAppPreview: true,
+          returnUrl: checkoutReturnUrl().toString(),
         },
         fetchOptions: { signal },
       }),
@@ -1267,16 +1255,12 @@ export const startCreditCheckout$ = command(
 
     const createClient = get(apiClient$);
     const client = createClient(billingCreditCheckoutContract);
-    const savedBillingCreditPurchaseEnabled =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const result = await accept(
       client.create({
         body: {
           credits: selection.credits,
           ...(selection.customAmount === true ? { customAmount: true } : {}),
-          ...(savedBillingCreditPurchaseEnabled
-            ? { supportsInAppPreview: true }
-            : {}),
+          supportsInAppPreview: true,
           successUrl: stripeSuccessUrl,
           cancelUrl: cancelUrl.toString(),
         },
@@ -1292,10 +1276,7 @@ export const startCreditCheckout$ = command(
       });
       return;
     }
-    // Hosted Checkout is the canonical response when saved billing is absent.
-    // During rollout it also lets a switched-on app tolerate an API from before
-    // preview support for the ~2-day old-client window. Remove that rollout-only
-    // responsibility after #26842; the unavailable-billing path remains.
+    // Hosted Checkout remains the fallback when saved billing is unavailable.
     if (newTab) {
       window.open(result.body.url, "_blank");
     } else {
@@ -1402,16 +1383,13 @@ export const openConcurrencyPurchaseReview$ = command(
   ): Promise<void> => {
     const createClient = get(apiClient$);
     const client = createClient(billingConcurrencyCheckoutContract);
-    const supportsInAppPreview =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const returnUrl = checkoutReturnUrl().toString();
     const result = await accept(
       client.preview({
         body: {
           quantity,
-          ...(supportsInAppPreview
-            ? { supportsInAppPreview: true, returnUrl }
-            : {}),
+          supportsInAppPreview: true,
+          returnUrl,
         },
         fetchOptions: { signal },
       }),
@@ -1450,19 +1428,13 @@ const loadConcurrencySubscriptionChangePreview$ = command(
   ): Promise<ConcurrencySubscriptionChangePreviewResponse | null> => {
     const createClient = get(apiClient$);
     const client = createClient(billingConcurrencySubscriptionContract);
-    const supportsInAppPreview =
-      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const result = await accept(
       client.previewChange({
         params: { subscriptionId: args.subscriptionId },
         body: {
           quantity: args.quantity,
-          ...(supportsInAppPreview
-            ? {
-                supportsInAppPreview: true,
-                returnUrl: checkoutReturnUrl().toString(),
-              }
-            : {}),
+          supportsInAppPreview: true,
+          returnUrl: checkoutReturnUrl().toString(),
         },
         fetchOptions: { signal },
       }),

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -572,21 +572,14 @@ export const inviteMember$ = command(
     const createClient = get(apiClient$);
     const client = createClient(orgInviteContract);
     if (usagePackUsd !== null) {
-      const supportsInAppPreview =
-        get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
-        false;
       const result = await accept(
         client.previewPurchase({
           body: {
             email,
             role,
             usagePackUsd,
-            ...(supportsInAppPreview
-              ? {
-                  supportsInAppPreview: true,
-                  returnUrl: window.location.href,
-                }
-              : {}),
+            supportsInAppPreview: true,
+            returnUrl: window.location.href,
           },
           fetchOptions: { signal },
         }),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-billing-and-errors.test.tsx
@@ -11,7 +11,6 @@ import {
   billingCreditCheckoutContract,
   billingStatusContract,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core";
 import { logsByIdContract } from "@okouai/api-contracts/contracts/logs";
 import { runsByIdContract } from "@okouai/api-contracts/contracts/run-routes";
 import { queuePositionContract } from "@okouai/api-contracts/contracts/queue-position";
@@ -335,9 +334,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -4281,9 +4281,7 @@ describe("organization billing settings", () => {
       });
     });
 
-    await openBillingTab("/?settings=billing", {
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-    });
+    await openBillingTab("/?settings=billing");
     const locationBeforePurchase = window.location.href;
     click(screen.getByText("Upgrade"));
     await screen.findByText("Compare plans");
@@ -4370,9 +4368,7 @@ describe("organization billing settings", () => {
       });
     });
 
-    await openBillingTab("/?settings=billing", {
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-    });
+    await openBillingTab("/?settings=billing");
     click(screen.getByText("Upgrade"));
     await screen.findByText("Compare plans");
     click(buttonByText("Upgrade to Team"));
@@ -4456,9 +4452,7 @@ describe("organization billing settings", () => {
       },
     );
 
-    await openBillingTab("/?settings=billing", {
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-    });
+    await openBillingTab("/?settings=billing");
     const locationBeforePurchase = window.location.href;
     const quickBuyButton = buttonByText("Quick buy $20.00");
     click(quickBuyButton);
@@ -4539,9 +4533,7 @@ describe("organization billing settings", () => {
       });
     });
 
-    await openBillingTab("/?settings=billing", {
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
-    });
+    await openBillingTab("/?settings=billing");
     click(buttonByText("Quick buy $20.00"));
 
     const firstDialog = await screen.findByRole("dialog", {
@@ -4574,9 +4566,7 @@ describe("organization billing settings", () => {
 
   it("manages plan changes, credit purchases, and auto-recharge settings", async () => {
     const billingStory = mockBillingStory();
-    await openBillingTab("/?settings=billing", {
-      [FeatureSwitchKey.SavedBillingCreditPurchase]: false,
-    });
+    await openBillingTab("/?settings=billing");
 
     await waitFor(() => {
       expect(screen.getByText("Pro plan")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -626,7 +626,6 @@ describe("organization members settings", () => {
       path: "/?settings=people",
       featureSwitches: {
         [FeatureSwitchKey.UsagePackPlans]: true,
-        [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
       },
     });
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/credit-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/credit-purchase-confirm-dialog.tsx
@@ -2,7 +2,6 @@ import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import type { CreditPurchasePreviewResponse } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core";
 import { Button } from "@okouai/ui";
 import {
   Dialog,
@@ -14,7 +13,6 @@ import {
 } from "@okouai/ui/components/ui/dialog";
 
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   closeCreditPurchasePreview$,
@@ -136,12 +134,9 @@ function CreditPurchaseConfirmDialogContent({
 }
 
 export function CreditPurchaseConfirmDialog() {
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
-    false;
   const preview = useGet(creditPurchasePreview$);
 
-  if (!enabled || !preview) {
+  if (!preview) {
     return null;
   }
 

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "@okouai/core";
 import type {
   PlanPurchasePreviewResponse,
   UsagePackPurchasePreviewResponse,
@@ -17,7 +16,6 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import {
@@ -186,12 +184,9 @@ function SubscriptionPurchaseConfirmDialogContent({
 }
 
 export function SubscriptionPurchaseConfirmDialog() {
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
-    false;
   const state = useGet(subscriptionPurchasePreview$);
 
-  if (!enabled || !state) {
+  if (!state) {
     return null;
   }
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -127,9 +127,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
-      true,
-    );
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -162,9 +159,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
-      true,
-    );
   });
 
   it("should enable composer submit DOM reconciliation only for Bingjie", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -52,7 +52,6 @@ export enum FeatureSwitchKey {
   NewChatDefaultModelAction = "newChatDefaultModelAction",
   RealAgentInPreview = "realAgentInPreview",
   UsagePackPlans = "usagePackPlans",
-  SavedBillingCreditPurchase = "savedBillingCreditPurchase",
 
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -347,12 +347,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.SavedBillingCreditPurchase]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Preview purchases with saved billing and confirm them in the app.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make the fully rolled-out saved-billing purchase experience permanent
- remove `savedBillingCreditPurchase` / `SavedBillingCreditPurchase` from the feature-switch enum, registry, state checks, and test fixtures
- keep the explicit client capability contract so CLI and older clients can still fall back to hosted Stripe Checkout

## Switch history

- introduced in `135585db4ea65e2c93cd37c7053012d268eedf86` (`feat: confirm saved-billing credit purchases in app`)
- rolled out globally in `84b2e721648cfe8af360bd773690203301228bc9` (`feat: roll out saved-billing credit purchases`), which changed the switch from staff-only to `enabled: true`
- terminal behavior preserved: supported app clients request in-app purchase previews and render confirmation dialogs; clients without that capability continue to receive hosted Checkout

## Scope

- Platform billing flows now always send `supportsInAppPreview: true` for plan, usage-pack, credit, concurrency, and member-invitation purchases
- API billing routes now use the request capability directly instead of re-evaluating a user/org feature switch
- confirmation dialogs now depend only on the preview state
- removed the pass-through `billingPurchasePreviewEnabled$` adapter, switch registry/key entries, matrix assertions, and switch-only test setup

Search keywords reviewed: `savedBillingCreditPurchase`, `SavedBillingCreditPurchase`, `billingPurchasePreviewEnabled`.

`supportsInAppPreview` and `previewExistingBilling` intentionally remain: they are API compatibility/capability fields, not rollout controls.

## Verification

- Prettier and `git diff --check`: passed
- core, API, and Platform type checks: passed; API core and test type checks were repeated after rebasing onto latest `main`
- core feature-switch tests: 25 passed
- targeted Platform billing tests: 84 passed across 3 files
- core, API, and Platform lint checks: passed (repository-baseline warnings only)
- Knip: post-cleanup output matches the pre-cleanup baseline (48 existing configuration hints, no new unused findings)
- exact switch-identifier search: no remaining matches

## Local environment caveat

The targeted API billing route suite could not initialize because PostgreSQL is not available at `localhost:5432` (`ECONNREFUSED`); no route assertions ran. This PR is therefore opened as a draft so CI can provide the database-backed verification.
