### PR TITLE
refactor(runtime): reserve okou namespace in cloud execution

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -5,11 +5,11 @@
 //! through [`USER_ENV_FILE_ENV`], so user-provided keys cannot override runner
 //! bootstrap controls directly.
 //!
-//! The `VM0_` namespace is runner-owned, including keys defined in sibling
-//! modules such as [`crate::runtime_paths::GUEST_RUNTIME_DIR_ENV`]. User env
-//! filtering should treat current, future, and retired `VM0_` keys as
-//! protected. Canonical bootstrap keys outside that retired namespace are
-//! listed explicitly below; the whole `OKOU_` namespace is not protected.
+//! The `OKOU_` and `VM0_` namespaces are runner-owned, including keys defined
+//! in sibling modules such as [`crate::runtime_paths::GUEST_RUNTIME_DIR_ENV`].
+//! User env filtering should treat current and future `OKOU_` keys plus current,
+//! future, and retired `VM0_` keys as protected. Bootstrap keys outside those
+//! namespaces are listed explicitly below.
 //!
 //! [`GUEST_AGENT_TUNING_ENV_KEYS`] is the only intentional exception where
 //! selected runner-owned keys may cross the local user-env boundary as
@@ -434,11 +434,20 @@ pub fn is_guest_agent_tuning_env_key(key: &str) -> bool {
 
 /// Returns whether `key` belongs to the runner-owned bootstrap namespace.
 ///
-/// This covers every `VM0_` key, including future and retired names, plus the
-/// explicit bootstrap keys required by established runner, guest-agent, or
-/// integration contracts. Runner and local-submit code use this predicate to
+/// This covers every `OKOU_` and `VM0_` key, including future and retired names,
+/// plus the explicit bootstrap keys required by established runner, guest-agent,
+/// or integration contracts. Runner and local-submit code use this predicate to
 /// scrub or reject user-provided env keys before the guest-agent starts.
 pub fn is_runner_owned_env_key(key: &str) -> bool {
+    key.starts_with("OKOU_") || is_pre_platform_environment_runner_owned_env_key(key)
+}
+
+/// Returns whether `key` was runner-owned before `platformEnvironment` claims.
+///
+/// New runners use this only for old API claims or legitimately stored pre-field
+/// contexts. Remove it after previous API rollback targets, supported pre-field
+/// contexts, and old runners/sandboxes pass the #28914 drain gates.
+pub fn is_pre_platform_environment_runner_owned_env_key(key: &str) -> bool {
     key.starts_with("VM0_") || EXPLICIT_RUNNER_OWNED_ENV_KEYS.contains(&key)
 }
 
@@ -678,9 +687,26 @@ mod tests {
         ] {
             assert!(is_runner_owned_env_key(key), "{key} should be runner-owned");
         }
-        assert!(!is_runner_owned_env_key("OKOU_TOKEN"));
-        assert!(!is_runner_owned_env_key("OKOU_UNRELATED"));
+        assert!(is_runner_owned_env_key("OKOU_TOKEN"));
+        assert!(is_runner_owned_env_key("OKOU_UNRELATED"));
         assert!(!is_runner_owned_env_key("CUSTOM_ENV"));
+    }
+
+    #[test]
+    fn pre_platform_environment_detection_preserves_previous_ownership() {
+        assert!(is_pre_platform_environment_runner_owned_env_key(RUN_ID_ENV));
+        assert!(is_pre_platform_environment_runner_owned_env_key(
+            "VM0_FUTURE_RUNNER_KEY"
+        ));
+        assert!(!is_pre_platform_environment_runner_owned_env_key(
+            "OKOU_TOKEN"
+        ));
+        assert!(!is_pre_platform_environment_runner_owned_env_key(
+            "OKOU_UNRELATED"
+        ));
+        assert!(!is_pre_platform_environment_runner_owned_env_key(
+            "CUSTOM_ENV"
+        ));
     }
 
     #[test]
