### PR TITLE
test(runner): rename private test-process environment keys

### DIFF
--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -14,18 +14,18 @@ use crate::test_fixtures::ignored_child::{
     ignored_child_test_env_guard_enabled, run_ignored_child_test,
 };
 
-const ENABLED_SERVICE_SCENARIO_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_SCENARIO";
-const ENABLED_SERVICE_CONFIG_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_CONFIG";
-const ENABLED_SERVICE_HOME_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_HOME";
-const ENABLED_SERVICE_SYSTEM_DIR_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_SYSTEM_DIR";
-const ENABLED_SERVICE_INVOCATIONS_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_INVOCATIONS";
+const ENABLED_SERVICE_SCENARIO_ENV: &str = "OKOU_RUN_GC_ENABLED_SERVICE_SCENARIO";
+const ENABLED_SERVICE_CONFIG_ENV: &str = "OKOU_RUN_GC_ENABLED_SERVICE_CONFIG";
+const ENABLED_SERVICE_HOME_ENV: &str = "OKOU_RUN_GC_ENABLED_SERVICE_HOME";
+const ENABLED_SERVICE_SYSTEM_DIR_ENV: &str = "OKOU_RUN_GC_ENABLED_SERVICE_SYSTEM_DIR";
+const ENABLED_SERVICE_INVOCATIONS_ENV: &str = "OKOU_RUN_GC_ENABLED_SERVICE_INVOCATIONS";
 const ENABLED_SERVICE_CHILD_TEST: &str =
     "cmd::gc::image_refs::tests::enabled_service_systemctl_child";
 const FAKE_SYSTEMCTL: &str = r#"#!/bin/sh
-printf '%s\n' "$*" >> "$VM0_RUN_GC_ENABLED_SERVICE_INVOCATIONS"
+printf '%s\n' "$*" >> "$OKOU_RUN_GC_ENABLED_SERVICE_INVOCATIONS"
 
 if [ "$1" = "is-enabled" ]; then
-  if [ "$VM0_RUN_GC_ENABLED_SERVICE_SCENARIO" = "enablement-error" ]; then
+  if [ "$OKOU_RUN_GC_ENABLED_SERVICE_SCENARIO" = "enablement-error" ]; then
     printf '%s\n' 'cannot determine unit file state' >&2
     exit 1
   fi
@@ -34,7 +34,7 @@ if [ "$1" = "is-enabled" ]; then
 fi
 
 if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
-  case "$VM0_RUN_GC_ENABLED_SERVICE_SCENARIO" in
+  case "$OKOU_RUN_GC_ENABLED_SERVICE_SCENARIO" in
     cat-error)
       printf '%s\n' 'cannot read selected drop-in' >&2
       exit 1
@@ -60,7 +60,7 @@ if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
         '# /run/systemd/system/vm0-runner-test.service.d/20-runtime.conf' \
         '[Service]' \
         'ExecStart=' \
-        "ExecStart=/usr/bin/runner start --config $VM0_RUN_GC_ENABLED_SERVICE_CONFIG"
+        "ExecStart=/usr/bin/runner start --config $OKOU_RUN_GC_ENABLED_SERVICE_CONFIG"
       exit 0
       ;;
   esac

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -1124,7 +1124,7 @@ async fn gc_nested_images_symlink_snapshot_entry_preserves_rootfs() {
     );
 }
 
-const LOW_FD_IMAGE_GC_CHILD_ENV: &str = "VM0_RUNNER_LOW_FD_IMAGE_GC_CHILD";
+const LOW_FD_IMAGE_GC_CHILD_ENV: &str = "OKOU_RUNNER_LOW_FD_IMAGE_GC_CHILD";
 
 #[tokio::test]
 async fn gc_nested_images_many_candidates_does_not_exhaust_lock_fds() {

--- a/crates/runner/src/cmd/gc/storage/tests.rs
+++ b/crates/runner/src/cmd/gc/storage/tests.rs
@@ -868,7 +868,7 @@ async fn gc_storage_cache_delete_recheck_keeps_candidate_that_became_recent() {
     );
 }
 
