### PR TITLE
fix(python): reject negative x response counts

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -34,7 +34,10 @@ from .x_billing import (
     include_billing_category,
     refine_bucket_with_body,
 )
-from .x_response_inspection import parse_json_response_fields_from_body
+from .x_response_inspection import (
+    as_non_negative_response_count,
+    parse_json_response_fields_from_body,
+)
 
 # HTTP 2xx success range (RFC 9110). Also defined in ``response_streaming.py``
 # and ``x_response_inspection.py``; kept local to avoid a constants module for a
@@ -160,10 +163,6 @@ def _compile_request_fallback_hint_policies(
 _REQUEST_FALLBACK_HINT_POLICIES = _compile_request_fallback_hint_policies(
     _REQUEST_FALLBACK_HINT_POLICY_SPECS
 )
-
-
-def _as_non_bool_int(value: object) -> int | None:
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _count_bounded_non_empty_comma_segments(value: str, max_count: int) -> int | None:
@@ -522,7 +521,7 @@ def _compute_billable_counts(
 
     if resp_meta.get("body_parsed"):
         if req_meta.get("is_count_endpoint"):
-            total = _as_non_bool_int(resp_meta.get("response_total_tweet_count"))
+            total = as_non_negative_response_count(resp_meta.get("response_total_tweet_count"))
             primary = 0 if total is None else total
         else:
             # Body was parsed — trust actual response counts.
@@ -748,7 +747,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         method == "GET"
         and req_meta.get("is_count_endpoint")
         and resp_meta.get("body_parsed")
-        and _as_non_bool_int(resp_meta.get("response_total_tweet_count")) is None
+        and as_non_negative_response_count(resp_meta.get("response_total_tweet_count")) is None
     ):
         log_usage_underbilling(
             proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
@@ -70,8 +70,9 @@ _X_JSON_RESULT_COUNT_FIELDS = {
 }
 
 
-def _as_non_bool_int(value: object) -> int | None:
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
+def as_non_negative_response_count(value: object) -> int | None:
+    """Return an X response count only when it is a non-negative integer."""
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
 def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
@@ -109,11 +110,13 @@ def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
     if includes:
         result["response_includes"] = dict(includes)
 
-    result_count = _as_non_bool_int(extracted.values.get(("meta", "result_count")))
+    result_count = as_non_negative_response_count(extracted.values.get(("meta", "result_count")))
     if result_count is not None:
         result["response_result_count"] = result_count
 
-    total_tweet_count = _as_non_bool_int(extracted.values.get(("meta", "total_tweet_count")))
+    total_tweet_count = as_non_negative_response_count(
+        extracted.values.get(("meta", "total_tweet_count"))
+    )
     if total_tweet_count is not None:
         result["response_total_tweet_count"] = total_tweet_count
 

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -444,6 +444,21 @@ class TestXJsonFinalize:
         response_streaming.finalize_connector_response_state(flow)
         assert flow.metadata[metadata_keys.X_JSON_STATE] == state
 
+    def test_finalizes_x_json_state_without_negative_counts(self, real_flow):
+        flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(flow)
+
+        response_stream(flow)(
+            b'{"data":[{"id":"1"}],"meta":{"result_count":-1,"total_tweet_count":-2}}'
+        )
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == {
+            "body_parsed": True,
+            "body_truncated": False,
+            "response_data_count": 1,
+        }
+
     def test_protocol_shaped_data_array_stays_within_work_limit(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
         data_item = b'{"id":"123456"}'

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
@@ -462,27 +462,39 @@ def test_tweet_counts_path_matching_requires_exact_endpoint(x_usage, tmp_path, r
     assert p["quantity"] == 3
 
 
-def test_tweet_counts_missing_total_skips_billing_and_logs_underbilling(
-    x_usage, tmp_path, real_flow
+@pytest.mark.parametrize(
+    ("meta", "query"),
+    [
+        pytest.param({}, "query=missing_total", id="missing"),
+        pytest.param(
+            {"total_tweet_count": -1},
+            "query=negative_total",
+            id="negative",
+        ),
+    ],
+)
+def test_tweet_counts_invalid_total_skips_billing_and_logs_underbilling(
+    x_usage, tmp_path, real_flow, meta, query
 ):
-    """Parsed count endpoint responses without total_tweet_count should not bill buckets."""
+    """Parsed count endpoints without a valid total should not bill buckets."""
     body = json.dumps(
         {
             "data": [
                 {"start": "2026-04-14T00:00", "end": "2026-04-15T00:00", "tweet_count": 2},
                 {"start": "2026-04-15T00:00", "end": "2026-04-16T00:00", "tweet_count": 3},
             ],
-            "meta": {},
+            "meta": meta,
         }
     ).encode()
     flow = x_usage.make_flow(
         real_flow,
         tmp_path,
         path="/2/tweets/counts/recent",
-        query="query=missing_total",
+        query=query,
         body=body,
         rule="GET /2/tweets/counts/recent",
     )
+    assert metadata_keys.X_JSON_STATE not in flow.metadata
 
     assert x_usage.call_and_get_billing(flow) == []
 


### PR DESCRIPTION
## Summary

- treat X `result_count` and `total_tweet_count` metadata as non-negative integers
- share one response-count normalizer across inspection and usage reporting
- preserve parsed response data while routing invalid count-endpoint totals to the existing confirmed-underbilling diagnostic
- cover incremental response finalization and buffered usage reporting

## Behavior

Negative X response counts are now omitted from billing metadata instead of being treated as present. This does not fail the run or invalidate unrelated response observations. A parsed count endpoint with a negative `total_tweet_count` emits no usage event and records `missing_count_endpoint_total`, matching the existing behavior for a missing total. Zero and positive counts are unchanged.

This PR does not change the generic selective JSON parser, add fallback billing estimates, introduce a new diagnostic reason, or touch API/protocol/persisted-state compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_x_response_parsers.py tests/x_connector_usage/test_reads.py` (80 passed)
- `uv run --no-sync python -m pytest tests/` (6594 passed)
- `git diff --check`

Closes #28958
