### PR TITLE
refactor(ci): rename verified-download tuning environment keys

### DIFF
--- a/.github/scripts/download-verified.sh
+++ b/.github/scripts/download-verified.sh
@@ -9,19 +9,19 @@ fi
 url="$1"
 expected_sha256="$2"
 destination="$3"
-max_attempts="${VM0_DOWNLOAD_VERIFIED_MAX_ATTEMPTS:-3}"
-retry_delay_seconds="${VM0_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS:-2}"
+max_attempts="${OKOU_DOWNLOAD_VERIFIED_MAX_ATTEMPTS:-3}"
+retry_delay_seconds="${OKOU_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS:-2}"
 
 if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
   echo "Expected SHA-256 must contain exactly 64 lowercase hexadecimal characters" >&2
   exit 1
 fi
 if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
-  echo "VM0_DOWNLOAD_VERIFIED_MAX_ATTEMPTS must be a positive integer" >&2
+  echo "OKOU_DOWNLOAD_VERIFIED_MAX_ATTEMPTS must be a positive integer" >&2
   exit 1
 fi
 if [[ ! "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
-  echo "VM0_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  echo "OKOU_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
   exit 1
 fi
 

--- a/.github/scripts/tests/download-verified-test.sh
+++ b/.github/scripts/tests/download-verified-test.sh
@@ -53,6 +53,9 @@ case "$MOCK_CURL_MODE" in
     fi
     cp "$MOCK_CURL_SOURCE" "$output"
     ;;
+  success)
+    cp "$MOCK_CURL_SOURCE" "$output"
+    ;;
   corrupt-then-success)
     if ((attempt == 1)); then
       printf 'invalid release response\n' > "$output"
@@ -85,8 +88,8 @@ run_download() {
   MOCK_CURL_MODE="$mode" \
     MOCK_CURL_SOURCE="$source_file" \
     MOCK_CURL_STATE="$state_file" \
-    VM0_DOWNLOAD_VERIFIED_MAX_ATTEMPTS=3 \
-    VM0_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS=0 \
+    OKOU_DOWNLOAD_VERIFIED_MAX_ATTEMPTS=3 \
+    OKOU_DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS=0 \
     PATH="${tmp_dir}/bin:${PATH}" \
     bash "$script" "$url" "$expected_sha256" "$destination" \
       > /dev/null 2> "$stderr_file"
@@ -138,5 +141,21 @@ if find "$tmp_dir" -maxdepth 1 -name 'existing.tar.gz.partial.*' -print -quit | 
   echo "Expected failed downloads to remove their partial file" >&2
   exit 1
 fi
+
+legacy_state="${tmp_dir}/legacy.state"
+legacy_destination="${tmp_dir}/legacy.tar.gz"
+retired_prefix="VM0_"
+printf '0\n' > "$legacy_state"
+env \
+  "${retired_prefix}DOWNLOAD_VERIFIED_MAX_ATTEMPTS=invalid" \
+  "${retired_prefix}DOWNLOAD_VERIFIED_RETRY_DELAY_SECONDS=invalid" \
+  MOCK_CURL_MODE=success \
+  MOCK_CURL_SOURCE="$source_file" \
+  MOCK_CURL_STATE="$legacy_state" \
+  PATH="${tmp_dir}/bin:${PATH}" \
+  bash "$script" "$url" "$expected_sha256" "$legacy_destination" \
+    > /dev/null
+cmp "$source_file" "$legacy_destination"
+[[ "$(<"$legacy_state")" == "1" ]]
 
 echo "download-verified tests passed"


### PR DESCRIPTION
## Summary

- Rename the verified-download retry tuning overrides and validation diagnostics from `VM0_*` to `OKOU_*`.
- Update the focused shell harness and add a fast, no-network regression proving the retired names are ignored.
- Preserve all caller defaults and the existing retry, checksum, temporary-file, and destination semantics without changing caller files.

## Verification

- `bash -n .github/scripts/download-verified.sh .github/scripts/tests/download-verified-test.sh`
- `npx --yes shellcheck .github/scripts/download-verified.sh .github/scripts/tests/download-verified-test.sh`
- `bash .github/scripts/tests/download-verified-test.sh`
- `bash .github/scripts/tests/release-tool-downloads-test.sh`
- `git diff --check`
- Repository-wide exact-name search returns zero matches for both retired environment keys.
- Diff inspection confirms no helper caller file changed.

Closes #29023
Part of #28914
