### PR TITLE
refactor(api): dual-read preview job reference aliases

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -398,6 +398,10 @@ export default [
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
       "src/signals/services/__tests__/connector-catalog-rejection-authority.test.ts",
       "src/signals/services/__tests__/connector-authorization-provider-state.test.ts",
+      // Preview job-ref aliases are process environment state, and both Stripe
+      // metadata entry points must share one value-free resolution matrix that
+      // cannot be observed completely through a single production API route.
+      "src/signals/services/__tests__/stripe-preview-metadata.service.test.ts",
       // A pre-migration schema cannot be constructed through a production API.
       // This focused transaction validates the rollout contract against real
       // PostgreSQL tables before and after the autonomy-budget columns exist.
@@ -526,6 +530,10 @@ export default [
       // with the sandbox runtime; route output cannot expose its full virtual
       // filesystem, ignore-rule, and precedence matrix.
       "src/signals/services/__tests__/pi-resource-snapshot.service.test.ts",
+      // Preview job-ref aliases are process environment state, and both Stripe
+      // metadata entry points must share one value-free resolution matrix that
+      // cannot be observed completely through a single production API route.
+      "src/signals/services/__tests__/stripe-preview-metadata.service.test.ts",
       // A pre-migration schema cannot be constructed through a production API.
       // This focused transaction validates the rollout contract against real
       // PostgreSQL tables before and after the autonomy-budget columns exist.

--- a/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
@@ -1,0 +1,203 @@
+import { EVENT } from "@axiomhq/logging";
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import {
+  isCurrentStripePreviewMetadata,
+  stripePreviewMetadata,
+} from "../stripe-preview-metadata.service";
+
+const context = testContext();
+
+const CANONICAL_PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
+const LEGACY_PREVIEW_JOB_REF_ENV_KEY = "VM0_PREVIEW_JOB_REF";
+const PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT =
+  "stripe_preview_job_ref_alias_resolution";
+const PREVIEW_JOB_REF_LOG_CONTEXT = "StripePreviewMetadata";
+
+type PreviewJobRefAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "dual";
+
+interface PreviewJobRefAliasFixture {
+  readonly name: string;
+  readonly canonical: string | undefined;
+  readonly legacy: string | undefined;
+  readonly state: PreviewJobRefAliasState;
+  readonly jobRef: string | null;
+}
+
+const PREVIEW_JOB_REF_ALIAS_FIXTURES: readonly PreviewJobRefAliasFixture[] = [
+  {
+    name: "absent aliases",
+    canonical: undefined,
+    legacy: undefined,
+    state: "absent",
+    jobRef: null,
+  },
+  {
+    name: "empty canonical alias",
+    canonical: "",
+    legacy: undefined,
+    state: "absent",
+    jobRef: null,
+  },
+  {
+    name: "empty legacy alias",
+    canonical: undefined,
+    legacy: "",
+    state: "absent",
+    jobRef: null,
+  },
+  {
+    name: "empty dual aliases",
+    canonical: "",
+    legacy: "",
+    state: "absent",
+    jobRef: null,
+  },
+  {
+    name: "canonical-only alias",
+    canonical: "canonical-preview-job",
+    legacy: undefined,
+    state: "canonical-only",
+    jobRef: "canonical-preview-job",
+  },
+  {
+    name: "canonical-only alias with an empty legacy value",
+    canonical: "canonical-preview-job",
+    legacy: "",
+    state: "canonical-only",
+    jobRef: "canonical-preview-job",
+  },
+  {
+    name: "legacy-only alias",
+    canonical: undefined,
+    legacy: "legacy-preview-job",
+    state: "legacy-only",
+    jobRef: "legacy-preview-job",
+  },
+  {
+    name: "legacy-only alias with an empty canonical value",
+    canonical: "",
+    legacy: "legacy-preview-job",
+    state: "legacy-only",
+    jobRef: "legacy-preview-job",
+  },
+  {
+    name: "equal dual aliases",
+    canonical: "shared-preview-job",
+    legacy: "shared-preview-job",
+    state: "dual",
+    jobRef: "shared-preview-job",
+  },
+];
+
+function configureAliases(
+  environment: "preview" | "production",
+  canonical: string | undefined,
+  legacy: string | undefined,
+): void {
+  mockEnv("ENV", environment);
+  mockOptionalEnv(CANONICAL_PREVIEW_JOB_REF_ENV_KEY, canonical);
+  mockOptionalEnv(LEGACY_PREVIEW_JOB_REF_ENV_KEY, legacy);
+}
+
+function aliasEvidence(
+  state: PreviewJobRefAliasState,
+): Record<string, unknown> {
+  return {
+    [EVENT]: { source: "api" },
+    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
+    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
+    state,
+    context: PREVIEW_JOB_REF_LOG_CONTEXT,
+  };
+}
+
+describe("Stripe preview metadata job reference aliases", () => {
+  it.each(PREVIEW_JOB_REF_ALIAS_FIXTURES)(
+    "resolves $name for metadata creation and matching",
+    ({ canonical, legacy, state, jobRef }) => {
+      configureAliases("preview", canonical, legacy);
+      const expectedMetadata: Readonly<Record<string, string>> = jobRef
+        ? { vm0_environment: "preview", job_ref: jobRef }
+        : {};
+
+      expect(stripePreviewMetadata()).toStrictEqual(expectedMetadata);
+      expect(isCurrentStripePreviewMetadata(expectedMetadata)).toBeTruthy();
+      expect(isCurrentStripePreviewMetadata(null)).toBe(jobRef === null);
+
+      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledTimes(3);
+      for (const call of context.mocks.axiomLogging.debug.mock.calls) {
+        expect(call).toStrictEqual([
+          PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+          aliasEvidence(state),
+        ]);
+      }
+      const evidence = JSON.stringify(
+        context.mocks.axiomLogging.debug.mock.calls,
+      );
+      const configuredValues = [canonical, legacy].filter(
+        (value): value is string => {
+          return Boolean(value);
+        },
+      );
+      expect(
+        configuredValues.some((value) => {
+          return evidence.includes(value);
+        }),
+      ).toBeFalsy();
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed on unequal dual aliases without exposing either value", () => {
+    const canonical = "canonical-job-ref-must-not-leak";
+    const legacy = "legacy-job-ref-must-not-leak";
+    configureAliases("preview", canonical, legacy);
+    const expectedMessage =
+      "Preview job reference aliases conflict: canonicalKey=OKOU_PREVIEW_JOB_REF legacyKey=VM0_PREVIEW_JOB_REF state=dual";
+
+    expect(() => {
+      stripePreviewMetadata();
+    }).toThrow(expectedMessage);
+    expect(() => {
+      isCurrentStripePreviewMetadata({
+        vm0_environment: "preview",
+        job_ref: "metadata-job-ref",
+      });
+    }).toThrow(expectedMessage);
+
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(2);
+    for (const call of context.mocks.axiomLogging.warn.mock.calls) {
+      expect(call).toStrictEqual([
+        PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+        aliasEvidence("dual"),
+      ]);
+    }
+    const diagnostics = JSON.stringify({
+      error: expectedMessage,
+      logs: context.mocks.axiomLogging.warn.mock.calls,
+    });
+    expect(diagnostics).not.toContain(canonical);
+    expect(diagnostics).not.toContain(legacy);
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+  });
+
+  it("ignores preview alias conflicts outside preview deployments", () => {
+    configureAliases(
+      "production",
+      "canonical-production-job-ref",
+      "legacy-production-job-ref",
+    );
+
+    expect(stripePreviewMetadata()).toStrictEqual({});
+    expect(isCurrentStripePreviewMetadata(null)).toBeTruthy();
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -1,17 +1,69 @@
 import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 
 const PREVIEW_ENVIRONMENT_METADATA_KEY = "vm0_environment";
 const PREVIEW_JOB_REF_METADATA_KEY = "job_ref";
+const CANONICAL_PREVIEW_JOB_REF_ENV_KEY = "OKOU_PREVIEW_JOB_REF";
+const LEGACY_PREVIEW_JOB_REF_ENV_KEY = "VM0_PREVIEW_JOB_REF";
+const PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT =
+  "stripe_preview_job_ref_alias_resolution";
 
-function stripePreviewJobRef(): string | null {
+const log = logger("StripePreviewMetadata");
+
+type PreviewJobRefAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "dual";
+
+// The preview deployment action intentionally remains legacy-only during this
+// reader-expansion stage. Remove the legacy alias only after #28914 completes
+// writer cutover, retires pre-reader rollback targets, and observes zero
+// legacy-only resolutions through the supported rollback window.
+function resolveStripePreviewJobRef(): string | null {
   if (env("ENV") !== "preview") {
     return null;
   }
-  return optionalEnv("VM0_PREVIEW_JOB_REF") ?? null;
+
+  const canonical = optionalEnv(CANONICAL_PREVIEW_JOB_REF_ENV_KEY);
+  const legacy = optionalEnv(LEGACY_PREVIEW_JOB_REF_ENV_KEY);
+  if (canonical && legacy && canonical !== legacy) {
+    log.warn(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, {
+      canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
+      legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
+      state: "dual",
+    });
+    throw new Error(
+      `Preview job reference aliases conflict: canonicalKey=${CANONICAL_PREVIEW_JOB_REF_ENV_KEY} legacyKey=${LEGACY_PREVIEW_JOB_REF_ENV_KEY} state=dual`,
+    );
+  }
+
+  let jobRef: string | null;
+  let state: PreviewJobRefAliasState;
+  if (canonical && legacy) {
+    jobRef = canonical;
+    state = "dual";
+  } else if (canonical) {
+    jobRef = canonical;
+    state = "canonical-only";
+  } else if (legacy) {
+    jobRef = legacy;
+    state = "legacy-only";
+  } else {
+    jobRef = null;
+    state = "absent";
+  }
+
+  log.debug(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, {
+    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
+    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
+    state,
+  });
+  return jobRef;
 }
 
 export function stripePreviewMetadata(): Record<string, string> {
-  const jobRef = stripePreviewJobRef();
+  const jobRef = resolveStripePreviewJobRef();
   if (!jobRef) {
     return {};
   }
@@ -24,7 +76,7 @@ export function stripePreviewMetadata(): Record<string, string> {
 export function isCurrentStripePreviewMetadata(
   metadata: Readonly<Record<string, string>> | null | undefined,
 ): boolean {
-  const jobRef = stripePreviewJobRef();
+  const jobRef = resolveStripePreviewJobRef();
   if (!jobRef) {
     return true;
   }


### PR DESCRIPTION
## Summary

- centralize Stripe preview metadata job-ref alias resolution for both creation and matching
- accept absent, canonical-only, legacy-only, and equal dual values while preserving empty and non-preview behavior
- fail closed on unequal dual values with fixed, value-free key and state diagnostics
- add bounded alias-source evidence and a focused state-matrix test without changing the legacy-only production writer

## Rollout

- This is reader-expansion Stage 1 for `VM0_PREVIEW_JOB_REF` to `OKOU_PREVIEW_JOB_REF`.
- `.github/actions/web-api-env/action.yml` and all production writers remain legacy-only.
- Legacy removal remains gated on the parent rollout and rollback window in #28914.

## Fallbacks

- Legacy-only preview deployments continue to resolve through `VM0_PREVIEW_JOB_REF`.
- Non-preview deployments continue to ignore both aliases.
- Unequal dual values stop metadata construction and matching before either value can be used or exposed.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/services/__tests__/stripe-preview-metadata.service.test.ts` (11 passed)

Closes #29039

Parent EPIC: #28914
