### PR TITLE
refactor(api): drop the branded compatibility row for uploads/prepare

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -12,7 +12,6 @@ import { slackConnectRoutes } from "../signals/routes/slack-connect";
 import { slackOauthRoutes } from "../signals/routes/slack-oauth";
 import { teamsConnectRoutes } from "../signals/routes/teams-connect";
 import { teamsOauthRoutes } from "../signals/routes/teams-oauth";
-import { uploadsPrepareRoutes } from "../signals/routes/uploads-prepare";
 import { voiceIoQuotaRoutes } from "../signals/routes/voice-io-quota";
 import { webFileUrlRoutes } from "../signals/routes/web-file-url";
 import {
@@ -432,10 +431,6 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/uploads/multipart/complete",
     "/api/zero/uploads/multipart/complete",
   ],
-  "/api/uploads/prepare": [
-    "/api/okou/uploads/prepare",
-    "/api/zero/uploads/prepare",
-  ],
   "/api/voice-io/quota": [
     "/api/okou/voice-io/quota",
     "/api/zero/voice-io/quota",
@@ -674,41 +669,30 @@ describe("branded paths for migrated neutral routes", () => {
     }
   });
 
-  // The #28463 twin of the two assertions above, and the one that covers a GET
-  // as well as a POST: the slice moved a mix of methods, and a row is matched on
+  // The #28463 twin of the two assertions above. A row is matched on
   // `entry.route.path` alone. Every branded path below exists only because of
   // a table row, and the request goes through the app factory production wires,
   // so a row that never reaches the registration chain fails here rather than
