### PR TITLE
refactor(runtime): dual-read resume session environment aliases

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -176,4 +176,36 @@ mod tests {
             1
         );
     }
+
+    #[test]
+    fn apply_values_clears_resume_session_bootstrap_aliases() {
+        let mut command = tokio::process::Command::new("unused");
+        command
+            .env(
+                guest_contracts::env::RESUME_SESSION_ID_ENV,
+                "legacy-session-id",
+            )
+            .env(
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+                "canonical-session-id",
+            );
+
+        let values = values_with_inputs("/tmp/home", &HashMap::new(), "");
+        apply_values_to_tokio_command(&mut command, &values);
+
+        let explicit_keys = command
+            .as_std()
+            .get_envs()
+            .map(|(key, _)| key)
+            .collect::<Vec<_>>();
+        for key in [
+            guest_contracts::env::RESUME_SESSION_ID_ENV,
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+        ] {
+            assert!(
+                !explicit_keys.contains(&std::ffi::OsStr::new(key)),
+                "CLI child environment retained bootstrap key {key}"
+            );
+        }
+    }
 }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -1220,7 +1220,7 @@ fn resume_thread_id_from_runtime(
     }
     canonical_codex_thread_id(
         resume_id,
-        "VM0_RESUME_SESSION_ID is not a valid Codex thread id",
+        "resume session id is not a valid Codex thread id",
     )
     .map(Some)
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -314,7 +314,10 @@ impl GuestConfigRaw {
                 guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV,
             )?,
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
-            resume_session_id: env_or_empty(guest_contracts::env::RESUME_SESSION_ID_ENV),
+            resume_session_id: run_metadata_env_or_empty(
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+                guest_contracts::env::RESUME_SESSION_ID_ENV,
+            )?,
             api_start_time: run_metadata_env_or_empty(
                 guest_contracts::env::CANONICAL_API_START_TIME_ENV,
                 guest_contracts::env::API_START_TIME_ENV,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1174,6 +1174,7 @@ mod tests {
             guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
             guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
             guest_contracts::env::RESUME_SESSION_ID_ENV,
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
             guest_contracts::env::API_START_TIME_ENV,
             guest_contracts::env::CANONICAL_API_START_TIME_ENV,
             guest_contracts::env::SECRET_VALUES_ENV,

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -13,6 +13,7 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
 -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let missing_mock = tmp.path().join("missing-mock-codex");
+    let invalid_resume_id = "not-a-valid-codex-thread-id";
 
     unsafe {
         common::setup_codex_app_server_env(
@@ -22,9 +23,14 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
                 run_id: "codex-app-server-backend-invalid-resume-id-test",
                 prompt: "drive the app-server backend invalid resume id path",
                 scenario: None,
-                resume_session_id: Some("not-a-valid-codex-thread-id"),
+                resume_session_id: Some(invalid_resume_id),
             },
         )?;
+        std::env::remove_var(guest_contracts::env::RESUME_SESSION_ID_ENV);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+            invalid_resume_id,
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
@@ -40,8 +46,12 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
     let error = result.expect_err("invalid resume id should fail the app-server backend");
     let message = error.to_string();
     assert!(
-        message.contains("VM0_RESUME_SESSION_ID is not a valid Codex thread id"),
+        message.contains("resume session id is not a valid Codex thread id"),
         "unexpected error: {message}"
+    );
+    assert!(
+        !message.contains(invalid_resume_id),
+        "invalid resume id diagnostic echoed the value: {message}"
     );
     assert!(
         !message.contains("failed to spawn codex app-server"),

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -28,6 +28,11 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
                 resume_session_id: Some(resume_thread_id),
             },
         )?;
+        std::env::remove_var(guest_contracts::env::RESUME_SESSION_ID_ENV);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+            resume_thread_id,
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1014,6 +1014,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
         guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
         guest_contracts::env::RESUME_SESSION_ID_ENV,
+        guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
         guest_contracts::env::API_START_TIME_ENV,
         guest_contracts::env::CANONICAL_API_START_TIME_ENV,
         guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,

--- a/crates/guest-agent/tests/run_metadata_env_aliases.rs
+++ b/crates/guest-agent/tests/run_metadata_env_aliases.rs
@@ -14,7 +14,7 @@ struct RunMetadataEnvPair {
     value: fn(&GuestConfigRaw) -> &str,
 }
 
-const RUN_METADATA_ENV_PAIRS: [RunMetadataEnvPair; 4] = [
+const RUN_METADATA_ENV_PAIRS: [RunMetadataEnvPair; 5] = [
     RunMetadataEnvPair {
         canonical: guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
         legacy: guest_contracts::env::SANDBOX_ID_ENV,
@@ -29,6 +29,11 @@ const RUN_METADATA_ENV_PAIRS: [RunMetadataEnvPair; 4] = [
         canonical: guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
         legacy: guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV,
         value: |raw| &raw.workspace_reuse_result,
+    },
+    RunMetadataEnvPair {
+        canonical: guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+        legacy: guest_contracts::env::RESUME_SESSION_ID_ENV,
+        value: |raw| &raw.resume_session_id,
     },
     RunMetadataEnvPair {
         canonical: guest_contracts::env::CANONICAL_API_START_TIME_ENV,
@@ -198,9 +203,15 @@ fn assert_non_unicode_behaviors(tmp: &Path, index: usize, pair: RunMetadataEnvPa
     Ok(())
 }
 
-fn assert_legacy_guest_config(tmp: &Path) -> TestResult {
+fn assert_guest_config_for_source(tmp: &Path, canonical: bool) -> TestResult {
     clear_run_metadata_env();
-    let runtime_dir = tmp.join("legacy-config-runtime");
+    let source = if canonical { "canonical" } else { "legacy" };
+    let source_label = if canonical {
+        "canonical-only"
+    } else {
+        "legacy-only"
+    };
+    let runtime_dir = tmp.join(format!("{source}-config-runtime"));
     let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
     let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
     std::fs::create_dir_all(&payload_dir)?;
@@ -209,13 +220,17 @@ fn assert_legacy_guest_config(tmp: &Path) -> TestResult {
         serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
     )?;
 
-    let legacy_values = [
-        "legacy-sandbox-id",
+    let values = [
+        "shared-sandbox-id",
         "reused",
         "sandboxReused",
+        "resume-session-id",
         "1700000000000",
     ];
-    set_test_env(guest_contracts::env::RUN_ID_ENV, "legacy-config-run");
+    set_test_env(
+        guest_contracts::env::RUN_ID_ENV,
+        format!("{source}-config-run"),
+    );
     set_test_env("HOME", tmp.join("home"));
     set_test_env(
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
@@ -223,23 +238,29 @@ fn assert_legacy_guest_config(tmp: &Path) -> TestResult {
     );
     set_test_env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, &payload_path);
     remove_test_env(guest_contracts::env::USER_ENV_FILE_ENV);
-    for (pair, value) in RUN_METADATA_ENV_PAIRS.into_iter().zip(legacy_values) {
-        set_test_env(pair.legacy, value);
+    for (pair, value) in RUN_METADATA_ENV_PAIRS.into_iter().zip(values) {
+        let key = if canonical {
+            pair.canonical
+        } else {
+            pair.legacy
+        };
+        set_test_env(key, value);
     }
 
-    let config_log_path = tmp.join("legacy-config.log");
+    let config_log_path = tmp.join(format!("{source}-config.log"));
     guest_common::log::set_system_log_file(&config_log_path);
     let config =
         guest_agent::env::GuestConfig::from_process_env().map_err(std::io::Error::other)?;
     guest_common::log::clear_system_log_file();
 
-    assert_eq!(config.sandbox_id, legacy_values[0]);
-    assert_eq!(config.sandbox_reuse_result, legacy_values[1]);
-    assert_eq!(config.workspace_reuse_result, legacy_values[2]);
-    assert_eq!(config.api_start_time, legacy_values[3]);
+    assert_eq!(config.sandbox_id, values[0]);
+    assert_eq!(config.sandbox_reuse_result, values[1]);
+    assert_eq!(config.workspace_reuse_result, values[2]);
+    assert_eq!(config.resume_session_id, values[3]);
+    assert_eq!(config.api_start_time, values[4]);
     let config_log = std::fs::read_to_string(config_log_path)?;
-    for (pair, value) in RUN_METADATA_ENV_PAIRS.into_iter().zip(legacy_values) {
-        assert_source_log(&config_log, pair, "legacy-only", Some(value));
+    for (pair, value) in RUN_METADATA_ENV_PAIRS.into_iter().zip(values) {
+        assert_source_log(&config_log, pair, source_label, Some(value));
     }
 
     clear_run_metadata_env();
@@ -257,5 +278,6 @@ fn process_env_dual_reads_run_metadata_without_value_leaks() -> TestResult {
         assert_non_unicode_behaviors(tmp.path(), index, pair)?;
     }
 
-    assert_legacy_guest_config(tmp.path())
+    assert_guest_config_for_source(tmp.path(), false)?;
+    assert_guest_config_for_source(tmp.path(), true)
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -84,6 +84,12 @@ pub const VERCEL_PROTECTION_BYPASS_ENV: &str = "VERCEL_PROTECTION_BYPASS";
 /// The runner normalizes Codex thread ids before emitting this key.
 pub const RESUME_SESSION_ID_ENV: &str = "VM0_RESUME_SESSION_ID";
 
+/// Canonical resume-session alias accepted by guest readers during migration.
+///
+/// Runner writers keep using [`RESUME_SESSION_ID_ENV`] until the deployed reader
+/// floor, sandbox drain, rollback window, and legacy-read-zero gates are complete.
+pub const CANONICAL_RESUME_SESSION_ID_ENV: &str = "OKOU_RESUME_SESSION_ID";
+
 /// Optional Unix epoch millisecond timestamp for when the API accepted the
 /// run.
 ///
@@ -519,6 +525,8 @@ mod tests {
             CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
             "OKOU_WORKSPACE_REUSE_RESULT"
         );
+        assert_eq!(RESUME_SESSION_ID_ENV, "VM0_RESUME_SESSION_ID");
+        assert_eq!(CANONICAL_RESUME_SESSION_ID_ENV, "OKOU_RESUME_SESSION_ID");
         assert_eq!(API_START_TIME_ENV, "VM0_API_START_TIME");
         assert_eq!(CANONICAL_API_START_TIME_ENV, "OKOU_API_START_TIME");
         assert_eq!(PI_SESSION_ID_ENV, "OKOU_PI_SESSION_ID");
@@ -720,6 +728,8 @@ mod tests {
             CANONICAL_SANDBOX_ID_ENV,
             CANONICAL_SANDBOX_REUSE_RESULT_ENV,
             CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
+            RESUME_SESSION_ID_ENV,
+            CANONICAL_RESUME_SESSION_ID_ENV,
             CANONICAL_API_START_TIME_ENV,
             PI_SESSION_ID_ENV,
             PI_LAUNCH_CONFIG_ENV,

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -919,9 +919,11 @@ fn build_env_json_codex_keeps_shared_runner_env() {
     assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
     assert_eq!(payload.append_system_prompt, "Use terse answers.");
     assert_eq!(
-        env.get("VM0_RESUME_SESSION_ID").unwrap(),
+        env.get(guest_contracts::env::RESUME_SESSION_ID_ENV)
+            .unwrap(),
         "019e9154-c304-70f0-adde-36efb1be1701"
     );
+    assert!(!env.contains_key(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
 }
 
@@ -1097,7 +1099,12 @@ fn build_env_json_with_resume_session() {
     ctx.resume_session = Some(ResumeSession::inline("sess-123".into(), "{}".into()));
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(env.get("VM0_RESUME_SESSION_ID").unwrap(), "sess-123");
+    assert_eq!(
+        env.get(guest_contracts::env::RESUME_SESSION_ID_ENV)
+            .unwrap(),
+        "sess-123"
+    );
+    assert!(!env.contains_key(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `OKOU_RESUME_SESSION_ID` as a reader-only guest bootstrap alias while preserving `RESUME_SESSION_ID_ENV = "VM0_RESUME_SESSION_ID"` as the runner writer contract
- resolve the canonical and legacy names once through the existing `run_metadata_env_or_empty` path, including value-free source evidence and fail-closed conflict handling
- extend the existing run-metadata state matrix and downstream resume coverage, keep both aliases out of CLI child environment, and make the Codex invalid-id diagnostic source-neutral

## Scope and rollout

This is the reader-only Stage 1 change from #29065 and parent #28914. The runner production writer remains legacy-only. This PR does not perform writer cutover, legacy removal, release, deployment, sandbox drain, production configuration mutation, or any Cloudflare Access work from #25722.

Implementation base: `1f21af778ef9513a49ee40de8e6176aba08e80ac`

## Safety evidence

- `RESUME_SESSION_ID_ENV` remains exactly `VM0_RESUME_SESSION_ID`; `crates/runner/src/executor/env.rs` still writes only that constant
- runner regression assertions reject accidental canonical emission for both Claude and normalized Codex resume ids
- canonical-only, legacy-only, equal-dual, empty, conflicting-dual, absent, and non-Unicode states reuse the existing run-metadata resolver matrix
- conflict diagnostics and source evidence contain only fixed alias names and source labels, never a session id
- canonical-only and legacy-only inputs construct the same owned resume-session value; representative Codex and Claude downstream resume paths remain covered
- the Codex invalid-id diagnostic is source-neutral and does not echo the invalid id
- the curated CLI command environment clears both spellings before applying its allowlist

## Open PR overlap

#25722 is the only open PR with shared files. Its actual overlap is limited to unrelated Cloudflare Access constants in `crates/guest-contracts/src/env.rs` and separate runner changes. No Cloudflare scope is included here.

## Verification

All Rust commands below used the CI-aligned Rust 1.96.0 toolchain:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features --no-deps -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --no-deps`
- `cargo check --manifest-path crates/Cargo.toml -p runner --tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test run_metadata_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib apply_values_clears_resume_session_bootstrap_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend_resume`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend_error_visibility`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend_invalid_resume_id`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_resume_id_stderr_visibility`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test api_token_process_isolation`
- `git diff --check`

The local environment has 3.8 GiB RAM and no swap, so the runner test binary was compiled with `cargo check` rather than linked locally; PR CI is authoritative for runner test execution and the full repository.

## Fallbacks

- `crates/guest-agent/src/env.rs:run_metadata_env_or_empty` temporarily accepts both `VM0_RESUME_SESSION_ID` and `OKOU_RESUME_SESSION_ID` at the runner/sandbox-to-guest bootstrap boundary. This is bounded cross-version compatibility for existing legacy-only writers and a later canonical writer across the existing runner/sandbox surface, whose drain window is the two-hour guest runtime budget plus bounded finalization. Remove the legacy branch only after #28914 records the deployed runner artifact, embedded guest SHA, and rootfs reader floor; every pre-reader service and reusable sandbox passes the drain gate; the supported rollback window closes; and value-free source evidence shows zero legacy-only reads. The runner remains legacy-only in this PR.

Closes #29065
Parent: #28914
