### PR TITLE
fix(composer): keep the feedback note chrome outside the editable flow

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -83,6 +83,15 @@ export const composerRestoredAttachmentValidationEnabled$ = computed(
   },
 );
 
+export const composerNoteEditableIsolationEnabled$ = computed(
+  (get): boolean => {
+    return (
+      get(featureSwitch$)[FeatureSwitchKey.ComposerNoteEditableIsolation] ??
+      false
+    );
+  },
+);
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -32,7 +32,10 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
-import { composerSubmitDomReconcileEnabled$ } from "../external/feature-switch.ts";
+import {
+  composerNoteEditableIsolationEnabled$,
+  composerSubmitDomReconcileEnabled$,
+} from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import { sentryLogContext } from "../../lib/sentry-config.ts";
 import { onRef, resetSignal } from "../utils.ts";
@@ -643,6 +646,7 @@ function createFeedbackItemNodeView(
   node: ProseMirrorNode,
   removeFeedback: (id: number) => void,
   localizedUi: Set<() => void>,
+  editableIsolationEnabled: () => boolean,
 ): NodeView {
   const dom = document.createElement("div");
   dom.dataset.feedbackItem = "";
@@ -691,6 +695,14 @@ function createFeedbackItemNodeView(
   contentDOM.setAttribute("aria-multiline", "true");
   noteDom.append(placeholderDom, contentDOM);
   dom.append(quoteDom, noteDom);
+  if (editableIsolationEnabled()) {
+    // Everything around contentDOM is chrome. Keeping it outside the editable
+    // region denies WebKit's editing machinery a reason to restructure it and
+    // keeps the caret from landing between the wrappers (#27787); contentDOM
+    // opts back in as its own editing host.
+    dom.contentEditable = "false";
+    contentDOM.contentEditable = "true";
+  }
 
   let currentNode = node;
   function localize(): void {
@@ -1606,6 +1618,8 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
+  /** Resolved ComposerNoteEditableIsolation switch, set while mounted. */
+  noteEditableIsolation: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1777,6 +1791,9 @@ function createFeedbackItemNode(
             runtime.removeFeedback(id);
           },
           runtime.localizedUi,
+          () => {
+            return runtime.noteEditableIsolation;
+          },
         );
       };
     },
@@ -1940,6 +1957,7 @@ function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
   runtime.blur = () => {};
   runtime.replaceFeedbackItems = () => {};
   runtime.removeFeedback = () => {};
+  runtime.noteEditableIsolation = false;
 }
 
 function applyWorkflowNames(editor: Editor, names: readonly string[]): void {
@@ -2156,6 +2174,9 @@ function createMountEditorCommand({
       runtime.removeFeedback = (id) => {
         set(feedback.signals.remove$, id);
       };
+      runtime.noteEditableIsolation = get(
+        composerNoteEditableIsolationEnabled$,
+      );
       configureMountedWorkflowEditor(editor, singleLineOnMobile);
       setWorkflowComposerDocument(
         editor,
@@ -2566,6 +2587,7 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
+    noteEditableIsolation: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1692,6 +1692,65 @@ describe("chat inline feedback", () => {
     });
   });
 
+  it("keeps the note editable and submits typed text with editable isolation enabled", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+    const sentMessages: RunCreateCapture[] = [];
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-isolation-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-isolation",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-isolation-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-isolation",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerNoteEditableIsolation]: true,
+      },
+    });
+
+    await findComposerEditor();
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const feedbackComment = await findFeedbackNote();
+    const [feedbackItem] = await findFeedbackItems(1);
+    expect(feedbackItem?.getAttribute("contenteditable")).toBe("false");
+    expect(feedbackComment.getAttribute("contenteditable")).toBe("true");
+
+    await user.click(feedbackComment);
+    pastePlainText(feedbackComment, "Make the dates explicit");
+    await waitFor(() => {
+      expect(feedbackComment).toHaveTextContent("Make the dates explicit");
+    });
+
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(sentMessages).toHaveLength(1);
+    });
+    expect(sentMessages[0]?.prompt).toContain("Make the dates explicit");
+  });
+
   it("waits until mouseup before showing the inline feedback toolbar", async () => {
     const assistantReply = "The rollout dates are unclear in this summary.";
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -174,6 +174,9 @@ describe("getAllFeatureStates", () => {
     expect(
       bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(true);
+    expect(bingjieStates[FeatureSwitchKey.ComposerNoteEditableIsolation]).toBe(
+      true,
+    );
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -184,6 +187,9 @@ describe("getAllFeatureStates", () => {
     );
     expect(
       otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
+    ).toBe(false);
+    expect(
+      otherStaffStates[FeatureSwitchKey.ComposerNoteEditableIsolation],
     ).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -85,4 +85,5 @@ export enum FeatureSwitchKey {
   ComposerSubmitDomReconcile = "composerSubmitDomReconcile",
   ComposerImageAnnotation = "composerImageAnnotation",
   ComposerRestoredAttachmentValidation = "composerRestoredAttachmentValidation",
+  ComposerNoteEditableIsolation = "composerNoteEditableIsolation",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -396,6 +396,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
+  [FeatureSwitchKey.ComposerNoteEditableIsolation]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Keep the feedback note's wrapper elements outside the editable flow, with the note content opting back in as its own editing host, so WebKit's editing machinery can neither restructure the wrappers during an IME composition nor land the caret between them.",
+    enabled: false,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

The structural fix for #27787: the feedback note node view leaves its wrapper elements (`dom`, `noteDom`, the placeholder) editable, so WebKit's editing machinery treats them as part of the editable region. Two observed consequences:

1. During an IME composition, WebKit's delete-and-prune editing primitive can climb through the "emptied" anonymous editable wrappers and remove them, leaving a bare `<br>` — the collapse traced in desktop Safari that makes everything typed afterwards silently missing from submissions.
2. With multiple quotes, pressing Backspace mid-composition can land the DOM caret between the wrappers; the gap has no view desc, so ProseMirror resolves the position at the block boundary into the **previous** note's text.

Behind the new `composerNoteEditableIsolation` switch (default off, `bingjie@vm0.ai` only), the node view marks its `dom` `contenteditable="false"` and opts `contentDOM` back in as its own editing host. Nothing around the note content belongs to the editable region anymore: WebKit's ancestor pruning stops at the editing-host boundary, and the caret can no longer land between the wrappers. With the switch off the node view renders exactly as before.

## Relationship to #29015

Standalone and intended to merge first. #29015 (collapse detection, zero-loss reattachment, and collapse telemetry) remains open as the complementary safety net and the field instrument: with both switches on, #29015's collapse log going quiet is the proof this prevention works. #29015 will be rebased over this change after it lands.

## Interaction surface to verify in dogfood

Nested editing hosts change selection physics at the note boundary. Manual checklist:

- quote → compose pinyin in the note until the composer previously collapsed — must no longer collapse
- two quotes → compose pinyin in the second note → Backspace mid-composition — caret must stay in the second note (the newly reported symptom)
- drag-select from the plain paragraph across into a note; select-all; arrow keys into/out of the note; Backspace at note start
- iOS: tap-to-focus the note, software keyboard behavior, long-press selection

## Verification

- `pnpm exec prettier --write <changed files>` — clean
- `apps/platform` `pnpm run lint` — exit 0
- `pnpm --filter @okouai/core run check-types`, `pnpm --filter @okouai/app run check-types` — clean
- `pnpm knip` — exit 0
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx` — 33 passed, including a new page test with the switch enabled asserting the item is `contenteditable=false`, the note is `contenteditable=true`, and text typed into the note still reaches the submission

Related to #27787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)