### PR TITLE
refactor(api): drop the branded compatibility rows with no traffic in the window

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -6,18 +6,14 @@ import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
 import { billingStatusRoutes } from "../signals/routes/billing-status";
 import { featureSwitchesRoutes } from "../signals/routes/feature-switches";
-import { feishuConnectRoutes } from "../signals/routes/feishu-connect";
 import { orgReadRoutes } from "../signals/routes/org-read";
 import { slackChannelsRoutes } from "../signals/routes/slack-channels";
 import { slackConnectRoutes } from "../signals/routes/slack-connect";
 import { slackOauthRoutes } from "../signals/routes/slack-oauth";
-import { strapiIntegrationsRoutes } from "../signals/routes/strapi-integrations";
-import { teamsBotRoutes } from "../signals/routes/teams-bot";
 import { teamsConnectRoutes } from "../signals/routes/teams-connect";
 import { teamsOauthRoutes } from "../signals/routes/teams-oauth";
 import { uploadsPrepareRoutes } from "../signals/routes/uploads-prepare";
 import { voiceIoQuotaRoutes } from "../signals/routes/voice-io-quota";
-import { weatherRoutes } from "../signals/routes/weather";
 import { webFileUrlRoutes } from "../signals/routes/web-file-url";
 import {
   assertUniqueRouteRegistrations,
@@ -95,17 +91,6 @@ const MIGRATED_TABLE: Readonly<Record<string, readonly string[]>> = {
   ],
 };
 
