### PR TITLE
docs(runner): document wait-running stdout contract

### DIFF
--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -65,7 +65,9 @@ enum ServiceCommand {
     Drain(drain_resume::DrainArgs),
     /// Resume a draining runner (SIGUSR2, reverses `drain` before teardown begins)
     Resume(drain_resume::ResumeArgs),
-    /// Wait until a runner service is active and job-admitting
+    /// Wait until a runner service is active and job-admitting. On success, emit the resolved
+    /// max_concurrent as one machine-readable integer line on stdout for scripts; diagnostics go
+    /// to stderr.
     WaitRunning(ServiceWaitRunningArgs),
     /// Show machine-readable systemd unit state for runner services
     UnitState(state::UnitStateArgs),

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -390,6 +390,23 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn service_wait_running_help_describes_stdout_contract() {
+        let error = Cli::try_parse_from(["runner", "service", "wait-running", "--help"])
+            .err()
+            .expect("service wait-running --help should exit through clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let normalized_help = error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(normalized_help.contains(
+            "Wait until a runner service is active and job-admitting. On success, emit the resolved max_concurrent as one machine-readable integer line on stdout for scripts; diagnostics go to stderr."
+        ));
+    }
+
     #[tokio::test]
     async fn runner_help_hides_token_environment_values() {
         for subcommand in ["config", "start"] {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -402,9 +402,12 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" ");
 
-        assert!(normalized_help.contains(
-            "Wait until a runner service is active and job-admitting. On success, emit the resolved max_concurrent as one machine-readable integer line on stdout for scripts; diagnostics go to stderr."
-        ));
+        assert!(
+            normalized_help.contains(
+                "Wait until a runner service is active and job-admitting. On success, emit the resolved max_concurrent as one machine-readable integer line on stdout for scripts; diagnostics go to stderr"
+            ),
+            "unexpected help output: {normalized_help}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Document that `runner service wait-running` emits the resolved `max_concurrent` as one machine-readable integer line on stdout when readiness succeeds.
- Clarify that diagnostics remain on stderr.
- Add focused coverage for `runner service wait-running --help` without treating Clap-normalized trailing punctuation as part of the contract.

## Scope

This PR changes only the generated `wait-running` help text and its CLI help coverage. Runtime
readiness behavior, stdout bytes, shell/Ansible consumers, configuration, deployment, and rollback
logic are unchanged.

## Validation

- `cd crates && cargo fmt --all -- --check` — passed.
- `cd crates && CARGO_BUILD_JOBS=2 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p runner --bin runner --all-features tests::service_wait_running_help_describes_stdout_contract -- --exact` — passed; the same command reproduced the assertion failure before the fix.
- Pre-commit `cargo clippy --all-targets --all-features` — passed.
- Pre-commit `cargo doc --workspace --all-features --no-deps` — passed.
- Pre-commit file-size validation — passed.

Closes #28956
