### PR TITLE
refactor(rust): generate pi runtime config dtos

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -43,7 +43,7 @@ pub mod runners {
         pub struct PiLaunchConfigApiFirstTurnBaseSession {
             /// Pi session identifier.
             pub session_id: String,
-            /// Optional lowercase SHA-256 of the base session JSONL.
+            /// Nullable lowercase SHA-256 of the base session JSONL.
             pub sha256: Option<String>,
         }
 

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -37,6 +37,99 @@ pub mod runners {
             pub model_catalog: Option<serde_json::Value>,
         }
 
+        /// Pi session checkpoint used as the first-turn base.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiLaunchConfigApiFirstTurnBaseSession {
+            /// Pi session identifier.
+            pub session_id: String,
+            /// Optional lowercase SHA-256 of the base session JSONL.
+            pub sha256: Option<String>,
+        }
+
+        /// API-mediated first-turn configuration for Pi.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiLaunchConfigApiFirstTurn {
+            /// Pi API first-turn contract version.
+            pub schema_version: i64,
+            /// Digest identifying the runtime resource snapshot.
+            pub resource_snapshot_digest: String,
+            /// URL of the first-turn resource manifest.
+            pub manifest_url: String,
+            /// URL of the first-turn session JSONL.
+            pub session_url: String,
+            /// Unix timestamp in milliseconds for first-turn expiry.
+            pub deadline_at: i64,
+            /// Checkpoint used as the base Pi session.
+            pub base_session: PiLaunchConfigApiFirstTurnBaseSession,
+            /// First sandbox event sequence number for the resumed session.
+            pub sandbox_event_sequence_start: i64,
+        }
+
+        /// API-owned launch configuration forwarded to Pi in the sandbox.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiLaunchConfig {
+            /// Pi launch contract version.
+            pub schema_version: i64,
+            /// Configuration for the API-mediated first turn.
+            pub api_first_turn: PiLaunchConfigApiFirstTurn,
+        }
+
+        /// Model providers supported by the Pi runtime contract.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigProvider {
+            /// DeepSeek provider.
+            #[serde(rename = "deepseek")]
+            Deepseek,
+            /// Moonshot AI provider.
+            #[serde(rename = "moonshotai")]
+            Moonshotai,
+            /// OpenAI provider.
+            #[serde(rename = "openai")]
+            Openai,
+            /// OpenRouter provider.
+            #[serde(rename = "openrouter")]
+            Openrouter,
+            /// Vercel AI Gateway provider.
+            #[serde(rename = "vercel-ai-gateway")]
+            VercelAiGateway,
+            /// Codex provider.
+            #[serde(rename = "codex")]
+            Codex,
+        }
+
+        /// Environment variables supported for Pi provider credentials.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigApiKeyEnv {
+            /// Anthropic authentication token.
+            #[serde(rename = "ANTHROPIC_AUTH_TOKEN")]
+            ANTHROPICAUTHTOKEN,
+            /// OpenAI-compatible API key.
+            #[serde(rename = "OPENAI_API_KEY")]
+            OPENAIAPIKEY,
+            /// ChatGPT access token.
+            #[serde(rename = "CHATGPT_ACCESS_TOKEN")]
+            CHATGPTACCESSTOKEN,
+        }
+
+        /// API-owned non-secret Pi model configuration.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiModelConfig {
+            /// Model provider selected for the Pi runtime.
+            pub provider: PiModelConfigProvider,
+            /// Base URL used for model requests.
+            pub base_url: String,
+            /// Provider model identifier.
+            pub model: String,
+            /// Environment variable containing the provider key.
+            pub api_key_env: PiModelConfigApiKeyEnv,
+            /// API-owned credential secret backing the environment entry.
+            pub credential_secret_name: String,
+        }
+
         /// DTOs for durable active-input delivery.
         pub mod active_inputs {
             /// DTOs for recording active-input acceptance receipts.

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,7 +1,14 @@
 use std::collections::BTreeMap;
 
 use api_contracts::generated::types::{
-    runners::{runs::CodexRuntimeConfig, storage as runner_storage},
+    runners::{
+        runs::{
+            CodexRuntimeConfig, PiLaunchConfig, PiLaunchConfigApiFirstTurn,
+            PiLaunchConfigApiFirstTurnBaseSession, PiModelConfig, PiModelConfigApiKeyEnv,
+            PiModelConfigProvider,
+        },
+        storage as runner_storage,
+    },
     webhooks::agent::{
         checkpoints,
         storages::{FileEntryWithHash, commit, prepare},
@@ -94,6 +101,119 @@ fn generated_codex_runtime_config_omits_absent_options_and_accepts_legacy_null()
     .unwrap();
     assert_eq!(legacy.model_catalog, None);
     assert_eq!(serde_json::to_value(legacy).unwrap(), canonical);
+}
+
+#[test]
+fn generated_pi_runtime_configs_round_trip_full_wire_shapes() {
+    let session_id = "22222222-2222-4222-8222-222222222222";
+    let launch = PiLaunchConfig {
+        schema_version: 2,
+        api_first_turn: PiLaunchConfigApiFirstTurn {
+            schema_version: 1,
+            resource_snapshot_digest: "a".repeat(64),
+            manifest_url: "https://storage.example/manifest.json".to_string(),
+            session_url: "https://storage.example/session.jsonl".to_string(),
+            deadline_at: 2_000_000_000_000,
+            base_session: PiLaunchConfigApiFirstTurnBaseSession {
+                session_id: session_id.to_string(),
+                sha256: Some("b".repeat(64)),
+            },
+            sandbox_event_sequence_start: 1,
+        },
+    };
+    let model = PiModelConfig {
+        provider: PiModelConfigProvider::Deepseek,
+        base_url: "https://api.deepseek.com/".to_string(),
+        model: "deepseek-v4-flash".to_string(),
+        api_key_env: PiModelConfigApiKeyEnv::OPENAIAPIKEY,
+        credential_secret_name: "DEEPSEEK_API_KEY".to_string(),
+    };
+
+    let launch_value = serde_json::to_value(&launch).unwrap();
+    assert_eq!(
+        launch_value,
+        json!({
+            "schemaVersion": 2,
+            "apiFirstTurn": {
+                "schemaVersion": 1,
+                "resourceSnapshotDigest": "a".repeat(64),
+                "manifestUrl": "https://storage.example/manifest.json",
+                "sessionUrl": "https://storage.example/session.jsonl",
+                "deadlineAt": 2_000_000_000_000_i64,
+                "baseSession": {
+                    "sessionId": session_id,
+                    "sha256": "b".repeat(64),
+                },
+                "sandboxEventSequenceStart": 1,
+            },
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<PiLaunchConfig>(launch_value).unwrap(),
+        launch
+    );
+
+    let model_value = serde_json::to_value(&model).unwrap();
+    assert_eq!(
+        model_value,
+        json!({
+            "provider": "deepseek",
+            "baseUrl": "https://api.deepseek.com/",
+            "model": "deepseek-v4-flash",
+            "apiKeyEnv": "OPENAI_API_KEY",
+            "credentialSecretName": "DEEPSEEK_API_KEY",
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<PiModelConfig>(model_value).unwrap(),
+        model
+    );
+}
+
+#[test]
+fn generated_pi_launch_config_round_trips_null_base_hash() {
+    let value = json!({
+        "schemaVersion": 2,
+        "apiFirstTurn": {
+            "schemaVersion": 1,
+            "resourceSnapshotDigest": "a".repeat(64),
+            "manifestUrl": "https://storage.example/manifest.json",
+            "sessionUrl": "https://storage.example/session.jsonl",
+            "deadlineAt": 2_000_000_000_000_i64,
+            "baseSession": {
+                "sessionId": "22222222-2222-4222-8222-222222222222",
+                "sha256": null,
+            },
+            "sandboxEventSequenceStart": 1,
+        },
+    });
+
+    let launch: PiLaunchConfig = serde_json::from_value(value.clone()).unwrap();
+
+    assert_eq!(launch.api_first_turn.base_session.sha256, None);
+    assert_eq!(serde_json::to_value(launch).unwrap(), value);
+}
+
+#[test]
+fn generated_pi_model_config_rejects_unknown_enums() {
+    for (field, value) in [
+        ("provider", "future-provider"),
+        ("apiKeyEnv", "FUTURE_API_KEY"),
+    ] {
+        let mut config = json!({
+            "provider": "deepseek",
+            "baseUrl": "https://api.deepseek.com/",
+            "model": "deepseek-v4-flash",
+            "apiKeyEnv": "OPENAI_API_KEY",
+            "credentialSecretName": "DEEPSEEK_API_KEY",
+        });
+        config[field] = json!(value);
+
+        assert!(
+            serde_json::from_value::<PiModelConfig>(config).is_err(),
+            "{field} should reject {value}"
+        );
+    }
 }
 
 #[test]

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -154,6 +154,9 @@ fn is_sha256(value: &str) -> bool {
 fn validate_pi_launch_config(value: &serde_json::Value, session_id: &str) -> Result<(), String> {
     let launch: PiLaunchConfig = serde_json::from_value(value.clone())
         .map_err(|error| format!("Pi launch config v2 is invalid: {error}"))?;
+    if value.pointer("/apiFirstTurn/baseSession/sha256").is_none() {
+        return Err("Pi H0 sha256 must be present".to_string());
+    }
     if launch.schema_version != 2 {
         return Err("Pi launch config schemaVersion must be 2".to_string());
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
-use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
+use api_contracts::generated::types::runners::runs::{
+    CodexRuntimeConfig, PiLaunchConfig, PiModelConfig,
+};
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use sandbox::Sandbox;
-use serde::Deserialize;
 
 use super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
@@ -139,32 +140,6 @@ pub(super) fn validate_execution_context_before_sandbox_with_host_env(
     Ok(prepared_run_payload)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PiLaunchConfigV2 {
-    schema_version: u8,
-    api_first_turn: PiApiFirstTurnConfigV1,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PiApiFirstTurnConfigV1 {
-    schema_version: u8,
-    resource_snapshot_digest: String,
-    manifest_url: String,
-    session_url: String,
-    deadline_at: u64,
-    base_session: PiBaseSession,
-    sandbox_event_sequence_start: u8,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PiBaseSession {
-    session_id: String,
-    sha256: serde_json::Value,
-}
-
 fn is_sha256(value: &str) -> bool {
     value.len() == 64
         && value
@@ -172,8 +147,12 @@ fn is_sha256(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
+// Generated enums and explicit versions intentionally fail closed. A future
+// enum value or schema version must reach runners before the API emits it;
+// unknown additive object fields remain safe because the original JSON is
+// forwarded after this validation view is discarded.
 fn validate_pi_launch_config(value: &serde_json::Value, session_id: &str) -> Result<(), String> {
-    let launch: PiLaunchConfigV2 = serde_json::from_value(value.clone())
+    let launch: PiLaunchConfig = serde_json::from_value(value.clone())
         .map_err(|error| format!("Pi launch config v2 is invalid: {error}"))?;
     if launch.schema_version != 2 {
         return Err("Pi launch config schemaVersion must be 2".to_string());
@@ -195,7 +174,7 @@ fn validate_pi_launch_config(value: &serde_json::Value, session_id: &str) -> Res
             return Err(format!("Pi API first-turn {name} must use HTTP or HTTPS"));
         }
     }
-    if slot.deadline_at == 0 {
+    if slot.deadline_at <= 0 {
         return Err("Pi API first-turn deadlineAt must be positive".to_string());
     }
     if slot.sandbox_event_sequence_start != 1 {
@@ -204,10 +183,30 @@ fn validate_pi_launch_config(value: &serde_json::Value, session_id: &str) -> Res
     if slot.base_session.session_id != session_id {
         return Err("Pi H0 session id does not match pi_session_id".to_string());
     }
-    match slot.base_session.sha256 {
-        serde_json::Value::Null => {}
-        serde_json::Value::String(hash) if is_sha256(&hash) => {}
-        _ => return Err("Pi H0 sha256 must be null or a lowercase SHA-256".to_string()),
+    if let Some(hash) = slot.base_session.sha256
+        && !is_sha256(&hash)
+    {
+        return Err("Pi H0 sha256 must be null or a lowercase SHA-256".to_string());
+    }
+    Ok(())
+}
+
+fn is_pi_credential_secret_name(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    matches!(bytes.next(), Some(b'A'..=b'Z' | b'_'))
+        && bytes.all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn validate_pi_model_config(value: &serde_json::Value) -> Result<(), String> {
+    let model: PiModelConfig = serde_json::from_value(value.clone())
+        .map_err(|error| format!("Pi model config is invalid: {error}"))?;
+    url::Url::parse(&model.base_url)
+        .map_err(|_| "Pi model config baseUrl is invalid".to_string())?;
+    if model.model.is_empty() {
+        return Err("Pi model config model must not be empty".to_string());
+    }
+    if !is_pi_credential_secret_name(&model.credential_secret_name) {
+        return Err("Pi model config credentialSecretName is invalid".to_string());
     }
     Ok(())
 }
@@ -228,9 +227,11 @@ fn validate_pi_execution_context(context: &ExecutionContext) -> Result<(), Strin
         .as_ref()
         .ok_or_else(|| "Pi execution context is missing pi_launch_config".to_string())?;
     validate_pi_launch_config(launch_config, session_id)?;
-    if context.pi_model_config.is_none() {
-        return Err("Pi execution context is missing pi_model_config".to_string());
-    }
+    let model_config = context
+        .pi_model_config
+        .as_ref()
+        .ok_or_else(|| "Pi execution context is missing pi_model_config".to_string())?;
+    validate_pi_model_config(model_config)?;
     if let Some(resume) = &context.resume_session
         && resume.cli_agent_session_id != session_id
     {

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1376,6 +1376,24 @@ fn pi_execution_context_rejects_mismatched_h0_before_sandbox() {
 }
 
 #[test]
+fn pi_execution_context_rejects_missing_required_base_hash_before_sandbox() {
+    let mut context = pi_context_for_test();
+    context
+        .pi_launch_config
+        .as_mut()
+        .unwrap()
+        .pointer_mut("/apiFirstTurn/baseSession")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .remove("sha256");
+
+    let error = validate_context_for_test(&context).unwrap_err();
+
+    assert!(error.contains("H0 sha256 must be present"));
+}
+
+#[test]
 fn pi_execution_context_rejects_invalid_launch_fields_before_sandbox() {
     let cases = [
         ("/schemaVersion", json!(3), "schemaVersion must be 2"),

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -29,7 +29,7 @@ use crate::host_env::{
 };
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
-use crate::types::{ExecutionContext, PiModelConfig, ResumeSession, SandboxReuseResult};
+use crate::types::{ExecutionContext, ResumeSession, SandboxReuseResult};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();
@@ -72,6 +72,27 @@ fn pi_launch_config_for_test(session_id: &str) -> serde_json::Value {
             "sandboxEventSequenceStart": 1
         }
     })
+}
+
+fn pi_model_config_for_test() -> serde_json::Value {
+    json!({
+        "provider": "deepseek",
+        "baseUrl": "https://api.deepseek.com/",
+        "model": "deepseek-v4-flash",
+        "apiKeyEnv": "OPENAI_API_KEY",
+        "credentialSecretName": "DEEPSEEK_API_KEY"
+    })
+}
+
+fn pi_context_for_test() -> ExecutionContext {
+    let mut context = minimal_context();
+    context.cli_agent_type = "pi".to_string();
+    context.pi_session_id = Some("22222222-2222-4222-8222-222222222222".to_string());
+    context.pi_launch_config = Some(pi_launch_config_for_test(
+        "22222222-2222-4222-8222-222222222222",
+    ));
+    context.pi_model_config = Some(pi_model_config_for_test());
+    context
 }
 
 #[test]
@@ -1298,19 +1319,11 @@ fn non_pi_execution_contexts_do_not_require_pi_resources() {
 
 #[test]
 fn build_run_payload_for_run_preserves_pi_resources() {
-    let mut ctx = minimal_context();
-    ctx.cli_agent_type = "pi".to_string();
-    ctx.pi_session_id = Some("22222222-2222-4222-8222-222222222222".to_string());
-    ctx.pi_launch_config = Some(pi_launch_config_for_test(
-        "22222222-2222-4222-8222-222222222222",
-    ));
-    ctx.pi_model_config = Some(PiModelConfig {
-        provider: "deepseek".to_string(),
-        base_url: "https://api.deepseek.com/".to_string(),
-        model: "deepseek-v4-flash".to_string(),
-        api_key_env: "OPENAI_API_KEY".to_string(),
-        credential_secret_name: "DEEPSEEK_API_KEY".to_string(),
-    });
+    let mut ctx = pi_context_for_test();
+    ctx.pi_launch_config.as_mut().unwrap()["futureLaunchField"] = json!("launch-root");
+    ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["futureFirstTurnField"] =
+        json!("first-turn");
+    ctx.pi_model_config.as_mut().unwrap()["futureModelField"] = json!("model-root");
     let payload = build_run_payload_for_run(&ctx).unwrap();
 
     assert_eq!(
@@ -1319,10 +1332,13 @@ fn build_run_payload_for_run_preserves_pi_resources() {
     );
     let launch: serde_json::Value = serde_json::from_str(&payload.pi_launch_config).unwrap();
     assert_eq!(launch["schemaVersion"], 2);
+    assert_eq!(launch["futureLaunchField"], "launch-root");
+    assert_eq!(launch["apiFirstTurn"]["futureFirstTurnField"], "first-turn");
     let model: serde_json::Value = serde_json::from_str(&payload.pi_model_config).unwrap();
     assert_eq!(model["provider"], "deepseek");
     assert_eq!(model["apiKeyEnv"], "OPENAI_API_KEY");
     assert_eq!(model["credentialSecretName"], "DEEPSEEK_API_KEY");
+    assert_eq!(model["futureModelField"], "model-root");
 }
 
 #[test]
@@ -1331,13 +1347,7 @@ fn pi_execution_context_rejects_missing_handoff_fields_before_sandbox() {
     ctx.cli_agent_type = "pi".to_string();
     ctx.pi_session_id = Some("22222222-2222-4222-8222-222222222222".to_string());
     ctx.pi_launch_config = Some(json!({ "schemaVersion": 2 }));
-    ctx.pi_model_config = Some(PiModelConfig {
-        provider: "deepseek".to_string(),
-        base_url: "https://api.deepseek.com/".to_string(),
-        model: "deepseek-v4-flash".to_string(),
-        api_key_env: "OPENAI_API_KEY".to_string(),
-        credential_secret_name: "DEEPSEEK_API_KEY".to_string(),
-    });
+    ctx.pi_model_config = Some(pi_model_config_for_test());
 
     let error = validate_context_for_test(&ctx).unwrap_err();
 
@@ -1346,23 +1356,113 @@ fn pi_execution_context_rejects_missing_handoff_fields_before_sandbox() {
 
 #[test]
 fn pi_execution_context_rejects_mismatched_h0_before_sandbox() {
-    let mut ctx = minimal_context();
-    ctx.cli_agent_type = "pi".to_string();
-    ctx.pi_session_id = Some("22222222-2222-4222-8222-222222222222".to_string());
+    let mut ctx = pi_context_for_test();
     ctx.pi_launch_config = Some(pi_launch_config_for_test(
         "33333333-3333-4333-8333-333333333333",
     ));
-    ctx.pi_model_config = Some(PiModelConfig {
-        provider: "deepseek".to_string(),
-        base_url: "https://api.deepseek.com/".to_string(),
-        model: "deepseek-v4-flash".to_string(),
-        api_key_env: "OPENAI_API_KEY".to_string(),
-        credential_secret_name: "DEEPSEEK_API_KEY".to_string(),
-    });
 
     let error = validate_context_for_test(&ctx).unwrap_err();
 
     assert!(error.contains("H0 session id"));
+}
+
+#[test]
+fn pi_execution_context_rejects_invalid_launch_fields_before_sandbox() {
+    let cases = [
+        ("/schemaVersion", json!(3), "schemaVersion must be 2"),
+        (
+            "/apiFirstTurn/schemaVersion",
+            json!(2),
+            "schemaVersion must be 1",
+        ),
+        (
+            "/apiFirstTurn/resourceSnapshotDigest",
+            json!("not-a-digest"),
+            "resource snapshot digest",
+        ),
+        (
+            "/apiFirstTurn/manifestUrl",
+            json!("ftp://storage.example/manifest.json"),
+            "manifestUrl must use HTTP or HTTPS",
+        ),
+        (
+            "/apiFirstTurn/sessionUrl",
+            json!("not a URL"),
+            "sessionUrl is invalid",
+        ),
+        (
+            "/apiFirstTurn/deadlineAt",
+            json!(-1),
+            "deadlineAt must be positive",
+        ),
+        (
+            "/apiFirstTurn/sandboxEventSequenceStart",
+            json!(2),
+            "event sequence must start at 1",
+        ),
+        (
+            "/apiFirstTurn/baseSession/sha256",
+            json!("not-a-digest"),
+            "H0 sha256",
+        ),
+    ];
+
+    for (pointer, value, expected) in cases {
+        let mut context = pi_context_for_test();
+        *context
+            .pi_launch_config
+            .as_mut()
+            .unwrap()
+            .pointer_mut(pointer)
+            .unwrap() = value;
+
+        let error = validate_context_for_test(&context).unwrap_err();
+
+        assert!(
+            error.contains(expected),
+            "{pointer} produced unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn pi_execution_context_rejects_invalid_model_fields_before_sandbox() {
+    let cases = [
+        (
+            "/provider",
+            json!("future-provider"),
+            "Pi model config is invalid",
+        ),
+        (
+            "/apiKeyEnv",
+            json!("FUTURE_API_KEY"),
+            "Pi model config is invalid",
+        ),
+        ("/baseUrl", json!("not a URL"), "baseUrl is invalid"),
+        ("/model", json!(""), "model must not be empty"),
+        (
+            "/credentialSecretName",
+            json!("lowercase-secret"),
+            "credentialSecretName is invalid",
+        ),
+    ];
+
+    for (pointer, value, expected) in cases {
+        let mut context = pi_context_for_test();
+        *context
+            .pi_model_config
+            .as_mut()
+            .unwrap()
+            .pointer_mut(pointer)
+            .unwrap() = value;
+
+        let error = validate_context_for_test(&context).unwrap_err();
+
+        assert!(
+            error.contains(expected),
+            "{pointer} produced unexpected error: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1318,13 +1318,22 @@ fn non_pi_execution_contexts_do_not_require_pi_resources() {
 }
 
 #[test]
-fn build_run_payload_for_run_preserves_pi_resources() {
+fn pi_execution_context_preserves_additive_fields_in_run_payload() {
     let mut ctx = pi_context_for_test();
     ctx.pi_launch_config.as_mut().unwrap()["futureLaunchField"] = json!("launch-root");
     ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["futureFirstTurnField"] =
         json!("first-turn");
     ctx.pi_model_config.as_mut().unwrap()["futureModelField"] = json!("model-root");
-    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let sandbox_id = SandboxId::new_v4().to_string();
+    let payload = validate_execution_context_before_sandbox(
+        &ctx,
+        "http://localhost",
+        &sandbox_id,
+        SandboxReuseResult::Reused,
+    )
+    .unwrap()
+    .into_run_payload(&ctx)
+    .unwrap();
 
     assert_eq!(
         payload.pi_session_id,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3715,7 +3715,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_client_claim_decode_path_uses_current_codex_and_pi_schema_fields() {
+    async fn api_client_claim_decode_path_uses_current_codex_schema_fields() {
         let server = MockServer::start_async().await;
         let run_id = RunId::nil();
         let codex_error = claim_decode_error(
@@ -3743,34 +3743,6 @@ mod tests {
             "unexpected Codex decode error: {codex_error}"
         );
         assert!(!codex_error.contains("claim-sandbox-token"));
-
-        let pi_error = claim_decode_error(
-            &server,
-            run_id,
-            serde_json::json!({
-                "runId": run_id,
-                "prompt": "hello",
-                "sandboxToken": "claim-sandbox-token",
-                "cliAgentType": "pi",
-                "connectorRuntimeTargets": [],
-                "piLaunchConfig": {
-                    "schemaVersion": 2
-                },
-                "piSessionId": "00000000-0000-0000-0000-000000000001",
-                "piModelConfig": {
-                    "provider": "openai",
-                    "baseUrl": "https://api.example.com",
-                    "model": "gpt-5",
-                    "apiKeyEnv": 123
-                }
-            }),
-        )
-        .await;
-        assert!(
-            pi_error.contains("failed at piModelConfig.apiKeyEnv"),
-            "unexpected Pi decode error: {pi_error}"
-        );
-        assert!(!pi_error.contains("claim-sandbox-token"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -139,26 +139,16 @@ pub struct ExecutionContext {
     pub model_usage_provider: Option<String>,
     #[serde(default)]
     pub codex_runtime_config: Option<CodexRuntimeConfig>,
-    /// Schema-v2 Pi launch config marker. Runtime resources are discovered from
-    /// Pi's canonical filesystem locations by the official loader.
+    /// Raw Pi launch config retained so additive API fields survive forwarding
+    /// through a draining older runner.
     #[serde(default)]
     pub pi_launch_config: Option<serde_json::Value>,
-    /// Non-secret model metadata for the Pi Sandbox runtime.
+    /// Raw non-secret Pi model config retained for the same rollout boundary.
     #[serde(default)]
-    pub pi_model_config: Option<PiModelConfig>,
+    pub pi_model_config: Option<serde_json::Value>,
     /// Chat Thread id used as Pi's official JSONL session id.
     #[serde(default)]
     pub pi_session_id: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PiModelConfig {
-    pub provider: String,
-    pub base_url: String,
-    pub model: String,
-    pub api_key_env: String,
-    pub credential_secret_name: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1874,7 +1864,7 @@ mod tests {
             context
                 .pi_model_config
                 .as_ref()
-                .map(|config| config.model.as_str()),
+                .and_then(|config| config["model"].as_str()),
             Some("deepseek-v4-flash")
         );
     }

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -11,7 +11,11 @@ import {
   rustTypeBindings,
 } from "../types";
 import { modelProviderCodexRuntimeConfigSchema } from "../../contracts/model-providers";
-import { storageMountEntrySchema } from "../../contracts/runners";
+import {
+  piLaunchConfigSchema,
+  piModelConfigSchema,
+  storageMountEntrySchema,
+} from "../../contracts/runners";
 import { fileEntryWithHashSchema } from "../../contracts/storages";
 import {
   webhookCheckpointsContract,
@@ -23,6 +27,16 @@ const expectedBindings = [
   {
     rustModulePath: ["runners", "runs"],
     rustTypeName: "CodexRuntimeConfig",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiLaunchConfig",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiModelConfig",
     direction: "response",
   },
   {
@@ -214,6 +228,14 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("pub uploads: Option<ResponseUploads>,");
     expect(firstRender).toContain("pub struct StorageMountEntry {");
     expect(firstRender).toContain("pub struct CodexRuntimeConfig {");
+    expect(firstRender).toContain("pub struct PiLaunchConfig {");
+    expect(firstRender).toContain("pub struct PiLaunchConfigApiFirstTurn {");
+    expect(firstRender).toContain(
+      "pub struct PiLaunchConfigApiFirstTurnBaseSession {",
+    );
+    expect(firstRender).toContain("pub struct PiModelConfig {");
+    expect(firstRender).toContain("pub enum PiModelConfigProvider {");
+    expect(firstRender).toContain("pub enum PiModelConfigApiKeyEnv {");
     expect(firstRender).toContain(
       "pub http_headers: Option<std::collections::BTreeMap<String, String>>",
     );
@@ -298,6 +320,80 @@ describe("Rust type bindings", () => {
         },
       },
     );
+  });
+
+  it("keeps the Pi runtime bindings aligned with their canonical schemas", () => {
+    const launchBinding: RustTypeBinding | undefined = rustTypeBindings.find(
+      ({ rustModulePath, rustTypeName }) => {
+        return (
+          rustTypeName === "PiLaunchConfig" &&
+          rustModulePath.join("/") === "runners/runs"
+        );
+      },
+    );
+    const modelBinding: RustTypeBinding | undefined = rustTypeBindings.find(
+      ({ rustModulePath, rustTypeName }) => {
+        return (
+          rustTypeName === "PiModelConfig" &&
+          rustModulePath.join("/") === "runners/runs"
+        );
+      },
+    );
+
+    expect(launchBinding?.schema).toBe(piLaunchConfigSchema);
+    expect(modelBinding?.schema).toBe(piModelConfigSchema);
+    expect(z.toJSONSchema(piLaunchConfigSchema)).toMatchObject({
+      required: ["schemaVersion", "apiFirstTurn"],
+      properties: {
+        schemaVersion: { const: 2 },
+        apiFirstTurn: {
+          required: [
+            "schemaVersion",
+            "resourceSnapshotDigest",
+            "manifestUrl",
+            "sessionUrl",
+            "deadlineAt",
+            "baseSession",
+            "sandboxEventSequenceStart",
+          ],
+          properties: {
+            schemaVersion: { const: 1 },
+            sandboxEventSequenceStart: { const: 1 },
+            baseSession: {
+              required: ["sessionId", "sha256"],
+            },
+          },
+        },
+      },
+    });
+    expect(z.toJSONSchema(piModelConfigSchema)).toMatchObject({
+      required: [
+        "provider",
+        "baseUrl",
+        "model",
+        "apiKeyEnv",
+        "credentialSecretName",
+      ],
+      properties: {
+        provider: {
+          enum: [
+            "deepseek",
+            "moonshotai",
+            "openai",
+            "openrouter",
+            "vercel-ai-gateway",
+            "codex",
+          ],
+        },
+        apiKeyEnv: {
+          enum: [
+            "ANTHROPIC_AUTH_TOKEN",
+            "OPENAI_API_KEY",
+            "CHATGPT_ACCESS_TOKEN",
+          ],
+        },
+      },
+    });
   });
 
   it("keeps canonical Storage mount override aligned with its schema", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -179,7 +179,7 @@ export const rustTypeBindings = [
         rustDoc: ["Pi session checkpoint used as the first-turn base."],
         fields: {
           sessionId: ["Pi session identifier."],
-          sha256: ["Optional lowercase SHA-256 of the base session JSONL."],
+          sha256: ["Nullable lowercase SHA-256 of the base session JSONL."],
         },
       },
     ],

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -4,6 +4,8 @@ import {
   activeInputDeliveryReserveResponseSchema,
   activeInputDeliveryReceiptResponseSchema,
   artifactMissingRootPolicySchema,
+  piLaunchConfigSchema,
+  piModelConfigSchema,
   runnersModelProviderFailuresContract,
   storageMountEntrySchema,
 } from "../contracts/runners";
@@ -135,6 +137,93 @@ export const rustTypeBindings = [
           modelCatalog: [
             "Optional opaque Codex model catalog supplied by the API.",
           ],
+        },
+      },
+    ],
+  },
+  {
+    schema: piLaunchConfigSchema,
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiLaunchConfig",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "PiLaunchConfig",
+        rustDoc: [
+          "API-owned launch configuration forwarded to Pi in the sandbox.",
+        ],
+        fields: {
+          schemaVersion: ["Pi launch contract version."],
+          apiFirstTurn: ["Configuration for the API-mediated first turn."],
+        },
+      },
+      {
+        rustTypeName: "PiLaunchConfigApiFirstTurn",
+        rustDoc: ["API-mediated first-turn configuration for Pi."],
+        fields: {
+          schemaVersion: ["Pi API first-turn contract version."],
+          resourceSnapshotDigest: [
+            "Digest identifying the runtime resource snapshot.",
+          ],
+          manifestUrl: ["URL of the first-turn resource manifest."],
+          sessionUrl: ["URL of the first-turn session JSONL."],
+          deadlineAt: ["Unix timestamp in milliseconds for first-turn expiry."],
+          baseSession: ["Checkpoint used as the base Pi session."],
+          sandboxEventSequenceStart: [
+            "First sandbox event sequence number for the resumed session.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "PiLaunchConfigApiFirstTurnBaseSession",
+        rustDoc: ["Pi session checkpoint used as the first-turn base."],
+        fields: {
+          sessionId: ["Pi session identifier."],
+          sha256: ["Optional lowercase SHA-256 of the base session JSONL."],
+        },
+      },
+    ],
+  },
+  {
+    schema: piModelConfigSchema,
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiModelConfig",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "PiModelConfig",
+        rustDoc: ["API-owned non-secret Pi model configuration."],
+        fields: {
+          provider: ["Model provider selected for the Pi runtime."],
+          baseUrl: ["Base URL used for model requests."],
+          model: ["Provider model identifier."],
+          apiKeyEnv: ["Environment variable containing the provider key."],
+          credentialSecretName: [
+            "API-owned credential secret backing the environment entry.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "PiModelConfigProvider",
+        rustDoc: ["Model providers supported by the Pi runtime contract."],
+        variants: {
+          deepseek: ["DeepSeek provider."],
+          moonshotai: ["Moonshot AI provider."],
+          openai: ["OpenAI provider."],
+          openrouter: ["OpenRouter provider."],
+          "vercel-ai-gateway": ["Vercel AI Gateway provider."],
+          codex: ["Codex provider."],
+        },
+      },
+      {
+        rustTypeName: "PiModelConfigApiKeyEnv",
+        rustDoc: [
+          "Environment variables supported for Pi provider credentials.",
+        ],
+        variants: {
+          ANTHROPIC_AUTH_TOKEN: ["Anthropic authentication token."],
+          OPENAI_API_KEY: ["OpenAI-compatible API key."],
+          CHATGPT_ACCESS_TOKEN: ["ChatGPT access token."],
         },
       },
     ],


### PR DESCRIPTION
## Summary

- register the canonical Pi launch and model schemas in the TypeScript-to-Rust binding generator
- validate Pi runtime config with the generated DTOs before sandbox launch while forwarding the original JSON unchanged
- cover canonical nesting, literals, enums, semantic validation, and additive-field preservation across the runner handoff

## Deployment compatibility

- additive object fields remain preserved when a newer API is served by a draining older runner
- unknown provider/API-key enum values and schema versions continue to fail closed; future values require a runner-first rollout or explicit capability routing
- no API or guest wire field names or current payload shapes change

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm -F @okouai/api-contracts test`
- `cd turbo && pnpm knip --workspace @okouai/api-contracts`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm -F @okouai/api-contracts generate:rust` (deterministic output verified)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p api-contracts -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p api-contracts -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`

Closes #28889
