### PR TITLE
refactor: remove chat mark unread feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-mark-unread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-mark-unread.ts
@@ -1,11 +1,9 @@
 import { command } from "ccstate";
 import { chatThreadMarkUnreadContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
 import { reloadChatIndicators$ } from "../chat-thread-list-reload.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   applyUnreadSnapshot$,
   clearOptimisticReadMark$,
@@ -21,9 +19,6 @@ export const markChatThreadUnread$ = command(
     { threadId }: MarkUnreadArgs,
     signal: AbortSignal,
   ): Promise<void> => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatMarkUnread] ?? false)) {
-      return;
-    }
     const client = get(apiClient$)(chatThreadMarkUnreadContract);
     const result = await accept(
       client.markUnread({

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1039,27 +1039,6 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("hides mark unread while the feature switch is off", async () => {
-    prepareDefaultAgent();
-    mockSidebarThreadStory([
-      createThread(EXISTING_THREAD_ID, "Release plan"),
-      createThread(INCIDENT_THREAD_ID, "Incident notes"),
-    ]);
-
-    setupSidebarPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.ChatMarkUnread]: false },
-      path: `/chats/${EXISTING_THREAD_ID}`,
-    });
-
-    await waitFor(() => {
-      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
-    });
-
-    openThreadMenu("Release plan");
-    expect(queryMenuItemByText("Mark unread")).toBeNull();
-  });
-
   it("marks the current chat unread from the sidebar menu", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([
@@ -1098,7 +1077,6 @@ describe("zero sidebar", () => {
 
     setupSidebarPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatMarkUnread]: true },
       path: `/chats/${EXISTING_THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -20,7 +20,6 @@ import {
   Pin,
   PinOff,
 } from "lucide-react";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { useChatThreadsTitleLabels } from "./sidebar-shared.tsx";
 import {
   Tooltip,
@@ -47,7 +46,6 @@ import {
 import { Skeleton } from "@okouai/ui/components/ui/skeleton";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   deleteChatThread$,
@@ -175,14 +173,8 @@ function ChatThreadMarkUnreadMenuItem({
   signals: SidebarChatThreadItemSignals;
 }) {
   const { t } = useTranslation();
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatMarkUnread] ?? false;
   const markUnread = useSet(signals.markUnread$);
   const pageSignal = useGet(pageSignal$);
-
-  if (!enabled) {
-    return null;
-  }
 
   return (
     <DropdownMenuItem

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -105,7 +105,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -140,7 +139,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatForward]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -59,7 +59,6 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   ManagedModelProviderFallback = "managedModelProviderFallback",
   ChatForward = "chatForward",
-  ChatMarkUnread = "chatMarkUnread",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   HomeStartCards = "homeStartCards",
   HomeGrowthEntry = "homeGrowthEntry",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -399,12 +399,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatMarkUnread]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Show the Mark unread action in the chat thread sidebar menu.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make the chat Mark unread action permanently available
- remove `chatMarkUnread` / `ChatMarkUnread` from the feature-switch enum, registry, UI gate, command guard, and test fixtures
- preserve the existing mark-unread behavior and optimistic unread-state update

## Switch history

- introduced behind a staff-only gate in `e6e1e79e3df60e0564b2186503faaf6f3cb8290c` (`feat(chat): add mark unread action`)
- terminal state for this cleanup: fully enabled, as confirmed for this cleanup request

## Scope

- the sidebar action is always rendered
- the mark-unread command always executes when invoked
- removed the switch-off test and switch-on fixture while retaining the positive behavior coverage
- removed the registry/key entries and core matrix assertions

Search keywords reviewed: `chatMarkUnread`, `ChatMarkUnread`.

Human-readable `Mark unread` names intentionally remain because they describe the permanent product action, not a rollout control.

## Verification

- Prettier and `git diff --check`: passed
- core and Platform type checks: passed
- core feature-switch tests after rebasing onto latest `main`: 25 passed
- targeted sidebar tests after rebasing onto latest `main`: 79 passed
- core and Platform lint checks: passed (repository-baseline warnings only)
- Knip: post-cleanup output matches the pre-cleanup baseline (48 existing configuration hints, no new unused findings)
- exact switch-identifier search: no remaining matches

No API behavior or API test scope is affected by this cleanup.
