### PR TITLE
test(guest-agent): scrub inherited tool cgroup endpoint

### DIFF
--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1029,6 +1029,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
         "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL",
         "VM0_TEST_CLAUDE_CONFIG_DIR",
         "VM0_TEST_CODEX_HOME_DIR",

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -8,11 +8,19 @@ mod common;
 use std::time::Duration;
 
 #[test]
-fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
+fn runtime_bootstrap_scrubs_runner_env_and_installs_explicit_paths() {
     let tmp = tempfile::tempdir().unwrap();
     let runtime_dir = tmp.path().join("runtime");
 
     unsafe {
+        std::env::remove_var(process_control_ipc::BOOTSTRAP_ENV);
+        std::env::remove_var(
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        );
+        std::env::set_var(
+            guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+            "inherited-tool-placement",
+        );
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(
             guest_contracts::env::RUN_ID_ENV,
@@ -52,6 +60,7 @@ fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
 
     let runtime = guest_agent::run_context::GuestRuntime::from_process_env().unwrap();
 
+    assert!(runtime.workload_containment.is_none());
     assert_eq!(runtime.paths.runtime_dir(), runtime_dir.as_path());
 
     guest_common::log_info!(


### PR DESCRIPTION
## Summary

- scrub the runner-owned tool cgroup endpoint in shared guest-agent integration setup
- make the isolated runtime bootstrap scenario inherit only that endpoint before cleanup
- verify the constructed test runtime remains unmanaged after cleanup

## Scope

- test infrastructure only
- production process-containment parsing remains unchanged and fail-closed
- no API, protocol, migration, or rollout changes

## Validation

- `cargo test -p guest-agent --test guest_runtime_process_env -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p guest-agent`
- pre-commit Cargo formatting, Clippy, documentation, file-size, and commit message hooks

Closes #29000
