### PR TITLE
refactor(runner): rename private codex cleanup environment keys

### DIFF
--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -1,5 +1,5 @@
 root="$codex_home/sessions"
-restore_path="$VM0_CODEX_RESTORE_SESSION_PATH"
+restore_path="$OKOU_CODEX_RESTORE_SESSION_PATH"
 restore_dir="${restore_path%/*}"
 case "$restore_dir" in
   "$root"/*/*/*) ;;
@@ -41,7 +41,7 @@ while [ -n "$remaining" ]; do
   current="$current/$component"
   check_restore_dir_component "$current"
 done
-id="$VM0_CODEX_RESTORE_SESSION_ID"
+id="$OKOU_CODEX_RESTORE_SESSION_ID"
 case "$id" in
   ""|*[!0123456789abcdefABCDEF-]*)
     echo "invalid codex restore session id" >&2
@@ -52,7 +52,7 @@ if [ "${#id}" -ne 36 ]; then
   echo "invalid codex restore session id" >&2
   exit 1
 fi
-id_no_dashes="$VM0_CODEX_RESTORE_SESSION_FILENAME_KEY"
+id_no_dashes="$OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY"
 case "$id_no_dashes" in
   ""|*[!0123456789abcdefABCDEF]*)
     echo "invalid codex restore session id" >&2
@@ -63,7 +63,7 @@ if [ "${#id_no_dashes}" -ne 32 ]; then
   echo "invalid codex restore session id" >&2
   exit 1
 fi
-scan_budget="${VM0_CODEX_SESSION_CLEANUP_SCAN_BUDGET:-16384}"
+scan_budget="${OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET:-16384}"
 case "$scan_budget" in
   ""|*[!0123456789]*)
     echo "invalid codex session cleanup scan budget" >&2

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -91,12 +91,12 @@ async fn cleanup_existing_codex_session_files(
 ) -> RunnerResult<Option<String>> {
     let cleanup_cmd = codex_session_cleanup_command(CANONICAL_CODEX_HOME_DIR);
     let env = [
-        ("VM0_CODEX_RESTORE_SESSION_ID", session_id),
+        ("OKOU_CODEX_RESTORE_SESSION_ID", session_id),
         (
-            "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY",
+            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY",
             session_filename_key,
         ),
-        ("VM0_CODEX_RESTORE_SESSION_PATH", fallback_logical_path),
+        ("OKOU_CODEX_RESTORE_SESSION_PATH", fallback_logical_path),
     ];
     let result = sandbox
         .exec_with_diagnostic_label(
@@ -293,7 +293,7 @@ mod tests {
 
     fn run_cleanup_with_budget(codex_home: &Path, restore_path: &Path, budget: &str) -> Output {
         cleanup_command(codex_home, restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
-            .env("VM0_CODEX_SESSION_CLEANUP_SCAN_BUDGET", budget)
+            .env("OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET", budget)
             .output()
             .unwrap()
     }
@@ -310,13 +310,13 @@ mod tests {
             .arg(codex_session_cleanup_command(
                 codex_home.to_str().expect("test path should be utf-8"),
             ))
-            .env("VM0_CODEX_RESTORE_SESSION_ID", session_id)
+            .env("OKOU_CODEX_RESTORE_SESSION_ID", session_id)
             .env(
-                "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY",
+                "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY",
                 session_filename_key,
             )
             .env(
-                "VM0_CODEX_RESTORE_SESSION_PATH",
+                "OKOU_CODEX_RESTORE_SESSION_PATH",
                 restore_path.to_str().expect("test path should be utf-8"),
             );
         command

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -26,6 +26,36 @@ fn restore_session_writes_codex_session() {
 }
 
 #[test]
+fn restore_session_keeps_agent_environment_out_of_codex_cleanup() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = codex_context();
+    ctx.environment = Some(std::collections::HashMap::from([
+        (
+            "OKOU_CODEX_RESTORE_SESSION_ID".to_string(),
+            "user-session-id".to_string(),
+        ),
+        (
+            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY".to_string(),
+            "user-filename-key".to_string(),
+        ),
+        (
+            "OKOU_CODEX_RESTORE_SESSION_PATH".to_string(),
+            "/tmp/user-restore-path".to_string(),
+        ),
+        (
+            "OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET".to_string(),
+            "1".to_string(),
+        ),
+        ("USER_ENV_MARKER".to_string(), "user-value".to_string()),
+    ]));
+    let session = materialized_text_session(CODEX_SESSION_ID, "{}\n");
+
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
+}
+
+#[test]
 fn restore_session_writes_codex_session_at_existing_logical_path() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult::new(

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -147,9 +147,9 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert_eq!(
         exec_calls[0].env_keys,
         [
-            "VM0_CODEX_RESTORE_SESSION_ID".to_string(),
-            "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY".to_string(),
-            "VM0_CODEX_RESTORE_SESSION_PATH".to_string()
+            "OKOU_CODEX_RESTORE_SESSION_ID".to_string(),
+            "OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY".to_string(),
+            "OKOU_CODEX_RESTORE_SESSION_PATH".to_string()
         ]
     );
     assert_eq!(exec_calls[0].timeout, DEFAULT_EXEC_TIMEOUT);
@@ -194,7 +194,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(
         exec_calls[0]
             .cmd
-            .contains("VM0_CODEX_RESTORE_SESSION_FILENAME_KEY")
+            .contains("OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY")
     );
     assert!(!exec_calls[0].cmd.contains("tr -d"));
     assert!(!exec_calls[0].cmd.contains("-delete"));


### PR DESCRIPTION
## Summary

- atomically rename the four private Codex cleanup helper environment keys from `VM0_*` to `OKOU_*` in the Rust producer and embedded shell consumer
- update focused helper and diagnostic assertions without changing cleanup behavior, validation, paths, limits, persisted data, or build wiring
- add a regression proving agent-provided environment entries are not forwarded into the private cleanup helper request

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --bin runner --all-features --no-deps -- -A clippy::result_large_err`
- `cargo doc -p runner --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS="-Aunused-imports" cargo check -p runner --tests`
- `sh -n runner/scripts/codex-session-cleanup.sh`
- direct canonical-key smoke execution of `codex-session-cleanup.sh`
- focused repository search confirming all four legacy names are absent

The focused `cargo test -p runner session_restore` binary compiled but could not link in the local 4 GiB, no-swap container: the linker was killed with exit 137 both normally and with `CARGO_BUILD_JOBS=1`. The test targets compile successfully; the PR pipeline will execute them using the repository's pinned Rust toolchain and CI resources.

Closes #28922

Part of #28914
