### PR TITLE
test(vsock-guest): rename production env-script fixture key

### DIFF
--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -220,7 +220,7 @@ fn production_env_script_remains_until_operation_cleanup() {
     assert_eq!(script_metadata.permissions().mode() & 0o777, 0o440);
     let script = fs::read_to_string(&script_path)
         .unwrap_or_else(|error| panic!("read active env script {script_path:?}: {error}"));
-    assert!(script.contains("export VM0_ENV_SCRIPT_READY='ready'"));
+    assert!(script.contains("export OKOU_TEST_ENV_SCRIPT_READY='ready'"));
 
     send_exec_cancel(&mut stream, 3);
     let result = read_message(&mut stream);
@@ -307,8 +307,8 @@ fn send_supervised_env_exec(stream: &mut UnixStream, sequence: u32) {
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::Supervised,
         timeout: ExecTimeoutPolicy::None,
-        command: "printf '%s' \"$VM0_ENV_SCRIPT_READY\"; sleep 60",
-        env: &[("VM0_ENV_SCRIPT_READY", "ready")],
+        command: "printf '%s' \"$OKOU_TEST_ENV_SCRIPT_READY\"; sleep 60",
+        env: &[("OKOU_TEST_ENV_SCRIPT_READY", "ready")],
         sudo: false,
         label: "production-env-script-cleanup",
         stdout: ExecOutputPolicy::Stream {


### PR DESCRIPTION
## Summary

- Rename the sole private vsock production env-script fixture key from `VM0_ENV_SCRIPT_READY` to `OKOU_TEST_ENV_SCRIPT_READY`.
- Update the encoded environment producer, shell command reader, and generated private env-script assertion atomically.
- Preserve stdout expectations, protocol encoding, script serialization, permissions, ownership, containment, cancellation, and cleanup behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features --no-deps`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets --no-deps`
- `cargo doc -p vsock-guest --all-features --no-deps`
- `cargo test -p vsock-guest --release --no-default-features --test production_identity` (2 passed; 3 production/root tests ignored by their declared contract)
- Repository-wide fixed-string audit: zero `VM0_ENV_SCRIPT_READY` occurrences and exactly three `OKOU_TEST_ENV_SCRIPT_READY` occurrences in the intended test file.

## Local environment notes

- Dependency-inclusive Clippy under local Rust 1.98 is blocked by the two new `chunks_exact_to_as_chunks` lints in unchanged `vsock-proto/src/payloads/memory_snapshot.rs`; both affected-crate `--no-deps` configurations pass, and pinned CI remains authoritative for the dependency-inclusive check.
- The exact ignored production env-script test requires root plus a production sandbox account at UID/GID 42420/42421. This environment runs as UID 1000 and already has `user` at UID 1000, so the production/root case is left to the PR pipeline that provisions the required identity.

Closes #29028
Refs #28914
