### PR TITLE
feat: pull presentation reverse-template from r2

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { registryResourceDownloadContract } from "@okouai/api-contracts/contracts/registry-resources";
-import {
-  findPresentationReverseTemplateResource,
-  findWebsiteTemplateResource,
-} from "@okouai/core/resource-registry";
+import { findWebsiteTemplateResource } from "@okouai/core/resource-registry";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -134,10 +131,6 @@ describe("registry resource download", () => {
       "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5";
     const versionId =
       "108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988";
-    expect(
-      findPresentationReverseTemplateResource(id)?.source.archive,
-    ).toStrictEqual({ type: "tar.gz", sha256 });
-
     const s3Key = "registry-fixture/presentation-reverse-template/version";
     const fixture = await seedPrivateRegistryResourceVersionFixture({
       storageName: `registry-resource@${id}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { registryResourceDownloadContract } from "@okouai/api-contracts/contracts/registry-resources";
-import { findWebsiteTemplateResource } from "@okouai/core/resource-registry";
+import {
+  findPresentationReverseTemplateResource,
+  findWebsiteTemplateResource,
+} from "@okouai/core/resource-registry";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -115,6 +118,56 @@ describe("registry resource download", () => {
       versionId,
       fileCount: 1,
       size: 6054,
+    });
+    const signedCommand = context.mocks.s3.getSignedUrl.mock.calls.at(-1)?.[1];
+    expect(signedCommand).toMatchObject({
+      input: {
+        Bucket: "registry-resource-test",
+        Key: `${s3Key}/archive.tar.gz`,
+      },
+    });
+  });
+
+  it("downloads the presentation reverse-template guide through the route", async () => {
+    const id = "skill:presentation-reverse-template";
+    const sha256 =
+      "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5";
+    const versionId =
+      "108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988";
+    expect(
+      findPresentationReverseTemplateResource(id)?.source.archive,
+    ).toStrictEqual({ type: "tar.gz", sha256 });
+
+    const s3Key = "registry-fixture/presentation-reverse-template/version";
+    const fixture = await seedPrivateRegistryResourceVersionFixture({
+      storageName: `registry-resource@${id}`,
+      versionId,
+      s3Key,
+      size: 270_821,
+      archiveSize: 82_804,
+      fileCount: 17,
+    });
+    onTestFinished(fixture.cleanup);
+
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", "registry-resource-test");
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.com/registry/presentation-reverse-template.tar.gz",
+    );
+
+    const response = await accept(
+      client().download({
+        headers: authHeaders(),
+        query: { id, expectedSha256: sha256 },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id,
+      sha256,
+      versionId,
+      fileCount: 17,
+      size: 270_821,
     });
     const signedCommand = context.mocks.s3.getSignedUrl.mock.calls.at(-1)?.[1];
     expect(signedCommand).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1617,7 +1617,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     // The guide is not a mounted skill, so the prompt is the only thing that
-    // tells a run where to find it. Off, it must stay out of every run.
+    // tells a run where to pull it. Off, it must stay out of every run.
     const gatedOff = await api.createRun(actor, {
       agentId,
       prompt: "turn this deck into a template",
@@ -1627,7 +1627,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const gatedOffClaim = await api.claimRunnerJob(gatedOff.runId);
     expect(gatedOffClaim.appendSystemPrompt ?? "").toContain("# Agent Tools");
     expect(gatedOffClaim.appendSystemPrompt ?? "").not.toContain(
-      "vm0-ai/Template-artifact",
+      "skill:presentation-reverse-template",
     );
 
     await connectors.updateFeatureSwitches(actor, {
@@ -1642,9 +1642,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.heartbeatRunner(runnerGroup);
     const gatedOnClaim = await api.claimRunnerJob(gatedOn.runId);
     const appendSystemPrompt = gatedOnClaim.appendSystemPrompt ?? "";
-    expect(appendSystemPrompt).toContain("vm0-ai/Template-artifact");
-    expect(appendSystemPrompt).toContain("reverse-template");
-    expect(appendSystemPrompt).toContain("feat/reverse-template-skill");
+    expect(appendSystemPrompt).toContain(
+      "okou resource pull skill:presentation-reverse-template --dir ./generated/resources",
+    );
+    expect(appendSystemPrompt).toContain(
+      "./generated/resources/reverse-template/SKILL.md",
+    );
+    expect(appendSystemPrompt).not.toContain("vm0-ai/Template-artifact");
   });
 
   it("emits api dispatch timing for exact-empty direct dispatch runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1648,7 +1648,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(appendSystemPrompt).toContain(
       "./generated/resources/reverse-template/SKILL.md",
     );
-    expect(appendSystemPrompt).not.toContain("vm0-ai/Template-artifact");
   });
 
   it("emits api dispatch timing for exact-empty direct dispatch runs", async () => {

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -4,6 +4,7 @@ import {
   findColorSystem,
   findDesignSystem,
   findImageStyle,
+  findPresentationReverseTemplateResource,
   findPresentationRunbookResource,
   findSkill,
   findTemplate,
@@ -49,6 +50,9 @@ function storageServiceNotConfigured() {
 }
 
 const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
+  // Presentation reverse-template guide from vm0-ai/Template-artifact@fc829f4.
+  "skill:presentation-reverse-template":
+    "108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988",
   "color-system:bauhaus-primary":
     "26c34a2a33a5c7b751b6741da5e4013020d5dbe138e60f5b3a444f4a5d3a351b",
   "color-system:berry-pop":
@@ -209,6 +213,7 @@ function findRegistryResource(id: string): PullableRegistryEntry | undefined {
     findColorSystem(id) ??
     findImageStyle(id) ??
     findVideoTemplate(id) ??
+    findPresentationReverseTemplateResource(id) ??
     findPresentationRunbookResource(id) ??
     findWebsiteTemplateResource(id)
   );

--- a/turbo/apps/cli/src/commands/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/artifacts.test.ts
@@ -191,6 +191,9 @@ describe("okou generate source-backed artifact commands", () => {
     expect(posterSkillIds).toContain("skill:article-magazine");
     expect(posterSkillIds).toContain("skill:algorithmic-art");
     expect(presentationSkillIds).toContain("skill:slides");
+    expect(presentationSkillIds).not.toContain(
+      "skill:presentation-reverse-template",
+    );
     expect(imageSkillIds).toContain("skill:algorithmic-art");
     expect(videoSkillIds).toContain("skill:video-hyperframes");
     expect(videoSkillIds).toContain("skill:8-bit-orbit-video-template");

--- a/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
@@ -56,6 +56,26 @@ describe("okou resource pull registry resolver", () => {
     );
   });
 
+  it("resolves the pull-only presentation reverse-template guide", () => {
+    expect(
+      findRegistryResourceForPull("skill:presentation-reverse-template"),
+    ).toEqual(
+      expect.objectContaining({
+        id: "skill:presentation-reverse-template",
+        kind: "skill",
+        targets: ["presentation"],
+        source: {
+          path: "reverse-template",
+          archive: {
+            type: "tar.gz",
+            sha256:
+              "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
+          },
+        },
+      }),
+    );
+  });
+
   it("resolves a built-in website template package archive", () => {
     expect(findRegistryResourceForPull("template:dot-matrix")).toEqual(
       expect.objectContaining({

--- a/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
@@ -56,26 +56,6 @@ describe("okou resource pull registry resolver", () => {
     );
   });
 
-  it("resolves the pull-only presentation reverse-template guide", () => {
-    expect(
-      findRegistryResourceForPull("skill:presentation-reverse-template"),
-    ).toEqual(
-      expect.objectContaining({
-        id: "skill:presentation-reverse-template",
-        kind: "skill",
-        targets: ["presentation"],
-        source: {
-          path: "reverse-template",
-          archive: {
-            type: "tar.gz",
-            sha256:
-              "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
-          },
-        },
-      }),
-    );
-  });
-
   it("resolves a built-in website template package archive", () => {
     expect(findRegistryResourceForPull("template:dot-matrix")).toEqual(
       expect.objectContaining({
@@ -221,6 +201,53 @@ describe("okou resource pull command", () => {
     expect(skill).toContain("# vm0 Illustration");
     expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
       "✓ Pulled image-style:vm0-illustration",
+    );
+  });
+
+  it("resolves the pull-only presentation reverse-template guide through the command", async () => {
+    const reverseTemplateSha256 =
+      "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5";
+    server.use(
+      http.get(
+        "http://localhost:3000/api/registry/resources/download",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("id")).toBe(
+            "skill:presentation-reverse-template",
+          );
+          expect(url.searchParams.get("expectedSha256")).toBe(
+            reverseTemplateSha256,
+          );
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer test-token",
+          );
+          return HttpResponse.json({
+            url: downloadUrl,
+            id: "skill:presentation-reverse-template",
+            type: "tar.gz",
+            sha256: "0".repeat(64),
+            expiresInSeconds: 900,
+            versionId,
+            fileCount: 17,
+            size: 270_821,
+          });
+        },
+      ),
+    );
+
+    await expect(
+      resourceCommand.parseAsync([
+        "node",
+        "cli",
+        "pull",
+        "skill:presentation-reverse-template",
+        "--dir",
+        outputDir,
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Resource archive digest metadata mismatch",
     );
   });
 

--- a/turbo/apps/cli/src/commands/resource/index.ts
+++ b/turbo/apps/cli/src/commands/resource/index.ts
@@ -10,6 +10,7 @@ import {
   findColorSystem,
   findDesignSystem,
   findImageStyle,
+  findPresentationReverseTemplateResource,
   findPresentationRunbookResource,
   findTool,
   findTemplate,
@@ -59,6 +60,7 @@ export function findRegistryResourceForPull(
       findTool(candidate) ??
       findImageStyle(candidate) ??
       findVideoTemplate(candidate) ??
+      findPresentationReverseTemplateResource(candidate) ??
       findPresentationRunbookResource(
         candidate,
         presentationRunbookArchiveVersion,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -4019,7 +4019,6 @@ describe("chat composer templates", () => {
       expect(sentPrompt).toContain(
         "./generated/resources/reverse-template/SKILL.md",
       );
-      expect(sentPrompt).not.toContain("vm0-ai/Template-artifact");
       expect(sentMessage?.parts).toContainEqual(
         expect.objectContaining({
           type: "file",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -4012,9 +4012,14 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(sentPrompt).toContain("reusable presentation template");
       // The guide is not a mounted skill, so the message has to carry the
-      // pointer; without it the thread opens with nothing to follow.
-      expect(sentPrompt).toContain("vm0-ai/Template-artifact");
-      expect(sentPrompt).toContain("reverse-template");
+      // private resource pull and its extracted entrypoint.
+      expect(sentPrompt).toContain(
+        "okou resource pull skill:presentation-reverse-template --dir ./generated/resources",
+      );
+      expect(sentPrompt).toContain(
+        "./generated/resources/reverse-template/SKILL.md",
+      );
+      expect(sentPrompt).not.toContain("vm0-ai/Template-artifact");
       expect(sentMessage?.parts).toContainEqual(
         expect.objectContaining({
           type: "file",

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -5,9 +5,7 @@ import {
 } from "../presentation-template-items";
 import {
   findColorSystem,
-  findPresentationReverseTemplateResource,
   findPresentationRunbookPackage,
-  listSkills,
   listTemplates,
 } from "../resource-registry";
 
@@ -288,33 +286,6 @@ function expectPinnedPickerPreviewImages(
 }
 
 describe("presentation template items", () => {
-  it("keeps the reverse-template guide pull-only and pinned to private R2", () => {
-    expect(
-      findPresentationReverseTemplateResource(
-        "skill:presentation-reverse-template",
-      ),
-    ).toEqual(
-      expect.objectContaining({
-        id: "skill:presentation-reverse-template",
-        kind: "skill",
-        targets: ["presentation"],
-        source: {
-          path: "reverse-template",
-          archive: {
-            type: "tar.gz",
-            sha256:
-              "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
-          },
-        },
-      }),
-    );
-    expect(listSkills("presentation")).not.toContainEqual(
-      expect.objectContaining({
-        id: "skill:presentation-reverse-template",
-      }),
-    );
-  });
-
   it("defines direct card preview assets for picker thumbnails", () => {
     for (const item of PRESENTATION_TEMPLATE_PICKER_ITEMS) {
       expect(item.cardPreviewImage, item.slug).toMatch(

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -5,7 +5,9 @@ import {
 } from "../presentation-template-items";
 import {
   findColorSystem,
+  findPresentationReverseTemplateResource,
   findPresentationRunbookPackage,
+  listSkills,
   listTemplates,
 } from "../resource-registry";
 
@@ -286,6 +288,33 @@ function expectPinnedPickerPreviewImages(
 }
 
 describe("presentation template items", () => {
+  it("keeps the reverse-template guide pull-only and pinned to private R2", () => {
+    expect(
+      findPresentationReverseTemplateResource(
+        "skill:presentation-reverse-template",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        id: "skill:presentation-reverse-template",
+        kind: "skill",
+        targets: ["presentation"],
+        source: {
+          path: "reverse-template",
+          archive: {
+            type: "tar.gz",
+            sha256:
+              "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
+          },
+        },
+      }),
+    );
+    expect(listSkills("presentation")).not.toContainEqual(
+      expect.objectContaining({
+        id: "skill:presentation-reverse-template",
+      }),
+    );
+  });
+
   it("defines direct card preview assets for picker thumbnails", () => {
     for (const item of PRESENTATION_TEMPLATE_PICKER_ITEMS) {
       expect(item.cardPreviewImage, item.slug).toMatch(

--- a/turbo/packages/core/src/presentation-reverse-template-resource.ts
+++ b/turbo/packages/core/src/presentation-reverse-template-resource.ts
@@ -1,0 +1,7 @@
+export const PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID =
+  "skill:presentation-reverse-template";
+
+export const PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH = "reverse-template";
+
+export const PRESENTATION_REVERSE_TEMPLATE_ARCHIVE_SHA256 =
+  "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5";

--- a/turbo/packages/core/src/presentation-template-skill.ts
+++ b/turbo/packages/core/src/presentation-template-skill.ts
@@ -1,21 +1,9 @@
-/**
- * Where the deck-reverse-engineering guide lives.
- *
- * Not in `vm0-ai/vm0-skills`, and so not mounted by the skills sync, because
- * the guide is still being revised against real decks and its scripts change
- * with each run. Pointing at the working branch keeps that iteration out of
- * the every-minute sync and out of every unrelated run's skill mounts.
- *
- * The consequence is that this only resolves for a run whose GitHub access
- * covers a vm0 private repository, which is why every use of it is behind the
- * `PresentationTemplates` switch. Moving the guide into `vm0-skills` later
- * turns this constant into a plain skill name and removes the clone step;
- * that move is tracked in vm0-ai/vm0#28374, which is what stops this branch
- * pin from outliving the switch.
- */
-const PRESENTATION_TEMPLATE_SKILL_REPO = "vm0-ai/Template-artifact";
-const PRESENTATION_TEMPLATE_SKILL_BRANCH = "feat/reverse-template-skill";
-const PRESENTATION_TEMPLATE_SKILL_PATH = "reverse-template";
+import {
+  PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID,
+  PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH,
+} from "./presentation-reverse-template-resource";
+
+const PRESENTATION_TEMPLATE_RESOURCE_DIR = "./generated/resources";
 
 /**
  * Tell a run how to reach the guide.
@@ -25,8 +13,9 @@ const PRESENTATION_TEMPLATE_SKILL_PATH = "reverse-template";
  * reaches the same instructions as one picked through the dialog.
  */
 export function presentationTemplateSkillInstruction(): string {
+  const skillPath = `${PRESENTATION_TEMPLATE_RESOURCE_DIR}/${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH}/SKILL.md`;
   return [
-    `Turning an uploaded deck (.pptx, .ppt, or .pdf) into a reusable presentation template follows the ${PRESENTATION_TEMPLATE_SKILL_PATH} guide, which is not mounted as a skill.`,
-    `Clone it first with \`gh repo clone ${PRESENTATION_TEMPLATE_SKILL_REPO} <dir> -- --depth 1 -b ${PRESENTATION_TEMPLATE_SKILL_BRANCH}\`, read \`<dir>/${PRESENTATION_TEMPLATE_SKILL_PATH}/SKILL.md\`, and follow it exactly, including its page-rendering and publish steps.`,
+    `Turning an uploaded deck (.pptx, .ppt, or .pdf) into a reusable presentation template follows the ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH} guide, which is not mounted as a skill.`,
+    `Pull it first with \`okou resource pull ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID} --dir ${PRESENTATION_TEMPLATE_RESOURCE_DIR}\`, read \`${skillPath}\`, and follow it exactly, including its page-rendering and publish steps.`,
   ].join(" ");
 }

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -7,6 +7,11 @@ import {
   PRESENTATION_IMAGE_BATCH_INSTRUCTION,
   PRESENTATION_STATIC_HTML_INSTRUCTION,
 } from "./presentation-generation-instructions";
+import {
+  PRESENTATION_REVERSE_TEMPLATE_ARCHIVE_SHA256,
+  PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID,
+  PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH,
+} from "./presentation-reverse-template-resource";
 
 export type GenerationTarget =
   | "image"
@@ -3325,6 +3330,32 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     source: vm0ImageStyleSource("ink-storefront"),
   },
 ];