-  // 404ing a released CLI or platform build.
+  // 404ing a released CLI or platform build. The POST arm this loop used to
+  // carry went with `uploads/prepare` in #28974; both endpoints left are GETs,
+  // so the request builder no longer branches on a method.
   it("serves the migrated product paths through the production app factory", async () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
 
     const endpoints = [
-      {
-        routes: uploadsPrepareRoutes,
-        method: "POST",
-        suffix: "uploads/prepare",
-      },
-      { routes: voiceIoQuotaRoutes, method: "GET", suffix: "voice-io/quota" },
-      { routes: webFileUrlRoutes, method: "GET", suffix: "web/file-url" },
+      { routes: voiceIoQuotaRoutes, suffix: "voice-io/quota" },
+      { routes: webFileUrlRoutes, suffix: "web/file-url" },
     ] as const;
 
-    for (const { routes, method, suffix } of endpoints) {
+    for (const { routes, suffix } of endpoints) {
       const app = createAppWithRoutes({ signal: context.signal, routes });
 
       async function statusFor(path: string): Promise<number> {
-        const response = await app.request(
-          `${REQUEST_ORIGIN}${path}`,
-          method === "GET"
-            ? { method }
-            : {
-                method,
-                headers: { "content-type": "application/json" },
-                body: "{}",
-              },
-        );
+        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
+          method: "GET",
+        });
         return response.status;
       }
 
@@ -749,10 +733,11 @@ describe("branded paths for migrated neutral routes", () => {
   // because nothing enumerated it.
   //
   // That is the guard #28709 left behind when it took the table from 314 rows
-  // to 184, #28711 kept when it took the 42 drained rows that left 142, and
-  // #28917 kept when it took 53 more and left 89. None of them left a case
-  // asserting the removed rows now 404: `docs/fallback.md` section 1 rules that
-  // class out, and the route table already proves the registration is gone.
+  // to 184, #28711 kept when it took the 42 drained rows that left 142, #28917
+  // kept when it took 53 more and left 89, and #28974 kept when it took
+  // `uploads/prepare` and left 88. None of them left a case asserting the
+  // removed rows now 404: `docs/fallback.md` section 1 rules that class out,
+  // and the route table already proves the registration is gone.
   // What needs a test is the opposite direction — a row disappearing without
   // the request-log evidence #26701 requires — which is what this count and the
   // per-family cases catch.
@@ -764,7 +749,7 @@ describe("branded paths for migrated neutral routes", () => {
   // whole table. Raise the number only with that evidence; an unexplained edit
   // here is the failure this is for.
   it("holds the branded rows this suite has evidence for and no others", () => {
-    const MIGRATED_BRANDED_ROW_COUNT = 89;
+    const MIGRATED_BRANDED_ROW_COUNT = 88;
 
     expect(Object.keys(MIGRATED_ROUTE_PATHS)).toHaveLength(
       MIGRATED_BRANDED_ROW_COUNT,

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -825,9 +825,18 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   //
   // #28917 removed five more on zero-traffic evidence: both per-token browser
   // authorization-request rows, `mail/drafts/:mailDraftId/send`, the
-  // per-template presentation read, and `uploads/multipart/abort`. What the
-  // slice still owns below is the mail draft read, the multipart completion,
-  // `uploads/prepare`, the two voice-io rows, and `web/file-url`.
+  // per-template presentation read, and `uploads/multipart/abort`.
+  //
+  // #28974 removed `uploads/prepare`. #28916 and #28917 had both excluded it
+  // under "rows with a Desktop or CLI caller stay, because installed builds
+  // have no expiry window", which misreads its callers: neither is an installed
+  // build. The CLI caller runs under the pinned `CLI_PKG_URL` described below,
+  // and the App caller is the browser bundle on its ~2 day refresh. Both had
+  // visibly crossed over in the log — every App build up to `0.779.x` called
+  // the branded form and every build from `0.780.0` called the neutral one,
+  // with no version on both sides of the split. What the slice still owns below
+  // is the mail draft read, the multipart completion, the two voice-io rows,
+  // and `web/file-url`.
   //
   // Published CLI builds hold the `okou` form directly: `domains/web.ts` builds
   // its URLs by hand rather than from the contract, so the path it carries
@@ -846,10 +855,6 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
   "/api/uploads/multipart/complete": [
     "/api/okou/uploads/multipart/complete",
     "/api/zero/uploads/multipart/complete",
-  ],
-  "/api/uploads/prepare": [
-    "/api/okou/uploads/prepare",
-    "/api/zero/uploads/prepare",
   ],
   "/api/voice-io/quota": [
     "/api/okou/voice-io/quota",

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -45,7 +45,7 @@ function validBody() {
   return { filename: "hello.txt", contentType: "text/plain", size: 13 };
 }
 
-describe("POST /api/zero/uploads/prepare", () => {
+describe("POST /api/uploads/prepare", () => {
   it("returns 401 when unauthenticated", async () => {
     const client = setupApp({ context, routes: uploadsTestRoutes })(
       uploadsContract,


### PR DESCRIPTION
Part of #26701, closes #28974. Takes `MIGRATED_BRANDED_PATHS` from 89 rows to 88 by dropping the `uploads/prepare` row and its two branded aliases. The neutral path is declared by `packages/api-contracts/src/contracts/uploads.ts` and is untouched — it serves exactly as it does now.

## Evidence

Re-derived against `vm0-request-log-prod` rather than copied from the issue. The retained window at implementation time was **2026-08-20 06:34:30Z → 2026-08-24 09:40:58Z** (~4.1 days, 3,191,134 events). Grouped by `user_agent` as well as `x_client_type`, per the issue's method note.

| Path | Requests | Hosts | First → last |
|---|---|---|---|
| `/api/uploads/prepare` | 2665 | 86 | 08-21 08:36 → 08-24 09:39 |
| `/api/okou/uploads/prepare` | 72 | 17 | 08-20 06:34 → **08-22 10:58** |
| `/api/zero/uploads/prepare` | 0 | — | — |

A `contains 'uploads/prepare'` sweep returns only those two `path_template` values, so the `zero` form has no request at all in the window. Method/status mix: neutral 2474 POST 200 + 1 POST 401 + 190 OPTIONS 204; branded 67 POST 200 + 5 OPTIONS 204. No probe or monitoring user agents appear on either form.

These numbers differ slightly from the issue's (2661 neutral, last neutral 09:38) because the window advanced during measurement. Reported as measured, not reconciled.

**Condition 1 — the branded form is at zero.** Last branded request 2026-08-22 10:58:29Z, 46h44m before the end of the window, none since.

**Condition 2 — the neutral form carries enough volume for that zero to mean something.** 2665 requests from 86 distinct hosts over the same window. A client that had not cut over would still be visible on the branded form at that rate.

### Caller cutover

The version split is clean on both callers, with no version appearing on both sides:

- **App** (browser bundle): `0.773.0`, `0.774.0`, `0.775.0`, `0.776.0`, `0.778.0`, `0.778.1`, `0.779.0` called the branded form and nothing else; `0.780.0` through `0.785.0` (14 versions, all live in the window) call the neutral form and nothing else.
- **CLI**: `9.279.4` on the branded form 08-20 09:48 → 08-21 09:03, then the neutral form from 08-21 08:36. `CLI_PKG_URL` is commit-addressed, so one release-please version string spans both sides of the contract change. Subsequent versions `9.280.0` → `9.281.4` are neutral-only.

The CLI has no long tail: across `9.279.4`→`9.281.4` the longest any version outlived its successor's first request was 27 minutes (`9.281.2` past `9.281.3`).

This is why the #28916/#28917 exclusion rule — "rows with a Desktop or CLI caller stay, because installed builds have no expiry window" — does not apply here. Neither caller is an installed build: the CLI is `okou` resolved from the commit-addressed `CLI_PKG_URL` the API deploy writes into its own environment, and the App caller is the browser bundle on its ordinary ~2 day refresh.

### `x_client_type` check

Grouping on `x_client_type` alone would have hidden callers — 319,479 POSTs in this window have it empty (the issue measured 306,819; the window moved). For this row the empty-header requests resolve to browsers: all 195 of them (190 neutral, 5 branded) carry a `Mozilla/…` user agent and are exactly the OPTIONS preflight counts. No `node` user agent appears without an `x_client_type`, so there is no Desktop family hidden here like the one #28939 found. Checked rather than assumed.

### Removal gate: the client-version floor

Stronger than the traffic argument on its own. `docs/fallback.md` section 7 gives the gate for "old web/app -> API" as *the replacement app is live and the client-version floor excludes the old build*, and that floor is already closed:

- `turbo/apps/api/src/lib/web-client-compatibility.json` sets `minimumSupportedVersion` to `0.781.1` (raised by #28708 on 2026-08-23).
- Every App build observed on the branded form is `0.773.0`, `0.774.0`, `0.775.0`, `0.776.0`, `0.778.0`, `0.778.1`, or `0.779.0` — all strictly below that floor.
- Per `docs/deployment-compatibility.md` the floor rejects with `426 Upgrade Required` **before route handlers run**, so no App build that would emit the branded path can reach a handler at all, whether or not the alias is registered.

For the CLI the gate is the pinned `CLI_PKG_URL` plus the runner's 2h `JOB_TIMEOUT`; the last branded CLI request was 08-21 09:03, about 72h before the end of the retained window.

## Changes

- `route-entry.ts`: remove the row; record in the slice comment why the earlier exclusion was wrong and what the slice still owns.
- `migrated-branded-paths.test.ts`: remove the `MIGRATED_ROUTE_PATHS` mirror entry, decrement `MIGRATED_BRANDED_ROW_COUNT` 89 → 88 (read off `main`, not copied from the issue), and drop the `uploads/prepare` entry from the product-paths request case, which would otherwise assert the removed aliases still reach the handler. No case asserting the removed forms now 404 — `docs/fallback.md` section 1 rules that class out.
- Both maps verified to be exactly 88 keys with identical key sets.

### Two consequential edits beyond the issue's list

- `uploads/prepare` was the only POST in the product-paths loop. With it gone both remaining endpoints are GETs, so the `method` field and the POST arm of the request builder are dead. Collapsed to a plain GET, following what #28941 did to the same construct in the sibling loop when its entries became homogeneous.
- `signals/routes/__tests__/uploads-prepare.test.ts` had a `describe` titled `POST /api/zero/uploads/prepare`. It is a label only — the test drives the contract client, which resolves the neutral path — but it named a path this PR deletes, so it is retitled `POST /api/uploads/prepare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)