### PR TITLE
test(guest-mock-codex): remove unused completion scenario

### DIFF
--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -345,13 +345,6 @@ impl AppServerState {
             )?;
             return Ok(ServerAction::Stop);
         }
-        if self.scenario == Scenario::UnexpectedThreadTurnCompleted {
-            write_json_line(
-                output,
-                &turn_completed_notification("unexpected-thread-id", &turn_id),
-            )?;
-            return Ok(ServerAction::Stop);
-        }
         if self.scenario == Scenario::SecondaryThreadNotifications {
             write_secondary_thread_notifications(output, &thread_id, &turn_id, response_text)?;
             return Ok(ServerAction::Continue);

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -42,7 +42,6 @@ pub(super) enum Scenario {
     ThreadStartInvalidThreadId,
     UnexpectedThreadOutputItemStarted,
     UnexpectedTurnOutputItemStarted,
-    UnexpectedThreadTurnCompleted,
     SecondaryThreadNotifications,
 }
 
@@ -102,7 +101,6 @@ impl Scenario {
                     Ok(Self::UnexpectedThreadOutputItemStarted)
                 }
                 "unexpected-turn-output-item-started" => Ok(Self::UnexpectedTurnOutputItemStarted),
-                "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 "secondary-thread-notifications" => Ok(Self::SecondaryThreadNotifications),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,


### PR DESCRIPTION
## Summary

- remove the unused `UnexpectedThreadTurnCompleted` mock scenario
- remove its unselected environment parser entry and handler branch
- preserve the existing malformed-scope and secondary-thread integration coverage unchanged

## Exclusions

- no production behavior, protocol, or persisted state changes
- no replacement test for the undocumented dead fixture

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-mock-codex -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-mock-codex -p guest-agent --all-features --no-deps`
- `cargo test -p guest-mock-codex`
- `cargo test -p guest-agent --test codex_app_server_backend_scope --test codex_app_server_backend_secondary_thread`
- repository-wide tracked-file search for both removed names
- repository pre-commit hooks

Closes #29002
