### PR TITLE
refactor(runner): reject reserved okou keys in local user environment

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -591,6 +591,11 @@ impl SubmitPlan {
                     "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
                 )));
             }
+            if key.starts_with("OKOU_") {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} key '{key}': the OKOU_ environment variable namespace is platform-reserved"
+                )));
+            }
             let is_guest_agent_tuning_key =
                 guest_contracts::env::is_guest_agent_tuning_env_key(key);
             if is_guest_agent_tuning_key && !allow_guest_agent_tuning_keys {

--- a/crates/runner/src/cmd/local/submit/tests/request.rs
+++ b/crates/runner/src/cmd/local/submit/tests/request.rs
@@ -228,7 +228,7 @@ async fn rejects_invalid_env_entries_before_submit() {
         (
             vec!["OKOU_RUN_ID=user-controlled".to_string()],
             Vec::new(),
-            "runner-owned environment variables",
+            "platform-reserved",
         ),
         (
             Vec::new(),
@@ -262,5 +262,46 @@ async fn rejects_invalid_env_entries_before_submit() {
         let err = run_submit_with_home(args, home).await.unwrap_err();
 
         assert!(err.to_string().contains(expected), "got: {err}");
+    }
+}
+
+#[tokio::test]
+async fn rejects_reserved_okou_env_keys_without_exposing_values() {
+    let cases = [
+        (
+            vec!["OKOU_TOKEN=ordinary-boundary-secret".to_string()],
+            Vec::new(),
+            "--env",
+            "OKOU_TOKEN",
+            "ordinary-boundary-secret",
+        ),
+        (
+            Vec::new(),
+            vec!["OKOU_UNRELATED=secret-boundary-secret".to_string()],
+            "--secret-env",
+            "OKOU_UNRELATED",
+            "secret-boundary-secret",
+        ),
+    ];
+
+    for (env, secret_env, flag, key, value) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let mut args = submit_args_for_test();
+        args.env = env;
+        args.secret_env = secret_env;
+
+        let err = run_submit_with_home(args, home).await.unwrap_err();
+        let diagnostic = err.to_string();
+
+        assert!(
+            diagnostic.contains(&format!("invalid {flag} key '{key}'")),
+            "got: {diagnostic}"
+        );
+        assert!(
+            diagnostic.contains("OKOU_ environment variable namespace is platform-reserved"),
+            "got: {diagnostic}"
+        );
+        assert!(!diagnostic.contains(value), "got: {diagnostic}");
     }
 }


### PR DESCRIPTION
## Summary

- reject every syntactically valid `OKOU_*` key supplied through local `--env` or `--secret-env`
- preserve existing legacy `VM0_*`, explicit runner-owned, guest-agent tuning, and ordinary environment behavior
- cover both input flags and verify rejection diagnostics include the key name without exposing its value

## Scope

This change is limited to the local runner submission input boundary. It does not change the shared runner-owned predicate, cloud executor filtering, API contracts, job shape, or runtime environment readers and writers.

## Verification

- `cargo +1.96.0 fmt --all -- --check`
- `cargo +1.96.0 clippy -p runner --all-targets --all-features`
- `cargo +1.96.0 doc -p runner --no-deps`
- `cargo test -p runner cmd::local::submit::tests::request` — local test binary linking was terminated with exit 137 in a 3.8 GiB, no-swap environment on both the normal run and the required `CARGO_BUILD_JOBS=1` retry; delegated to PR CI

Closes #28930

Parent EPIC: #28914
