### PR TITLE
refactor(runner): migrate status to sandbox terminology

### DIFF
--- a/.github/scripts/runner-behavior-keep-alive.sh
+++ b/.github/scripts/runner-behavior-keep-alive.sh
@@ -108,32 +108,32 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --prompt 'touch /tmp/keepalive-marker && echo turn1-done' \
   || fail "Turn 1 failed"
 
-# Turn 2: submit with the same chat thread — should reuse the VM.
-# If VM was reused, the marker file from turn 1 still exists (exit 0).
-# If a new VM was created, the file is missing and test exits non-zero.
-echo "--- Turn 2: verify marker file persists (VM reused) ---"
+# Turn 2: submit with the same chat thread — should reuse the sandbox.
+# If sandbox was reused, the marker file from turn 1 still exists (exit 0).
+# If a new sandbox was created, the file is missing and test exits non-zero.
+echo "--- Turn 2: verify marker file persists (sandbox reused) ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$CHAT_THREAD_ID" \
   --session-id "$SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt 'test -f /tmp/keepalive-marker' \
-  || fail "Turn 2: marker file not found — VM was not reused"
-echo "PASS: Turn 2 completed (VM reused, filesystem persisted)"
+  || fail "Turn 2: marker file not found — sandbox was not reused"
+echo "PASS: Turn 2 completed (sandbox reused, filesystem persisted)"
 
-# Turn 3: keep the provider session but use a different chat thread — should create a new VM.
-# The marker file must NOT exist in the new VM (thread isolation).
-echo "--- Turn 3: different chat thread creates new VM ---"
+# Turn 3: keep the provider session but use a different chat thread — should create a new sandbox.
+# The marker file must NOT exist in the new sandbox (thread isolation).
+echo "--- Turn 3: different chat thread creates new sandbox ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$ISOLATED_CHAT_THREAD_ID" \
   --session-id "$SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt 'test ! -f /tmp/keepalive-marker' \
   || fail "Turn 3: marker file found — chat thread isolation broken"
-echo "PASS: Turn 3 completed (new VM for different chat thread)"
+echo "PASS: Turn 3 completed (new sandbox for different chat thread)"
 
 # A privileged guest can stack an unrelated mount over the canonical workspace
 # after a turn starts. Idle admission must reject that sandbox, so the next turn
-# receives a fresh VM whose workspace is backed by /dev/vdb.
+# receives a fresh sandbox whose workspace is backed by /dev/vdb.
 TAMPER_SESSION_ID="e2e-keepalive-tampered-mount"
 echo "--- Tamper turn 1: replace canonical workspace mount before idle admission ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
@@ -274,7 +274,7 @@ test "$(readlink -f "$source")" = /dev/vdb' \
 echo "PASS: overlapping runner exec could not produce a reusable sandbox"
 
 # Regression gate for sandbox_id/run_id conflation (#9552):
-# at this point the runner has parked idle VMs whose FC workspace
+# at this point the runner has parked idle sandboxes whose FC workspace
 # names (= sandbox_id) are divorced from any active run_id.
 # `runner doctor --name <svc>` must still report 0 warnings.
 # Scope to this CI run's runner name so that unrelated runners
@@ -283,9 +283,9 @@ echo "--- runner doctor --name $SVC (expect 0 warnings) ---"
 DOCTOR_OUT=$(sudo "$BIN_DIR/runner" doctor --name "$SVC" 2>&1 || true)
 echo "$DOCTOR_OUT"
 if ! grep -q '^0 warning(s) found$' <<<"$DOCTOR_OUT"; then
-  fail "runner doctor reported warnings with parked idle VMs — regression for #9552"
+  fail "runner doctor reported warnings with parked idle sandboxes — regression for #9552"
 fi
-echo "PASS: runner doctor clean with parked VMs"
+echo "PASS: runner doctor clean with parked sandboxes"
 
 # Stop transient service (drains idle pool)
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -359,7 +359,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --session-id "$SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt "$VERIFY_PROMPT" \
-  || fail "Turn 2 failed; VM was not safely reused"
+  || fail "Turn 2 failed; sandbox was not safely reused"
 
 echo "--- Turn 3: prove healthy Turn 2 cleanup was also reusable ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
@@ -370,7 +370,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   || fail "Turn 3 failed; healthy cleanup did not re-enter reuse"
 
 echo "--- Pressure: sustain CPU saturation with live process control ---"
-# Continue the prepared conversation so the pressure turn must reuse the VM
+# Continue the prepared conversation so the pressure turn must reuse the sandbox
 # whose containment state and cleanup were verified above. Keep the provider
 # session independent so active input starts with a fresh stream.
 PRESSURE_CHAT_THREAD_ID="$CHAT_THREAD_ID"
@@ -553,7 +553,7 @@ workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
 control = guest_agent_control_cgroup()
 marker_dir = pathlib.Path("/tmp/vm0-process-containment")
 if not marker_dir.is_dir():
-    raise RuntimeError("memory pressure did not reuse the prepared VM")
+    raise RuntimeError("memory pressure did not reuse the prepared sandbox")
 guest_memory_bytes = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
 legacy_memory_max = guest_memory_bytes - CONTROL_MEMORY_MIN
 configured_memory_max = read_int(workload / "memory.max")
@@ -700,7 +700,7 @@ echo "--- Pressure: group-kill only the high-memory Bash tool ---"
 # The mock CLI launches two Bash children directly from the managed runtime.
 # The launcher places them in distinct tool cgroups before either shell runs.
 # One tool drives the existing workload limit to OOM while the other remains alive.
-# Use a fresh VM so the preceding extreme balloon-reclaim scenario cannot
+# Use a fresh sandbox so the preceding extreme balloon-reclaim scenario cannot
 # delay Guest Agent startup and obscure the tool-isolation assertion.
 MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 MEMORY_SESSION_ID="e2e-process-containment-memory"
@@ -730,13 +730,13 @@ sudo grep -E -q 'memory_oom_kill=[1-9][0-9]*' "$MEMORY_STREAM_LOG" \
 sudo grep -E -q 'memory_oom_group_kill=[1-9][0-9]*' "$MEMORY_STREAM_LOG" \
   || fail "memory-pressure diagnostics omitted the group OOM event"
 
-echo "--- Pressure: prove tool-group OOM preserved VM reuse ---"
+echo "--- Pressure: prove tool-group OOM preserved sandbox reuse ---"
 MEMORY_REUSE_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$MEMORY_CHAT_THREAD_ID" \
   --session-id "$MEMORY_SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt 'true') \
-  || fail "memory-pressure recovery did not preserve safe VM reuse"
+  || fail "memory-pressure recovery did not preserve safe sandbox reuse"
 printf '%s\n' "$MEMORY_REUSE_RESULT"
 MEMORY_REUSE_RESULT_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$MEMORY_REUSE_RESULT")
 MEMORY_REUSE_RUN_ID=$(jq -r '.run_id // empty' <<<"$MEMORY_REUSE_RESULT_JSON")
@@ -818,13 +818,13 @@ sudo grep -F -q 'pid-pressure-complete children=' "$PID_STREAM_LOG" \
 sudo grep -E -q 'pids_max=[1-9][0-9]*' "$PID_STREAM_LOG" \
   || fail "PID-pressure diagnostics omitted the pids.max event"
 
-echo "--- Pressure: prove PID-exhaustion cleanup preserved VM reuse ---"
+echo "--- Pressure: prove PID-exhaustion cleanup preserved sandbox reuse ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$PID_CHAT_THREAD_ID" \
   --session-id "$PID_SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt 'test -f /tmp/vm0-process-containment/pid-pressure-vm' \
-  || fail "PID-pressure cleanup did not preserve safe VM reuse"
+  || fail "PID-pressure cleanup did not preserve safe sandbox reuse"
 
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
   || fail "failed to read runner logs"

--- a/.github/scripts/tests/vm0-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-runner-status-collect-test.sh
@@ -96,6 +96,10 @@ test_aggregates_current_legacy_and_future_statuses() {
     {"sandbox_id": "$uuid_e", "phase": "running"},
     {"sandbox_id": "$uuid_e", "phase": "preparing"}
   ],
+  "idle_sandboxes": [
+    {"sandbox_id": "$uuid_a", "reuse_key": "overlap"},
+    {"sandbox_id": "$uuid_d", "reuse_key": "idle"}
+  ],
   "idle_vms": [
     {"sandbox_id": "$uuid_a", "reuse_key": "overlap"},
     {"sandbox_id": "$uuid_d", "reuse_key": "idle"}
@@ -151,12 +155,49 @@ EOF
   fi
 }
 
+test_idle_field_compatibility_precedence() {
+  reset_dirs
+  mkdir -p \
+    "$runners_dir/canonical" \
+    "$runners_dir/legacy" \
+    "$runners_dir/mirrored" \
+    "$runners_dir/canonical-empty" \
+    "$runners_dir/omitted"
+
+  printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
+    >"$runners_dir/canonical/status.json"
+  printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_vms\":[{\"sandbox_id\":\"$uuid_b\"}]}" \
+    >"$runners_dir/legacy/status.json"
+  printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_c\"}],\"idle_vms\":[{\"sandbox_id\":\"$uuid_d\"}]}" \
+    >"$runners_dir/mirrored/status.json"
+  printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_sandboxes\":[],\"idle_vms\":[{\"sandbox_id\":\"$uuid_e\"}]}" \
+    >"$runners_dir/canonical-empty/status.json"
+  printf '%s\n' '{"mode":"running"}' \
+    >"$runners_dir/omitted/status.json"
+
+  run_collector
+
+  assert_line 'vm0_runner_sandboxes{state="active"} 0'
+  assert_line 'vm0_runner_sandboxes{state="idle"} 3'
+  assert_line 'vm0_runner_sandboxes{state="preparing"} 0'
+  assert_line 'vm0_runner_sandboxes{state="unknown"} 0'
+  assert_line 'vm0_runner_instances{mode="running"} 5'
+  assert_line 'vm0_runner_status_files{result="included"} 5'
+  assert_line 'vm0_runner_status_files{result="invalid"} 0'
+  assert_line 'vm0_runner_status_collection_success 1'
+}
+
 test_invalid_files_publish_partial_metrics() {
   reset_dirs
   mkdir -p \
     "$runners_dir/valid" \
     "$runners_dir/malformed-json" \
     "$runners_dir/malformed-shape" \
+    "$runners_dir/malformed-canonical" \
     "$runners_dir/invalid-id"
 
   cat >"$runners_dir/valid/status.json" <<EOF
@@ -166,6 +207,9 @@ EOF
   printf '%s\n' '{"mode":"running","active_runs":{}}' \
     >"$runners_dir/malformed-shape/status.json"
   printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_sandboxes\":null,\"idle_vms\":[{\"sandbox_id\":\"$uuid_b\"}]}" \
+    >"$runners_dir/malformed-canonical/status.json"
+  printf '%s\n' \
     '{"mode":"running","idle_vms":[{"sandbox_id":"not-a-uuid"}]}' \
     >"$runners_dir/invalid-id/status.json"
 
@@ -174,12 +218,14 @@ EOF
   assert_line 'vm0_runner_sandboxes{state="preparing"} 1'
   assert_line 'vm0_runner_instances{mode="starting"} 1'
   assert_line 'vm0_runner_status_files{result="included"} 1'
-  assert_line 'vm0_runner_status_files{result="invalid"} 3'
+  assert_line 'vm0_runner_status_files{result="invalid"} 4'
   assert_line 'vm0_runner_status_collection_success 0'
   grep -q 'malformed-json/status.json' "$stderr_file" ||
     fail "malformed JSON diagnostic was not reported"
   grep -q 'malformed-shape/status.json' "$stderr_file" ||
     fail "malformed shape diagnostic was not reported"
+  grep -q 'malformed-canonical/status.json' "$stderr_file" ||
+    fail "malformed canonical diagnostic was not reported"
   grep -q 'invalid-id/status.json' "$stderr_file" ||
     fail "invalid UUID diagnostic was not reported"
 }
