### PR TITLE
refactor(runner): dual-read and dual-write mitmdump runtime markers

### DIFF
--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -871,6 +871,14 @@ mod tests {
     use crate::paths::HomePaths;
     use std::os::unix::fs::PermissionsExt;
 
+    // Mirrors the pre-#28989 reader retained by rollback runners. Keep this
+    // test-only so Stage 1 proves its dual writer remains legacy-readable.
+    fn legacy_only_runtime_marker(environ: &[u8]) -> Option<&[u8]> {
+        environ
+            .split(|byte| *byte == 0)
+            .find_map(|entry| entry.strip_prefix(b"VM0_MITMDUMP_RUNTIME_DIR="))
+    }
+
     fn write_fake_listening_mitmdump(path: &Path) {
         std::fs::write(
             path,
@@ -879,6 +887,7 @@ set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
 printf '%s\n%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
   "$VM0_MITMDUMP_RUNTIME_DIR" "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
+cp "/proc/$$/environ" "$0.environ"
 port=""
 ready_path=""
 usage_state_id=""
@@ -1603,6 +1612,12 @@ exit 42
         assert_eq!(environment[0], environment[1]);
         assert_eq!(environment[0], environment[2]);
         assert_eq!(environment[3], "runner-token");
+        let launched_environ = std::fs::read(fake_mitmdump.with_extension("environ")).unwrap();
+        assert_eq!(
+            legacy_only_runtime_marker(&launched_environ),
+            Some(environment[0].as_bytes()),
+            "the pre-migration legacy-only reader must recognize Stage 1 launch environments"
+        );
         let launch_path = Path::new(environment[0]);
         assert_eq!(launch_path.parent(), Some(config.runtime_dir.as_path()));
         assert!(

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -14,7 +14,7 @@ use super::flush::{
 };
 use super::managed_process::ManagedMitmdump;
 use super::registry::{ProxyRegistryHandle, SandboxRegistration, write_empty_registry};
-use super::runtime::{MitmdumpRuntime, RUNTIME_MARKER_ENV};
+use super::runtime::{CANONICAL_RUNTIME_MARKER_ENV, LEGACY_RUNTIME_MARKER_ENV, MitmdumpRuntime};
 use super::stderr::log_mitmdump_stderr_line;
 use crate::error::{RunnerError, RunnerResult};
 
@@ -634,7 +634,8 @@ async fn spawn_mitmdump(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     cmd.env("TMPDIR", &launch_path)
-        .env(RUNTIME_MARKER_ENV, &launch_path)
+        .env(CANONICAL_RUNTIME_MARKER_ENV, &launch_path)
+        .env(LEGACY_RUNTIME_MARKER_ENV, &launch_path)
         .process_group(0);
     cmd.kill_on_drop(true);
 
@@ -876,8 +877,8 @@ mod tests {
             r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
-printf '%s\n%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" \
-  "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
+printf '%s\n%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
+  "$VM0_MITMDUMP_RUNTIME_DIR" "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
 port=""
 ready_path=""
 usage_state_id=""
@@ -939,7 +940,8 @@ PY
             path,
             r#"#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+printf '%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
+  "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
 ready_path=""
 usage_state_id=""
 for arg in "$@"; do
@@ -984,7 +986,9 @@ import time
 from pathlib import Path
 
 Path(f"{sys.argv[0]}.env").write_text(
-    f"{os.environ['TMPDIR']}\n{os.environ['VM0_MITMDUMP_RUNTIME_DIR']}\n",
+    f"{os.environ['TMPDIR']}\n"
+    f"{os.environ['OKOU_MITMDUMP_RUNTIME_DIR']}\n"
+    f"{os.environ['VM0_MITMDUMP_RUNTIME_DIR']}\n",
     encoding="utf-8",
 )
 port = None
@@ -1033,7 +1037,8 @@ while True:
             path,
             r#"#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+printf '%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
+  "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
 printf 'attempt\n' >> "$0.attempts"
 python3 - "$0.descendant" <<'PY' &
 import os
@@ -1594,9 +1599,10 @@ exit 42
         let args = std::fs::read_to_string(fake_mitmdump.with_extension("args")).unwrap();
         let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
         let environment: Vec<&str> = environment.lines().collect();
-        assert_eq!(environment.len(), 3);
+        assert_eq!(environment.len(), 4);
         assert_eq!(environment[0], environment[1]);
-        assert_eq!(environment[2], "runner-token");
+        assert_eq!(environment[0], environment[2]);
+        assert_eq!(environment[3], "runner-token");
         let launch_path = Path::new(environment[0]);
         assert_eq!(launch_path.parent(), Some(config.runtime_dir.as_path()));
         assert!(
@@ -1916,28 +1922,43 @@ exit 42
     }
 
     #[tokio::test]
-    async fn proxy_startup_reconciles_only_marked_private_launches() {
+    async fn proxy_startup_reconciles_all_marker_sources_and_only_private_launches() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         let config = test_proxy_config(dir.path(), &home, dir.path().join("mitmdump"));
         let runtime = acquire_test_runtime(&config).await;
-        let launch = runtime.create_launch_dir().await.unwrap();
-        let stale_launch = launch.path().to_path_buf();
-        std::fs::create_dir(stale_launch.join("_MEI-stale")).unwrap();
-        std::fs::write(stale_launch.join("_MEI-stale/payload"), b"stale").unwrap();
+        let mut stale_processes = Vec::new();
+        for (source, canonical, legacy) in [
+            ("legacy-only", false, true),
+            ("canonical-only", true, false),
+            ("dual", true, true),
+        ] {
+            let stale_launch = config.runtime_dir.join(format!("launch-{source}"));
+            std::fs::create_dir(&stale_launch).unwrap();
+            std::fs::create_dir(stale_launch.join("_MEI-stale")).unwrap();
+            std::fs::write(stale_launch.join("_MEI-stale/payload"), b"stale").unwrap();
 
-        let mut stale_process = tokio::process::Command::new("sleep")
-            .arg("60")
-            .env("TMPDIR", &stale_launch)
-            .env(RUNTIME_MARKER_ENV, &stale_launch)
-            .process_group(0)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .unwrap();
-        let stale_pid = stale_process.id().unwrap();
-        let stale_launch = launch.keep();
+            let mut command = tokio::process::Command::new("sleep");
+            command
+                .arg("60")
+                .env_remove(CANONICAL_RUNTIME_MARKER_ENV)
+                .env_remove(LEGACY_RUNTIME_MARKER_ENV)
+                .env("TMPDIR", &stale_launch)
+                .process_group(0)
+                .kill_on_drop(true)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            if canonical {
+                command.env(CANONICAL_RUNTIME_MARKER_ENV, &stale_launch);
+            }
+            if legacy {
+                command.env(LEGACY_RUNTIME_MARKER_ENV, &stale_launch);
+            }
+            let stale_process = command.spawn().unwrap();
+            let stale_pid = stale_process.id().unwrap();
+            stale_processes.push((source, stale_process, stale_pid, stale_launch));
+        }
         drop(runtime);
 
         let unrelated_sibling = config.runtime_dir.join("keep-me");
@@ -1949,21 +1970,76 @@ exit 42
 
         let (_proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
 
-        let status = tokio::time::timeout(Duration::from_secs(2), stale_process.wait())
-            .await
-            .expect("stale marked process was not terminated")
-            .unwrap();
-        assert!(
-            !status.success(),
-            "stale process unexpectedly exited cleanly"
-        );
-        assert!(
-            wait_for_pid_absent(stale_pid).await,
-            "stale marked process {stale_pid} remains live"
-        );
-        assert!(!stale_launch.exists());
+        for (source, mut stale_process, stale_pid, stale_launch) in stale_processes {
+            let status = tokio::time::timeout(Duration::from_secs(2), stale_process.wait())
+                .await
+                .unwrap_or_else(|_| panic!("stale {source} marked process was not terminated"))
+                .unwrap();
+            assert!(
+                !status.success(),
+                "stale {source} process unexpectedly exited cleanly"
+            );
+            assert!(
+                wait_for_pid_absent(stale_pid).await,
+                "stale {source} process {stale_pid} remains live"
+            );
+            assert!(
+                !stale_launch.exists(),
+                "stale {source} launch directory remains"
+            );
+        }
         assert!(unrelated_sibling.is_dir());
         assert!(unrelated_shared.path().is_dir());
+    }
+
+    #[tokio::test]
+    async fn proxy_startup_preserves_launches_for_conflicting_runtime_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let config = test_proxy_config(dir.path(), &home, dir.path().join("mitmdump"));
+        let runtime = acquire_test_runtime(&config).await;
+        let canonical = config
+            .runtime_dir
+            .join("launch-canonical-value-should-not-leak");
+        let legacy = config
+            .runtime_dir
+            .join("launch-legacy-value-should-not-leak");
+        std::fs::create_dir(&canonical).unwrap();
+        std::fs::create_dir(&legacy).unwrap();
+        drop(runtime);
+
+        let mut conflicting_process = tokio::process::Command::new("sleep")
+            .arg("60")
+            .env_remove(CANONICAL_RUNTIME_MARKER_ENV)
+            .env_remove(LEGACY_RUNTIME_MARKER_ENV)
+            .env("TMPDIR", &canonical)
+            .env(CANONICAL_RUNTIME_MARKER_ENV, &canonical)
+            .env(LEGACY_RUNTIME_MARKER_ENV, &legacy)
+            .process_group(0)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        let error = MitmProxy::new(config)
+            .await
+            .err()
+            .expect("expected conflicting runtime markers")
+            .to_string();
+
+        assert!(error.contains(CANONICAL_RUNTIME_MARKER_ENV));
+        assert!(error.contains(LEGACY_RUNTIME_MARKER_ENV));
+        assert!(!error.contains("canonical-value-should-not-leak"));
+        assert!(!error.contains("legacy-value-should-not-leak"));
+        assert!(
+            conflicting_process.try_wait().unwrap().is_none(),
+            "conflicting marker process was signalled"
+        );
+        assert!(canonical.is_dir());
+        assert!(legacy.is_dir());
+        conflicting_process.kill().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -14,11 +14,50 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::process::{ProcessStat, ProcessStatRead, process_stat_is_live};
 
-pub(super) const RUNTIME_MARKER_ENV: &str = "VM0_MITMDUMP_RUNTIME_DIR";
-const RUNTIME_MARKER_PREFIX: &[u8] = b"VM0_MITMDUMP_RUNTIME_DIR=";
+// Marker-bearing descendants can outlive their runner. Expansion Stage 1 keeps
+// both names so current runners can reconcile old launches and rollback runners
+// can reconcile current launches; removal remains gated by #28914.
+pub(super) const CANONICAL_RUNTIME_MARKER_ENV: &str = "OKOU_MITMDUMP_RUNTIME_DIR";
+pub(super) const LEGACY_RUNTIME_MARKER_ENV: &str = "VM0_MITMDUMP_RUNTIME_DIR";
+const CANONICAL_RUNTIME_MARKER_PREFIX: &[u8] = b"OKOU_MITMDUMP_RUNTIME_DIR=";
+const LEGACY_RUNTIME_MARKER_PREFIX: &[u8] = b"VM0_MITMDUMP_RUNTIME_DIR=";
 const LAUNCH_PREFIX: &str = "launch-";
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeMarkerSource {
+    LegacyOnly,
+    CanonicalOnly,
+    Dual,
+}
+
+impl RuntimeMarkerSource {
+    const ALL: [Self; 3] = [Self::LegacyOnly, Self::CanonicalOnly, Self::Dual];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyOnly => "legacy-only",
+            Self::CanonicalOnly => "canonical-only",
+            Self::Dual => "dual",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct ResolvedRuntimeMarker<'a> {
+    value: &'a [u8],
+    source: RuntimeMarkerSource,
+}
+
+#[derive(Clone, Copy)]
+enum RuntimeMarkerResolution<'a> {
+    Resolved(ResolvedRuntimeMarker<'a>),
+    Conflict {
+        canonical: &'a [u8],
+        legacy: &'a [u8],
+    },
+}
 
 #[derive(Clone, Copy)]
 struct ProcessIdentity {
@@ -31,6 +70,7 @@ struct ProcessObservation {
     identity: ProcessIdentity,
     stat: ProcessStat,
     command: String,
+    marker_source: RuntimeMarkerSource,
 }
 
 struct ProcessSnapshot {
@@ -100,7 +140,7 @@ impl MitmdumpRuntime {
             )));
         }
         if let Err(error) = self.terminate_marked_processes(Some(&path)).await {
-            warn!(path = %path.display(), error = %error, "preserving mitmdump launch directory for later reconciliation");
+            warn!(error = %error, "preserving mitmdump launch directory for later reconciliation");
             return Err(error);
         }
         match tokio::fs::remove_dir_all(&path).await {
@@ -271,10 +311,19 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
         let Some(environ) = read_process_environ(pid)? else {
             continue;
         };
-        let Some(marker) = runtime_marker(&environ) else {
+        let Some(marker) = resolve_runtime_marker(&environ) else {
             continue;
         };
-        let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker));
+        let marker = match marker {
+            RuntimeMarkerResolution::Resolved(marker) => marker,
+            RuntimeMarkerResolution::Conflict { canonical, legacy } => {
+                if conflicting_runtime_marker_claims_target(root, exact_path, canonical, legacy) {
+                    return Err(runtime_marker_conflict_error());
+                }
+                continue;
+            }
+        };
+        let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker.value));
         if !is_launch_path(root, marker_path)
             || exact_path.is_some_and(|expected| marker_path != expected)
         {
@@ -298,7 +347,7 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
         let Some(rechecked_environ) = read_process_environ(pid)? else {
             continue;
         };
-        if runtime_marker(&rechecked_environ) != Some(marker) {
+        if resolve_unambiguous_runtime_marker(&rechecked_environ)? != Some(marker) {
             continue;
         }
         let after = match crate::process::read_process_stat_checked_blocking(pid) {
@@ -329,6 +378,7 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
             },
             stat: after,
             command,
+            marker_source: marker.source,
         });
     }
     Ok(ProcessSnapshot {
@@ -376,10 +426,62 @@ fn process_disappeared(error: &std::io::Error) -> bool {
     error.kind() == std::io::ErrorKind::NotFound || error.raw_os_error() == Some(nix::libc::ESRCH)
 }
 
-fn runtime_marker(environ: &[u8]) -> Option<&[u8]> {
-    environ
+fn resolve_runtime_marker(environ: &[u8]) -> Option<RuntimeMarkerResolution<'_>> {
+    let canonical = environ
         .split(|byte| *byte == 0)
-        .find_map(|entry| entry.strip_prefix(RUNTIME_MARKER_PREFIX))
+        .find_map(|entry| entry.strip_prefix(CANONICAL_RUNTIME_MARKER_PREFIX));
+    let legacy = environ
+        .split(|byte| *byte == 0)
+        .find_map(|entry| entry.strip_prefix(LEGACY_RUNTIME_MARKER_PREFIX));
+
+    match (canonical, legacy) {
+        (None, None) => None,
+        (None, Some(value)) => Some(RuntimeMarkerResolution::Resolved(ResolvedRuntimeMarker {
+            value,
+            source: RuntimeMarkerSource::LegacyOnly,
+        })),
+        (Some(value), None) => Some(RuntimeMarkerResolution::Resolved(ResolvedRuntimeMarker {
+            value,
+            source: RuntimeMarkerSource::CanonicalOnly,
+        })),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            Some(RuntimeMarkerResolution::Resolved(ResolvedRuntimeMarker {
+                value: canonical,
+                source: RuntimeMarkerSource::Dual,
+            }))
+        }
+        (Some(canonical), Some(legacy)) => {
+            Some(RuntimeMarkerResolution::Conflict { canonical, legacy })
+        }
+    }
+}
+
+fn resolve_unambiguous_runtime_marker(
+    environ: &[u8],
+) -> RunnerResult<Option<ResolvedRuntimeMarker<'_>>> {
+    match resolve_runtime_marker(environ) {
+        None => Ok(None),
+        Some(RuntimeMarkerResolution::Resolved(marker)) => Ok(Some(marker)),
+        Some(RuntimeMarkerResolution::Conflict { .. }) => Err(runtime_marker_conflict_error()),
+    }
+}
+
+fn conflicting_runtime_marker_claims_target(
+    root: &Path,
+    exact_path: Option<&Path>,
+    canonical: &[u8],
+    legacy: &[u8],
+) -> bool {
+    [canonical, legacy].into_iter().any(|value| {
+        let path = Path::new(std::ffi::OsStr::from_bytes(value));
+        is_launch_path(root, path) && exact_path.is_none_or(|expected| path == expected)
+    })
+}
+
+fn runtime_marker_conflict_error() -> RunnerError {
+    RunnerError::Internal(format!(
+        "conflicting mitmdump runtime marker environment keys {CANONICAL_RUNTIME_MARKER_ENV} and {LEGACY_RUNTIME_MARKER_ENV}"
+    ))
 }
 
 fn is_launch_path(root: &Path, path: &Path) -> bool {
@@ -390,6 +492,19 @@ fn is_launch_path(root: &Path, path: &Path) -> bool {
 }
 
 fn log_process_snapshot(target: &Path, snapshot: &ProcessSnapshot) {
+    for source in RuntimeMarkerSource::ALL {
+        let matched = snapshot
+            .processes
+            .iter()
+            .filter(|process| process.marker_source == source)
+            .count();
+        if matched > 0 {
+            info!(
+                marker_source = source.as_str(),
+                matched, "observed mitmdump runtime marker source during reconciliation"
+            );
+        }
+    }
     if snapshot.elapsed >= PROCESS_EXIT_TIMEOUT {
         let elapsed_ms = snapshot.elapsed.as_millis();
         let matched = snapshot.processes.len();
@@ -438,6 +553,7 @@ async fn observe_stable_process(
                 identity: process.identity,
                 stat,
                 command: process.command.clone(),
+                marker_source: process.marker_source,
             }))
         }
         ProcessStatRead::Found(_) | ProcessStatRead::Missing => Ok(None),
@@ -559,10 +675,10 @@ async fn marked_process_matches_after_pidfd_open(
             )));
         }
     };
