### PR TITLE
test(runner): exercise workspace cache statvfs boundary

### DIFF
--- a/crates/runner/src/workspace_image_cache/fs.rs
+++ b/crates/runner/src/workspace_image_cache/fs.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-#[cfg(not(test))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use tokio::fs;
@@ -27,9 +26,13 @@ impl WorkspaceImageCache {
 
         #[cfg(not(test))]
         {
-            let path = self.workspace_image_cache_fs_stats_path();
-            statvfs_bytes(&path).await
+            self.query_fs_stats().await
         }
+    }
+
+    pub(super) async fn query_fs_stats(&self) -> RunnerResult<FsStats> {
+        let path = self.workspace_image_cache_fs_stats_path();
+        statvfs_bytes(&path).await
     }
 
     pub(super) async fn ensure_workspace_cache_entry_dir(
@@ -202,7 +205,6 @@ fn cp_command_error(error: BoundedCommandError) -> RunnerError {
     }
 }
 
-#[cfg(not(test))]
 pub(super) async fn statvfs_bytes(path: &Path) -> RunnerResult<FsStats> {
     let path = path.to_owned();
     tokio::task::spawn_blocking(move || statvfs_bytes_sync(&path))
@@ -233,26 +235,29 @@ pub(super) async fn entry_file_type_matches(
     }
 }
 
-#[cfg(not(test))]
 pub(super) fn statvfs_bytes_sync(path: &Path) -> RunnerResult<FsStats> {
-    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    let stats = statvfs_for_path(path)?;
+    Ok(fs_stats_from_statvfs(&stats))
+}
+
+pub(super) fn statvfs_for_path(path: &Path) -> RunnerResult<libc::statvfs> {
     let bytes = path.as_os_str().as_bytes();
-    let c_path = std::ffi::CString::new(bytes).map_err(|_| {
-        RunnerError::Internal(format!(
-            "statvfs path contains nul byte: {}",
-            path.display()
-        ))
-    })?;
+    let c_path = std::ffi::CString::new(bytes)
+        .map_err(|_| RunnerError::Internal("statvfs path contains nul byte".to_owned()))?;
+    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
     let rc = unsafe { libc::statvfs(c_path.as_ptr(), stats.as_mut_ptr()) };
     if rc != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    let stats = unsafe { stats.assume_init() };
+    Ok(unsafe { stats.assume_init() })
+}
+
+pub(super) fn fs_stats_from_statvfs(stats: &libc::statvfs) -> FsStats {
     let block_size = stats.f_frsize;
-    Ok(FsStats {
+    FsStats {
         total_bytes: stats.f_blocks.saturating_mul(block_size),
         available_bytes: stats.f_bavail.saturating_mul(block_size),
-    })
+    }
 }
 
 async fn path_tree_allocated_bytes(path: &Path, metadata: std::fs::Metadata) -> u64 {

--- a/crates/runner/src/workspace_image_cache/tests/storage.rs
+++ b/crates/runner/src/workspace_image_cache/tests/storage.rs
@@ -1,10 +1,11 @@
 use tokio::fs;
 
 use super::super::fs::{
-    allocated_bytes, has_copy_headroom, sparse_copy_with_timeout,
-    workspace_cache_path_allocated_bytes,
+    allocated_bytes, fs_stats_from_statvfs, has_copy_headroom, sparse_copy_with_timeout,
+    statvfs_bytes_sync, statvfs_for_path, workspace_cache_path_allocated_bytes,
 };
 use super::super::{CacheBudget, FsStats, GIB, WorkspaceImageCache};
+use crate::error::RunnerError;
 use crate::paths::RunnerPaths;
 
 #[test]
@@ -55,6 +56,82 @@ fn fs_stats_path_falls_back_to_existing_parent_when_cache_dir_is_missing() {
         cache.workspace_image_cache_fs_stats_path(),
         paths.base_dir().to_path_buf()
     );
+}
+
+#[tokio::test]
+async fn real_fs_stats_queries_selected_existing_parent() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    std::fs::create_dir_all(paths.base_dir()).unwrap();
+    let cache = WorkspaceImageCache::new(paths.clone());
+
+    assert!(!paths.workspace_image_cache_dir().exists());
+    assert_eq!(
+        cache.workspace_image_cache_fs_stats_path(),
+        paths.base_dir().to_path_buf()
+    );
+
+    let stats = cache.query_fs_stats().await.unwrap();
+
+    assert!(stats.total_bytes > 0);
+    assert!(stats.available_bytes <= stats.total_bytes);
+}
+
+#[test]
+fn statvfs_conversion_uses_fragment_size_and_saturates() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut stats = statvfs_for_path(dir.path()).unwrap();
+    stats.f_bsize = 11;
+    stats.f_frsize = 3;
+    stats.f_blocks = 4;
+    stats.f_bavail = 5;
+
+    assert_eq!(
+        fs_stats_from_statvfs(&stats),
+        FsStats {
+            total_bytes: 12,
+            available_bytes: 15,
+        }
+    );
+
+    stats.f_frsize = 2;
+    stats.f_blocks = u64::MAX;
+    stats.f_bavail = u64::MAX;
+
+    assert_eq!(
+        fs_stats_from_statvfs(&stats),
+        FsStats {
+            total_bytes: u64::MAX,
+            available_bytes: u64::MAX,
+        }
+    );
+}
+
+#[test]
+fn statvfs_missing_path_preserves_io_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let error = statvfs_bytes_sync(&dir.path().join("missing"))
+        .expect_err("missing path should fail statvfs");
+    let RunnerError::Io(error) = error else {
+        panic!("missing path should preserve the io error");
+    };
+
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[test]
+fn statvfs_nul_path_is_rejected_without_path_contents() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let path =
+        std::path::PathBuf::from(OsString::from_vec(b"private-statvfs-path\0suffix".to_vec()));
+    let message = statvfs_bytes_sync(&path)
+        .expect_err("nul path should fail before statvfs")
+        .to_string();
+
+    assert_eq!(message, "internal error: statvfs path contains nul byte");
+    assert!(!message.contains("private-statvfs-path"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- compile the production workspace-cache `statvfs` query in Rust test builds while retaining deterministic injected filesystem statistics for higher-level tests
- share cache path selection, the blocking syscall wrapper, and fragment-size conversion between production and focused boundary coverage
- cover real filesystem capacity invariants, selected-parent fallback, `f_frsize` accounting, saturation, missing paths, and pre-FFI NUL rejection without echoing raw path contents

## Explicit exclusions

- no cache budget, GC, admission, inspection, or promotion policy changes
- no filesystem-statistics provider abstraction or new runner command/test hook
- no API, protocol, persisted-state, configuration, or rollout changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner workspace_image_cache::tests::storage` (14 passed)
- `cargo test -p runner --bin runner` (3272 passed, 20 ignored)

Closes #28962
