### PR TITLE
test(api): await cancellation before deletion interlock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
@@ -587,6 +587,7 @@ describe("DELETE /api/agents/:id bounded deletion interlock", () => {
       modelProvider: "anthropic-api-key",
     });
     await api.requestCancelRun(actor, run.runId, [200]);
+    await flushWaitUntilForTest();
     const usageEventId = await store.set(
       insertUsageEvent$,
       {


### PR DESCRIPTION
## Summary

- wait for cancellation `waitUntil` side effects before constructing the synthetic usage-event lock boundary
- ensure the fixture waiter can only represent the deletion transaction under test
- preserve the real cancel/delete routes, PostgreSQL lock timeout, rollback, billing linkage, and retry assertions

## Exclusions

- no production cancellation or deletion behavior changes
- no retry, sleep, timeout increase, worker serialization, skipped test, or new tracking abstraction
- no API, schema, migration, deployment, or compatibility change

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts -t "rolls back a cascade-child timeout and retains billing on retry" --reporter=default`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts --reporter=default`
- `pnpm vitest run --project=api --shard=7/8 --coverage.enabled --coverage.reporter=json`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace apps/api`
- pre-commit hook: Prettier, full Knip, full Turbo typecheck, file-size check, and commitlint

Closes #29036
