### PR TITLE
docs(rust): document guest event preparation and posting boundaries

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -64,6 +64,16 @@ pub async fn send_event_for_config(
     post_event(http, &payload).await
 }
 
+/// Prepare one event for delivery in a `runId` envelope.
+///
+/// Event-controlled content is masked before the system-owned
+/// `sequenceNumber` is added. The sequence number is added only when the event
+/// is a JSON object. The returned payload contains exactly one event under the
+/// supplied `run_id`.
+///
+/// This helper only prepares the payload; it does not capture session metadata
+/// or perform network I/O. Use [`send_event_for_config`] for the normal path
+/// that captures metadata, prepares the payload, and posts the event.
 pub fn prepare_event_payload_for_run_id(
     event: Value,
     seq: u32,
@@ -343,6 +353,14 @@ fn truncate_diagnostic_message(message: &str) -> String {
     format!("{}{}", &message[..end], FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX)
 }
 
+/// Post an already-prepared event payload to the configured events endpoint.
+///
+/// The payload is serialized and sent using the existing
+/// `HTTP_MAX_ATTEMPTS` retry policy. This function does not mask payload
+/// content or capture session metadata, and successful HTTP responses are
+/// accepted without parsing their response bodies. Use
+/// [`send_event_for_config`] for the normal path that captures metadata,
+/// masks the event, prepares the envelope, and posts it.
 pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
     let url = http.events_url()?;
     let payload = Bytes::from(serde_json::to_vec(payload)?);


### PR DESCRIPTION
## Summary

- Document the masking, sequence-number, single-event envelope, and side-effect boundaries of `prepare_event_payload_for_run_id`.
- Document the prepared-payload, configured-endpoint, retry, and response-body boundaries of `post_event`.
- Cross-reference `send_event_for_config` as the normal composed delivery path.

## Scope

- Documentation-only change in `crates/guest-agent/src/events.rs`.
- No event shape, masking behavior, metadata capture, retry behavior, network handling, signatures, or tests changed.

## Validation

Passed:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib` — 594 passed
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration event` — 15 passed, 81 filtered
- `git diff --check`
- Direct inspection of the generated Rustdoc pages and resolved `send_event_for_config` links

Environment limitations:

- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings` reaches an existing `vsock-proto` `clippy::chunks-exact-to-as-chunks` failure in `crates/vsock-proto/src/payloads/memory_snapshot.rs:77,92`; this PR does not touch that file.
- The initial full guest-agent test command hit the linker after the workspace disk filled with generated Cargo artifacts. After removing only the ignored `crates/target` build output, the low-concurrency library and event integration runs above completed successfully.

Closes #28886
