### PR TITLE
refactor(guest-agent): dual-read codex service-tier environment aliases

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -2159,6 +2159,8 @@ mod tests {
         expected: Option<(&str, super::CodexServiceTierSource)>,
         expected_fast_mode: bool,
     ) {
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        guest_common::log::clear_system_log_file();
         assert_eq!(
             super::resolve_codex_service_tier(&user_env).unwrap(),
             expected

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -80,6 +80,9 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const AGENT_LOG_BUFFER_BYTES: usize = 8 * 1024;
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 const OKOU_AGENT_ID_ENV_KEY: &str = "OKOU_AGENT_ID";
+const CODEX_SERVICE_TIER_CANONICAL_ENV: &str = "OKOU_CODEX_SERVICE_TIER";
+const CODEX_SERVICE_TIER_LEGACY_ENV: &str = "VM0_CODEX_SERVICE_TIER";
+const CODEX_SERVICE_TIER_RESOLUTION_EVENT: &str = "codex_service_tier_environment_resolution";
 const CLI_PACKAGE_URL_ENV_KEY: &str = "CLI_PKG_URL";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
 const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
@@ -92,6 +95,23 @@ const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];
 const CODEX_WEB_SEARCH_DISABLED_CONFIG: &str = r#"web_search="disabled""#;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CodexServiceTierSource {
+    CanonicalOnly,
+    LegacyOnly,
+    Dual,
+}
+
+impl CodexServiceTierSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CanonicalOnly => "canonical_only",
+            Self::LegacyOnly => "legacy_only",
+            Self::Dual => "dual",
+        }
+    }
+}
 
 #[derive(serde::Serialize)]
 struct ClaudeUserFrame<'a> {
@@ -362,6 +382,18 @@ impl<'a> CliRuntimeConfig<'a> {
         } else {
             None
         };
+        let codex_service_tier = if matches!(config.framework, env::Framework::Codex) {
+            resolve_codex_service_tier(&config.user_env)?
+        } else {
+            None
+        };
+        if let Some((_, source)) = codex_service_tier {
+            log_info!(
+                LOG_TAG,
+                "{CODEX_SERVICE_TIER_RESOLUTION_EVENT} source={}",
+                source.as_str()
+            );
+        }
         let disable_builtin_web_search = config.user_env.contains_key(OKOU_AGENT_ID_ENV_KEY);
         let disallowed_tools = disallowed_tools_with_builtin_web_search_disabled(
             &config.disallowed_tools,
@@ -410,7 +442,7 @@ impl<'a> CliRuntimeConfig<'a> {
             )),
             codex_runtime_config,
             codex_oauth_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty(),
-            codex_fast_mode: user_env_value(&config.user_env, "VM0_CODEX_SERVICE_TIER") == "fast",
+            codex_fast_mode: codex_service_tier.is_some_and(|(value, _)| value == "fast"),
             disable_builtin_web_search,
             agent_execution_deadline,
             stuck_tool_timeout_secs: config.stuck_tool_timeout_secs,
@@ -475,6 +507,28 @@ impl<'a> CliRuntimeConfig<'a> {
         let mut user_env = self.user_env.clone();
         user_env.remove(OPENAI_BASE_URL_ENV_KEY);
         Cow::Owned(user_env)
+    }
+}
+
+/// Stage 1 compatibility for the API-authored Codex service tier environment.
+/// Remove the legacy reader only after #28914 cuts the API writer over and
+/// observes zero legacy-only use through the supported rollback window.
+fn resolve_codex_service_tier(
+    user_env: &HashMap<String, String>,
+) -> Result<Option<(&str, CodexServiceTierSource)>, AgentError> {
+    match (
+        user_env.get(CODEX_SERVICE_TIER_CANONICAL_ENV),
+        user_env.get(CODEX_SERVICE_TIER_LEGACY_ENV),
+    ) {
+        (None, None) => Ok(None),
+        (Some(value), None) => Ok(Some((value, CodexServiceTierSource::CanonicalOnly))),
+        (None, Some(value)) => Ok(Some((value, CodexServiceTierSource::LegacyOnly))),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            Ok(Some((canonical, CodexServiceTierSource::Dual)))
+        }
+        (Some(_), Some(_)) => Err(AgentError::Execution(format!(
+            "conflicting Codex service-tier environment keys: {CODEX_SERVICE_TIER_CANONICAL_ENV} and {CODEX_SERVICE_TIER_LEGACY_ENV}"
+        ))),
     }
 }
 