-const LOW_FD_STORAGE_GC_CHILD_ENV: &str = "VM0_RUNNER_LOW_FD_STORAGE_GC_CHILD";
+const LOW_FD_STORAGE_GC_CHILD_ENV: &str = "OKOU_RUNNER_LOW_FD_STORAGE_GC_CHILD";
 
 #[tokio::test]
 async fn gc_storage_cache_many_candidates_does_not_exhaust_lock_fds() {

--- a/crates/runner/src/cmd/kill/orphan.rs
+++ b/crates/runner/src/cmd/kill/orphan.rs
@@ -537,7 +537,7 @@ mod tests {
         ignored_child_test_env_guard_enabled, run_ignored_child_test,
     };
 
-    const ORPHAN_KILL_CHILD_ENV: &str = "VM0_RUNNER_ORPHAN_KILL_TEST_CHILD";
+    const ORPHAN_KILL_CHILD_ENV: &str = "OKOU_RUNNER_ORPHAN_KILL_TEST_CHILD";
     const ORPHAN_KILL_READY_LINE: &str = "vm0 orphan kill test ready";
 
     fn process_stat(identity: &FirecrackerProcessIdentity) -> ProcessStat {

--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -137,17 +137,17 @@ mod tests {
         ignored_child_test_env_guard_enabled, run_ignored_child_test,
     };
 
-    const SCENARIO_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_SCENARIO";
-    const SIGNAL_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_NAME";
-    const INVOCATIONS_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_INVOCATIONS";
+    const SCENARIO_ENV: &str = "OKOU_RUN_SERVICE_SIGNAL_SCENARIO";
+    const SIGNAL_ENV: &str = "OKOU_RUN_SERVICE_SIGNAL_NAME";
+    const INVOCATIONS_ENV: &str = "OKOU_RUN_SERVICE_SIGNAL_INVOCATIONS";
     const CHILD_TEST: &str = "cmd::service::signal::tests::signal_service_main_systemctl_child";
     const BOUNDED_OUTCOME_SCENARIO_BUDGET: Duration = Duration::from_secs(5);
     const BOUNDED_TIMEOUT_SCENARIO_BUDGET: Duration = Duration::from_millis(100);
     const FAKE_SYSTEMCTL: &str = r#"#!/bin/sh
-printf '%s\n' "$*" >> "$VM0_RUN_SERVICE_SIGNAL_INVOCATIONS"
+printf '%s\n' "$*" >> "$OKOU_RUN_SERVICE_SIGNAL_INVOCATIONS"
 
 if [ "$1" = "kill" ]; then
-  case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
+  case "$OKOU_RUN_SERVICE_SIGNAL_SCENARIO" in
     success-*|bounded-success) exit 0 ;;
     bounded-timeout) while :; do :; done ;;
     absent|bounded-absent|live|recheck-failed)
@@ -158,7 +158,7 @@ if [ "$1" = "kill" ]; then
 fi
 
 if [ "$1" = "show" ]; then
-  case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
+  case "$OKOU_RUN_SERVICE_SIGNAL_SCENARIO" in
     absent|bounded-absent)
       printf '%s\n' 'LoadState=loaded' 'MainPID=0'
       exit 0

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -248,7 +248,7 @@ mod tests {
         ignored_child_test_env_guard_enabled, run_ignored_child_test,
     };
 
-    const EARLY_SIGNAL_CHILD_ENV: &str = "VM0_RUNNER_EARLY_SIGNAL_TEST";
+    const EARLY_SIGNAL_CHILD_ENV: &str = "OKOU_RUNNER_EARLY_SIGNAL_TEST";
     const EARLY_SIGTERM_CHILD: &str =
         "cmd::start::signals::tests::early_sigterm_buffered_before_spawn_child";
     const EARLY_SIGINT_CHILD: &str =

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -756,7 +756,7 @@ mod tests {
         ignored_child_test_env_guard_enabled, run_ignored_child_test,
     };
 
