### PR TITLE
refactor(ops): dual-read monitoring collector environment aliases

### DIFF
--- a/.github/scripts/tests/vm0-monitoring-collect-test.sh
+++ b/.github/scripts/tests/vm0-monitoring-collect-test.sh
@@ -10,6 +10,7 @@ trap 'rm -rf "$tmp_root"' EXIT
 cache_dir="$tmp_root/cache"
 textfile_dir="$tmp_root/textfile"
 output_file="$textfile_dir/workspace-image-cache.prom"
+stderr_file="$tmp_root/stderr.log"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -17,14 +18,24 @@ fail() {
 }
 
 reset_dirs() {
-  rm -rf "$cache_dir" "$textfile_dir"
+  rm -rf "$cache_dir" "$textfile_dir" "$stderr_file"
   mkdir -p "$textfile_dir"
 }
 
+run_with_aliases() {
+  env \
+    -u OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+    -u VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    -u OKOU_MONITORING_TEXTFILE_DIR \
+    -u VM0_MONITORING_TEXTFILE_DIR \
+    "$@" \
+    bash "$script" 2>"$stderr_file"
+}
+
 run_metrics() {
-  VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    bash "$script"
+  run_with_aliases \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
 
   [ -f "$output_file" ] || fail "metrics output file was not created"
 }
