### PR TITLE
refactor(guest-agent): dual-read api token environment aliases

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -29,6 +29,35 @@ fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
 }
 
+/// Resolve the sensitive runner-to-guest API token at the single process-env
+/// capture boundary. Both aliases are reader-only during #28914 migration
+/// Stage 1; the runner writer remains [`guest_contracts::env::API_TOKEN_ENV`].
+fn api_token_env_or_empty() -> Result<String, String> {
+    let canonical_key = guest_contracts::env::CANONICAL_API_TOKEN_ENV;
+    let legacy_key = guest_contracts::env::API_TOKEN_ENV;
+    let canonical = std::env::var(canonical_key).ok();
+    let legacy = std::env::var(legacy_key).ok();
+
+    let (value, source) = match (canonical, legacy) {
+        (None, None) => return Ok(String::new()),
+        (Some(value), None) => (value, "canonical-only"),
+        (None, Some(value)) => (value, "legacy-only"),
+        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(_), Some(_)) => {
+            return Err(format!(
+                "conflicting API token environment aliases: canonical_key={canonical_key} \
+                 legacy_key={legacy_key} state=conflict"
+            ));
+        }
+    };
+
+    log_info!(
+        LOG_TAG,
+        "api_token_env_source key={canonical_key} source={source}"
+    );
+    Ok(value)
+}
+
 #[derive(Clone, Copy)]
 enum RunMetadataEnvSource {
     CanonicalOnly,
@@ -260,7 +289,7 @@ pub struct GuestConfigRaw {
 impl GuestConfigRaw {
     /// Capture raw startup values from the current process environment.
     ///
-    /// Returns an error when a canonical and legacy run-metadata alias pair
+    /// Returns an error when a canonical and legacy bootstrap alias pair
     /// contains conflicting values.
     pub fn from_process_env() -> Result<Self, String> {
         let guest_runtime_dir =
@@ -271,7 +300,7 @@ impl GuestConfigRaw {
         Ok(Self {
             run_id: env_or_empty(guest_contracts::env::RUN_ID_ENV),
             api_url: env_or_empty(guest_contracts::env::API_URL_ENV),
-            api_token: env_or_empty(guest_contracts::env::API_TOKEN_ENV),
+            api_token: api_token_env_or_empty()?,
             sandbox_id: run_metadata_env_or_empty(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 guest_contracts::env::SANDBOX_ID_ENV,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1163,6 +1163,7 @@ mod tests {
             guest_contracts::env::API_URL_ENV,
             guest_contracts::env::RUN_ID_ENV,
             guest_contracts::env::API_TOKEN_ENV,
+            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
             guest_contracts::env::SANDBOX_ID_ENV,
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -1,0 +1,387 @@
+//! Sensitive API-token aliases are resolved once at the process-env boundary.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
+use std::path::Path;
+
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::http::HttpClient;
+use guest_agent::run_context::GuestRuntime;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CANONICAL_TOKEN: &str = "canonical-token-must-not-leak";
+const LEGACY_TOKEN: &str = "legacy-token-must-not-leak";
+const SHARED_TOKEN: &str = "shared-token-must-not-leak";
+const TOKEN_VALUES: [&str; 3] = [CANONICAL_TOKEN, LEGACY_TOKEN, SHARED_TOKEN];
+const SOURCE_EVENT: &str = "api_token_env_source";
+
+#[derive(Clone, Copy)]
+enum AliasInput {
+    Absent,
+    Readable(&'static str),
+    NonUnicode,
+}
+
+#[derive(Clone, Copy)]
+struct SuccessCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_value: &'static str,
+    expected_source: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct ConflictCase {
+    name: &'static str,
+    canonical: &'static str,
+    legacy: &'static str,
+}
+
+const SUCCESS_CASES: [SuccessCase; 14] = [
+    SuccessCase {
+        name: "both-absent",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-only",
+        canonical: AliasInput::Readable(CANONICAL_TOKEN),
+        legacy: AliasInput::Absent,
+        expected_value: CANONICAL_TOKEN,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(LEGACY_TOKEN),
+        expected_value: LEGACY_TOKEN,
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual",
+        canonical: AliasInput::Readable(SHARED_TOKEN),
+        legacy: AliasInput::Readable(SHARED_TOKEN),
+        expected_value: SHARED_TOKEN,
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-empty-only",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-non-unicode-only",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "legacy-non-unicode-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "both-non-unicode",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-with-unreadable-legacy",
+        canonical: AliasInput::Readable(CANONICAL_TOKEN),
+        legacy: AliasInput::NonUnicode,
+        expected_value: CANONICAL_TOKEN,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(LEGACY_TOKEN),
+        expected_value: LEGACY_TOKEN,
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "canonical-empty-with-unreadable-legacy",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("legacy-only"),
+    },
+];
+
+const CONFLICT_CASES: [ConflictCase; 3] = [
+    ConflictCase {
+        name: "different-non-empty-values",
+        canonical: CANONICAL_TOKEN,
+        legacy: LEGACY_TOKEN,
+    },
+    ConflictCase {
+        name: "canonical-empty-legacy-non-empty",
+        canonical: "",
+        legacy: LEGACY_TOKEN,
+    },
+    ConflictCase {
+        name: "canonical-non-empty-legacy-empty",
+        canonical: CANONICAL_TOKEN,
+        legacy: "",
+    },
+];
+
+fn set_test_env(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env(key: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+fn apply_alias(key: &str, input: AliasInput) {
+    remove_test_env(key);
+    match input {
+        AliasInput::Absent => {}
+        AliasInput::Readable(value) => set_test_env(key, value),
+        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+    }
+}
+
+fn clear_api_token_env() {
+    remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
+    remove_test_env(guest_contracts::env::API_TOKEN_ENV);
+}
+
+fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
+    guest_common::log::set_system_log_file(log_path);
+    let raw = GuestConfigRaw::from_process_env();
+    guest_common::log::clear_system_log_file();
+    let log = match std::fs::read_to_string(log_path) {
+        Ok(log) => log,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    Ok((raw, log))
+}
+
+fn assert_value_free(text: &str, context: &str) {
+    for token in TOKEN_VALUES {
+        assert!(
+            !text.contains(token),
+            "{context} exposed API token material"
+        );
+    }
+}
+
+fn assert_source_evidence(log: &str, case: SuccessCase) {
+    assert_value_free(log, case.name);
+    let source_lines = log
+        .lines()
+        .filter(|line| line.contains(SOURCE_EVENT))
+        .collect::<Vec<_>>();
+    match case.expected_source {
+        Some(source) => {
+            let expected = format!(
+                "{SOURCE_EVENT} key={} source={source}",
+                guest_contracts::env::CANONICAL_API_TOKEN_ENV
+            );
+            assert!(
+                source_lines.len() == 1
+                    && source_lines
+                        .first()
+                        .and_then(|line| line.rsplit_once("] "))
+                        .is_some_and(|(_, message)| message == expected),
+                "{} emitted incorrect fixed source evidence",
+                case.name
+            );
+        }
+        None => assert!(
+            source_lines.is_empty(),
+            "{} emitted source evidence for unreadable aliases",
+            case.name
+        ),
+    }
+}
+
+fn assert_http_mode(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestResult {
+    let runtime_dir = tmp.join(format!("{}-runtime", case.name));
+    let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&payload_dir)?;
+    std::fs::write(
+        &payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+    )?;
+
+    let raw = GuestConfigRaw {
+        run_id: format!("api-token-alias-{}", case.name),
+        api_url: "http://127.0.0.1:1".to_string(),
+        home: Some(tmp.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir),
+        run_payload_file: payload_path.to_string_lossy().into_owned(),
+        ..raw
+    };
+    let config = match GuestConfig::from_raw(raw) {
+        Ok(config) => config,
+        Err(error) => {
+            assert_value_free(&error, case.name);
+            return Err(std::io::Error::other(format!(
+                "{} failed to materialize guest config",
+                case.name
+            ))
+            .into());
+        }
+    };
+    let http = match HttpClient::for_config(&config) {
+        Ok(http) => http,
+        Err(error) => {
+            assert_value_free(&error.to_string(), case.name);
+            return Err(std::io::Error::other(format!(
+                "{} failed to construct HTTP client mode",
+                case.name
+            ))
+            .into());
+        }
+    };
+    assert!(
+        http.has_api() == !case.expected_value.is_empty(),
+        "{} constructed the wrong HTTP client mode",
+        case.name
+    );
+    Ok(())
+}
+
+fn expected_conflict_error() -> String {
+    format!(
+        "conflicting API token environment aliases: canonical_key={} legacy_key={} state=conflict",
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+        guest_contracts::env::API_TOKEN_ENV
+    )
+}
+
+#[test]
+fn process_env_dual_reads_api_token_aliases_without_value_leaks() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+
+    for case in SUCCESS_CASES {
+        apply_alias(
+            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+            case.canonical,
+        );
+        apply_alias(guest_contracts::env::API_TOKEN_ENV, case.legacy);
+        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+        let raw = match raw {
+            Ok(raw) => raw,
+            Err(error) => {
+                assert_value_free(&error, case.name);
+                return Err(std::io::Error::other(format!(
+                    "{} unexpectedly rejected a readable state",
+                    case.name
+                ))
+                .into());
+            }
+        };
+        assert!(
+            raw.api_token == case.expected_value,
+            "{} resolved the wrong token state",
+            case.name
+        );
+        assert_source_evidence(&log, case);
+        assert_http_mode(tmp.path(), case, raw)?;
+    }
+
+    let expected_error = expected_conflict_error();
+    for case in CONFLICT_CASES {
+        set_test_env(
+            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+            case.canonical,
+        );
+        set_test_env(guest_contracts::env::API_TOKEN_ENV, case.legacy);
+        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+        let error = match raw {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} accepted conflicting readable aliases",
+                    case.name
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+        assert_value_free(&error, case.name);
+        assert_value_free(&log, case.name);
+        assert!(
+            error == expected_error,
+            "{} returned the wrong value-free conflict error",
+            case.name
+        );
+        assert!(
+            !log.contains(SOURCE_EVENT),
+            "{} emitted success evidence for a conflict",
+            case.name
+        );
+    }
+
+    set_test_env(
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+        CANONICAL_TOKEN,
+    );
+    set_test_env(guest_contracts::env::API_TOKEN_ENV, LEGACY_TOKEN);
+    for key in [
+        process_control_ipc::BOOTSTRAP_ENV,
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+    ] {
+        remove_test_env(key);
+    }
+    let runtime_error = match GuestRuntime::from_process_env() {
+        Ok(_) => return Err("production runtime accepted conflicting API token aliases".into()),
+        Err(error) => error,
+    };
+    assert_value_free(&runtime_error, "production-runtime-conflict");
+    assert!(
+        runtime_error == expected_error,
+        "production runtime did not fail at API token capture"
+    );
+
+    clear_api_token_env();
+    Ok(())
+}

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -282,7 +282,7 @@ fn assert_http_mode(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestR
         }
     };
     assert!(
-        http.has_api() == !case.expected_value.is_empty(),
+        http.has_api() != case.expected_value.is_empty(),
         "{} constructed the wrong HTTP client mode",
         case.name
     );

--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -19,13 +19,23 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 #[tokio::test]
-async fn guest_agent_hides_api_token_from_its_cli_child() -> TestResult {
+async fn guest_agent_hides_api_token_aliases_from_its_cli_child() -> TestResult {
     assert!(
         Path::new("/proc/self/environ").is_file(),
         "the process-isolation test requires procfs"
     );
     common::ensure_canonical_workspace_for_test()?;
 
+    for (case, token_env) in [
+        ("legacy", guest_contracts::env::API_TOKEN_ENV),
+        ("canonical", guest_contracts::env::CANONICAL_API_TOKEN_ENV),
+    ] {
+        assert_api_token_process_isolation(case, token_env).await?;
+    }
+    Ok(())
+}
+
+async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> TestResult {
     let tmp = tempfile::tempdir()?;
     let home = tmp.path().join("home");
     let runtime_dir = tmp.path().join("runtime");
@@ -56,8 +66,8 @@ async fn guest_agent_hides_api_token_from_its_cli_child() -> TestResult {
         .env("SHELL", "/bin/sh")
         .env("HOME", &home)
         .env(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1")
-        .env(guest_contracts::env::API_TOKEN_ENV, API_TOKEN)
-        .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
+        .env(token_env, API_TOKEN)
+        .env(guest_contracts::env::RUN_ID_ENV, format!("{RUN_ID}-{case}"))
         .env(
             guest_contracts::env::SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
@@ -88,11 +98,27 @@ async fn guest_agent_hides_api_token_from_its_cli_child() -> TestResult {
     )
     .await?;
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stderr.contains(API_TOKEN),
+        "{case} guest-agent stderr exposed API token material"
+    );
+    assert!(
+        !stdout.contains(API_TOKEN),
+        "{case} guest-agent stdout exposed API token material"
+    );
+    let system_log_path = guest_contracts::runtime_paths::system_log_file(&runtime_dir);
+    if let Ok(system_log) = std::fs::read_to_string(system_log_path) {
+        assert!(
+            !system_log.contains(API_TOKEN),
+            "{case} guest-agent system log exposed API token material"
+        );
+    }
     let observed = std::fs::read_to_string(&marker_path).map_err(|error| {
         std::io::Error::new(
             error.kind(),
             format!(
-                "read process-inspection marker after guest-agent exited with {}: {error}; stderr:\n{stderr}",
+                "read {case} process-inspection marker after guest-agent exited with {}: {error}",
                 output.status
             ),
         )
@@ -100,21 +126,28 @@ async fn guest_agent_hides_api_token_from_its_cli_child() -> TestResult {
 
     assert_eq!(
         observed, "parent-access-denied",
-        "CLI process inspection result was {observed}; guest-agent stderr:\n{stderr}"
+        "{case} CLI process inspection result was {observed}"
     );
     Ok(())
 }
 
 fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult {
-    let expected = format!("{}={API_TOKEN}", guest_contracts::env::API_TOKEN_ENV);
+    let expected_legacy = format!("{}={API_TOKEN}", guest_contracts::env::API_TOKEN_ENV);
+    let expected_canonical = format!(
+        "{}={API_TOKEN}",
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV
+    );
     let script = format!(
         "#!/bin/sh\n\
          set -eu\n\
          marker={}\n\
-         expected={}\n\
-         if env | grep -Fqx -- \"$expected\"; then\n\
+         expected_legacy={}\n\
+         expected_canonical={}\n\
+         if env | grep -Fqx -- \"$expected_legacy\" \
+             || env | grep -Fqx -- \"$expected_canonical\"; then\n\
            result=child-env-visible\n\
-         elif grep -aFq -- \"$expected\" \"/proc/$PPID/environ\" 2>/dev/null; then\n\
+         elif grep -aFq -- \"$expected_legacy\" \"/proc/$PPID/environ\" 2>/dev/null \
+             || grep -aFq -- \"$expected_canonical\" \"/proc/$PPID/environ\" 2>/dev/null; then\n\
            result=parent-token-visible\n\
          elif cat \"/proc/$PPID/environ\" >/dev/null 2>&1; then\n\
            result=parent-readable-token-absent\n\
@@ -124,7 +157,8 @@ fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult
          printf '%s' \"$result\" > \"$marker\"\n\
          exit 1\n",
         quote_shell_arg(&marker_path.to_string_lossy()),
-        quote_shell_arg(&expected),
+        quote_shell_arg(&expected_legacy),
+        quote_shell_arg(&expected_canonical),
     );
     std::fs::write(path, script)?;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1003,6 +1003,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::API_URL_ENV,
         guest_contracts::env::RUN_ID_ENV,
         guest_contracts::env::API_TOKEN_ENV,
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
         guest_contracts::env::SANDBOX_ID_ENV,
         guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
         guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -31,6 +31,12 @@ pub const RUN_ID_ENV: &str = "OKOU_RUN_ID";
 /// environment or CLI child env.
 pub const API_TOKEN_ENV: &str = "VM0_API_TOKEN";
 
+/// Canonical API token alias accepted by guest readers during migration.
+///
+/// Runner writers keep using [`API_TOKEN_ENV`] until the deployed reader floor,
+/// sandbox drain, rollback window, and legacy-read-zero gates are complete.
+pub const CANONICAL_API_TOKEN_ENV: &str = "OKOU_API_TOKEN";
+
 /// Sandbox identifier assigned by the runner.
 pub const SANDBOX_ID_ENV: &str = "VM0_SANDBOX_ID";
 
@@ -499,6 +505,8 @@ mod tests {
     fn contract_names_match_wire_values() {
         assert_eq!(API_URL_ENV, "VM0_API_BACKEND_URL");
         assert_eq!(RUN_ID_ENV, "OKOU_RUN_ID");
+        assert_eq!(API_TOKEN_ENV, "VM0_API_TOKEN");
+        assert_eq!(CANONICAL_API_TOKEN_ENV, "OKOU_API_TOKEN");
         assert_eq!(SANDBOX_ID_ENV, "VM0_SANDBOX_ID");
         assert_eq!(CANONICAL_SANDBOX_ID_ENV, "OKOU_SANDBOX_ID");
         assert_eq!(SANDBOX_REUSE_RESULT_ENV, "VM0_SANDBOX_REUSE_RESULT");
@@ -707,6 +715,8 @@ mod tests {
         for key in [
             API_URL_ENV,
             RUN_ID_ENV,
+            API_TOKEN_ENV,
+            CANONICAL_API_TOKEN_ENV,
             CANONICAL_SANDBOX_ID_ENV,
             CANONICAL_SANDBOX_REUSE_RESULT_ENV,
             CANONICAL_WORKSPACE_REUSE_RESULT_ENV,


### PR DESCRIPTION
## Summary

- add `OKOU_API_TOKEN` as a reader-only guest API token alias while retaining `VM0_API_TOKEN`
- capture both aliases exactly once at the guest process boundary, accept canonical-only, legacy-only, and equal-dual states, and fail closed on unequal readable values before HTTP client construction
- extend the Linux process-isolation regression to cover both input aliases and add the complete missing, empty, non-Unicode, and conflict state matrix

## Scope

This is the Stage 1 reader-only change from #29055. It does not change the runner writer, API URL, HTTP authentication semantics, deployment, drain, legacy-reader behavior, or existing `VM0_*` guards.

Implementation base: `feda3aafb652aca6dd3369ef18dd802635349e7f`

## Safety evidence

- token values are never logged, formatted into errors, hashed, or included in assertion failure messages
- source logs contain only fixed alias names and fixed source labels
- unequal readable values return a fixed value-free error before `HttpClient` construction
- empty resolved tokens still disable the API client
- child process isolation checks both key aliases and both values in the child environment, parent `/proc` environment, stdout, stderr, and system log
- `crates/runner` still writes only `API_TOKEN_ENV` (`VM0_API_TOKEN`); there is no runner reference to `CANONICAL_API_TOKEN_ENV` or `OKOU_API_TOKEN`

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test api_token_env_aliases --test api_token_process_isolation --test run_metadata_env_aliases --test no_api_mode`
- `git diff --check`

A full dependency Clippy run with the local Rust 1.98 toolchain reaches a pre-existing `chunks_exact_to_as_chunks` lint in untouched `vsock-proto`; the focused workspace targets pass, and repository CI uses the pinned Rust toolchain.

## Open PR overlap

#25722 is the only open PR with a shared file. Its overlap is limited to `crates/guest-contracts/src/env.rs` plus unrelated Cloudflare Access, HostEnv, HTTP, and runner changes. This PR only adds the canonical API token constant in that shared file and does not absorb #25722.

Closes #29055
Parent: #28914

## Fallbacks

- `crates/guest-agent/src/env.rs:api_token_env_or_empty` temporarily accepts the legacy `VM0_API_TOKEN` written by current runners and the canonical `OKOU_API_TOKEN` during the namespace migration. Surface: existing runner/sandbox bootstrap, with the two-hour guest drain and retained rollback window. Remove the legacy reader only after the deployed reader floor, sandbox drain, rollback window, and legacy-read-zero gates complete; sequencing and removal are tracked by #28914. The runner writer remains legacy-only in this PR.