+
+// ── Presentation reverse-template guide ─────────────────────────────────────
+// This is a pull-only authoring resource. Keep it out of RESOURCE_REGISTRY so
+// it does not appear as a presentation-generation skill candidate: it is used
+// only when an uploaded deck is being reverse-engineered into a new template.
+
+const PRESENTATION_REVERSE_TEMPLATE_RESOURCE: RegistryEntry = {
+  id: PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID,
+  kind: "skill",
+  name: "Presentation Reverse Template",
+  description:
+    "Extract reusable presentation identity guidance and high-fidelity visual assets from an uploaded deck.",
+  source: privateR2ArchiveSource(
+    PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH,
+    PRESENTATION_REVERSE_TEMPLATE_ARCHIVE_SHA256,
+  ),
+  targets: ["presentation"],
+};
+
+export function findPresentationReverseTemplateResource(
+  resourceId: string,
+): RegistryEntry | undefined {
+  return resourceId === PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID
+    ? PRESENTATION_REVERSE_TEMPLATE_RESOURCE
+    : undefined;
+}
 
 // ── Presentation runbook packages ────────────────────────────────────────────
 // Self-contained per-template presentation packages (agent runbook + renderer)


### PR DESCRIPTION
## Summary

- register `skill:presentation-reverse-template` as a pull-only private R2 resource pinned to archive SHA-256 `4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5`
- resolve the resource through both `okou resource pull` and the registry-resource download API, pinned to storage version `108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988`
- replace the private GitHub branch clone in presentation reverse-engineering instructions with `okou resource pull skill:presentation-reverse-template --dir ./generated/resources`
- keep the guide out of normal presentation generation skill candidates

The immutable archive was published successfully by [Actions run 32720681691](https://github.com/vm0-ai/vm0/actions/runs/32720681691). The audit-only publication PR was closed after deployment.

## Verification

- Prettier write and check for all changed files
- lint for affected packages, plus `pnpm knip`
- non-API, platform, and API TypeScript checks
- core resource registry: 15 tests passed
- CLI resource resolver: 9 tests passed
- platform template picker: 42 tests passed
- API registry download route: 7 tests passed

The focused run-lifecycle BDD assertion is also updated. In this local runtime it stops before the prompt assertion because the runner queue returns `404 Job not found in queue`; the same infrastructure failure reproduces against a fresh migrated local database and across unrelated lifecycle cases, so the standard PR pipeline remains the integration check.