### PR TITLE
perf(ci): rebalance runner behavior test lanes

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -858,6 +858,12 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-systemd-reload.sh
 
+      - name: Test VM keep-alive across conversation turns
+        timeout-minutes: 5
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-keep-alive.sh
+
       - name: Run upgrade test
         timeout-minutes: 5
         env:
@@ -892,12 +898,6 @@ jobs:
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-benchmark.sh
-
-      - name: Test VM keep-alive across conversation turns
-        timeout-minutes: 5
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-keep-alive.sh
 
       - name: Test exec process containment
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

- move the existing keep-alive runner behavior step from lane D to the lighter lane C
- keep upgrade last in lane C while leaving all ten scenarios, four lanes, fail-fast behavior, and Crates gate wiring unchanged
- reduce the observed lane D tail by the keep-alive step's approximately 24-29 second runtime

## Exclusions

- no runner behavior scripts or runtime behavior change
- no additional CI lanes, metal-host concurrency, timeout, dependency, or required-gate change
- no duration threshold is added because metal-host timing is observational and variable

## Validation

- `cd turbo && pnpm prettier --check --ignore-unknown ../.github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml` (v1.7.12)
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- static YAML contract check for four lanes, ten unique scenario commands, keep-alive/upgrade ordering, and Crates gate wiring
- `git diff --check`

Closes #29017

Parent: #29016
