### PR TITLE
test(python): complete inline futures for base exceptions

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -499,7 +499,7 @@ def sync_usage_executor():
             self._futures.append(future)
             try:
                 result = fn(*args, **kwargs)
-            except Exception as error:
+            except BaseException as error:
                 future.set_exception(error)
             else:
                 future.set_result(result)

--- a/crates/runner/mitm-addon/tests/test_sync_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_sync_usage_executor.py
@@ -35,6 +35,23 @@ def test_sync_usage_executor_captures_callable_exceptions(sync_usage_executor):
         sync_usage_executor.shutdown(wait=True)
 
 
+def test_sync_usage_executor_captures_base_exceptions(sync_usage_executor):
+    def fail() -> None:
+        raise SystemExit(7)
+
+    future = sync_usage_executor.submit(fail)
+
+    assert isinstance(future, Future)
+    assert future.done()
+    assert isinstance(future.exception(), SystemExit)
+    with pytest.raises(SystemExit) as result_error:
+        future.result()
+    assert result_error.value.code == 7
+    with pytest.raises(SystemExit) as shutdown_error:
+        sync_usage_executor.shutdown(wait=True)
+    assert shutdown_error.value.code == 7
+
+
 def test_sync_usage_executor_rejects_submit_after_shutdown(sync_usage_executor):
     sync_usage_executor.shutdown(wait=True)
 


### PR DESCRIPTION
## Summary

- complete inline executor futures when submitted callables raise direct `BaseException` values
- preserve `ThreadPoolExecutor`-style failure observation through `Future.result()`
- cover `SystemExit` completion and deterministic shutdown propagation

## Scope

- test fixture and focused fixture contract coverage only
- no production executor, API, protocol, database, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_sync_usage_executor.py` (4 passed)
- `uv run --no-sync python -m pytest tests/` (6595 passed)

Closes #29001
