### PR TITLE
refactor(runner): dual-read canonical host tuning environment aliases

### DIFF
--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -24,8 +24,9 @@ use super::support::{
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::{
-    RUNNER_CONCURRENCY_FACTOR_ENV, RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV, RUNNER_DISK_IOPS_ENV,
-    RUNNER_NET_RX_MIB_PER_SEC_ENV, RUNNER_NET_TX_MIB_PER_SEC_ENV,
+    LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV, LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+    LEGACY_RUNNER_DISK_IOPS_ENV, LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV,
+    LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV,
 };
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
@@ -633,11 +634,14 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
             r#"{"bad":true}"#.into(),
         ),
         ("VM0_FUTURE_RUNNER_KEY".into(), "future".into()),
-        (RUNNER_CONCURRENCY_FACTOR_ENV.into(), "99".into()),
-        (RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV.into(), "999".into()),
-        (RUNNER_DISK_IOPS_ENV.into(), "999".into()),
-        (RUNNER_NET_RX_MIB_PER_SEC_ENV.into(), "999".into()),
-        (RUNNER_NET_TX_MIB_PER_SEC_ENV.into(), "999".into()),
+        (LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV.into(), "99".into()),
+        (
+            LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV.into(),
+            "999".into(),
+        ),
+        (LEGACY_RUNNER_DISK_IOPS_ENV.into(), "999".into()),
+        (LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV.into(), "999".into()),
+        (LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV.into(), "999".into()),
         (
             guest_contracts::env::CLI_AGENT_TYPE_ENV.into(),
             "claude-code".into(),
@@ -709,11 +713,11 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         guest_contracts::env::FEATURE_FLAGS_ENV,
         "VM0_FUTURE_RUNNER_KEY",
-        RUNNER_CONCURRENCY_FACTOR_ENV,
-        RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
-        RUNNER_DISK_IOPS_ENV,
-        RUNNER_NET_RX_MIB_PER_SEC_ENV,
-        RUNNER_NET_TX_MIB_PER_SEC_ENV,
+        LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV,
+        LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+        LEGACY_RUNNER_DISK_IOPS_ENV,
+        LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV,
+        LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV,
         guest_contracts::env::CLI_AGENT_TYPE_ENV,
         guest_contracts::env::USE_MOCK_CLAUDE_ENV,
         guest_contracts::env::USE_MOCK_CODEX_ENV,

--- a/crates/runner/src/host_env.rs
+++ b/crates/runner/src/host_env.rs
@@ -15,6 +15,9 @@ pub(crate) const RUNNER_DISK_IOPS_ENV: &str = "OKOU_RUNNER_DISK_IOPS";
 pub(crate) const RUNNER_NET_RX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_RX_MIB_PER_SEC";
 pub(crate) const RUNNER_NET_TX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_TX_MIB_PER_SEC";
 
+// Deployed host.env files and retained runner rollback targets may still use VM0_*.
+// Remove these aliases only after every deployed host uses OKOU_* and every supported rollback
+// target reads those names; tracked by #28914.
 pub(crate) const LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV: &str = "VM0_RUNNER_CONCURRENCY_FACTOR";
 pub(crate) const LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV: &str =
     "VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC";

--- a/crates/runner/src/host_env.rs
+++ b/crates/runner/src/host_env.rs
@@ -8,19 +8,46 @@ use std::collections::BTreeMap;
 use crate::error::{RunnerError, RunnerResult};
 
 pub(crate) const RUNNER_HOST_ENV_FILE: &str = "/etc/vm0-runner/host.env";
-pub(crate) const RUNNER_CONCURRENCY_FACTOR_ENV: &str = "VM0_RUNNER_CONCURRENCY_FACTOR";
+pub(crate) const RUNNER_CONCURRENCY_FACTOR_ENV: &str = "OKOU_RUNNER_CONCURRENCY_FACTOR";
 pub(crate) const RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV: &str =
-    "VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC";
-pub(crate) const RUNNER_DISK_IOPS_ENV: &str = "VM0_RUNNER_DISK_IOPS";
-pub(crate) const RUNNER_NET_RX_MIB_PER_SEC_ENV: &str = "VM0_RUNNER_NET_RX_MIB_PER_SEC";
-pub(crate) const RUNNER_NET_TX_MIB_PER_SEC_ENV: &str = "VM0_RUNNER_NET_TX_MIB_PER_SEC";
+    "OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC";
+pub(crate) const RUNNER_DISK_IOPS_ENV: &str = "OKOU_RUNNER_DISK_IOPS";
+pub(crate) const RUNNER_NET_RX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_RX_MIB_PER_SEC";
+pub(crate) const RUNNER_NET_TX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_TX_MIB_PER_SEC";
 
-const ALLOWED_HOST_ENV_KEYS: [&str; 5] = [
-    RUNNER_CONCURRENCY_FACTOR_ENV,
-    RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
-    RUNNER_DISK_IOPS_ENV,
-    RUNNER_NET_RX_MIB_PER_SEC_ENV,
-    RUNNER_NET_TX_MIB_PER_SEC_ENV,
+pub(crate) const LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV: &str = "VM0_RUNNER_CONCURRENCY_FACTOR";
+pub(crate) const LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV: &str =
+    "VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC";
+pub(crate) const LEGACY_RUNNER_DISK_IOPS_ENV: &str = "VM0_RUNNER_DISK_IOPS";
+pub(crate) const LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV: &str = "VM0_RUNNER_NET_RX_MIB_PER_SEC";
+pub(crate) const LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV: &str = "VM0_RUNNER_NET_TX_MIB_PER_SEC";
+
+const HOST_ENV_KEY_ALIASES: [(&str, &str); 10] = [
+    (RUNNER_CONCURRENCY_FACTOR_ENV, RUNNER_CONCURRENCY_FACTOR_ENV),
+    (
+        LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV,
+        RUNNER_CONCURRENCY_FACTOR_ENV,
+    ),
+    (
+        RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+        RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+    ),
+    (
+        LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+        RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+    ),
+    (RUNNER_DISK_IOPS_ENV, RUNNER_DISK_IOPS_ENV),
+    (LEGACY_RUNNER_DISK_IOPS_ENV, RUNNER_DISK_IOPS_ENV),
+    (RUNNER_NET_RX_MIB_PER_SEC_ENV, RUNNER_NET_RX_MIB_PER_SEC_ENV),
+    (
+        LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV,
+        RUNNER_NET_RX_MIB_PER_SEC_ENV,
+    ),
+    (RUNNER_NET_TX_MIB_PER_SEC_ENV, RUNNER_NET_TX_MIB_PER_SEC_ENV),
+    (
+        LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV,
+        RUNNER_NET_TX_MIB_PER_SEC_ENV,
+    ),
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,6 +108,7 @@ fn read_host_env_file() -> RunnerResult<BTreeMap<&'static str, HostEnvValue>> {
 
 fn parse_host_env_file(content: &str) -> RunnerResult<BTreeMap<&'static str, HostEnvValue>> {
     let mut values = BTreeMap::new();
+    let mut provided_keys = BTreeMap::new();
 
     for (line_number, line) in content.lines().enumerate() {
         let line_number = line_number + 1;
@@ -95,23 +123,34 @@ fn parse_host_env_file(content: &str) -> RunnerResult<BTreeMap<&'static str, Hos
             )));
         };
         let key = key.trim();
