### PR TITLE
docs(runner): remove retired compose contract reference

### DIFF
--- a/crates/runner/src/org_name.rs
+++ b/crates/runner/src/org_name.rs
@@ -1,8 +1,7 @@
 //! Validation for runner `org/name` identifiers.
 //!
-//! Mirrors the `/^[a-z0-9-]+\/[a-z0-9-]+$/` contracts in:
+//! Mirrors the `/^[a-z0-9-]+\/[a-z0-9-]+$/` contract in:
 //! - `turbo/packages/api-contracts/src/contracts/runners.ts`
-//! - `turbo/packages/api-contracts/src/contracts/composes.ts`
 //!
 //! Keep the Rust and TypeScript contracts in sync.
 


### PR DESCRIPTION
## Summary

- Remove the retired `turbo/packages/api-contracts/src/contracts/composes.ts` reference from the runner `org/name` validator rustdoc.
- Keep the regex and the live `turbo/packages/api-contracts/src/contracts/runners.ts` synchronization reference unchanged.

## Scope

This PR changes documentation only. The Rust validator implementation, its callers and tests, the TypeScript contracts, and runtime behavior are unchanged. No new documentation-reference guard is included.

Closes #28996

## Validation

- Passed `git diff --check`.
- Passed `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`.
- Passed documentation/path checks: the live runner contract exists, the retired compose contract is absent, the live path remains documented, the retired path is not documented, and the exact regex is preserved.
- Passed focused validator tests with `rustc --edition=2024 --test crates/runner/src/org_name.rs -o codex-work/org-name-tests && codex-work/org-name-tests` (2 passed).
- Attempted `cargo test --manifest-path crates/Cargo.toml -p runner org_name::tests`; compilation is currently blocked by the pre-existing `unused import: AsyncReadExt` error at `crates/runner/src/network_logs.rs:716`, which is unchanged by this PR.
