### PR TITLE
perf(mitm-addon): reuse x unicode label classification

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -73,6 +73,11 @@ class _BodyRefinementRule(NamedTuple):
     matches_body: Callable[[bytes | None], bool]
 
 
+class _BillingDomainLabelNormalization(NamedTuple):
+    normalized_label: str | None
+    unsafe_compatibility_mapping: bool
+
+
 # Permission → default bucket.  The default matches the majority of
 # paths in the scope; outliers go in `_PATH_OVERRIDES`.  Prices are
 # defined in turbo/apps/api/src/scripts/dev-seed.ts.
@@ -390,6 +395,15 @@ def _label_has_tld_prefix_before_unicode(label: str) -> bool:
     return False
 
 
+def _normalize_billing_domain_label(label: str) -> _BillingDomainLabelNormalization:
+    try:
+        return _BillingDomainLabelNormalization(normalize_idna_label(label), False)
+    except UnsafeIdnaCompatibilityMappingError:
+        return _BillingDomainLabelNormalization(None, True)
+    except UnicodeError:
+        return _BillingDomainLabelNormalization(None, False)
+
+
 def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: str) -> bool:
     if candidate.isascii():
         simple_ascii_candidate = candidate.lower()
@@ -399,23 +413,33 @@ def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: s
     else:
         use_simple_ascii_labels = False
         labels = candidate.split(".")
+    label_normalizations: dict[str, _BillingDomainLabelNormalization] = {}
+    label_tld_prefixes: dict[str, bool] = {}
     last_label_index = len(labels) - 1
     for index, label in enumerate(labels):
         if use_simple_ascii_labels:
             normalized_label = label
         else:
-            if index > 0 and _label_has_tld_prefix_before_unicode(label):
-                return True
+            if index > 0:
+                has_tld_prefix = label_tld_prefixes.get(label)
+                if has_tld_prefix is None:
+                    has_tld_prefix = _label_has_tld_prefix_before_unicode(label)
+                    label_tld_prefixes[label] = has_tld_prefix
+                if has_tld_prefix:
+                    return True
 
-            try:
-                normalized_label = normalize_idna_label(label)
-            except UnsafeIdnaCompatibilityMappingError:
+            normalization = label_normalizations.get(label)
+            if normalization is None:
+                normalization = _normalize_billing_domain_label(label)
+                label_normalizations[label] = normalization
+            if normalization.unsafe_compatibility_mapping:
                 # Keep billing conservative for URL-like compatibility aliases,
                 # but do not fold them into unrelated ASCII domains.
                 if index == last_label_index:
                     return _is_twitter_text_tld_boundary(following_char)
                 continue
-            except UnicodeError:
+            normalized_label = normalization.normalized_label
+            if normalized_label is None:
                 return False
 
         if not _label_is_billing_domain_label(normalized_label):

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -675,6 +675,7 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
         "Sharp S faß.de",
         "Fullwidth compatibility \uff26\uff2f\uff2f.com",
         "Fullwidth terminal example.\uff23\uff2f\uff2d",
+        "Repeated fullwidth compatibility \uff26\uff2f\uff2f.\uff26\uff2f\uff2f",
     ],
 )
 def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_flow, text):
@@ -818,12 +819,16 @@ def test_tweet_create_long_unicode_label_does_not_restart_candidate_search(
     assert p["quantity"] == 1
 
 
-def test_tweet_create_near_limit_non_link_candidate_downgrades_to_content_create(
-    x_usage, tmp_path, real_flow
-):
-    """Near-limit Unicode labels avoid repeated IDNA work and remain non-link."""
-    text = "a." + (("é" * 20 + ".") * 1_400) + "notatld"
-    request_body = json.dumps({"text": text}, ensure_ascii=False).encode()
+def test_tweet_create_repeated_unicode_labels_reuse_classification(x_usage, tmp_path, real_flow):
+    """Repeated Unicode labels reuse IDNA work and remain non-link."""
+    text = "a." + (("é" * 20 + ".") * 1_189) + "notatld"
+    request_body = json.dumps(
+        {"text": text},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    assert len(text) == 24_978
+    assert len(request_body) == 48_769
     assert len(request_body) < REQUEST_BODY_BILLING_INSPECTION_LIMIT
     flow = x_usage.make_flow(
         real_flow,
@@ -837,8 +842,22 @@ def test_tweet_create_near_limit_non_link_candidate_downgrades_to_content_create
     flow.request.method = "POST"
     flow.request.content = request_body
 
-    p = x_usage.call_and_get_single_billing(flow)
+    with (
+        patch.object(
+            x_billing,
+            "normalize_idna_label",
+            wraps=x_billing.normalize_idna_label,
+        ) as normalize_idna_label,
+        patch.object(
+            x_billing,
+            "_label_has_tld_prefix_before_unicode",
+            wraps=x_billing._label_has_tld_prefix_before_unicode,
+        ) as label_has_tld_prefix_before_unicode,
+    ):
+        p = x_usage.call_and_get_single_billing(flow)
 
+    assert normalize_idna_label.call_count == 3
+    assert label_has_tld_prefix_before_unicode.call_count == 2
     assert p["category"] == "content.create"
     assert p["quantity"] == 1
 


### PR DESCRIPTION
## Summary

- memoize complete IDNA normalization outcomes and Unicode-prefix classifications within each X bare-domain candidate
- preserve occurrence-specific unsafe compatibility, invalid-label, TLD, boundary, and early-exit behavior
- turn the exact 24,978-character connector-flow reproduction into a deterministic regression that bounds repeated classification work
- retain the existing ordinary ASCII fast path and avoid persistent user-derived cache state

## Explicit exclusions

- no request-wide or process-global cache
- no API, schema, migration, dependency, configuration, persisted-state, or async usage lifecycle change

## Benchmark

Python 3.14.0, six direct calls per input with the first timing discarded, using the same instrumented benchmark before and after:

| Repeated labels | Before calls | After calls | Before median | After median |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 102 | 3 | 6.016 ms | 0.251 ms |
| 200 | 202 | 3 | 10.842 ms | 0.306 ms |
| 400 | 402 | 3 | 23.375 ms | 0.508 ms |
| 800 | 802 | 3 | 46.595 ms | 0.875 ms |
| 1,189 | 1,191 | 3 | 66.385 ms | 1.237 ms |

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused X write regressions: 37 passed
- `uv run --no-sync python -m pytest tests/x_connector_usage/`: 227 passed
- `uv run --no-sync python -m pytest tests/`: 6,593 passed
- pre-commit Ruff and file-size hooks
- commitlint

Closes #28965
