### PR TITLE
refactor(ci): rename peak-memory report environment controls

### DIFF
--- a/.github/actions/report-memory-peak/action.yml
+++ b/.github/actions/report-memory-peak/action.yml
@@ -13,5 +13,5 @@ runs:
     - name: Read cgroup peak memory
       shell: bash
       env:
-        VM0_MEMORY_REPORT_LABEL: ${{ inputs.job-label }}
+        OKOU_MEMORY_REPORT_LABEL: ${{ inputs.job-label }}
       run: bash "$GITHUB_ACTION_PATH/report.sh"

--- a/.github/actions/report-memory-peak/report.sh
+++ b/.github/actions/report-memory-peak/report.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cgroup_root=${VM0_CGROUP_ROOT:-/sys/fs/cgroup}
-proc_cgroup=${VM0_PROC_CGROUP:-/proc/self/cgroup}
-job_label=${VM0_MEMORY_REPORT_LABEL:-${GITHUB_JOB:-CI}}
+cgroup_root=${OKOU_CGROUP_ROOT:-/sys/fs/cgroup}
+proc_cgroup=${OKOU_PROC_CGROUP:-/proc/self/cgroup}
+job_label=${OKOU_MEMORY_REPORT_LABEL:-${GITHUB_JOB:-CI}}
 
 peak_bytes=""
 peak_source=""

--- a/.github/scripts/tests/report-cgroup-memory-peak-test.sh
+++ b/.github/scripts/tests/report-cgroup-memory-peak-test.sh
@@ -21,9 +21,9 @@ run_reporter() {
   local fixture=$1
   env -i \
     PATH="$PATH" \
-    VM0_CGROUP_ROOT="${fixture}/cgroup" \
-    VM0_PROC_CGROUP="${fixture}/proc-self-cgroup" \
-    VM0_MEMORY_REPORT_LABEL="test-job" \
+    OKOU_CGROUP_ROOT="${fixture}/cgroup" \
+    OKOU_PROC_CGROUP="${fixture}/proc-self-cgroup" \
+    OKOU_MEMORY_REPORT_LABEL="test-job" \
     GITHUB_STEP_SUMMARY="${fixture}/summary.md" \
     bash "$REPORTER" 2>&1
 }

--- a/.github/scripts/tests/rust-ci-memory-workflow-test.sh
+++ b/.github/scripts/tests/rust-ci-memory-workflow-test.sh
@@ -43,7 +43,7 @@ jq -e '
   .runs.using == "composite" and
   any(.runs.steps[];
     .shell == "bash" and
-    .env.VM0_MEMORY_REPORT_LABEL == "${{ inputs.job-label }}" and
+    .env.OKOU_MEMORY_REPORT_LABEL == "${{ inputs.job-label }}" and
     .run == "bash \"$GITHUB_ACTION_PATH/report.sh\""
   )
 ' <<<"$action_json" >/dev/null || fail "peak memory action must run the bundled cgroup reporter"


### PR DESCRIPTION
## Summary

- rename the peak-memory action label channel to `OKOU_MEMORY_REPORT_LABEL`
- rename the fixture-only cgroup path overrides to `OKOU_CGROUP_ROOT` and `OKOU_PROC_CGROUP`
- update the behavior and structural tests atomically while preserving action inputs, defaults, fallbacks, probing, rounding, and reporting behavior

## Verification

- `bash .github/scripts/tests/report-cgroup-memory-peak-test.sh`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash -n .github/actions/report-memory-peak/report.sh .github/scripts/tests/report-cgroup-memory-peak-test.sh .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `shellcheck .github/actions/report-memory-peak/report.sh .github/scripts/tests/report-cgroup-memory-peak-test.sh .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- repository-wide fixed-string search: zero occurrences of all three legacy keys
- confirmed no diff in `.github/workflows/crates.yml`, `.github/workflows/runner-image.yml`, or `.github/workflows/security.yml`

Closes #29027
