### PR TITLE
refactor(rust): centralize process termination codec

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -133,6 +133,17 @@
 //!
 //! Present stdin is bounded by `MAX_EXEC_STDIN_BYTES`.
 //!
+//! ### Process termination
+//!
+//! Exec, guest DNS readiness, and guest storage-manifest results share the same
+//! process termination encoding:
+//!
+//! - `0x00`: exited, followed by signed `[4B exit_code]`.
+//! - `0x01`: timed out.
+//! - `0x02`: cancelled.
+//! - `0x03`: start failed.
+//! - `0x04`: wait failed.
+//!
 //! ### `exec_result`
 //!
 //! ```text
@@ -143,13 +154,7 @@
 //! [2B diagnostic_len][diagnostic]
 //! ```
 //!
-//! `termination` values:
-//!
-//! - `0x00`: exited, followed by signed `[4B exit_code]`.
-//! - `0x01`: timed out.
-//! - `0x02`: cancelled.
-//! - `0x03`: start failed.
-//! - `0x04`: wait failed.
+//! `termination` uses the shared process termination encoding above.
 //!
 //! `stdout` and `stderr` use the same tagged captured-output payload:
 //!
@@ -168,13 +173,8 @@
 //! [2B diagnostic_len][diagnostic]
 //! ```
 //!
-//! `termination` values:
-//!
-//! - `0x00`: exited, followed by signed `[4B exit_code]`.
-//! - `0x01`: timed out.
-//! - `0x02`: cancelled by connection teardown.
-//! - `0x03`: start failed.
-//! - `0x04`: wait failed.
+//! `termination` uses the shared process termination encoding above. For DNS
+//! readiness, `cancelled` means cancellation by connection teardown.
 //!
 //! Result `flags` currently uses `OUTPUT_TRUNCATED=0x01`. `answer` is raw
 //! resolver stdout bounded by [`GUEST_DNS_READINESS_MAX_ANSWER_BYTES`], while

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -4,6 +4,8 @@ mod result;
 mod start;
 mod started_cancel;
 
