### PR TITLE
test(guest-agent): rename private subprocess fixture environment keys

### DIFF
--- a/crates/guest-agent/tests/command_output_timeout.rs
+++ b/crates/guest-agent/tests/command_output_timeout.rs
@@ -15,8 +15,8 @@ const MANAGED_TIMEOUT: Duration = Duration::from_secs(20);
 const FIXTURE_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const FIXTURE_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const DESCENDANT_EXIT_TIMEOUT: Duration = Duration::from_secs(1);
-const DESCENDANT_READY_ENV: &str = "VM0_TEST_DESCENDANT_READY_FILE";
-const DESCENDANT_RELEASE_ENV: &str = "VM0_TEST_DESCENDANT_RELEASE_FILE";
+const DESCENDANT_READY_ENV: &str = "OKOU_TEST_DESCENDANT_READY_FILE";
+const DESCENDANT_RELEASE_ENV: &str = "OKOU_TEST_DESCENDANT_RELEASE_FILE";
 const DESCENDANT_FIXTURE: &str = "command_output_timeout_descendant_fixture";
 
 struct DescendantCleanup {
@@ -64,8 +64,8 @@ async fn command_output_timeout_reaps_child_before_returning()
     let mut command = Command::new("/bin/sh");
     command
         .arg("-c")
-        .arg("printf '%s\n' \"$$\" > \"$VM0_TEST_CHILD_PID_FILE\"; exec /bin/sleep 60")
-        .env("VM0_TEST_CHILD_PID_FILE", &pid_file);
+        .arg("printf '%s\n' \"$$\" > \"$OKOU_TEST_CHILD_PID_FILE\"; exec /bin/sleep 60")
+        .env("OKOU_TEST_CHILD_PID_FILE", &pid_file);
     let execution = tokio::spawn(async move {
         common::command_output_with_timeout(
             &mut command,

--- a/crates/guest-agent/tests/mock_build_lock.rs
+++ b/crates/guest-agent/tests/mock_build_lock.rs
@@ -10,10 +10,10 @@ use std::time::Duration;
 use tokio::process::{Child, Command};
 
 const TEST_NAME: &str = "mock_build_lock_recovers_after_holder_exit";
-const HOLDER_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_HOLDER";
-const LOCK_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_PATH";
-const STARTED_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_STARTED_PATH";
-const READY_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_READY_PATH";
+const HOLDER_ENV: &str = "OKOU_MOCK_BUILD_LOCK_TEST_HOLDER";
+const LOCK_PATH_ENV: &str = "OKOU_MOCK_BUILD_LOCK_TEST_PATH";
+const STARTED_PATH_ENV: &str = "OKOU_MOCK_BUILD_LOCK_TEST_STARTED_PATH";
+const READY_PATH_ENV: &str = "OKOU_MOCK_BUILD_LOCK_TEST_READY_PATH";
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct HolderProcess {

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -10,9 +10,9 @@ use std::time::Duration;
 use tokio::process::Command;
 
 const ISOLATED_CHILD_TEST: &str = "process_control_endpoint_is_not_inherited_by_cli_child_isolated";
-const ISOLATED_CHILD_GUARD: &str = "VM0_PROCESS_CONTROL_ENV_ISOLATED_CHILD";
+const ISOLATED_CHILD_GUARD: &str = "OKOU_PROCESS_CONTROL_ENV_ISOLATED_CHILD";
 const ISOLATED_CHILD_GUARD_VALUE: &str = "1";
-const ISOLATED_CHILD_MOCK_PATH: &str = "VM0_PROCESS_CONTROL_ENV_ISOLATED_MOCK_PATH";
+const ISOLATED_CHILD_MOCK_PATH: &str = "OKOU_PROCESS_CONTROL_ENV_ISOLATED_MOCK_PATH";
 const ISOLATED_CHILD_MARKER: &str = "vm0 process-control env isolated child active";
 const ISOLATED_CHILD_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 const PROCESS_CONTROL_CHILD_TIMEOUT: Duration = Duration::from_secs(30);

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -888,16 +888,16 @@ fn run_helper_with_bind_mount(
             "/vm0-exec/exec-current/workload",
         )
         .env("VM0_TEST_CODEX_HOME_DIR", home.path().join(".codex"))
-        .env("VM0_MOUNT_SOURCE", mount_source)
-        .env("VM0_MOUNT_TARGET", mount_target)
-        .env("VM0_HELPER", env!("CARGO_BIN_EXE_guest-agent"))
+        .env("OKOU_MOUNT_SOURCE", mount_source)
+        .env("OKOU_MOUNT_TARGET", mount_target)
+        .env("OKOU_HELPER", env!("CARGO_BIN_EXE_guest-agent"))
         .args([
             "--user",
             "--map-root-user",
             "--mount",
             "/bin/sh",
             "-c",
-            "/usr/bin/mount --bind \"$VM0_MOUNT_SOURCE\" \"$VM0_MOUNT_TARGET\" && exec \"$VM0_HELPER\" prepare-for-reuse",
+            "/usr/bin/mount --bind \"$OKOU_MOUNT_SOURCE\" \"$OKOU_MOUNT_TARGET\" && exec \"$OKOU_HELPER\" prepare-for-reuse",
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary

- Rename exactly the twelve private guest-agent subprocess fixture environment keys from VM0_* to OKOU_*.
- Update constant-backed child readers and direct shell literal producers atomically.
- Preserve production bootstrap, containment, timeout, mount, lock, signal, subprocess, and negative leakage behavior.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p guest-agent --all-targets --all-features --no-deps
- cargo doc -p guest-agent --all-features --no-deps
- cargo test -p guest-agent --test command_output_timeout
- cargo test -p guest-agent --test mock_build_lock
- cargo test -p guest-agent --test process_control_env
- cargo test -p guest-agent --test reuse_preparation_helper
- Repository-wide fixed-string search: zero occurrences for each of the twelve selected VM0_* names.

The dependency-inclusive local Clippy invocation on Rust 1.98 was blocked by new lint errors in unchanged vsock-proto/src/payloads/memory_snapshot.rs. The affected guest-agent target passed with --no-deps, and pinned CI will run the repository check.

Closes #28932
Refs #28914