### PR TITLE
perf(api): resolve v2 attachments by exact key

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -10219,9 +10219,10 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
     const firstWaveStarted = createDeferredPromise<void>(context.signal);
     const releaseFirstWave = createDeferredPromise<void>(context.signal);
-    let startedLists = 0;
-    let activeLists = 0;
-    let peakActiveLists = 0;
+    let matchingListRequests = 0;
+    let startedHeads = 0;
+    let activeHeads = 0;
+    let peakActiveHeads = 0;
     context.mocks.s3.send.mockImplementation(
       async (command: unknown): Promise<unknown> => {
         if (command instanceof ListObjectsV2Command) {
@@ -10233,14 +10234,7 @@ describe("CHAT-02: generation templates and attachments", () => {
           if (!object) {
             return { Contents: [] };
           }
-          startedLists += 1;
-          activeLists += 1;
-          peakActiveLists = Math.max(peakActiveLists, activeLists);
-          if (startedLists === 4) {
-            firstWaveStarted.resolve(undefined);
-          }
-          await releaseFirstWave.promise;
-          activeLists -= 1;
+          matchingListRequests += 1;
           return {
             Contents: [
               {
@@ -10258,6 +10252,14 @@ describe("CHAT-02: generation templates and attachments", () => {
           if (!object) {
             return {};
           }
+          startedHeads += 1;
+          activeHeads += 1;
+          peakActiveHeads = Math.max(peakActiveHeads, activeHeads);
+          if (startedHeads === 4) {
+            firstWaveStarted.resolve(undefined);
+          }
+          await releaseFirstWave.promise;
+          activeHeads -= 1;
           return {
             ContentLength: object.size,
             ContentType: object.contentType,
@@ -10307,9 +10309,9 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
 
     await firstWaveStarted.promise;
-    expect(startedLists).toBe(4);
-    expect(activeLists).toBe(4);
-    expect(peakActiveLists).toBe(4);
+    expect(startedHeads).toBe(4);
+    expect(activeHeads).toBe(4);
+    expect(peakActiveHeads).toBe(4);
     releaseFirstWave.resolve(undefined);
 
     const sent = await send;
@@ -10317,8 +10319,9 @@ describe("CHAT-02: generation templates and attachments", () => {
     if (sent.status !== 201 || !sent.body.runId) {
       throw new Error("Expected the bounded attachment send to create a run");
     }
-    expect(startedLists).toBe(5);
-    expect(peakActiveLists).toBe(4);
+    expect(startedHeads).toBe(5);
+    expect(peakActiveHeads).toBe(4);
+    expect(matchingListRequests).toBe(0);
 
     const run = await api.readRun(actor, sent.body.runId);
     const promptPositions = files.map((file) => {
@@ -10366,9 +10369,186 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
   }, 60_000);
 
+  it("falls back to v2 listing when the attachment filename hint is stale", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const fileId = randomUUID();
+    const filenameSnapshot = "stale-extension.txt";
+    const storedFilename = "current-extension.png";
+    const exactKey = buildArtifactKeyV2(fileId, filenameSnapshot);
+    const storedKey = buildArtifactKeyV2(fileId, storedFilename);
+    const prefix = buildArtifactPrefixV2(fileId);
+    const operations: string[] = [];
+    context.mocks.s3.send.mockImplementation(
+      (command: unknown): Promise<unknown> => {
+        if (command instanceof HeadObjectCommand) {
+          if (command.input.Key === exactKey) {
+            operations.push("head:exact");
+            const notFound = new Error("exact attachment key not found");
+            notFound.name = "NotFound";
+            return Promise.reject(notFound);
+          }
+          if (command.input.Key === storedKey) {
+            operations.push("head:listed");
+            return Promise.resolve({
+              ContentLength: 42,
+              ContentType: "image/png",
+              LastModified: new Date("2026-08-24T00:00:00.000Z"),
+              Metadata: {
+                "artifact-id": fileId,
+                filename: encodeURIComponent(storedFilename),
+                "user-id": encodeURIComponent(actor.userId),
+              },
+            });
+          }
+          return Promise.resolve({});
+        }
+        if (
+          command instanceof ListObjectsV2Command &&
+          command.input.Prefix === prefix
+        ) {
+          operations.push("list:v2");
+          return Promise.resolve({
+            Contents: [
+              {
+                Key: storedKey,
+                Size: 42,
+                LastModified: new Date("2026-08-24T00:00:00.000Z"),
+              },
+            ],
+          });
+        }
+        return Promise.resolve({ Contents: [] });
+      },
+    );
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "read the stale filename attachment",
+      userMessage: {
+        version: 1,
+        parts: [
+          {
+            type: "file",
+            fileId,
+            filenameSnapshot,
+            contentType: "image/png",
+          },
+          { type: "text", text: "read the stale filename attachment" },
+        ],
+      },
+    });
+
+    expect(operations).toStrictEqual(["head:exact", "list:v2", "head:listed"]);
+    const created = await api.readRun(actor, run.runId);
+    expect(created.prompt).toContain(`[Web file] ${filenameSnapshot}`);
+  }, 60_000);
+
+  it("falls back to v2 listing when the exact head lacks size", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const fileId = randomUUID();
+    const filename = "incomplete-head.txt";
+    const key = buildArtifactKeyV2(fileId, filename);
+    const prefix = buildArtifactPrefixV2(fileId);
+    const operations: string[] = [];
+    let headRequests = 0;
+    context.mocks.s3.send.mockImplementation(
+      (command: unknown): Promise<unknown> => {
+        if (command instanceof HeadObjectCommand && command.input.Key === key) {
+          headRequests += 1;
+          operations.push(headRequests === 1 ? "head:exact" : "head:listed");
+          return Promise.resolve({
+            ContentType: "text/plain",
+            LastModified: new Date("2026-08-24T00:00:00.000Z"),
+            Metadata: {
+              "artifact-id": fileId,
+              filename: encodeURIComponent(filename),
+              "user-id": encodeURIComponent(actor.userId),
+            },
+          });
+        }
+        if (
+          command instanceof ListObjectsV2Command &&
+          command.input.Prefix === prefix
+        ) {
+          operations.push("list:v2");
+          return Promise.resolve({
+            Contents: [
+              {
+                Key: key,
+                Size: 73,
+                LastModified: new Date("2026-08-24T00:00:00.000Z"),
+              },
+            ],
+          });
+        }
+        return Promise.resolve({ Contents: [] });
+      },
+    );
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "read the incomplete head attachment",
+      userMessage: {
+        version: 1,
+        parts: [
+          {
+            type: "file",
+            fileId,
+            filenameSnapshot: filename,
+            contentType: "text/plain",
+          },
+          { type: "text", text: "read the incomplete head attachment" },
+        ],
+      },
+    });
+
+    expect(operations).toStrictEqual(["head:exact", "list:v2", "head:listed"]);
+    const catalog = await chat.listArtifactCatalog(actor, {
+      chatThreadId: run.threadId,
+      kind: "file",
+      limit: 20,
+    });
+    const summary = catalog.artifacts.find((artifact) => {
+      return artifact.title === filename;
+    });
+    if (!summary) {
+      throw new Error("Expected incomplete-head attachment in the catalog");
+    }
+    const detail = await chat.getArtifactCatalogEntry(actor, summary.id);
+    expect(detail.kind).toBe("file");
+    if (detail.kind !== "file") {
+      throw new Error("Expected incomplete-head file catalog entry");
+    }
+    expect(detail.file.size).toBe(73);
+  }, 60_000);
+
   it("does not create a run when an attachment is missing", async () => {
     const { actor, agentId } = await entitledChatActor();
-    chat.mockEmptyObjectStorage();
+    const fileId = randomUUID();
+    const filename = "missing.txt";
+    const exactKey = buildArtifactKeyV2(fileId, filename);
+    let exactHeadRequests = 0;
+    context.mocks.s3.send.mockImplementation(
+      (command: unknown): Promise<unknown> => {
+        if (
+          command instanceof HeadObjectCommand &&
+          command.input.Key === exactKey
+        ) {
+          exactHeadRequests += 1;
+          return Promise.resolve({
+            ContentLength: 42,
+            ContentType: "text/plain",
+            LastModified: new Date("2026-08-24T00:00:00.000Z"),
+            Metadata: {
+              "artifact-id": fileId,
+              filename: encodeURIComponent(filename),
+              "user-id": encodeURIComponent(`${actor.userId}-other`),
+            },
+          });
+        }
+        return Promise.resolve({ Contents: [] });
+      },
+    );
     const model = await chat.getDefaultCreateThreadModel(actor);
     const prompt = "reject the missing attachment";
     const response = await requestSendEventRaw(actor, {
@@ -10380,8 +10560,8 @@ describe("CHAT-02: generation templates and attachments", () => {
         parts: [
           {
             type: "file",
-            fileId: randomUUID(),
-            filenameSnapshot: "missing.txt",
+            fileId,
+            filenameSnapshot: filename,
             contentType: "text/plain",
           },
           { type: "text", text: prompt },
@@ -10394,6 +10574,7 @@ describe("CHAT-02: generation templates and attachments", () => {
       status: 500,
       body: { error: "Internal server error" },
     });
+    expect(exactHeadRequests).toBe(1);
     const runs = await api.listAgentRuns(actor, {
       status: "queued,pending,running,completed,failed,timeout,cancelled",
       limit: 100,

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -17,6 +17,7 @@ import {
   listS3Objects,
   putS3Object,
   s3ObjectHead,
+  type S3ObjectHead,
   tryListMultipartS3Parts,
 } from "../external/s3";
 import { safeUriComponentDecode } from "../utils";
@@ -237,6 +238,56 @@ export const storeGeneratedArtifactObject$ = command(
   },
 );
 
+function resolvedV2ArtifactObjectFromHead(args: {
+  readonly userId: string;
+  readonly id: string;
+  readonly key: string;
+  readonly head: S3ObjectHead;
+  readonly listed?: {
+    readonly size: number;
+    readonly lastModified: Date;
+  };
+}): ResolvedArtifactObject | null {
+  if (
+    args.head.kind === "missing" ||
+    args.head.metadata[ARTIFACT_ID_METADATA_KEY] !== args.id ||
+    args.head.metadata[ARTIFACT_USER_ID_METADATA_KEY] !==
+      encodeURIComponent(args.userId)
+  ) {
+    return null;
+  }
+  const size = args.head.contentLength ?? args.listed?.size;
+  const lastModified = args.head.lastModified ?? args.listed?.lastModified;
+  if (size === undefined || lastModified === undefined) {
+    return null;
+  }
+  const filename =
+    filenameFromMetadata(args.head.metadata) ?? filenameFromLegacyKey(args.key);
+  const publicBrand = publicBrandFromMetadata(args.head.metadata);
+  return {
+    key: args.key,
+    url: buildFileUrlFromKey(args.key, publicBrand),
+    publicBrand,
+    filename,
+    contentType: args.head.contentType ?? inferMimetype(filename),
+    size,
+    lastModified,
+  };
+}
+
+function resolveExactV2ArtifactObject(
+  bucket: string,
+  userId: string,
+  id: string,
+  filenameHint: string,
+): Computed<Promise<ResolvedArtifactObject | null>> {
+  return computed(async (get): Promise<ResolvedArtifactObject | null> => {
+    const key = buildArtifactKeyV2(id, filenameHint);
+    const head = await get(s3ObjectHead(bucket, key));
+    return resolvedV2ArtifactObjectFromHead({ userId, id, key, head });
+  });
+}
+
 function resolveV2ArtifactObject(
   bucket: string,
   userId: string,
@@ -246,27 +297,16 @@ function resolveV2ArtifactObject(
     const objects = await get(listS3Objects(bucket, buildArtifactPrefixV2(id)));
     for (const object of objects) {
       const head = await get(s3ObjectHead(bucket, object.key));
-      if (
-        head.kind === "missing" ||
-        head.metadata[ARTIFACT_ID_METADATA_KEY] !== id ||
-        head.metadata[ARTIFACT_USER_ID_METADATA_KEY] !==
-          encodeURIComponent(userId)
-      ) {
-        continue;
-      }
-      const filename =
-        filenameFromMetadata(head.metadata) ??
-        filenameFromLegacyKey(object.key);
-      const publicBrand = publicBrandFromMetadata(head.metadata);
-      return {
+      const resolved = resolvedV2ArtifactObjectFromHead({
+        userId,
+        id,
         key: object.key,
-        url: buildFileUrlFromKey(object.key, publicBrand),
-        publicBrand,
-        filename,
-        contentType: head.contentType ?? inferMimetype(filename),
-        size: head.contentLength ?? object.size,
-        lastModified: head.lastModified ?? object.lastModified,
-      };
+        head,
+        listed: object,
+      });
+      if (resolved) {
+        return resolved;
+      }
     }
     return null;
   });
@@ -304,9 +344,18 @@ function resolveV1ArtifactObject(
 export function resolvedArtifactObject(
   userId: string,
   id: string,
+  filenameHint?: string,
 ): Computed<Promise<ResolvedArtifactObject | null>> {
   return computed(async (get): Promise<ResolvedArtifactObject | null> => {
     const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    if (filenameHint !== undefined) {
+      const exact = await get(
+        resolveExactV2ArtifactObject(bucket, userId, id, filenameHint),
+      );
+      if (exact) {
+        return exact;
+      }
+    }
     return (
       (await get(resolveV2ArtifactObject(bucket, userId, id))) ??
       (await get(resolveV1ArtifactObject(bucket, userId, id)))
@@ -320,10 +369,13 @@ export const resolveArtifactObject$ = command(
     args: {
       readonly userId: string;
       readonly id: string;
+      readonly filenameHint?: string;
     },
     signal: AbortSignal,
   ): Promise<ResolvedArtifactObject | null> => {
-    const resolved = await get(resolvedArtifactObject(args.userId, args.id));
+    const resolved = await get(
+      resolvedArtifactObject(args.userId, args.id, args.filenameHint),
+    );
     signal.throwIfAborted();
     return resolved;
   },

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -814,7 +814,11 @@ const resolveIncomingAttachFileMetadata$ = command(
             wave.map(async (file) => {
               const object = await set(
                 resolveArtifactObject$,
-                { userId: args.userId, id: file.fileId },
+                {
+                  userId: args.userId,
+                  id: file.fileId,
+                  filenameHint: file.filenameSnapshot,
+                },
                 signal,
               );
               return { file, object };


### PR DESCRIPTION
## Summary

- resolve chat attachment V2 objects with one exact-key `HEAD` when the persisted filename snapshot still matches
- preserve artifact ownership and identity validation, falling back to the existing V2 listing and V1 lookup for stale, missing, or incomplete exact results
- cover exact-hit batching, stale filenames, incomplete `HEAD` metadata, and ownership mismatches at the chat event route

Explicit V2 variant keys, upload storage, external contracts, and telemetry are unchanged.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --testNamePattern attachment` (22 passed)
- `pnpm knip --workspace api`
- pre-commit hooks: repository Knip, repository TypeScript checks, formatting, file-size check, and commitlint

Closes #29033

Parent: #24203
