### PR TITLE
test(guest-agent): assert claude watchdog tracker bounds

### DIFF
--- a/crates/guest-agent/src/cli/claude.rs
+++ b/crates/guest-agent/src/cli/claude.rs
@@ -181,6 +181,35 @@ pub(super) fn track_claude_tool_events(event: &serde_json::Value, tracker: &mut 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    fn track_tool_use(tracker: &mut StuckToolTracker, id: &str, name: &str) {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "id": id, "name": name}]
+            }
+        });
+
+        track_claude_tool_events(&event, tracker);
+    }
+
+    fn track_tool_result(tracker: &mut StuckToolTracker, id: &str) {
+        let event = serde_json::json!({
+            "type": "user",
+            "message": {
+                "content": [{"type": "tool_result", "tool_use_id": id}]
+            }
+        });
+
+        track_claude_tool_events(&event, tracker);
+    }
+
+    fn fill_stuck_tool_tracker(tracker: &mut StuckToolTracker) {
+        for index in 0..MAX_TRACKED_STUCK_TOOLS {
+            track_tool_use(tracker, &format!("tool-{index}"), "WebFetch");
+        }
+    }
 
     #[test]
     fn claude_result_summary_captures_terminal_result_metadata() {
@@ -246,24 +275,82 @@ mod tests {
 
     #[test]
     fn track_claude_tools_updates_in_flight_state() {
-        let tool_use = serde_json::json!({
-            "type": "assistant",
-            "message": {
-                "content": [{"type": "tool_use", "id": "tool-1", "name": "WebFetch"}]
-            }
-        });
-        let tool_result = serde_json::json!({
-            "type": "user",
-            "message": {
-                "content": [{"type": "tool_result", "tool_use_id": "tool-1"}]
-            }
-        });
         let mut tracker = StuckToolTracker::new();
 
-        track_claude_tool_events(&tool_use, &mut tracker);
+        track_tool_use(&mut tracker, "tool-1", "WebFetch");
         assert!(tracker.contains_key("tool-1"));
 
-        track_claude_tool_events(&tool_result, &mut tracker);
+        track_tool_result(&mut tracker, "tool-1");
         assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn stuck_tool_tracker_enforces_capacity_and_reuses_freed_slot() {
+        let mut tracker = StuckToolTracker::new();
+        fill_stuck_tool_tracker(&mut tracker);
+
+        assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
+        assert!(tracker.contains_key("tool-0"));
+        assert!(tracker.contains_key(&format!("tool-{}", MAX_TRACKED_STUCK_TOOLS - 1)));
+
+        track_tool_use(&mut tracker, "overflow", "WebSearch");
+
+        assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
+        assert!(!tracker.contains_key("overflow"));
+        assert!(tracker.contains_key("tool-0"));
+
+        track_tool_result(&mut tracker, "tool-0");
+
+        assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS - 1);
+        assert!(!tracker.contains_key("tool-0"));
+
+        track_tool_use(&mut tracker, "later", "WebSearch");
+
+        assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
+        assert!(tracker.contains_key("later"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stuck_tool_tracker_refreshes_duplicate_at_capacity() {
+        let mut tracker = StuckToolTracker::new();
+        fill_stuck_tool_tracker(&mut tracker);
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        track_tool_use(&mut tracker, "tool-0", "WebSearch");
+
+        assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
+        for index in 1..MAX_TRACKED_STUCK_TOOLS {
+            track_tool_result(&mut tracker, &format!("tool-{index}"));
+        }
+        assert_eq!(tracker.len(), 1);
+        assert_eq!(tracker.oldest_expired(1), None);
+        assert_eq!(
+            tracker.oldest_expired(0).map(|(name, _)| name),
+            Some(StuckToolName::WebSearch)
+        );
+    }
+
+    #[test]
+    fn stuck_tool_tracker_ignores_unsupported_tools() {
+        let mut tracker = StuckToolTracker::new();
+
+        track_tool_use(&mut tracker, "unsupported", "Bash");
+
+        assert_eq!(tracker.len(), 0);
+        assert!(!tracker.contains_key("unsupported"));
+    }
+
+    #[test]
+    fn stuck_tool_tracker_enforces_id_size_limit() {
+        let mut tracker = StuckToolTracker::new();
+        let maximum_id = "x".repeat(MAX_TRACKED_STUCK_TOOL_ID_BYTES);
+        let oversized_id = "y".repeat(MAX_TRACKED_STUCK_TOOL_ID_BYTES + 1);
+
+        track_tool_use(&mut tracker, &maximum_id, "WebFetch");
+        track_tool_use(&mut tracker, &oversized_id, "WebFetch");
+
+        assert_eq!(tracker.len(), 1);
+        assert!(tracker.contains_key(&maximum_id));
+        assert!(!tracker.contains_key(&oversized_id));
     }
 }

--- a/crates/guest-agent/src/cli/claude.rs
+++ b/crates/guest-agent/src/cli/claude.rs
@@ -290,14 +290,14 @@ mod tests {
         fill_stuck_tool_tracker(&mut tracker);
 
         assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
-        assert!(tracker.contains_key("tool-0"));
-        assert!(tracker.contains_key(&format!("tool-{}", MAX_TRACKED_STUCK_TOOLS - 1)));
 
         track_tool_use(&mut tracker, "overflow", "WebSearch");
 
         assert_eq!(tracker.len(), MAX_TRACKED_STUCK_TOOLS);
         assert!(!tracker.contains_key("overflow"));
-        assert!(tracker.contains_key("tool-0"));
+        for index in 0..MAX_TRACKED_STUCK_TOOLS {
+            assert!(tracker.contains_key(&format!("tool-{index}")));
+        }
 
         track_tool_result(&mut tracker, "tool-0");
 


### PR DESCRIPTION
## Summary

- add direct behavioral coverage for the Claude stuck-tool tracker's exact entry limit, overflow
  rejection without eviction, result-based slot reuse, and duplicate refresh at capacity
- verify the production tool-use ID byte limit at both sides of the boundary and reject unsupported
  tool names
- keep the existing CLI integration tests as non-fatal execution coverage while making the retained
  control-process state invariant independently regression-safe

## Scope

This is a test-only change in `guest-agent`. It does not change tracker behavior, public APIs,
event schemas, persisted data, runner protocols, dependencies, or CI configuration.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --lib cli::claude::tests`
- `cargo test -p guest-agent --test claude_tool_tracking_overflow --test claude_tool_tracking_id_limit --test claude_tool_tracking_non_watchdog`
- `cargo test -p guest-agent --all-targets --all-features`
- pre-commit `cargo-fmt`, workspace `cargo-doc`, workspace `cargo-clippy`, file-size check, and
  commitlint
- manual mutation checks confirmed that weakening the count limit, ID-size limit, supported-tool
  filter, or duplicate refresh makes its focused test fail

Closes #28936
