### PR TITLE
fix(composer): repair the feedback note structure webkit collapses mid-composition

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -79,6 +79,12 @@ export const composerRestoredAttachmentValidationEnabled$ = computed(
   },
 );
 
+export const composerNoteStructureRepairEnabled$ = computed((get): boolean => {
+  return (
+    get(featureSwitch$)[FeatureSwitchKey.ComposerNoteStructureRepair] ?? false
+  );
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -32,7 +32,10 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
-import { composerSubmitDomReconcileEnabled$ } from "../external/feature-switch.ts";
+import {
+  composerNoteStructureRepairEnabled$,
+  composerSubmitDomReconcileEnabled$,
+} from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import { sentryLogContext } from "../../lib/sentry-config.ts";
 import { onRef, resetSignal } from "../utils.ts";
@@ -639,14 +642,13 @@ function createComposerIcon(
   return icon;
 }
 
-function createFeedbackItemNodeView(
-  node: ProseMirrorNode,
-  removeFeedback: (id: number) => void,
-  localizedUi: Set<() => void>,
-): NodeView {
-  const dom = document.createElement("div");
-  dom.dataset.feedbackItem = "";
+interface FeedbackQuoteChip {
+  readonly quoteDom: HTMLDivElement;
+  readonly quoteText: HTMLSpanElement;
+  readonly removeButton: HTMLButtonElement;
+}
 
+function createFeedbackQuoteChip(): FeedbackQuoteChip {
   const quoteDom = document.createElement("div");
   quoteDom.className = "flex";
   quoteDom.contentEditable = "false";
@@ -678,6 +680,19 @@ function createFeedbackItemNodeView(
   );
   quoteChip.append(quoteIconContainer, quoteText, removeButton);
   quoteDom.append(quoteChip);
+  return { quoteDom, quoteText, removeButton };
+}
+
+function createFeedbackItemNodeView(
+  node: ProseMirrorNode,
+  removeFeedback: (id: number) => void,
+  localizedUi: Set<() => void>,
+  structureRepairEnabled: () => boolean,
+): NodeView {
+  const dom = document.createElement("div");
+  dom.dataset.feedbackItem = "";
+
+  const { quoteDom, quoteText, removeButton } = createFeedbackQuoteChip();
 
   const noteDom = document.createElement("div");
   const placeholderDom = document.createElement("span");
@@ -709,15 +724,35 @@ function createFeedbackItemNodeView(
     const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
     // The top padding is breathing room for the dashed divider, so only the
     // items that draw one get it. The first item keeps the editor's own pt-4.
-    dom.className = `flex flex-col gap-1.5 pb-1.5${
+    const domClass = `flex flex-col gap-1.5 pb-1.5${
       showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
     }`;
-    noteDom.className = `relative${fill ? " min-h-[96px]" : ""}`;
-    placeholderDom.hidden = nodeText(nextNode).length > 0;
-    contentDOM.className =
+    const noteDomClass = `relative${fill ? " min-h-[96px]" : ""}`;
+    const placeholderHidden = nodeText(nextNode).length > 0;
+    const contentDomClass =
       "relative w-full px-1 py-1 text-[0.9375rem] leading-snug " +
       `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`;
-    quoteText.textContent = quote;
+    // Assigning an unchanged value still queues an observer record, and with
+    // the repair switch on the record for contentDOM is no longer ignored —
+    // it would force a whole-node re-parse per keystroke and break a live
+    // composition. Write only real changes there; keep the legacy writes
+    // byte-for-byte when the switch is off.
+    const skipUnchanged = structureRepairEnabled();
+    if (!skipUnchanged || dom.className !== domClass) {
+      dom.className = domClass;
+    }
+    if (!skipUnchanged || noteDom.className !== noteDomClass) {
+      noteDom.className = noteDomClass;
+    }
+    if (!skipUnchanged || placeholderDom.hidden !== placeholderHidden) {
+      placeholderDom.hidden = placeholderHidden;
+    }
+    if (!skipUnchanged || contentDOM.className !== contentDomClass) {
+      contentDOM.className = contentDomClass;
+    }
+    if (!skipUnchanged || quoteText.textContent !== quote) {
+      quoteText.textContent = quote;
+    }
   }
   removeButton.addEventListener("mousedown", (event) => {
     event.preventDefault();
@@ -746,14 +781,91 @@ function createFeedbackItemNodeView(
         quoteDom.contains(event.target)
       );
     },
-    ignoreMutation(mutation) {
-      return (
-        mutation.type !== "selection" && !contentDOM.contains(mutation.target)
-      );
-    },
+    ignoreMutation: createFeedbackItemIgnoreMutation({
+      dom,
+      quoteDom,
+      noteDom,
+      placeholderDom,
+      contentDOM,
+      structureRepairEnabled,
+    }),
     destroy() {
       localizedUi.delete(localize);
     },
+  };
+}
+
+interface FeedbackItemMutationContext {
+  readonly dom: HTMLElement;
+  readonly quoteDom: HTMLElement;
+  readonly noteDom: HTMLElement;
+  readonly placeholderDom: HTMLElement;
+  readonly contentDOM: HTMLElement;
+  readonly structureRepairEnabled: () => boolean;
+}
+
+// The legacy branch ignores everything outside contentDOM — including the
+// record for WebKit removing the note wrappers, after which the structure is
+// never repaired and every later keystroke is silently dropped from
+// submissions (#27787). The repaired branch hides only what the node view
+// writes itself and keeps all other damage visible to ProseMirror.
+function createFeedbackItemIgnoreMutation(
+  context: FeedbackItemMutationContext,
+): NonNullable<NodeView["ignoreMutation"]> {
+  const {
+    dom,
+    quoteDom,
+    noteDom,
+    placeholderDom,
+    contentDOM,
+    structureRepairEnabled,
+  } = context;
+
+  /**
+   * WebKit can tear the note wrappers out of the item mid-composition and
+   * leave a bare <br> behind (#27787). The detached subtree still holds
+   * contentDOM and every text node, so reattaching it restores screen =
+   * document with nothing lost; whatever the browser put in the gap was never
+   * part of the document. Returns false for stranger damage so the caller
+   * hands it to ProseMirror's own dirty-node redraw.
+   */
+  function repairNoteStructure(): boolean {
+    if (!noteDom.contains(contentDOM)) {
+      return false;
+    }
+    for (const child of Array.from(dom.childNodes)) {
+      if (child !== quoteDom && child !== noteDom) {
+        child.remove();
+      }
+    }
+    dom.append(noteDom);
+    return true;
+  }
+
+  return (mutation) => {
+    if (!structureRepairEnabled()) {
+      return (
+        mutation.type !== "selection" && !contentDOM.contains(mutation.target)
+      );
+    }
+    if (mutation.type === "selection") {
+      return false;
+    }
+    if (!dom.contains(contentDOM)) {
+      return repairNoteStructure();
+    }
+    if (quoteDom.contains(mutation.target)) {
+      return true;
+    }
+    if (
+      mutation.type === "attributes" &&
+      (mutation.target === dom ||
+        mutation.target === noteDom ||
+        mutation.target === placeholderDom)
+    ) {
+      return true;
+    }
+    return placeholderDom.contains(mutation.target);
   };
 }
 
@@ -1606,6 +1718,8 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
+  /** Resolved ComposerNoteStructureRepair switch, set while mounted. */
+  noteStructureRepair: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1777,6 +1891,9 @@ function createFeedbackItemNode(
             runtime.removeFeedback(id);
           },
           runtime.localizedUi,
+          () => {
+            return runtime.noteStructureRepair;
+          },
         );
       };
     },
@@ -1940,6 +2057,7 @@ function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
   runtime.blur = () => {};
   runtime.replaceFeedbackItems = () => {};
   runtime.removeFeedback = () => {};
+  runtime.noteStructureRepair = false;
 }
 
 function applyWorkflowNames(editor: Editor, names: readonly string[]): void {
@@ -2156,6 +2274,7 @@ function createMountEditorCommand({
       runtime.removeFeedback = (id) => {
         set(feedback.signals.remove$, id);
       };
+      runtime.noteStructureRepair = get(composerNoteStructureRepairEnabled$);
       configureMountedWorkflowEditor(editor, singleLineOnMobile);
       setWorkflowComposerDocument(
         editor,
@@ -2566,6 +2685,7 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
+    noteStructureRepair: false,
   };
 }
 

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -820,6 +820,7 @@ function createFeedbackItemIgnoreMutation(
     contentDOM,
     structureRepairEnabled,
   } = context;
+  let reportedCollapse = false;
 
   /**
    * WebKit can tear the note wrappers out of the item mid-composition and
@@ -852,7 +853,17 @@ function createFeedbackItemIgnoreMutation(
       return false;
     }
     if (!dom.contains(contentDOM)) {
-      return repairNoteStructure();
+      const repaired = repairNoteStructure();
+      // Field evidence for how often WebKit collapses the note and whether
+      // the reattachment holds; never includes composer content.
+      if (!reportedCollapse) {
+        reportedCollapse = true;
+        L.error(
+          "composer feedback note structure collapsed",
+          sentryLogContext({ tags: { repaired } }),
+        );
+      }
+      return repaired;
     }
     if (quoteDom.contains(mutation.target)) {
       return true;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1799,12 +1799,24 @@ describe("chat inline feedback", () => {
   });
 
   it("repairs a collapsed note structure and keeps later input when the repair switch is enabled", async () => {
+    // The collapse report goes through L.error; the strict test console turns
+    // unexpected console.error calls into failures, so capture it here and
+    // assert the report below.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     const { sentMessage } = await submitAfterNoteStructureCollapse(
       true,
       "enabled",
     );
     expect(sentMessage.prompt).toContain("Make the dates");
     expect(sentMessage.prompt).toContain("explicit");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[E][WorkflowComposer]",
+      "composer feedback note structure collapsed",
+      expect.anything(),
+    );
   });
 
   it("keeps dropping input after a note collapse with the repair switch disabled", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -418,6 +418,112 @@ async function submitWithStrandedComposerText(
   return { assistantReply, sentMessage };
 }
 
+// Reproduce the WebKit collapse traced in #27787 with the DOM observer live:
+// the wrappers between the item and its note are torn out, taking the note
+// text with them, and a bare <br> is left in their place.
+function collapseNoteStructure(item: HTMLElement, note: HTMLElement): void {
+  const wrapper = note.parentElement;
+  if (!(wrapper instanceof HTMLElement) || wrapper === item) {
+    throw new Error("Feedback note wrapper not found");
+  }
+  wrapper.remove();
+  item.append(document.createElement("br"));
+}
+
+async function submitAfterNoteStructureCollapse(
+  repairEnabled: boolean,
+  caseName: string,
+): Promise<{
+  readonly assistantReply: string;
+  readonly sentMessage: RunCreateCapture;
+}> {
+  const user = userEvent.setup({ delay: null });
+  const assistantReply = "The rollout dates are unclear in this summary.";
+  const sentMessages: RunCreateCapture[] = [];
+
+  mockChatLifecycle(context, {
+    threadId: FEEDBACK_THREAD_ID,
+    threadTitle: "Feedback review",
+    chatEvents: [
+      {
+        id: `msg-feedback-collapse-${caseName}-user`,
+        role: "user",
+        content: "Review this launch summary",
+        runId: `run-feedback-collapse-${caseName}`,
+        createdAt: "2026-06-09T10:00:00Z",
+      },
+      {
+        id: `msg-feedback-collapse-${caseName}-assistant`,
+        role: "assistant",
+        content: assistantReply,
+        runId: `run-feedback-collapse-${caseName}`,
+        createdAt: "2026-06-09T10:01:00Z",
+      },
+    ],
+    onRunCreate: (body) => {
+      sentMessages.push(body);
+    },
+  });
+
+  detachedSetupPage({
+    context,
+    path: `/chats/${FEEDBACK_THREAD_ID}`,
+    featureSwitches: {
+      [FeatureSwitchKey.ComposerNoteStructureRepair]: repairEnabled,
+    },
+  });
+
+  await findComposerEditor();
+  selectTextForInlineFeedback(await screen.findByText(assistantReply));
+  await user.click(await screen.findByText("Quote"));
+
+  const feedbackComment = await findFeedbackNote();
+  await user.click(feedbackComment);
+  pastePlainText(feedbackComment, "Make the dates");
+  await waitFor(() => {
+    expect(feedbackComment).toHaveTextContent("Make the dates");
+  });
+
+  const [feedbackItem] = await findFeedbackItems(1);
+  if (!feedbackItem) {
+    throw new Error("Feedback item not found");
+  }
+  collapseNoteStructure(feedbackItem, feedbackComment);
+
+  if (repairEnabled) {
+    const repairedNote = await waitFor(() => {
+      const note = document.querySelector("[data-feedback-note]");
+      if (!(note instanceof HTMLElement)) {
+        throw new Error("Feedback note was not repaired");
+      }
+      expect(note).toHaveTextContent("Make the dates");
+      return note;
+    });
+    await user.click(repairedNote);
+    pastePlainText(repairedNote, " explicit");
+    await waitFor(() => {
+      expect(repairedNote).toHaveTextContent("explicit");
+    });
+  } else {
+    await waitFor(() => {
+      expect(document.querySelector("[data-feedback-note]")).toBeNull();
+    });
+    // Later typing lands directly in the collapsed block, the shape the
+    // device capture shows; the legacy ignoreMutation discards it.
+    feedbackItem.append(document.createTextNode(" explicit"));
+  }
+
+  await user.click(screen.getByLabelText("Send"));
+  await waitFor(() => {
+    expect(sentMessages).toHaveLength(1);
+  });
+  const [sentMessage] = sentMessages;
+  if (!sentMessage) {
+    throw new Error("Submission was not captured");
+  }
+  return { assistantReply, sentMessage };
+}
+
 async function replaceFeedbackNote(
   note: HTMLElement,
   value: string,
@@ -1690,6 +1796,24 @@ describe("chat inline feedback", () => {
         },
       ],
     });
+  });
+
+  it("repairs a collapsed note structure and keeps later input when the repair switch is enabled", async () => {
+    const { sentMessage } = await submitAfterNoteStructureCollapse(
+      true,
+      "enabled",
+    );
+    expect(sentMessage.prompt).toContain("Make the dates");
+    expect(sentMessage.prompt).toContain("explicit");
+  });
+
+  it("keeps dropping input after a note collapse with the repair switch disabled", async () => {
+    const { sentMessage } = await submitAfterNoteStructureCollapse(
+      false,
+      "disabled",
+    );
+    expect(sentMessage.prompt).toContain("Make the dates");
+    expect(sentMessage.prompt).not.toContain("explicit");
   });
 
   it("waits until mouseup before showing the inline feedback toolbar", async () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -174,6 +174,9 @@ describe("getAllFeatureStates", () => {
     expect(
       bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(true);
+    expect(bingjieStates[FeatureSwitchKey.ComposerNoteStructureRepair]).toBe(
+      true,
+    );
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -185,6 +188,9 @@ describe("getAllFeatureStates", () => {
     expect(
       otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(false);
+    expect(otherStaffStates[FeatureSwitchKey.ComposerNoteStructureRepair]).toBe(
+      false,
+    );
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -84,4 +84,5 @@ export enum FeatureSwitchKey {
   SharedChatDatabase = "sharedChatDatabase",
   ComposerSubmitDomReconcile = "composerSubmitDomReconcile",
   ComposerRestoredAttachmentValidation = "composerRestoredAttachmentValidation",
+  ComposerNoteStructureRepair = "composerNoteStructureRepair",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -387,6 +387,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
+  [FeatureSwitchKey.ComposerNoteStructureRepair]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Let the composer notice damage to the feedback note's DOM: skip redundant note renders, stop ignoring mutations outside the note content, and reattach the note wrappers WebKit removes during an IME composition so text typed afterwards is no longer silently dropped from submissions.",
+    enabled: false,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

On Safari (desktop, mobile web, and the installed PWA), quoting a passage and then typing into the feedback note can send only the first part of the message. A desktop Safari trace pinned the moment: **~20–30 ms after an IME composition update, WebKit removes the note's wrapper elements** (`noteDom` and `contentDOM`, taking the note text with them) and leaves a bare `<br>` — the visible "composer gets shorter" moment, because the note's `min-h-[96px]` lived on the removed elements.

The node view's `ignoreMutation` ignored every mutation outside `contentDOM`, which also discarded the record for that removal. ProseMirror therefore never noticed and never repaired the structure, and **every keystroke typed afterwards** (composition or plain English) landed outside the now-detached `contentDOM`, was discarded the same way, and stayed visible on screen while missing from the document, the draft PATCH, and the submission.

Fixes are gated behind the new `composerNoteStructureRepair` switch (default off, `bingjie@vm0.ai` only):

- **Reattach on collapse**: when a mutation arrives while `contentDOM` is out of the item, remove what the browser left in the gap and reattach the detached wrapper subtree — it still holds `contentDOM` and every text node, so screen = document is restored with nothing lost. Stranger damage returns `false` so ProseMirror's own dirty-node redraw rebuilds the view.
- **Narrowed `ignoreMutation`**: only mutations the node view produces itself (the quote chip subtree, attribute writes on its wrappers, the localized placeholder) are ignored; structural damage stays visible to ProseMirror. Attribute records on `contentDOM` stay visible because the `composerSubmitDomReconcile` resync marker depends on them.
- **Value-guarded renders**: `render()` writes only real changes when the switch is on. An unchanged-value assignment still queues an observer record, and once records on `contentDOM` are no longer ignored, per-keystroke redundant writes would force a whole-node re-parse and break a live composition.

With the switch off the node view behaves byte-for-byte as before this PR.

## Why this differs from the reverted attempts

#28045 flushed the DOM observer at submit — a no-op here because the collapse record never survives `ignoreMutation`, so there is nothing to flush. #28168 only skipped redundant writes and kept the broad `ignoreMutation`, so the collapse was still swallowed. This PR removes the swallowing itself; the write guards return only as a prerequisite for the narrowed `ignoreMutation`, not as the fix. The failure now reproduces in desktop Safari (quote → compose Chinese in the note), so the fix is directly falsifiable on a desktop rather than only on devices.

Related to #27787.

## Rollout

- default: disabled
- `bingjie@vm0.ai`: enabled

## Verification

- `pnpm exec prettier --write <changed files>` — clean
- `pnpm run lint` in `apps/platform` — exit 0
- `pnpm --filter @okouai/core run check-types`, `pnpm --filter @okouai/app run check-types` — clean
- `pnpm knip` — exit 0
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx` — 34 passed, including two new page tests that reproduce the traced collapse (wrapper removed + `<br>` inserted with the DOM observer live): switch on → structure repaired, note text preserved, later input reaches the submission; switch off → later input dropped (documents the current failure)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-queue.test.tsx` — 32 passed
- negative control: with the repair callback forced to `false`, the new enabled-path test fails
- device verification: enable the switch, quote a passage, compose Chinese into the note until the composer height drops, keep typing, send — the full text must arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)