@@ -773,7 +799,7 @@ mod tests {
         assert!(
             unprotected.is_empty(),
             "these bootstrap env keys are not protected from user env injection. Add each to \
-             EXPLICIT_RUNNER_OWNED_ENV_KEYS, or keep the VM0_ prefix:\n  {}",
+             EXPLICIT_RUNNER_OWNED_ENV_KEYS, or keep an OKOU_/VM0_ prefix:\n  {}",
             unprotected.join("\n  ")
         );
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -372,7 +372,20 @@ fn for_each_guest_user_env_entry<'a>(
     context: &'a ExecutionContext,
     mut visit: impl FnMut(&'a str, &'a str),
 ) {
-    for_each_filtered_environment_entry(context.environment.as_ref(), &mut visit);
+    let is_untrusted_runner_owned: fn(&str) -> bool = if context.platform_environment.is_some() {
+        is_runner_owned_env_key
+    } else {
+        // Old API/stored context -> new runner: preserve the exact
+        // pre-platformEnvironment filter until prior API rollback targets,
+        // supported pre-field contexts, and old runners/sandboxes pass the
+        // #28914 drain gates.
+        guest_contracts::env::is_pre_platform_environment_runner_owned_env_key
+    };
+    for_each_filtered_environment_entry(
+        context.environment.as_ref(),
+        is_untrusted_runner_owned,
+        &mut visit,
+    );
 
     if let Some(tz) = &context.user_timezone {
         let has_tz = context
@@ -384,21 +397,21 @@ fn for_each_guest_user_env_entry<'a>(
         }
     }
 
-    // New runner before the namespace-ownership phase: both channels retain
-    // today's filtering, so a dual-carried claim cannot expose a key that the
-    // previous runner scrubbed. Replace this compatibility behavior only after
-    // the #28914 ownership phase activates the trusted channel; applying it last
-    // meanwhile gives deterministic precedence without changing effective env.
-    for_each_filtered_environment_entry(context.platform_environment.as_ref(), &mut visit);
+    if let Some(platform_environment) = &context.platform_environment {
+        for (key, value) in platform_environment {
+            visit(key, value);
+        }
+    }
 }
 
 fn for_each_filtered_environment_entry<'a>(
     environment: Option<&'a HashMap<String, String>>,