@@ -2040,6 +2094,21 @@ mod tests {
     use std::path::Path;
     use std::time::{Duration, Instant};
 
+    struct SystemLogOverrideGuard;
+
+    impl SystemLogOverrideGuard {
+        fn set(path: &Path) -> Self {
+            guest_common::log::set_system_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SystemLogOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::log::clear_system_log_file();
+        }
+    }
+
     fn guest_config_for_agent_context(user_env: HashMap<String, String>) -> env::GuestConfig {
         env::GuestConfig {
             run_id: "run-okou-env-test".to_string(),
@@ -2083,6 +2152,24 @@ mod tests {
                 constants::POST_RESULT_SIGKILL_GRACE_SECS,
             ),
         }
+    }
+
+    fn assert_codex_service_tier_resolution(
+        user_env: HashMap<String, String>,
+        expected: Option<(&str, super::CodexServiceTierSource)>,
+        expected_fast_mode: bool,
+    ) {
+        assert_eq!(
+            super::resolve_codex_service_tier(&user_env).unwrap(),
+            expected
+        );
+
+        let config = guest_config_for_agent_context(user_env);
+        let paths =
+            crate::paths::GuestPaths::from_runtime_dir("/tmp/codex-service-tier-resolution-test");
+        let runtime = CliRuntimeConfig::from_config(&config, &paths, Instant::now()).unwrap();
+
+        assert_eq!(runtime.codex_fast_mode, expected_fast_mode);
     }
 
     fn runtime_for_command_test<'a>(
@@ -2311,6 +2398,172 @@ mod tests {
                 .codex_startup_config_overrides()
                 .contains(&super::CODEX_WEB_SEARCH_DISABLED_CONFIG.to_string())
         );
+    }
+
+    #[test]
+    fn codex_service_tier_resolver_preserves_absence() {
+        assert_codex_service_tier_resolution(HashMap::new(), None, false);
+    }
+
+    #[test]
+    fn codex_service_tier_resolver_accepts_canonical_only() {
+        for (value, expected_fast_mode) in [("fast", true), ("", false), ("priority", false)] {
+            assert_codex_service_tier_resolution(
+                HashMap::from([(
+                    super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                    value.to_string(),
+                )]),
+                Some((value, super::CodexServiceTierSource::CanonicalOnly)),
+                expected_fast_mode,
+            );
+        }
+    }
+
+    #[test]
+    fn codex_service_tier_resolver_accepts_legacy_only() {
+        for (value, expected_fast_mode) in [("fast", true), ("", false), ("priority", false)] {
+            assert_codex_service_tier_resolution(
+                HashMap::from([(
+                    super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                    value.to_string(),
+                )]),
+                Some((value, super::CodexServiceTierSource::LegacyOnly)),
+                expected_fast_mode,
+            );
+        }
+    }
+
+    #[test]
+    fn codex_service_tier_resolver_accepts_equal_dual() {
+        for (value, expected_fast_mode) in [("fast", true), ("", false), ("priority", false)] {
+            assert_codex_service_tier_resolution(
+                HashMap::from([
+                    (
+                        super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                        value.to_string(),
+                    ),
+                    (
+                        super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                        value.to_string(),
+                    ),
+                ]),
+                Some((value, super::CodexServiceTierSource::Dual)),
+                expected_fast_mode,
+            );
+        }
+    }
+
+    #[test]
+    fn codex_service_tier_resolver_rejects_conflicting_dual_without_values() {
+        let canonical_value = "canonical-value-must-not-leak";
+        let legacy_value = "legacy-value-must-not-leak";
+        let user_env = HashMap::from([
+            (
+                super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                canonical_value.to_string(),
+            ),
+            (
+                super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                legacy_value.to_string(),
+            ),
+        ]);
+
+        let resolver_error = super::resolve_codex_service_tier(&user_env)
+            .expect_err("conflicting aliases must fail")
+            .to_string();
+        let config = guest_config_for_agent_context(user_env);
+        let paths =
+            crate::paths::GuestPaths::from_runtime_dir("/tmp/codex-service-tier-conflict-test");
+        let config_error = CliRuntimeConfig::from_config(&config, &paths, Instant::now())
+            .err()
+            .expect("conflicting aliases must fail before Codex startup")
+            .to_string();
+
+        assert_eq!(resolver_error, config_error);
+        assert!(
+            resolver_error.contains(super::CODEX_SERVICE_TIER_CANONICAL_ENV)
+                && resolver_error.contains(super::CODEX_SERVICE_TIER_LEGACY_ENV)
+        );
+        assert!(!resolver_error.contains(canonical_value));
+        assert!(!resolver_error.contains(legacy_value));
+    }
+
+    #[test]
+    fn codex_service_tier_resolution_log_is_fixed_shape_and_value_free() {
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        let system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let paths = crate::paths::GuestPaths::from_runtime_dir(tmp.path());
+        let successful_cases = [
+            HashMap::from([(
+                super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                "canonical-value-must-not-log".to_string(),
+            )]),
+            HashMap::from([(
+                super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                "legacy-value-must-not-log".to_string(),
+            )]),
+            HashMap::from([
+                (
+                    super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                    "dual-value-must-not-log".to_string(),
+                ),
+                (
+                    super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                    "dual-value-must-not-log".to_string(),
+                ),
+            ]),
+        ];
+
+        for user_env in successful_cases {
+            let config = guest_config_for_agent_context(user_env);
+            CliRuntimeConfig::from_config(&config, &paths, Instant::now()).unwrap();
+        }
+        let absent_config = guest_config_for_agent_context(HashMap::new());
+        CliRuntimeConfig::from_config(&absent_config, &paths, Instant::now()).unwrap();
+        let conflict_config = guest_config_for_agent_context(HashMap::from([
+            (
+                super::CODEX_SERVICE_TIER_CANONICAL_ENV.to_string(),
+                "conflicting-canonical-value-must-not-log".to_string(),
+            ),
+            (
+                super::CODEX_SERVICE_TIER_LEGACY_ENV.to_string(),
+                "conflicting-legacy-value-must-not-log".to_string(),
+            ),
+        ]));
+        assert!(CliRuntimeConfig::from_config(&conflict_config, &paths, Instant::now()).is_err());
+
+        drop(system_log_guard);
+        let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+        let event_prefix = format!("[{}] ", super::LOG_TAG);
+        let evidence = system_log
+            .lines()
+            .filter(|line| line.contains(super::CODEX_SERVICE_TIER_RESOLUTION_EVENT))
+            .map(|line| {
+                line.rsplit_once(&event_prefix)
+                    .expect("resolution evidence must use the guest logger tag")
+                    .1
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            evidence,
+            [
+                "codex_service_tier_environment_resolution source=canonical_only",
+                "codex_service_tier_environment_resolution source=legacy_only",
+                "codex_service_tier_environment_resolution source=dual",
+            ]
+        );
+        for value in [
+            "canonical-value-must-not-log",
+            "legacy-value-must-not-log",
+            "dual-value-must-not-log",
+            "conflicting-canonical-value-must-not-log",
+            "conflicting-legacy-value-must-not-log",
+        ] {
+            assert!(!system_log.contains(value));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- dual-read `OKOU_CODEX_SERVICE_TIER` and `VM0_CODEX_SERVICE_TIER` at the guest Codex CLI configuration boundary
- preserve absent, empty, non-`fast`, and exact `fast` behavior while accepting canonical-only, legacy-only, and equal-dual inputs
- fail closed on conflicting dual inputs before Codex startup without selecting, logging, or diagnosing either value
- emit one fixed, value-free `codex_service_tier_environment_resolution` log event with `canonical_only`, `legacy_only`, or `dual` source evidence
- keep the production API writer legacy-only and retain both ChatGPT and API-key Codex app-server fast-mode paths

## Fallbacks

- `crates/guest-agent/src/cli/mod.rs:resolve_codex_service_tier` retains `VM0_CODEX_SERVICE_TIER` as the Stage 1 compatibility reader for the API-authored guest environment. Surface: API to deployed runner/embedded guest across the supported rollback window. Remove it only after the canonical API writer cutover ships above the deployed reader floor and source evidence remains at zero `legacy_only` use through that window; operational follow-up: #28914.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --lib --tests --no-deps -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p guest-agent --lib --tests`
- `CARGO_BUILD_JOBS=1 RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib codex_service_tier_`
- `env -u VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT -u VM0_TOOL_CGROUP_PROCS_ENDPOINT -u VM0_PROCESS_CONTROL_ENDPOINT CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_fast_mode`
- `env -u VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT -u VM0_TOOL_CGROUP_PROCS_ENDPOINT -u VM0_PROCESS_CONTROL_ENDPOINT CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_fast_mode_without_chatgpt`
- `git diff --check origin/main...HEAD`

The app-server test commands unset bootstrap cgroup variables inherited from this guest runtime. #29011 owns that independent fixture cleanup; this PR does not modify its files.

Verified against `main@9ae9fb96b53b3e87c98169d6fb1d4943bcf4e2bc`. The sole production writer remains `VM0_CODEX_SERVICE_TIER` in `agent-runs-create.service.ts` and is unchanged by this diff.

Closes #29012

Parent EPIC: #28914