-// The maps operations that still owe a branded form. #28417 moved seven off
-// `/api/okou/maps/**`; #28709 removed the six that took no branded request in
-// the retained window, leaving the one a published CLI was still calling.
-// Written out rather than read from `mapsContract` or `MIGRATED_BRANDED_PATHS`,
-// so dropping a contract path or a table row fails the test that uses this.
-const MAPS_OPERATIONS = ["geocode"] as const;
-
-// The weather twin of the list above: #28357 moved five operations off
-// `/api/okou/weather/**` and #28709 kept only the one with measured traffic.
-const WEATHER_OPERATIONS = ["current"] as const;
-
 function registeredPaths(entries: readonly RouteEntry[]): readonly string[] {
   return entries.map((entry) => {
     return entry.route.path;
@@ -129,17 +114,9 @@ const BRANDED_PATHS_OWED = [
 // appends its own rows.
 const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28421
-  "/api/me/model-provider-accounts/:id/activate": [
-    "/api/okou/me/model-provider-accounts/:id/activate",
-    "/api/zero/me/model-provider-accounts/:id/activate",
-  ],
   "/api/me/model-providers": [
     "/api/okou/me/model-providers",
     "/api/zero/me/model-providers",
-  ],
-  "/api/onboarding/complete": [
-    "/api/okou/onboarding/complete",
-    "/api/zero/onboarding/complete",
   ],
   "/api/onboarding/status": [
     "/api/okou/onboarding/status",
@@ -153,29 +130,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/user-preferences": [
     "/api/okou/user-preferences",
     "/api/zero/user-preferences",
-  ],
-  // #28418
-  "/api/browsers/current": [
-    "/api/okou/browsers/current",
-    "/api/zero/browsers/current",
-  ],
-  "/api/browsers/lease": [
-    "/api/okou/browsers/lease",
-    "/api/zero/browsers/lease",
-  ],
-  "/api/finance/chart": ["/api/okou/finance/chart", "/api/zero/finance/chart"],
-  "/api/finance/profile": [
-    "/api/okou/finance/profile",
-    "/api/zero/finance/profile",
-  ],
-  "/api/finance/quote": ["/api/okou/finance/quote", "/api/zero/finance/quote"],
-  "/api/seo/backlinks-summary": [
-    "/api/okou/seo/backlinks-summary",
-    "/api/zero/seo/backlinks-summary",
-  ],
-  "/api/seo/keyword-ideas": [
-    "/api/okou/seo/keyword-ideas",
-    "/api/zero/seo/keyword-ideas",
   ],
   // #28415
   // #28416
@@ -194,19 +148,11 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-thread-unreads",
     "/api/zero/chat-thread-unreads",
   ],
-  "/api/chat-thread-unreads/mark-read": [
-    "/api/okou/chat-thread-unreads/mark-read",
-    "/api/zero/chat-thread-unreads/mark-read",
-  ],
   "/api/indicators": ["/api/okou/indicators", "/api/zero/indicators"],
   // #28422
   "/api/artifacts/catalog": [
     "/api/okou/artifacts/catalog",
     "/api/zero/artifacts/catalog",
-  ],
-  "/api/artifacts/catalog/:artifactId": [
-    "/api/okou/artifacts/catalog/:artifactId",
-    "/api/zero/artifacts/catalog/:artifactId",
   ],
   "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
   "/api/push-subscriptions": [
@@ -217,24 +163,10 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/realtime/token",
     "/api/zero/realtime/token",
   ],
-  "/api/runs/:id": ["/api/okou/runs/:id", "/api/zero/runs/:id"],
-  "/api/runs/:id/context": [
-    "/api/okou/runs/:id/context",
-    "/api/zero/runs/:id/context",
-  ],
-  "/api/runs/:id/network": [
-    "/api/okou/runs/:id/network",
-    "/api/zero/runs/:id/network",
-  ],
-  "/api/runs/:id/runner": [
-    "/api/okou/runs/:id/runner",
-    "/api/zero/runs/:id/runner",
-  ],
   "/api/runs/:id/telemetry/agent": [
     "/api/okou/runs/:id/telemetry/agent",
     "/api/zero/runs/:id/telemetry/agent",
   ],
-  "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
   // #28459: chat threads, chat events and search, shared threads,
   // per-thread browser sessions and goals, thread workflow automations,
   // queue position, and the X image share.
@@ -242,10 +174,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/chat-threads/:id": [
     "/api/okou/chat-threads/:id",
     "/api/zero/chat-threads/:id",
-  ],
-  "/api/chat-threads/:id/computer-use-host": [
-    "/api/okou/chat-threads/:id/computer-use-host",
-    "/api/zero/chat-threads/:id/computer-use-host",
   ],
   "/api/chat-threads/:id/draft": [
     "/api/okou/chat-threads/:id/draft",
@@ -262,10 +190,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/chat-threads/:id/pin": [
     "/api/okou/chat-threads/:id/pin",
     "/api/zero/chat-threads/:id/pin",
-  ],
-  "/api/chat-threads/:id/unpin": [
-    "/api/okou/chat-threads/:id/unpin",
-    "/api/zero/chat-threads/:id/unpin",
   ],
   "/api/chat-threads/:threadId/artifacts": [
     "/api/okou/chat-threads/:threadId/artifacts",
@@ -295,14 +219,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/event-snapshot",
     "/api/zero/chat-threads/:threadId/event-snapshot",
   ],
-  "/api/chat-threads/:threadId/goal": [
-    "/api/okou/chat-threads/:threadId/goal",
-    "/api/zero/chat-threads/:threadId/goal",
-  ],
-  "/api/chat-threads/:threadId/goal/pause": [
-    "/api/okou/chat-threads/:threadId/goal/pause",
-    "/api/zero/chat-threads/:threadId/goal/pause",
-  ],
   "/api/chat-threads/:threadId/workflow-automations": [
     "/api/okou/chat-threads/:threadId/workflow-automations",
     "/api/zero/chat-threads/:threadId/workflow-automations",
@@ -321,37 +237,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/billing/checkout",
     "/api/zero/billing/checkout",
   ],
-  "/api/billing/concurrency-checkout": [
-    "/api/okou/billing/concurrency-checkout",
-    "/api/zero/billing/concurrency-checkout",
-  ],
-  "/api/billing/concurrency-checkout/preview": [
-    "/api/okou/billing/concurrency-checkout/preview",
-    "/api/zero/billing/concurrency-checkout/preview",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/changes/preview": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-  ],
-  "/api/billing/credit-checkout/confirm": [
-    "/api/okou/billing/credit-checkout/confirm",
-    "/api/zero/billing/credit-checkout/confirm",
-  ],
   "/api/billing/invoices": [
     "/api/okou/billing/invoices",
     "/api/zero/billing/invoices",
-  ],
-  "/api/billing/portal": [
-    "/api/okou/billing/portal",
-    "/api/zero/billing/portal",
-  ],
-  "/api/billing/redeem-code": [
-    "/api/okou/billing/redeem-code",
-    "/api/zero/billing/redeem-code",
-  ],
-  "/api/billing/restore": [
-    "/api/okou/billing/restore",
-    "/api/zero/billing/restore",
   ],
   "/api/billing/status": [
     "/api/okou/billing/status",
@@ -360,10 +248,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/usage-pack-catalog": [
     "/api/okou/billing/usage-pack-catalog",
     "/api/zero/billing/usage-pack-catalog",
-  ],
-  "/api/billing/usage-pack-checkout": [
-    "/api/okou/billing/usage-pack-checkout",
-    "/api/zero/billing/usage-pack-checkout",
   ],
   "/api/billing/usage-pack-credits": [
     "/api/okou/billing/usage-pack-credits",
@@ -376,14 +260,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/usage-pack-subscription": [
     "/api/okou/billing/usage-pack-subscription",
     "/api/zero/billing/usage-pack-subscription",
-  ],
-  "/api/billing/usage-pack-subscription/subscription-change/confirm": [
-    "/api/okou/billing/usage-pack-subscription/subscription-change/confirm",
-    "/api/zero/billing/usage-pack-subscription/subscription-change/confirm",
-  ],
-  "/api/billing/usage-pack-subscription/subscription-change/preview": [
-    "/api/okou/billing/usage-pack-subscription/subscription-change/preview",
-    "/api/zero/billing/usage-pack-subscription/subscription-change/preview",
   ],
   // #28466
   "/api/computer-use/audit-events": [
@@ -415,10 +291,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/computer-use/hosts/start",
   ],
   // #28423
-  "/api/integrations/feishu": [
-    "/api/okou/integrations/feishu",
-    "/api/zero/integrations/feishu",
-  ],
   "/api/integrations/slack": [
     "/api/okou/integrations/slack",
     "/api/zero/integrations/slack",
@@ -443,10 +315,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/integrations/slack/upload-file/materialize",
     "/api/zero/integrations/slack/upload-file/materialize",
   ],
-  "/api/integrations/strapi": [
-    "/api/okou/integrations/strapi",
-    "/api/zero/integrations/strapi",
-  ],
   "/api/integrations/teams/connect": [
     "/api/okou/integrations/teams/connect",
     "/api/zero/integrations/teams/connect",
@@ -457,10 +325,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/connector-catalog/:connectorSlug",
     "/api/zero/connector-catalog/:connectorSlug",
   ],
-  "/api/connector-catalog/diagnostics": [
-    "/api/okou/connector-catalog/diagnostics",
-    "/api/zero/connector-catalog/diagnostics",
-  ],
   "/api/connector-catalog/discovery": [
     "/api/okou/connector-catalog/discovery",
     "/api/zero/connector-catalog/discovery",
@@ -468,10 +332,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/connector-catalog/status": [
     "/api/okou/connector-catalog/status",
     "/api/zero/connector-catalog/status",
-  ],
-  "/api/connectors/:connectorSlug/manual-grant": [
-    "/api/okou/connectors/:connectorSlug/manual-grant",
-    "/api/zero/connectors/:connectorSlug/manual-grant",
   ],
   "/api/connectors/:connectorSlug/oauth/start": [
     "/api/okou/connectors/:connectorSlug/oauth/start",
@@ -481,17 +341,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/custom-connectors",
     "/api/zero/custom-connectors",
   ],
-  "/api/model-provider-connections": [
-    "/api/okou/model-provider-connections",
-    "/api/zero/model-provider-connections",
-  ],
   "/api/user-permission-grants": [
     "/api/okou/user-permission-grants",
     "/api/zero/user-permission-grants",
-  ],
-  "/api/user-permission-grants/apply": [
-    "/api/okou/user-permission-grants/apply",
-    "/api/zero/user-permission-grants/apply",
   ],
   // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes. The
   // paths a provider console holds are not in this slice and stay branded;
@@ -533,31 +385,9 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/model-providers",
     "/api/zero/model-providers",
   ],
-  "/api/model-providers/codex/device-auth/sessions": [
-    "/api/okou/model-providers/codex/device-auth/sessions",
-    "/api/zero/model-providers/codex/device-auth/sessions",
-  ],
-  "/api/model-providers/codex/device-auth/sessions/cancel": [
-    "/api/okou/model-providers/codex/device-auth/sessions/cancel",
-    "/api/zero/model-providers/codex/device-auth/sessions/cancel",
-  ],
-  "/api/model-providers/codex/device-auth/sessions/complete": [
-    "/api/okou/model-providers/codex/device-auth/sessions/complete",
-    "/api/zero/model-providers/codex/device-auth/sessions/complete",
-  ],
   "/api/org": ["/api/okou/org", "/api/zero/org"],
-  "/api/org/invite": ["/api/okou/org/invite", "/api/zero/org/invite"],
-  "/api/org/invite/purchase/:purchaseId/confirm": [
-    "/api/okou/org/invite/purchase/:purchaseId/confirm",
-    "/api/zero/org/invite/purchase/:purchaseId/confirm",
-  ],
-  "/api/org/invite/purchase/preview": [
-    "/api/okou/org/invite/purchase/preview",
-    "/api/zero/org/invite/purchase/preview",
-  ],
   "/api/org/logo": ["/api/okou/org/logo", "/api/zero/org/logo"],
   "/api/org/members": ["/api/okou/org/members", "/api/zero/org/members"],
-  "/api/usage/members": ["/api/okou/usage/members", "/api/zero/usage/members"],
   "/api/usage/record": ["/api/okou/usage/record", "/api/zero/usage/record"],
   // #28461
   "/api/agents": ["/api/okou/agents", "/api/zero/agents"],
@@ -578,52 +408,25 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflow-automations/:id",
     "/api/zero/workflow-automations/:id",
   ],
-  "/api/workflow-automations/:id/disable": [
-    "/api/okou/workflow-automations/:id/disable",
-    "/api/zero/workflow-automations/:id/disable",
-  ],
-  "/api/workflow-automations/:id/enable": [
-    "/api/okou/workflow-automations/:id/enable",
-    "/api/zero/workflow-automations/:id/enable",
-  ],
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
-  // #28545: the Teams OAuth callback and the Teams bot ingress, moved off
-  // `FINAL_PROVIDER_CONSOLE_PATHS` now that both Microsoft consoles hold the
-  // final URL. `/api/zero/teams/oauth/callback` is still emitted on purpose by
-  // the VM0 brand, so it is a producer target rather than drain-window
-  // compatibility; `route-entry.ts` records why on the row.
+  // #28545: the Teams OAuth callback, moved off `FINAL_PROVIDER_CONSOLE_PATHS`
+  // now that the Microsoft consoles hold the final URL. #28917 removed the
+  // slice's other row, the Teams bot ingress, whose branded forms nothing holds
+  // once the Azure Bot messaging endpoint moved. `/api/zero/teams/oauth/callback`
+  // is still emitted on purpose by the VM0 brand, so it is a producer target
+  // rather than drain-window compatibility; `route-entry.ts` records why on the
+  // row, and it is why #28917 kept this row against its own inventory.
   "/api/integrations/teams/oauth/callback": [
     "/api/okou/teams/oauth/callback",
     "/api/zero/teams/oauth/callback",
   ],
-  "/api/webhooks/teams/bot": ["/api/okou/teams/bot", "/api/zero/teams/bot"],
   // #28463: avatar video, banking, browser authorization requests, inbound
   // email, the GitHub user-connect start, mail drafts, people search,
   // presentation templates, the Strapi webhook, uploads, video-io, voice-io and
   // the web file reads.
-  "/api/browser/authorization-requests/:requestToken": [
-    "/api/okou/browser/authorization-requests/:requestToken",
-    "/api/zero/browser/authorization-requests/:requestToken",
-  ],
-  "/api/browser/authorization-requests/:requestToken/apply": [
-    "/api/okou/browser/authorization-requests/:requestToken/apply",
-    "/api/zero/browser/authorization-requests/:requestToken/apply",
-  ],
   "/api/mail/drafts/:mailDraftId": [
     "/api/okou/mail/drafts/:mailDraftId",
     "/api/zero/mail/drafts/:mailDraftId",
-  ],
-  "/api/mail/drafts/:mailDraftId/send": [
-    "/api/okou/mail/drafts/:mailDraftId/send",
-    "/api/zero/mail/drafts/:mailDraftId/send",
-  ],
-  "/api/presentation-templates/:templateId": [
-    "/api/okou/presentation-templates/:templateId",
-    "/api/zero/presentation-templates/:templateId",
-  ],
-  "/api/uploads/multipart/abort": [
-    "/api/okou/uploads/multipart/abort",
-    "/api/zero/uploads/multipart/abort",
   ],
   "/api/uploads/multipart/complete": [
     "/api/okou/uploads/multipart/complete",
@@ -788,84 +591,6 @@ describe("branded paths for migrated neutral routes", () => {
     expect(movedWithRow).toStrictEqual([]);
   });
 
-  // #28417 fills the table for maps. The contract declares the neutral paths,
-  // so the blanket expansion no longer derives a branded form for them and
-  // every branded maps path below exists only because of a table row. The paths
-  // are written out here rather than derived from the table, so deleting a row
-  // fails this test instead of changing what it asserts.
-  it("serves the migrated maps routes on neutral and branded paths", () => {
-    const registered = withMigratedBrandedPaths(
-      withApiNamespaceAliases(ROUTES),
-    );
-
-    function requireRoute(path: string): RouteEntry {
-      const matches = registered.filter((entry) => {
-        return entry.route.method === "POST" && entry.route.path === path;
-      });
-      const match = matches[0];
-      if (!match) {
-        throw new Error(`Missing maps registration for POST ${path}`);
-      }
-      expect(matches).toHaveLength(1);
-      return match;
-    }
-
-    for (const operation of MAPS_OPERATIONS) {
-      const neutral = requireRoute(`/api/maps/${operation}`);
-
-      // One contract route behind all three paths, so a branded form cannot
-      // drift into a second handler or a stale schema.
-      for (const namespace of ["okou", "zero"]) {
-        const brandedPath = `/api/${namespace}/maps/${operation}`;
-        const branded = requireRoute(brandedPath);
-
-        expect(branded.handler).toBe(neutral.handler);
-        expect(branded.route).toStrictEqual({
-          ...neutral.route,
-          path: brandedPath,
-        });
-      }
-    }
-  });
-
-  // The weather twin of the assertion above (#28357). Kept as its own test so a
-  // failure names the family that regressed, and so the paths stay written out
-  // per family rather than derived from the table under test.
-  it("serves the migrated weather routes on neutral and branded paths", () => {
-    const registered = withMigratedBrandedPaths(
-      withApiNamespaceAliases(ROUTES),
-    );
-
-    function requireRoute(path: string): RouteEntry {
-      const matches = registered.filter((entry) => {
-        return entry.route.method === "POST" && entry.route.path === path;
-      });
-      const match = matches[0];
-      if (!match) {
-        throw new Error(`Missing weather registration for POST ${path}`);
-      }
-      expect(matches).toHaveLength(1);
-      return match;
-    }
-
-    for (const operation of WEATHER_OPERATIONS) {
-      const neutral = requireRoute(`/api/weather/${operation}`);
-
-      // One contract route behind all three paths, so a branded form cannot
-      // drift into a second handler or a stale schema.
-      for (const namespace of ["okou", "zero"]) {
-        const brandedPath = `/api/${namespace}/weather/${operation}`;
-        const branded = requireRoute(brandedPath);
-
-        expect(branded.handler).toBe(neutral.handler);
-        expect(branded.route).toStrictEqual({
-          ...neutral.route,
-          path: brandedPath,
-        });
-      }
-    }
-  });
-
   // The synthetic cases above cover the mechanism; this runs the real route
   // table through the composition production registers, so a moved contract
   // that lost its rows fails here rather than 404ing a released caller.
@@ -918,13 +643,13 @@ describe("branded paths for migrated neutral routes", () => {
       isAuthenticated: false,
     });
 
-    // One GET per contract file this slice moved, written out rather than read
-    // back from `MIGRATED_BRANDED_PATHS`.
+    // One GET per contract file this slice moved that still has a row, written
+    // out rather than read back from `MIGRATED_BRANDED_PATHS`. #28917 removed
+    // the Feishu and Strapi connect rows on zero-traffic evidence, so those two
+    // are no longer driven here.
     const families = [
-      { routes: feishuConnectRoutes, suffix: "integrations/feishu" },
       { routes: slackConnectRoutes, suffix: "integrations/slack/connect" },
       { routes: teamsConnectRoutes, suffix: "integrations/teams/connect" },
-      { routes: strapiIntegrationsRoutes, suffix: "integrations/strapi" },
     ];
 
     for (const { routes, suffix } of families) {
@@ -1024,67 +749,26 @@ describe("branded paths for migrated neutral routes", () => {
   // because nothing enumerated it.
   //
   // That is the guard #28709 left behind when it took the table from 314 rows
-  // to 184, and #28711 kept when it took the 42 drained rows that left 142.
-  // Neither left a case asserting the removed rows now 404: `docs/fallback.md`
-  // section 1 rules that class out, and the route table already proves the
-  // registration is gone. What needs a test is the opposite direction — a row
-  // disappearing without the request-log evidence #26701 requires — which is
-  // what this count and the per-family cases catch.
+  // to 184, #28711 kept when it took the 42 drained rows that left 142, and
+  // #28917 kept when it took 53 more and left 89. None of them left a case
+  // asserting the removed rows now 404: `docs/fallback.md` section 1 rules that
+  // class out, and the route table already proves the registration is gone.
+  // What needs a test is the opposite direction — a row disappearing without
+  // the request-log evidence #26701 requires — which is what this count and the
+  // per-family cases catch.
   //
-  // `MIGRATED_ROUTE_PATHS` carries every row but the two the maps and weather
-  // cases own, which is why the total below is two higher than its size. Raise
-  // both numbers only with that evidence; an unexplained edit here is the
-  // failure this is for.
+  // `MIGRATED_ROUTE_PATHS` carries every row. It used to be two short, because
+  // the maps and weather cases owned `/api/maps/geocode` and
+  // `/api/weather/current`; #28917 drained both families out of the table, so
+  // those cases and the offset they needed are gone and the size below is the
+  // whole table. Raise the number only with that evidence; an unexplained edit
+  // here is the failure this is for.
   it("holds the branded rows this suite has evidence for and no others", () => {
-    const MIGRATED_ROWS_WITH_OWN_CASE = 2;
-    const MIGRATED_BRANDED_ROW_COUNT = 142;
+    const MIGRATED_BRANDED_ROW_COUNT = 89;
 
-    expect(
-      Object.keys(MIGRATED_ROUTE_PATHS).length + MIGRATED_ROWS_WITH_OWN_CASE,
-    ).toBe(MIGRATED_BRANDED_ROW_COUNT);
-
-    // The rows the maps and weather cases own, named rather than counted, so
-    // the arithmetic above cannot be satisfied by the wrong two rows.
-    for (const owned of ["/api/maps/geocode", "/api/weather/current"]) {
-      expect(MIGRATED_ROUTE_PATHS).not.toHaveProperty(owned);
-    }
-  });
-
-  // The route-table assertion above rebuilds the composition itself, so it
-  // cannot see how `createAppWithRoutes` wires it. This one goes through the
-  // app factory production uses: if `withMigratedBrandedPaths` were dropped
-  // from or reordered in that chain, the branded weather paths would 404 here
-  // while the table assertion still passed. Requests are unauthenticated, so
-  // the status is whatever the auth layer returns — the point is that all
-  // three forms reach the same handler instead of falling through to 404.
-  it("serves the migrated weather paths through the production app factory", async () => {
-    const app = createAppWithRoutes({
-      signal: context.signal,
-      routes: weatherRoutes,
-    });
-
-    async function statusFor(path: string): Promise<number> {
-      const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: "{}",
-      });
-      return response.status;
-    }
-
-    for (const operation of WEATHER_OPERATIONS) {
-      const neutral = await statusFor(`/api/weather/${operation}`);
-      const okou = await statusFor(`/api/okou/weather/${operation}`);
-      const zero = await statusFor(`/api/zero/weather/${operation}`);
-
-      expect({ operation, neutral, okou, zero }).toStrictEqual({
-        operation,
-        neutral,
-        okou: neutral,
-        zero: neutral,
-      });
-      expect(neutral).not.toBe(404);
-    }
+    expect(Object.keys(MIGRATED_ROUTE_PATHS)).toHaveLength(
+      MIGRATED_BRANDED_ROW_COUNT,
+    );
   });
 
   // The #28457 twin of the two assertions above, for the billing slice. Every
@@ -1211,11 +895,15 @@ describe("branded paths for migrated neutral routes", () => {
 
   // The #28545 twin, and the one slice where the branded forms are held by a
   // provider console rather than by a released client: the Microsoft app
-  // registration still lists both callback URLs and Azure Bot can still be
-  // pointed at either bot URL, so a dropped row 404s Microsoft itself with no
-  // drain window to wait out. Requests carry no credentials, so the status is
-  // whatever the handler returns before it has any — the point is that the
-  // neutral path and both branded forms reach the same handler.
+  // registration still lists both callback URLs, so a dropped row 404s
+  // Microsoft itself with no drain window to wait out. The `zero` form is also
+  // what `callbackRedirectUri` emits for the VM0 brand, so this row has a live
+  // producer as well as a console holder. #28917 removed the slice's bot row —
+  // the Azure Bot messaging endpoint had already been repointed at the neutral
+  // path — which is why only the callback is exercised here now. Requests carry
+  // no credentials, so the status is whatever the handler returns before it has
+  // any; the point is that the neutral path and both branded forms reach the
+  // same handler.
   it("serves the migrated Teams console paths through the production app factory", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
@@ -1224,26 +912,18 @@ describe("branded paths for migrated neutral routes", () => {
     const families = [
       {
         routes: teamsOauthRoutes,
-        method: "GET",
         neutralSuffix: "integrations/teams/oauth/callback",
         brandedSuffix: "teams/oauth/callback",
       },
-      {
-        routes: teamsBotRoutes,
-        method: "POST",
-        neutralSuffix: "webhooks/teams/bot",
-        brandedSuffix: "teams/bot",
-      },
     ] as const;
 
-    for (const { routes, method, neutralSuffix, brandedSuffix } of families) {
+    for (const { routes, neutralSuffix, brandedSuffix } of families) {
       const app = createAppWithRoutes({ signal: context.signal, routes });
 
       async function statusFor(path: string): Promise<number> {
         const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
-          method,
+          method: "GET",
           headers: { "content-type": "application/json" },
-          ...(method === "POST" ? { body: "{}" } : {}),
         });
         return response.status;
       }

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -231,36 +231,51 @@ export function withApiNamespaceAliases(
  *   and twelve of its rows turned out to have a web-app caller too, which is
  *   the ~2 day bundle window rather than the two-hour one. Group the log by
  *   `x_client_type` before reading a silence as a drain.
+ *
+ * #28917 then took fifty-three of the 142, leaving 89. Every one of them was
+ * silent on both branded forms across the whole retained window — 2026-08-20
+ * 06:34Z to 2026-08-24 08:28Z, 4.1 days, all 685 distinct branded templates
+ * pulled without truncation and matched with `:param` rewritten to `[^/]+`.
+ * Three whole slices drained: #28417 (maps), #28357 (weather) and #28418
+ * (browser, finance, SEO) no longer have a row here.
+ *
+ * Silence alone is weak for the rarer rows, so it was corroborated rather than
+ * trusted: for thirty-five of the fifty-three the neutral path carried traffic
+ * inside the same window while both branded forms stayed at zero, and no
+ * shipped CLI, desktop or platform build emits a branded literal for any of
+ * them. The desktop build's entire hardcoded surface is `auth/me`,
+ * `computer-use/{heartbeat,host/*,hosts/start}`, `desktop/{updates,
+ * migration-policy}`, `feature-switches` and `org`, and every one of those
+ * rows is kept.
+ *
+ * Three rows the #28917 inventory listed were held back, and each names a way
+ * a zero-count reading fails:
+ *
+ * - `integrations/teams/oauth/callback`. `callbackRedirectUri` in
+ *   `routes/teams-oauth.ts` still emits its `zero` form for the VM0 brand, so
+ *   the row is an active producer target. No window can drain it and no count
+ *   can retire it; see the comment on the row itself.
+ * - `computer-use/hosts/start` and `computer-use/host/stop`. Both are
+ *   hardcoded in every Desktop build up to 0.38.53, and those builds were
+ *   still sending branded `heartbeat` and `host/commands/next` inside this
+ *   window. Start and stop fire once per session, so at the measured rate the
+ *   branded count they should produce over four days is under one request.
+ *   Zero is not a drain; it is the absence of statistical power.
+ *
+ * The general rule those three leave behind: a zero count retires a row only
+ * when the row's caller both has a bounded window and would have been expected
+ * to appear in the window at all. Check the call rate before reading a silence.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 
 const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
-  // #28417. Published CLI builds post to the `okou` form — `callMaps` builds
-  // the URL by hand rather than from the contract, so the path it holds shipped
-  // independently of this table — and the `zero` form was reachable through the
-  // blanket expansion until the contract moved. Both are owed.
-  //
-  // Surface: commit-addressed CLI packages, not web clients. A run execution
-  // context pins `CLI_PKG_URL` when it is created and keeps that artifact after
-  // a later API deploy, so the exposure is the context drain described in
-  // `docs/deployment-compatibility.md` — maximum queue lifetime plus maximum
-  // claimed execution and finalization lifetime, with execution bounded by the
-  // runner's 2h `JOB_TIMEOUT` — rather than the ~2 day web-client window. That
-  // drain is the floor for removal, not the condition: these rows retire under
-  // #26701's evidence rules like every other row in this file.
-  "/api/maps/geocode": ["/api/okou/maps/geocode", "/api/zero/maps/geocode"],
   // #28421: personal model providers, onboarding, team, and user preferences.
-  "/api/me/model-provider-accounts/:id/activate": [
-    "/api/okou/me/model-provider-accounts/:id/activate",
-    "/api/zero/me/model-provider-accounts/:id/activate",
-  ],
+  // #28917 removed `me/model-provider-accounts/:id/activate` and
+  // `onboarding/complete`: both branded forms were silent across the whole
+  // retained window while their neutral paths carried traffic.
   "/api/me/model-providers": [
     "/api/okou/me/model-providers",
     "/api/zero/me/model-providers",
-  ],
-  "/api/onboarding/complete": [
-    "/api/okou/onboarding/complete",
-    "/api/zero/onboarding/complete",
   ],
   "/api/onboarding/status": [
     "/api/okou/onboarding/status",
@@ -275,61 +290,15 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/user-preferences",
     "/api/zero/user-preferences",
   ],
-  // #28357, the first #28278 slice. Published CLI builds post to the `okou`
-  // form (`callWeather` built it by hand rather than from the contract, so it
-  // shipped independently of this path), and the `zero` form was reachable
-  // through the blanket expansion until the contract moved. Both are owed.
-  //
-  // Surface: commit-addressed CLI packages pinned by run contexts created
-  // before this deploy, so the branded form outlives the deploy by the queue
-  // and claimed-execution drain — up to the 2h runner/sandbox window — plus any
-  // external holder of the `zero` brand path, which has no time box. Removal
-  // therefore follows the table's #26701 evidence gate above, not a clock.
-  "/api/weather/current": [
-    "/api/okou/weather/current",
-    "/api/zero/weather/current",
-  ],
-  // #28418: the browser, finance, and SEO routes. The slice also covered
-  // `browsers/use` and the MCP connector routes; #28711 removed those rows
-  // because the log measured only CLI callers on their branded forms, so the
-  // pinning window bounded them and the drain had already happened. The callers
-  // the remaining rows keep working are a released web or app client, which holds the
-  // branded path until a refresh loads a build that derives the neutral one
-  // (~2 days), and a CLI artifact pinned by an execution context's
-  // `CLI_PKG_URL`, which holds it for that context's queue and claimed-run
-  // lifetime. Neither window is the removal condition on its own: a row is
-  // removed under #26701's evidence rules, because the request log retains
-  // about three days and cannot tell a drained caller from a weekly one.
-  "/api/browsers/current": [
-    "/api/okou/browsers/current",
-    "/api/zero/browsers/current",
-  ],
-  "/api/browsers/lease": [
-    "/api/okou/browsers/lease",
-    "/api/zero/browsers/lease",
-  ],
-  "/api/finance/chart": ["/api/okou/finance/chart", "/api/zero/finance/chart"],
-  "/api/finance/profile": [
-    "/api/okou/finance/profile",
-    "/api/zero/finance/profile",
-  ],
-  "/api/finance/quote": ["/api/okou/finance/quote", "/api/zero/finance/quote"],
-  "/api/seo/backlinks-summary": [
-    "/api/okou/seo/backlinks-summary",
-    "/api/zero/seo/backlinks-summary",
-  ],
-  "/api/seo/keyword-ideas": [
-    "/api/okou/seo/keyword-ideas",
-    "/api/zero/seo/keyword-ideas",
-  ],
-  // #28420. Every caller of these five derives its URL from the contract, so
+  // #28420. Every caller of these derives its URL from the contract, so
   // nothing in this repository still asks for a branded form. Released builds
   // do: a browser tab holding already-loaded platform code keeps calling the
   // `okou` path it was built against until it navigates or reloads, which is
   // the ~2 day old-web-client window in `docs/fallback.md` section 7. The
   // `zero` form was reachable through the blanket expansion until the contract
   // moved. Both are owed, and both are removable only under #26701's evidence
-  // rules, like every other row in this table.
+  // rules, like every other row in this table. #28917 removed
+  // `chat-thread-unreads/mark-read` on zero-traffic evidence.
   "/api/attribution/signup": [
     "/api/okou/attribution/signup",
     "/api/zero/attribution/signup",
@@ -342,20 +311,16 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-thread-unreads",
     "/api/zero/chat-thread-unreads",
   ],
-  "/api/chat-thread-unreads/mark-read": [
-    "/api/okou/chat-thread-unreads/mark-read",
-    "/api/zero/chat-thread-unreads/mark-read",
-  ],
   "/api/indicators": ["/api/okou/indicators", "/api/zero/indicators"],
   // #28422: artifact catalog, logs, push subscriptions, the platform realtime
-  // token, and the run reads.
+  // token, and the run reads. #28917 removed the per-artifact catalog read and
+  // every run row but the agent telemetry write — `runs/:id`, its `context`,
+  // `network` and `runner` reads, and `runs/queue` — because their branded
+  // forms were silent across the whole retained window while the neutral paths
+  // carried the same callers.
   "/api/artifacts/catalog": [
     "/api/okou/artifacts/catalog",
     "/api/zero/artifacts/catalog",
-  ],
-  "/api/artifacts/catalog/:artifactId": [
-    "/api/okou/artifacts/catalog/:artifactId",
-    "/api/zero/artifacts/catalog/:artifactId",
   ],
   "/api/logs/:id": ["/api/okou/logs/:id", "/api/zero/logs/:id"],
   "/api/push-subscriptions": [
@@ -366,31 +331,19 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/realtime/token",
     "/api/zero/realtime/token",
   ],
-  "/api/runs/:id": ["/api/okou/runs/:id", "/api/zero/runs/:id"],
-  "/api/runs/:id/context": [
-    "/api/okou/runs/:id/context",
-    "/api/zero/runs/:id/context",
-  ],
-  "/api/runs/:id/network": [
-    "/api/okou/runs/:id/network",
-    "/api/zero/runs/:id/network",
-  ],
-  "/api/runs/:id/runner": [
-    "/api/okou/runs/:id/runner",
-    "/api/zero/runs/:id/runner",
-  ],
   "/api/runs/:id/telemetry/agent": [
     "/api/okou/runs/:id/telemetry/agent",
     "/api/zero/runs/:id/telemetry/agent",
   ],
-  "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
   // #28459: the chat threads themselves, the chat event reader, per-thread
   // browser sessions, per-thread goals, and workflow automations.
   // The slice also covered shared threads, queue position and the X image
   // share; #28709 removed those rows on zero-traffic evidence, which is why the
   // `okou-app` share worker no longer appears among the holders below. #28711
   // removed the search reader, `chat-threads/:id/metadata` and
-  // `chat-threads/:id/rename` on drained-traffic evidence. Every
+  // `chat-threads/:id/rename` on drained-traffic evidence, and #28917 removed
+  // `chat-threads/:id/computer-use-host`, `chat-threads/:id/unpin` and both
+  // per-thread goal rows, which is why goals no longer appear below. Every
   // caller in this repository derives its URL from the contract, so nothing
   // here still asks for a branded form. Released builds do: a browser tab
   // holding already-loaded platform code keeps calling the `okou` path it was
@@ -408,10 +361,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:id",
     "/api/zero/chat-threads/:id",
   ],
-  "/api/chat-threads/:id/computer-use-host": [
-    "/api/okou/chat-threads/:id/computer-use-host",
-    "/api/zero/chat-threads/:id/computer-use-host",
-  ],
   "/api/chat-threads/:id/draft": [
     "/api/okou/chat-threads/:id/draft",
     "/api/zero/chat-threads/:id/draft",
@@ -427,10 +376,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/chat-threads/:id/pin": [
     "/api/okou/chat-threads/:id/pin",
     "/api/zero/chat-threads/:id/pin",
-  ],
-  "/api/chat-threads/:id/unpin": [
-    "/api/okou/chat-threads/:id/unpin",
-    "/api/zero/chat-threads/:id/unpin",
   ],
   "/api/chat-threads/:threadId/artifacts": [
     "/api/okou/chat-threads/:threadId/artifacts",
@@ -460,14 +405,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/chat-threads/:threadId/event-snapshot",
     "/api/zero/chat-threads/:threadId/event-snapshot",
   ],
-  "/api/chat-threads/:threadId/goal": [
-    "/api/okou/chat-threads/:threadId/goal",
-    "/api/zero/chat-threads/:threadId/goal",
-  ],
-  "/api/chat-threads/:threadId/goal/pause": [
-    "/api/okou/chat-threads/:threadId/goal/pause",
-    "/api/zero/chat-threads/:threadId/goal/pause",
-  ],
   "/api/chat-threads/:threadId/workflow-automations": [
     "/api/okou/chat-threads/:threadId/workflow-automations",
     "/api/zero/chat-threads/:threadId/workflow-automations",
@@ -490,46 +427,28 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // 7, and a CLI package pinned by an execution context's `CLI_PKG_URL` embeds
   // the contract path it was built from for that context's queue and claimed-run
   // lifetime. The `zero` form was reachable through the blanket expansion until
-  // the contract moved, and `/api/zero/billing/concurrency-checkout/preview`
-  // carried measured traffic of its own, so it is owed by evidence rather than
-  // by symmetry — #28701 dropped its `LEGACY_ZERO_PATHS` row because these rows
-  // are what serve it, not because the evidence expired. Both forms are
-  // removable only under #26701's evidence rules, like every other row here.
+  // the contract moved. Both forms are removable only under #26701's evidence
+  // rules, like every other row here.
+  //
+  // #28917 removed nine of these rows — both concurrency-checkout rows, the
+  // concurrency subscription change preview, the credit-checkout confirm, the
+  // Stripe portal, code redemption, purchase restore, the usage-pack checkout,
+  // and both usage-pack subscription-change rows. Several of them fire only on
+  // a user action that need not occur inside a four-day window, so the reading
+  // rests on the corroborating sweep as much as on the silence: no shipped CLI,
+  // desktop, or platform build emits a branded literal for any of them, and
+  // every caller derives its URL from a contract that has declared the neutral
+  // path since #28457. `/api/zero/billing/concurrency-checkout/preview` was
+  // among the nine: it carried measured traffic when #28701 dropped its
+  // `LEGACY_ZERO_PATHS` row and these rows are what served it afterwards, but
+  // the retained window recorded no request on either branded form.
   "/api/billing/checkout": [
     "/api/okou/billing/checkout",
     "/api/zero/billing/checkout",
   ],
-  "/api/billing/concurrency-checkout": [
-    "/api/okou/billing/concurrency-checkout",
-    "/api/zero/billing/concurrency-checkout",
-  ],
-  "/api/billing/concurrency-checkout/preview": [
-    "/api/okou/billing/concurrency-checkout/preview",
-    "/api/zero/billing/concurrency-checkout/preview",
-  ],
-  "/api/billing/concurrency-subscriptions/:subscriptionId/changes/preview": [
-    "/api/okou/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-    "/api/zero/billing/concurrency-subscriptions/:subscriptionId/changes/preview",
-  ],
-  "/api/billing/credit-checkout/confirm": [
-    "/api/okou/billing/credit-checkout/confirm",
-    "/api/zero/billing/credit-checkout/confirm",
-  ],
   "/api/billing/invoices": [
     "/api/okou/billing/invoices",
     "/api/zero/billing/invoices",
-  ],
-  "/api/billing/portal": [
-    "/api/okou/billing/portal",
-    "/api/zero/billing/portal",
-  ],
-  "/api/billing/redeem-code": [
-    "/api/okou/billing/redeem-code",
-    "/api/zero/billing/redeem-code",
-  ],
-  "/api/billing/restore": [
-    "/api/okou/billing/restore",
-    "/api/zero/billing/restore",
   ],
   "/api/billing/status": [
     "/api/okou/billing/status",
@@ -538,10 +457,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/usage-pack-catalog": [
     "/api/okou/billing/usage-pack-catalog",
     "/api/zero/billing/usage-pack-catalog",
-  ],
-  "/api/billing/usage-pack-checkout": [
-    "/api/okou/billing/usage-pack-checkout",
-    "/api/zero/billing/usage-pack-checkout",
   ],
   "/api/billing/usage-pack-credits": [
     "/api/okou/billing/usage-pack-credits",
@@ -554,14 +469,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/billing/usage-pack-subscription": [
     "/api/okou/billing/usage-pack-subscription",
     "/api/zero/billing/usage-pack-subscription",
-  ],
-  "/api/billing/usage-pack-subscription/subscription-change/confirm": [
-    "/api/okou/billing/usage-pack-subscription/subscription-change/confirm",
-    "/api/zero/billing/usage-pack-subscription/subscription-change/confirm",
-  ],
-  "/api/billing/usage-pack-subscription/subscription-change/preview": [
-    "/api/okou/billing/usage-pack-subscription/subscription-change/preview",
-    "/api/zero/billing/usage-pack-subscription/subscription-change/preview",
   ],
   // #28466: the desktop Computer Use family. The highest-traffic branded family
   // in the repository — about 716,000 requests over the retained request-log
@@ -579,6 +486,18 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // agent side of the family, called by the CLI rather than by an installed
   // Desktop build, and the log measured no Desktop caller on their branded
   // forms at all. The host endpoints the Desktop build hardcodes are untouched.
+  //
+  // #28917 measured `hosts/start` and `host/stop` silent on both branded forms
+  // and kept them anyway, because for this family silence is not drain
+  // evidence. Both are hardcoded — see `computer-use-host.ts` at 5edd3c9c^ —
+  // in every Desktop build up to 0.38.53, and those builds were still sending
+  // `/api/okou/computer-use/heartbeat` and `/api/okou/computer-use/host/
+  // commands/next` inside the same window. Start and stop fire once per
+  // session, so the branded count they should produce over four days is under
+  // one request: the neutral paths took ~70 each against ~130,000 neutral
+  // `host/commands/next`. Zero is what a fully live caller looks like at that
+  // rate. Removing them would also strand a build that can still poll and
+  // heartbeat but can no longer open or close a session.
   //
   // Four of these paths — `host/commands/next`, `audit-events`, `heartbeat`,
   // and `hosts/start` — were served by `LEGACY_ZERO_PATHS` before this move and
@@ -620,9 +539,10 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // #28423: the integration control plane and the CLI messaging and file
   // surfaces. The slice covered Feishu, Slack, Microsoft Teams, Telegram,
   // GitHub, AgentPhone and Strapi; #28709 removed the Telegram, GitHub,
-  // AgentPhone and Feishu messaging and file rows on zero-traffic evidence, so
-  // what remains is the Slack messaging and file surface plus the Feishu,
-  // Slack, Teams and Strapi control-plane reads. That removal also retired
+  // AgentPhone and Feishu messaging and file rows on zero-traffic evidence, and
+  // #28917 removed the Feishu and Strapi control-plane reads on the same
+  // evidence, so what remains is the Slack messaging and file surface plus the
+  // Slack and Teams control-plane reads. That removal also retired
   // `downloadFeishuFile` and `downloadPhoneFile`, the two CLI callers that
   // built a branded URL by hand rather than from the contract. Every remaining
   // caller derives its URL from the contract, which a published CLI package
@@ -639,10 +559,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   //
   // A key holds its path parameter verbatim, because the lookup below matches
   // `entry.route.path` exactly rather than an expanded request path.
-  "/api/integrations/feishu": [
-    "/api/okou/integrations/feishu",
-    "/api/zero/integrations/feishu",
-  ],
   "/api/integrations/slack": [
     "/api/okou/integrations/slack",
     "/api/zero/integrations/slack",
@@ -667,10 +583,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/integrations/slack/upload-file/materialize",
     "/api/zero/integrations/slack/upload-file/materialize",
   ],
-  "/api/integrations/strapi": [
-    "/api/okou/integrations/strapi",
-    "/api/zero/integrations/strapi",
-  ],
   "/api/integrations/teams/connect": [
     "/api/okou/integrations/teams/connect",
     "/api/zero/integrations/teams/connect",
@@ -680,7 +592,10 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // connections, and the user permission grants. #28711 removed the slice's
   // `connector-catalog/:connectorSlug/permissions`, `connectors`,
   // `connectors/:connectorSlug` and `connectors/diagnostics/check` rows once
-  // the log showed their callers drained. Two surfaces hold the branded paths
+  // the log showed their callers drained, and #28917 removed
+  // `connector-catalog/diagnostics`, `connectors/:connectorSlug/manual-grant`,
+  // `model-provider-connections` and `user-permission-grants/apply` on
+  // zero-traffic evidence. Two surfaces hold the branded paths
   // that remain. A released web or app build keeps calling the form it was
   // compiled against until it reloads, the ~2 day old-web-client window in
   // `docs/fallback.md` section 7; and a commit-addressed CLI package pinned by
@@ -692,10 +607,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/connector-catalog/:connectorSlug",
     "/api/zero/connector-catalog/:connectorSlug",
   ],
-  "/api/connector-catalog/diagnostics": [
-    "/api/okou/connector-catalog/diagnostics",
-    "/api/zero/connector-catalog/diagnostics",
-  ],
   "/api/connector-catalog/discovery": [
     "/api/okou/connector-catalog/discovery",
     "/api/zero/connector-catalog/discovery",
@@ -703,10 +614,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/connector-catalog/status": [
     "/api/okou/connector-catalog/status",
     "/api/zero/connector-catalog/status",
-  ],
-  "/api/connectors/:connectorSlug/manual-grant": [
-    "/api/okou/connectors/:connectorSlug/manual-grant",
-    "/api/zero/connectors/:connectorSlug/manual-grant",
   ],
   "/api/connectors/:connectorSlug/oauth/start": [
     "/api/okou/connectors/:connectorSlug/oauth/start",
@@ -716,17 +623,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/custom-connectors",
     "/api/zero/custom-connectors",
   ],
-  "/api/model-provider-connections": [
-    "/api/okou/model-provider-connections",
-    "/api/zero/model-provider-connections",
-  ],
   "/api/user-permission-grants": [
     "/api/okou/user-permission-grants",
     "/api/zero/user-permission-grants",
-  ],
-  "/api/user-permission-grants/apply": [
-    "/api/okou/user-permission-grants/apply",
-    "/api/zero/user-permission-grants/apply",
   ],
   // #28464: the Slack, Teams, and Feishu connect and OAuth-start routes, of
   // which #28709 kept only the Slack rows — the Teams and Feishu connect and
@@ -796,6 +695,12 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   //   `CLI_PKG_URL`, draining over that context's queue lifetime plus claimed
   //   execution bounded by the runner's 2h `JOB_TIMEOUT`.
   //
+  // #28917 removed the three `model-providers/codex/device-auth/sessions`
+  // rows, the three `org/invite` rows, and `usage/members`. None of them has a
+  // desktop caller — the installed build hardcodes only `/api/okou/org` and
+  // `/api/okou/feature-switches`, both kept — and every one was silent on both
+  // branded forms across the retained window.
+  //
   // The CI bootstrap steps in `.github/workflows/turbo.yml` also call the
   // branded forms on purpose: they exercise the compatibility these rows
   // guarantee. None of those windows is the removal condition — a row retires
@@ -815,38 +720,19 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/model-providers",
     "/api/zero/model-providers",
   ],
-  "/api/model-providers/codex/device-auth/sessions": [
-    "/api/okou/model-providers/codex/device-auth/sessions",
-    "/api/zero/model-providers/codex/device-auth/sessions",
-  ],
-  "/api/model-providers/codex/device-auth/sessions/cancel": [
-    "/api/okou/model-providers/codex/device-auth/sessions/cancel",
-    "/api/zero/model-providers/codex/device-auth/sessions/cancel",
-  ],
-  "/api/model-providers/codex/device-auth/sessions/complete": [
-    "/api/okou/model-providers/codex/device-auth/sessions/complete",
-    "/api/zero/model-providers/codex/device-auth/sessions/complete",
-  ],
   "/api/org": ["/api/okou/org", "/api/zero/org"],
-  "/api/org/invite": ["/api/okou/org/invite", "/api/zero/org/invite"],
-  "/api/org/invite/purchase/:purchaseId/confirm": [
-    "/api/okou/org/invite/purchase/:purchaseId/confirm",
-    "/api/zero/org/invite/purchase/:purchaseId/confirm",
-  ],
-  "/api/org/invite/purchase/preview": [
-    "/api/okou/org/invite/purchase/preview",
-    "/api/zero/org/invite/purchase/preview",
-  ],
   "/api/org/logo": ["/api/okou/org/logo", "/api/zero/org/logo"],
   "/api/org/members": ["/api/okou/org/members", "/api/zero/org/members"],
-  "/api/usage/members": ["/api/okou/usage/members", "/api/zero/usage/members"],
   "/api/usage/record": ["/api/okou/usage/record", "/api/zero/usage/record"],
   // #28461: the agent reads and writes and the workflow and
   // workflow-automation management routes. The slice also covered the manual
   // Morning Brief trigger; #28709 removed that row on zero-traffic evidence,
   // and #28711 removed `agents/:id/instructions`, `workflow-automations`,
   // `workflows/:workflowId`, `workflows/:workflowId/automations` and
-  // `workflows/:workflowId/run` on drained-traffic evidence. Every caller in
+  // `workflows/:workflowId/run` on drained-traffic evidence; #28917 removed
+  // `workflow-automations/:id/enable` and `workflow-automations/:id/disable`,
+  // which were silent on both branded forms while the neutral paths served
+  // them. Every caller in
   // this repository derives its URL from the contract, so nothing here still
   // asks for a branded form; released builds do. Two surfaces hold these paths,
   // and each has its own window.
@@ -886,26 +772,25 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflow-automations/:id",
     "/api/zero/workflow-automations/:id",
   ],
-  "/api/workflow-automations/:id/disable": [
-    "/api/okou/workflow-automations/:id/disable",
-    "/api/zero/workflow-automations/:id/disable",
-  ],
-  "/api/workflow-automations/:id/enable": [
-    "/api/okou/workflow-automations/:id/enable",
-    "/api/zero/workflow-automations/:id/enable",
-  ],
   "/api/workflows": ["/api/okou/workflows", "/api/zero/workflows"],
-  // #28545: the two Microsoft console routes, the first rows whose branded
-  // forms a provider console holds rather than a released client. The Azure Bot
+  // #28545: the Microsoft console routes, the first rows whose branded forms a
+  // provider console holds rather than a released client. The Azure Bot
   // messaging endpoint and the Microsoft identity platform redirect URIs now
   // hold the final paths, so the contracts declare them and both branded forms
   // are owed from here.
   //
-  // What holds the branded forms open is not a released client but the two
+  // What holds the branded forms open is not a released client but the
   // Microsoft consoles themselves, which have no drain window: they keep
   // sending to whatever URL is registered until an operator changes it.
   // Removal follows #26701's evidence rules, and for the `zero` callback the
   // ordering constraint recorded there.
+  //
+  // #28917 removed the slice's `webhooks/teams/bot` row. #28545 records that an
+  // operator had already repointed the Azure Bot messaging endpoint at the
+  // neutral path before that slice landed, so nothing on the Microsoft side
+  // still holds either branded bot URL, and the retained window measured both
+  // silent. The OAuth callback row below stays for the reason its own comment
+  // gives, which is not a drain window and is not measurable in the log at all.
   "/api/integrations/teams/oauth/callback": [
     "/api/okou/teams/oauth/callback",
     // Not drain-window compatibility. `callbackRedirectUri` in
@@ -915,9 +800,13 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     // `api.vm0.ai` brand host. So this row is an active producer target, not a
     // leftover — do not prune it merely for being an `/api/zero/` path, or
     // live VM0-brand connects lose the callback they were sent to.
+    //
+    // A traffic sweep cannot retire this row: a quiet window means nobody
+    // connected Teams under the VM0 brand that week, and the next person who
+    // does is sent here regardless. #28917 listed this row for removal on that
+    // silence and it was held back for exactly this reason.
     "/api/zero/teams/oauth/callback",
   ],
-  "/api/webhooks/teams/bot": ["/api/okou/teams/bot", "/api/zero/teams/bot"],
   // #28463: avatar video generation, the per-token browser authorization
   // requests, mail drafts, the per-template presentation read, uploads,
   // voice-io quota and speech, and the web file-url read. The slice also
@@ -934,6 +823,12 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // the CLI pinning window; the log measured both branded forms silent for
   // longer than that before the removal.
   //
+  // #28917 removed five more on zero-traffic evidence: both per-token browser
+  // authorization-request rows, `mail/drafts/:mailDraftId/send`, the
+  // per-template presentation read, and `uploads/multipart/abort`. What the
+  // slice still owns below is the mail draft read, the multipart completion,
+  // `uploads/prepare`, the two voice-io rows, and `web/file-url`.
+  //
   // Published CLI builds hold the `okou` form directly: `domains/web.ts` builds
   // its URLs by hand rather than from the contract, so the path it carries
   // shipped independently of this table, and a run execution context pins its
@@ -944,29 +839,9 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   // expansion until these contracts moved, which has no window at all. Removal
   // therefore follows the #26701 evidence gate above rather than any of those
   // clocks.
-  "/api/browser/authorization-requests/:requestToken": [
-    "/api/okou/browser/authorization-requests/:requestToken",
-    "/api/zero/browser/authorization-requests/:requestToken",
-  ],
-  "/api/browser/authorization-requests/:requestToken/apply": [
-    "/api/okou/browser/authorization-requests/:requestToken/apply",
-    "/api/zero/browser/authorization-requests/:requestToken/apply",
-  ],
   "/api/mail/drafts/:mailDraftId": [
     "/api/okou/mail/drafts/:mailDraftId",
     "/api/zero/mail/drafts/:mailDraftId",
-  ],
-  "/api/mail/drafts/:mailDraftId/send": [
-    "/api/okou/mail/drafts/:mailDraftId/send",
-    "/api/zero/mail/drafts/:mailDraftId/send",
-  ],
-  "/api/presentation-templates/:templateId": [
-    "/api/okou/presentation-templates/:templateId",
-    "/api/zero/presentation-templates/:templateId",
-  ],
-  "/api/uploads/multipart/abort": [
-    "/api/okou/uploads/multipart/abort",
-    "/api/zero/uploads/multipart/abort",
   ],
   "/api/uploads/multipart/complete": [
     "/api/okou/uploads/multipart/complete",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -537,15 +537,19 @@ const malformedChatThreadIdRequests = [
     path: "/api/zero/chat-threads/:id/model-selection",
     paramName: "id",
   },
+  // Neutral rather than branded: #28917 retired this row's branded forms, so a
+  // branded request here would 404 before the parameter check it exists to
+  // exercise.
   {
     method: "POST",
-    path: "/api/zero/chat-threads/:id/computer-use-host",
+    path: "/api/chat-threads/:id/computer-use-host",
     paramName: "id",
   },
   { method: "POST", path: "/api/zero/chat-threads/:id/pin", paramName: "id" },
+  // Neutral for the same reason as `computer-use-host` above.
   {
     method: "POST",
-    path: "/api/zero/chat-threads/:id/unpin",
+    path: "/api/chat-threads/:id/unpin",
     paramName: "id",
   },
   // Neutral rather than branded: #28711 retired this row's branded forms, so a

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-maps-billing.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-maps-billing.ts
@@ -4,10 +4,7 @@ import {
 } from "@okouai/api-contracts/contracts/billing";
 import { mapsContract } from "@okouai/api-contracts/contracts/maps";
 
-import {
-  setupAppWithRoutes,
-  setupRawAppRequestWithRoutes,
-} from "../../../../__tests__/test-app";
+import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { mockEnv } from "../../../../lib/env";
 import type { RouteEntry } from "../../../route-entry";
@@ -86,32 +83,6 @@ export function createMapsBillingApi(context: TestContext) {
   return {
     configureMapsProvider(): void {
       mockEnv("OKOU_MAPS_GOOGLE_MAPS_TOKEN", "test-google-maps-key");
-    },
-
-    /**
-     * Geocodes through a path the typed client cannot express. `mapsContract`
-     * declares only the neutral path, so the branded paths that
-     * `MIGRATED_BRANDED_PATHS` keeps alive for released CLI builds are
-     * unreachable through `mapsContract` by construction.
-     */
-    async requestMapsGeocodeAtPath(
-      actor: ApiTestUser,
-      path: string,
-      body: { readonly address: string },
-    ): Promise<{ readonly status: number; readonly body: unknown }> {
-      authenticate(context, actor);
-      const request = setupRawAppRequestWithRoutes({
-        context,
-        routes: mapsBillingRoutes,
-      });
-      return await request(path, {
-        method: "POST",
-        headers: {
-          authorization: CLERK_SESSION_AUTHORIZATION,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
     },
 
     async readBillingStatus(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
@@ -242,7 +242,7 @@ export async function postTeamsActivityForTest(args: {
   });
   const apiOrigin =
     args.publicBrand === "okou" ? "https://api.okou.ai" : "http://api.test";
-  return await app.request(`${apiOrigin}/api/zero/teams/bot`, {
+  return await app.request(`${apiOrigin}/api/webhooks/teams/bot`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${teamsToken()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -561,49 +561,6 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(tooLong.body.error.message).toContain("96");
   });
 
-  // #28417 moved the maps contract to `/api/maps/**`, so the blanket expansion
-  // no longer derives either branded form and both exist only because
-  // `MIGRATED_BRANDED_PATHS` names them. Asserted through the endpoint rather
-  // than the route table: a registration entry cannot show that a request from
-  // a released CLI build actually reaches the maps handler and is charged.
-  it("serves geocode on the neutral path and both branded paths released CLI builds hold [MAPS-COMPAT]", async () => {
-    const bdd = createBddApi(context);
-    const billing = createMapsBillingApi(context);
-    const runs = createRunsApi(context);
-    const admin = bdd.user();
-    await runs.grantProEntitlement(admin);
-    billing.configureMapsProvider();
-
-    const geocodeRequests: URL[] = [];
-    server.use(geocodeOkHandler(geocodeRequests));
-
-    // Written out rather than derived from the contract or the table, so a
-    // deleted row fails this test instead of changing what it asserts.
-    const paths = [
-      "/api/maps/geocode",
-      "/api/okou/maps/geocode",
-      "/api/zero/maps/geocode",
-    ];
-
-    for (const path of paths) {
-      const response = await billing.requestMapsGeocodeAtPath(admin, path, {
-        address: "1 Infinite Loop, Cupertino",
-      });
-
-      expect(response.status, `Expected ${path} to be served`).toBe(200);
-      expect(response.body).toMatchObject({
-        operation: "geocode",
-        provider: "google-maps",
-        billingCategory: "geocoding",
-        billingQuantity: 1,
-      });
-    }
-
-    // Every path reached the provider, so none of them was answered by an
-    // unrelated route that happens to share the prefix.
-    expect(geocodeRequests).toHaveLength(paths.length);
-  });
-
   it("charges marked-up Google Maps prices across geocode, directions, places, and details [MAPS-A]", async () => {
     const bdd = createBddApi(context);
     const billing = createMapsBillingApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -58,13 +58,11 @@ const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
     await removeTeamsForTest(context.signal, fixture);
   },
 );
-const TEAMS_BOT_PATH = "http://api.test/api/zero/teams/bot";
-// The branded paths plus the final Microsoft console path from #28278.
-const TEAMS_BOT_URLS = [
-  "http://api.test/api/okou/teams/bot",
-  TEAMS_BOT_PATH,
-  "http://api.test/api/webhooks/teams/bot",
-] as const;
+// The final Microsoft console path from #28278. #28917 retired this route's
+// `MIGRATED_BRANDED_PATHS` row — the Azure Bot messaging endpoint was already
+// repointed here before #28545 landed — so the branded forms this file used to
+// replay are no longer registered.
+const TEAMS_BOT_PATH = "http://api.test/api/webhooks/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
@@ -712,11 +710,6 @@ function teamsBotInstallationAddedActivity(
   };
 }
 
-interface TeamsBotRawResponse {
-  readonly status: number;
-  readonly body: string;
-}
-
 async function postTeamsActivity(
   args: {
     readonly activity: Record<string, unknown>;
@@ -919,7 +912,7 @@ async function setupConnectedTeamsBotActor(): Promise<{
   return { fixture, actor, runnerGroup, outboundRequests };
 }
 
-describe("POST /api/zero/teams/bot", () => {
+describe("POST /api/webhooks/teams/bot", () => {
   beforeEach(() => {
     setupTeamsConnectTestEnv(APP_ORIGIN);
     mockEnv("MICROSOFT_TEAMS_BOT_APP_PASSWORD", BOT_APP_PASSWORD);
@@ -950,40 +943,13 @@ describe("POST /api/zero/teams/bot", () => {
     botFrameworkHandlers();
     const fixture = botFixture();
     const activity = teamsMessageActivity(fixture, { type: "typing" });
-    const token = teamsToken();
 
-    const results: TeamsBotRawResponse[] = [];
-    for (const url of TEAMS_BOT_URLS) {
-      const response = await postTeamsActivity({ activity, token, url });
-      results.push({
-        status: response.status,
-        body: await response.text(),
-      });
-    }
+    const response = await postTeamsActivity({
+      activity,
+      token: teamsToken(),
+    });
 
-    const [okou, zero, final] = results;
-    expect(okou?.status).toBe(200);
-    expect(zero).toStrictEqual(okou);
-    expect(final).toStrictEqual(okou);
-  });
-
-  it("rejects an unauthorized activity on every namespace", async () => {
-    const fixture = botFixture();
-    const activity = teamsMessageActivity(fixture);
-
-    const results: TeamsBotRawResponse[] = [];
-    for (const url of TEAMS_BOT_URLS) {
-      const response = await postTeamsActivity({ activity, url });
-      results.push({
-        status: response.status,
-        body: await response.text(),
-      });
-    }
-
-    const [okou, zero, final] = results;
-    expect(okou?.status).toBe(401);
-    expect(zero).toStrictEqual(okou);
-    expect(final).toStrictEqual(okou);
+    expect(response.status).toBe(200);
   });
 
   it("rejects a Teams activity without a stable identifier", async () => {


### PR DESCRIPTION
Part of #26701, closes #28917. Continues the drain of `MIGRATED_BRANDED_PATHS` after #28709 (314 → 184) and #28716/#28711 (184 → 142).

**The table goes from 142 rows to 89** — 53 rows removed, not the 56 the issue listed. The three differences are explained below and each is a case where a zero request count is not drain evidence.

## Re-derivation method

The issue's list was re-derived from scratch rather than copied, following its own `Method` rules.

**Window.** `vm0-request-log-prod` retained 2026-08-20T06:34:30Z through 2026-08-24T08:27:51Z — 4.08 days, 3,146,718 requests, of which 39,195 were branded across **685 distinct branded `path_template` values**, matching the issue's count.

**No truncation.** All 685 templates were pulled in one `summarize by path_template, x_client_type` (736 groups, `sum(count) == 39,196` against the 39,195 total, the difference being one late-arriving row) and matched locally. Nothing was ranked or limited.

**Pattern matching, not literals.** Each row's two branded forms had `:param` rewritten to `[^/]+`, anchored, and matched against every observed template — so `/api/okou/chat-threads/<uuid>/goal` is attributed to `/api/chat-threads/:threadId/goal`.

**One template counts toward every row it matches.** No batched `case()`. `/api/connector-catalog/status` keeps its 7 requests rather than being absorbed by `/api/connector-catalog/:connectorSlug`; both are retained.

**Independent cross-check.** After the local match, a second query issued one `countif(path_template matches regex ...)` per candidate row server-side. All 56 candidates returned 0, confirming the local matcher.

The result reproduced the issue's 56-row list **exactly** — zero set difference in either direction. The classification also reconciles with the issue's holdback tally: of 142 rows, 68 were silent for the whole window, 42 took traffic on or after 2026-08-23 (38 once the 4 Slack rows are set aside), and 32 took traffic only before it (4 of those with a Desktop or CLI caller). 13 Slack rows and the 3 documented holdbacks account for the rest.

## Corroboration beyond silence

Several rows fire only on a user action that need not occur in four days, so silence alone was not treated as sufficient.

- **35 of the 53 removed rows carried live traffic on their neutral path** inside the same window while both branded forms stayed at zero — a caller that migrated, not a caller that vanished. Examples: `presentation-templates/:templateId` 2,534, `onboarding/complete` 213, `computer-use/host/stop` 70, `model-provider-connections` 34.
- **No shipped client emits a branded literal for any removed row.** A sweep of `apps/{cli,desktop,platform,host-worker}` plus `crates/`, `e2e/` and `.github/`, including percent-encoded (`%2Fokou`) and backslash-escaped (`api\/okou`) forms, finds only the 7 occurrences the issue lists — 4 never-migrated CLI `download-file` routes, a README line, an eslint comment and a changelog entry.
- **The desktop app's entire hardcoded API surface** is `auth/me`, `computer-use/{heartbeat,host/commands/*,host/stop,hosts/start}`, `desktop/{updates,migration-policy}`, `feature-switches` and `org`. Every one of those rows is kept.

## Where this disagrees with the issue: 3 rows held back

### `/api/integrations/teams/oauth/callback`

`callbackRedirectUri()` in `turbo/apps/api/src/signals/routes/teams-oauth.ts:178` still **emits** `/api/zero/teams/oauth/callback` as the `redirect_uri` for the VM0 brand. The row's own in-file comment says so and warns against pruning it. Removing the row would 404 the callback Microsoft was told to redirect to, breaking every live VM0-brand Teams connect — permanently, with no drain window. #26701 records that this path retires together with the `api.vm0.ai` brand host, not on a traffic reading.

The issue's corroborating sweep covered `apps/{cli,desktop,platform,host-worker}`; this producer lives in `apps/api`, which the sweep did not include.

### `/api/computer-use/hosts/start` and `/api/computer-use/host/stop`

Both are hardcoded in every Desktop build up to 0.38.53 (see `computer-use-host.ts` at `5edd3c9c^`, before #28487 moved them). Those builds were **still live inside this window**, sending 221 requests to `/api/okou/computer-use/heartbeat` and 114 to `/api/okou/computer-use/host/commands/next`, the last at 2026-08-21T01:14Z.

Start and stop fire once per session. At the measured rate — ~70 neutral `hosts/start` against ~130,000 neutral `host/commands/next` — the branded count those builds should have produced over four days is **under one request**. Zero is exactly what a fully live caller looks like at that rate, so this is absent statistical power rather than a drain. This is the issue's own exclusion #3 ("installed builds have no expiry window"), which it applied by measured traffic and therefore missed for the two rarest calls in the family.

Removing them would also strand a build that can still poll and heartbeat but can no longer open or close a session, while `heartbeat`, `host/commands/next` and `host/commands/:commandId/complete` stay.

`/api/webhooks/teams/bot` **was** removed: #28545 records that an operator repointed the Azure Bot messaging endpoint at the neutral path before that slice landed, so nothing Microsoft-side holds either branded bot URL.

The general rule is written into the table's header comment: a zero count retires a row only when the row's caller both has a bounded window and would have been expected to appear in the window at all.

## Tests

`migrated-branded-paths.test.ts` restates the table literally. The 51 corresponding entries were deleted from `MIGRATED_ROUTE_PATHS` and the count literal updated 142 → 89.

The count assertion is now a plain size check. It used to be `size + MIGRATED_ROWS_WITH_OWN_CASE (2)` because the maps and weather cases owned `/api/maps/geocode` and `/api/weather/current` outside the inventory; both families drained out of the table entirely, so those cases and the offset are gone and the inventory is now the whole table. Deleting a still-needed row still fails this test rather than passing silently.

No case asserts that a removed branded form now 404s — `docs/fallback.md` §1 rules that class out, and #28715 was rolled back for it.

Tests that drove a removed route **through** a branded path are repointed to the neutral path rather than keeping the branded call:

- `chat-threads.bdd.test.ts` — the `computer-use-host` and `unpin` parameter cases, following the same treatment #28711 left on `rename` in that file.
- `teams-bot.test.ts` and `helpers/teams-connect.ts` — `TEAMS_BOT_PATH` and the `describe` move to `/api/webhooks/teams/bot`. The two cases that replayed all three namespaces collapse to one; the 401 half duplicated the existing `rejects missing Teams authorization` case on the same path.
- `migrated-branded-paths.test.ts` — the Feishu and Strapi families drop out of the integration app-factory case, and the Teams console case now drives only the OAuth callback.
- `host-maps.bdd.test.ts` — the `MAPS-COMPAT` case existed only to prove branded compatibility for geocode. Its handler-and-billing coverage on the neutral path is already asserted by `MAPS-A` (`charges marked-up Google Maps prices across geocode, directions, places, and details`), so the case and the `requestMapsGeocodeAtPath` helper it was the only caller of are removed.

Three slice comments in `route-entry.ts` (#28417 maps, #28357 weather, #28418 browser/finance/SEO) lost all their rows and are deleted; the remaining slice comments record what this round removed.

## Fallbacks

This PR removes fallbacks rather than adding any. Every removed row was a `MIGRATED_BRANDED_PATHS` entry under the #26701 removal gate, and the evidence that gate requires is above. The three rows held back keep their fallbacks, and each now carries an in-code note explaining why a traffic sweep cannot retire it — so the next drain does not have to rediscover it.

## Verification

- `pnpm -F api check-types` — clean
- `pnpm -F api lint` — clean
- `pnpm knip --workspace apps/api` — clean
- `pnpm prettier --check` on all changed files — clean
- `migrated-branded-paths`, `api-namespace-compatibility`, `provider-console-paths`, `teams-oauth`, `desktop-updates`, `agents-list` — 79 passed

The `chat-threads.bdd`, `artifact-catalog.bdd`, `host-maps.bdd` and `teams-bot` suites have failures in this sandbox, all rooted in `claimRunnerJob`. A/B against `main` with the branch stashed produces the identical failures (30 and 6 respectively, same tests), so they are environmental and not caused by this change. CI is the authority.
