### PR TITLE
feat(auth): refine v2 presentation shell

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "Anmelden",
       "signUp": "Registrieren"
     },
+    "homeLink": "Zur {{brandName}}-Startseite",
     "loading": "Authentifizierung wird geladen",
+    "theme": {
+      "darkEnabled": "Dunkles Design aktiviert",
+      "lightEnabled": "Helles Design aktiviert"
+    },
     "toggleTheme": "Design wechseln",
     "v2": {
-      "continueToSignIn": "Weiter zur Anmeldung",
-      "continueToSignUp": "Weiter zur Registrierung",
-      "unavailable": "Die neue Anmeldeoberfläche ist noch nicht verfügbar."
+      "signIn": {
+        "action": "Aktuelle Anmeldung verwenden",
+        "description": "Die neue Anmeldeoberfläche ist noch nicht verfügbar.",
+        "title": "Bei {{brandName}} anmelden"
+      },
+      "signUp": {
+        "action": "Aktuelle Registrierung verwenden",
+        "description": "Die neue Registrierungsoberfläche ist noch nicht verfügbar.",
+        "title": "Ihr {{brandName}}-Konto erstellen"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "Sign in",
       "signUp": "Sign up"
     },
+    "homeLink": "Go to {{brandName}} home",
     "loading": "Loading authentication",
+    "theme": {
+      "darkEnabled": "Dark theme enabled",
+      "lightEnabled": "Light theme enabled"
+    },
     "toggleTheme": "Toggle theme",
     "v2": {
-      "continueToSignIn": "Continue to sign in",
-      "continueToSignUp": "Continue to sign up",
-      "unavailable": "The new authentication experience is not ready yet."
+      "signIn": {
+        "action": "Use current sign-in",
+        "description": "The new sign-in experience is not ready yet.",
+        "title": "Sign in to {{brandName}}"
+      },
+      "signUp": {
+        "action": "Use current sign-up",
+        "description": "The new sign-up experience is not ready yet.",
+        "title": "Create your {{brandName}} account"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1033,12 +1033,24 @@
       "signIn": "Iniciar sesión",
       "signUp": "Crear una cuenta"
     },
+    "homeLink": "Ir al inicio de {{brandName}}",
     "loading": "Cargando autenticación",
+    "theme": {
+      "darkEnabled": "Tema oscuro activado",
+      "lightEnabled": "Tema claro activado"
+    },
     "toggleTheme": "Cambiar tema",
     "v2": {
-      "continueToSignIn": "Continuar para iniciar sesión",
-      "continueToSignUp": "Continuar para crear una cuenta",
-      "unavailable": "La nueva experiencia de autenticación aún no está disponible."
+      "signIn": {
+        "action": "Usar el inicio de sesión actual",
+        "description": "La nueva experiencia de inicio de sesión aún no está disponible.",
+        "title": "Iniciar sesión en {{brandName}}"
+      },
+      "signUp": {
+        "action": "Usar el registro actual",
+        "description": "La nueva experiencia de registro aún no está disponible.",
+        "title": "Crea tu cuenta de {{brandName}}"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1033,12 +1033,24 @@
       "signIn": "Se connecter",
       "signUp": "S'inscrire"
     },
+    "homeLink": "Accéder à l'accueil de {{brandName}}",
     "loading": "Chargement de l'authentification",
+    "theme": {
+      "darkEnabled": "Thème sombre activé",
+      "lightEnabled": "Thème clair activé"
+    },
     "toggleTheme": "Changer de thème",
     "v2": {
-      "continueToSignIn": "Continuer vers la connexion",
-      "continueToSignUp": "Continuer vers l'inscription",
-      "unavailable": "La nouvelle expérience d'authentification n'est pas encore disponible."
+      "signIn": {
+        "action": "Utiliser la connexion actuelle",
+        "description": "La nouvelle expérience de connexion n'est pas encore disponible.",
+        "title": "Se connecter à {{brandName}}"
+      },
+      "signUp": {
+        "action": "Utiliser l'inscription actuelle",
+        "description": "La nouvelle expérience d'inscription n'est pas encore disponible.",
+        "title": "Créer votre compte {{brandName}}"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "दाखिल करना",
       "signUp": "साइन अप करें"
     },
+    "homeLink": "{{brandName}} होम पर जाएं",
     "loading": "प्रमाणीकरण लोड हो रहा है",
+    "theme": {
+      "darkEnabled": "डार्क थीम चालू है",
+      "lightEnabled": "लाइट थीम चालू है"
+    },
     "toggleTheme": "थीम टॉगल करें",
     "v2": {
-      "continueToSignIn": "साइन इन जारी रखें",
-      "continueToSignUp": "साइन अप जारी रखें",
-      "unavailable": "नया प्रमाणीकरण अनुभव अभी उपलब्ध नहीं है।"
+      "signIn": {
+        "action": "मौजूदा साइन-इन का उपयोग करें",
+        "description": "नया साइन-इन अनुभव अभी उपलब्ध नहीं है।",
+        "title": "{{brandName}} में साइन इन करें"
+      },
+      "signUp": {
+        "action": "मौजूदा साइन-अप का उपयोग करें",
+        "description": "नया साइन-अप अनुभव अभी उपलब्ध नहीं है।",
+        "title": "अपना {{brandName}} खाता बनाएं"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "Masuk",
       "signUp": "Daftar"
     },
+    "homeLink": "Buka beranda {{brandName}}",
     "loading": "Memuat autentikasi",
+    "theme": {
+      "darkEnabled": "Tema gelap diaktifkan",
+      "lightEnabled": "Tema terang diaktifkan"
+    },
     "toggleTheme": "Beralih tema",
     "v2": {
-      "continueToSignIn": "Lanjutkan untuk masuk",
-      "continueToSignUp": "Lanjutkan untuk mendaftar",
-      "unavailable": "Pengalaman autentikasi baru belum tersedia."
+      "signIn": {
+        "action": "Gunakan proses masuk saat ini",
+        "description": "Pengalaman masuk baru belum tersedia.",
+        "title": "Masuk ke {{brandName}}"
+      },
+      "signUp": {
+        "action": "Gunakan pendaftaran saat ini",
+        "description": "Pengalaman pendaftaran baru belum tersedia.",
+        "title": "Buat akun {{brandName}} Anda"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1033,12 +1033,24 @@
       "signIn": "Accedi",
       "signUp": "Iscriviti"
     },
+    "homeLink": "Vai alla home di {{brandName}}",
     "loading": "Caricamento dell'autenticazione",
+    "theme": {
+      "darkEnabled": "Tema scuro attivato",
+      "lightEnabled": "Tema chiaro attivato"
+    },
     "toggleTheme": "Cambia tema",
     "v2": {
-      "continueToSignIn": "Continua per accedere",
-      "continueToSignUp": "Continua per registrarti",
-      "unavailable": "La nuova esperienza di autenticazione non è ancora disponibile."
+      "signIn": {
+        "action": "Usa l'accesso attuale",
+        "description": "La nuova esperienza di accesso non è ancora disponibile.",
+        "title": "Accedi a {{brandName}}"
+      },
+      "signUp": {
+        "action": "Usa la registrazione attuale",
+        "description": "La nuova esperienza di registrazione non è ancora disponibile.",
+        "title": "Crea il tuo account {{brandName}}"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "サインイン",
       "signUp": "サインアップ"
     },
+    "homeLink": "{{brandName}} のホームに移動",
     "loading": "認証を読み込み中",
+    "theme": {
+      "darkEnabled": "ダークテーマを有効にしました",
+      "lightEnabled": "ライトテーマを有効にしました"
+    },
     "toggleTheme": "テーマの切り替え",
     "v2": {
-      "continueToSignIn": "現在のサインインに進む",
-      "continueToSignUp": "現在のサインアップに進む",
-      "unavailable": "新しい認証画面はまだ利用できません。"
+      "signIn": {
+        "action": "現在のサインインを使用",
+        "description": "新しいサインイン画面はまだ利用できません。",
+        "title": "{{brandName}} にサインイン"
+      },
+      "signUp": {
+        "action": "現在のサインアップを使用",
+        "description": "新しいサインアップ画面はまだ利用できません。",
+        "title": "{{brandName}} アカウントを作成"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1015,12 +1015,24 @@
       "signIn": "로그인",
       "signUp": "회원가입"
     },
+    "homeLink": "{{brandName}} 홈으로 이동",
     "loading": "인증 중",
+    "theme": {
+      "darkEnabled": "어두운 테마가 켜졌습니다",
+      "lightEnabled": "밝은 테마가 켜졌습니다"
+    },
     "toggleTheme": "테마 전환",
     "v2": {
-      "continueToSignIn": "현재 로그인으로 계속",
-      "continueToSignUp": "현재 회원가입으로 계속",
-      "unavailable": "새 인증 화면은 아직 사용할 수 없습니다."
+      "signIn": {
+        "action": "현재 로그인 사용",
+        "description": "새 로그인 화면은 아직 사용할 수 없습니다.",
+        "title": "{{brandName}}에 로그인"
+      },
+      "signUp": {
+        "action": "현재 회원가입 사용",
+        "description": "새 회원가입 화면은 아직 사용할 수 없습니다.",
+        "title": "{{brandName}} 계정 만들기"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1033,12 +1033,24 @@
       "signIn": "Entrar",
       "signUp": "Criar conta"
     },
+    "homeLink": "Ir para a página inicial do {{brandName}}",
     "loading": "Carregando autenticação",
+    "theme": {
+      "darkEnabled": "Tema escuro ativado",
+      "lightEnabled": "Tema claro ativado"
+    },
     "toggleTheme": "Alternar tema",
     "v2": {
-      "continueToSignIn": "Continuar para entrar",
-      "continueToSignUp": "Continuar para criar uma conta",
-      "unavailable": "A nova experiência de autenticação ainda não está disponível."
+      "signIn": {
+        "action": "Usar o login atual",
+        "description": "A nova experiência de login ainda não está disponível.",
+        "title": "Entrar no {{brandName}}"
+      },
+      "signUp": {
+        "action": "Usar o cadastro atual",
+        "description": "A nova experiência de cadastro ainda não está disponível.",
+        "title": "Criar sua conta do {{brandName}}"
+      }
     }
   },
   "authorization": {

--- a/turbo/apps/platform/src/signals/auth-v2-presentation.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-presentation.ts
@@ -1,0 +1,12 @@
+import { command } from "ccstate";
+
+import { onRef } from "./utils.ts";
+
+export const focusAuthV2HeadingRef$ = onRef(
+  command(
+    (_context, heading: HTMLHeadingElement, signal: AbortSignal): void => {
+      signal.throwIfAborted();
+      heading.focus();
+    },
+  ),
+);

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -54,7 +54,7 @@ function buttonByLabel(label: string): HTMLButtonElement {
 }
 
 describe("auth v2 presentation", () => {
-  it("provides branded landmarks, descriptions, announcements, and focus order", async () => {
+  it("provides branded landmarks, descriptions, announcements, and initial focus", async () => {
     setBrowserUrl("https://app.vm0.ai/v2/sign-in");
 
     detachedSetupPage({ context, path: "/v2/sign-in" });
@@ -79,19 +79,13 @@ describe("auth v2 presentation", () => {
     expect(announcer).toHaveAttribute("aria-atomic", "true");
     expect(announcer).toHaveAttribute("aria-live", "polite");
 
-    const action = linkByText("Use current sign-in");
-    action.focus();
-    expect(action).toHaveFocus();
-
-    const layout = screen.getByTestId("app-auth-layout");
-    expect(layout).toHaveAttribute("data-auth-brand", "vm0");
-    expect(layout).toHaveAttribute("data-auth-version", "v2");
-    expect(layout).toHaveClass("p-4");
-    expect(layout).toHaveClass("sm:p-6");
-    expect(screen.getByRole("main")).toHaveClass("py-14");
+    expect(linkByText("Use current sign-in")).toHaveAttribute(
+      "href",
+      "/sign-in",
+    );
   });
 
-  it("toggles light and dark themes from the keyboard and announces the result", async () => {
+  it("toggles themes with pointer and keyboard input while preserving focus", async () => {
     const user = userEvent.setup();
     context.mocks.browser.matchMedia(false);
     setBrowserUrl("https://app.vm0.ai/v2/sign-in");
@@ -104,8 +98,7 @@ describe("auth v2 presentation", () => {
     const themeToggle = buttonByLabel("Toggle theme");
     expect(themeToggle).toHaveAttribute("aria-pressed", "false");
 
-    themeToggle.focus();
-    await user.keyboard("{Enter}");
+    await user.click(themeToggle);
 
     expect(themeToggle).toHaveFocus();
     expect(themeToggle).toHaveAttribute("aria-pressed", "true");
@@ -144,10 +137,6 @@ describe("auth v2 presentation", () => {
       "/sign-up",
     );
     expect(heading).toBeVisible();
-    expect(screen.getByTestId("app-auth-layout")).toHaveAttribute(
-      "data-auth-brand",
-      "okou",
-    );
     expect(document.title).toBe("サインアップ | Okou");
   });
 });

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -1,0 +1,153 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { platformVm0LogoImg } from "../../../lib/static-assets.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function setBrowserUrl(url: string): void {
+  context.mocks.browser.url(url);
+}
+
+function useJapaneseLocale(): void {
+  document.documentElement.lang = "ja-JP";
+  context.mocks.data.userPreferences({
+    locale: "ja-JP",
+    supportedLocales: ["en-US", "ja-JP"],
+  });
+}
+
+function linkByText(text: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.trim() === text;
+  });
+  if (!(link instanceof HTMLAnchorElement)) {
+    throw new Error(`Link not found: ${text}`);
+  }
+  return link;
+}
+
+function linkByLabel(label: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!(link instanceof HTMLAnchorElement)) {
+    throw new Error(`Link not found: ${label}`);
+  }
+  return link;
+}
+
+function buttonByLabel(label: string): HTMLButtonElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  return button;
+}
+
+describe("auth v2 presentation", () => {
+  it("provides branded landmarks, descriptions, announcements, and focus order", async () => {
+    setBrowserUrl("https://app.vm0.ai/v2/sign-in");
+
+    detachedSetupPage({ context, path: "/v2/sign-in" });
+
+    const heading = await screen.findByRole("heading", {
+      level: 1,
+      name: "Sign in to VM0",
+    });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+
+    expect(screen.getByRole("main")).toContainElement(heading);
+    expect(
+      screen.getByRole("region", { name: "Sign in to VM0" }),
+    ).toHaveAccessibleDescription(
+      "The new sign-in experience is not ready yet.",
+    );
+    expect(linkByLabel("Go to VM0 home")).toHaveAttribute("href", "/");
+
+    const announcer = screen.getByTestId("auth-v2-announcer");
+    expect(announcer).toHaveAttribute("aria-atomic", "true");
+    expect(announcer).toHaveAttribute("aria-live", "polite");
+
+    const action = linkByText("Use current sign-in");
+    action.focus();
+    expect(action).toHaveFocus();
+
+    const layout = screen.getByTestId("app-auth-layout");
+    expect(layout).toHaveAttribute("data-auth-brand", "vm0");
+    expect(layout).toHaveAttribute("data-auth-version", "v2");
+    expect(layout).toHaveClass("p-4");
+    expect(layout).toHaveClass("sm:p-6");
+    expect(screen.getByRole("main")).toHaveClass("py-14");
+  });
+
+  it("toggles light and dark themes from the keyboard and announces the result", async () => {
+    const user = userEvent.setup();
+    context.mocks.browser.matchMedia(false);
+    setBrowserUrl("https://app.vm0.ai/v2/sign-in");
+
+    detachedSetupPage({ context, path: "/v2/sign-in" });
+
+    await screen.findByRole("heading", {
+      name: "Sign in to VM0",
+    });
+    const themeToggle = buttonByLabel("Toggle theme");
+    expect(themeToggle).toHaveAttribute("aria-pressed", "false");
+
+    themeToggle.focus();
+    await user.keyboard("{Enter}");
+
+    expect(themeToggle).toHaveFocus();
+    expect(themeToggle).toHaveAttribute("aria-pressed", "true");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    expect(screen.getByRole("status")).toHaveTextContent("Dark theme enabled");
+    expect(screen.getByAltText("VM0")).toHaveAttribute(
+      "src",
+      platformVm0LogoImg,
+    );
+
+    await user.keyboard("{Enter}");
+
+    expect(themeToggle).toHaveAttribute("aria-pressed", "false");
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(screen.getByRole("status")).toHaveTextContent("Light theme enabled");
+  });
+
+  it("localizes the Okou presentation boundary through platform resources", async () => {
+    useJapaneseLocale();
+    setBrowserUrl("https://app.okou.ai/v2/sign-up");
+
+    detachedSetupPage({ context, path: "/v2/sign-up" });
+
+    const heading = await screen.findByRole("heading", {
+      level: 1,
+      name: "Okou アカウントを作成",
+    });
+    expect(
+      screen.getByRole("region", { name: "Okou アカウントを作成" }),
+    ).toHaveAccessibleDescription(
+      "新しいサインアップ画面はまだ利用できません。",
+    );
+    expect(linkByLabel("Okou のホームに移動")).toHaveAttribute("href", "/");
+    expect(linkByText("現在のサインアップを使用")).toHaveAttribute(
+      "href",
+      "/sign-up",
+    );
+    expect(heading).toBeVisible();
+    expect(screen.getByTestId("app-auth-layout")).toHaveAttribute(
+      "data-auth-brand",
+      "okou",
+    );
+    expect(document.title).toBe("サインアップ | Okou");
+  });
+});

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
@@ -1,15 +1,10 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-} from "@okouai/ui";
+import { Button } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import { resolveAuthBrandContext } from "../../signals/auth.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { AuthShell } from "../auth/auth-shell.tsx";
 import { Link } from "../router/link.tsx";
+import { AuthV2Shell } from "./auth-v2-shell.tsx";
 
 export type AuthV2PageMode = "sign-in" | "sign-up";
 
@@ -22,42 +17,44 @@ export function AuthV2Page({ mode }: AuthV2PageProps) {
   const authBrand = resolveAuthBrandContext();
   const signIn = mode === "sign-in";
   const legacyRoute = signIn ? ROUTES.signIn : ROUTES.signUp;
+  const title = signIn
+    ? t(
+        ($) => {
+          return $.auth.v2.signIn.title;
+        },
+        { brandName: authBrand.brandName },
+      )
+    : t(
+        ($) => {
+          return $.auth.v2.signUp.title;
+        },
+        { brandName: authBrand.brandName },
+      );
+  const description = t(($) => {
+    return signIn ? $.auth.v2.signIn.description : $.auth.v2.signUp.description;
+  });
+  const action = t(($) => {
+    return signIn ? $.auth.v2.signIn.action : $.auth.v2.signUp.action;
+  });
 
   return (
-    <AuthShell authBrand={authBrand}>
-      <Card className="w-full max-w-md rounded-3xl" data-testid="app-auth-v2">
-        <CardHeader className="items-center text-center">
-          <h1 className="text-lg font-medium text-foreground">
-            {t(($) => {
-              return signIn
-                ? $.auth.documentTitles.signIn
-                : $.auth.documentTitles.signUp;
-            })}
-          </h1>
-          <CardDescription>
-            {t(($) => {
-              return $.auth.v2.unavailable;
-            })}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="pt-4">
-          <Button className="w-full" asChild>
-            <Link
-              pathname={legacyRoute}
-              options={{
-                hash: location.hash,
-                searchParams: new URLSearchParams(location.search),
-              }}
-            >
-              {t(($) => {
-                return signIn
-                  ? $.auth.v2.continueToSignIn
-                  : $.auth.v2.continueToSignUp;
-              })}
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
+    <AuthShell authBrand={authBrand} variant="v2">
+      <AuthV2Shell description={description} focusKey={mode} title={title}>
+        <Button
+          asChild
+          className="h-9 w-full bg-foreground text-background hover:bg-foreground-hover active:bg-foreground-pressed"
+        >
+          <Link
+            pathname={legacyRoute}
+            options={{
+              hash: location.hash,
+              searchParams: new URLSearchParams(location.search),
+            }}
+          >
+            {action}
+          </Link>
+        </Button>
+      </AuthV2Shell>
     </AuthShell>
   );
 }

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
@@ -1,12 +1,11 @@
 import { Card, CardContent, CardDescription, CardHeader } from "@okouai/ui";
+import { useSet } from "ccstate-react";
 import type { ReactNode } from "react";
+
+import { focusAuthV2HeadingRef$ } from "../../signals/auth-v2-presentation.ts";
 
 const AUTH_V2_TITLE_ID = "auth-v2-title";
 const AUTH_V2_DESCRIPTION_ID = "auth-v2-description";
-
-function focusAuthHeading(heading: HTMLHeadingElement | null): void {
-  heading?.focus();
-}
 
 interface AuthV2ShellProps {
   readonly announcement?: ReactNode;
@@ -23,6 +22,8 @@ export function AuthV2Shell({
   focusKey,
   title,
 }: AuthV2ShellProps) {
+  const focusHeading = useSet(focusAuthV2HeadingRef$);
+
   return (
     <Card
       aria-describedby={AUTH_V2_DESCRIPTION_ID}
@@ -36,7 +37,7 @@ export function AuthV2Shell({
           className="text-lg font-medium text-foreground outline-none"
           id={AUTH_V2_TITLE_ID}
           key={focusKey}
-          ref={focusAuthHeading}
+          ref={focusHeading}
           tabIndex={-1}
         >
           {title}

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
@@ -1,0 +1,64 @@
+import { Card, CardContent, CardDescription, CardHeader } from "@okouai/ui";
+import type { ReactNode } from "react";
+
+const AUTH_V2_TITLE_ID = "auth-v2-title";
+const AUTH_V2_DESCRIPTION_ID = "auth-v2-description";
+
+function focusAuthHeading(heading: HTMLHeadingElement | null): void {
+  heading?.focus();
+}
+
+interface AuthV2ShellProps {
+  readonly announcement?: ReactNode;
+  readonly children: ReactNode;
+  readonly description: ReactNode;
+  readonly focusKey: string;
+  readonly title: ReactNode;
+}
+
+export function AuthV2Shell({
+  announcement,
+  children,
+  description,
+  focusKey,
+  title,
+}: AuthV2ShellProps) {
+  return (
+    <Card
+      aria-describedby={AUTH_V2_DESCRIPTION_ID}
+      aria-labelledby={AUTH_V2_TITLE_ID}
+      className="zero-composer relative w-full max-w-md overflow-visible"
+      data-testid="app-auth-v2"
+      role="region"
+    >
+      <CardHeader className="items-center bg-transparent px-5 pt-6 pb-2 text-center sm:px-6 sm:pt-7">
+        <h1
+          className="text-lg font-medium text-foreground outline-none"
+          id={AUTH_V2_TITLE_ID}
+          key={focusKey}
+          ref={focusAuthHeading}
+          tabIndex={-1}
+        >
+          {title}
+        </h1>
+        <CardDescription
+          className="max-w-sm leading-5"
+          id={AUTH_V2_DESCRIPTION_ID}
+        >
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-5 pt-4 pb-5 sm:px-6 sm:pb-6">
+        {children}
+      </CardContent>
+      <p
+        aria-atomic="true"
+        aria-live="polite"
+        className="sr-only"
+        data-testid="auth-v2-announcer"
+      >
+        {announcement}
+      </p>
+    </Card>
+  );
+}

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -367,26 +367,30 @@ describe("app auth pages", () => {
 
   it.each([
     {
-      action: "Continue to sign in",
-      heading: "Sign in",
+      action: "Use current sign-in",
+      documentTitle: "Sign in | VM0",
+      heading: "Sign in to VM0",
       legacyPath: "/sign-in",
       path: "/v2/sign-in",
     },
     {
-      action: "Continue to sign in",
-      heading: "Sign in",
+      action: "Use current sign-in",
+      documentTitle: "Sign in | VM0",
+      heading: "Sign in to VM0",
       legacyPath: "/sign-in",
       path: "/v2/sign-in/tasks/choose-organization",
     },
     {
-      action: "Continue to sign up",
-      heading: "Sign up",
+      action: "Use current sign-up",
+      documentTitle: "Sign up | VM0",
+      heading: "Create your VM0 account",
       legacyPath: "/sign-up",
       path: "/v2/sign-up",
     },
     {
-      action: "Continue to sign up",
-      heading: "Sign up",
+      action: "Use current sign-up",
+      documentTitle: "Sign up | VM0",
+      heading: "Create your VM0 account",
       legacyPath: "/sign-up",
       path: "/v2/sign-up/verify-email-address",
     },
@@ -408,7 +412,7 @@ describe("app auth pages", () => {
       "aria-hidden",
       "true",
     );
-    expect(document.title).toBe(`${routeCase.heading} | VM0`);
+    expect(document.title).toBe(routeCase.documentTitle);
   });
 
   it("preserves branded auth intent when leaving the v2 scaffold", async () => {
@@ -420,6 +424,9 @@ describe("app auth pages", () => {
     detachedSetupPage({ context, path });
 
     await expect(screen.findByTestId("app-auth-v2")).resolves.toBeVisible();
+    expect(
+      screen.getByRole("heading", { name: "Sign in to Okou" }),
+    ).toBeVisible();
     const continueLink = authV2ActionLink();
     expect(continueLink).toHaveAttribute(
       "href",

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -1,3 +1,4 @@
+import { Button, cn } from "@okouai/ui";
 import { Moon, Sun } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
@@ -10,18 +11,29 @@ import type { AuthBrandContext } from "../../signals/auth.ts";
 import { setTheme$, theme$ } from "../../signals/theme.ts";
 
 interface AuthShellProps {
-  authBrand: AuthBrandContext;
-  children: ReactNode;
+  readonly authBrand: AuthBrandContext;
+  readonly children: ReactNode;
+  readonly variant?: "legacy" | "v2";
 }
 
-export function AuthShell({ authBrand, children }: AuthShellProps) {
+export function AuthShell({
+  authBrand,
+  children,
+  variant = "legacy",
+}: AuthShellProps) {
   const { t } = useTranslation();
   const theme = useGet(theme$);
   const setTheme = useSet(setTheme$);
+  const v2 = variant === "v2";
 
   return (
     <div
-      className="relative flex h-full min-h-0 overflow-x-hidden overflow-y-auto bg-background p-6"
+      className={cn(
+        "relative flex h-full min-h-0 overflow-x-hidden overflow-y-auto bg-background",
+        v2 ? "zero-app p-4 sm:p-6" : "p-6",
+      )}
+      data-auth-brand={authBrand.brandName.toLowerCase()}
+      data-auth-version={variant}
       data-testid="app-auth-layout"
     >
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--primary)/0.06)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--primary)/0.06)_1px,transparent_1px)] bg-[size:3rem_3rem]" />
@@ -30,21 +42,57 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
       <div className="pointer-events-none absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#A6DEFF]/10 blur-3xl" />
       <div className="pointer-events-none absolute -right-40 -bottom-40 h-96 w-96 rounded-full bg-[#FFE7A2]/15 blur-3xl" />
 
-      <button
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
         onClick={() => {
-          setTheme(theme === "dark" ? "light" : "dark");
+          const nextTheme = theme === "dark" ? "light" : "dark";
+          setTheme(nextTheme);
         }}
-        className="fixed right-[calc(1.5rem+var(--sar))] top-[calc(1.5rem+var(--sat))] z-50 flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-card text-foreground transition-colors hover:bg-card-hover"
+        className={cn(
+          "fixed z-50 border-border bg-card text-foreground hover:bg-card-hover",
+          v2
+            ? "right-[calc(1rem+var(--sar))] top-[calc(1rem+var(--sat))] sm:right-[calc(1.5rem+var(--sar))] sm:top-[calc(1.5rem+var(--sat))]"
+            : "right-[calc(1.5rem+var(--sar))] top-[calc(1.5rem+var(--sat))]",
+        )}
         aria-label={t(($) => {
           return $.auth.toggleTheme;
         })}
+        aria-pressed={theme === "dark"}
       >
-        {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
-      </button>
+        {theme === "dark" ? (
+          <Sun size={16} aria-hidden="true" />
+        ) : (
+          <Moon size={16} aria-hidden="true" />
+        )}
+      </Button>
+
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        className="sr-only"
+        role="status"
+      >
+        {t(($) => {
+          return theme === "dark"
+            ? $.auth.theme.darkEnabled
+            : $.auth.theme.lightEnabled;
+        })}
+      </span>
 
       <a
         href={authBrand.homeUrl}
-        className="absolute left-6 top-6 flex items-center gap-2"
+        aria-label={t(
+          ($) => {
+            return $.auth.homeLink;
+          },
+          { brandName: authBrand.brandName },
+        )}
+        className={cn(
+          "absolute flex items-center gap-2 transition-opacity hover:opacity-75 focus-visible:opacity-75 focus-visible:outline-none",
+          v2 ? "left-4 top-4 sm:left-6 sm:top-6" : "left-6 top-6",
+        )}
       >
         {authBrand.brandName === "Okou" ? (
           <span className="text-xl font-semibold tracking-tight">
@@ -63,9 +111,14 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
         )}
       </a>
 
-      <div className="relative z-10 m-auto flex w-full min-w-0 justify-center">
+      <main
+        className={cn(
+          "relative z-10 m-auto flex w-full min-w-0 justify-center",
+          v2 && "py-14 sm:py-16",
+        )}
+      >
         {children}
-      </div>
+      </main>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -32,8 +32,6 @@ export function AuthShell({
         "relative flex h-full min-h-0 overflow-x-hidden overflow-y-auto bg-background",
         v2 ? "zero-app p-4 sm:p-6" : "p-6",
       )}
-      data-auth-brand={authBrand.brandName.toLowerCase()}
-      data-auth-version={variant}
       data-testid="app-auth-layout"
     >
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--primary)/0.06)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--primary)/0.06)_1px,transparent_1px)] bg-[size:3rem_3rem]" />


### PR DESCRIPTION
## Summary

- refine the Clerk-neutral shared AuthShell and Auth v2 surface for VM0 and Okou branding, responsive safe-area spacing, and light/dark themes
- add deterministic heading focus, linked accessible descriptions, polite live regions, and keyboard-operable theme controls
- structure the v2 presentation copy by auth mode across every platform locale and add focused page coverage

## Scope

- presentation boundary only; legacy v1 routes and Clerk prebuilt behavior remain unchanged
- no Clerk API operations, factor or status logic, sign-in or sign-up strategies, redirect security, campaign attribution, or organization continuation
- no .cl-* selectors, Clerk prebuilt components in v2, or edits to core-owned shared flow modules

Refs #28927

## Verification

- pnpm -F @okouai/app lint
- pnpm -F @okouai/app check-types
- pnpm -F @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx (32 passed)
- pnpm knip --workspace apps/platform
- targeted Prettier check for all changed files

The full local Vitest suite and a local dev server were intentionally not run per repository guidance.