### PR TITLE
perf(e2e): provision runner credentials concurrently

### DIFF
--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { clerkSetup } from "@clerk/testing/playwright";
-import { chromium, type Page } from "@playwright/test";
+import { chromium, type Browser, type Page } from "@playwright/test";
 
 import {
   refreshClerkSessionToken,
@@ -21,11 +21,22 @@ import {
   fillStripeCheckout,
 } from "./lib/stripe-checkout";
 
+const RUNNER_CREDENTIAL_CONCURRENCY = 2;
+
 interface RunnerCredentialTarget {
   readonly email: string;
   readonly fileName: string;
   readonly organizationId: string;
   readonly upgradeToPro: boolean;
+}
+
+interface ProvisionRunnerCredentialOptions {
+  readonly apiUrl: string;
+  readonly appUrl: string;
+  readonly browser: Browser;
+  readonly outputDirectory: string;
+  readonly target: RunnerCredentialTarget;
+  readonly vercelAutomationBypassSecret?: string;
 }
 
 async function main(): Promise<void> {
@@ -77,59 +88,110 @@ async function main(): Promise<void> {
   await clerkSetup();
   const browser = await chromium.launch();
   try {
-    for (const target of targets) {
-      await withLoadedClerkTestingPage(
-        browser,
-        {
-          appUrl,
-          contextOptions: {
-            ignoreHTTPSErrors: true,
-            extraHTTPHeaders: vercelAutomationBypassSecret
-              ? {
-                  "x-vercel-protection-bypass": vercelAutomationBypassSecret,
-                }
-              : undefined,
-          },
-        },
-        async (page) => {
-          let clerkSessionToken = await signInWithLoadedClerkTestingHelper(
-            page,
-            target.email,
-            appUrl,
-            { activeOrganizationId: target.organizationId },
-          );
-          await ensureRunnerOrganizationReady({
-            apiUrl,
-            clerkSessionToken,
-            vercelAutomationBypassSecret,
-          });
-          if (target.upgradeToPro) {
-            await completePaidOnboarding(page, target, appUrl, outputDirectory);
-            clerkSessionToken = await refreshClerkSessionToken(page, {
-              activeOrganizationId: target.organizationId,
-            });
-          }
-          const token = await issueCliToken({
-            apiUrl,
-            clerkSessionToken,
-            vercelAutomationBypassSecret,
-          });
-          const outputFile = join(outputDirectory, target.fileName);
-          await writeFile(
-            outputFile,
-            `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
-            { encoding: "utf8", mode: 0o600 },
-          );
-          console.log("Generated runner E2E API credential", {
-            email: target.email,
-            outputFile,
-          });
-        },
+    for (
+      let batchStart = 0;
+      batchStart < targets.length;
+      batchStart += RUNNER_CREDENTIAL_CONCURRENCY
+    ) {
+      const batch = targets.slice(
+        batchStart,
+        batchStart + RUNNER_CREDENTIAL_CONCURRENCY,
       );
+      const results = await Promise.allSettled(
+        batch.map((target) =>
+          provisionRunnerCredential({
+            apiUrl,
+            appUrl,
+            browser,
+            outputDirectory,
+            target,
+            vercelAutomationBypassSecret,
+          }),
+        ),
+      );
+      const failures = results.flatMap((result, index) => {
+        if (result.status === "fulfilled") {
+          return [];
+        }
+        const target = batch[index];
+        return [
+          new Error(
+            `Failed to provision runner E2E credential for ${target.email} (${target.fileName})`,
+            { cause: result.reason },
+          ),
+        ];
+      });
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures,
+          failures.map((failure) => failure.message).join("; "),
+        );
+      }
     }
   } finally {
     await browser.close();
   }
+}
+
+async function provisionRunnerCredential(
+  options: ProvisionRunnerCredentialOptions,
+): Promise<void> {
+  const {
+    apiUrl,
+    appUrl,
+    browser,
+    outputDirectory,
+    target,
+    vercelAutomationBypassSecret,
+  } = options;
+  await withLoadedClerkTestingPage(
+    browser,
+    {
+      appUrl,
+      contextOptions: {
+        ignoreHTTPSErrors: true,
+        extraHTTPHeaders: vercelAutomationBypassSecret
+          ? {
+              "x-vercel-protection-bypass": vercelAutomationBypassSecret,
+            }
+          : undefined,
+      },
+    },
+    async (page) => {
+      let clerkSessionToken = await signInWithLoadedClerkTestingHelper(
+        page,
+        target.email,
+        appUrl,
+        { activeOrganizationId: target.organizationId },
+      );
+      await ensureRunnerOrganizationReady({
+        apiUrl,
+        clerkSessionToken,
+        vercelAutomationBypassSecret,
+      });
+      if (target.upgradeToPro) {
+        await completePaidOnboarding(page, target, appUrl, outputDirectory);
+        clerkSessionToken = await refreshClerkSessionToken(page, {
+          activeOrganizationId: target.organizationId,
+        });
+      }
+      const token = await issueCliToken({
+        apiUrl,
+        clerkSessionToken,
+        vercelAutomationBypassSecret,
+      });
+      const outputFile = join(outputDirectory, target.fileName);
+      await writeFile(
+        outputFile,
+        `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+      console.log("Generated runner E2E API credential", {
+        email: target.email,
+        outputFile,
+      });
+    },
+  );
 }
 
 async function completePaidOnboarding(


### PR DESCRIPTION
## Summary

- provision the four existing runner E2E credentials in ordered batches of two
- wait for every started target before advancing or closing the shared browser
- retain target-specific context when one or both provisioning flows fail

## Behavior

Each account keeps its isolated browser context and the existing Clerk sign-in, organization readiness request, public Stripe checkout for paid accounts, session refresh, CLI device authorization, and credential output. The four filenames, `{ token, apiUrl }` JSON shape, file permissions, account order, and downstream artifact contract are unchanged.

A failed batch settles both already-started tasks, reports the affected email and filename, and prevents the next batch from starting. The workflow's existing success condition continues to prevent partial credentials from being published as a successful artifact.

## Scope

This PR does not change the account matrix, shard matrix, merge queue concurrency, workflow configuration, billing path, API contract, database, or runner protocol.

## Validation

- `cd e2e && pnpm install --frozen-lockfile`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (39 passed, 0 skipped)
- `cd turbo && pnpm exec prettier --check ../e2e/playwright/runner-token.ts`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `./scripts/check-file-size.sh e2e/playwright/runner-token.ts`
- PR run `32724816952`: all runner E2E shards passed, including real Codex and real Claude coverage

## Timing evidence

- Baseline merge-queue run `32716466666`: approximately 81.2 seconds in `Generate runner E2E API tokens`
- PR run `32724816952`: 58 seconds in the same step (`12:03:40Z` to `12:04:38Z`)
- Observed reduction: approximately 23.2 seconds, or 29%

This is one representative before/after comparison rather than a statistical benchmark. The real PR flow completed without a checkout diagnostic upload or failed runner shard.

Closes #29020

Parent context: #29016

