### PR TITLE
fix(db): bound stage 8 production migration

### DIFF
--- a/turbo/packages/db/scripts/test-retired-agent-plane-contraction.ts
+++ b/turbo/packages/db/scripts/test-retired-agent-plane-contraction.ts
@@ -51,13 +51,22 @@ const artifactRunIds = [
   "00000000-0000-4000-8200-000000980002",
 ] as const;
 const artifactThreadId = "00000000-0000-4000-8300-000000980001";
+const artifactConversationIds = artifactRunIds.map((_, index) => {
+  return `00000000-0000-4000-9000-${String(980_001 + index).padStart(12, "0")}`;
+});
+const artifactCheckpointIds = artifactRunIds.map((_, index) => {
+  return `00000000-0000-4000-9100-${String(980_001 + index).padStart(12, "0")}`;
+});
 const canonicalAgentId = "00000000-0000-4000-8400-000000980001";
 const canonicalSessionId = "00000000-0000-4000-8500-000000980001";
 const canonicalRunId = "00000000-0000-4000-8600-000000980001";
 const canonicalConversationId = "00000000-0000-4000-8700-000000980001";
 const canonicalCheckpointId = "00000000-0000-4000-8800-000000980001";
+const canonicalThreadId = "00000000-0000-4000-8300-000000980002";
+const canonicalThreadEventId = "00000000-0000-4000-9200-000000980028";
 const storageId = "00000000-0000-4000-8900-000000980001";
 const usageEventId = "00000000-0000-4000-8a00-000000980001";
+const protectedUsageEventId = "00000000-0000-4000-8a00-000000980002";
 const usageRollupId = "00000000-0000-4000-8b00-000000980001";
 const usageAllocationId = "00000000-0000-4000-8c00-000000980001";
 const entitlementId = "00000000-0000-4000-8d00-000000980001";
@@ -319,12 +328,6 @@ async function seedApprovedClosure(
       [artifactThreadId, artifactIds[0]],
     );
 
-    const conversations = artifactRunIds.map((_, index) => {
-      return `00000000-0000-4000-9000-${String(980_001 + index).padStart(12, "0")}`;
-    });
-    const checkpoints = artifactRunIds.map((_, index) => {
-      return `00000000-0000-4000-9100-${String(980_001 + index).padStart(12, "0")}`;
-    });
     await client.query(
       `
         INSERT INTO "conversations" (
@@ -335,7 +338,7 @@ async function seedApprovedClosure(
         FROM unnest($1::uuid[], $2::uuid[])
           AS "conversation"("conversation_id", "run_id")
       `,
-      [conversations, artifactRunIds],
+      [artifactConversationIds, artifactRunIds],
     );
     await client.query(
       `
@@ -348,7 +351,7 @@ async function seedApprovedClosure(
         FROM unnest($1::uuid[], $2::uuid[], $3::uuid[])
           AS "checkpoint"("checkpoint_id", "run_id", "conversation_id")
       `,
-      [checkpoints, artifactRunIds, conversations],
+      [artifactCheckpointIds, artifactRunIds, artifactConversationIds],
     );
 
     await seedProtectedHistory(client);