+    is_runner_owned: fn(&str) -> bool,
     visit: &mut impl FnMut(&'a str, &'a str),
 ) {
     if let Some(environment) = environment {
         for (key, value) in environment {
-            if !is_runner_owned_env_key(key) {
+            if !is_runner_owned(key) {
                 visit(key, value);
             }
         }
@@ -779,8 +792,8 @@ impl HostEnv {
 }
 
 pub(super) fn is_runner_owned_env_key(key: &str) -> bool {
-    // The entire VM0_ namespace is runner-owned, including retired keys such
-    // as VM0_WORKING_DIR. Canonical keys outside it must stay explicit.
+    // The entire OKOU_ and VM0_ namespaces are runner-owned. Bootstrap keys
+    // outside them must stay explicit.
     guest_contracts::env::is_runner_owned_env_key(key)
 }
 

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -594,30 +594,44 @@ fn build_env_json_unknown_framework_preserves_claude_compatible_env() {
 }
 
 #[test]
-fn dual_carried_platform_environment_preserves_effective_agent_environment() {
+fn platform_environment_claim_filters_untrusted_namespaces_and_applies_trusted_last() {
     let mut ctx = minimal_context();
-    let platform_environment = HashMap::from([
-        ("OKOU_TOKEN".into(), "trusted-token".into()),
-        ("VM0_CODEX_SERVICE_TIER".into(), "fast".into()),
+    ctx.environment = Some(HashMap::from([
+        ("CUSTOM_ENV".into(), "kept".into()),
+        ("DUPLICATE".into(), "untrusted".into()),
+        ("OKOU_TOKEN".into(), "untrusted-token".into()),
+        ("OKOU_FUTURE_PLATFORM_KEY".into(), "untrusted".into()),
+        ("VM0_FUTURE_RUNNER_KEY".into(), "untrusted".into()),
         (
             guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV.into(),
-            "trusted-bypass".into(),
+            "untrusted-bypass".into(),
         ),
-    ]);
-    ctx.environment = Some(HashMap::from([
-        ("USER_VALUE".into(), "user-value".into()),
+    ]));
+    ctx.platform_environment = Some(HashMap::from([
+        ("DUPLICATE".into(), "trusted".into()),
         ("OKOU_TOKEN".into(), "trusted-token".into()),
+        ("OKOU_PLATFORM_ONLY".into(), "trusted-platform".into()),
         ("VM0_CODEX_SERVICE_TIER".into(), "fast".into()),
         (
             guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV.into(),
             "trusted-bypass".into(),
         ),
     ]));
-    let previous_runner_environment = build_user_env_json(&ctx);
 
-    ctx.platform_environment = Some(platform_environment);
-
-    assert_eq!(build_user_env_json(&ctx), previous_runner_environment);
+    assert_eq!(
+        build_user_env_json(&ctx),
+        HashMap::from([
+            ("CUSTOM_ENV".into(), "kept".into()),
+            ("DUPLICATE".into(), "trusted".into()),
+            ("OKOU_TOKEN".into(), "trusted-token".into()),
+            ("OKOU_PLATFORM_ONLY".into(), "trusted-platform".into()),
+            ("VM0_CODEX_SERVICE_TIER".into(), "fast".into()),
+            (
+                guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV.into(),
+                "trusted-bypass".into(),
+            ),
+        ])
+    );
 }
 
 #[test]
@@ -640,12 +654,13 @@ fn platform_environment_overlays_legacy_environment() {
 }
 
 #[test]
-fn build_env_json_scrubs_user_provided_runner_owned_env() {
+fn fieldless_context_preserves_pre_platform_environment_filtering() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     ctx.environment = Some(HashMap::from([
         ("CUSTOM_ENV".into(), "kept".into()),
         ("OKOU_TOKEN".into(), "legitimate-okou-token".into()),
+        ("OKOU_UNRELATED".into(), "legacy-okou-value".into()),
         (
             guest_contracts::env::RUN_ID_ENV.into(),
             "user-controlled-run-id".into(),
@@ -748,6 +763,7 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
     assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert_eq!(user_env.get("OKOU_TOKEN").unwrap(), "legitimate-okou-token");
+    assert_eq!(user_env.get("OKOU_UNRELATED").unwrap(), "legacy-okou-value");
     for key in [
         guest_contracts::env::RUN_ID_ENV,
         guest_contracts::env::PI_SESSION_ID_ENV,
@@ -845,8 +861,8 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
             "explicit runner key {key} should be runner-owned"
         );
     }
-    assert!(!is_runner_owned_env_key("OKOU_TOKEN"));
-    assert!(!is_runner_owned_env_key("OKOU_UNRELATED"));
+    assert!(is_runner_owned_env_key("OKOU_TOKEN"));
+    assert!(is_runner_owned_env_key("OKOU_UNRELATED"));
 }
 
 #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-environment-ownership.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-environment-ownership.test.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { createBddApi } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+
+const context = testContext();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runContextSnapshotForRun(runId: string): Record<string, unknown> {
+  for (const [dataset, events] of context.mocks.axiom.ingest.mock.calls) {
+    if (dataset !== "run-context" || !Array.isArray(events)) {
+      continue;
+    }
+    const snapshot = events.find((event) => {
+      return isRecord(event) && event.runId === runId;
+    });
+    if (isRecord(snapshot)) {
+      return snapshot;
+    }
+  }
+  throw new Error(`Expected a run-context snapshot for ${runId}`);
+}
+
+describe("runner environment ownership", () => {
+  it("removes untrusted OKOU entries before dual-carrying platform environment", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    const untrustedSecretValue = "api-untrusted-secret-value";
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+
+    const agentName = `environment-ownership-${randomUUID().slice(0, 8)}`;
+    const agent = await runs.createDirectAgent(actor, {
+      version: "1",
+      agents: {
+        [agentName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            USER_VALUE: "user-value",
+            OKOU_UNTRUSTED_LITERAL: "untrusted-literal-value",
+            OKOU_UNTRUSTED_SECRET: `\${{ secrets.OKOU_UNTRUSTED_SECRET }}`,
+          },
+        },
+      },
+    });
+    const run = await runs.createDirectRun(actor, {
+      agentId: agent.agentId,
+      prompt: "exercise environment ownership",
+      modelProviderType: "anthropic-api-key",
+      secrets: { OKOU_UNTRUSTED_SECRET: untrustedSecretValue },
+    });
+    await runs.heartbeatRunner(runnerGroup);
+    const claim = await runs.claimRunnerJob(run.runId);
+
+    expect(claim.environment).toMatchObject({ USER_VALUE: "user-value" });
+    expect(claim.environment).not.toHaveProperty("OKOU_UNTRUSTED_LITERAL");
+    expect(claim.environment).not.toHaveProperty("OKOU_UNTRUSTED_SECRET");
+    expect(claim.secretValues ?? []).not.toContain(untrustedSecretValue);
+    expect(claim.platformEnvironment).toMatchObject({
+      CLI_PKG_URL: expect.any(String),
+    });
+    for (const [key, value] of Object.entries(
+      claim.platformEnvironment ?? {},
+    )) {
+      expect(claim.environment?.[key]).toBe(value);
+    }
+
+    const snapshot = runContextSnapshotForRun(run.runId);
+    expect(snapshot.secretNames).toContain("OKOU_UNTRUSTED_SECRET");
+    expect(snapshot.environmentEntries).not.toContainEqual(
+      expect.objectContaining({ name: "OKOU_UNTRUSTED_LITERAL" }),
+    );
+    expect(snapshot.environmentEntries).not.toContainEqual(
+      expect.objectContaining({ name: "OKOU_UNTRUSTED_SECRET" }),
+    );
+    expect(JSON.stringify(snapshot)).not.toContain(untrustedSecretValue);
+
+    await runs.requestCancelRun(actor, run.runId, [200]);
+  });
+});

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2949,6 +2949,21 @@ function withoutLegacyZeroEntries<T>(
   return compactRecord(canonical);
 }
 
+function withoutOkouNamespaceEntries<T>(
+  values: Readonly<Record<string, T>> | null,
+): Record<string, T> | null {
+  if (!values) {
+    return null;
+  }
+  const untrusted: Record<string, T> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (!key.startsWith("OKOU_")) {
+      untrusted[key] = value;
+    }
+  }
+  return compactRecord(untrusted) ?? null;
+}
+
 function filterSecretConnectorMap(args: {
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly overriddenSecrets: readonly (
@@ -6346,15 +6361,19 @@ async function buildStoredExecutionContextDraft(args: {
     permissionManifest: permissions,
     customTargets: args.customConnectorContext.targets,
   });
-  const expandedEnvironment = expandEnvironment({
-    content: args.resolved.content,
-    vars: args.body.vars,
-    secrets: executionSecrets.secrets,
-    additionalEnvironment: args.modelProvider?.environment,
-    environmentSecretPlaceholders: permissions?.environmentSecretPlaceholders,
-    storedConnectorEnvironment: args.connectorContext.storedEnvironment,
-    connectorVars: args.connectorContext.vars,
-  });
+  // Newly constructed API context: remove the reserved namespace from the
+  // fully expanded untrusted/content environment before the trusted overlay.
+  const expandedEnvironment = withoutOkouNamespaceEntries(
+    expandEnvironment({
+      content: args.resolved.content,
+      vars: args.body.vars,
+      secrets: executionSecrets.secrets,
+      additionalEnvironment: args.modelProvider?.environment,
+      environmentSecretPlaceholders: permissions?.environmentSecretPlaceholders,
+      storedConnectorEnvironment: args.connectorContext.storedEnvironment,
+      connectorVars: args.connectorContext.vars,
+    }),
+  );
   const platformEnvironment = buildStoredPlatformEnvironment({
     platformEnvironment: args.platformEnvironment,
     okouTokenPublicBrand: args.okouTokenPublicBrand,


### PR DESCRIPTION
## Summary

- remove every `OKOU_*` entry from the fully expanded untrusted API environment before applying the trusted platform overlay
- reserve both `OKOU_*` and `VM0_*` in the canonical runner predicate, while applying a present `platformEnvironment` unfiltered and last
- preserve the exact pre-`platformEnvironment` predicate for fieldless historical claims
- cover the API security boundary and both runner claim shapes without editing the overlapping lifecycle test

## Compatibility

- new API -> old runner: untrusted `OKOU_*` entries are removed and every trusted platform entry remains dual-carried in legacy `environment`
- new API -> new runner: the runner filters untrusted `OKOU_*` and `VM0_*`, then the trusted channel wins last
- old API or pre-field stored context -> new runner: the absent-field branch preserves the old predicate, including arbitrary `OKOU_*` passthrough and explicit `OKOU_RUN_ID` protection
- old API -> old runner: unchanged

## Fallbacks

- `crates/guest-contracts/src/env.rs:is_pre_platform_environment_runner_owned_env_key` and `crates/runner/src/executor/env.rs:for_each_guest_user_env_entry` — preserve old API or legitimately stored fieldless claims when read by a new runner. Surface: old API/stored context -> new runner. Remove after the previous API rollback target cannot create fieldless contexts, no supported queued or resumable context predates `platformEnvironment`, and pre-ownership runners and sandboxes complete their drain; follow-up #28914.

## Validation

- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/runner-environment-ownership.test.ts`
- `cargo fmt --manifest-path Cargo.toml --all --check`
- `cargo test --manifest-path Cargo.toml -p guest-contracts env::tests` (12 passed)
- `cargo check --manifest-path Cargo.toml -p runner --bin runner`
- `cargo check --manifest-path Cargo.toml -p runner --tests` passed after a local-only removal of the pre-existing unused `AsyncReadExt` test import in `network_logs.rs`; that workaround was restored and is not in this diff
- the filtered runner test binary type-checked, but its local link was killed with exit 137; the PR pipeline will execute the Rust test target with CI resources

No full local Vitest suite or development server was run.

Closes #28995
Part of #28914
