### PR TITLE
ci: avoid corepack bootstrap in runner e2e

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -81,7 +81,6 @@ account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
 pnpm_setup_action =
   "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86"
 pnpm_version = "10.33.4"
-pnpm_setup_steps = {}
 {
   "runner E2E preparation" => account_prepare,
   "runner E2E shards" => runner,
@@ -114,7 +113,6 @@ pnpm_setup_steps = {}
       "cd e2e && pnpm install --frozen-lockfile"
     raise "#{job_name} must keep the frozen E2E dependency install"
   end
-  pnpm_setup_steps[job_name] = pnpm_setup_step
 end
 
 playwright_step_names = playwright.fetch("steps").map { |step| step["name"] }
@@ -616,7 +614,9 @@ unless retain_step &&
   raise "failed runner work must retain reusable accounts explicitly"
 end
 
-cleanup_pnpm_setup_step = pnpm_setup_steps.fetch("runner E2E cleanup")
+cleanup_pnpm_setup_step = cleanup_steps.find do |step|
+  step["uses"] == pnpm_setup_action
+end
 cleanup_node_setup_step = cleanup_steps.find do |step|
   step.fetch("uses", "").start_with?("actions/setup-node@")
 end

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -78,6 +78,44 @@ account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 bootstrap = jobs.fetch("cli-e2e-03-runner-bootstrap")
 runner = jobs.fetch("cli-e2e-03-runner")
 account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
+pnpm_setup_action =
+  "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86"
+pnpm_version = "10.33.4"
+pnpm_setup_steps = {}
+{
+  "runner E2E preparation" => account_prepare,
+  "runner E2E shards" => runner,
+  "runner E2E cleanup" => account_cleanup,
+}.each do |job_name, job|
+  steps = job.fetch("steps")
+  pnpm_setup_index = steps.index do |step|
+    step["uses"] == pnpm_setup_action
+  end
+  node_setup_index = steps.index do |step|
+    step.fetch("uses", "").start_with?("actions/setup-node@")
+  end
+  unless pnpm_setup_index && node_setup_index &&
+      pnpm_setup_index < node_setup_index
+    raise "#{job_name} must install pnpm before selecting Node.js 22"
+  end
+  pnpm_setup_step = steps.fetch(pnpm_setup_index)
+  unless pnpm_setup_step.dig("with", "version") == pnpm_version
+    raise "#{job_name} must install the pinned pnpm version"
+  end
+  if steps.any? do |step|
+      step.fetch("run", "").include?("corepack enable pnpm")
+    end
+    raise "#{job_name} must not download pnpm through Node.js 22 Corepack"
+  end
+  dependency_install = steps.find do |step|
+    step["name"] == "Install E2E dependencies"
+  end
+  unless dependency_install&.fetch("run", nil) ==
+      "cd e2e && pnpm install --frozen-lockfile"
+    raise "#{job_name} must keep the frozen E2E dependency install"
+  end
+  pnpm_setup_steps[job_name] = pnpm_setup_step
+end
 
 playwright_step_names = playwright.fetch("steps").map { |step| step["name"] }
 browser_install_index = playwright_step_names.index("Install Playwright browsers")
@@ -578,10 +616,15 @@ unless retain_step &&
   raise "failed runner work must retain reusable accounts explicitly"
 end
 
+cleanup_pnpm_setup_step = pnpm_setup_steps.fetch("runner E2E cleanup")
+cleanup_node_setup_step = cleanup_steps.find do |step|
+  step.fetch("uses", "").start_with?("actions/setup-node@")
+end
+
 conditional_setup_steps = [
   cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") },
-  cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/setup-node@") },
-  cleanup_steps.find { |step| step["name"] == "Install pnpm" },
+  cleanup_pnpm_setup_step,
+  cleanup_node_setup_step,
   cleanup_steps.find { |step| step["name"] == "Install E2E dependencies" },
 ]
 unless conditional_setup_steps.all? do |step|

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2470,11 +2470,12 @@ jobs:
       runner-shard-matrix: ${{ steps.shards.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.33.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Install pnpm
-        run: corepack enable pnpm
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
       - name: Generate runner E2E shard matrix
@@ -2765,11 +2766,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.33.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Install pnpm
-        run: corepack enable pnpm
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
       - name: Download runner E2E API tokens
@@ -2902,13 +2904,14 @@ jobs:
         run: echo "Retaining runner E2E accounts until a successful rerun or fallback cleanup"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.cleanup-scope.outputs.scope != 'retain'
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        if: steps.cleanup-scope.outputs.scope != 'retain'
+        with:
+          version: 10.33.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         if: steps.cleanup-scope.outputs.scope != 'retain'
         with:
           node-version: 22
-      - name: Install pnpm
-        if: steps.cleanup-scope.outputs.scope != 'retain'
-        run: corepack enable pnpm
       - name: Install E2E dependencies
         if: steps.cleanup-scope.outputs.scope != 'retain'
         run: cd e2e && pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- install pnpm through the commit-pinned `pnpm/action-setup` action before selecting Node.js 22 in runner E2E preparation, shards, and cleanup
- keep pnpm `10.33.4`, Node.js 22, and frozen E2E dependency installation unchanged
- enforce one bootstrap contract across all three runner E2E lifecycle jobs

## Problem

Fresh runner E2E jobs enabled Corepack and left the first `pnpm install` to download pnpm through Node.js 22's bundled Undici. That path can intermittently crash with `assert(!this.paused)` before tests start.

## Validation

- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- all 12 workflow-contract test scripts that consume `.github/workflows/turbo.yml`
- `cd turbo && pnpm exec prettier --check --ignore-unknown ../.github/workflows/turbo.yml ../.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/turbo.yml`
- `./scripts/check-file-size.sh .github/workflows/turbo.yml .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`

## Scope

This PR changes only runner E2E lifecycle bootstrap. Independent Playwright and maintenance workflows that use Corepack remain unchanged.

Closes #28980
