### PR TITLE
docs(rust): document session-history cpu pool invariants

### DIFF
--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -1,4 +1,36 @@
 //! Bounded CPU execution for resume-session history materialization.
+//!
+//! A production Runner creates one shared `SessionHistoryCpuPool` per Runner
+//! process from the logical CPU count reported by `host::cpu_count()`. Its
+//! production capacity is half that count (integer division), clamped to a
+//! minimum of one and a maximum of four permits. The pool is stored in the
+//! shared `ExecutorConfig`, so downloaded history, workspace-sidecar history,
+//! and inline Codex timestamp extraction contend for the same CPU budget.
+//!
+//! `SessionHistoryCpuPool::materialize` acquires an owned semaphore permit
+//! before spawning the blocking task and moves that permit into
+//! `spawn_blocking`. The permit therefore covers the complete materialization,
+//! including validation, decompression, hashing, UTF-8 processing, and Codex
+//! timestamp scanning; it is not only an admission or decompression limit.
+//!
+//! Cancellation is cooperative once the blocking task has started. Caller
+//! cancellation signals a child token and the task's abort handle, and the
+//! cancellation path joins the blocking task before returning. Dropping an
+//! in-flight materialization future signals the same child token and abort
+//! handle through its task guard. `spawn_blocking` work must therefore retain
+//! bounded cancellation checkpoints: CPU loops call `check_cancelled`, and
+//! blocking read loops use `CancellationReader`, which checks cancellation
+//! around each read. New long-running CPU or read phases must preserve this
+//! contract rather than relying on task abortion to stop active work.
+//!
+//! Jobs enter this boundary as raw bytes, gzip or zstd encoded bytes, or
+//! inline Codex text. The raw and compressed paths validate declared sizes,
+//! decompress when needed, verify SHA-256, and extract a Codex timestamp when
+//! applicable. The inline Codex path performs the UTF-8 and timestamp work
+//! through the same pool. The downloaded-history materializer in
+//! `session_history_download.rs` and the workspace-sidecar materializer in
+//! `workspace_session_history_materializer.rs` use the pool for their raw,
+//! gzip, and zstd jobs; `agent_run.rs` uses it for inline Codex history.
 
 use std::fmt;
 use std::io::{self, BufReader, Read};


### PR DESCRIPTION
## Summary

- Expand the session-history CPU module rustdoc with its production sizing and shared ownership contract.
- Document semaphore permit lifetime across `spawn_blocking`, cooperative cancellation/drop behavior, bounded checkpoints, supported representations, and shared materialization callers.

Closes #28997

## Scope and exclusions

This is a documentation-only change. It does not alter runtime behavior, CPU capacity, cancellation logic, job representations, tests, protocols, persisted state, migrations, fallbacks, or rollout configuration.

## Validation

- `git diff --check` — passed
- `cd crates && cargo fmt --all -- --check` — passed
- `cd crates && cargo doc --workspace --all-features --no-deps` — passed
- `cd crates && cargo clippy --all-targets --all-features` — blocked by existing Clippy 1.98 errors in the unchanged `vsock-proto/src/payloads/memory_snapshot.rs:77,92` (`chunks_exact_to_as_chunks`)
- `cd crates && cargo test -p runner session_history_cpu::tests` — blocked by the existing `runner/src/network_logs.rs:716` unused import under `-D warnings`; a retry with `RUSTFLAGS=-Aunused-imports` was terminated with exit 137 by the constrained environment before test execution