@@ -39,6 +50,40 @@ assert_no_match() {
   if grep -qE "$pattern" "$output_file"; then
     fail "unexpected output matching: $pattern"
   fi
+}
+
+assert_source_state() {
+  local canonical_key="$1"
+  local legacy_key="$2"
+  local state="$3"
+  local expected
+  expected="monitoring path alias source canonical_key=$canonical_key legacy_key=$legacy_key state=$state"
+
+  grep -qxF "$expected" "$stderr_file" ||
+    fail "expected fixed-shape alias source evidence"
+}
+
+assert_conflict_state() {
+  local canonical_key="$1"
+  local legacy_key="$2"
+  local expected
+  expected="monitoring path alias conflict canonical_key=$canonical_key legacy_key=$legacy_key state=conflict"
+
+  grep -qxF "$expected" "$stderr_file" ||
+    fail "expected fixed-shape alias conflict diagnostic"
+}
+
+assert_stderr_excludes_values() {
+  local value
+  for value in "$@"; do
+    if grep -Fq -- "$value" "$stderr_file"; then
+      fail "alias diagnostic exposed a path value"
+    fi
+  done
+}
+
+assert_output_absent() {
+  [ ! -e "$output_file" ] || fail "collector published output before rejecting aliases"
 }
 
 assert_all_buckets_zero() {
@@ -161,16 +206,152 @@ test_ignores_incomplete_and_non_regular_entries() {
   assert_all_buckets_zero
 }
 
+test_workspace_image_cache_dir_alias_matrix() {
+  reset_dirs
+  mkdir -p "$cache_dir/alias-entry"
+  touch "$cache_dir/alias-entry/current.ext4"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    canonical-only
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    legacy-only
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    dual
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  run_with_aliases OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 0"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 0"
+
+  rm -f "$output_file"
+  local canonical_conflict="$tmp_root/cache-canonical-conflict-value"
+  local legacy_conflict="$tmp_root/cache-legacy-conflict-value"
+  if run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$canonical_conflict" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$legacy_conflict" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
+    fail "expected conflicting cache aliases to fail"
+  fi
+  assert_conflict_state \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR
+  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  assert_output_absent
+}
+
+test_monitoring_textfile_dir_alias_matrix() {
+  reset_dirs
+  mkdir -p "$cache_dir/alias-entry"
+  touch "$cache_dir/alias-entry/current.ext4"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR=""
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    canonical-only
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    legacy-only
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    dual
+  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+
+  rm -f "$output_file"
+  if run_with_aliases OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir"; then
+    fail "expected the absent textfile alias pair to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "absent textfile aliases did not use the fixed default"
+  assert_output_absent
+
+  if run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="" \
+    VM0_MONITORING_TEXTFILE_DIR=""; then
+    fail "expected empty textfile aliases to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "empty textfile aliases did not use the fixed default"
+  assert_output_absent
+
+  local canonical_conflict="$tmp_root/textfile-canonical-conflict-value"
+  local legacy_conflict="$tmp_root/textfile-legacy-conflict-value"
+  if run_with_aliases \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$canonical_conflict" \
+    VM0_MONITORING_TEXTFILE_DIR="$legacy_conflict"; then
+    fail "expected conflicting textfile aliases to fail"
+  fi
+  assert_conflict_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR
+  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  assert_output_absent
+}
+
 test_missing_textfile_dir_fails() {
   rm -rf "$cache_dir" "$textfile_dir"
 
-  if VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    bash "$script" 2>"$tmp_root/error.log"; then
+  if run_with_aliases \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
     fail "expected missing textfile directory to fail"
   fi
 
-  grep -q "missing textfile directory" "$tmp_root/error.log" ||
+  grep -q "missing textfile directory" "$stderr_file" ||
     fail "missing textfile directory error was not reported"
 }
 
@@ -180,6 +361,8 @@ test_sparse_file_uses_allocated_bytes_not_logical_size
 test_regular_file_bucket_counts
 test_multiple_entries_aggregate_across_buckets
 test_ignores_incomplete_and_non_regular_entries
+test_workspace_image_cache_dir_alias_matrix
+test_monitoring_textfile_dir_alias_matrix
 test_missing_textfile_dir_fails
 
 echo "vm0 monitoring collector tests passed"

--- a/.github/scripts/tests/vm0-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-runner-status-collect-test.sh
@@ -32,10 +32,20 @@ reset_dirs() {
   mkdir -p "$textfile_dir"
 }
 
-run_collector() {
-  VM0_RUNNERS_DIR="$runners_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+run_with_aliases() {
+  env \
+    -u OKOU_RUNNERS_DIR \
+    -u VM0_RUNNERS_DIR \
+    -u OKOU_MONITORING_TEXTFILE_DIR \
+    -u VM0_MONITORING_TEXTFILE_DIR \
+    "$@" \
     python3 "$script" 2>"$stderr_file"
+}
+
+run_collector() {
+  run_with_aliases \
+    VM0_RUNNERS_DIR="$runners_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
 
   [ -f "$output_file" ] || fail "metrics output file was not created"
 }
@@ -48,6 +58,40 @@ assert_line() {
 assert_playbook_contains() {
   local expected="$1"
   grep -qF "$expected" "$playbook" || fail "playbook is missing: $expected"
+}
+
+assert_source_state() {
+  local canonical_key="$1"
+  local legacy_key="$2"
+  local state="$3"
+  local expected
+  expected="monitoring path alias source canonical_key=$canonical_key legacy_key=$legacy_key state=$state"
+
+  grep -qxF "$expected" "$stderr_file" ||
+    fail "expected fixed-shape alias source evidence"
+}
+
+assert_conflict_state() {
+  local canonical_key="$1"
+  local legacy_key="$2"
+  local expected
+  expected="monitoring path alias conflict canonical_key=$canonical_key legacy_key=$legacy_key state=conflict"
+
+  grep -qxF "$expected" "$stderr_file" ||
+    fail "expected fixed-shape alias conflict diagnostic"
+}
+
+assert_stderr_excludes_values() {
+  local value
+  for value in "$@"; do
+    if grep -Fq -- "$value" "$stderr_file"; then
+      fail "alias diagnostic exposed a path value"
+    fi
+  done
+}
+
+assert_output_absent() {
+  [ ! -e "$output_file" ] || fail "collector published output before rejecting aliases"
 }
 
 assert_zero_snapshot() {
@@ -271,12 +315,142 @@ test_output_is_deterministic_and_replaced_atomically() {
   assert_line 'vm0_runner_sandboxes{state="idle"} 1'
 }
 
+test_runners_dir_alias_matrix() {
+  reset_dirs
+  mkdir -p "$runners_dir/alias-runner"
+  printf '%s\n' '{"mode":"running"}' \
+    >"$runners_dir/alias-runner/status.json"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    VM0_RUNNERS_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 1'
+  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR canonical-only
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="" \
+    VM0_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 1'
+  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR legacy-only
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    VM0_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 1'
+  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR dual
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  run_with_aliases OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_zero_snapshot
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="" \
+    VM0_RUNNERS_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_zero_snapshot
+
+  rm -f "$output_file"
+  local canonical_conflict="$tmp_root/runners-canonical-conflict-value"
+  local legacy_conflict="$tmp_root/runners-legacy-conflict-value"
+  if run_with_aliases \
+    OKOU_RUNNERS_DIR="$canonical_conflict" \
+    VM0_RUNNERS_DIR="$legacy_conflict" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
+    fail "expected conflicting runners aliases to fail"
+  fi
+  assert_conflict_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR
+  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  assert_output_absent
+}
+
+test_monitoring_textfile_dir_alias_matrix() {
+  reset_dirs
+  mkdir -p "$runners_dir/alias-runner"
+  printf '%s\n' '{"mode":"running"}' \
+    >"$runners_dir/alias-runner/status.json"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR=""
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    canonical-only
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    legacy-only
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_source_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR \
+    dual
+  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+
+  rm -f "$output_file"
+  if run_with_aliases OKOU_RUNNERS_DIR="$runners_dir"; then
+    fail "expected the absent textfile alias pair to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "absent textfile aliases did not use the fixed default"
+  assert_output_absent
+
+  if run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="" \
+    VM0_MONITORING_TEXTFILE_DIR=""; then
+    fail "expected empty textfile aliases to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "empty textfile aliases did not use the fixed default"
+  assert_output_absent
+
+  local canonical_conflict="$tmp_root/textfile-canonical-conflict-value"
+  local legacy_conflict="$tmp_root/textfile-legacy-conflict-value"
+  if run_with_aliases \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$canonical_conflict" \
+    VM0_MONITORING_TEXTFILE_DIR="$legacy_conflict"; then
+    fail "expected conflicting textfile aliases to fail"
+  fi
+  assert_conflict_state \
+    OKOU_MONITORING_TEXTFILE_DIR \
+    VM0_MONITORING_TEXTFILE_DIR
+  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  assert_output_absent
+}
+
 test_missing_textfile_dir_fails() {
   rm -rf "$runners_dir" "$textfile_dir"
 
-  if VM0_RUNNERS_DIR="$runners_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    python3 "$script" 2>"$stderr_file"; then
+  if run_with_aliases \
+    VM0_RUNNERS_DIR="$runners_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
     fail "expected missing textfile directory to fail"
   fi
 
@@ -300,6 +474,8 @@ test_idle_field_compatibility_precedence
 test_invalid_files_publish_partial_metrics
 test_rejects_runner_and_status_symlinks
 test_output_is_deterministic_and_replaced_atomically
+test_runners_dir_alias_matrix
+test_monitoring_textfile_dir_alias_matrix
 test_missing_textfile_dir_fails
 test_playbook_provisions_independent_collector_cadence
 

--- a/ansible/files/vm0-monitoring-collect.sh
+++ b/ansible/files/vm0-monitoring-collect.sh
@@ -46,9 +46,10 @@ resolve_path_alias() {
     >&2
 }
 
-# Stage 1 keeps legacy aliases available until #28914 records an all-host
-# canonical configuration floor, completes the rollback window, and verifies
-# that no active host has a legacy-only override.
+# Stage 1 keeps legacy aliases for operator-managed collector process
+# environments until #28914 records an all-host canonical configuration floor,
+# completes the rollback window, and verifies that no active host has a
+# legacy-only override.
 resolve_path_alias \
   OKOU_WORKSPACE_IMAGE_CACHE_DIR \
   VM0_WORKSPACE_IMAGE_CACHE_DIR \

--- a/ansible/files/vm0-monitoring-collect.sh
+++ b/ansible/files/vm0-monitoring-collect.sh
@@ -1,9 +1,64 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+set +x
 
-cache_dir="${VM0_WORKSPACE_IMAGE_CACHE_DIR:-/var/lib/vm0-runner/workspace-image-cache}"
-textfile_dir="${VM0_MONITORING_TEXTFILE_DIR:-/var/lib/vm0-monitoring/textfile-collector}"
+resolve_path_alias() {
+  local canonical_key="$1"
+  local legacy_key="$2"
+  local default_value="$3"
+  local canonical_value=""
+  local legacy_value=""
+  local state
+
+  if [[ -v "$canonical_key" ]]; then
+    canonical_value="${!canonical_key}"
+  fi
+  if [[ -v "$legacy_key" ]]; then
+    legacy_value="${!legacy_key}"
+  fi
+
+  if [[ -n "$canonical_value" && -n "$legacy_value" ]]; then
+    if [[ "$canonical_value" != "$legacy_value" ]]; then
+      printf 'monitoring path alias conflict canonical_key=%s legacy_key=%s state=conflict\n' \
+        "$canonical_key" \
+        "$legacy_key" \
+        >&2
+      return 1
+    fi
+    resolved_path_alias_value="$canonical_value"
+    state="dual"
+  elif [[ -n "$canonical_value" ]]; then
+    resolved_path_alias_value="$canonical_value"
+    state="canonical-only"
+  elif [[ -n "$legacy_value" ]]; then
+    resolved_path_alias_value="$legacy_value"
+    state="legacy-only"
+  else
+    resolved_path_alias_value="$default_value"
+    return 0
+  fi
+
+  printf 'monitoring path alias source canonical_key=%s legacy_key=%s state=%s\n' \
+    "$canonical_key" \
+    "$legacy_key" \
+    "$state" \
+    >&2
+}
+
+# Stage 1 keeps legacy aliases available until #28914 records an all-host
+# canonical configuration floor, completes the rollback window, and verifies
+# that no active host has a legacy-only override.
+resolve_path_alias \
+  OKOU_WORKSPACE_IMAGE_CACHE_DIR \
+  VM0_WORKSPACE_IMAGE_CACHE_DIR \
+  /var/lib/vm0-runner/workspace-image-cache
+cache_dir="$resolved_path_alias_value"
+resolve_path_alias \
+  OKOU_MONITORING_TEXTFILE_DIR \
+  VM0_MONITORING_TEXTFILE_DIR \
+  /var/lib/vm0-monitoring/textfile-collector
+textfile_dir="$resolved_path_alias_value"
 output_file="$textfile_dir/workspace-image-cache.prom"
 
 mib=$((1024 * 1024))

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -257,9 +257,10 @@ def write_metrics(textfile_dir: Path, metrics: str) -> None:
 
 
 def main() -> None:
-    # Stage 1 keeps legacy aliases available until #28914 records an all-host
-    # canonical configuration floor, completes the rollback window, and verifies
-    # that no active host has a legacy-only override.
+    # Stage 1 keeps legacy aliases for operator-managed collector process
+    # environments until #28914 records an all-host canonical configuration floor,
+    # completes the rollback window, and verifies that no active host has a
+    # legacy-only override.
     runners_dir = resolve_path_alias(
         CANONICAL_RUNNERS_DIR_ENV,
         LEGACY_RUNNERS_DIR_ENV,

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -14,10 +14,46 @@ SANDBOX_STATES = ("active", "idle", "preparing", "unknown")
 RUNNER_MODES = ("starting", "running", "draining", "stopping", "unknown")
 STATUS_RESULTS = ("included", "stopped", "invalid")
 STATE_PRECEDENCE = {"unknown": 0, "preparing": 1, "active": 2, "idle": 3}
+CANONICAL_RUNNERS_DIR_ENV = "OKOU_RUNNERS_DIR"
+LEGACY_RUNNERS_DIR_ENV = "VM0_RUNNERS_DIR"
+DEFAULT_RUNNERS_DIR = "/var/lib/vm0-runner/runners"
+CANONICAL_TEXTFILE_DIR_ENV = "OKOU_MONITORING_TEXTFILE_DIR"
+LEGACY_TEXTFILE_DIR_ENV = "VM0_MONITORING_TEXTFILE_DIR"
+DEFAULT_TEXTFILE_DIR = "/var/lib/vm0-monitoring/textfile-collector"
 
 
 class InvalidStatus(ValueError):
     pass
+
+
+def resolve_path_alias(canonical_key: str, legacy_key: str, default: str) -> Path:
+    canonical = os.environ.get(canonical_key) or None
+    legacy = os.environ.get(legacy_key) or None
+
+    if canonical is not None and legacy is not None:
+        if canonical != legacy:
+            raise SystemExit(
+                "monitoring path alias conflict "
+                f"canonical_key={canonical_key} legacy_key={legacy_key} "
+                "state=conflict"
+            )
+        value = canonical
+        state = "dual"
+    elif canonical is not None:
+        value = canonical
+        state = "canonical-only"
+    elif legacy is not None:
+        value = legacy
+        state = "legacy-only"
+    else:
+        return Path(default)
+
+    print(
+        "monitoring path alias source "
+        f"canonical_key={canonical_key} legacy_key={legacy_key} state={state}",
+        file=sys.stderr,
+    )
+    return Path(value)
 
 
 def parse_sandbox_entry(entry: object) -> tuple[dict[object, object], str]:
@@ -148,7 +184,12 @@ def collect(
         for sandbox_id, state in entries:
             record_state(sandbox_states, sandbox_id, state)
 
-    return Counter(sandbox_states.values()), runner_modes, status_results, collection_success
+    return (
+        Counter(sandbox_states.values()),
+        runner_modes,
+        status_results,
+        collection_success,
+    )
 
 
 def render_metrics(
@@ -216,14 +257,18 @@ def write_metrics(textfile_dir: Path, metrics: str) -> None:
 
 
 def main() -> None:
-    runners_dir = Path(
-        os.environ.get("VM0_RUNNERS_DIR", "/var/lib/vm0-runner/runners")
+    # Stage 1 keeps legacy aliases available until #28914 records an all-host
+    # canonical configuration floor, completes the rollback window, and verifies
+    # that no active host has a legacy-only override.
+    runners_dir = resolve_path_alias(
+        CANONICAL_RUNNERS_DIR_ENV,
+        LEGACY_RUNNERS_DIR_ENV,
+        DEFAULT_RUNNERS_DIR,
     )
-    textfile_dir = Path(
-        os.environ.get(
-            "VM0_MONITORING_TEXTFILE_DIR",
-            "/var/lib/vm0-monitoring/textfile-collector",
-        )
+    textfile_dir = resolve_path_alias(
+        CANONICAL_TEXTFILE_DIR_ENV,
+        LEGACY_TEXTFILE_DIR_ENV,
+        DEFAULT_TEXTFILE_DIR,
     )
 
     metrics = render_metrics(*collect(runners_dir))


### PR DESCRIPTION
## Summary

- dual-read `OKOU_WORKSPACE_IMAGE_CACHE_DIR` / `VM0_WORKSPACE_IMAGE_CACHE_DIR`, `OKOU_MONITORING_TEXTFILE_DIR` / `VM0_MONITORING_TEXTFILE_DIR`, and `OKOU_RUNNERS_DIR` / `VM0_RUNNERS_DIR` at the two monitoring collector entry points
- preserve the fixed defaults for unset and empty values, accept canonical-only, legacy-only, and equal-dual values, and fail closed on unequal dual values before collector filesystem access
- emit only fixed-shape, value-free source and conflict evidence
- cover the full alias matrix in both focused collector suites while retaining the existing metrics, symlink, permissions, atomic replacement, and cadence checks

Closes #29064
Parent EPIC: #28914

## Implementation baseline

- fetched `origin/main` immediately before editing and branched from `1f21af778ef9513a49ee40de8e6176aba08e80ac`
- refreshed all-open-PR overlap multiple times; the final scan covered 24 open PRs and found no file or patch overlap with the four scoped files or six environment spellings
- full repository caller searches found the production readers only in the two collectors, repository producers only in their focused tests, and installation/invocation only through `ansible/playbooks/provision-monitoring.yml`
- the official systemd units are unchanged and still invoke the collectors without either environment spelling

## State matrix

| Canonical value | Legacy value | Result |
| --- | --- | --- |
| unset/empty | unset/empty | existing fixed default |
| non-empty | unset/empty | canonical value unchanged |
| unset/empty | non-empty | legacy value unchanged |
| equal non-empty | equal non-empty | shared value unchanged |
| different non-empty | different non-empty | fail closed before collector filesystem access |

Conflict diagnostics and migration source evidence contain only the fixed canonical key, fixed legacy key, and one of `canonical-only`, `legacy-only`, `dual`, or `conflict`. Shell tracing is disabled before alias values are read. Focused tests assert that neither configured conflict path appears in stderr and that no metrics file is published on conflict.

## Fallbacks

- `ansible/files/vm0-monitoring-collect.sh:resolve_path_alias` retains the current `VM0_WORKSPACE_IMAGE_CACHE_DIR` and `VM0_MONITORING_TEXTFILE_DIR` readers for operator-managed collector environments and systemd drop-ins. This fallback is bounded to the #28914 reader-floor, all-host inventory, supported host rollback-window, and zero-legacy-only gates; remove the legacy branches only after all four gates are recorded.
- `ansible/files/vm0-runner-status-collect.py:resolve_path_alias` retains the current `VM0_RUNNERS_DIR` and `VM0_MONITORING_TEXTFILE_DIR` readers under the same bounded gate. No production configuration is changed in this reader-only stage.

## Scope and configuration safety

- no `VM0_*` reader was removed
- no default path, metric, label, cadence, permission, symlink rule, temporary-file pattern, or atomic replacement behavior was changed
- no systemd unit, drop-in, `host.env`, runner binary, repository variable, secret, release, deployment, or production host configuration was changed
- the diff is limited to the two collectors and their two focused tests

## Verification

- `bash .github/scripts/tests/vm0-monitoring-collect-test.sh`
- `bash .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `bash -n ansible/files/vm0-monitoring-collect.sh .github/scripts/tests/vm0-monitoring-collect-test.sh .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `npx --yes shellcheck@4.1.0 .github/scripts/tests/vm0-monitoring-collect-test.sh .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `npx --yes shellcheck@4.1.0 --exclude=SC2004 ansible/files/vm0-monitoring-collect.sh` (`SC2004` is limited to two pre-existing arithmetic-array expressions outside this diff)
- pinned Ruff 0.16.0: `ruff format --check ansible/files/vm0-runner-status-collect.py`
- pinned Ruff 0.16.0: `ruff check ansible/files/vm0-runner-status-collect.py`
- `git diff --check`

No full local Vitest suite or development server was run. PR CI is authoritative for repository-wide validation.