+pub use super::process_termination::ExecTermination;
+
 pub use control::{
     DecodedExecControl, DecodedExecControlResult, EXEC_CONTROL_MAX_PAYLOAD_BYTES,
     EXEC_CONTROL_NONCE_LEN, ExecControlNonce, ExecControlStatus, decode_exec_control,
@@ -15,7 +17,7 @@ pub use output::{
     encode_exec_output_frame_into,
 };
 pub use result::{
-    DecodedExecResult, ExecCapturedOutput, ExecTermination, decode_exec_result, encode_exec_result,
+    DecodedExecResult, ExecCapturedOutput, decode_exec_result, encode_exec_result,
     encode_exec_result_frame_into,
 };
 pub use start::{
@@ -29,9 +31,9 @@ pub use started_cancel::{
 };
 
 #[cfg(test)]
-use crate::error::ProtocolError;
+use super::process_termination::TERMINATION_CANCELLED as EXEC_TERMINATION_CANCELLED;
 #[cfg(test)]
-use result::EXEC_TERMINATION_CANCELLED;
+use crate::error::ProtocolError;
 #[cfg(test)]
 use start::{
     EXEC_LIFECYCLE_ONE_SHOT, EXEC_OUTPUT_POLICY_CAPTURE, EXEC_OUTPUT_POLICY_DISCARD,

--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -1,37 +1,18 @@
 use crate::error::ProtocolError;
 use crate::frame::encode_into;
+use crate::payloads::process_termination::{
+    TerminationDecodeErrors, append_termination, decode_termination, termination_encoded_len,
+};
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
-    expect_consumed, read_i32, read_slice, read_str, read_u8, read_u16, read_u32,
+    expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
 use crate::wire::{EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, MSG_EXEC_RESULT};
 
-pub(super) const EXEC_TERMINATION_EXITED: u8 = 0x00;
-pub(super) const EXEC_TERMINATION_TIMED_OUT: u8 = 0x01;
-pub(super) const EXEC_TERMINATION_CANCELLED: u8 = 0x02;
-pub(super) const EXEC_TERMINATION_START_FAILED: u8 = 0x03;
-pub(super) const EXEC_TERMINATION_WAIT_FAILED: u8 = 0x04;
+use super::ExecTermination;
 
 pub(super) const EXEC_CAPTURED_OUTPUT_DISCARDED: u8 = 0x00;
 pub(super) const EXEC_CAPTURED_OUTPUT_CAPTURED: u8 = 0x01;
-
-/// Exec terminal state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExecTermination {
-    /// Process exited with an exit status.
-    Exited {
-        /// Signed process exit code reported by the guest.
-        exit_code: i32,
-    },
-    /// Operation timed out before completion.
-    TimedOut,
-    /// Operation was cancelled before completion.
-    Cancelled,
-    /// Guest failed to start the process.
-    StartFailed,
-    /// Guest failed while waiting for the process to finish.
-    WaitFailed,
-}
 
 /// Captured stdout/stderr in an exec result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,29 +43,6 @@ pub struct DecodedExecResult<'a> {
     pub stderr: ExecCapturedOutput<'a>,
     /// UTF-8 diagnostic text borrowed from the decoded payload.
     pub diagnostic: &'a str,
-}
-
-fn exec_termination_encoded_len(termination: ExecTermination) -> usize {
-    match termination {
-        ExecTermination::Exited { .. } => 5,
-        ExecTermination::TimedOut
-        | ExecTermination::Cancelled
-        | ExecTermination::StartFailed
-        | ExecTermination::WaitFailed => 1,
-    }
-}
-
-fn append_exec_termination(p: &mut Vec<u8>, termination: ExecTermination) {
-    match termination {
-        ExecTermination::Exited { exit_code } => {
-            p.push(EXEC_TERMINATION_EXITED);
-            p.extend_from_slice(&exit_code.to_be_bytes());
-        }
-        ExecTermination::TimedOut => p.push(EXEC_TERMINATION_TIMED_OUT),
-        ExecTermination::Cancelled => p.push(EXEC_TERMINATION_CANCELLED),
-        ExecTermination::StartFailed => p.push(EXEC_TERMINATION_START_FAILED),
-        ExecTermination::WaitFailed => p.push(EXEC_TERMINATION_WAIT_FAILED),
-    }
 }
 
 fn exec_operation_captured_output_encoded_len(
@@ -126,7 +84,7 @@ fn validate_exec_result_payload(
     let stdout_len = exec_operation_captured_output_encoded_len(stdout, "stdout")?;
     let stderr_len = exec_operation_captured_output_encoded_len(stderr, "stderr")?;
 
-    let mut payload_len = exec_termination_encoded_len(termination);
+    let mut payload_len = termination_encoded_len(termination);
     payload_len = checked_payload_len_add(payload_len, 4)?;
     payload_len = checked_payload_len_add(payload_len, stdout_len)?;
     payload_len = checked_payload_len_add(payload_len, stderr_len)?;
@@ -146,7 +104,7 @@ fn append_exec_result_payload(
     diagnostic: &str,
     diagnostic_len: u16,
 ) {
-    append_exec_termination(p, termination);
+    append_termination(p, termination);
     p.extend_from_slice(&duration_ms.to_be_bytes());
     append_exec_operation_captured_output(p, stdout);
     append_exec_operation_captured_output(p, stderr);
@@ -220,25 +178,6 @@ pub fn encode_exec_result_frame_into(
     })
 }
 
-fn decode_exec_termination(
-    payload: &[u8],
-    offset: &mut usize,
-) -> Result<ExecTermination, ProtocolError> {
-    match read_u8(payload, offset, "exec result termination truncated")? {
-        EXEC_TERMINATION_EXITED => {
-            let exit_code = read_i32(payload, offset, "exec result exit_code truncated")?;
-            Ok(ExecTermination::Exited { exit_code })
-        }
-        EXEC_TERMINATION_TIMED_OUT => Ok(ExecTermination::TimedOut),
-        EXEC_TERMINATION_CANCELLED => Ok(ExecTermination::Cancelled),
-        EXEC_TERMINATION_START_FAILED => Ok(ExecTermination::StartFailed),
-        EXEC_TERMINATION_WAIT_FAILED => Ok(ExecTermination::WaitFailed),
-        _ => Err(ProtocolError::InvalidPayload(
-            "invalid exec termination tag",
-        )),
-    }
-}
-
 fn decode_exec_operation_captured_output<'a>(
     payload: &'a [u8],
     offset: &mut usize,
@@ -274,7 +213,15 @@ fn decode_exec_operation_captured_output<'a>(
 /// Decode exec_result payload into a [`DecodedExecResult`] struct.
 pub fn decode_exec_result(payload: &[u8]) -> Result<DecodedExecResult<'_>, ProtocolError> {
     let mut offset = 0;
-    let termination = decode_exec_termination(payload, &mut offset)?;
+    let termination = decode_termination(
+        payload,
+        &mut offset,
+        TerminationDecodeErrors {
+            termination_truncated: "exec result termination truncated",
+            exit_code_truncated: "exec result exit_code truncated",
+            invalid_tag: "invalid exec termination tag",
+        },
+    )?;
     let duration_ms = read_u32(payload, &mut offset, "exec result duration truncated")?;
     let stdout = decode_exec_operation_captured_output(payload, &mut offset)?;
     let stderr = decode_exec_operation_captured_output(payload, &mut offset)?;

--- a/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
+++ b/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
@@ -1,14 +1,16 @@
+use super::process_termination::{
+    TerminationDecodeErrors, append_termination, decode_termination as decode_process_termination,
+    termination_encoded_len,
+};
 use crate::ProtocolError;
 use crate::frame::encode_into;
-use crate::read::{expect_consumed, read_i32, read_slice, read_str, read_u8, read_u16, read_u32};
+use crate::read::{expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32};
 use crate::wire::MSG_GUEST_DNS_READINESS;
 
-const TERMINATION_EXITED: u8 = 0x00;
-const TERMINATION_TIMED_OUT: u8 = 0x01;
-const TERMINATION_CANCELLED: u8 = 0x02;
-const TERMINATION_START_FAILED: u8 = 0x03;
-const TERMINATION_WAIT_FAILED: u8 = 0x04;
 const RESULT_FLAG_OUTPUT_TRUNCATED: u8 = 0x01;
+
+/// Backward-compatible name for the shared guest process terminal state.
+pub use super::process_termination::ExecTermination as GuestDnsReadinessTermination;
 
 /// Maximum encoded hostname length accepted by a guest DNS readiness request.
 pub const GUEST_DNS_READINESS_MAX_HOSTNAME_BYTES: usize = 253;
@@ -26,24 +28,6 @@ pub struct DecodedGuestDnsReadinessRequest<'a> {
     pub timeout_ms: u32,
     /// Hostname passed as one argument to the fixed guest resolver command.
     pub hostname: &'a str,
-}
-
-/// Terminal state of the fixed guest DNS readiness process.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GuestDnsReadinessTermination {
-    /// The process exited with the supplied exit code.
-    Exited {
-        /// Process exit code, with signals represented as `128 + signal`.
-        exit_code: i32,
-    },
-    /// The process exceeded its request timeout and was killed.
-    TimedOut,
-    /// The owning guest connection was cancelled and the process was killed.
-    Cancelled,
-    /// The process could not be started.
-    StartFailed,
-    /// Waiting for or cleaning up the process failed.
-    WaitFailed,
 }
 
 /// Decoded result of the fixed guest DNS readiness process.
