### PR TITLE
fix(python): drain retained diagnostics after webhook shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1960,8 +1960,10 @@ def done():
     so its worker shutdown stops new forwards and best-effort closes active
     upstream sockets without waiting for slow upstream responses. JSONL writer
     shutdown is also bounded and best-effort; if it times out, process shutdown
-    continues with accepted log entries possibly still pending. Model-provider
-    failure delivery stops admission and receives one bounded drain window.
+    continues with accepted log entries possibly still pending. After joining
+    the usage executor, retained billing and diagnostic work is drained through
+    synchronous delivery. Model-provider failure delivery stops admission and
+    receives one bounded drain window.
     """
     try:
         runner_flush_lifecycle.drain_and_close()
@@ -1969,7 +1971,7 @@ def done():
         try:
             try:
                 usage.webhook.usage_executor.shutdown(wait=True)
-                usage.drain_usage_events_after_executor_shutdown()
+                runner_flush_lifecycle.drain_delivery_work_after_executor_shutdown()
             finally:
                 auth_base_forwarder.shutdown_forward_request_workers(wait=False)
         finally:

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -223,9 +223,25 @@ def _flush_usage_for_runner_request() -> None:
 def _flush_delivery_work(*, trigger: _DeliveryFlushTrigger) -> None:
     """Admit billing work before retained diagnostic reports."""
     usage.flush_usage_events(trigger=trigger)
+    _retry_retained_diagnostic_reports()
+
+
+def _retry_retained_diagnostic_reports() -> None:
+    """Retry every retained diagnostic source in its established order."""
     anthropic_accounting.retry_all_pending()
     claude_output_timing.retry_all_pending()
     codex_output_timing.retry_all_pending()
+
+
+def drain_delivery_work_after_executor_shutdown() -> None:
+    """Synchronously drain work after the usage executor has been joined.
+
+    The caller must first shut down and join the executor so completed delivery
+    callbacks cannot retain new billing work after the usage drain observes an
+    empty state. New admissions then use webhook delivery's synchronous fallback.
+    """
+    usage.drain_usage_events_after_executor_shutdown()
+    _retry_retained_diagnostic_reports()
 
 
 def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> None:

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_anthropic.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_anthropic.py
@@ -2,6 +2,7 @@
 
 import gzip
 import json
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -27,11 +28,13 @@ from tests.model_provider_sse_usage_helpers import (
     run_response,
 )
 from tests.pending_helpers import assert_current_pending, assert_pending
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
 from tests.usage_buffer_helpers import event as usage_event
 from tests.usage_helpers import (
     CapturedWebhookRequest,
     UsageWebhookServer,
     compact_observation_quantities,
+    fresh_usage_executor_context,
 )
 from tests.webhook_test_helpers import (
     QueuedUsageExecutor,
@@ -317,6 +320,89 @@ class TestAnthropicMessagesSseUsage:
             if captured.path != "/filler"
         ] == ["/usage-priority", _TELEMETRY_PATH]
         assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+    def test_done_retries_incomplete_anthropic_accounting_after_executor_join(
+        self,
+        tmp_path: Path,
+        real_flow,
+        mitm_ctx,
+        usage_webhook_server: UsageWebhookServer,
+    ) -> None:
+        flow = _anthropic_messages_sse_flow(tmp_path, real_flow)
+        pending_path = tmp_path / "usage-pending"
+        filler_log_path = tmp_path / "filler.jsonl"
+        release_fillers = threading.Event()
+        executor_shutdown_started = threading.Event()
+        usage.set_pending_path(str(pending_path))
+
+        for _ in range(usage.webhook.USAGE_WEBHOOK_WORKERS):
+            usage_webhook_server.queue_response(204, release_event=release_fillers)
+
+        with fresh_usage_executor_context() as executor:
+            original_shutdown = executor.shutdown
+
+            def shutdown_executor(*, wait: bool) -> None:
+                executor_shutdown_started.set()
+                original_shutdown(wait=wait)
+
+            with (
+                mitm_ctx(api_url=usage_webhook_server.api_url),
+                patch.object(executor, "shutdown", side_effect=shutdown_executor),
+                patch.object(
+                    mitm_addon.auth_base_forwarder,
+                    "shutdown_forward_request_workers",
+                ),
+                patch.object(mitm_addon, "shutdown_log_writer"),
+            ):
+                done_thread = ThreadUnderTest(target=mitm_addon.done)
+                try:
+                    for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+                        assert usage.webhook.enqueue_webhook_delivery(
+                            usage_webhook_server.url("/filler"),
+                            "tok-xyz",
+                            {"runId": f"filler-{index}", "events": []},
+                            str(filler_log_path),
+                            "usage_event",
+                        )
+                    assert usage_webhook_server.wait_for_request_count(
+                        usage.webhook.USAGE_WEBHOOK_WORKERS
+                    )
+
+                    _feed_incomplete_anthropic_sse_without_recoverable_usage(flow)
+                    mitm_addon.response(flow)
+                    assert _anthropic_accounting_requests(usage_webhook_server) == []
+                    assert_current_pending(
+                        pending_path,
+                        flows=0,
+                        buffered=1,
+                        reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+                    )
+
+                    done_thread.start()
+                    wait_for_event(
+                        executor_shutdown_started,
+                        timeout=1,
+                        threads=(done_thread,),
+                        message="done did not begin executor shutdown",
+                    )
+                    assert done_thread.is_alive()
+                    release_fillers.set()
+                    done_thread.join_and_raise(timeout=2)
+                finally:
+                    release_fillers.set()
+                    done_thread.join(timeout=2)
+
+        [request] = _anthropic_accounting_requests(usage_webhook_server)
+        assert request.json_body()["runId"] == "00000000-0000-0000-0000-000000025133"
+        [operation] = _anthropic_accounting_operations(usage_webhook_server)
+        assert operation["action_type"] == "anthropic_sse_incomplete_no_recoverable_usage"
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+        )
 
     def test_incomplete_anthropic_accounting_retention_overflow_is_action_specific(
         self,


### PR DESCRIPTION
## Summary

- drain retained billing and diagnostic delivery after the webhook executor joins
- reuse one ordered Anthropic, Claude, and Codex diagnostic retry path before and after executor shutdown
- cover the saturated Anthropic shutdown race with a real executor and local HTTP server

## Behavior

When all webhook delivery slots are occupied during the pre-shutdown flush, an incomplete Anthropic accounting report remains retained. Once the executor join releases those slots, shutdown now retries it through the existing synchronous delivery fallback, releases its buffered ownership exactly once, and reaches zero pending counters.

The same final lifecycle pass includes the two existing provider-output timing stores because they share the retained diagnostic boundary. This PR does not change admission limits, HTTP retry policy, timeout policy, payloads, APIs, schemas, dependencies, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_sse_usage_anthropic.py tests/test_done_hook.py` (36 passed)
- `uv run --no-sync python -m pytest tests/` (6593 passed)

Closes #28961