@@ -408,6 +411,34 @@ async function seedProtectedHistory(client: Client): Promise<void> {
   );
   await client.query(
     `
+      INSERT INTO "chat_threads" (
+        "id", "user_id", "agent_id", "title"
+      ) VALUES ($1, 'stage8-protected-user', $2, 'stage8 protected thread')
+    `,
+    [canonicalThreadId, canonicalAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_thread_events" (
+        "id", "user_id", "org_id", "chat_thread_id", "kind",
+        "agent_id", "title", "seq_id"
+      ) VALUES ($1, 'stage8-protected-user', 'stage8-protected-org', $2,
+        'created', $3, 'stage8 protected thread', 1)
+    `,
+    [canonicalThreadEventId, canonicalThreadId, canonicalAgentId],
+  );
+  await client.query(
+    `
+      INSERT INTO "chat_event_search_messages" (
+        "chat_thread_id", "seq_id", "user_id", "org_id", "agent_id",
+        "role", "created_at", "text", "text_bigram"
+      ) VALUES ($1, 1, 'stage8-protected-user', 'stage8-protected-org', $2,
+        'user', now(), 'stage8 protected message', 'stage8 protected message')
+    `,
+    [canonicalThreadId, canonicalAgentId],
+  );
+  await client.query(
+    `
       INSERT INTO "storages" (
         "id", "user_id", "org_id", "name", "s3_prefix"
       ) VALUES ($1, 'stage8-protected-user', 'stage8-protected-org',
@@ -423,6 +454,20 @@ async function seedProtectedHistory(client: Client): Promise<void> {
         'stage8-protected-user', 1)
     `,
     ["f".repeat(64), storageId],
+  );
+  await client.query(
+    `
+      INSERT INTO "usage_event" (
+        "id", "run_id", "idempotency_key", "org_id", "user_id", "kind",
+        "provider", "category", "quantity", "credits_charged", "status"
+      ) VALUES ($1, $2, $3, 'stage8-protected-org', 'stage8-protected-user',
+        'model', 'fixture', 'tokens', 20, 2, 'processed')
+    `,
+    [
+      protectedUsageEventId,
+      canonicalRunId,
+      "00000000-0000-4000-9500-000000980002",
+    ],
   );
 
   const anchorEventIds = Array.from({ length: 27 }, (_, index) => {
@@ -545,37 +590,136 @@ async function assertFinalState(client: Client): Promise<void> {
   `);
   assert.equal(legacyColumns.rows[0]?.count, 0);
 
+  const deletedArtifactRows = await client.query<{
+    sessionCount: number;
+    runCount: number;
+    conversationCount: number;
+    checkpointCount: number;
+    threadCount: number;
+    searchMessageCount: number;
+  }>(
+    `
+      SELECT
+        (SELECT count(*)::integer FROM "agent_sessions"
+          WHERE "id" = ANY($1::uuid[])) AS "sessionCount",
+        (SELECT count(*)::integer FROM "agent_runs"
+          WHERE "id" = ANY($2::uuid[])) AS "runCount",
+        (SELECT count(*)::integer FROM "conversations"
+          WHERE "id" = ANY($3::uuid[])) AS "conversationCount",
+        (SELECT count(*)::integer FROM "checkpoints"
+          WHERE "id" = ANY($4::uuid[])) AS "checkpointCount",
+        (SELECT count(*)::integer FROM "chat_threads"
+          WHERE "id" = $5) AS "threadCount",
+        (SELECT count(*)::integer FROM "chat_event_search_messages"
+          WHERE "chat_thread_id" = $5) AS "searchMessageCount"
+    `,
+    [
+      artifactSessionIds,
+      artifactRunIds,
+      artifactConversationIds,
+      artifactCheckpointIds,
+      artifactThreadId,
+    ],
+  );
+  assert.deepEqual(deletedArtifactRows.rows, [
+    {
+      sessionCount: 0,
+      runCount: 0,
+      conversationCount: 0,
+      checkpointCount: 0,
+      threadCount: 0,
+      searchMessageCount: 0,
+    },
+  ]);
+
   const protectedRows = await client.query<{
     agentCount: number;
     sessionCount: number;
     runCount: number;
+    conversationCount: number;
     checkpointCount: number;
+    threadCount: number;
+    eventCount: number;
+    searchMessageCount: number;
     storageCount: number;
     storageVersionCount: number;
+    usageEventCount: number;
     anchorCount: number;
   }>(
     `
       SELECT
-        (SELECT count(*)::integer FROM "agents" WHERE "id" = $1) AS "agentCount",
-        (SELECT count(*)::integer FROM "agent_sessions" WHERE "id" = $2) AS "sessionCount",
+        (SELECT count(*)::integer FROM "agents"
+          WHERE "id" = $1
+            AND "org_id" = 'stage8-protected-org'
+            AND "owner" = 'stage8-protected-user'
+            AND "name" = 'stage8-protected-agent') AS "agentCount",
+        (SELECT count(*)::integer FROM "agent_sessions"
+          WHERE "id" = $2
+            AND "user_id" = 'stage8-protected-user'
+            AND "org_id" = 'stage8-protected-org'
+            AND "agent_id" = $1) AS "sessionCount",
         (SELECT count(*)::integer FROM "agent_runs"
-          WHERE "id" = $3 AND "launch_snapshot" IS NOT NULL) AS "runCount",
+          WHERE "id" = $3
+            AND "status" = 'completed'
+            AND "session_id" = $2
+            AND "launch_snapshot" =
+              '{"schemaVersion":1,"framework":"claude-code","runnerProfile":"default"}'::jsonb)
+          AS "runCount",
+        (SELECT count(*)::integer FROM "conversations"
+          WHERE "id" = $4
+            AND "run_id" = $3
+            AND "cli_agent_session_id" = 'stage8-protected-session')
+          AS "conversationCount",
         (SELECT count(*)::integer FROM "checkpoints"
-          WHERE "id" = $4 AND "storage_mounts" = '{"protected":true}'::jsonb)
+          WHERE "id" = $5
+            AND "run_id" = $3
+            AND "conversation_id" = $4
+            AND "storage_mounts" = '{"protected":true}'::jsonb)
           AS "checkpointCount",
-        (SELECT count(*)::integer FROM "storages" WHERE "id" = $5) AS "storageCount",
-        (SELECT count(*)::integer FROM "storage_versions" WHERE "storage_id" = $5)
+        (SELECT count(*)::integer FROM "chat_threads"
+          WHERE "id" = $6
+            AND "user_id" = 'stage8-protected-user'
+            AND "agent_id" = $1
+            AND "title" = 'stage8 protected thread') AS "threadCount",
+        (SELECT count(*)::integer FROM "chat_thread_events"
+          WHERE "id" = $7
+            AND "chat_thread_id" = $6
+            AND "agent_id" = $1
+            AND "title" = 'stage8 protected thread') AS "eventCount",
+        (SELECT count(*)::integer FROM "chat_event_search_messages"
+          WHERE "chat_thread_id" = $6
+            AND "seq_id" = 1
+            AND "agent_id" = $1
+            AND "text" = 'stage8 protected message') AS "searchMessageCount",
+        (SELECT count(*)::integer FROM "storages"
+          WHERE "id" = $8
+            AND "name" = 'stage8-protected-storage'
+            AND "s3_prefix" = 'stage8/protected/storage') AS "storageCount",
+        (SELECT count(*)::integer FROM "storage_versions"
+          WHERE "storage_id" = $8
+            AND "s3_key" = 'stage8/protected/storage/version'
+            AND "archive_size" = 1)
           AS "storageVersionCount",
+        (SELECT count(*)::integer FROM "usage_event"
+          WHERE "id" = $9
+            AND "run_id" = $3
+            AND "quantity" = 20
+            AND "credits_charged" = 2) AS "usageEventCount",
         (SELECT count(*)::integer FROM "chat_thread_events"
           WHERE "id"::text LIKE '00000000-0000-4000-9200-%'
+            AND "id" <> $7
             AND "agent_id" IS NULL) AS "anchorCount"
     `,
     [
       canonicalAgentId,
       canonicalSessionId,
       canonicalRunId,
+      canonicalConversationId,
       canonicalCheckpointId,
+      canonicalThreadId,
+      canonicalThreadEventId,
       storageId,
+      protectedUsageEventId,
     ],
   );
   assert.deepEqual(protectedRows.rows, [
@@ -583,32 +727,57 @@ async function assertFinalState(client: Client): Promise<void> {
       agentCount: 1,
       sessionCount: 1,
       runCount: 1,
+      conversationCount: 1,
       checkpointCount: 1,
+      threadCount: 1,
+      eventCount: 1,
+      searchMessageCount: 1,
       storageCount: 1,
       storageVersionCount: 1,
+      usageEventCount: 1,
       anchorCount: 27,
     },
   ]);
 
   const billing = await client.query<{
-    usageEventRunId: string | null;
-    rollupRunId: string | null;
-    allocationRunId: string | null;
-    shortWindowRunId: string | null;
-    weeklyWindowRunId: string | null;
+    usageEventCount: number;
+    rollupCount: number;
+    allocationCount: number;
+    shortWindowCount: number;
+    weeklyWindowCount: number;
+    entitlementCount: number;
   }>(
     `
       SELECT
-        (SELECT "run_id"::text FROM "usage_event" WHERE "id" = $1)
-          AS "usageEventRunId",
-        (SELECT "run_id"::text FROM "usage_event_hourly_rollup" WHERE "id" = $2)
-          AS "rollupRunId",
-        (SELECT "run_id"::text FROM "usage_allowance_allocations" WHERE "id" = $3)
-          AS "allocationRunId",
-        (SELECT "created_by_run_id"::text FROM "org_usage_allowance_windows"
-          WHERE "id" = $4) AS "shortWindowRunId",
-        (SELECT "created_by_run_id"::text FROM "org_usage_allowance_windows"
-          WHERE "id" = $5) AS "weeklyWindowRunId"
+        (SELECT count(*)::integer FROM "usage_event"
+          WHERE "id" = $1
+            AND "run_id" IS NULL
+            AND "quantity" = 10
+            AND "credits_charged" = 1) AS "usageEventCount",
+        (SELECT count(*)::integer FROM "usage_event_hourly_rollup"
+          WHERE "id" = $2
+            AND "run_id" IS NULL
+            AND "quantity" = 10
+            AND "credits_charged" = 1) AS "rollupCount",
+        (SELECT count(*)::integer FROM "usage_allowance_allocations"
+          WHERE "id" = $3
+            AND "run_id" IS NULL
+            AND "usage_event_id" = $1
+            AND "units_applied" = 1) AS "allocationCount",
+        (SELECT count(*)::integer FROM "org_usage_allowance_windows"
+          WHERE "id" = $4
+            AND "created_by_run_id" IS NULL
+            AND "kind" = 'short'
+            AND "unit_limit" = 100) AS "shortWindowCount",
+        (SELECT count(*)::integer FROM "org_usage_allowance_windows"
+          WHERE "id" = $5
+            AND "created_by_run_id" IS NULL
+            AND "kind" = 'weekly'
+            AND "unit_limit" = 1000) AS "weeklyWindowCount",
+        (SELECT count(*)::integer FROM "org_usage_allowance_entitlements"
+          WHERE "id" = $6
+            AND "short_window_units" = 100
+            AND "weekly_window_units" = 1000) AS "entitlementCount"
     `,
     [
       usageEventId,
@@ -616,15 +785,17 @@ async function assertFinalState(client: Client): Promise<void> {
       usageAllocationId,
       shortWindowId,
       weeklyWindowId,
+      entitlementId,
     ],
   );
   assert.deepEqual(billing.rows, [
     {
-      usageEventRunId: null,
-      rollupRunId: null,
-      allocationRunId: null,
-      shortWindowRunId: null,
-      weeklyWindowRunId: null,
+      usageEventCount: 1,
+      rollupCount: 1,
+      allocationCount: 1,
+      shortWindowCount: 1,
+      weeklyWindowCount: 1,
+      entitlementCount: 1,
     },
   ]);
 }
@@ -635,6 +806,14 @@ function assertStaticBoundary(): void {
   );
   assert.doesNotMatch(productionMigrationSql, /\bCASCADE\b/u);
   assert.doesNotMatch(productionMigrationSql, /\bLOCK\s+TABLE\b/u);
+  assert.doesNotMatch(
+    productionMigrationSql,
+    /_stage8_preservation|current_preservation|\bbit_xor\s*\(|\bhashtextextended\s*\(/u,
+  );
+  assert.match(
+    productionMigrationSql,
+    /Broad before\/after preservation acceptance is controller-owned through\s+-- read-only MaskDB/u,
+  );
   assert.match(
     productionMigrationSql,
     /01390c8ae78016cf5cb60f7cf50ee70d5400e4a4/u,
@@ -856,14 +1035,64 @@ async function validateExactCleanupAndLockRetry(): Promise<void> {
         syntheticMigrationSql(),
         /lock timeout|canceling statement due to lock timeout/u,
       );
-      const artifactsAfterRollback = await client.query<{ count: number }>(
+      const rollbackState = await client.query<{
+        artifactCount: number;
+        sessionCount: number;
+        runCount: number;
+        threadCount: number;
+        searchMessageCount: number;
+        protectedCount: number;
+        triggerCount: number;
+        functionCount: number;
+      }>(
         `
-        SELECT count(*)::integer AS "count" FROM "agent_composes"
-        WHERE "id" = ANY($1::uuid[])
-      `,
-        [artifactIds],
+          SELECT
+            (SELECT count(*)::integer FROM "agent_composes"
+              WHERE "id" = ANY($1::uuid[])) AS "artifactCount",
+            (SELECT count(*)::integer FROM "agent_sessions"
+              WHERE "id" = ANY($2::uuid[])) AS "sessionCount",
+            (SELECT count(*)::integer FROM "agent_runs"
+              WHERE "id" = ANY($3::uuid[])) AS "runCount",
+            (SELECT count(*)::integer FROM "chat_threads"
+              WHERE "id" = $4) AS "threadCount",
+            (SELECT count(*)::integer FROM "chat_event_search_messages"
+              WHERE "chat_thread_id" = $4) AS "searchMessageCount",
+            (SELECT count(*)::integer FROM "agents" WHERE "id" = $5) +
+              (SELECT count(*)::integer FROM "agent_runs" WHERE "id" = $6) +
+              (SELECT count(*)::integer FROM "storages" WHERE "id" = $7)
+              AS "protectedCount",
+            (SELECT count(*)::integer FROM "pg_trigger"
+              WHERE NOT "tgisinternal"
+                AND "tgname" IN (
+                  'agent_compose_versions_delete_veto',
+                  'bridge_agent_composes_to_agents_0966'
+                )) AS "triggerCount",
+            (SELECT count(*)::integer FROM "pg_proc"
+              WHERE "proname" = 'bridge_legacy_agent_to_agents_0966')
+              AS "functionCount"
+        `,
+        [
+          artifactIds,
+          artifactSessionIds,
+          artifactRunIds,
+          artifactThreadId,
+          canonicalAgentId,
+          canonicalRunId,
+          storageId,
+        ],
       );
-      assert.equal(artifactsAfterRollback.rows[0]?.count, 6);
+      assert.deepEqual(rollbackState.rows, [
+        {
+          artifactCount: 6,
+          sessionCount: 22,
+          runCount: 2,
+          threadCount: 1,
+          searchMessageCount: 2,
+          protectedCount: 3,
+          triggerCount: 2,
+          functionCount: 1,
+        },
+      ]);
 
       await lockClient.query("ROLLBACK");
       await runMigration(client, syntheticMigrationSql());

--- a/turbo/packages/db/src/migrations/0978_remove_retired_agent_compose_plane.sql
+++ b/turbo/packages/db/src/migrations/0978_remove_retired_agent_compose_plane.sql
@@ -6,6 +6,9 @@
 --
 -- This is intentionally a normal migration. migration-runner.ts owns the
 -- enclosing transaction plus lock_timeout=1s and statement_timeout=10s.
+-- Broad before/after preservation acceptance is controller-owned through
+-- read-only MaskDB. This transaction keeps only the exact mutation-boundary
+-- gates needed to prove that the frozen artifact closure is safe to remove.
 
 DO $$
 DECLARE
@@ -742,164 +745,6 @@ BEGIN
 END
 $$;--> statement-breakpoint
 
-CREATE TEMP TABLE "_stage8_preservation" (
-  "cohort" text PRIMARY KEY,
-  "row_count" bigint NOT NULL,
-  "row_digest" bigint NOT NULL
-) ON COMMIT DROP;--> statement-breakpoint
-
-INSERT INTO "_stage8_preservation" ("cohort", "row_count", "row_digest")
-SELECT
-  'agents',
-  count(*),
-  coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-FROM "agents" AS "row"
-UNION ALL
-SELECT
-  'agent_sessions',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "agent_sessions" AS "row"
-WHERE "row"."id" NOT IN (SELECT "id" FROM "_stage8_artifact_sessions")
-UNION ALL
-SELECT
-  'agent_runs',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_version_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "agent_runs" AS "row"
-WHERE "row"."id" NOT IN (SELECT "id" FROM "_stage8_artifact_runs")
-UNION ALL
-SELECT
-  'chat_threads',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "chat_threads" AS "row"
-WHERE "row"."id" NOT IN (SELECT "id" FROM "_stage8_artifact_threads")
-UNION ALL
-SELECT
-  'chat_thread_events',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "chat_thread_events" AS "row"
-UNION ALL
-SELECT
-  'chat_event_search_messages',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "chat_event_search_messages" AS "row"
-WHERE ("row"."chat_thread_id", "row"."seq_id") NOT IN (
-  SELECT "chat_thread_id", "seq_id"
-  FROM "_stage8_artifact_search_messages"
-)
-UNION ALL
-SELECT
-  'checkpoints',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'agent_compose_snapshot')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "checkpoints" AS "row"
-WHERE "row"."run_id" NOT IN (SELECT "id" FROM "_stage8_artifact_runs")
-UNION ALL
-SELECT
-  'storages',
-  count(*),
-  coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-FROM "storages" AS "row"
-UNION ALL
-SELECT
-  'storage_versions',
-  count(*),
-  coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-FROM "storage_versions" AS "row"
-UNION ALL
-SELECT
-  'usage_event',
-  count(*),
-  coalesce(
-    bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-    0
-  )
-FROM "usage_event" AS "row"
-UNION ALL
-SELECT
-  'usage_event_hourly_rollup',
-  count(*),
-  coalesce(
-    bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-    0
-  )
-FROM "usage_event_hourly_rollup" AS "row"
-UNION ALL
-SELECT
-  'usage_allowance_allocations',
-  count(*),
-  coalesce(
-    bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-    0
-  )
-FROM "usage_allowance_allocations" AS "row"
-UNION ALL
-SELECT
-  'org_usage_allowance_windows',
-  count(*),
-  coalesce(
-    bit_xor(
-      hashtextextended(
-        (to_jsonb("row") - 'created_by_run_id')::text,
-        0
-      )
-    ),
-    0
-  )
-FROM "org_usage_allowance_windows" AS "row";--> statement-breakpoint
-
 CREATE TEMP TABLE "_stage8_artifact_billing" ON COMMIT DROP AS
 SELECT
   'usage_event'::text AS "cohort",
@@ -1038,6 +883,11 @@ BEGIN
         "row"."run_id",
         (to_jsonb("row") - 'run_id')::text AS "payload"
       FROM "usage_event" AS "row"
+      WHERE "row"."id" IN (
+        SELECT "id"
+        FROM "_stage8_artifact_billing"
+        WHERE "cohort" = 'usage_event'
+      )
       UNION ALL
       SELECT
         'usage_event_hourly_rollup',
@@ -1045,6 +895,11 @@ BEGIN
         "row"."run_id",
         (to_jsonb("row") - 'run_id')::text
       FROM "usage_event_hourly_rollup" AS "row"
+      WHERE "row"."id" IN (
+        SELECT "id"
+        FROM "_stage8_artifact_billing"
+        WHERE "cohort" = 'usage_event_hourly_rollup'
+      )
       UNION ALL
       SELECT
         'usage_allowance_allocations',
@@ -1052,6 +907,11 @@ BEGIN
         "row"."run_id",
         (to_jsonb("row") - 'run_id')::text
       FROM "usage_allowance_allocations" AS "row"
+      WHERE "row"."id" IN (
+        SELECT "id"
+        FROM "_stage8_artifact_billing"
+        WHERE "cohort" = 'usage_allowance_allocations'
+      )
       UNION ALL
       SELECT
         'org_usage_allowance_windows',
@@ -1059,6 +919,11 @@ BEGIN
         "row"."created_by_run_id",
         (to_jsonb("row") - 'created_by_run_id')::text
       FROM "org_usage_allowance_windows" AS "row"
+      WHERE "row"."id" IN (
+        SELECT "id"
+        FROM "_stage8_artifact_billing"
+        WHERE "cohort" = 'org_usage_allowance_windows'
+      )
     )
     SELECT 1
     FROM "_stage8_artifact_billing" AS "frozen"
@@ -1322,116 +1187,6 @@ $$;--> statement-breakpoint
 
 DO $$
 BEGIN
-  IF EXISTS (
-    WITH current_preservation AS (
-      SELECT
-        'agents'::text AS "cohort",
-        count(*) AS "row_count",
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-          AS "row_digest"
-      FROM "agents" AS "row"
-      UNION ALL
-      SELECT
-        'agent_sessions',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "agent_sessions" AS "row"
-      UNION ALL
-      SELECT
-        'agent_runs',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "agent_runs" AS "row"
-      UNION ALL
-      SELECT
-        'chat_threads',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "chat_threads" AS "row"
-      UNION ALL
-      SELECT
-        'chat_thread_events',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "chat_thread_events" AS "row"
-      UNION ALL
-      SELECT
-        'chat_event_search_messages',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "chat_event_search_messages" AS "row"
-      UNION ALL
-      SELECT
-        'checkpoints',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "checkpoints" AS "row"
-      UNION ALL
-      SELECT
-        'storages',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "storages" AS "row"
-      UNION ALL
-      SELECT
-        'storage_versions',
-        count(*),
-        coalesce(bit_xor(hashtextextended(to_jsonb("row")::text, 0)), 0)
-      FROM "storage_versions" AS "row"
-      UNION ALL
-      SELECT
-        'usage_event',
-        count(*),
-        coalesce(
-          bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-          0
-        )
-      FROM "usage_event" AS "row"
-      UNION ALL
-      SELECT
-        'usage_event_hourly_rollup',
-        count(*),
-        coalesce(
-          bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-          0
-        )
-      FROM "usage_event_hourly_rollup" AS "row"
-      UNION ALL
-      SELECT
-        'usage_allowance_allocations',
-        count(*),
-        coalesce(
-          bit_xor(hashtextextended((to_jsonb("row") - 'run_id')::text, 0)),
-          0
-        )
-      FROM "usage_allowance_allocations" AS "row"
-      UNION ALL
-      SELECT
-        'org_usage_allowance_windows',
-        count(*),
-        coalesce(
-          bit_xor(
-            hashtextextended(
-              (to_jsonb("row") - 'created_by_run_id')::text,
-              0
-            )
-          ),
-          0
-        )
-      FROM "org_usage_allowance_windows" AS "row"
-    )
-    SELECT 1
-    FROM "_stage8_preservation" AS "frozen"
-    FULL OUTER JOIN current_preservation AS "current"
-      ON "current"."cohort" = "frozen"."cohort"
-    WHERE "current"."cohort" IS NULL
-      OR "frozen"."cohort" IS NULL
-      OR "current"."row_count" IS DISTINCT FROM "frozen"."row_count"
-      OR "current"."row_digest" IS DISTINCT FROM "frozen"."row_digest"
-  ) THEN
-    RAISE EXCEPTION 'Stage 8 protected history/Storage preservation drift';
-  END IF;
-
   IF EXISTS (
     SELECT 1
     FROM "_stage8_deleted_anchor_events" AS "frozen"


### PR DESCRIPTION
## Summary

- amend migration 0978 in place to remove the production-wide 13-table preservation hashes that exceeded the runner's 10-second statement bound
- keep the approved exact-six, identity, canonical reference, catalog, closure, active-Run, dependency, billing/usage, protected-anchor, exact-delete, and final-schema gates transactional and fail-closed
- restrict billing/usage postflight reads to the frozen artifact billing keys and strengthen the focused PostgreSQL harness around exact mutation scope, rollback/retry, protected sentinels, billing retention, and final schema

## Pre-first-production-application exception

`db-v1.218.10` has already been published, but production migration 0978 has not run. [Production run 32710405987](https://github.com/vm0-ai/vm0/actions/runs/32710405987) failed in **Run Production Migration Smoke Test** with SQLSTATE `57014`, and **Run Production Migrations** was skipped. A new 0979 cannot correct the blocker because the migration runner must execute 0978 first, so this PR applies the reviewed pre-first-production-application exception and edits 0978 in place.

The removed whole-table byte-digest acceptance is controller-owned through read-only MaskDB before and after release; Axiom remains the runtime observation plane. The migration itself still owns the exact mutation-boundary safety gates that must be atomic with the drop. It remains a normal transaction with the existing `lock_timeout=1s` and `statement_timeout=10s`, without `CASCADE`, expanded deletion scope, synthesized data, or direct production access.

## Verification

Per controller direction, no local tests or development server were run; GitHub PR CI is the sole validation source. `CI_CHECK_IMMUTABLE_MIGRATE` remains `1`, so the initial migration immutability failure is expected until the controller authorizes its temporary override.

References #28742

Parent #26938