### PR TITLE
docs(python): document percent-decoded host contract

### DIFF
--- a/crates/runner/mitm-addon/src/authority_utils.py
+++ b/crates/runner/mitm-addon/src/authority_utils.py
@@ -24,6 +24,19 @@ _DEFAULT_SCHEME_PORTS = MappingProxyType({"http": 80, "https": 443})
 
 
 class PercentDecodedHost(NamedTuple):
+    """Result of percent-decoding a host for caller-specific authority policy.
+
+    ``value`` is the fully percent-decoded host when ``invalid_encoding`` is
+    false. When ``invalid_encoding`` is true, it is the original input,
+    unchanged; it must not be treated as decoded or validated.
+
+    ``invalid_encoding`` is true when a percent escape is malformed or the
+    percent-encoded bytes cannot be decoded as UTF-8. ``decoded_syntax`` is
+    true only when a character from the caller-provided ``syntax_chars`` was
+    introduced by percent decoding. Neither flag performs complete authority
+    validation, and a false flag does not make ``value`` a validated host.
+    """
+
     value: str
     invalid_encoding: bool
     decoded_syntax: bool
@@ -46,6 +59,23 @@ def percent_decode_host(
     *,
     syntax_chars: frozenset[str],
 ) -> PercentDecodedHost:
+    """Decode percent escapes in a host and report caller-relevant conditions.
+
+    ``host`` is raw host text. Percent-encoded bytes are decoded as UTF-8.
+    ``syntax_chars`` selects characters whose introduction by a
+    percent-decoded run should be reported through ``decoded_syntax``; syntax
+    already present in ``host`` does not set that flag.
+
+    The returned ``PercentDecodedHost.value`` is fully decoded when
+    ``invalid_encoding`` is false. If a percent escape is malformed or
+    percent-encoded bytes are not valid UTF-8, ``invalid_encoding`` is true,
+    ``value`` is the original ``host`` unchanged, and ``decoded_syntax`` is
+    false. A successful result is not complete authority or hostname
+    validation. Every caller must inspect both flags and apply the
+    boundary-specific host validation and rejection policy required for its
+    trust boundary.
+    """
+
     if "%" not in host:
         return PercentDecodedHost(host, invalid_encoding=False, decoded_syntax=False)
 

--- a/crates/runner/mitm-addon/tests/test_authority_utils.py
+++ b/crates/runner/mitm-addon/tests/test_authority_utils.py
@@ -6,6 +6,51 @@ import authority_utils
 
 
 @pytest.mark.parametrize(
+    ("host", "syntax_chars", "expected"),
+    [
+        pytest.param(
+            "api.example.com",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api.example.com", False, False),
+            id="unencoded-host",
+        ),
+        pytest.param(
+            "api%2Eexample.com",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api.example.com", False, False),
+            id="decoded-without-configured-syntax",
+        ),
+        pytest.param(
+            "api%2Fexample.com",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api/example.com", False, True),
+            id="decoded-configured-syntax",
+        ),
+        pytest.param(
+            "api/example.com",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api/example.com", False, False),
+            id="raw-configured-syntax",
+        ),
+        pytest.param(
+            "api%2",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api%2", True, False),
+            id="malformed-percent-escape",
+        ),
+        pytest.param(
+            "api%FF",
+            frozenset(("/", ":")),
+            authority_utils.PercentDecodedHost("api%FF", True, False),
+            id="invalid-utf8",
+        ),
+    ],
+)
+def test_percent_decode_host_contract(host, syntax_chars, expected):
+    assert authority_utils.percent_decode_host(host, syntax_chars=syntax_chars) == expected
+
+
+@pytest.mark.parametrize(
     ("netloc", "expected"),
     [
         pytest.param("", False, id="malformed-empty"),


### PR DESCRIPTION
## Summary

- Document the `PercentDecodedHost` result fields and the `percent_decode_host()` contract, including invalid-result value preservation, decoded syntax semantics, and caller-owned validation.
- Add focused contract tests for normal decoding, configured and raw syntax, malformed escapes, and invalid UTF-8.

## Scope

- No runtime behavior, result shape, caller policy, or authority validation logic changes.
- No consumer modules or cross-language contracts are modified.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_authority_utils.py` — 15 passed
- `uv run --no-sync python -m pytest tests/` — 6587 passed, 59 warnings

Closes #28883
