### PR TITLE
docs(skills): repoint stale code references

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -751,7 +751,7 @@ Each factory call returns fresh `state()`/`computed()`/`command()` instances, so
 
 ```typescript
 // chat-message.ts
-const internalLocalMessages$ = state<ZeroChatMessage[]>([]);
+const internalLocalMessages$ = state<ChatEvent[]>([]);
 export const resetLocalMessages$ = command(({ set }) => {
   set(internalLocalMessages$, []);
 });
@@ -810,7 +810,7 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef } from "../utils.ts";
 
 export interface ChatThreadSignals {
-  messages$: Computed<Promise<ZeroChatMessage[]>>;
+  messages$: Computed<Promise<ChatEvent[]>>;
   allFinished$: Computed<Promise<boolean>>;
   sendMessage$: Command<Promise<void>, [string, AbortSignal]>;
   setScrollContainer$: Command<(() => void) | undefined, [HTMLElement | null]>;
@@ -822,7 +822,7 @@ export interface ChatThreadSignals {
 
 ```typescript
 function createMessageState(threadData$: Computed<Promise<ThreadData | null>>) {
-  const internalLocalMessages$ = state<ZeroChatMessage[]>([]);
+  const internalLocalMessages$ = state<ChatEvent[]>([]);
 
   const messages$ = computed(async (get) => {
     const serverMsgs = (await get(threadData$))?.chatMessages ?? [];

--- a/.claude/skills/cli-design/SKILL.md
+++ b/.claude/skills/cli-design/SKILL.md
@@ -8,10 +8,6 @@ context: fork
 
 Use this skill when writing new CLI commands, reviewing CLI code, or fixing inconsistencies.
 
-## Documentation
-
-Read the CLI design guideline: [docs/cli-design-guideline.md](../../../docs/cli-design-guideline.md)
-
 ## Key Principles
 
 1. **Atomic Command** — each command does one operation, agents compose them freely

--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -13,7 +13,7 @@ A feature switch is required when adding:
 - New UI pages, sections, or sidebar navigation items
 - New API endpoints exposed to users or agents
 - New integrations (connectors, Slack, Telegram, etc.)
-- New zero token capabilities
+- New agent token capabilities
 
 A feature switch is **not** required for:
 - Internal refactors or code cleanup
@@ -98,39 +98,49 @@ const showMyFeature = features?.[FeatureSwitchKey.MyFeature] ?? false;
 
 #### Sidebar navigation gating
 
-In `turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx`, add a `featureGate` to the sidebar item:
+Sidebar entries are not gated declaratively. The nav item records in
+`turbo/apps/platform/src/views/okou-page/sidebar.tsx` (`MANAGE_NAV`,
+`FOOTER_NAV`) carry no feature-switch field. Read `featureSwitch$` in the
+component that renders the entry and omit the item when the switch is off —
+`turbo/apps/platform/src/views/okou-page/sidebar-account.tsx` gates the Lab
+entry this way:
 
 ```typescript
-{
-  id: "my-feature",
-  label: "My Feature",
-  icon: MyIcon,
-  featureGate: FeatureSwitchKey.MyFeature,
-}
+const features = useLastResolved(featureSwitch$);
+const labEnabled = features?.[FeatureSwitchKey.Lab] ?? false;
+
+// In the render:
+{labEnabled && <DropdownMenuItem>{/* ... */}</DropdownMenuItem>}
 ```
 
 #### Connector gating
 
-In `turbo/packages/core/src/contracts/connectors.ts`, add `featureFlag` to the connector config:
+Connector definitions live in `vm0-ai/vm0-connectors`, but vm0 owns the rollout
+association. Add an entry to `FEATURE_SWITCH_BY_AUTH_METHOD` in
+`turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts`,
+keyed by `` `${connectorSlug}\0${authMethodId}` ``:
 
 ```typescript
-myConnector: {
-  label: "My Connector",
-  featureFlag: FeatureSwitchKey.MyConnector,
-  // ...
-}
+const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
+  Record<string, FeatureSwitchKey | undefined>
+>({
+  // ... existing entries
+  "my-connector\0oauth": FeatureSwitchKey.MyConnector,
+});
 ```
 
-#### Zero token capability gating
+Deploy the association before publishing a method that should be gated, and
+remove it once the switch graduates.
+
+#### Agent token capability gating
 
 In `turbo/apps/api/src/signals/auth/tokens.ts`, add to `CONDITIONAL_CAPABILITIES`:
 
 ```typescript
-const CONDITIONAL_CAPABILITIES: ReadonlyMap<Capability, FeatureSwitchKey> =
-  new Map([
-    // ... existing entries
-    ["my-feature:write", FeatureSwitchKey.MyFeature],
-  ]);
+const CONDITIONAL_CAPABILITIES = [
+  // ... existing entries
+  ["my-feature:write", FeatureSwitchKey.MyFeature],
+] as const satisfies readonly (readonly [Capability, FeatureSwitchKey])[];
 ```
 
 ## Key Files
@@ -140,8 +150,9 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<Capability, FeatureSwitchKey> =
 | `turbo/packages/core/src/feature-switch-key.ts` | Enum of all feature switch keys |
 | `turbo/packages/core/src/feature-switch.ts` | Registry and evaluation logic |
 | `turbo/apps/platform/src/signals/external/feature-switch.ts` | Client-side reactive state with override layers |
-| `turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx` | Sidebar nav items with `featureGate` |
-| `turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts` | External connector auth-method schema with `featureSwitch` field |
+| `turbo/apps/platform/src/views/okou-page/sidebar.tsx` | Sidebar nav item records (`MANAGE_NAV`, `FOOTER_NAV`) |
+| `turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts` | Connector auth-method → feature switch rollout associations |
+| `turbo/apps/api/src/signals/services/feature-switches.service.ts` | Override loading/writing and the org-scoped key list |
 | `turbo/apps/api/src/signals/auth/tokens.ts` | Token capability gating |
 
 ## Override Layers
@@ -151,14 +162,16 @@ Evaluation has two layers (lowest to highest priority):
 1. **Core registry** — static config in source code, evaluated against `userId` / `email` / `orgId` hashes.
 2. **DB overrides** — most switches are per-user rows in
    `user_feature_switches` keyed by `(orgId, userId)`. Some switches are
-   org-scoped and stored under the org sentinel user id (`__org__`); currently
-   `ChatErrorRecovery` and `PiLoop` are org-scoped. Written via the Lab page
-   toggles or `window._vm0.featureSwitches.myFeature = true` (both call
-   `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all"
-   button (`DELETE /api/zero/feature-switches`).
+   org-scoped and stored under the org sentinel user id (`ORG_SENTINEL_USER_ID`,
+   `"__org__"`); `ORG_SCOPED_FEATURE_SWITCH_KEYS` currently holds
+   `ChatErrorRecovery`, `ManagedModelProviderFallback`, and `PiLoop`. Written
+   via the Lab page toggles or
+   `window._vm0.featureSwitches.myFeature = true` (both call
+   `POST /api/feature-switches`). Cleared via the Lab page "Reset all"
+   button (`DELETE /api/feature-switches`).
 
 The same two-layer resolution applies on the server: route handlers that call
-`isFeatureEnabled(..., { userId, orgId, overrides })` pass overrides loaded via
-`loadFeatureSwitchOverrides(orgId, userId)`.
+`isFeatureEnabled(..., { userId, orgId, overrides })` pass a context built by
+`loadUserFeatureSwitchContext(db, orgId, userId)`.
 
 There is **no** client-only layer. `window._vm0.featureSwitches` requires auth and persists across refreshes; there is no device-local override.

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -168,8 +168,9 @@ grep -r 'globalThis\.services\.db\.\(insert\|update\|delete\)' turbo \
 
 **21. Tests Importing Internal Services**
 ```bash
-# Test files importing from internal lib/ — means testing implementation, not behavior
-grep -rE "from.*['\"].*lib/infra|from.*['\"].*lib/zero" turbo \
+# Test files importing service modules directly — means testing implementation,
+# not behavior. Route tests should go through the API helpers instead.
+grep -rE "from ['\"].*\.service" turbo \
   --include="*.test.ts" --include="*.test.tsx" -l
 ```
 


### PR DESCRIPTION
Closes #28890

Every path and symbol cited under `.claude/skills/` was resolved against current `main` with a script (markdown-link resolution + `rg` symbol lookup over `turbo/` and `crates/`), not by reading. Each replacement was re-derived from current code.

## Changed

| File | Was | Now |
|---|---|---|
| `feature-switch/SKILL.md:16` | `New zero token capabilities` | `New agent token capabilities` — the auth discriminant is `tokenType: "agent"` (`signals/auth/auth-context.ts`) |
| `feature-switch/SKILL.md:101` | `turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx` + `featureGate` nav field | `okou-page/sidebar.tsx`. **`featureGate` does not exist anywhere in `turbo/`** — nav records (`MANAGE_NAV`, `FOOTER_NAV`) carry no switch field. Rewrote the section around the real pattern: read `featureSwitch$` in the rendering component, as `okou-page/sidebar-account.tsx:860` does for `FeatureSwitchKey.Lab` |
| `feature-switch/SKILL.md:114` | `turbo/packages/core/src/contracts/connectors.ts` + `featureFlag` | That file does not exist (`packages/core/src/contracts/` holds only `index.ts`). Connector gating is now `FEATURE_SWITCH_BY_AUTH_METHOD` in `apps/api/src/signals/services/connector-auth-method-feature-switches.ts`, keyed `` `${connectorSlug}\0${authMethodId}` `` |
| `feature-switch/SKILL.md:124` | heading `Zero token capability gating`, `CONDITIONAL_CAPABILITIES: ReadonlyMap<…> = new Map([…])` | `Agent token capability gating`. `CONDITIONAL_CAPABILITIES` is a tuple array (`as const satisfies readonly (readonly [Capability, FeatureSwitchKey])[]`), `tokens.ts:32` — the `Map` shape was also stale |
| `feature-switch/SKILL.md:157,158` | `POST` / `DELETE /api/zero/feature-switches` | `/api/feature-switches` — all three methods in `packages/api-contracts/src/contracts/feature-switches.ts` |
| `feature-switch/SKILL.md` Key Files | sidebar row; `connector-catalog-artifacts/source.ts` "auth-method schema with `featureSwitch` field" | Repointed. `connectorAuthMethodSourceSchema` is `.strict()` and has no `featureSwitch` field. Added a row for `feature-switches.service.ts` |
| `feature-switch/SKILL.md` Override Layers | `loadFeatureSwitchOverrides(orgId, userId)`; org-scoped = `ChatErrorRecovery`, `PiLoop` | `loadUserFeatureSwitchContext(db, orgId, userId)` (`feature-switches.service.ts:125`). `ORG_SCOPED_FEATURE_SWITCH_KEYS` holds three keys — `ManagedModelProviderFallback` was missing |
| `ccstate/SKILL.md:754,813,825` | `ZeroChatMessage[]` | `ChatEvent[]` — exported from `apps/platform/src/signals/chat-page/chat-event-types.ts:11` and used throughout `create-chat-thread.ts`. `ZeroChatMessage` survives only in `apps/platform/CHANGELOG.md` |
| `tech-debt/SKILL.md:172` | `grep … lib/infra\|lib/zero` | Both lived in `turbo/apps/web/src/lib/`, deleted wholesale with the legacy web app (#19310), so the audit matched nothing. Repointed to direct `.service` module imports in tests — the same "testing implementation, not behavior" signal, currently 3 hits |
| `cli-design/SKILL.md:13` | link to `docs/cli-design-guideline.md` | **Not in the issue list, found by the sweep.** Deleted in #22332 with no successor (`docs/docs.md` has no CLI design entry). Removed the dead Documentation section; the skill's Key Principles stand on their own |

## Kept deliberately

- **`zero` as the number** — `Zero Tolerance for Lint Violations`, `zero warnings`, `zero lint violations`, `Dynamic Imports (zero tolerance)`. `project-principles/zero-lint.md` not renamed.
- **`vm0`** — repo/org name, unchanged.
- **`ZeroChatAttachment` (23 uses in `apps/platform`) and `ZeroChatThreadPage` (4 uses)** — resolved; the docs are accurate and the code has not been renamed.
- **Pedagogical identifiers in `ccstate/SKILL.md`** that intentionally do not resolve: `ChatThreadSignals` (:922, the interface the tutorial asks you to define), `useFileUploadHandlers` (:942, cited *because* it was inlined away), `getFlow`/`setFlow` (:638, named as the anti-pattern to avoid), and the illustrative import paths `../../signals/chat-message.ts`, `chat-auto-scroll.ts`, `page-signal.ts`, `some-command.ts` (the "before" state of the singleton→factory narrative). Also placeholders like `codereviews/YYYYMMDD/`, `src/auth/login.ts`, `path/file.ts`, `NNN-description`.

## ⚠️ One "leave alone" item whose premise did not survive resolution

The issue says to leave `window._vm0.featureSwitches` (`feature-switch/SKILL.md:156,164`) because it is a real browser global. **The `_vm0` prefix is real and unchanged — but the `featureSwitches` member is gone.** `VM0Global` (`apps/platform/src/global.d.ts:3-8`) declares only `loggers`, `inspectLogs`, `getBuildCommitSha`, `getBuildVersion`, and `global-method.ts:29` assigns exactly those. It was removed in #11729 ("the awaited featureSwitches setup was removed in the parent commit").

I left both lines untouched per the explicit instruction — the instruction's stated reason was about not renaming the runtime API, which still holds. Flagging it because the fix is a product decision, not a docs decision: either restore the debug setter or drop it from the doc. Happy to follow up either way.

## Verification

- Markdown links under `.claude/skills/`: 0 broken (the 4 remaining `./critical/`-style links are inside the report *template* the skill generates, not repo references).
- Backticked repo-rooted paths: all resolve (`/docs/…`, `/.claude/…` are repo-root-relative by the file's own convention and were checked as such).
- Backticked identifiers: 80 candidates, 77 resolve in `turbo/`/`crates/`; the 3 that do not are the pedagogical ones listed above. `featureGate` and `ZeroChatMessage` no longer appear.
- The repointed tech-debt audit command was executed and returns 3 files rather than silently nothing.
- No file outside `.claude/skills/` was touched; no symbol in `turbo/` was renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