-        let Some(&allowed_key) = ALLOWED_HOST_ENV_KEYS
+        let Some(&(provided_key, logical_key)) = HOST_ENV_KEY_ALIASES
             .iter()
-            .find(|&&allowed| allowed == key)
+            .find(|&&(alias, _)| alias == key)
         else {
+            let allowed_keys = HOST_ENV_KEY_ALIASES
+                .iter()
+                .map(|(alias, _)| *alias)
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(RunnerError::Config(format!(
                 "{RUNNER_HOST_ENV_FILE}:{line_number}: unsupported host env key {key:?}; allowed keys: {}",
-                ALLOWED_HOST_ENV_KEYS.join(", ")
+                allowed_keys
             )));
         };
-        if values.contains_key(allowed_key) {
+        if let Some(existing_key) = provided_keys.get(logical_key) {
+            let message = if *existing_key == provided_key {
+                format!("duplicate host env key {provided_key}")
+            } else {
+                format!("conflicting host env aliases for {logical_key}")
+            };
             return Err(RunnerError::Config(format!(
-                "{RUNNER_HOST_ENV_FILE}:{line_number}: duplicate host env key {allowed_key}"
+                "{RUNNER_HOST_ENV_FILE}:{line_number}: {message}"
             )));
         }
 
+        provided_keys.insert(logical_key, provided_key);
         values.insert(
-            allowed_key,
+            logical_key,
             HostEnvValue {
                 value: raw_value.trim().to_string(),
             },
@@ -128,7 +167,7 @@ mod tests {
     #[test]
     fn parse_host_env_file_accepts_allowed_keys_with_comments() {
         let values = parse_host_env_file(
-            "\n# host-local runner overrides\nVM0_RUNNER_CONCURRENCY_FACTOR = 1.5\nVM0_RUNNER_DISK_IOPS = 200000\n",
+            "\n# host-local runner overrides\nOKOU_RUNNER_CONCURRENCY_FACTOR = 1.5\nVM0_RUNNER_DISK_IOPS = 200000\n",
         )
         .unwrap();
 
@@ -154,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn runner_host_env_projects_concurrency_and_io_values() {
+    fn parse_host_env_file_preserves_legacy_only_configuration() {
         let values = parse_host_env_file(
             "\
 VM0_RUNNER_CONCURRENCY_FACTOR=1.5
@@ -201,6 +240,97 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
     }
 
     #[test]
+    fn parse_host_env_file_accepts_canonical_only_configuration() {
+        let canonical_values = parse_host_env_file(
+            "\
+OKOU_RUNNER_CONCURRENCY_FACTOR=1.5
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
+OKOU_RUNNER_DISK_IOPS=50000
+OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
+OKOU_RUNNER_NET_TX_MIB_PER_SEC=125
+",
+        )
+        .unwrap();
+        let legacy_values = parse_host_env_file(
+            "\
+VM0_RUNNER_CONCURRENCY_FACTOR=1.5
+VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
+VM0_RUNNER_DISK_IOPS=50000
+VM0_RUNNER_NET_RX_MIB_PER_SEC=250
+VM0_RUNNER_NET_TX_MIB_PER_SEC=125
+",
+        )
+        .unwrap();
+
+        assert_eq!(canonical_values, legacy_values);
+    }
+
+    #[test]
+    fn parse_host_env_file_normalizes_mixed_io_aliases() {
+        let values = parse_host_env_file(
+            "\
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
+VM0_RUNNER_DISK_IOPS=50000
+OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
+VM0_RUNNER_NET_TX_MIB_PER_SEC=125
+",
+        )
+        .unwrap();
+        let host_env = RunnerHostEnv { values };
+
+        assert_eq!(
+            host_env.io_values(),
+            RunnerIoEnvValues {
+                disk_bandwidth_mib_per_sec: Some(HostEnvValue {
+                    value: "1000".to_string(),
+                }),
+                disk_iops: Some(HostEnvValue {
+                    value: "50000".to_string(),
+                }),
+                net_rx_mib_per_sec: Some(HostEnvValue {
+                    value: "250".to_string(),
+                }),
+                net_tx_mib_per_sec: Some(HostEnvValue {
+                    value: "125".to_string(),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn mixed_alias_partial_io_group_remains_all_or_none() {
+        let values = parse_host_env_file(
+            "\
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
+VM0_RUNNER_DISK_IOPS=50000
+OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
+",
+        )
+        .unwrap();
+        let host_env = RunnerHostEnv { values };
+        let profiles = BTreeMap::from([(
+            "vm0/default".to_string(),
+            crate::config::ProfileConfig {
+                rootfs_hash: "rootfs".to_string(),
+                snapshot_hash: "snapshot".to_string(),
+                vcpu: 2,
+                memory_mb: 4096,
+                rootfs_disk_mb: 8192,
+                workspace_disk_mb: 16_384,
+            },
+        )]);
+        let budget = crate::resource_budget::ResourceBudget::new(2, 4096, 1.0, 1);
+
+        let resolution = crate::io_limits::resolve_io_limits(&profiles, &budget, &host_env);
+
+        let crate::io_limits::IoLimitResolution::Misconfigured { reason } = &resolution else {
+            panic!("expected misconfigured resolution");
+        };
+        assert!(reason.contains(RUNNER_NET_TX_MIB_PER_SEC_ENV));
+        assert_eq!(resolution.device_rate_limits(), None);
+    }
+
+    #[test]
     fn parse_host_env_file_rejects_unknown_keys() {
         let err = parse_host_env_file("VM0_API_BACKEND_URL=https://example.test\n")
             .unwrap_err()
@@ -209,19 +339,56 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
         assert!(err.contains("unsupported host env key"));
         assert!(err.contains("VM0_API_BACKEND_URL"));
         assert!(err.contains(RUNNER_CONCURRENCY_FACTOR_ENV));
+        assert!(err.contains(LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV));
         assert!(err.contains(RUNNER_DISK_IOPS_ENV));
+        assert!(err.contains(LEGACY_RUNNER_DISK_IOPS_ENV));
     }
 
     #[test]
-    fn parse_host_env_file_rejects_duplicate_keys() {
-        let err = parse_host_env_file(
-            "VM0_RUNNER_CONCURRENCY_FACTOR=1.0\nVM0_RUNNER_CONCURRENCY_FACTOR=1.5\n",
-        )
-        .unwrap_err()
-        .to_string();
+    fn parse_host_env_file_rejects_exact_duplicate_keys() {
+        for (key, first_value, second_value) in [
+            (
+                RUNNER_CONCURRENCY_FACTOR_ENV,
+                "canonical-first-value",
+                "canonical-second-value",
+            ),
+            (
+                LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV,
+                "legacy-first-value",
+                "legacy-second-value",
+            ),
+        ] {
+            let content = format!("{key}={first_value}\n{key}={second_value}\n");
+            let err = parse_host_env_file(&content).unwrap_err().to_string();
 
-        assert!(err.contains("duplicate host env key"));
-        assert!(err.contains(RUNNER_CONCURRENCY_FACTOR_ENV));
+            assert!(err.contains("duplicate host env key"));
+            assert!(err.contains(key));
+            assert!(!err.contains(first_value));
+            assert!(!err.contains(second_value));
+        }
+    }
+
+    #[test]
+    fn parse_host_env_file_rejects_alias_conflicts_without_values() {
+        for content in [
+            format!(
+                "{LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV}=legacy-value-should-not-leak\n{RUNNER_CONCURRENCY_FACTOR_ENV}=canonical-value-should-not-leak\n"
+            ),
+            format!(
+                "{RUNNER_CONCURRENCY_FACTOR_ENV}=canonical-value-should-not-leak\n{LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV}=legacy-value-should-not-leak\n"
+            ),
+            format!(
+                "{LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV}=same-value-should-not-leak\n{RUNNER_CONCURRENCY_FACTOR_ENV}=same-value-should-not-leak\n"
+            ),
+        ] {
+            let err = parse_host_env_file(&content).unwrap_err().to_string();
+
+            assert!(err.contains("conflicting host env aliases"));
+            assert!(err.contains(RUNNER_CONCURRENCY_FACTOR_ENV));
+            assert!(!err.contains("legacy-value-should-not-leak"));
+            assert!(!err.contains("canonical-value-should-not-leak"));
+            assert!(!err.contains("same-value-should-not-leak"));
+        }
     }
 
     #[test]

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -15,7 +15,7 @@ values is ignored:
 
 ```text
 # Optional host-local concurrency override
-VM0_RUNNER_CONCURRENCY_FACTOR = 1.5
+OKOU_RUNNER_CONCURRENCY_FACTOR = 1.5
 ```
 
 Do not use `export`, shell interpolation, quoted numeric values, or inline
@@ -23,13 +23,33 @@ comments. The parser accepts only the keys listed below. An unreadable file, a
 line without `=`, an unsupported key, or a duplicate key is a configuration
 error that prevents the runner from starting.
 
-| Key                                     | Unit                   | Valid values                               | Behavior                                                                                             |
-| --------------------------------------- | ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `VM0_RUNNER_CONCURRENCY_FACTOR`         | Dimensionless multiple | Positive finite number                     | Optional; overrides `sandbox.concurrency_factor` from `runner.yaml`. An invalid value fails startup. |
-| `VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC` | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
-| `VM0_RUNNER_DISK_IOPS`                  | Operations/s           | Integer in `1..=u64::MAX`                  | Required with the other three I/O keys.                                                              |
-| `VM0_RUNNER_NET_RX_MIB_PER_SEC`         | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
-| `VM0_RUNNER_NET_TX_MIB_PER_SEC`         | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
+## Temporary Dual-Read Migration
+
+The `OKOU_*` names are canonical. During the temporary dual-read stage, the
+runner also accepts the corresponding legacy `VM0_*` alias for each logical
+field:
+
+| Canonical key                            | Temporary legacy alias                  | Unit                   | Valid values                               | Behavior                                                                                             |
+| ---------------------------------------- | --------------------------------------- | ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `OKOU_RUNNER_CONCURRENCY_FACTOR`         | `VM0_RUNNER_CONCURRENCY_FACTOR`         | Dimensionless multiple | Positive finite number                     | Optional; overrides `sandbox.concurrency_factor` from `runner.yaml`. An invalid value fails startup. |
+| `OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC` | `VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC` | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
+| `OKOU_RUNNER_DISK_IOPS`                  | `VM0_RUNNER_DISK_IOPS`                  | Operations/s           | Integer in `1..=u64::MAX`                  | Required with the other three I/O keys.                                                              |
+| `OKOU_RUNNER_NET_RX_MIB_PER_SEC`         | `VM0_RUNNER_NET_RX_MIB_PER_SEC`         | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
+| `OKOU_RUNNER_NET_TX_MIB_PER_SEC`         | `VM0_RUNNER_NET_TX_MIB_PER_SEC`         | MiB/s                  | Positive finite decimal in the `u64` range | Required with the other three I/O keys.                                                              |
+
+Use exactly one spelling for each field. If both aliases for the same field
+appear, the runner fails startup even when their values are identical; the
+error does not include either value. Different I/O fields may use different
+spellings during migration, and they still form one all-or-none group after
+alias normalization. A planned host cutover should rewrite all four I/O fields
+to their canonical spelling in the same file update.
+
+Do not change a deployed `host.env` to canonical names until every supported
+runner and rollback target includes this dual reader. An older reader rejects
+the canonical names as unsupported. Rolling back to an older reader therefore
+requires atomically restoring the legacy spellings before starting the older
+binary. Every file change still requires the normal runner drain and restart;
+the running process does not reload it.
 
 Bandwidth values may be fractional. After conversion from MiB/s, the byte/s
 value must be at least `1`, must fit in a `u64`, and is rounded down to an
@@ -45,10 +65,10 @@ all four:
 
 ```text
 # Example sustainable aggregate host capacity; measure values for this host.
-VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=2000
-VM0_RUNNER_DISK_IOPS=200000
-VM0_RUNNER_NET_RX_MIB_PER_SEC=1250
-VM0_RUNNER_NET_TX_MIB_PER_SEC=1000
+OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=2000
+OKOU_RUNNER_DISK_IOPS=200000
+OKOU_RUNNER_NET_RX_MIB_PER_SEC=1250
+OKOU_RUNNER_NET_TX_MIB_PER_SEC=1000
 ```
 
 These values describe sustainable total host capacity, not desired per-sandbox
@@ -112,13 +132,14 @@ disk budget into `209715200 bytes/s` and `20000 ops/s` for each drive.
 
 Host-file parsing and I/O resolution have different failure boundaries:
 
-| Configuration state                                                   | Runner behavior                                                                                                                                  |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| File missing, or none of the four I/O keys present                    | Starts with I/O limiters disabled and logs `I/O limiters disabled`.                                                                              |
-| All four I/O keys present and usable                                  | Starts with all jobs limited and logs `I/O limiter capacity configured; applying limiters to all jobs`.                                          |
-| I/O keys partial, numerically invalid, or insufficient after division | Starts, logs `I/O limiter host env config invalid; disabling I/O limiter capacity` with a `reason`, and disables every disk and network limiter. |
-| File unreadable, line malformed, key unsupported, or key duplicated   | Fails startup with a runner configuration error.                                                                                                 |
-| `VM0_RUNNER_CONCURRENCY_FACTOR` present but invalid                   | Fails startup with a runner configuration error naming the key and `host.env`.                                                                   |
+| Configuration state                                                       | Runner behavior                                                                                                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| File missing, or none of the four I/O keys present                        | Starts with I/O limiters disabled and logs `I/O limiters disabled`.                                                                              |
+| All four logical I/O fields present and usable                            | Starts with all jobs limited and logs `I/O limiter capacity configured; applying limiters to all jobs`.                                          |
+| I/O fields partial, numerically invalid, or insufficient after division   | Starts, logs `I/O limiter host env config invalid; disabling I/O limiter capacity` with a `reason`, and disables every disk and network limiter. |
+| File unreadable, line malformed, key unsupported, or exact key duplicated | Fails startup with a runner configuration error.                                                                                                 |
+| Both aliases for one logical field present                                | Fails startup with a value-free alias conflict error.                                                                                            |
+| `OKOU_RUNNER_CONCURRENCY_FACTOR` or its legacy alias present but invalid  | Fails startup with a runner configuration error naming the canonical key and `host.env`.                                                         |
 
 The non-fatal I/O warning is all-or-nothing. A valid disk pair does not stay
 enabled when the network pair is missing or invalid, and vice versa.


### PR DESCRIPTION
## Summary

- accept the five canonical `OKOU_RUNNER_*` host tuning keys while retaining every legacy `VM0_RUNNER_*` alias
- normalize aliases to canonical logical fields before duplicate and atomic I/O-group validation, with value-free conflict failures for both spellings of one field
- document the temporary dual-read state, restart requirement, atomic I/O cutover, and rollback constraint

## Scope

This is reader Stage 1 only. It does not change deployed `host.env` files, Ansible, CI, secrets, configuration management, `VM0_RUNNER_TOKEN`, resource calculations, or the global user-environment guard.

## Fallbacks

- `crates/runner/src/host_env.rs:HOST_ENV_KEY_ALIASES` accepts legacy `VM0_RUNNER_*` host configuration in the new runner during the reader-first migration. Surface: runner host configuration and retained rollback targets. Remove only after every deployed host file uses the canonical aliases and every supported rollback target reads them; tracked by #28914.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p runner --bin runner`
- `cargo clippy -p runner --bin runner --no-deps -- -A clippy::result_large_err`
- `cargo doc -p runner --no-deps`
- `npx --yes prettier@3.8.1 --check docs/runner-host-configuration.md`
- `cargo test -p runner host_env::tests` type-checked the changed tests, but local execution was blocked by a Rust 1.98-only unused-import error reproduced on untouched `origin/main`; the diagnostic retry then hit the local linker memory limit (exit 137), including with `CARGO_BUILD_JOBS=1`. The pinned PR pipeline is the authoritative test run.

Closes #28920

Part of #28914