@@ -207,7 +253,7 @@ test_output_is_deterministic_and_replaced_atomically() {
   reset_dirs
   mkdir -p "$runners_dir/current"
   printf '%s\n' \
-    "{\"mode\":\"running\",\"idle_vms\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
+    "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
     >"$runners_dir/current/status.json"
   printf '%s\n' 'stale output' >"$output_file"
 
@@ -250,6 +296,7 @@ test_playbook_provisions_independent_collector_cadence() {
 
 test_missing_and_empty_runner_roots_emit_zero_metrics
 test_aggregates_current_legacy_and_future_statuses
+test_idle_field_compatibility_precedence
 test_invalid_files_publish_partial_metrics
 test_rejects_runner_and_status_symlinks
 test_output_is_deterministic_and_replaced_atomically

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -69,7 +69,8 @@ def parse_status(path: Path) -> tuple[str, list[tuple[str, str]]]:
             )
         sandbox_states.append((sandbox_id, state))
 
-    for entry in parse_collection(status, "idle_vms"):
+    idle_field = "idle_sandboxes" if "idle_sandboxes" in status else "idle_vms"
+    for entry in parse_collection(status, idle_field):
         _, sandbox_id = parse_sandbox_entry(entry)
         sandbox_states.append((sandbox_id, "idle"))
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -62,7 +62,7 @@ fn validate_timezone_arg(timezone: &str) -> RunnerResult<()> {
 
 #[derive(Args)]
 pub struct BenchmarkArgs {
-    /// The bash command to execute in the VM
+    /// The bash command to execute in the sandbox
     command: String,
     /// Path to runner.yaml config file
     #[arg(long, short)]
@@ -73,7 +73,7 @@ pub struct BenchmarkArgs {
     /// Environment variables to pass (KEY=VALUE), can be repeated
     #[arg(long, short)]
     env: Vec<String>,
-    /// Guest zoneinfo name to configure; benchmark fails if unavailable in the VM
+    /// Guest zoneinfo name to configure; benchmark fails if unavailable in the sandbox
     #[arg(long, default_value = DEFAULT_BENCHMARK_TIMEZONE)]
     timezone: String,
     /// Run the command as root (sudo)
@@ -514,7 +514,7 @@ mod tests {
         let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
 
         assert!(normalized_help.contains(
-            "Guest zoneinfo name to configure; benchmark fails if unavailable in the VM"
+            "Guest zoneinfo name to configure; benchmark fails if unavailable in the sandbox"
         ));
     }
 

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -34,7 +34,7 @@ pub struct ConfigArgs {
     #[arg(long)]
     runner_dirname: String,
 
-    /// Maximum concurrent VMs (0 = auto-detect from host CPU/memory)
+    /// Maximum concurrent sandboxes (0 = auto-detect from host CPU/memory)
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
     max_concurrent: usize,
     /// Overcommit factor for auto-detected concurrency (must be > 0)

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -78,7 +78,7 @@ enum Warning {
         base_dir: PathBuf,
     },
     /// A firecracker process exists but its sandbox_id is not tracked in
-    /// either `active_runs` or `idle_vms` for this runner.
+    /// either `active_runs` or `idle_sandboxes` for this runner.
     FirecrackerNotInStatus {
         pid: u32,
         sandbox_id: String,
@@ -275,7 +275,10 @@ impl Warning {
                 match read_status(base_dir).await {
                     Some(st) => {
                         let active = st.active_runs.iter().any(|r| r.sandbox_id == *sandbox_id);
-                        let idle = st.idle_vms.iter().any(|v| v.sandbox_id == *sandbox_id);
+                        let idle = st
+                            .idle_sandboxes
+                            .iter()
+                            .any(|v| v.sandbox_id == *sandbox_id);
                         !(active || idle)
                     }
                     None => true,
@@ -381,7 +384,7 @@ struct StatusInfo {
     mode: String,
     started_at: String,
     active_runs: Vec<ActiveRun>,
-    idle_vms: Vec<IdleVm>,
+    idle_sandboxes: Vec<IdleSandbox>,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
 }
@@ -915,7 +918,7 @@ impl ActiveRun {
     }
 }
 
-struct IdleVm {
+struct IdleSandbox {
     reuse_key: String,
     sandbox_id: String,
 }
@@ -930,6 +933,14 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
         .await
         .ok()
         .flatten()?;
+    let idle_sandboxes = file
+        .idle_sandboxes()
+        .iter()
+        .map(|sandbox| IdleSandbox {
+            reuse_key: sandbox.reuse_key.clone(),
+            sandbox_id: sandbox.sandbox_id.clone(),
+        })
+        .collect();
     let active_runs = file
         .active_runs
         .into_iter()
@@ -940,19 +951,11 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
             phase_started_at: run.phase_started_at,
         })
         .collect();
-    let idle_vms = file
-        .idle_vms
-        .into_iter()
-        .map(|vm| IdleVm {
-            reuse_key: vm.reuse_key,
-            sandbox_id: vm.sandbox_id,
-        })
-        .collect();
     Some(StatusInfo {
         mode: file.mode,
         started_at: file.started_at,
         active_runs,
-        idle_vms,
+        idle_sandboxes,
         proxy_port: file.proxy_port,
         dns_port: file.dns_port,
     })
@@ -1083,7 +1086,7 @@ fn correlate_jobs(
             .iter()
             .any(|r| r.sandbox_id == fc.sandbox_id)
             || status
-                .idle_vms
+                .idle_sandboxes
                 .iter()
                 .any(|v| v.sandbox_id == fc.sandbox_id);
         if !known {
@@ -1368,13 +1371,13 @@ fn print_report(
             println!("    Jobs:    0 active");
         }
 
-        // Idle VMs (keep-alive)
+        // Idle sandboxes (keep-alive)
         if let Some(st) = &r.status
-            && !st.idle_vms.is_empty()
+            && !st.idle_sandboxes.is_empty()
         {
-            println!("    Idle:    {} VMs", st.idle_vms.len());
-            for vm in &st.idle_vms {
-                println!("{}", format_idle_vm_diagnostic_line(vm));
+            println!("    Idle:    {} sandboxes", st.idle_sandboxes.len());
+            for sandbox in &st.idle_sandboxes {
+                println!("{}", format_idle_sandbox_diagnostic_line(sandbox));
             }
         }
 
@@ -1411,10 +1414,10 @@ fn print_report(
     total_warnings
 }
 
-fn format_idle_vm_diagnostic_line(vm: &IdleVm) -> String {
+fn format_idle_sandbox_diagnostic_line(sandbox: &IdleSandbox) -> String {
     format!(
         "      - reuse key {} -> sandbox {}",
-        vm.reuse_key, vm.sandbox_id
+        sandbox.reuse_key, sandbox.sandbox_id
     )
 }
 
@@ -1520,7 +1523,7 @@ mod tests {
         let status = read_status(dir.path()).await.unwrap();
 
         assert!(status.active_runs.is_empty());
-        assert!(status.idle_vms.is_empty());
+        assert!(status.idle_sandboxes.is_empty());
     }
 
     #[tokio::test]
@@ -1584,14 +1587,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_status_missing_idle_vm_identifier_returns_none() {
+    async fn read_status_missing_idle_sandbox_identifier_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("status.json"),
             r#"{
                 "mode":"running",
                 "started_at":"2026-01-01T00:00:00.000Z",
-                "idle_vms":[{"reuse_key":"session-a"}]
+                "idle_sandboxes":[{"reuse_key":"session-a"}]
             }"#,
         )
         .unwrap();
@@ -1659,12 +1662,12 @@ mod tests {
             mode: "running".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
             active_runs,
-            // Tests only need sandbox_id lookup for idle VMs; synthesize a
+            // Tests only need sandbox_id lookup for idle sandboxes; synthesize a
             // placeholder reuse key.
-            idle_vms: idle_sandboxes
+            idle_sandboxes: idle_sandboxes
                 .into_iter()
                 .enumerate()
-                .map(|(i, sbid)| IdleVm {
+                .map(|(i, sbid)| IdleSandbox {
                     reuse_key: format!("thread:test-{i}"),
                     sandbox_id: sbid.into(),
                 })
@@ -1721,8 +1724,8 @@ mod tests {
     }
 
     #[test]
-    fn correlate_idle_vm_no_warning() {
-        // Parked idle VM: no active run, sandbox_id listed in idle_vms.
+    fn correlate_idle_sandbox_no_warning() {
+        // Parked idle sandbox: no active run, sandbox_id listed in idle_sandboxes.
         // This is the exact prod-3 v0.79.12 scenario that used to
         // false-positive with 2 `FirecrackerNotInStatus` warnings.
         let status = status_info(vec![], vec!["sandbox-idle"]);
@@ -2323,7 +2326,7 @@ mod tests {
     #[tokio::test]
     async fn firecracker_not_in_status_clears_when_sandbox_becomes_idle() {
         // A FirecrackerNotInStatus warning must clear once its sandbox_id
-        // shows up in idle_vms (the VM was parked between scans).
+        // shows up in idle_sandboxes (the sandbox was parked between scans).
         let dir = tempfile::tempdir().unwrap();
         let base_dir = dir.path().to_path_buf();
         write_status_json(
@@ -2332,7 +2335,7 @@ mod tests {
                 "mode": "running",
                 "max_concurrent": 4,
                 "active_runs": [],
-                "idle_vms": [
+                "idle_sandboxes": [
                     {"reuse_key": "sess-1", "sandbox_id": "S1"}
                 ],
                 "started_at": "2026-01-01T00:00:00.000Z",
@@ -2604,9 +2607,9 @@ mod tests {
     }
 
     #[test]
-    fn idle_vm_diagnostic_line_includes_reuse_key() {
+    fn idle_sandbox_diagnostic_line_includes_reuse_key() {
         let reuse_key = "thread:doctor-17975";
-        let line = format_idle_vm_diagnostic_line(&IdleVm {
+        let line = format_idle_sandbox_diagnostic_line(&IdleSandbox {
             reuse_key: reuse_key.into(),
             sandbox_id: "sandbox-123".into(),
         });

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -1,4 +1,4 @@
-//! Execute a command inside a running VM for live debugging.
+//! Execute a command inside a running sandbox for live debugging.
 
 use std::io::Write;
 use std::process::ExitCode;
@@ -41,11 +41,11 @@ pub struct ExecArgs {
     #[arg(long, default_value = "30")]
     timeout: u32,
 
-    /// Run the command with sudo inside the VM
+    /// Run the command with sudo inside the sandbox
     #[arg(long)]
     sudo: bool,
 
-    /// Command to execute inside the VM (after `--`).
+    /// Command to execute inside the sandbox (after `--`).
     ///
     /// Arguments are preserved as argv — pipes, redirects, globs, and
     /// variable expansion must be invoked explicitly via a shell:

--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -248,7 +248,7 @@ pub(super) async fn gc_workspace_orphans(
 
     // Discover active workspaces after initial candidate selection. This
     // protects orphaned Firecrackers whose parent runner already died but
-    // whose VM is still running.
+    // whose sandbox is still running.
     let discovered = crate::process::discover_all_with_status().await;
     if !discovered.proc_scan_complete {
         warn!(

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -46,7 +46,7 @@ pub struct SubmitArgs {
     /// Agent type
     #[arg(long, default_value = "claude-code")]
     cli_agent_type: String,
-    /// VM profile to use (e.g. "vm0/default")
+    /// Sandbox profile to use (e.g. "vm0/default")
     #[arg(long)]
     profile: Option<String>,
     /// Chat thread ID for sandbox and workspace reuse across turns

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -407,7 +407,7 @@ mod tests {
                     "phase_started_at":"2026-04-13T00:00:02.000Z"
                 }
             ],
-            "idle_vms": [
+            "idle_sandboxes": [
                 {"reuse_key":"sess-1","sandbox_id":"bbbbbbbb-0000-7000-8000-000000000001"}
             ],
             "proxy_port": 8080,

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -320,7 +320,7 @@ async fn stop_default_with_ops(
     let svc = unit.service_name();
 
     if ops.is_active(unit).await? {
-        // Active unit: stop must succeed; otherwise the runner process and VMs
+        // Active unit: stop must succeed; otherwise the runner process and sandboxes
         // can keep running.
         ops.stop(unit).await?;
         info!(unit = %unit.unit_name(), "stopped");

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -705,7 +705,7 @@ async fn acquire_fallback_resource(
                 info!(
                     run_id = %run_id,
                     profile = %retiring.profile_name(),
-                    "evicting idle VM for finalizing fallback"
+                    "evicting idle sandbox for finalizing fallback"
                 );
                 retiring_leases.push(retiring.into_budget_lease());
                 ctx.reuse_state_notify.notify_one();

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -768,7 +768,7 @@ pub(super) fn collect_heartbeat_state(
         "Stopped is never live-heartbeated",
     );
     let (allocated_vcpu, allocated_memory_mb, budget_running) = budget.allocated();
-    // budget.allocated() includes parked (idle) VMs that hold their budget.
+    // budget.allocated() includes parked (idle) sandboxes that hold their budget.
     // Report only actively running jobs so the scheduler sees real capacity.
     let idle_count = idle_pool.len();
     let running_count = budget_running.saturating_sub(idle_count);

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -65,7 +65,7 @@ impl IdleDestroyTracker {
 ///
 /// A SIGUSR2 resume can reopen parking while a soft-drain destroy is still in
 /// progress, so write the current post-destroy pool snapshot rather than
-/// blindly clearing `idle_vms`.
+/// blindly clearing `idle_sandboxes`.
 ///
 /// `context` is logged alongside the destroyed count for operator clarity
 /// (e.g. "draining" vs "shutdown").
@@ -76,7 +76,7 @@ pub(super) async fn drain_idle_pool(
 ) {
     let jobs = idle_pool.lock().await.drain();
     if !jobs.is_empty() {
-        info!(count = jobs.len(), context, "destroying idle VMs");
+        info!(count = jobs.len(), context, "destroying idle sandboxes");
         destroy_idle_jobs_and_wait(jobs, context).await;
     }
     let snapshot = idle_pool.lock().await.status_snapshot();
@@ -168,7 +168,7 @@ pub(super) async fn select_idle_entry_for_pressure(
 
 pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {
     let applied = status
-        .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+        .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
         .await;
     if !applied {
         info!(
@@ -189,7 +189,7 @@ pub(super) async fn add_running_run_with_idle_status_snapshot(
             run_id,
             sandbox_id,
             snapshot.revision,
-            snapshot.idle_vms,
+            snapshot.idle_sandboxes,
         )
         .await;
     if !applied {
@@ -211,7 +211,7 @@ pub(super) async fn add_preparing_run_with_idle_status_snapshot(
             run_id,
             sandbox_id,
             snapshot.revision,
-            snapshot.idle_vms,
+            snapshot.idle_sandboxes,
         )
         .await;
     if !applied {
@@ -247,7 +247,7 @@ pub(super) async fn destroy_idle_jobs_and_wait(
 ) -> bool {
     // Destroy in parallel -- each `stop_and_destroy` is ~1-3s (FC shutdown +
     // cgroup/NBD/netns teardown). Serial destroy blows past shutdown and
-    // budget-pressure recovery budgets on multi-VM cleanup.
+    // budget-pressure recovery budgets on multi-sandbox cleanup.
     let mut set = JoinSet::new();
     for job in jobs {
         set.spawn(destroy_idle_job(job, context));

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1180,7 +1180,7 @@ async fn acquire_local_admission_resource(
             profile = %retiring.profile_name(),
             vcpu = retiring.budget_vcpu(),
             memory_mb = retiring.budget_memory_mb(),
-            "evicting idle VM for candidate admission"
+            "evicting idle sandbox for candidate admission"
         );
         retiring_leases.push(retiring.into_budget_lease());
         ctx.spawn_ctx.reuse_state_notify.notify_one();
@@ -1541,7 +1541,7 @@ async fn activate_speculated_exact(
             run_id = %run_id,
             reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
             reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
-            "claimed reuse key does not match speculatively prepared idle VM"
+            "claimed reuse key does not match speculatively prepared idle sandbox"
         );
         return cleanup_reserved_for_fresh_fallback(
             sandbox.into_destroy_job("speculative_reuse_session_mismatch"),
@@ -1693,7 +1693,7 @@ async fn finish_exact_activation(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
                 reuse_key_kind = reuse_key_kind(&reuse_key),
-                "committing speculatively prepared exact-reuse VM"
+                "committing speculatively prepared exact-reuse sandbox"
             );
             ExactActivation::Ready {
                 reuse_entry: Some(Box::new(reuse_entry)),
@@ -1774,7 +1774,7 @@ pub(super) async fn activate_reserved_idle(
             reuse_key_fingerprint = %reuse_key_fingerprint,
             reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
             profile = %profile_name,
-            "reserved idle VM configuration does not match claimed job, destroying before fresh fallback"
+            "reserved idle sandbox configuration does not match claimed job, destroying before fresh fallback"
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
@@ -1797,7 +1797,7 @@ pub(super) async fn activate_reserved_idle(
             run_id = %run_id,
             reuse_key_fingerprint = %reuse_key_fingerprint,
             reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
-            "claimed reuse key does not match reserved idle VM, destroying before fresh fallback"
+            "claimed reuse key does not match reserved idle sandbox, destroying before fresh fallback"
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
@@ -1827,7 +1827,7 @@ pub(super) async fn activate_reserved_idle(
                 reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
                 profile = %profile_name,
                 mismatch = mismatch.as_str(),
-                "workspace promotion identity mismatch, destroying reserved idle VM before fresh fallback"
+                "workspace promotion identity mismatch, destroying reserved idle sandbox before fresh fallback"
             );
             return cleanup_reserved_for_fresh_fallback(
                 reservation.into_destroy_job_without_workspace_promotion_for_mismatch(),
@@ -1852,7 +1852,7 @@ pub(super) async fn activate_reserved_idle(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
                 reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
-                "reusing pre-claim reserved idle VM for reuse key"
+                "reusing pre-claim reserved idle sandbox for reuse key"
             );
             let idle_snapshot = ctx.idle_pool.lock().await.status_snapshot();
             ReservedActivation::Ready {
@@ -1868,7 +1868,7 @@ pub(super) async fn activate_reserved_idle(
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
                 reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
                 error = %error,
-                "reserved idle VM unpark failed, destroying before fresh fallback"
+                "reserved idle sandbox unpark failed, destroying before fresh fallback"
             );
             cleanup_reserved_for_fresh_fallback(
                 *destroy_job,
@@ -2013,7 +2013,7 @@ async fn try_reuse_from_pool(
                         reuse_key_kind = reuse_key_kind(reuse_key),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
-                        "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
+                        "workspace promotion identity mismatch, destroying idle sandbox and falling through to fresh create"
                     );
                     spawn_idle_destroy_job(
                         &ctx.spawn_ctx.idle_destroy_tracker,
@@ -2041,7 +2041,7 @@ async fn try_reuse_from_pool(
                         run_id = %run_id,
                         reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
                         reuse_key_kind = reuse_key_kind(reuse_key),
-                        "reusing idle VM for reuse key"
+                        "reusing idle sandbox for reuse key"
                     );
                     // Idle entry already holds budget. Drop the speculative
                     // fresh-job lease and move the idle lease to the outer job
@@ -2061,7 +2061,7 @@ async fn try_reuse_from_pool(
                         reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
                         reuse_key_kind = reuse_key_kind(reuse_key),
                         error = %error,
-                        "unpark failed, destroying idle VM and falling through to fresh create"
+                        "unpark failed, destroying idle sandbox and falling through to fresh create"
                     );
                     spawn_idle_destroy_job(
                         &ctx.spawn_ctx.idle_destroy_tracker,
@@ -2084,7 +2084,7 @@ async fn try_reuse_from_pool(
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
                 reuse_key_kind = reuse_key_kind(reuse_key),
                 profile = %profile_name,
-                "idle VM device rate limiter mismatch, destroying"
+                "idle sandbox device rate limiter mismatch, destroying"
             );
             spawn_idle_destroy_job(
                 &ctx.spawn_ctx.idle_destroy_tracker,
@@ -2106,7 +2106,7 @@ async fn try_reuse_from_pool(
                 reuse_key_kind = reuse_key_kind(reuse_key),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
-                "idle VM profile mismatch, destroying"
+                "idle sandbox profile mismatch, destroying"
             );
             spawn_idle_destroy_job(
                 &ctx.spawn_ctx.idle_destroy_tracker,
@@ -2126,7 +2126,7 @@ async fn try_reuse_from_pool(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
                 reuse_key_kind = reuse_key_kind(reuse_key),
-                "no idle VM found for reuse key"
+                "no idle sandbox found for reuse key"
             );
             (
                 None,
@@ -2143,7 +2143,7 @@ async fn try_reuse_from_pool(
 mod tests {
     use super::*;
 
-    use crate::status::IdleVm;
+    use crate::status::IdleSandbox;
 
     fn read_active_run_phase(path: &std::path::Path) -> String {
         let raw = std::fs::read_to_string(path).unwrap();
@@ -2157,7 +2157,7 @@ mod tests {
     fn idle_snapshot() -> IdlePoolSnapshot {
         IdlePoolSnapshot {
             revision: 1,
-            idle_vms: vec![IdleVm {
+            idle_sandboxes: vec![IdleSandbox {
                 reuse_key: "sess-removed-from-pool".into(),
                 sandbox_id: SandboxId::new_v4(),
             }],

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1479,10 +1479,10 @@ mod tests {
         let raw = tokio::fs::read_to_string(status_path).await.unwrap();
         let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let mut reuse_keys: Vec<String> = status
-            .get("idle_vms")
+            .get("idle_sandboxes")
             .and_then(|v| v.as_array())
-            .map(|idle_vms| {
-                idle_vms
+            .map(|idle_sandboxes| {
+                idle_sandboxes
                     .iter()
                     .filter_map(|vm| {
                         vm.get("reuse_key")

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -616,7 +616,7 @@ async fn run_start_with_home(
         }
     }
 
-    // Idle sandbox pool for VM reuse across conversation turns.
+    // Idle sandbox pool for sandbox reuse across conversation turns.
     let parking_gate = ParkingGate::new_open();
     let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
         IdlePoolConfig { max_idle },
@@ -997,7 +997,7 @@ enum StartLoopEvent {
     FinalizingCapacityWaitEntered { run_id: RunId },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
-    VmParkedForReuse { run_id: RunId, reuse_key: String },
+    SandboxParkedForReuse { run_id: RunId, reuse_key: String },
     UsageFlushRequested,
 }
 
@@ -1178,7 +1178,7 @@ impl StartLoopTestObserver {
     }
 
     fn notify_vm_parked_for_reuse(&self, run_id: RunId, reuse_key: String) {
-        self.record(StartLoopEvent::VmParkedForReuse { run_id, reuse_key });
+        self.record(StartLoopEvent::SandboxParkedForReuse { run_id, reuse_key });
     }
 
     fn notify_usage_flush_requested(&self) {
@@ -1264,8 +1264,8 @@ impl StartLoopTestObserver {
     }
 
     async fn wait_vm_parked_for_reuse(&self, run_id: RunId, timeout: Duration) -> String {
-        self.wait_for(timeout, "VM parked for reuse", |event| match event {
-            StartLoopEvent::VmParkedForReuse {
+        self.wait_for(timeout, "sandbox parked for reuse", |event| match event {
+            StartLoopEvent::SandboxParkedForReuse {
                 run_id: observed_run_id,
                 reuse_key,
             } if *observed_run_id == run_id => Some(reuse_key.clone()),
@@ -2167,8 +2167,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.event("drop_discover_fut");
     drop(workspace_cache_change_fut);
 
-    // Drain idle pool first — these VMs hold budget reservations. This
-    // also clears `idle_vms` in status.json so the final snapshot is
+    // Drain idle pool first — these sandboxes hold budget reservations. This
+    // also clears `idle_sandboxes` in status.json so the final snapshot is
     // consistent with the empty pool.
     lifecycle.close_parking();
     let phase = teardown.phase_start("drain_idle_pool");

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -26,7 +26,7 @@ struct OrphanedActiveRunState {
     absent_scans: u8,
 }
 
-/// Claimed runs whose outer task is gone but whose VM ownership is uncertain.
+/// Claimed runs whose outer task is gone but whose sandbox ownership is uncertain.
 #[derive(Clone)]
 pub(super) struct OrphanedActiveRuns {
     inner: Arc<Mutex<BTreeMap<RunId, OrphanedActiveRunState>>>,
@@ -466,22 +466,22 @@ mod tests {
 
         async fn assert_status(
             &self,
-            expected_idle_vms: &[(&str, SandboxId)],
+            expected_idle_sandboxes: &[(&str, SandboxId)],
             expected_active_runs: &[(RunId, SandboxId)],
         ) {
-            let (idle_vms, active_runs) = self.status_idle_vms_and_active_runs().await;
-            let mut expected_idle_vms = expected_idle_vms
+            let (idle_sandboxes, active_runs) = self.status_idle_sandboxes_and_active_runs().await;
+            let mut expected_idle_sandboxes = expected_idle_sandboxes
                 .iter()
                 .map(|(reuse_key, sandbox_id)| ((*reuse_key).to_string(), sandbox_id.to_string()))
                 .collect::<Vec<_>>();
-            expected_idle_vms.sort_unstable();
+            expected_idle_sandboxes.sort_unstable();
             let mut expected_active_runs = expected_active_runs
                 .iter()
                 .map(|(run_id, sandbox_id)| (run_id.to_string(), sandbox_id.to_string()))
                 .collect::<Vec<_>>();
             expected_active_runs.sort_unstable();
 
-            assert_eq!(idle_vms, expected_idle_vms);
+            assert_eq!(idle_sandboxes, expected_idle_sandboxes);
             assert_eq!(active_runs, expected_active_runs);
         }
 
@@ -505,32 +505,32 @@ mod tests {
             assert_eq!(self.orphans.is_empty(), expected == 0);
         }
 
-        async fn status_idle_vms_and_active_runs(
+        async fn status_idle_sandboxes_and_active_runs(
             &self,
         ) -> (Vec<(String, String)>, Vec<(String, String)>) {
             let raw = tokio::fs::read_to_string(&self.status_path).await.unwrap();
             let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
-            let mut idle_vms: Vec<(String, String)> = status
-                .get("idle_vms")
+            let mut idle_sandboxes: Vec<(String, String)> = status
+                .get("idle_sandboxes")
                 .and_then(|v| v.as_array())
-                .map(|idle_vms| {
-                    idle_vms
+                .map(|idle_sandboxes| {
+                    idle_sandboxes
                         .iter()
                         .map(|vm| {
                             let reuse_key = vm
                                 .get("reuse_key")
                                 .and_then(|reuse_key| reuse_key.as_str())
-                                .expect("idle VM must include reuse_key");
+                                .expect("idle sandbox must include reuse_key");
                             let sandbox_id = vm
                                 .get("sandbox_id")
                                 .and_then(|sandbox| sandbox.as_str())
-                                .expect("idle VM must include sandbox_id");
+                                .expect("idle sandbox must include sandbox_id");
                             (reuse_key.to_string(), sandbox_id.to_string())
                         })
                         .collect()
                 })
                 .unwrap_or_default();
-            idle_vms.sort_unstable();
+            idle_sandboxes.sort_unstable();
             let mut active_runs: Vec<(String, String)> = status["active_runs"]
                 .as_array()
                 .unwrap()
@@ -548,7 +548,7 @@ mod tests {
                 })
                 .collect();
             active_runs.sort_unstable();
-            (idle_vms, active_runs)
+            (idle_sandboxes, active_runs)
         }
     }
 
@@ -912,7 +912,7 @@ mod tests {
                 ORPHANED_ACTIVE_RUN_ABSENT_SCANS_BEFORE_REMOVE,
             )
             .await;
-        let (_idle_vms, active_runs) = fixture.status_idle_vms_and_active_runs().await;
+        let (_idle_sandboxes, active_runs) = fixture.status_idle_sandboxes_and_active_runs().await;
         assert!(
             active_runs.is_empty(),
             "incomplete discovery should not count as absent, but should not globally reset prior conclusive absence"

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -142,15 +142,15 @@ fn idle_snapshot_contains_sandbox_id(
     sandbox_id: SandboxId,
 ) -> bool {
     idle_snapshot
-        .idle_vms
+        .idle_sandboxes
         .iter()
-        .any(|idle_vm| idle_vm.sandbox_id == sandbox_id)
+        .any(|idle_sandbox| idle_sandbox.sandbox_id == sandbox_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::status::IdleVm;
+    use crate::status::IdleSandbox;
 
     async fn status_idle_reuse_keys_and_active_runs(
         status_path: &std::path::Path,
@@ -158,10 +158,10 @@ mod tests {
         let raw = tokio::fs::read_to_string(status_path).await.unwrap();
         let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let mut reuse_keys: Vec<String> = status
-            .get("idle_vms")
+            .get("idle_sandboxes")
             .and_then(|v| v.as_array())
-            .map(|idle_vms| {
-                idle_vms
+            .map(|idle_sandboxes| {
+                idle_sandboxes
                     .iter()
                     .filter_map(|vm| {
                         vm.get("reuse_key")
@@ -190,7 +190,7 @@ mod tests {
     fn idle_snapshot(reuse_key: &str, sandbox_id: SandboxId) -> IdlePoolSnapshot {
         IdlePoolSnapshot {
             revision: 1,
-            idle_vms: vec![IdleVm {
+            idle_sandboxes: vec![IdleSandbox {
                 reuse_key: reuse_key.to_string(),
                 sandbox_id,
             }],

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -581,7 +581,7 @@ async fn finalize_sandbox_for_completion_inner(
                 run_id = %run_id,
                 reuse_key_fingerprint = %reuse_key_fingerprint,
                 reuse_key_kind = reuse_kind,
-                "job hard-cancelled while parking, destroying VM"
+                "job hard-cancelled while parking, destroying sandbox"
             );
             let destroy_result = destroy_active_owned_idle_payload(
                 payload,
@@ -671,7 +671,7 @@ async fn finalize_sandbox_for_completion_inner(
                         guest_swap_free_bytes = guest.map(|snapshot| snapshot.swap_free_bytes),
                         reason = reason.as_str(),
                         admission_action = "reject_and_destroy",
-                        "sandbox parked with severe memory retention, destroying VM"
+                        "sandbox parked with severe memory retention, destroying sandbox"
                     );
                 }
             }
@@ -824,7 +824,7 @@ async fn finalize_sandbox_for_completion_inner(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
                             reuse_key_kind = reuse_kind,
-                            "job hard-cancelled before idle pool ownership transfer, destroying VM"
+                            "job hard-cancelled before idle pool ownership transfer, destroying sandbox"
                         );
                         drop(transfer_guard);
                         let (payload, budget_lease) = candidate.into_active_destroy_parts();
@@ -857,7 +857,7 @@ async fn finalize_sandbox_for_completion_inner(
                         run_id = %run_id,
                         reuse_key_fingerprint = %reuse_key_fingerprint,
                         reuse_key_kind = reuse_kind,
-                        "job hard-cancelled before idle pool ownership transfer, destroying VM"
+                        "job hard-cancelled before idle pool ownership transfer, destroying sandbox"
                     );
                     drop(transfer_guard);
                     drop(pool);
@@ -887,7 +887,7 @@ async fn finalize_sandbox_for_completion_inner(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
                             reuse_key_kind = reuse_kind,
-                            "VM parked for reuse"
+                            "sandbox parked for reuse"
                         );
                         #[cfg(test)]
                         test_observer.notify_vm_parked_for_reuse(run_id, reuse_key.clone());
@@ -924,7 +924,7 @@ async fn finalize_sandbox_for_completion_inner(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
                             reuse_key_kind = reuse_kind,
-                            "VM parked, evicting previous"
+                            "sandbox parked, evicting previous"
                         );
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
@@ -946,7 +946,7 @@ async fn finalize_sandbox_for_completion_inner(
                         reuse_state_changed = true;
                         telemetry.record_idle_publication(true, None);
                         reuse_state_notify.notify_one();
-                        // The replaced VM was park()ed when it entered the
+                        // The replaced sandbox was park()ed when it entered the
                         // pool; destroying a parked sandbox is safe — Drop
                         // aborts any leftover handles and the FC process is
                         // killed regardless of balloon state.
@@ -961,7 +961,7 @@ async fn finalize_sandbox_for_completion_inner(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
                             reuse_key_kind = reuse_kind,
-                            "idle parking rejected, destroying VM"
+                            "idle parking rejected, destroying sandbox"
                         );
                         drop(transfer_guard);
                         drop(pool);
@@ -1730,14 +1730,14 @@ mod tests {
             .iter()
             .filter(|event| {
                 event.fields.get("message").is_some_and(|message| {
-                    message == "sandbox parked with severe memory retention, destroying VM"
+                    message == "sandbox parked with severe memory retention, destroying sandbox"
                 })
             })
             .collect();
         assert_eq!(matching_events.len(), 1, "captured={events:#?}");
         let event = captured_event(
             &events,
-            "sandbox parked with severe memory retention, destroying VM",
+            "sandbox parked with severe memory retention, destroying sandbox",
         );
         assert_eq!(event.level, Level::WARN);
         assert_event_field(event, "run_id", &run_id.to_string());

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -126,11 +126,11 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
 }
 
 // -----------------------------------------------------------------------
-// Test 15: Idle VMs remain reusable until capacity is needed
+// Test 15: Idle sandboxes remain reusable until capacity is needed
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn idle_vm_remains_reusable_until_capacity_is_needed() {
+async fn idle_sandbox_remains_reusable_until_capacity_is_needed() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -161,7 +161,7 @@ async fn idle_vm_remains_reusable_until_capacity_is_needed() {
 
     tokio::time::advance(Duration::from_secs(3600)).await;
     assert_eq!(idle_pool.lock().await.len(), 1, "idle age must not evict");
-    assert_eq!(budget.allocated().2, 1, "aged idle VM keeps its lease");
+    assert_eq!(budget.allocated().2, 1, "aged idle sandbox keeps its lease");
 
     let run_id = RunId::new_v4();
     push_job(
@@ -174,7 +174,7 @@ async fn idle_vm_remains_reusable_until_capacity_is_needed() {
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await
-        .expect("aged idle VM should remain reusable");
+        .expect("aged idle sandbox should remain reusable");
     assert_eq!(
         completion.reuse_result,
         Some(crate::types::SandboxReuseResult::Reused)
@@ -184,7 +184,7 @@ async fn idle_vm_remains_reusable_until_capacity_is_needed() {
 }
 
 // -----------------------------------------------------------------------
-// Test 16: Budget exhausted → evict idle VM → admit new job
+// Test 16: Budget exhausted → evict idle sandbox → admit new job
 // -----------------------------------------------------------------------
 
 #[tokio::test(flavor = "current_thread")]
@@ -201,7 +201,7 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
 
-    // Pre-seed: idle VM fills the entire budget.
+    // Pre-seed: idle sandbox fills the entire budget.
     seed_idle_pool_with_overrides(
         &idle_pool,
         &budget,
@@ -226,11 +226,11 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
     destroy_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("idle VM should enter tracked destroy");
+        .expect("idle sandbox should enter tracked destroy");
     wait_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("fresh VM should activate while idle destroy is blocked");
+        .expect("fresh sandbox should activate while idle destroy is blocked");
     assert_eq!(
         budget.allocated(),
         (2, 4096, 1),
@@ -348,11 +348,11 @@ async fn smaller_fresh_profile_releases_only_net_idle_capacity() {
     destroy_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("large idle VM should enter tracked destroy");
+        .expect("large idle sandbox should enter tracked destroy");
     wait_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("smaller fresh VM should activate before destroy completes");
+        .expect("smaller fresh sandbox should activate before destroy completes");
     assert_eq!(budget.allocated(), (2, 4096, 1));
     assert!(
         budget.can_afford(2, 4096),
@@ -364,7 +364,7 @@ async fn smaller_fresh_profile_releases_only_net_idle_capacity() {
     destroy_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("fresh VM should enter normal active cleanup");
+        .expect("fresh sandbox should enter normal active cleanup");
     destroy_gate.release_one();
     let completion = env
         .handle
@@ -441,7 +441,7 @@ async fn budget_pressure_evicts_oldest_idle_regardless_of_age() {
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-newer-large".to_string()],
-        "status.json should reflect the remaining idle VM"
+        "status.json should reflect the remaining idle sandbox"
     );
 
     shutdown(&env, run_handle).await;
@@ -525,14 +525,14 @@ async fn larger_profile_retires_only_the_required_oldest_idle_entries() {
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-newest".to_string()],
-        "status.json should reflect only the remaining idle VM"
+        "status.json should reflect only the remaining idle sandbox"
     );
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn idle_vm_is_reclaimed_only_after_candidate_discovery() {
+async fn idle_sandbox_is_reclaimed_only_after_candidate_discovery() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -553,13 +553,13 @@ async fn idle_vm_is_reclaimed_only_after_candidate_discovery() {
     assert!(completion.is_some(), "job should complete and park");
     assert_eq!(completion.unwrap().exit_code, 0);
 
-    // The single parked VM fills the whole budget. It must remain reusable
+    // The single parked sandbox fills the whole budget. It must remain reusable
     // until a concrete candidate proves that generic capacity is needed.
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
     assert_eq!(
         idle_pool.lock().await.len(),
         1,
-        "idle VM should be retained"
+        "idle sandbox should be retained"
     );
     wait_status_idle_reuse_keys_and_active_runs(
         &status_path,
@@ -589,7 +589,7 @@ async fn idle_vm_is_reclaimed_only_after_candidate_discovery() {
     assert_eq!(idle_pool.lock().await.len(), 0, "idle pool should be empty");
     assert!(
         status_idle_reuse_keys(&status_path).await.is_empty(),
-        "status.json should clear the candidate-reclaimed idle VM"
+        "status.json should clear the candidate-reclaimed idle sandbox"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -38,7 +38,7 @@ async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
     shutdown(&env, run_handle).await;
 }
 
-/// Test 20: A healthy non-zero process exit remains failed but retains its VM.
+/// Test 20: A healthy non-zero process exit remains failed but retains its sandbox.
 #[tokio::test(start_paused = true)]
 async fn nonzero_job_parks_and_successor_reuses_sandbox() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -69,7 +69,7 @@ async fn nonzero_job_parks_and_successor_reuses_sandbox() {
     assert_eq!(
         budget.allocated().2,
         1,
-        "parked VM should retain its budget"
+        "parked sandbox should retain its budget"
     );
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -254,13 +254,13 @@ async fn non_reusable_park_keeps_budget_until_destroy_and_never_enters_idle_stat
         &counter,
         &budget,
         1,
-        "non-reusable parked VM should be sent to destroy exactly once",
-        "non-reusable parked VM must retain budget while destroy is in-flight",
+        "non-reusable parked sandbox should be sent to destroy exactly once",
+        "non-reusable parked sandbox must retain budget while destroy is in-flight",
     );
     assert_idle_pool_len(
         &idle_pool,
         0,
-        "non-reusable parked VM must never enter the idle pool",
+        "non-reusable parked sandbox must never enter the idle pool",
     )
     .await;
     wait_status_idle_reuse_keys_and_active_runs(
@@ -273,7 +273,7 @@ async fn non_reusable_park_keeps_budget_until_destroy_and_never_enters_idle_stat
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while non-reusable VM destroy is blocked",
+        "host completion should report while non-reusable sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();
@@ -312,14 +312,14 @@ async fn repeated_non_reusable_parks_use_fresh_sandboxes() {
             .handle
             .wait_completion(run_id, Duration::from_secs(5))
             .await
-            .expect("successful job should complete after non-reusable VM destroy");
+            .expect("successful job should complete after non-reusable sandbox destroy");
         assert_eq!(completion.exit_code, 0);
         assert!(completion.error.is_none());
         wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
         assert_idle_pool_len(
             &idle_pool,
             0,
-            "repeated non-reusable VMs must never cycle through the idle pool",
+            "repeated non-reusable sandboxes must never cycle through the idle pool",
         )
         .await;
     }
@@ -481,13 +481,13 @@ async fn assert_workspace_cache_after_late_cancellation(
         &counter,
         &budget,
         1,
-        "cancelled VM should be sent to destroy exactly once",
-        "cancelled VM must retain budget while destroy is in-flight",
+        "cancelled sandbox should be sent to destroy exactly once",
+        "cancelled sandbox must retain budget while destroy is in-flight",
     );
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while cancelled VM destroy is blocked",
+        "host completion should report while cancelled sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();
@@ -562,13 +562,13 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         &counter,
         &budget,
         2,
-        "rejected VM should be sent to destroy",
-        "rejected active VM must retain its budget while destroy is in-flight",
+        "rejected sandbox should be sent to destroy",
+        "rejected active sandbox must retain its budget while destroy is in-flight",
     );
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while rejected VM destroy is blocked",
+        "host completion should report while rejected sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();
@@ -621,8 +621,8 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         &counter,
         &budget,
         1,
-        "rejected VM should be sent to destroy exactly once",
-        "rejected VM must retain budget while destroy is in-flight",
+        "rejected sandbox should be sent to destroy exactly once",
+        "rejected sandbox must retain budget while destroy is in-flight",
     );
     assert_idle_pool_len(
         &idle_pool,
@@ -633,7 +633,7 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while rejected VM destroy is blocked",
+        "host completion should report while rejected sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();
@@ -685,19 +685,19 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
         &counter,
         &budget,
         1,
-        "cancelled VM should be sent to destroy exactly once",
-        "cancelled VM must retain budget while destroy is in-flight",
+        "cancelled sandbox should be sent to destroy exactly once",
+        "cancelled sandbox must retain budget while destroy is in-flight",
     );
     assert_idle_pool_len(
         &idle_pool,
         0,
-        "cancelled VM must not enter the idle pool after waiting for the lock",
+        "cancelled sandbox must not enter the idle pool after waiting for the lock",
     )
     .await;
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while cancelled VM destroy is blocked",
+        "host completion should report while cancelled sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();
@@ -747,19 +747,19 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
         &counter,
         &budget,
         1,
-        "cancelled VM should be sent to destroy exactly once",
-        "cancelled VM must retain budget while destroy is in-flight",
+        "cancelled sandbox should be sent to destroy exactly once",
+        "cancelled sandbox must retain budget while destroy is in-flight",
     );
     assert_idle_pool_len(
         &idle_pool,
         0,
-        "cancelled VM must not enter the idle pool after park returns",
+        "cancelled sandbox must not enter the idle pool after park returns",
     )
     .await;
     assert_successful_completion_for_run(
         &env,
         run_id,
-        "host completion should report while cancelled VM destroy is blocked",
+        "host completion should report while cancelled sandbox destroy is blocked",
     )
     .await;
     destroy_gate.release_one();

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -76,7 +76,7 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
     );
 
     // Wait for resource ownership to settle: the failed idle entry has been
-    // destroyed and the fresh-create VM is parked as the single idle lease.
+    // destroyed and the fresh-create sandbox is parked as the single idle lease.
     // `idle_pool.len() == 1` is true before the job starts, so budget must be
     // the first terminal-state probe.
     wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
@@ -131,7 +131,7 @@ async fn unpark_failure_status_switches_from_idle_to_active_while_job_runs() {
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-unpark-status".to_string()],
-        "pre-run status should list the idle VM",
+        "pre-run status should list the idle sandbox",
     );
 
     let run_handle = tokio::spawn(run(config));

--- a/crates/runner/src/cmd/start/tests/idle_reuse/device_limits.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/device_limits.rs
@@ -51,7 +51,7 @@ async fn configured_io_limiter_capacity_applies_limits_on_fresh_create() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn absent_io_limiter_capacity_reuses_unlimited_idle_vm() {
+async fn absent_io_limiter_capacity_reuses_unlimited_idle_sandbox() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
@@ -97,7 +97,7 @@ async fn absent_io_limiter_capacity_reuses_unlimited_idle_vm() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn device_limit_mismatch_destroys_idle_vm_and_fresh_creates() {
+async fn device_limit_mismatch_destroys_idle_sandbox_and_fresh_creates() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));

--- a/crates/runner/src/cmd/start/tests/idle_reuse/drain.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/drain.rs
@@ -101,7 +101,7 @@ async fn job_completing_during_active_draining_is_not_parked() {
     assert_eq!(
         idle_pool.lock().await.len(),
         0,
-        "teardown must leave no idle VM",
+        "teardown must leave no idle sandbox",
     );
     assert_eq!(
         budget.allocated().2,
@@ -168,7 +168,7 @@ async fn soft_drain_resume_opens_parking_before_running_ack() {
     assert_eq!(
         budget.allocated().2,
         1,
-        "parked VM should retain its budget lease",
+        "parked sandbox should retain its budget lease",
     );
 
     env.trigger_stopping().await;
@@ -181,17 +181,17 @@ async fn soft_drain_resume_opens_parking_before_running_ack() {
 }
 
 /// Regression (G2): on SIGTERM from Running, teardown's
-/// `drain_idle_pool` is the *only* site that clears `idle_vms` in
+/// `drain_idle_pool` is the *only* site that clears `idle_sandboxes` in
 /// `status.json` — Draining mode is skipped entirely. Pre-fix, the
 /// stale list leaked into the final `"stopped"` snapshot.
 #[tokio::test(start_paused = true)]
-async fn shutdown_clears_idle_vms_in_status_json() {
+async fn shutdown_clears_idle_sandboxes_in_status_json() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let status_path = env._temp_dir.path().join("status.json");
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
-    // Park a VM via a normal job → status.json records the idle VM.
+    // Park a sandbox via a normal job → status.json records the idle sandbox.
     let run_id = RunId::new_v4();
     push_job(
         &env,
@@ -204,9 +204,9 @@ async fn shutdown_clears_idle_vms_in_status_json() {
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
     wait_idle_pool_reuse_keys(&idle_pool, &["sess-status-clean"], Duration::from_secs(5)).await;
-    assert_eq!(idle_pool.lock().await.len(), 1, "VM parked");
+    assert_eq!(idle_pool.lock().await.len(), 1, "sandbox parked");
 
-    // Pre-shutdown sanity: status.json lists the idle VM.
+    // Pre-shutdown sanity: status.json lists the idle sandbox.
     wait_status_idle_reuse_keys_and_active_runs(
         &status_path,
         &["sess-status-clean"],
@@ -217,14 +217,17 @@ async fn shutdown_clears_idle_vms_in_status_json() {
     let pre: serde_json::Value =
         serde_json::from_str(&tokio::fs::read_to_string(&status_path).await.unwrap()).unwrap();
     let pre_len = pre
-        .get("idle_vms")
+        .get("idle_sandboxes")
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    assert_eq!(pre_len, 1, "pre-shutdown status.json should list the VM");
+    assert_eq!(
+        pre_len, 1,
+        "pre-shutdown status.json should list the sandbox"
+    );
 
     // SIGTERM path: Draining mode is bypassed, so teardown's
-    // drain_idle_pool is the only site that can clear idle_vms.
+    // drain_idle_pool is the only site that can clear idle_sandboxes.
     env.trigger_stopping().await;
     assert_run_exits_within(
         run_handle,
@@ -233,17 +236,17 @@ async fn shutdown_clears_idle_vms_in_status_json() {
     )
     .await;
 
-    // Post-shutdown: mode=stopped, idle_vms empty/absent.
+    // Post-shutdown: mode=stopped, idle_sandboxes empty/absent.
     let post: serde_json::Value =
         serde_json::from_str(&tokio::fs::read_to_string(&status_path).await.unwrap()).unwrap();
     assert_eq!(post["mode"], "stopped");
     let post_len = post
-        .get("idle_vms")
+        .get("idle_sandboxes")
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
     assert_eq!(
         post_len, 0,
-        "status.json idle_vms must be cleared after shutdown: {post}",
+        "status.json idle_sandboxes must be cleared after shutdown: {post}",
     );
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -44,7 +44,11 @@ async fn job_with_session_parks_vm() {
     assert_eq!(c.unwrap().exit_code, 0);
 
     let pool = env.idle_pool.lock().await;
-    assert_eq!(pool.len(), 1, "VM should be parked when session is present");
+    assert_eq!(
+        pool.len(),
+        1,
+        "sandbox should be parked when session is present"
+    );
     assert!(
         pool.held_reuse_keys()
             .contains(&"thread:idle-sess-1".to_string())
@@ -72,7 +76,11 @@ async fn job_without_reuse_key_does_not_park() {
     assert_eq!(c.unwrap().exit_code, 0);
 
     let pool = env.idle_pool.lock().await;
-    assert_eq!(pool.len(), 0, "VM should not be parked without a reuse key");
+    assert_eq!(
+        pool.len(),
+        0,
+        "sandbox should not be parked without a reuse key"
+    );
     drop(pool);
 
     shutdown(&env, run_handle).await;
@@ -168,7 +176,7 @@ async fn job_without_cli_session_parks_and_reuses_by_reuse_key() {
 }
 
 // -----------------------------------------------------------------------
-// Test 10: Successful job parks VM in idle pool
+// Test 10: Successful job parks sandbox in idle pool
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
@@ -193,18 +201,18 @@ async fn successful_job_parks_in_idle_pool() {
     assert!(completion.is_some(), "job should complete");
     assert_eq!(completion.unwrap().exit_code, 0);
 
-    // VM should be parked in idle pool, holding budget.
+    // sandbox should be parked in idle pool, holding budget.
     wait_idle_pool_reuse_keys(&idle_pool, &["sess-park"], Duration::from_secs(5)).await;
     {
         let pool = idle_pool.lock().await;
-        assert_eq!(pool.len(), 1, "VM should be parked");
+        assert_eq!(pool.len(), 1, "sandbox should be parked");
         assert!(
             pool.held_reuse_keys().contains(&"sess-park".to_string()),
             "parked session should be sess-park"
         );
     }
     let (_, _, count) = budget.allocated();
-    assert_eq!(count, 1, "parked VM should hold budget");
+    assert_eq!(count, 1, "parked sandbox should hold budget");
 
     shutdown(&env, run_handle).await;
 }
@@ -392,7 +400,7 @@ async fn job_without_reuse_key_destroys_sandbox() {
 //
 // Exercises the full reuse cycle: park → take → reuse → park.
 // After two jobs the pool should have exactly 1 entry (the second job's
-// VM) and the budget count should be 1.
+// sandbox) and the budget count should be 1.
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
@@ -402,7 +410,7 @@ async fn sequential_same_reuse_key_cycle() {
     let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
-    // Job 1: parks VM for reuse key "sess-seq".
+    // Job 1: parks sandbox for reuse key "sess-seq".
     let id1 = RunId::new_v4();
     push_job(
         &env,
@@ -416,7 +424,11 @@ async fn sequential_same_reuse_key_cycle() {
         .await;
     assert!(c1.is_some(), "job 1 should complete");
     wait_idle_pool_reuse_keys(&idle_pool, &["sess-seq"], Duration::from_secs(5)).await;
-    assert_eq!(idle_pool.lock().await.len(), 1, "job 1 VM should be parked");
+    assert_eq!(
+        idle_pool.lock().await.len(),
+        1,
+        "job 1 sandbox should be parked"
+    );
 
     // Job 2: same reuse key → take → reuse → re-park.
     let id2 = RunId::new_v4();
@@ -434,7 +446,7 @@ async fn sequential_same_reuse_key_cycle() {
     assert_eq!(
         c2.unwrap().reuse_result,
         Some(SandboxReuseResult::Reused),
-        "job 2 should reuse the first job's parked VM",
+        "job 2 should reuse the first job's parked sandbox",
     );
     wait_idle_pool_reuse_keys(&idle_pool, &["sess-seq"], Duration::from_secs(5)).await;
 
@@ -443,7 +455,11 @@ async fn sequential_same_reuse_key_cycle() {
         1,
         "pool should have 1 entry after two sequential jobs"
     );
-    assert_eq!(budget.allocated().2, 1, "only one VM should hold budget");
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "only one sandbox should hold budget"
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -479,7 +495,7 @@ async fn same_thread_reuses_vm_across_provider_session_change() {
     assert_eq!(
         completion.reuse_result,
         Some(SandboxReuseResult::Reused),
-        "the thread reuse key should select the first job's parked VM"
+        "the thread reuse key should select the first job's parked sandbox"
     );
     wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
 
@@ -534,7 +550,7 @@ async fn discovered_cli_session_does_not_substitute_for_reuse_key() {
         "the discovered CLI session ID must not create a reuse identity"
     );
     assert_eq!(
-        pool.status_snapshot().idle_vms[0].sandbox_id,
+        pool.status_snapshot().idle_sandboxes[0].sandbox_id,
         seeded_sandbox_id
     );
     drop(pool);
@@ -606,7 +622,7 @@ async fn reuse_cycle_invokes_park_and_unpark_symmetrically() {
 }
 
 /// A successful job with a session triggers `Sandbox::park()` exactly once
-/// when the VM is handed off to the idle pool.
+/// when the sandbox is handed off to the idle pool.
 #[tokio::test(start_paused = true)]
 async fn park_called_when_vm_enters_idle_pool() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -641,7 +657,7 @@ async fn park_called_when_vm_enters_idle_pool() {
         0,
         "unpark() must not be called for a fresh park"
     );
-    assert_eq!(idle_pool.lock().await.len(), 1, "VM should be parked");
+    assert_eq!(idle_pool.lock().await.len(), 1, "sandbox should be parked");
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
@@ -8,23 +8,23 @@ use super::super::support::{
 use crate::types::{SandboxReuseResult, WorkspaceReuseResult};
 
 // -----------------------------------------------------------------------
-// Test 13: Same-thread work reuses an idle VM
+// Test 13: Same-thread work reuses an idle sandbox
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn same_thread_reuses_idle_vm() {
+async fn same_thread_reuses_idle_sandbox() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
 
-    // Pre-seed: park a VM for reuse key "sess-reuse" with matching profile.
+    // Pre-seed: park a sandbox for reuse key "sess-reuse" with matching profile.
     let seeded_sandbox_id =
         seed_idle_pool(&idle_pool, &budget, "sess-reuse", "vm0/default", 2, 4096).await;
     assert_eq!(budget.allocated().2, 1, "seeded entry holds budget");
 
     let run_handle = tokio::spawn(run(config));
 
-    // Push job for same reuse key — should reuse the idle VM.
+    // Push job for same reuse key — should reuse the idle sandbox.
     let run_id = RunId::new_v4();
     push_job(
         &env,
@@ -59,7 +59,7 @@ async fn same_thread_reuses_idle_vm() {
     wait_idle_pool_reuse_keys(&idle_pool, &["sess-reuse"], Duration::from_secs(5)).await;
     {
         let pool = idle_pool.lock().await;
-        assert_eq!(pool.len(), 1, "VM should be re-parked after reuse");
+        assert_eq!(pool.len(), 1, "sandbox should be re-parked after reuse");
     }
     assert_eq!(
         budget.allocated().2,
@@ -143,7 +143,7 @@ async fn invalid_reserved_resume_session_fails_before_reuse() {
     assert!(!error.contains(invalid_session_id));
     wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
     assert_eq!(
-        idle_pool.lock().await.status_snapshot().idle_vms[0].sandbox_id,
+        idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id,
         seeded_sandbox_id,
         "invalid continuation metadata must restore the reserved sandbox",
     );
@@ -200,7 +200,7 @@ async fn profile_mismatch_destroys_stale_vm() {
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
 
-    // Pre-seed: park a "vm0/default" (2vcpu) VM for session "sess-mm".
+    // Pre-seed: park a "vm0/default" (2vcpu) sandbox for session "sess-mm".
     seed_idle_pool(&idle_pool, &budget, "sess-mm", "vm0/default", 2, 4096).await;
 
     let run_handle = tokio::spawn(run(config));
@@ -231,19 +231,19 @@ async fn profile_mismatch_destroys_stale_vm() {
         "freshly created sandbox still reports its id"
     );
 
-    // Stale VM destruction runs in a background destroy_task. Poll until
+    // Stale sandbox destruction runs in a background destroy_task. Poll until
     // its budget is released rather than using a fixed sleep.
     // Expected: stale 2vcpu released, new 4vcpu held → count=1.
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
 
     {
         let pool = idle_pool.lock().await;
-        assert_eq!(pool.len(), 1, "new VM should be parked");
+        assert_eq!(pool.len(), 1, "new sandbox should be parked");
     }
     let (alloc_vcpu, alloc_mem, alloc_count) = budget.allocated();
-    assert_eq!(alloc_count, 1, "only new VM should hold budget");
-    assert_eq!(alloc_vcpu, 4, "new VM is vm0/large (4 vcpu)");
-    assert_eq!(alloc_mem, 8192, "new VM is vm0/large (8192 MB)");
+    assert_eq!(alloc_count, 1, "only new sandbox should hold budget");
+    assert_eq!(alloc_vcpu, 4, "new sandbox is vm0/large (4 vcpu)");
+    assert_eq!(alloc_mem, 8192, "new sandbox is vm0/large (8192 MB)");
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
@@ -71,13 +71,13 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
     let snapshot = idle_pool.lock().await.status_snapshot();
     assert!(
         status
-            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
             .await
     );
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-reuse-status".to_string()],
-        "pre-run status should list the seeded idle VM",
+        "pre-run status should list the seeded idle sandbox",
     );
 
     let run_handle = tokio::spawn(run(config));
@@ -155,7 +155,7 @@ async fn profile_mismatch_status_switches_from_idle_to_active_while_job_runs() {
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-mm-status".to_string()],
-        "pre-run status should list the stale idle VM",
+        "pre-run status should list the stale idle sandbox",
     );
 
     let run_handle = tokio::spawn(run(config));

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -503,7 +503,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     assert_eq!(
         env.idle_pool.lock().await.len(),
         0,
-        "soft-drained parking gate should prevent VM parking",
+        "soft-drained parking gate should prevent sandbox parking",
     );
 
     assert!(
@@ -566,7 +566,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates() {
+async fn workspace_promotion_mismatch_destroys_stale_idle_sandbox_and_fresh_creates() {
     let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -622,7 +622,7 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
     assert!(
         workspace_cache.held_workspace_states().await.is_empty(),
-        "mismatched stale idle VM must be destroyed without publishing its workspace image"
+        "mismatched stale idle sandbox must be destroyed without publishing its workspace image"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -830,7 +830,7 @@ async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
     wait_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("finalizing fallback should activate fresh VM before destroy completes");
+        .expect("finalizing fallback should activate fresh sandbox before destroy completes");
     assert_eq!(budget.allocated(), (2, 4096, 1));
     assert_eq!(env.idle_pool.lock().await.len(), 0);
 
@@ -931,7 +931,7 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
     wait_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("finalizing fallback should start after the active VM becomes idle");
+        .expect("finalizing fallback should start after the active sandbox becomes idle");
     assert_eq!(budget.allocated(), (2, 4096, 1));
     assert_eq!(env.idle_pool.lock().await.len(), 0);
 
@@ -1181,7 +1181,7 @@ async fn ordinary_and_finalizing_pressure_admission_do_not_double_spend_idle_cap
     destroy_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("ordinary and finalizing admission should each retire one idle VM");
+        .expect("ordinary and finalizing admission should each retire one idle sandbox");
     wait_gate
         .wait_entered(2, Duration::from_secs(5))
         .await

--- a/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
@@ -74,8 +74,8 @@ async fn drain_then_resume_keeps_jobs_running() {
 /// Regression guard for the unified reactor's Draining-entry state.
 ///
 /// The first SIGUSR1 drains the idle pool, then SIGUSR2 resumes Running.
-/// A later job completion parks a VM, and the second SIGUSR1 must drain
-/// that newly parked VM. If `draining_idle_pool_drained` is not reset on
+/// A later job completion parks a sandbox, and the second SIGUSR1 must drain
+/// that newly parked sandbox. If `draining_idle_pool_drained` is not reset on
 /// Running, the second drain skips idle-pool cleanup and leaks budget.
 #[tokio::test]
 async fn drain_resume_then_second_drain_drains_idle_pool() {
@@ -116,11 +116,11 @@ async fn drain_resume_then_second_drain_drains_idle_pool() {
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
     assert!(completion.is_some(), "job should complete after resume");
-    assert_eq!(idle_pool.lock().await.len(), 1, "job should park a VM");
+    assert_eq!(idle_pool.lock().await.len(), 1, "job should park a sandbox");
     assert_eq!(
         budget.allocated().2,
         1,
-        "parked VM should hold a budget slot"
+        "parked sandbox should hold a budget slot"
     );
 
     env.drain();
@@ -139,7 +139,7 @@ async fn drain_resume_then_second_drain_drains_idle_pool() {
     assert_eq!(
         budget.allocated().2,
         0,
-        "second drain must release the parked VM budget",
+        "second drain must release the parked sandbox budget",
     );
 }
 

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1052,7 +1052,7 @@ async fn duplicate_repark_keeps_newer_idle_sandbox_and_destroys_speculation() {
     wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
     assert_eq!(
-        env.idle_pool.lock().await.status_snapshot().idle_vms[0].sandbox_id,
+        env.idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id,
         replacement_id
     );
     assert_eq!(original_overrides.park_call_count(), 1);

--- a/crates/runner/src/cmd/start/tests/support/status.rs
+++ b/crates/runner/src/cmd/start/tests/support/status.rs
@@ -5,7 +5,7 @@ use super::wait::{WaitProbe, wait_for_probe};
 struct StatusSnapshot {
     active_runs: Vec<ActiveRunSnapshot>,
     #[serde(default)]
-    idle_vms: Vec<IdleVmSnapshot>,
+    idle_sandboxes: Vec<IdleSandboxSnapshot>,
 }
 
 #[derive(serde::Deserialize)]
@@ -25,7 +25,7 @@ struct ActiveRunSnapshot {
 }
 
 #[derive(serde::Deserialize)]
-struct IdleVmSnapshot {
+struct IdleSandboxSnapshot {
     reuse_key: String,
 }
 
@@ -34,7 +34,11 @@ pub(in super::super) async fn status_idle_reuse_keys_and_active_runs(
 ) -> (Vec<String>, Vec<String>) {
     let raw = tokio::fs::read_to_string(status_path).await.unwrap();
     let status: StatusSnapshot = serde_json::from_str(&raw).unwrap();
-    let mut reuse_keys: Vec<String> = status.idle_vms.into_iter().map(|vm| vm.reuse_key).collect();
+    let mut reuse_keys: Vec<String> = status
+        .idle_sandboxes
+        .into_iter()
+        .map(|vm| vm.reuse_key)
+        .collect();
     reuse_keys.sort_unstable();
     let mut run_ids: Vec<String> = status
         .active_runs
@@ -92,7 +96,7 @@ pub(in super::super) async fn wait_status_mode(
 }
 
 #[tokio::test]
-async fn status_parser_defaults_omitted_idle_vms_to_empty() {
+async fn status_parser_defaults_omitted_idle_sandboxes_to_empty() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("status.json");
     tokio::fs::write(
@@ -113,7 +117,9 @@ async fn status_parser_defaults_omitted_idle_vms_to_empty() {
 async fn status_parser_requires_active_runs() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("status.json");
-    tokio::fs::write(&path, r#"{"idle_vms":[]}"#).await.unwrap();
+    tokio::fs::write(&path, r#"{"idle_sandboxes":[]}"#)
+        .await
+        .unwrap();
 
     let _ = status_idle_reuse_keys_and_active_runs(&path).await;
 }
@@ -169,7 +175,7 @@ pub(in super::super) async fn publish_idle_status(pool: &SharedIdlePool, status:
     let snapshot = pool.lock().await.status_snapshot();
     assert!(
         status
-            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_vms)
+            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
             .await
     );
 }
@@ -187,7 +193,7 @@ pub(in super::super) async fn wait_status_idle_empty_with_active_run(
             WaitProbe::Ready(())
         } else {
             WaitProbe::Pending(format!(
-                "status did not atomically clear idle_vms and add active run {expected} within {timeout:?} (idle: {idle_reuse_keys:?}, active: {active_runs:?})",
+                "status did not atomically clear idle_sandboxes and add active run {expected} within {timeout:?} (idle: {idle_reuse_keys:?}, active: {active_runs:?})",
             ))
         }
     })

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -1,7 +1,7 @@
 //! Runner YAML config (`runner.yaml`) — the schema the operator writes.
 //!
 //! The file is loaded once at startup via [`load`], validated, and then
-//! consumed by the rest of the runner. For each VM spawn, a profile is
+//! consumed by the rest of the runner. For each sandbox spawn, a profile is
 //! turned into a [`sandbox::FactoryConfig`] via
 //! [`RunnerConfig::factory_config`].
 //!
@@ -78,7 +78,7 @@ pub struct RunnerConfig {
     /// runners on the server and to build on-disk paths; validated by
     /// [`crate::group::validate_or_err`].
     pub group: String,
-    /// Runtime data root for this runner — holds per-VM workspaces, COW
+    /// Runtime data root for this runner — holds per-sandbox workspaces, COW
     /// devices, sockets, etc. Locked exclusively on startup so two runner
     /// processes can't share the same directory.
     pub base_dir: PathBuf,
@@ -133,19 +133,19 @@ pub struct ProfileConfig {
     pub workspace_disk_mb: u32,
 }
 
-/// Sandbox-level knobs for concurrency and the idle-VM pool.
+/// Sandbox-level knobs for concurrency and the idle-sandbox pool.
 ///
 /// All fields accept defaults via `#[serde(default)]`, so the whole
 /// `sandbox:` block may be omitted from the YAML.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SandboxConfig {
-    /// Hard cap on concurrent VMs. `0` auto-detects from host CPU and
+    /// Hard cap on concurrent sandboxes. `0` auto-detects from host CPU and
     /// memory at startup (see [`DEFAULT_MAX_CONCURRENT`]).
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
+    /// Maximum number of idle sandboxes to keep (0 = no limit, default: 0).
     pub max_idle: usize,
 }
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -5,8 +5,8 @@
 //! caller owns provider completion and the final sandbox lifecycle decision.
 //!
 //! The fresh path starts and prepares a new Firecracker VM and can notify the
-//! caller once the VM is ready to run the job. The reuse path runs in a
-//! kept-alive idle VM.
+//! caller once the sandbox is ready to run the job. The reuse path runs in a
+//! kept-alive idle sandbox.
 //!
 //! Both paths return `ExecuteOutcome` plus a pending `JobTelemetry`
 //! buffer. When `ExecuteOutcome::sandbox` is `Some`, the executor transfers
@@ -204,7 +204,7 @@ pub struct ExecutorConfig {
     pub workspace_cache: Option<WorkspaceImageCache>,
 }
 
-/// Per-job VM parameters resolved from the profile config.
+/// Per-job sandbox parameters resolved from the profile config.
 pub struct JobParams {
     pub profile_name: String,
     pub vcpu: u32,
@@ -667,7 +667,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     (outcome, telemetry)
 }
 
-/// Execute a single job inside a **reused** (kept-alive) VM.
+/// Execute a single job inside a **reused** (kept-alive) sandbox.
 ///
 /// Skips create + start. Re-registers proxy, fixes clock, then runs the agent.
 /// Returns [`ExecuteOutcome`] with the sandbox still alive plus the pending
@@ -931,8 +931,8 @@ fn workspace_promotion_identity_failure(
     ))
 }
 
-/// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM
-/// and the categorized reason no idle VM was reused. The id is selected in job
+/// Dispatch inputs for the fresh-create path. Holds the UUID for the new sandbox
+/// and the categorized reason no idle sandbox was reused. The id is selected in job
 /// discovery after the reuse decision, then forwarded by `job_spawn`; it becomes
 /// the sandbox's identity, and the reuse result is forwarded to the guest for
 /// /complete metadata.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1086,7 +1086,7 @@ async fn create_started_sandbox(
                 false,
                 Some(SANDBOX_FACTORY_CREATE_FAILED),
             );
-            telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+            telemetry.record("sandbox_create", t.elapsed(), false, Some(&e.to_string()));
             return Err(SandboxPrepareError::retry_without_workspace_image(
                 e.into(),
                 true,
@@ -1095,7 +1095,12 @@ async fn create_started_sandbox(
     };
 
     if let Err(error) = sandbox.bind_run_control(&context.run_id.to_string()) {
-        telemetry.record("vm_create", t.elapsed(), false, Some(&error.to_string()));
+        telemetry.record(
+            "sandbox_create",
+            t.elapsed(),
+            false,
+            Some(&error.to_string()),
+        );
         let _ = destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(SandboxPrepareError::fatal(error.into()));
     }
@@ -1134,7 +1139,7 @@ async fn create_started_sandbox(
                 proxy_register_elapsed,
                 &e.to_string(),
             );
-            telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+            telemetry.record("sandbox_create", t.elapsed(), false, Some(&e.to_string()));
             let _ = destroy_sandbox_panic_safe(factory, sandbox).await;
             return Err(SandboxPrepareError::fatal(e));
         }
@@ -1170,7 +1175,7 @@ async fn create_started_sandbox(
             false,
             Some(SANDBOX_START_FAILED),
         );
-        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+        telemetry.record("sandbox_create", t.elapsed(), false, Some(&e.to_string()));
         let unregister_completed =
             match unregister_proxy_registry(config, &source_ip, context.run_id).await {
                 Ok(()) => true,
@@ -1224,7 +1229,7 @@ async fn create_started_sandbox(
         true,
         None,
     );
-    telemetry.record("vm_create", t.elapsed(), true, None);
+    telemetry.record("sandbox_create", t.elapsed(), true, None);
 
     let mut prepared_guest_runtime =
         PreparedGuestRuntime::prepare_for_codex_model_catalog_prefetch(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -457,7 +457,7 @@ fn build_env_json_required_keys() {
     assert!(!env.contains_key("VM0_PROMPT"));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
-    // checkpoint lands before VM teardown.
+    // checkpoint lands before sandbox teardown.
     assert!(
         env.get("VM0_SANDBOX_ID")
             .unwrap()

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -4,7 +4,7 @@ use super::*;
 use tokio_util::sync::CancellationToken;
 
 // -----------------------------------------------------------------------
-// Keep-alive VM reuse integration tests
+// Keep-alive sandbox reuse integration tests
 // -----------------------------------------------------------------------
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -770,7 +770,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_agent_env_build",
         "runner_agent_start_process",
         "sandbox_reuse_miss",
-        "vm_create",
+        "sandbox_create",
         "workspace_drive_mount",
         "workspace_drive_mount_guest_exec",
         "agent_execute",
@@ -1076,7 +1076,7 @@ async fn execute_job_records_failed_fresh_sandbox_factory_stage_timing() {
         false,
         Some("sandbox_factory_create_failed"),
     );
-    assert_action_success(&telemetry, "vm_create", false);
+    assert_action_success(&telemetry, "sandbox_create", false);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
 }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -5,7 +5,7 @@ use sandbox::{DeviceRateLimits, SandboxId};
 use tokio::sync::watch;
 
 use crate::ids::RunId;
-use crate::status::IdleVm;
+use crate::status::IdleSandbox;
 use crate::types::{HeldSandboxState, ReusableSandboxState};
 
 mod entry;
@@ -35,7 +35,7 @@ pub(crate) mod test_support;
 /// Configuration for the idle sandbox pool.
 #[derive(Debug, Clone, Default)]
 pub struct IdlePoolConfig {
-    /// Maximum number of idle VMs (0 = unlimited).
+    /// Maximum number of idle sandboxes (0 = unlimited).
     pub max_idle: usize,
 }
 
@@ -43,18 +43,18 @@ pub struct IdlePoolConfig {
 ///
 /// Status writes happen after dropping the pool lock, so an older snapshot can
 /// otherwise complete after a newer drain/evict write and reintroduce stale
-/// `idle_vms` in status.json.
+/// `idle_sandboxes` in status.json.
 #[derive(Clone, Debug)]
 pub struct IdlePoolSnapshot {
     pub revision: u64,
-    pub idle_vms: Vec<IdleVm>,
+    pub idle_sandboxes: Vec<IdleSandbox>,
 }
 
 /// Pool of idle sandboxes keyed by reuse key.
 ///
 /// After a job reaches a terminal state that is proven reusable, its sandbox
 /// can be parked here instead of being destroyed. A subsequent job for the same
-/// reuse key can reuse the parked sandbox, skipping VM creation and startup.
+/// reuse key can reuse the parked sandbox, skipping sandbox creation and startup.
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,
@@ -248,11 +248,12 @@ impl IdlePool {
     /// Produced in a single iteration so `reuse_key` and `sandbox_id` can never
     /// drift out of pairing.
     pub fn status_snapshot(&self) -> IdlePoolSnapshot {
-        let mut vms: Vec<IdleVm> = self.entries.values().map(idle_vm_for_entry).collect();
-        vms.sort_unstable_by(|a, b| a.reuse_key.cmp(&b.reuse_key));
+        let mut sandboxes: Vec<IdleSandbox> =
+            self.entries.values().map(idle_sandbox_for_entry).collect();
+        sandboxes.sort_unstable_by(|a, b| a.reuse_key.cmp(&b.reuse_key));
         IdlePoolSnapshot {
             revision: self.revision,
-            idle_vms: vms,
+            idle_sandboxes: sandboxes,
         }
     }
 
@@ -267,8 +268,8 @@ impl IdlePool {
     /// for status.json. Produced in a single iteration so `reuse_key` and
     /// `sandbox_id` can never drift out of pairing.
     #[cfg(test)]
-    pub fn held_snapshot(&self) -> Vec<IdleVm> {
-        self.status_snapshot().idle_vms
+    pub fn held_snapshot(&self) -> Vec<IdleSandbox> {
+        self.status_snapshot().idle_sandboxes
     }
 
     /// Return every reusable sandbox currently held in the pool, sorted by
@@ -306,7 +307,7 @@ impl IdlePool {
         reuse_keys
     }
 
-    /// Number of idle VMs in the pool.
+    /// Number of idle sandboxes in the pool.
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -351,8 +352,8 @@ impl IdlePool {
     }
 }
 
-fn idle_vm_for_entry(entry: &IdleEntry) -> IdleVm {
-    IdleVm {
+fn idle_sandbox_for_entry(entry: &IdleEntry) -> IdleSandbox {
+    IdleSandbox {
         reuse_key: entry.reuse_key().to_owned(),
         sandbox_id: entry.metadata.sandbox_id,
     }
@@ -363,7 +364,7 @@ fn idle_vm_for_entry(entry: &IdleEntry) -> IdleVm {
 pub enum ParkResult {
     /// Successfully parked; no previous entry for this reuse key.
     Parked,
-    /// Successfully parked; the returned job destroys the replaced idle VM.
+    /// Successfully parked; the returned job destroys the replaced idle sandbox.
     Replaced(IdleDestroyJob),
     /// Parking is closed/soft-draining or at capacity; the entry could not be parked.
     Rejected(RejectedParkedIdleCandidate),

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -39,7 +39,7 @@ pub(super) struct IdleSandboxMetadata {
     pub(super) guest_timezone_intent: GuestTimezoneIntent,
     /// Local terminal timestamp for this parked sandbox.
     ///
-    /// `None` is reserved for synthetic test entries and means the VM is not
+    /// `None` is reserved for synthetic test entries and means the sandbox is not
     /// advertised as reusable.
     pub(super) last_completed_at: Option<String>,
 }
@@ -93,7 +93,7 @@ pub(super) enum WorkspacePromotionPolicy {
 /// ownership is accepted.
 ///
 /// This state proves only same-reuse-key idle park. It does not imply clean
-/// cross-run reuse, snapshot readiness, or any broader VM correctness.
+/// cross-run reuse, snapshot readiness, or any broader sandbox correctness.
 #[must_use = "parked idle candidates must be accepted by the idle pool or explicitly destroyed"]
 pub struct ParkedIdleCandidate {
     pub(super) resources: IdleSandboxResources,
@@ -375,7 +375,7 @@ impl ReusableIdleSandbox {
     }
 }
 
-/// Physical resources needed to destroy an idle VM, without its budget lease.
+/// Physical resources needed to destroy an idle sandbox, without its budget lease.
 pub(crate) struct IdleDestroyPayload {
     pub(super) resources: IdleSandboxResources,
     pub(super) workspace_promotion_policy: WorkspacePromotionPolicy,

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -85,7 +85,10 @@ fn reusable_reservation_is_exclusive_and_restorable() {
     ));
     assert_eq!(pool.len(), 1);
     assert_eq!(pool.status_snapshot().revision, parked_revision + 2);
-    assert_eq!(pool.status_snapshot().idle_vms[0].sandbox_id, sandbox_id);
+    assert_eq!(
+        pool.status_snapshot().idle_sandboxes[0].sandbox_id,
+        sandbox_id
+    );
 }
 
 #[test]
@@ -142,7 +145,7 @@ async fn reserved_restore_preserves_newer_same_session_entry() {
         panic!("collision must reject the older reservation");
     };
     assert_eq!(
-        pool.status_snapshot().idle_vms[0].sandbox_id,
+        pool.status_snapshot().idle_sandboxes[0].sandbox_id,
         replacement_sandbox_id
     );
     assert_ne!(old_sandbox_id, replacement_sandbox_id);
@@ -421,12 +424,12 @@ fn held_snapshot_pairs_and_sorts() {
     let _ = pool.park(entry_b);
     let _ = pool.park(entry_a);
 
-    let vms = pool.held_snapshot();
-    assert_eq!(vms.len(), 2);
-    assert_eq!(vms[0].reuse_key, "sess-a");
-    assert_eq!(vms[0].sandbox_id, sid_a);
-    assert_eq!(vms[1].reuse_key, "sess-b");
-    assert_eq!(vms[1].sandbox_id, sid_b);
+    let sandboxes = pool.held_snapshot();
+    assert_eq!(sandboxes.len(), 2);
+    assert_eq!(sandboxes[0].reuse_key, "sess-a");
+    assert_eq!(sandboxes[0].sandbox_id, sid_a);
+    assert_eq!(sandboxes[1].reuse_key, "sess-b");
+    assert_eq!(sandboxes[1].sandbox_id, sid_b);
 }
 
 #[test]
@@ -450,7 +453,7 @@ fn contains_sandbox_id_tracks_current_idle_ownership() {
 }
 
 #[test]
-fn status_snapshot_revision_tracks_idle_vm_mutations() {
+fn status_snapshot_revision_tracks_idle_sandbox_mutations() {
     let mut pool = IdlePool::new(pool_config(0));
     assert_eq!(pool.status_snapshot().revision, 0);
 
@@ -465,7 +468,7 @@ fn status_snapshot_revision_tracks_idle_vm_mutations() {
     assert_eq!(
         pool.status_snapshot().revision,
         2,
-        "empty drain must not create a fake idle_vms mutation",
+        "empty drain must not create a fake idle_sandboxes mutation",
     );
 
     let _ = pool.park(make_candidate_for("s2", 2, 2048));

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -97,9 +97,9 @@ enum Command {
     Build(cmd::BuildArgs),
     /// Generate runner.yaml from a pre-built image hash
     Config(cmd::ConfigArgs),
-    /// Run a single bash command in a VM for benchmarking
+    /// Run a single bash command in a sandbox for benchmarking
     Benchmark(cmd::BenchmarkArgs),
-    /// Execute a command inside a running VM for debugging
+    /// Execute a command inside a running sandbox for debugging
     Exec(cmd::ExecArgs),
     /// Start the runner and poll for jobs (must run setup + build first)
     Start(Box<cmd::StartArgs>),

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -10,7 +10,7 @@
 //! opens that file as a separate trust boundary and independently validates its
 //! ownership, permissions, schema, and firewall payload.
 //!
-//! Cache publication contains unresolved builtin definitions. For each VM, the
+//! Cache publication contains unresolved builtin definitions. For each sandbox, the
 //! Python registry path substitutes base URL variables, validates the resolved
 //! credentialed destination and host policy, assigns run-scoped API IDs, and
 //! compiles matchers before request enforcement.
@@ -21,7 +21,7 @@
 //! retries prevents provider startup readiness. A rejected periodic refresh
 //! never replaces the published file, so any previously published valid cache
 //! remains available. If the Python consumer rejects a new file identity, it
-//! exposes no catalog for that identity and marks builtin-dependent VM entries
+//! exposes no catalog for that identity and marks builtin-dependent sandbox entries
 //! invalid until a usable cache is loaded.
 //!
 //! # Cross-language compatibility

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -28,7 +28,7 @@ pub struct ResourceBudget {
 /// Owned reservation against a [`ResourceBudget`].
 ///
 /// The lease releases its reservation when dropped. Drop must never panic:
-/// idle VM cleanup may run while unwinding from sandbox/factory failures, and
+/// idle sandbox cleanup may run while unwinding from sandbox/factory failures, and
 /// a panic here would turn a cleanup failure into a budget leak or task abort.
 #[must_use = "dropping a BudgetLease releases the reserved resources"]
 pub struct BudgetLease {

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -27,13 +27,13 @@ pub enum ActiveRunPhase {
 ///
 /// `run_id` is the user/control-plane visible run identity. `sandbox_id` is
 /// the sandbox identity used by runner maintenance commands to correlate
-/// Firecracker state. After sandbox reuse these can differ: the VM keeps its
+/// Firecracker state. After sandbox reuse these can differ: the sandbox keeps its
 /// original `sandbox_id`, while each successive job has a fresh `run_id`.
 #[derive(Debug, Clone, Serialize)]
 pub struct ActiveRun {
     /// User/control-plane visible run id.
     pub run_id: RunId,
-    /// Sandbox/VM id assigned to this run.
+    /// Sandbox id assigned to this run.
     ///
     /// Runner doctor, kill, and exec use this as the join key when correlating
     /// status entries with Firecracker processes.
@@ -57,18 +57,34 @@ struct ActiveRunState {
 
 /// One parked sandbox's reuse identity and Firecracker sandbox identity.
 #[derive(Debug, Clone, Serialize)]
-pub struct IdleVm {
+pub struct IdleSandbox {
     pub reuse_key: String,
     pub sandbox_id: SandboxId,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 struct RunnerStatus {
     mode: RunnerMode,
     max_concurrent: usize,
     active_runs: Vec<ActiveRun>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    idle_vms: Vec<IdleVm>,
+    idle_sandboxes: Vec<IdleSandbox>,
+    proxy_port: Option<u16>,
+    dns_port: Option<u16>,
+    started_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+struct RunnerStatusWire<'a> {
+    mode: RunnerMode,
+    max_concurrent: usize,
+    active_runs: &'a [ActiveRun],
+    #[serde(skip_serializing_if = "borrowed_slice_is_empty")]
+    idle_sandboxes: &'a [IdleSandbox],
+    // Compatibility for previous runner tools during rollout. Remove after
+    // the collector and rollback gates recorded in #28926 are satisfied.
+    #[serde(rename = "idle_vms", skip_serializing_if = "borrowed_slice_is_empty")]
+    legacy_idle_sandboxes: &'a [IdleSandbox],
     #[serde(skip_serializing_if = "Option::is_none")]
     proxy_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,6 +93,22 @@ struct RunnerStatus {
     started_at: DateTime<Utc>,
     #[serde(serialize_with = "serialize_iso")]
     updated_at: DateTime<Utc>,
+}
+
+impl RunnerStatus {
+    fn wire(&self) -> RunnerStatusWire<'_> {
+        RunnerStatusWire {
+            mode: self.mode,
+            max_concurrent: self.max_concurrent,
+            active_runs: &self.active_runs,
+            idle_sandboxes: &self.idle_sandboxes,
+            legacy_idle_sandboxes: &self.idle_sandboxes,
+            proxy_port: self.proxy_port,
+            dns_port: self.dns_port,
+            started_at: self.started_at,
+            updated_at: self.updated_at,
+        }
+    }
 }
 
 struct StatusSnapshot {
@@ -98,6 +130,10 @@ struct StatusWriteGate {
 /// Serialize as ISO 8601 with millisecond precision, matching JS `Date.toISOString()`.
 fn serialize_iso<S: serde::Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
     s.serialize_str(&dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+}
+
+fn borrowed_slice_is_empty<T>(value: &&[T]) -> bool {
+    value.is_empty()
 }
 
 /// Thread-safe status tracker that persists state to a JSON file atomically.
@@ -126,13 +162,13 @@ struct MutableState {
     /// BTreeMap (not HashMap) for deterministic iteration order — status.json
     /// output should be stable across runs for readability and diffing.
     active_runs: BTreeMap<RunId, ActiveRunState>,
-    /// Monotonic idle pool mutation revision last reflected in `idle_vms`.
+    /// Monotonic idle pool mutation revision last reflected in `idle_sandboxes`.
     ///
     /// Idle pool callers snapshot under the pool lock, drop it, then write
     /// status asynchronously. The revision prevents an older delayed snapshot
     /// from overwriting a newer drain/evict state.
     idle_revision: u64,
-    idle_vms: Vec<IdleVm>,
+    idle_sandboxes: Vec<IdleSandbox>,
 }
 
 impl StatusTracker {
@@ -161,7 +197,7 @@ impl StatusTracker {
                 mode: RunnerMode::Starting,
                 active_runs: BTreeMap::new(),
                 idle_revision: 0,
-                idle_vms: Vec::new(),
+                idle_sandboxes: Vec::new(),
             }),
             persistence: Mutex::new(PersistenceState {
                 published_generation: 0,
@@ -237,47 +273,47 @@ impl StatusTracker {
         self.persist_snapshot(snapshot).await;
     }
 
-    /// Register an active run and replace the idle VM list in the same status
+    /// Register an active run and replace the idle sandbox list in the same status
     /// write if the idle snapshot is current. On duplicate `run_id`, the
     /// previous `sandbox_id` is overwritten.
     ///
     /// This avoids a transient status.json gap during idle reuse where a sandbox
-    /// has been removed from `idle_vms` but has not yet appeared in
+    /// has been removed from `idle_sandboxes` but has not yet appeared in
     /// `active_runs`.
-    /// Register a running active run and replace the idle VM list in the same
+    /// Register a running active run and replace the idle sandbox list in the same
     /// status write if the idle snapshot is current.
     pub async fn add_running_run_with_idle_info_at_revision(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
         revision: u64,
-        idle_vms: Vec<IdleVm>,
+        idle_sandboxes: Vec<IdleSandbox>,
     ) -> bool {
         self.add_run_with_idle_info_at_revision(
             run_id,
             sandbox_id,
             ActiveRunPhase::Running,
             revision,
-            idle_vms,
+            idle_sandboxes,
         )
         .await
     }
 
-    /// Register a preparing active run and replace the idle VM list in the
+    /// Register a preparing active run and replace the idle sandbox list in the
     /// same status write if the idle snapshot is current.
     pub async fn add_preparing_run_with_idle_info_at_revision(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
         revision: u64,
-        idle_vms: Vec<IdleVm>,
+        idle_sandboxes: Vec<IdleSandbox>,
     ) -> bool {
         self.add_run_with_idle_info_at_revision(
             run_id,
             sandbox_id,
             ActiveRunPhase::Preparing,
             revision,
-            idle_vms,
+            idle_sandboxes,
         )
         .await
     }
@@ -288,7 +324,7 @@ impl StatusTracker {
         sandbox_id: SandboxId,
         phase: ActiveRunPhase,
         revision: u64,
-        idle_vms: Vec<IdleVm>,
+        idle_sandboxes: Vec<IdleSandbox>,
     ) -> bool {
         let (applied, snapshot) = {
             let mut state = self.state.lock().await;
@@ -300,7 +336,7 @@ impl StatusTracker {
                     phase_started_at: Utc::now(),
                 },
             );
-            let applied = apply_idle_info_at_revision(&mut state, revision, idle_vms);
+            let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);
             let snapshot = self.capture_changed_snapshot(&mut state);
             (applied, snapshot)
         };
@@ -345,15 +381,19 @@ impl StatusTracker {
         true
     }
 
-    /// Replace the idle VM list only if the snapshot is at least as new as the
+    /// Replace the idle sandbox list only if the snapshot is at least as new as the
     /// last applied idle-pool mutation revision.
     ///
     /// Returns `false` when a stale async writer lost the race to a newer
     /// snapshot and was intentionally ignored.
-    pub async fn set_idle_info_at_revision(&self, revision: u64, idle_vms: Vec<IdleVm>) -> bool {
+    pub async fn set_idle_info_at_revision(
+        &self,
+        revision: u64,
+        idle_sandboxes: Vec<IdleSandbox>,
+    ) -> bool {
         let snapshot = {
             let mut state = self.state.lock().await;
-            let applied = apply_idle_info_at_revision(&mut state, revision, idle_vms);
+            let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);
             if !applied {
                 return false;
             }
@@ -389,7 +429,7 @@ impl StatusTracker {
             mode: state.mode,
             max_concurrent: self.max_concurrent,
             active_runs,
-            idle_vms: state.idle_vms.clone(),
+            idle_sandboxes: state.idle_sandboxes.clone(),
             proxy_port: self.proxy_port,
             dns_port: self.dns_port,
             started_at: self.started_at,
@@ -404,7 +444,7 @@ impl StatusTracker {
 
     /// Publish an owned snapshot through same-directory atomic replacement.
     async fn persist_snapshot(&self, snapshot: StatusSnapshot) {
-        let json = match serde_json::to_string_pretty(&snapshot.status) {
+        let json = match serde_json::to_string_pretty(&snapshot.status.wire()) {
             Ok(j) => j,
             Err(e) => {
                 warn!(error = %e, "failed to serialize status");
@@ -457,13 +497,13 @@ pub async fn remove_stale_status_file(path: &Path) -> RunnerResult<()> {
 fn apply_idle_info_at_revision(
     state: &mut MutableState,
     revision: u64,
-    idle_vms: Vec<IdleVm>,
+    idle_sandboxes: Vec<IdleSandbox>,
 ) -> bool {
     if revision < state.idle_revision {
         return false;
     }
     state.idle_revision = revision;
-    state.idle_vms = idle_vms;
+    state.idle_sandboxes = idle_sandboxes;
     true
 }
 
@@ -833,7 +873,8 @@ mod tests {
         tracker.write_initial().await;
 
         let status = read_status(&path);
-        assert!(status.get("idle_vms").is_none()); // empty vec omitted
+        assert!(status.get("idle_sandboxes").is_none());
+        assert!(status.get("idle_vms").is_none());
 
         let sb1 = SandboxId::new_v4();
         let sb2 = SandboxId::new_v4();
@@ -842,11 +883,11 @@ mod tests {
                 .set_idle_info_at_revision(
                     1,
                     vec![
-                        IdleVm {
+                        IdleSandbox {
                             reuse_key: "sess-1".into(),
                             sandbox_id: sb1,
                         },
-                        IdleVm {
+                        IdleSandbox {
                             reuse_key: "sess-2".into(),
                             sandbox_id: sb2,
                         },
@@ -856,12 +897,13 @@ mod tests {
         );
 
         let status = read_status(&path);
-        let vms = status["idle_vms"].as_array().unwrap();
-        assert_eq!(vms.len(), 2);
-        assert_eq!(vms[0]["reuse_key"], "sess-1");
-        assert_eq!(vms[0]["sandbox_id"], sb1.to_string());
-        assert_eq!(vms[1]["reuse_key"], "sess-2");
-        assert_eq!(vms[1]["sandbox_id"], sb2.to_string());
+        assert_eq!(status["idle_sandboxes"], status["idle_vms"]);
+        let sandboxes = status["idle_sandboxes"].as_array().unwrap();
+        assert_eq!(sandboxes.len(), 2);
+        assert_eq!(sandboxes[0]["reuse_key"], "sess-1");
+        assert_eq!(sandboxes[0]["sandbox_id"], sb1.to_string());
+        assert_eq!(sandboxes[1]["reuse_key"], "sess-2");
+        assert_eq!(sandboxes[1]["sandbox_id"], sb2.to_string());
     }
 
     #[tokio::test]
@@ -877,7 +919,7 @@ mod tests {
             tracker
                 .set_idle_info_at_revision(
                     2,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "fresh".into(),
                         sandbox_id: fresh_id,
                     }],
@@ -888,7 +930,7 @@ mod tests {
             !tracker
                 .set_idle_info_at_revision(
                     1,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "stale".into(),
                         sandbox_id: stale_id,
                     }],
@@ -897,10 +939,10 @@ mod tests {
         );
 
         let status = read_status(&path);
-        let vms = status["idle_vms"].as_array().unwrap();
-        assert_eq!(vms.len(), 1);
-        assert_eq!(vms[0]["reuse_key"], "fresh");
-        assert_eq!(vms[0]["sandbox_id"], fresh_id.to_string());
+        let sandboxes = status["idle_sandboxes"].as_array().unwrap();
+        assert_eq!(sandboxes.len(), 1);
+        assert_eq!(sandboxes[0]["reuse_key"], "fresh");
+        assert_eq!(sandboxes[0]["sandbox_id"], fresh_id.to_string());
     }
 
     #[tokio::test]
@@ -916,7 +958,7 @@ mod tests {
             tracker
                 .set_idle_info_at_revision(
                     1,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "sess-replaced".into(),
                         sandbox_id: original_id,
                     }],
@@ -925,7 +967,7 @@ mod tests {
         );
 
         // A cleanup/pressure eviction path captured this empty snapshot after
-        // removing the original VM, then got delayed before publishing it.
+        // removing the original sandbox, then got delayed before publishing it.
         let delayed_cleanup_revision = 2;
         let delayed_cleanup_snapshot = Vec::new();
 
@@ -934,7 +976,7 @@ mod tests {
             tracker
                 .set_idle_info_at_revision(
                     3,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "sess-replaced".into(),
                         sandbox_id: replacement_id,
                     }],
@@ -949,10 +991,10 @@ mod tests {
         );
 
         let status = read_status(&path);
-        let vms = status["idle_vms"].as_array().unwrap();
-        assert_eq!(vms.len(), 1);
-        assert_eq!(vms[0]["reuse_key"], "sess-replaced");
-        assert_eq!(vms[0]["sandbox_id"], replacement_id.to_string());
+        let sandboxes = status["idle_sandboxes"].as_array().unwrap();
+        assert_eq!(sandboxes.len(), 1);
+        assert_eq!(sandboxes[0]["reuse_key"], "sess-replaced");
+        assert_eq!(sandboxes[0]["sandbox_id"], replacement_id.to_string());
     }
 
     #[tokio::test]
@@ -970,7 +1012,7 @@ mod tests {
             tracker
                 .set_idle_info_at_revision(
                     2,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "fresh".into(),
                         sandbox_id: idle_id,
                     }],
@@ -983,7 +1025,7 @@ mod tests {
                     run_id,
                     active_id,
                     1,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "stale".into(),
                         sandbox_id: stale_id,
                     }],
@@ -997,10 +1039,10 @@ mod tests {
         assert_eq!(runs[0]["run_id"], run_id.to_string());
         assert_eq!(runs[0]["sandbox_id"], active_id.to_string());
         assert_eq!(runs[0]["phase"], "running");
-        let vms = status["idle_vms"].as_array().unwrap();
-        assert_eq!(vms.len(), 1);
-        assert_eq!(vms[0]["reuse_key"], "fresh");
-        assert_eq!(vms[0]["sandbox_id"], idle_id.to_string());
+        let sandboxes = status["idle_sandboxes"].as_array().unwrap();
+        assert_eq!(sandboxes.len(), 1);
+        assert_eq!(sandboxes[0]["reuse_key"], "fresh");
+        assert_eq!(sandboxes[0]["sandbox_id"], idle_id.to_string());
     }
 
     #[tokio::test]
@@ -1019,7 +1061,7 @@ mod tests {
                     run_id,
                     active_id,
                     1,
-                    vec![IdleVm {
+                    vec![IdleSandbox {
                         reuse_key: "fresh-create-after-reuse-miss".into(),
                         sandbox_id: idle_id,
                     }],
@@ -1033,10 +1075,10 @@ mod tests {
         assert_eq!(runs[0]["run_id"], run_id.to_string());
         assert_eq!(runs[0]["sandbox_id"], active_id.to_string());
         assert_eq!(runs[0]["phase"], "preparing");
-        let vms = status["idle_vms"].as_array().unwrap();
-        assert_eq!(vms.len(), 1);
-        assert_eq!(vms[0]["reuse_key"], "fresh-create-after-reuse-miss");
-        assert_eq!(vms[0]["sandbox_id"], idle_id.to_string());
+        let sandboxes = status["idle_sandboxes"].as_array().unwrap();
+        assert_eq!(sandboxes.len(), 1);
+        assert_eq!(sandboxes[0]["reuse_key"], "fresh-create-after-reuse-miss");
+        assert_eq!(sandboxes[0]["sandbox_id"], idle_id.to_string());
     }
 
     #[tokio::test]
@@ -1049,8 +1091,12 @@ mod tests {
 
         let status = read_status(&path);
         assert!(
+            status.get("idle_sandboxes").is_none(),
+            "empty idle_sandboxes should be omitted from JSON"
+        );
+        assert!(
             status.get("idle_vms").is_none(),
-            "empty idle_vms should be omitted from JSON"
+            "empty legacy idle_vms should be omitted from JSON"
         );
     }
 }

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
 
 use crate::error::RunnerError;
 use crate::ids::RunId;
@@ -87,12 +87,31 @@ pub(crate) struct StatusForDoctor {
     #[serde(default)]
     pub(crate) active_runs: Vec<StatusActiveRun>,
     pub(crate) started_at: String,
-    #[serde(default)]
-    pub(crate) idle_vms: Vec<StatusIdleVm>,
+    #[serde(default, deserialize_with = "deserialize_present_idle_sandboxes")]
+    idle_sandboxes: Option<Vec<StatusIdleSandbox>>,
+    #[serde(default, rename = "idle_vms")]
+    legacy_idle_sandboxes: Vec<StatusIdleSandbox>,
     #[serde(default)]
     pub(crate) proxy_port: Option<u16>,
     #[serde(default)]
     pub(crate) dns_port: Option<u16>,
+}
+
+impl StatusForDoctor {
+    pub(crate) fn idle_sandboxes(&self) -> &[StatusIdleSandbox] {
+        self.idle_sandboxes
+            .as_deref()
+            .unwrap_or(&self.legacy_idle_sandboxes)
+    }
+}
+
+fn deserialize_present_idle_sandboxes<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<StatusIdleSandbox>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize)]
@@ -118,7 +137,7 @@ pub(crate) struct StatusActiveRun {
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct StatusIdleVm {
+pub(crate) struct StatusIdleSandbox {
     pub(crate) reuse_key: String,
     pub(crate) sandbox_id: String,
 }
@@ -162,7 +181,7 @@ mod tests {
                     "phase_started_at":"2026-04-13T00:00:01.000Z"
                 }
             ],
-            "idle_vms": [
+            "idle_sandboxes": [
                 {"reuse_key":"sess-1","sandbox_id":"bbbbbbbb-0000-7000-8000-000000000001"}
             ],
             "proxy_port": 8080,
@@ -193,8 +212,78 @@ mod tests {
             status.active_runs[0].phase_started_at,
             "2026-04-13T00:00:01.000Z"
         );
-        assert_eq!(status.idle_vms.len(), 1);
-        assert_eq!(status.idle_vms[0].reuse_key, "sess-1");
+        assert_eq!(status.idle_sandboxes().len(), 1);
+        assert_eq!(status.idle_sandboxes()[0].reuse_key, "sess-1");
+    }
+
+    #[tokio::test]
+    async fn doctor_idle_sandbox_fields_follow_compatibility_precedence() {
+        let cases = [
+            (
+                "legacy only",
+                r#""idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
+                &["legacy"][..],
+            ),
+            (
+                "mirrored",
+                r#""idle_sandboxes":[{"reuse_key":"canonical","sandbox_id":"sandbox-canonical"}],"idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
+                &["canonical"][..],
+            ),
+            (
+                "canonical only",
+                r#""idle_sandboxes":[{"reuse_key":"canonical","sandbox_id":"sandbox-canonical"}]"#,
+                &["canonical"][..],
+            ),
+            (
+                "canonical empty",
+                r#""idle_sandboxes":[],"idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]"#,
+                &[][..],
+            ),
+            ("neither", "", &[][..]),
+        ];
+
+        for (name, idle_fields, expected_reuse_keys) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let separator = if idle_fields.is_empty() { "" } else { "," };
+            let content = format!(
+                r#"{{"mode":"running","started_at":"2026-04-13T00:00:00.000Z"{separator}{idle_fields}}}"#
+            );
+            tokio::fs::write(dir.path().join("status.json"), content)
+                .await
+                .unwrap();
+
+            let status = read_as::<StatusForDoctor>(dir.path())
+                .await
+                .unwrap()
+                .unwrap();
+            let reuse_keys: Vec<&str> = status
+                .idle_sandboxes()
+                .iter()
+                .map(|sandbox| sandbox.reuse_key.as_str())
+                .collect();
+
+            assert_eq!(reuse_keys, expected_reuse_keys, "{name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn doctor_rejects_malformed_present_canonical_idle_sandboxes() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "mode":"running",
+                "started_at":"2026-04-13T00:00:00.000Z",
+                "idle_sandboxes":null,
+                "idle_vms":[{"reuse_key":"legacy","sandbox_id":"sandbox-legacy"}]
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let error = read_as::<StatusForDoctor>(dir.path()).await.unwrap_err();
+
+        assert!(matches!(error, StatusFileReadError::ParseJson { .. }));
     }
 
     #[tokio::test]
@@ -224,7 +313,7 @@ mod tests {
                 "mode":"running",
                 "active_runs":[],
                 "started_at":"2026-04-13T00:00:00.000Z",
-                "idle_vms":null
+                "idle_sandboxes":null
             }"#,
         )
         .await
@@ -270,7 +359,7 @@ mod tests {
                     {"run_id":"run-a","sandbox_id":"sandbox-a"}
                 ],
                 "started_at": [],
-                "idle_vms": null
+                "idle_sandboxes": null
             }"#,
         )
         .await

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1894,7 +1894,7 @@ fn collect_targets(plan: &StoragePlan) -> Vec<CacheTarget> {
 ///
 /// The executor calls this after workspace-image selection fixes the plan and
 /// before sandbox creation, allowing eligible full-archive fetches to overlap
-/// VM startup. Preparation examines at most `FRESH_DELIVERY_SCAN_LIMIT` target
+/// sandbox startup. Preparation examines at most `FRESH_DELIVERY_SCAN_LIMIT` target
 /// groups, admits at most `FRESH_DELIVERY_PER_RUN_LIMIT`, and draws each
 /// admission from the shared `FRESH_DELIVERY_RUNNER_LIMIT`.
 ///

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -607,7 +607,7 @@ mod tests {
     fn sandbox_op_omits_optional_fields_without_session_history() {
         let op = SandboxOp {
             ts: "2026-01-15T10:00:00+00:00".to_string(),
-            action_type: "vm_create".to_string(),
+            action_type: "sandbox_create".to_string(),
             duration_ms: 1500,
             success: true,
             error: None,
@@ -623,7 +623,7 @@ mod tests {
             json,
             serde_json::json!({
                 "ts": "2026-01-15T10:00:00+00:00",
-                "action_type": "vm_create",
+                "action_type": "sandbox_create",
                 "duration_ms": 1500,
                 "success": true,
             })
@@ -819,7 +819,7 @@ mod tests {
             "test-runner".to_string(),
         );
 
-        telemetry.record("vm_create", Duration::from_millis(500), true, None);
+        telemetry.record("sandbox_create", Duration::from_millis(500), true, None);
         telemetry.record(
             "agent_execute",
             Duration::from_secs(10),
@@ -828,7 +828,7 @@ mod tests {
         );
 
         assert_eq!(telemetry.pending_ops.len(), 2);
-        assert_eq!(telemetry.pending_ops[0].action_type, "vm_create");
+        assert_eq!(telemetry.pending_ops[0].action_type, "sandbox_create");
         assert_eq!(telemetry.pending_ops[0].duration_ms, 500);
         assert!(telemetry.pending_ops[0].success);
         assert!(telemetry.pending_ops[0].error.is_none());

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -205,7 +205,7 @@ impl Firewall {
     /// Validates an unresolved builtin firewall before cache publication.
     ///
     /// This gate checks the structural and syntax invariants available before
-    /// per-VM resolution. Catalog API IDs must be empty because the Python
+    /// per-sandbox resolution. Catalog API IDs must be empty because the Python
     /// registry resolver assigns run-scoped IDs after resolving the entries.
     ///
     /// The Python consumer still independently validates the cache file,
@@ -1664,7 +1664,7 @@ pub struct CompleteRequest {
 }
 
 /// Outcome of the sandbox-reuse decision made at job dispatch time. `Reused`
-/// means the VM was unparked from the idle pool; the other variants describe
+/// means the sandbox was unparked from the idle pool; the other variants describe
 /// why reuse did not happen. Wire name: `sandboxReuseResult`.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -167,18 +167,6 @@ status writer, and the independently deployed host monitoring collector scans
 every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
-During the idle-status terminology migration, current writers publish the same
-non-empty collection under canonical `idle_sandboxes` and temporary legacy
-`idle_vms`; both fields are omitted when the collection is empty. Current
-readers and the host collector select `idle_sandboxes` whenever that key is
-present, even when it is empty, and fall back to `idle_vms` only when the
-canonical key is absent. They never concatenate the fields. Remove the writer
-mirror only after the updated collector is installed on every runner host, the
-new runner rollout is complete, the previous-runner rollback window is closed,
-and no supported old maintenance command still needs `idle_vms` (tracked by
-#28926). Legacy read fallback is a separate decision because stopped old runner
-directories can remain supported inputs.
-
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and
 registry at startup, and keeps them in its version-specific base directory.
@@ -186,12 +174,6 @@ Their registry schema and process-local flow metadata can therefore change
 atomically in one runner release without fallback keys or cross-version readers.
 This exemption does not extend to registry data persisted outside that runner
 artifact or consumed by an independently deployed component.
-
-Runner sandbox-operation telemetry uses open string action names rather than a
-versioned enum. Historical rows keep `vm_create`; new fresh-sandbox creation
-events use `sandbox_create`. Readers that compare periods across this boundary
-must query both historical and current names rather than expecting rows to be
-rewritten or dual-emitted.
 
 Each sandbox is owned exclusively by the runner process that created it. A
 different runner never adopts that sandbox, and stopping the owning runner also

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -153,6 +153,32 @@ runner can also survive briefly talking to an old backend.
 Runner and guest binaries are deployed as one runner artifact. Compatibility is
 not required between a runner binary and a guest binary from a different version.
 
+Use **sandbox** for provider-neutral runner lifecycle, ownership, status,
+network-policy, and operator concepts. Use **VM** only for concrete
+Firecracker/KVM implementation details such as the Firecracker `/vm` API, VM
+pause and resume, snapshots, vCPUs, VMGenID, KVM, and Firecracker processes.
+The VM0 brand, established environment-variable namespace, and fixed paths are
+not lifecycle terminology and remain unchanged.
+
+Each runner version's `status.json` is a host-local persisted cross-version
+boundary. Current runner maintenance commands can inspect status files written
+by previous runner versions, rollback can expose an older command to a newer
+status writer, and the independently deployed host monitoring collector scans
+every versioned runner directory. Status schema changes must cover those
+old/new combinations rather than treating the file as process-private state.
+
+During the idle-status terminology migration, current writers publish the same
+non-empty collection under canonical `idle_sandboxes` and temporary legacy
+`idle_vms`; both fields are omitted when the collection is empty. Current
+readers and the host collector select `idle_sandboxes` whenever that key is
+present, even when it is empty, and fall back to `idle_vms` only when the
+canonical key is absent. They never concatenate the fields. Remove the writer
+mirror only after the updated collector is installed on every runner host, the
+new runner rollout is complete, the previous-runner rollback window is closed,
+and no supported old maintenance command still needs `idle_vms` (tracked by
+#28926). Legacy read fallback is a separate decision because stopped old runner
+directories can remain supported inputs.
+
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and
 registry at startup, and keeps them in its version-specific base directory.
@@ -160,6 +186,12 @@ Their registry schema and process-local flow metadata can therefore change
 atomically in one runner release without fallback keys or cross-version readers.
 This exemption does not extend to registry data persisted outside that runner
 artifact or consumed by an independently deployed component.
+
+Runner sandbox-operation telemetry uses open string action names rather than a
+versioned enum. Historical rows keep `vm_create`; new fresh-sandbox creation
+events use `sandbox_create`. Readers that compare periods across this boundary
+must query both historical and current names rather than expecting rows to be
+rewritten or dual-emitted.
 
 Each sandbox is owned exclusively by the runner process that created it. A
 different runner never adopts that sandbox, and stopping the owning runner also

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -335,7 +335,7 @@ describe("webhook telemetry contract", () => {
         }),
         {
           ts: "2026-01-15T10:00:00.000Z",
-          action_type: "vm_create",
+          action_type: "sandbox_create",
           duration_ms: 5,
           success: true,
         },


### PR DESCRIPTION
## Summary

- rename provider-neutral idle runner state to `IdleSandbox` / `idle_sandboxes`
- dual-write canonical `idle_sandboxes` and legacy `idle_vms` from one collection during rollout
- make runner readers and the host collector prefer canonical-by-presence, with legacy fallback only when canonical is absent
- rename remaining provider-neutral runner text and new fresh-sandbox telemetry to `sandbox_create`
- document the provider-neutral terminology rule and the `status.json` cross-version boundary

## Fallbacks

- `crates/runner/src/status.rs:RunnerStatusWire` — mirrors non-empty `idle_sandboxes` as `idle_vms` so an old runner maintenance command can read status written by a new runner. Surface: old runner reader -> new runner status writer. Remove after the new runner rollout is complete, the updated collector is installed on every runner host, the previous-runner rollback window is closed, and no supported old maintenance command needs the mirror; follow-up #28926.
- `crates/runner/src/status_file.rs:StatusForDoctor::idle_sandboxes` — reads `idle_vms` only when canonical `idle_sandboxes` is absent so current maintenance commands can inspect status from an older or stopped runner directory. Surface: new runner reader -> old persisted runner status. Re-evaluate after the rollout gates above; remove only when old status directories are no longer supported inputs; follow-up #28926.
- `ansible/files/vm0-runner-status-collect.py:parse_status` — applies the same canonical-first legacy fallback for the independently deployed host collector. Surface: new collector -> old persisted runner status. Re-evaluate after the collector rollout and runner rollback gates; remove only when legacy-only status directories are no longer supported inputs; follow-up #28926.

All three are bounded cross-version compatibility for a host-local persisted status boundary. Mirrored fields are never concatenated, and canonical presence wins even when the collection is empty.

## Compatibility notes

- historical telemetry remains `vm_create`; only newly emitted events use `sandbox_create`

## Out of scope

- removing the legacy writer mirror before the rollout and rollback gates in #28926
- rewriting historical telemetry rows
- the private proxy registry/addon rename already delivered by #28924

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner` (3270 passed, 20 ignored)
- `.github/scripts/tests/vm0-runner-status-collect-test.sh`
- `bash -n` for the changed runner behavior and collector test scripts
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test` (600 passed)
- `pnpm exec prettier --check ../docs/deployment-compatibility.md`
- pre-commit hooks: Prettier, Knip, full Turbo type checks, Cargo fmt/doc/Clippy, file-size check, commitlint

Closes #28925
Relates to #28900
