### PR TITLE
test(runner): cover claim cooldown transitions

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3221,15 +3221,26 @@ mod tests {
         let first = provider.discover().await.unwrap();
         assert!(provider.claim(first).await.is_none());
         let overflow = provider.try_discover_ready().await.unwrap();
+        let claim_started_at = tokio::time::Instant::now();
         let (claim, events) = capture_api_provider_events(provider.claim(overflow)).await;
+        let claim_finished_at = tokio::time::Instant::now();
         assert!(claim.is_none());
         let event = captured_event(&events, "claim failed, candidate cooldown capacity reached");
         assert_eq!(event_field(event, "retry_scope"), "provider");
         assert_eq!(event_field(event, "retry_after_ms"), "5000");
         assert_eq!(event_field(event, "active_cooldowns"), "1");
+        let deferred_poll_at = wakeups
+            .snapshot()
+            .await
+            .deferred_poll_at
+            .expect("saturation should defer HTTP polling");
         assert!(
-            wakeups.snapshot().await.deferred_poll_at.is_some(),
-            "saturation should defer HTTP polling"
+            deferred_poll_at >= claim_started_at + POLL_FAST,
+            "deferred polling should use at least the fast fallback from claim start"
+        );
+        assert!(
+            deferred_poll_at <= claim_finished_at + POLL_FAST,
+            "deferred polling should use at most the fast fallback from claim completion"
         );
 
         push_direct_candidate_for_test(

--- a/crates/runner/src/provider/api_claim_cooldowns.rs
+++ b/crates/runner/src/provider/api_claim_cooldowns.rs
@@ -120,3 +120,135 @@ fn prune_expired(state: &mut ClaimCooldownState, now: Instant) {
         state.global_deadline = None;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_id(value: u128) -> RunId {
+        RunId::from(uuid::Uuid::from_u128(value))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn records_refreshes_and_saturates_without_eviction() {
+        let cooldowns = ClaimCooldowns::new(2);
+        let first_run_id = run_id(1);
+        let second_run_id = run_id(2);
+        let overflow_run_id = run_id(3);
+
+        assert!(matches!(
+            cooldowns
+                .record(second_run_id, Duration::from_secs(30))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 1 }
+        ));
+        assert!(matches!(
+            cooldowns
+                .record(first_run_id, Duration::from_secs(20))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 2 }
+        ));
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![first_run_id, second_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(20)));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(matches!(
+            cooldowns
+                .record(second_run_id, Duration::from_secs(30))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 2 }
+        ));
+        assert!(matches!(
+            cooldowns
+                .record(overflow_run_id, Duration::from_secs(30))
+                .await,
+            ClaimCooldownRecord::Saturated { active_count: 2 }
+        ));
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![first_run_id, second_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(15)));
+
+        tokio::time::advance(Duration::from_secs(15)).await;
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![second_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(15)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn global_deadline_precedes_per_run_deadline_until_expiry() {
+        let cooldowns = ClaimCooldowns::new(1);
+        let first_run_id = run_id(1);
+        let next_run_id = run_id(2);
+
+        assert!(matches!(
+            cooldowns
+                .record(first_run_id, Duration::from_secs(30))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 1 }
+        ));
+        cooldowns.block_all(Duration::from_secs(5)).await;
+
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![first_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(5)));
+        assert_eq!(
+            cooldowns.remaining(first_run_id).await,
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            cooldowns.remaining(next_run_id).await,
+            Some(Duration::from_secs(5))
+        );
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![first_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(25)));
+        assert_eq!(
+            cooldowns.remaining(first_run_id).await,
+            Some(Duration::from_secs(25))
+        );
+        assert_eq!(cooldowns.remaining(next_run_id).await, None);
+
+        tokio::time::advance(Duration::from_secs(25)).await;
+        assert!(matches!(
+            cooldowns.record(next_run_id, Duration::from_secs(10)).await,
+            ClaimCooldownRecord::Recorded { active_count: 1 }
+        ));
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![next_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(10)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remove_clears_only_requested_run_and_updates_retry_deadline() {
+        let cooldowns = ClaimCooldowns::new(2);
+        let first_run_id = run_id(1);
+        let second_run_id = run_id(2);
+
+        assert!(matches!(
+            cooldowns
+                .record(first_run_id, Duration::from_secs(10))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 1 }
+        ));
+        assert!(matches!(
+            cooldowns
+                .record(second_run_id, Duration::from_secs(20))
+                .await,
+            ClaimCooldownRecord::Recorded { active_count: 2 }
+        ));
+
+        cooldowns.remove(first_run_id).await;
+
+        let snapshot = cooldowns.snapshot().await;
+        assert_eq!(snapshot.run_ids, vec![second_run_id]);
+        assert_eq!(snapshot.retry_after, Some(Duration::from_secs(20)));
+        assert_eq!(cooldowns.remaining(first_run_id).await, None);
+        assert_eq!(
+            cooldowns.remaining(second_run_id).await,
+            Some(Duration::from_secs(20))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add deterministic paused-time coverage for claim cooldown capacity, refresh, saturation, global precedence, expiry, capacity reuse, and removal transitions
- verify cooldown snapshots keep exclusions sorted and select the expected retry deadline at each boundary
- strengthen the provider saturation test to prove deferred polling uses `POLL_FAST` instead of only checking that a deadline exists

## Scope

- test-only change; no runner production behavior, API, protocol, persistence, migration, or deployment change
- keep the provider scenario on the normal Tokio clock because it exercises a real mock-server I/O boundary; bound its deadline by claim start and completion instants plus `POLL_FAST`

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_claim_cooldowns::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests::saturated_claim_cooldowns_gate_repeated_direct_candidates`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3243 passed, 20 ignored; inventory integration test passed)

Closes #28893
