### PR TITLE
fix(platform): keep the model picker measurement row hidden on category switch

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1315,6 +1315,54 @@ test("model picker category switch marks its selection without a raised shadow",
   expect(selected.backgroundColor).not.toBe(unselected.backgroundColor);
 });
 
+test("model picker category switch keeps its measurement row hidden", async ({
+  page,
+}) => {
+  await mockModelPickerBoundary(page);
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+  await page
+    .getByRole("combobox", { name: "Claude Fable 5", exact: true })
+    .click();
+  const imageCategory = page
+    .getByRole("radiogroup", { name: "Models" })
+    .getByRole("radio", { name: "Image" });
+  await expect(imageCategory).toBeVisible();
+
+  // A media category replaces the model rows, so the selected chat model stays
+  // in the list as a 1px, transparent row the select can still measure. The
+  // swap fades the rows it brings in, and a keyframe outranks the class that
+  // hides that row: fading it printed the model name over the header for the
+  // whole fade. The click and the read share one evaluate because a round trip
+  // between them can outlast the fade and miss the row while it is lit.
+  const measurementRowOpacity = await imageCategory.evaluate(
+    async (segment) => {
+      if (!(segment instanceof HTMLElement)) {
+        throw new Error("Model picker category segment is not an HTML element");
+      }
+      segment.click();
+      // The fade starts once the swapped list has laid out, so let one frame
+      // carry the resize and read on the next.
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+      const measurementRow = document.querySelector(
+        '[data-slot="select-list"] [data-slot="select-item"][aria-hidden="true"]',
+      );
+      if (measurementRow === null) {
+        throw new Error("Model picker has no measurement row");
+      }
+      return getComputedStyle(measurementRow).opacity;
+    },
+  );
+  expect(measurementRowOpacity).toBe("0");
+});
+
 test("chat composer keeps the model icon unclipped on narrow screens", async ({
   page,
 }) => {

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1336,31 +1336,42 @@ test("model picker category switch keeps its measurement row hidden", async ({
   // hides that row: fading it printed the model name over the header for the
   // whole fade. The click and the read share one evaluate because a round trip
   // between them can outlast the fade and miss the row while it is lit.
-  const measurementRowOpacity = await imageCategory.evaluate(
-    async (segment) => {
-      if (!(segment instanceof HTMLElement)) {
-        throw new Error("Model picker category segment is not an HTML element");
-      }
-      segment.click();
-      // The fade starts once the swapped list has laid out, so let one frame
-      // carry the resize and read on the next.
-      await new Promise<void>((resolve) => {
+  const swap = await imageCategory.evaluate(async (segment) => {
+    if (!(segment instanceof HTMLElement)) {
+      throw new Error("Model picker category segment is not an HTML element");
+    }
+    segment.click();
+    // The fade starts once the swapped list has laid out, so let one frame
+    // carry the resize and read on the next.
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            resolve();
-          });
+          resolve();
         });
       });
-      const measurementRow = document.querySelector(
-        '[data-slot="select-list"] [data-slot="select-item"][aria-hidden="true"]',
-      );
-      if (measurementRow === null) {
-        throw new Error("Model picker has no measurement row");
-      }
-      return getComputedStyle(measurementRow).opacity;
-    },
-  );
-  expect(measurementRowOpacity).toBe("0");
+    });
+    const list = document.querySelector('[data-slot="select-list"]');
+    if (list === null) {
+      throw new Error("Model picker has no list");
+    }
+    const measurementRow = list.querySelector(
+      '[data-slot="select-item"][aria-hidden="true"]',
+    );
+    const modelRows = list.querySelector('[data-slot="select-group"]');
+    if (measurementRow === null || modelRows === null) {
+      throw new Error("Model picker list has no measurement row or model rows");
+    }
+    return {
+      measurementRowOpacity: getComputedStyle(measurementRow).opacity,
+      modelRowsOpacity: getComputedStyle(modelRows).opacity,
+    };
+  });
+  expect(swap.measurementRowOpacity).toBe("0");
+  // The rows the swap brings in are mid-fade at that same instant. Asserting
+  // that keeps the swap covered from both sides: the fade the picker still
+  // owes its rows, and proof that the sample landed inside the fade rather
+  // than after it, where a hidden row reads as transparent either way.
+  expect(Number(swap.modelRowsOpacity)).toBeLessThan(1);
 });
 
 test("chat composer keeps the model icon unclipped on narrow screens", async ({

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-panel-height.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-panel-height.ts
@@ -37,6 +37,14 @@ const SELECT_LIST_SELECTOR = '[data-slot="select-list"]';
 const PANEL_HEADER_SELECTOR = "[data-model-picker-header]";
 
 /**
+ * A media category replaces the model rows, so the selected chat model stays in
+ * the list as a 1px, transparent row the select can still measure. A keyframe
+ * outranks the class that hides it, so fading that row in would print the model
+ * name over the header for the length of the fade.
+ */
+const PANEL_MEASUREMENT_ROW_SELECTOR = '[aria-hidden="true"]';
+
+/**
  * Animates the model picker popup between the heights its category panels ask
  * for. Attach to the popup; it finds the list underneath on its own.
  *
@@ -100,7 +108,10 @@ export const modelPickerPanelHeightRef$ = onRef(
         if (!(row instanceof HTMLElement)) {
           continue;
         }
-        if (row.matches(PANEL_HEADER_SELECTOR)) {
+        if (
+          row.matches(PANEL_HEADER_SELECTOR) ||
+          row.matches(PANEL_MEASUREMENT_ROW_SELECTOR)
+        ) {
           continue;
         }
         row.animate([{ opacity: PANEL_CONTENT_FADE_FROM }, { opacity: 1 }], {


### PR DESCRIPTION
## Problem

Switching the model picker's category on mobile flashes a stray model name over the panel header for a moment. Reported from an iPhone recording; frame-stepping the 120fps capture puts the artifact on screen for 14 frames (117ms), and it reads as the selected chat model's name wrapped one word per line on top of `Video models`.

## Cause

`model-picker-panel-height.ts` reacts to the list resizing by animating the popup's height (180ms) and fading the new rows in (120ms). The fade loop walks every direct child of the select list and skips only the sticky header:

```ts
for (const row of list.children) {
  if (row.matches(PANEL_HEADER_SELECTOR)) continue;
  row.animate([{ opacity: 0.4 }, { opacity: 1 }], { duration: 120 });
}
```

A media category replaces the model rows, so the picker keeps the selected chat model in the list as a measurement-only item — `absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0`, `disabled`, `aria-hidden` — so the select can still resolve its label. That item is a direct child of the list, so the loop animates it too, and a keyframe outranks the class that hides it: its opacity is driven from 0.4 to 1 for exactly the fade's duration, which is the 117ms measured in the capture.

On iOS Safari the running animation promotes the row to its own compositing layer, which escapes both its own 1px `overflow: hidden` clip and the header's stacking order, so the name paints in full over the header. Engines that keep the clip render the row as an invisible 1px sliver, which is why this only shows on mobile.

The measurement row landed in #21319; the fade loop that lights it up landed in #28335.

## Fix

Skip `aria-hidden` rows alongside the header. Measurement rows are not content and have nothing to fade in.

## Test

New Playwright case in `chat.spec.ts`: after clicking the Image category, the measurement row's computed opacity must still be `0`. The click and the read share one `evaluate` because a Playwright round trip between them can outlast the 120ms fade and miss the row while it is lit. The assertion is engine-independent — the row is forced visible everywhere, only the clip escape is WebKit-specific — so Chromium CI catches a regression.

## Verification

- `pnpm check-types` in `e2e/` passes
- `prettier@3.8.1` reports the touched `turbo/` file unchanged
- Remaining checks left to the PR pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)