-    const RESTRICTIVE_UMASK_CHILD_ENV: &str = "VM0_RUN_RESTRICTIVE_UMASK_TEST";
+    const RESTRICTIVE_UMASK_CHILD_ENV: &str = "OKOU_RUN_RESTRICTIVE_UMASK_TEST";
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -706,7 +706,7 @@ mod tests {
     use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
     use std::time::Duration;
 
-    const FIFO_READ_CHILD_PATH_ENV: &str = "VM0_RUN_PRIVATE_FILE_FIFO_READ_CHILD_PATH";
+    const FIFO_READ_CHILD_PATH_ENV: &str = "OKOU_RUN_PRIVATE_FILE_FIFO_READ_CHILD_PATH";
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777

--- a/crates/runner/src/r2_cache/tests/config.rs
+++ b/crates/runner/src/r2_cache/tests/config.rs
@@ -6,7 +6,7 @@ use crate::test_fixtures::ignored_child::{
 
 use super::super::{R2Error, R2ImageCache, config::ENV_VARS, keys::key_for_template_hash};
 
-const R2_ENV_CHILD_SCENARIO: &str = "VM0_RUNNER_R2_ENV_TEST_SCENARIO";
+const R2_ENV_CHILD_SCENARIO: &str = "OKOU_RUNNER_R2_ENV_TEST_SCENARIO";
 const R2_ENV_CHILD_TEST: &str = "r2_cache::tests::config::from_env_child";
 const R2_ENV_CHILD_TIMEOUT: Duration = Duration::from_secs(10);
 const ALL_MISSING_SCENARIO: &str = "all-missing";

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -243,7 +243,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    const FIFO_READ_CHILD_PATH_ENV: &str = "VM0_RUN_STATE_FILE_FIFO_READ_CHILD_PATH";
+    const FIFO_READ_CHILD_PATH_ENV: &str = "OKOU_RUN_STATE_FILE_FIFO_READ_CHILD_PATH";
 
     #[tokio::test]
     async fn read_to_string_rejects_symlink_without_reading_target() {

--- a/crates/runner/src/test_fixtures/ignored_child.rs
+++ b/crates/runner/src/test_fixtures/ignored_child.rs
@@ -664,9 +664,9 @@ mod tests {
 
     use super::*;
 
-    const LARGE_SUCCESS_OUTPUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_LARGE_SUCCESS_OUTPUT_TEST";
-    const LARGE_OUTPUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_LARGE_OUTPUT_TEST";
-    const TIMEOUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_TIMEOUT_TEST";
+    const LARGE_SUCCESS_OUTPUT_CHILD_ENV: &str = "OKOU_RUN_IGNORED_CHILD_LARGE_SUCCESS_OUTPUT_TEST";
+    const LARGE_OUTPUT_CHILD_ENV: &str = "OKOU_RUN_IGNORED_CHILD_LARGE_OUTPUT_TEST";
+    const TIMEOUT_CHILD_ENV: &str = "OKOU_RUN_IGNORED_CHILD_TIMEOUT_TEST";
 
     #[tokio::test]
     async fn run_ignored_child_test_preserves_tail_after_large_output() {

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -25,7 +25,7 @@ use crate::test_fixtures::ignored_child::{
     ignored_child_test_env_guard_enabled, run_ignored_child_test,
 };
 
-const PERMISSIVE_UMASK_CHILD_ENV: &str = "VM0_RUN_WORKSPACE_CACHE_PERMISSIVE_UMASK_TEST";
+const PERMISSIVE_UMASK_CHILD_ENV: &str = "OKOU_RUN_WORKSPACE_CACHE_PERMISSIVE_UMASK_TEST";
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777


### PR DESCRIPTION
## Summary

- rename exactly 20 runner-private test subprocess environment keys from `VM0_*` to `OKOU_*`
- update every Rust producer, child reader, assertion path, and embedded fake-`systemctl` shell reader atomically
- leave production contracts, `guest-contracts`, host configuration, output markers, sentinels, historical absence assertions, and unrelated test keys unchanged

## Verification

- `cargo +1.96.0 fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo +1.96.0 clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo +1.96.0 doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- final whitelist audit: all 20 legacy names have zero tracked-source occurrences, all expected `OKOU_*` replacements are present, and the 12-file diff is exactly the one-to-one prefix migration

The affected targeted runner tests did not start locally because the runner test binary was terminated with exit 137 during final linking in three independent configurations: GNU ld with the default test profile, GNU ld with one build job and test debuginfo disabled, and LLD with one build job and test debuginfo disabled. The local host has 3.8 GiB of memory and no swap. The pinned PR CI is left to link and execute the affected runner tests.

Closes #28931

Parent EPIC: #28914