@@ -275,14 +259,7 @@ fn result_payload_len(
     answer: &[u8],
     diagnostic: &str,
 ) -> usize {
-    let termination_len = match termination {
-        GuestDnsReadinessTermination::Exited { .. } => 5,
-        GuestDnsReadinessTermination::TimedOut
-        | GuestDnsReadinessTermination::Cancelled
-        | GuestDnsReadinessTermination::StartFailed
-        | GuestDnsReadinessTermination::WaitFailed => 1,
-    };
-    termination_len + 4 + 1 + 2 + answer.len() + 2 + diagnostic.len()
+    termination_encoded_len(termination) + 4 + 1 + 2 + answer.len() + 2 + diagnostic.len()
 }
 
 fn append_result_payload(
@@ -294,16 +271,7 @@ fn append_result_payload(
     diagnostic: &str,
     encoded: EncodedResultLengths,
 ) {
-    match termination {
-        GuestDnsReadinessTermination::Exited { exit_code } => {
-            payload.push(TERMINATION_EXITED);
-            payload.extend_from_slice(&exit_code.to_be_bytes());
-        }
-        GuestDnsReadinessTermination::TimedOut => payload.push(TERMINATION_TIMED_OUT),
-        GuestDnsReadinessTermination::Cancelled => payload.push(TERMINATION_CANCELLED),
-        GuestDnsReadinessTermination::StartFailed => payload.push(TERMINATION_START_FAILED),
-        GuestDnsReadinessTermination::WaitFailed => payload.push(TERMINATION_WAIT_FAILED),
-    }
+    append_termination(payload, termination);
     payload.extend_from_slice(&duration_ms.to_be_bytes());
     payload.push(u8::from(output_truncated) * RESULT_FLAG_OUTPUT_TRUNCATED);
     payload.extend_from_slice(&encoded.answer_len.to_be_bytes());
@@ -316,26 +284,15 @@ fn decode_termination(
     payload: &[u8],
     offset: &mut usize,
 ) -> Result<GuestDnsReadinessTermination, ProtocolError> {
-    match read_u8(
+    decode_process_termination(
         payload,
         offset,
-        "guest_dns_readiness_result termination truncated",
-    )? {
-        TERMINATION_EXITED => Ok(GuestDnsReadinessTermination::Exited {
-            exit_code: read_i32(
-                payload,
-                offset,
-                "guest_dns_readiness_result exit_code truncated",
-            )?,
-        }),
-        TERMINATION_TIMED_OUT => Ok(GuestDnsReadinessTermination::TimedOut),
-        TERMINATION_CANCELLED => Ok(GuestDnsReadinessTermination::Cancelled),
-        TERMINATION_START_FAILED => Ok(GuestDnsReadinessTermination::StartFailed),
-        TERMINATION_WAIT_FAILED => Ok(GuestDnsReadinessTermination::WaitFailed),
-        _ => Err(ProtocolError::InvalidPayload(
-            "guest_dns_readiness_result unknown termination",
-        )),
-    }
+        TerminationDecodeErrors {
+            termination_truncated: "guest_dns_readiness_result termination truncated",
+            exit_code_truncated: "guest_dns_readiness_result exit_code truncated",
+            invalid_tag: "guest_dns_readiness_result unknown termination",
+        },
+    )
 }
 
 #[cfg(test)]
@@ -445,7 +402,19 @@ mod tests {
 
         let mut unknown_termination = valid.clone();
         unknown_termination[0] = 0xFF;
-        assert!(decode_guest_dns_readiness_result(&unknown_termination).is_err());
+        assert!(matches!(
+            decode_guest_dns_readiness_result(&unknown_termination),
+            Err(ProtocolError::InvalidPayload(
+                "guest_dns_readiness_result unknown termination"
+            ))
+        ));
+
+        assert!(matches!(
+            decode_guest_dns_readiness_result(&[0x00, 0x00, 0x00, 0x00]),
+            Err(ProtocolError::InvalidPayload(
+                "guest_dns_readiness_result exit_code truncated"
+            ))
+        ));
 
         let mut unknown_flags = valid.clone();
         unknown_flags[9] = 0x80;

--- a/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
+++ b/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
@@ -10,6 +10,10 @@ use crate::wire::MSG_GUEST_DNS_READINESS;
 const RESULT_FLAG_OUTPUT_TRUNCATED: u8 = 0x01;
 
 /// Backward-compatible name for the shared guest process terminal state.
+///
+/// For DNS readiness, `TimedOut` means the request timeout elapsed, `Cancelled`
+/// means the owning connection was cancelled, and `WaitFailed` includes process
+/// wait or cleanup failures.
 pub use super::process_termination::ExecTermination as GuestDnsReadinessTermination;
 
 /// Maximum encoded hostname length accepted by a guest DNS readiness request.

--- a/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
+++ b/crates/vsock-proto/src/payloads/guest_storage_manifest.rs
@@ -371,6 +371,22 @@ mod tests {
     }
 
     #[test]
+    fn result_rejects_unknown_termination_and_truncated_exit_code() {
+        assert!(matches!(
+            decode_guest_storage_manifest_result(&[0xff]),
+            Err(ProtocolError::InvalidPayload(
+                "invalid exec termination tag"
+            ))
+        ));
+        assert!(matches!(
+            decode_guest_storage_manifest_result(&[0x00, 0x00, 0x00, 0x00]),
+            Err(ProtocolError::InvalidPayload(
+                "exec result exit_code truncated"
+            ))
+        ));
+    }
+
+    #[test]
     fn request_decoder_rejects_trailing_bytes() {
         let mut payload = encode_guest_storage_manifest_request(1, "run", "/run", b"{}").unwrap();
         payload.push(0);

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod exec_operation;
 pub(crate) mod guest_dns_readiness;
 pub(crate) mod guest_storage_manifest;
 pub(crate) mod memory_snapshot;
+pub(crate) mod process_termination;
 pub(crate) mod write_file;
 
 fn truncate_utf8_to_u16_bytes(value: &str) -> (&[u8], u16) {

--- a/crates/vsock-proto/src/payloads/process_termination.rs
+++ b/crates/vsock-proto/src/payloads/process_termination.rs
@@ -12,7 +12,8 @@ const TERMINATION_WAIT_FAILED: u8 = 0x04;
 pub enum ExecTermination {
     /// Process exited with an exit status.
     Exited {
-        /// Signed process exit code reported by the guest.
+        /// Signed process exit code reported by the guest, with signals
+        /// represented as `128 + signal`.
         exit_code: i32,
     },
     /// Operation timed out before completion.

--- a/crates/vsock-proto/src/payloads/process_termination.rs
+++ b/crates/vsock-proto/src/payloads/process_termination.rs
@@ -1,0 +1,127 @@
+use crate::ProtocolError;
+use crate::read::{read_i32, read_u8};
+
+const TERMINATION_EXITED: u8 = 0x00;
+const TERMINATION_TIMED_OUT: u8 = 0x01;
+pub(super) const TERMINATION_CANCELLED: u8 = 0x02;
+const TERMINATION_START_FAILED: u8 = 0x03;
+const TERMINATION_WAIT_FAILED: u8 = 0x04;
+
+/// Guest process terminal state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecTermination {
+    /// Process exited with an exit status.
+    Exited {
+        /// Signed process exit code reported by the guest.
+        exit_code: i32,
+    },
+    /// Operation timed out before completion.
+    TimedOut,
+    /// Operation was cancelled before completion.
+    Cancelled,
+    /// Guest failed to start the process.
+    StartFailed,
+    /// Guest failed while waiting for the process to finish.
+    WaitFailed,
+}
+
+pub(super) struct TerminationDecodeErrors {
+    pub(super) termination_truncated: &'static str,
+    pub(super) exit_code_truncated: &'static str,
+    pub(super) invalid_tag: &'static str,
+}
+
+pub(super) fn termination_encoded_len(termination: ExecTermination) -> usize {
+    match termination {
+        ExecTermination::Exited { .. } => 5,
+        ExecTermination::TimedOut
+        | ExecTermination::Cancelled
+        | ExecTermination::StartFailed
+        | ExecTermination::WaitFailed => 1,
+    }
+}
+
+pub(super) fn append_termination(payload: &mut Vec<u8>, termination: ExecTermination) {
+    match termination {
+        ExecTermination::Exited { exit_code } => {
+            payload.push(TERMINATION_EXITED);
+            payload.extend_from_slice(&exit_code.to_be_bytes());
+        }
+        ExecTermination::TimedOut => payload.push(TERMINATION_TIMED_OUT),
+        ExecTermination::Cancelled => payload.push(TERMINATION_CANCELLED),
+        ExecTermination::StartFailed => payload.push(TERMINATION_START_FAILED),
+        ExecTermination::WaitFailed => payload.push(TERMINATION_WAIT_FAILED),
+    }
+}
+
+pub(super) fn decode_termination(
+    payload: &[u8],
+    offset: &mut usize,
+    errors: TerminationDecodeErrors,
+) -> Result<ExecTermination, ProtocolError> {
+    match read_u8(payload, offset, errors.termination_truncated)? {
+        TERMINATION_EXITED => Ok(ExecTermination::Exited {
+            exit_code: read_i32(payload, offset, errors.exit_code_truncated)?,
+        }),
+        TERMINATION_TIMED_OUT => Ok(ExecTermination::TimedOut),
+        TERMINATION_CANCELLED => Ok(ExecTermination::Cancelled),
+        TERMINATION_START_FAILED => Ok(ExecTermination::StartFailed),
+        TERMINATION_WAIT_FAILED => Ok(ExecTermination::WaitFailed),
+        _ => Err(ProtocolError::InvalidPayload(errors.invalid_tag)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERRORS: TerminationDecodeErrors = TerminationDecodeErrors {
+        termination_truncated: "test termination truncated",
+        exit_code_truncated: "test exit_code truncated",
+        invalid_tag: "test invalid termination tag",
+    };
+
+    #[test]
+    fn every_termination_round_trips_with_stable_bytes() {
+        for (termination, expected) in [
+            (
+                ExecTermination::Exited { exit_code: -9 },
+                vec![0x00, 0xff, 0xff, 0xff, 0xf7],
+            ),
+            (ExecTermination::TimedOut, vec![0x01]),
+            (ExecTermination::Cancelled, vec![0x02]),
+            (ExecTermination::StartFailed, vec![0x03]),
+            (ExecTermination::WaitFailed, vec![0x04]),
+        ] {
+            let mut encoded = Vec::new();
+            append_termination(&mut encoded, termination);
+
+            assert_eq!(encoded, expected);
+            assert_eq!(encoded.len(), termination_encoded_len(termination));
+
+            let mut offset = 0;
+            assert_eq!(
+                decode_termination(&encoded, &mut offset, ERRORS).unwrap(),
+                termination
+            );
+            assert_eq!(offset, encoded.len());
+        }
+    }
+
+    #[test]
+    fn decoder_rejects_unknown_tag_and_truncated_exit_code() {
+        let mut offset = 0;
+        assert!(matches!(
+            decode_termination(&[0xff], &mut offset, ERRORS),
+            Err(ProtocolError::InvalidPayload(
+                "test invalid termination tag"
+            ))
+        ));
+
+        let mut offset = 0;
+        assert!(matches!(
+            decode_termination(&[0x00, 0x00, 0x00, 0x00], &mut offset, ERRORS),
+            Err(ProtocolError::InvalidPayload("test exit_code truncated"))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- move `ExecTermination` and its `0x00..0x04` wire codec into one shared payload module
- keep `GuestDnsReadinessTermination` as a source-compatible public alias while routing DNS readiness through the shared contract
- preserve operation-specific decode errors and wire bytes, centralize protocol documentation, and cover malformed termination prefixes through every public result decoder

## Scope

- no new public `ProcessTermination` concept
- no result-layout, message-type, migration, or version-negotiation changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-proto --all-targets --all-features -- -D warnings`
- `cargo doc -p vsock-proto --all-features --no-deps`
- `cargo test -p vsock-proto`
- `cargo test -p vsock-host`
- `cargo test -p vsock-guest`
- `cargo test -p sandbox-fc`
- pre-commit workspace Rust formatting, Clippy, documentation, and file-size checks

Closes #28955