-    let Some(marker) = runtime_marker(&environ) else {
+    let Some(marker) = resolve_unambiguous_runtime_marker(&environ)? else {
         return Ok(false);
     };
-    let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker));
+    let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker.value));
     if !is_launch_path(root, marker_path)
         || exact_path.is_some_and(|expected| marker_path != expected)
     {
@@ -610,14 +726,19 @@ mod tests {
     }
 
     impl ProbeChild {
-        fn spawn(marker: Option<&Path>) -> Self {
+        fn spawn(canonical_marker: Option<&Path>, legacy_marker: Option<&Path>) -> Self {
             let mut command = Command::new("cat");
             command
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
-                .stderr(Stdio::null());
-            if let Some(marker) = marker {
-                command.env(RUNTIME_MARKER_ENV, marker);
+                .stderr(Stdio::null())
+                .env_remove(CANONICAL_RUNTIME_MARKER_ENV)
+                .env_remove(LEGACY_RUNTIME_MARKER_ENV);
+            if let Some(marker) = canonical_marker {
+                command.env(CANONICAL_RUNTIME_MARKER_ENV, marker);
+            }
+            if let Some(marker) = legacy_marker {
+                command.env(LEGACY_RUNTIME_MARKER_ENV, marker);
             }
             let mut child = command.spawn().unwrap();
             let stdin = child.stdin.take().unwrap();
@@ -640,6 +761,65 @@ mod tests {
             self.stdout.read_line(&mut response).unwrap();
             assert_eq!(response, "probe\n");
         }
+    }
+
+    fn marker_environment(canonical: Option<&[u8]>, legacy: Option<&[u8]>) -> Vec<u8> {
+        let mut environ = b"UNRELATED=value\0".to_vec();
+        if let Some(value) = canonical {
+            environ.extend_from_slice(CANONICAL_RUNTIME_MARKER_PREFIX);
+            environ.extend_from_slice(value);
+            environ.push(0);
+        }
+        if let Some(value) = legacy {
+            environ.extend_from_slice(LEGACY_RUNTIME_MARKER_PREFIX);
+            environ.extend_from_slice(value);
+            environ.push(0);
+        }
+        environ
+    }
+
+    #[test]
+    fn runtime_marker_resolver_accepts_supported_sources() {
+        let value = b"/runtime/launch-marker".as_slice();
+        for (canonical, legacy, source) in [
+            (None, Some(value), RuntimeMarkerSource::LegacyOnly),
+            (Some(value), None, RuntimeMarkerSource::CanonicalOnly),
+            (Some(value), Some(value), RuntimeMarkerSource::Dual),
+        ] {
+            let environ = marker_environment(canonical, legacy);
+            let RuntimeMarkerResolution::Resolved(marker) =
+                resolve_runtime_marker(&environ).unwrap()
+            else {
+                panic!("expected resolved runtime marker");
+            };
+
+            assert_eq!(marker.value, value);
+            assert_eq!(marker.source, source);
+        }
+        assert!(resolve_runtime_marker(&marker_environment(None, None)).is_none());
+        assert_eq!(RuntimeMarkerSource::LegacyOnly.as_str(), "legacy-only");
+        assert_eq!(
+            RuntimeMarkerSource::CanonicalOnly.as_str(),
+            "canonical-only"
+        );
+        assert_eq!(RuntimeMarkerSource::Dual.as_str(), "dual");
+    }
+
+    #[test]
+    fn runtime_marker_resolver_rejects_conflicts_without_values() {
+        let canonical = b"canonical-value-should-not-leak";
+        let legacy = b"legacy-value-should-not-leak";
+        let environ = marker_environment(Some(canonical), Some(legacy));
+        let error = match resolve_unambiguous_runtime_marker(&environ) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("expected conflicting runtime markers"),
+        };
+
+        assert!(error.contains("conflicting mitmdump runtime marker"));
+        assert!(error.contains(CANONICAL_RUNTIME_MARKER_ENV));
+        assert!(error.contains(LEGACY_RUNTIME_MARKER_ENV));
+        assert!(!error.contains(std::str::from_utf8(canonical).unwrap()));
+        assert!(!error.contains(std::str::from_utf8(legacy).unwrap()));
     }
 
     impl Drop for ProbeChild {
@@ -665,7 +845,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let launch = root.path().join("launch-stale-generation");
         std::fs::create_dir(&launch).unwrap();
-        let mut replacement = ProbeChild::spawn(Some(&launch));
+        let mut replacement = ProbeChild::spawn(None, Some(&launch));
         let current = process_identity(replacement.pid()).await;
         let stale = ProcessIdentity {
             starttime: current.starttime.checked_add(1).unwrap(),
@@ -684,13 +864,35 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let launch = root.path().join("launch-removed-marker");
         std::fs::create_dir(&launch).unwrap();
-        let mut replacement = ProbeChild::spawn(None);
+        let mut replacement = ProbeChild::spawn(None, None);
         let current = process_identity(replacement.pid()).await;
 
         signal_stable_process(root.path(), Some(&launch), current)
             .await
             .unwrap();
 
+        replacement.assert_responds();
+    }
+
+    #[tokio::test]
+    async fn pidfd_signal_rejects_conflicting_runtime_markers_without_values() {
+        let root = tempfile::tempdir().unwrap();
+        let canonical = root.path().join("launch-canonical-value-should-not-leak");
+        let legacy = root.path().join("launch-legacy-value-should-not-leak");
+        std::fs::create_dir(&canonical).unwrap();
+        std::fs::create_dir(&legacy).unwrap();
+        let mut replacement = ProbeChild::spawn(Some(&canonical), Some(&legacy));
+        let current = process_identity(replacement.pid()).await;
+
+        let error = signal_stable_process(root.path(), Some(&canonical), current)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains(CANONICAL_RUNTIME_MARKER_ENV));
+        assert!(error.contains(LEGACY_RUNTIME_MARKER_ENV));
+        assert!(!error.contains("canonical-value-should-not-leak"));
+        assert!(!error.contains("legacy-value-should-not-leak"));
         replacement.assert_responds();
     }
 }


### PR DESCRIPTION
## Summary

- introduce the canonical `OKOU_MITMDUMP_RUNTIME_DIR` marker while retaining the explicitly named legacy `VM0_MITMDUMP_RUNTIME_DIR` marker
- dual-write both marker names with byte-identical values equal to the private `TMPDIR` for every mitmdump launch
- resolve legacy-only, canonical-only, and equal dual markers through one parser in the initial procfs scan, immediate environment recheck, and post-pidfd recheck
- record bounded, value-free `legacy-only`, `canonical-only`, and `dual` reconciliation source evidence
- fail closed on conflicting dual markers before signalling, preserve launch directories, and keep diagnostics free of either marker value
- exercise the pre-migration legacy-only parser against the raw process environment emitted by an actual Stage 1 dual-writing launch

## Compatibility and safety

- new runners continue reconciling legacy-only descendants from old runners
- rollback runners continue reconciling dual-written descendants through the retained legacy marker
- path ownership, same-UID filtering, process generation checks, pidfd signalling, runtime locking, timeouts, process groups, parent-death handling, and PyInstaller lifecycle behavior are unchanged
- `OKOU_MITM_RUNNER_TOKEN`, addon contracts, proxy registry contracts, and unrelated `VM0_*` names are unchanged
- canonical-only writing and legacy reader removal are deliberately deferred

## Fallbacks

- `crates/runner/src/proxy/runtime.rs:resolve_runtime_marker` — accepts the legacy-only marker emitted by descendants from pre-Stage 1 runners. Surface: existing runner / sandbox; gate: all old runner-owned launches and surviving descendants have drained through the two-hour guest runtime plus bounded finalization and the supported rollback window. Remove only in the legacy-reader-removal stage tracked by #28914 after legacy-only reconciliation remains zero through that window.
- `crates/runner/src/proxy/process.rs:spawn_mitmdump` — continues writing the legacy marker beside the canonical marker so a pre-Stage 1 rollback runner can reconcile Stage 1 descendants. Surface: existing runner / sandbox and retained runner rollback artifact; gate: the deployed reader floor, runner/rootfs artifact identity, drain evidence, and supported rollback window required by #28914. Replace with canonical-only writing only in Stage 2 tracked by #28914.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --bin runner --all-features --no-deps -- -D warnings -A clippy::result-large-err`
- `cargo check --manifest-path crates/Cargo.toml -p runner --bin runner --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- the all-target clippy rerun used the two pre-existing Rust 1.98 lint allowances on unchanged code, reached runner checking without a new diagnostic, and was then terminated by the 3.8 GiB local environment with exit 137
- the focused launcher test was attempted with `CARGO_BUILD_JOBS=1`; after temporarily removing and restoring an unrelated unused test import newly diagnosed by Rust 1.98 on main, the local environment terminated the runner test-binary link with exit 137 before the test started
- the PR pipeline will execute the focused rollback/lifecycle coverage and full pinned Rust checks

Closes #28989