### PR TITLE
docs(python): document selective json duplicate-key semantics

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -151,10 +151,21 @@ class JsonExtractionResult:
     array path lengths, ``wildcard_array_counts`` contains per-wildcard-key array
     lengths, ``object_present`` contains observed object paths, and
     ``value_present`` contains paths where any JSON value appeared.
+
+    The normal observation containers follow the final occurrence of each object
+    member. When a later duplicate replaces an earlier parent or changes its
+    value kind, observations rooted at the earlier value are cleared before the
+    later value is parsed. This includes descendant scalar values, exact and
+    wildcard array counts, object presence, and value presence.
+
     ``discarded_scalar_paths`` identifies selected strings discarded by their
-    configured overflow policy.
-    ``selected_string_max_raw_bytes`` retains the maximum encoded JSON string
-    length observed at each selected path, including duplicate occurrences.
+    configured overflow policy and intentionally retains that evidence across
+    duplicate occurrences. ``selected_string_max_raw_bytes`` retains the
+    maximum encoded JSON string length observed at each selected path across
+    duplicate occurrences.
+
+    Configured scalar-consistency tracking is separate from the normal result
+    containers and evaluates every occurrence, including overwritten duplicates.
 
     When ``complete`` is false, all observation containers are empty and
     ``error`` describes the parse or bound failure. This prevents callers from
@@ -236,6 +247,21 @@ class JsonSelectiveExtractor:
     - ``object_presence_paths`` records exact paths where JSON objects appear.
     - ``value_presence_paths`` records exact paths where any JSON value appears.
 
+    Duplicate object members are parsed in input order. Normal result
+    observations follow the final occurrence of each member: a later duplicate
+    clears observations rooted at the earlier value before parsing its
+    replacement. A parent replacement or value-kind change therefore clears
+    earlier descendant scalar, exact array-count, wildcard array-count,
+    object-presence, and value-presence observations. Unrelated wildcard
+    observations are retained.
+
+    The diagnostic result fields ``discarded_scalar_paths`` and
+    ``selected_string_max_raw_bytes`` intentionally retain information from all
+    duplicate occurrences. Configured ``scalar_consistency_paths`` also tracks
+    every occurrence, including values overwritten in the normal result. See
+    ``tests/test_json_selective_observations.py`` and
+    ``tests/test_json_selective_strings.py`` for focused contract examples.
+
     Oversized selected scalars fail extraction by default. Selected strings with
     ``overflow_policy="discard"`` instead drop that observation and continue
     validation. Oversized object keys are treated as unknown keys, so selected
@@ -269,7 +295,8 @@ class JsonSelectiveExtractor:
         ``max_work_units`` optionally bounds total parser work across all
         chunks and fails with ``"work limit exceeded"``.
         ``scalar_consistency_paths`` tracks whether every occurrence of a
-        selected scalar path has the expected kind and the same value.
+        selected scalar path has the expected kind and the same value,
+        including occurrences later overwritten by a duplicate object member.
         """
         self.scalar_fields: dict[Path, ScalarField] = {}
         if scalar_fields is not None:
@@ -424,8 +451,9 @@ class JsonSelectiveExtractor:
         """Return whether every occurrence is a valid, identical selected scalar.
 
         An absent field is consistent. Callers must use this only after a
-        complete extraction result; it intentionally considers overwritten
-        duplicate object keys so identity checks can reject conflicting input.
+        complete extraction result; it intentionally considers every
+        occurrence, including overwritten duplicate object keys, so identity
+        checks can reject conflicting input.
         """
         if path not in self._scalar_consistency_paths:
             raise ValueError("scalar consistency path was not configured")


### PR DESCRIPTION
## Summary

- Document duplicate object-member semantics for `JsonSelectiveExtractor` and
  `JsonExtractionResult`.
- Clarify final-occurrence behavior for normal observations, descendant and wildcard clearing,
  cumulative diagnostic fields, and scalar-consistency tracking.
- Point callers to the focused duplicate-key contract tests.

## Scope

- Documentation-only change in `crates/runner/mitm-addon/src/usage/json_selective.py`.
- Runtime parser behavior and existing tests are unchanged.
- No new dependencies, generated files, migrations, or separate documentation pages.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6594 passed)

Closes #28994
