### PR TITLE
fix(platform): preserve composer state during feature hydration

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
@@ -328,8 +328,6 @@ export const setAgentComposerContext$ = command(
 );
 
 export const agentChatComposerSignals$ = computed((get) => {
-  // Recreate the editor when delayed feature-switch bootstrap changes its semantics.
-  get(featureSwitch$);
   const agentId = get(currentAgentId$);
   if (!agentId) {
     throw new Error("Chat composer requires an active agent");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { agentsByIdContract } from "@okouai/api-contracts/contracts/agents";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import { agentCustomConnectorsContract } from "@okouai/api-contracts/contracts/agent-custom-connectors";
 import {
@@ -1817,6 +1818,55 @@ describe("chat composer models", () => {
     expect(
       screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the agent chat model picker open while feature switches hydrate", async () => {
+    const user = userEvent.setup({ delay: null });
+    const featureSwitchRequestStarted = context.mocks.deferred<void>();
+    const releaseFeatureSwitchResponse = context.mocks.deferred<void>();
+
+    context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
+      featureSwitchRequestStarted.resolve();
+      await releaseFeatureSwitchResponse.promise;
+      return respond(200, {
+        switches: { [FeatureSwitchKey.ImageModelSelection]: true },
+        effectiveSwitches: {
+          [FeatureSwitchKey.ImageModelSelection]: true,
+        },
+      });
+    });
+    mockOrgModelRoutes("claude-fable-5");
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      cachedFeatureSwitches: {
+        [FeatureSwitchKey.ImageModelSelection]: false,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await featureSwitchRequestStarted.promise;
+    await waitFor(() => {
+      expect(document.title).toContain("Scout");
+    });
+    await user.click(
+      await screen.findByRole("combobox", { name: "Claude Fable 5" }),
+    );
+    await expect(
+      screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    ).resolves.toBeInTheDocument();
+    expect(categoryTab("Image")).toBeUndefined();
+
+    releaseFeatureSwitchResponse.resolve();
+
+    await waitFor(() => {
+      expect(categoryTab("Image")).toBeInTheDocument();
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("shows thread override over user and workspace defaults, then remains editable", async () => {


### PR DESCRIPTION
## Summary

- stop feature-switch cache hydration from recreating the agent composer signal factory
- preserve picker and other factory-owned state while current dynamic switches update through their existing consumers
- add a page-level regression test that holds hydration, opens the picker, then verifies image-model selection appears without closing it

## Root cause

`agentChatComposerSignals$` still depended on the complete `featureSwitch$` snapshot for a creation-time editor switch removed in #25441. A delayed cache write therefore invalidated the factory and reset its new `modelPickerOpen$` state to `false`.

## Scope

- Platform-only state-lifecycle fix
- no API, persistence, runner, migration, or deployment-compatibility changes
- no Playwright retry, timeout, or geometry changes

## Validation

- regression test fails before the production fix and passes after it
- `pnpm exec prettier --write apps/platform/src/signals/okou-page/agent-composer-signals.ts apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (82 tests passed)
- `pnpm -F @okouai/app test` (145 files, 1869 tests passed)
- `lefthook run pre-commit`

Closes #29014
