### PR TITLE
refactor(runtime): dual-read process-control environment aliases

### DIFF
--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -70,10 +70,10 @@ impl Drop for StreamSlotCleanup {
 impl ControlHandle {
     /// Starts the process-control worker when process control is bootstrapped.
     ///
-    /// The bootstrap endpoint is read from [`process_control_ipc::BOOTSTRAP_ENV`],
-    /// whose environment variable name is `VM0_PROCESS_CONTROL_ENDPOINT`.
-    /// Missing or empty values mean this guest-agent run has no process-control
-    /// endpoint, so this method returns `None`.
+    /// The bootstrap endpoint is supplied from the once-resolved canonical or
+    /// legacy process environment. Missing or empty values mean this
+    /// guest-agent run has no process-control endpoint, so this method returns
+    /// `None`.
     ///
     /// This method also returns `None` if the worker thread cannot be spawned.
     /// A returned `Some(ControlHandle)` only means the worker thread was
@@ -85,14 +85,12 @@ impl ControlHandle {
     /// [`ActiveInputController`], and its outcome is mapped back to a local
     /// process-control response.
     pub fn spawn(
+        endpoint: Option<&str>,
         shutdown: CancellationToken,
         active_input: ActiveInputController,
         cli_cancellation: CancellationToken,
     ) -> Option<Self> {
-        let endpoint = match std::env::var(process_control_ipc::BOOTSTRAP_ENV) {
-            Ok(endpoint) if !endpoint.is_empty() => endpoint,
-            _ => return None,
-        };
+        let endpoint = endpoint.filter(|endpoint| !endpoint.is_empty())?.to_owned();
         Self::spawn_endpoint(endpoint, shutdown, active_input, cli_cancellation)
     }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -268,10 +268,7 @@ async fn run(runtime: GuestRuntime) -> i32 {
     let shutdown = CancellationToken::new();
     let cli_cancellation = CancellationToken::new();
     let framework_supports_active_input = framework_supports_active_input(runtime.config.framework);
-    let has_process_control_endpoint = matches!(
-        std::env::var(process_control_ipc::BOOTSTRAP_ENV),
-        Ok(endpoint) if !endpoint.is_empty()
-    );
+    let has_process_control_endpoint = runtime.process_control_endpoint.is_some();
     let active_input_enabled = framework_supports_active_input && has_process_control_endpoint;
     let active_input = if active_input_enabled {
         let receipt_journal_path =
@@ -302,6 +299,7 @@ async fn run(runtime: GuestRuntime) -> i32 {
         )
     };
     let control_handle = control::ControlHandle::spawn(
+        runtime.process_control_endpoint.as_deref(),
         shutdown.clone(),
         active_input.controller(),
         cli_cancellation.clone(),
@@ -1072,6 +1070,7 @@ mod tests {
             paths: paths::GuestPaths::from_runtime_dir(test_runtime_dir()),
             http,
             workload_containment: None,
+            process_control_endpoint: None,
         }
     }
 
@@ -1196,6 +1195,7 @@ mod tests {
             guest_contracts::env::MOCK_CODEX_PATH_ENV,
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             process_control_ipc::BOOTSTRAP_ENV,
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
             guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             "MOCK_CODEX_APP_SERVER_SCENARIO",
         ] {

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -86,9 +86,11 @@ impl GuestRuntime {
 }
 
 /// Resolve Stage 1 compatibility between an existing runner or sandbox and a
-/// new guest reader. #28914 owns the later writer-cutover and reader-removal
-/// issues; remove the legacy branch only after the reader floor, sandbox drain,
-/// rollback window, and legacy-read-zero gates are complete.
+/// new guest reader. Existing instances can expose the legacy writer for the
+/// two-hour guest runtime budget plus bounded finalization. #28914 owns the
+/// later writer-cutover and reader-removal issues; remove the legacy branch
+/// only after the reader floor, sandbox drain, rollback window, and
+/// legacy-read-zero gates are complete.
 fn process_control_endpoint_from_process_env() -> Result<ProcessControlEnvResolution, String> {
     let canonical = process_control_env_value(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)?;
     let legacy = process_control_env_value(process_control_ipc::BOOTSTRAP_ENV)?;

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -5,6 +5,27 @@ use crate::http::HttpClient;
 use crate::paths::GuestPaths;
 use crate::workload_containment::WorkloadContainment;
 
+const LOG_TAG: &str = "sandbox:guest-agent";
+
+#[derive(Clone, Copy)]
+enum ProcessControlEnvSource {
+    CanonicalOnly,
+    LegacyOnly,
+    Dual,
+}
+
+type ProcessControlEnvResolution = (Option<String>, Option<ProcessControlEnvSource>);
+
+impl ProcessControlEnvSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CanonicalOnly => "canonical-only",
+            Self::LegacyOnly => "legacy-only",
+            Self::Dual => "dual",
+        }
+    }
+}
+
 /// Production runtime services for one guest-agent run.
 #[derive(Clone)]
 pub struct GuestRuntime {
@@ -12,6 +33,7 @@ pub struct GuestRuntime {
     pub paths: GuestPaths,
     pub http: HttpClient,
     pub workload_containment: Option<WorkloadContainment>,
+    pub process_control_endpoint: Option<String>,
 }
 
 impl GuestRuntime {
@@ -32,12 +54,23 @@ impl GuestRuntime {
     /// process-wide setup and consume runner-owned inputs before returning, so
     /// callers must not retry it in the same process.
     pub fn from_process_env() -> Result<Self, String> {
-        let workload_containment = WorkloadContainment::from_process_env()?;
+        let (process_control_endpoint, process_control_source) =
+            process_control_endpoint_from_process_env()?;
+        let workload_containment =
+            WorkloadContainment::from_process_env(process_control_endpoint.is_some())?;
         let raw = GuestConfigRaw::from_process_env()?;
         raw.require_run_payload_file()?;
         let paths = paths_from_raw(&raw)?;
         guest_common::log::set_system_log_file(paths.system_log_file());
         guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());
+        if let Some(source) = process_control_source {
+            guest_common::log_info!(
+                LOG_TAG,
+                "process_control_env_source key={} source={}",
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+                source.label()
+            );
+        }
 
         let config = GuestConfig::from_raw(raw)?;
         let http = HttpClient::for_config(&config).map_err(|error| error.to_string())?;
@@ -47,7 +80,45 @@ impl GuestRuntime {
             paths,
             http,
             workload_containment,
+            process_control_endpoint,
         })
+    }
+}
+
+/// Resolve Stage 1 compatibility between an existing runner or sandbox and a
+/// new guest reader. #28914 owns the later writer-cutover and reader-removal
+/// issues; remove the legacy branch only after the reader floor, sandbox drain,
+/// rollback window, and legacy-read-zero gates are complete.
+fn process_control_endpoint_from_process_env() -> Result<ProcessControlEnvResolution, String> {
+    let canonical = process_control_env_value(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)?;
+    let legacy = process_control_env_value(process_control_ipc::BOOTSTRAP_ENV)?;
+
+    match (canonical, legacy) {
+        (None, None) => Ok((None, None)),
+        (Some(endpoint), None) => {
+            Ok((Some(endpoint), Some(ProcessControlEnvSource::CanonicalOnly)))
+        }
+        (None, Some(endpoint)) => Ok((Some(endpoint), Some(ProcessControlEnvSource::LegacyOnly))),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            Ok((Some(canonical), Some(ProcessControlEnvSource::Dual)))
+        }
+        (Some(_), Some(_)) => Err(format!(
+            "conflicting process control environment aliases: canonical_key={} legacy_key={} \
+             state=conflict",
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            process_control_ipc::BOOTSTRAP_ENV
+        )),
+    }
+}
+
+fn process_control_env_value(key: &'static str) -> Result<Option<String>, String> {
+    match std::env::var_os(key) {
+        None => Ok(None),
+        Some(value) if value.is_empty() => Ok(None),
+        Some(value) => value
+            .into_string()
+            .map(Some)
+            .map_err(|_| format!("{key} must be valid UTF-8")),
     }
 }
 

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -52,21 +52,11 @@ impl WorkloadContainment {
     /// Receive and adopt the production bootstrap descriptor.
     ///
     /// This must run before any other thread can read or mutate process-global
-    /// environment state. A process-control bootstrap requires a matching
-    /// workload capability in production. Direct local execution is unmanaged
-    /// when neither bootstrap value exists.
-    pub fn from_process_env() -> Result<Option<Self>, String> {
-        let process_control_present = match std::env::var_os(process_control_ipc::BOOTSTRAP_ENV) {
-            None => false,
-            Some(endpoint) if endpoint.is_empty() => false,
-            Some(endpoint) if endpoint.to_str().is_none() => {
-                return Err(format!(
-                    "{} must be valid UTF-8",
-                    process_control_ipc::BOOTSTRAP_ENV
-                ));
-            }
-            Some(_) => true,
-        };
+    /// environment state. The caller supplies the once-resolved canonical or
+    /// legacy process-control presence. A process-control bootstrap requires a
+    /// matching workload capability in production. Direct local execution is
+    /// unmanaged when neither bootstrap value exists.
+    pub fn from_process_env(process_control_present: bool) -> Result<Option<Self>, String> {
         let placement_endpoint = std::env::var_os(WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV);
         let tool_endpoint = std::env::var_os(TOOL_CGROUP_PROCS_ENDPOINT_ENV);
 
@@ -96,15 +86,17 @@ impl WorkloadContainment {
                 })
             }
             (true, _, _) => Err(format!(
-                "{} and {} are required with {}",
+                "{} and {} are required with {} or {}",
                 WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
             (false, _, _) => Err(format!(
-                "{} and {} require {}",
+                "{} and {} require {} or {}",
                 WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
         }

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -367,6 +367,7 @@ fn process_env_dual_reads_api_token_aliases_without_value_leaks() -> TestResult 
     set_test_env(guest_contracts::env::API_TOKEN_ENV, LEGACY_TOKEN);
     for key in [
         process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
     ] {

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -109,6 +109,7 @@ fn test_runtime(
         paths,
         http,
         workload_containment: None,
+        process_control_endpoint: None,
     })
 }
 

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -30,6 +30,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             process_control_ipc::BOOTSTRAP_ENV,
             "runner-control-endpoint",
         );
+        std::env::set_var(
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            "runner-control-endpoint",
+        );
         std::env::set_var("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true");
         std::env::set_var("NODE_EXTRA_CA_CERTS", "/rootfs/vm0-proxy-ca.crt");
         std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
@@ -173,7 +177,15 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key("VM0_FEATURE_FLAGS"));
     assert!(!cli_env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
     assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
-    assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
+    for key in [
+        process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    ] {
+        assert!(
+            !cli_env.contains_key(key),
+            "Claude child env contains {key}"
+        );
+    }
     assert!(!cli_env.contains_key("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL"));
     assert!(
         !cli_env

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -235,6 +235,7 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
         paths: fixture.paths().clone(),
         http,
         workload_containment: None,
+        process_control_endpoint: None,
     };
     let session_metadata = guest_agent::session_metadata::CapturedSessionMetadata::for_test(
         thread_id,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1037,6 +1037,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
         "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL",

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1070,6 +1070,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
         paths,
         http: http_client!(),
         workload_containment: None,
+        process_control_endpoint: None,
     };
 
     unsafe {

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -159,7 +159,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
 
     common::ensure_canonical_workspace_for_test()?;
     let connection = start_host_and_guest(tmp.path()).await?;
-    let command = guest_agent_wrapper_command(guest_agent);
+    let command = canonical_process_control_guest_agent_wrapper_command(guest_agent);
     let sudo = needs_sudo_for_canonical_workspace();
     let mut handle = connection
         .host()
@@ -497,6 +497,20 @@ fn join_guest(guest: thread::JoinHandle<io::Result<()>>) -> TestResult<()> {
 
 fn guest_agent_wrapper_command(guest_agent: &str) -> String {
     quote_shell_arg(guest_agent)
+}
+
+fn canonical_process_control_guest_agent_wrapper_command(guest_agent: &str) -> String {
+    // The test process can itself run under vm0 and inherit an incomplete
+    // cgroup bootstrap pair. Keep this unmanaged fixture isolated from it.
+    format!(
+        "export {}=\"${}\"; unset {} {} {}; exec {}",
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+        process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::BOOTSTRAP_ENV,
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+        quote_shell_arg(guest_agent)
+    )
 }
 
 fn needs_sudo_for_canonical_workspace() -> bool {

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -18,28 +18,43 @@ const ISOLATED_CHILD_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 const PROCESS_CONTROL_CHILD_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[tokio::test]
-async fn process_control_endpoint_without_workload_capability_fails_closed()
+async fn process_control_endpoint_aliases_without_workload_capability_fail_closed()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
-    command
-        .env(process_control_ipc::BOOTSTRAP_ENV, "missing-capability")
-        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
-        .env_remove(guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV)
-        .env_remove("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL");
-    let output = common::command_output_with_timeout(
-        &mut command,
-        PROCESS_CONTROL_CHILD_TIMEOUT,
-        "missing-workload-capability guest-agent scenario did not finish",
-    )
-    .await?;
+    for bootstrap_env in [
+        process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    ] {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+        command
+            .env_remove(process_control_ipc::BOOTSTRAP_ENV)
+            .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
+            .env(bootstrap_env, "missing-capability")
+            .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
+            .env_remove(guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV)
+            .env_remove("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL");
+        let output = common::command_output_with_timeout(
+            &mut command,
+            PROCESS_CONTROL_CHILD_TIMEOUT,
+            "missing-workload-capability guest-agent scenario did not finish",
+        )
+        .await?;
 
-    assert_eq!(output.status.code(), Some(1));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
-        "stderr: {stderr}"
-    );
-    assert!(stderr.contains("are required with"), "stderr: {stderr}");
+        assert_eq!(output.status.code(), Some(1));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr
+                .contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
+            "{bootstrap_env} stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("are required with"),
+            "{bootstrap_env} stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains("missing-capability"),
+            "{bootstrap_env} stderr exposed endpoint material"
+        );
+    }
     Ok(())
 }
 
@@ -66,6 +81,7 @@ async fn workload_capability_is_received_over_scm_rights_and_validated()
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
     command
+        .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
         .env(
             process_control_ipc::BOOTSTRAP_ENV,
             "process-control-present",
@@ -153,7 +169,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child_isolated()
         common::setup_env(
             &mock,
             tmp.path(),
-            r#"if [ -n "${VM0_PROCESS_CONTROL_ENDPOINT:-}" ]; then echo "process control endpoint leaked" >&2; exit 42; fi"#,
+            r#"if [ -n "${VM0_PROCESS_CONTROL_ENDPOINT:-}" ] || [ -n "${OKOU_PROCESS_CONTROL_ENDPOINT:-}" ]; then echo "process control endpoint leaked" >&2; exit 42; fi"#,
             3,
             1,
         )?;
@@ -163,7 +179,11 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child_isolated()
     unsafe {
         std::env::set_var(
             process_control_ipc::BOOTSTRAP_ENV,
-            "stale-process-control-endpoint",
+            "stale-legacy-process-control-endpoint",
+        );
+        std::env::set_var(
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            "stale-canonical-process-control-endpoint",
         );
     }
 
@@ -181,8 +201,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child_isolated()
     assert_eq!(
         result.exit_code,
         common::CLEAN_EXIT,
-        "CLI child inherited {}",
-        process_control_ipc::BOOTSTRAP_ENV
+        "CLI child inherited a process-control endpoint alias"
     );
     Ok(())
 }

--- a/crates/guest-agent/tests/process_control_env_aliases.rs
+++ b/crates/guest-agent/tests/process_control_env_aliases.rs
@@ -1,0 +1,323 @@
+//! Process-control aliases are resolved once at the guest startup boundary.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Path, PathBuf};
+
+use guest_agent::run_context::GuestRuntime;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CANONICAL_ENDPOINT: &str = "canonical-endpoint-must-not-leak";
+const LEGACY_ENDPOINT: &str = "legacy-endpoint-must-not-leak";
+const SHARED_ENDPOINT: &str = "shared-endpoint-must-not-leak";
+const ENDPOINT_VALUES: [&str; 3] = [CANONICAL_ENDPOINT, LEGACY_ENDPOINT, SHARED_ENDPOINT];
+const SOURCE_EVENT: &str = "process_control_env_source";
+
+#[derive(Clone, Copy)]
+enum AliasInput {
+    Absent,
+    Readable(&'static str),
+    NonUnicode,
+}
+
+#[derive(Clone, Copy)]
+struct SuccessCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_endpoint: Option<&'static str>,
+    expected_source: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct InvalidEncodingCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_key: &'static str,
+}
+
+const SUCCESS_CASES: [SuccessCase; 9] = [
+    SuccessCase {
+        name: "absent",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Absent,
+        expected_endpoint: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Absent,
+        expected_endpoint: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "legacy-empty",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(""),
+        expected_endpoint: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "dual-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(""),
+        expected_endpoint: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-only",
+        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
+        legacy: AliasInput::Absent,
+        expected_endpoint: Some(CANONICAL_ENDPOINT),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
+        expected_endpoint: Some(LEGACY_ENDPOINT),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual",
+        canonical: AliasInput::Readable(SHARED_ENDPOINT),
+        legacy: AliasInput::Readable(SHARED_ENDPOINT),
+        expected_endpoint: Some(SHARED_ENDPOINT),
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-empty-with-legacy",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
+        expected_endpoint: Some(LEGACY_ENDPOINT),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "canonical-with-legacy-empty",
+        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
+        legacy: AliasInput::Readable(""),
+        expected_endpoint: Some(CANONICAL_ENDPOINT),
+        expected_source: Some("canonical-only"),
+    },
+];
+
+const INVALID_ENCODING_CASES: [InvalidEncodingCase; 4] = [
+    InvalidEncodingCase {
+        name: "canonical-non-unicode",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Absent,
+        expected_key: process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    },
+    InvalidEncodingCase {
+        name: "legacy-non-unicode",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::NonUnicode,
+        expected_key: process_control_ipc::BOOTSTRAP_ENV,
+    },
+    InvalidEncodingCase {
+        name: "canonical-with-non-unicode-legacy",
+        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
+        legacy: AliasInput::NonUnicode,
+        expected_key: process_control_ipc::BOOTSTRAP_ENV,
+    },
+    InvalidEncodingCase {
+        name: "non-unicode-canonical-with-legacy",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
+        expected_key: process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    },
+];
+
+fn set_test_env(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test starts no threads while configuring or capturing process env.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env(key: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test starts no threads while configuring or capturing process env.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+fn apply_alias(key: &str, input: AliasInput) {
+    remove_test_env(key);
+    match input {
+        AliasInput::Absent => {}
+        AliasInput::Readable(value) => set_test_env(key, value),
+        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+    }
+}
+
+fn configure_case(
+    root: &Path,
+    name: &str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+) -> Result<PathBuf, String> {
+    let runtime_dir = root.join(format!("{name}-runtime"));
+    guest_common::log::clear_system_log_file();
+    guest_common::telemetry::clear_sandbox_ops_log_file();
+    // SAFETY: the integration binary contains one test and has not started
+    // threads while configuring the next startup snapshot.
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::set_var(
+            guest_contracts::env::RUN_ID_ENV,
+            format!("process-control-alias-{name}"),
+        );
+        std::env::set_var("HOME", root.join(format!("{name}-home")));
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        );
+        std::env::set_var("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true");
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload::default(),
+        )?;
+    }
+    apply_alias(process_control_ipc::CANONICAL_BOOTSTRAP_ENV, canonical);
+    apply_alias(process_control_ipc::BOOTSTRAP_ENV, legacy);
+    Ok(runtime_dir)
+}
+
+fn read_system_log(runtime_dir: &Path) -> std::io::Result<String> {
+    let path = guest_contracts::runtime_paths::system_log_file(runtime_dir);
+    match std::fs::read_to_string(path) {
+        Ok(log) => Ok(log),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error),
+    }
+}
+
+fn assert_value_free(text: &str, context: &str) {
+    for endpoint in ENDPOINT_VALUES {
+        assert!(
+            !text.contains(endpoint),
+            "{context} exposed process-control endpoint material"
+        );
+    }
+}
+
+fn assert_source_evidence(log: &str, case: SuccessCase) {
+    assert_value_free(log, case.name);
+    let source_lines = log
+        .lines()
+        .filter(|line| line.contains(SOURCE_EVENT))
+        .collect::<Vec<_>>();
+    match case.expected_source {
+        Some(source) => {
+            let expected = format!(
+                "{SOURCE_EVENT} key={} source={source}",
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV
+            );
+            assert!(
+                source_lines.len() == 1
+                    && source_lines
+                        .first()
+                        .and_then(|line| line.rsplit_once("] "))
+                        .is_some_and(|(_, message)| message == expected),
+                "{} emitted incorrect fixed source evidence",
+                case.name
+            );
+        }
+        None => assert!(
+            source_lines.is_empty(),
+            "{} emitted source evidence without an endpoint",
+            case.name
+        ),
+    }
+}
+
+fn expected_conflict_error() -> String {
+    format!(
+        "conflicting process control environment aliases: canonical_key={} legacy_key={} state=conflict",
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+        process_control_ipc::BOOTSTRAP_ENV
+    )
+}
+
+#[test]
+fn startup_dual_reads_process_control_aliases_without_value_leaks() -> TestResult {
+    assert_eq!(
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+        "OKOU_PROCESS_CONTROL_ENDPOINT"
+    );
+    assert_eq!(
+        process_control_ipc::BOOTSTRAP_ENV,
+        "VM0_PROCESS_CONTROL_ENDPOINT"
+    );
+    let tmp = tempfile::tempdir()?;
+
+    for case in SUCCESS_CASES {
+        let runtime_dir = configure_case(tmp.path(), case.name, case.canonical, case.legacy)?;
+        let runtime = GuestRuntime::from_process_env().map_err(std::io::Error::other)?;
+        assert_eq!(
+            runtime.process_control_endpoint.as_deref(),
+            case.expected_endpoint,
+            "{} resolved the wrong endpoint",
+            case.name
+        );
+        assert!(
+            runtime.workload_containment.is_none(),
+            "{} unexpectedly initialized workload containment",
+            case.name
+        );
+        assert_source_evidence(&read_system_log(&runtime_dir)?, case);
+    }
+
+    configure_case(
+        tmp.path(),
+        "conflict",
+        AliasInput::Readable(CANONICAL_ENDPOINT),
+        AliasInput::Readable(LEGACY_ENDPOINT),
+    )?;
+    set_test_env(
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        OsString::from_vec(vec![0xff]),
+    );
+    set_test_env(
+        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+        "must-not-be-consumed",
+    );
+    let conflict_error = match GuestRuntime::from_process_env() {
+        Ok(_) => return Err("conflicting process-control aliases were accepted".into()),
+        Err(error) => error,
+    };
+    assert_eq!(conflict_error, expected_conflict_error());
+    assert_value_free(&conflict_error, "conflict");
+    assert!(
+        std::env::var_os(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
+            .is_some(),
+        "conflict reached workload-containment initialization"
+    );
+
+    for case in INVALID_ENCODING_CASES {
+        configure_case(tmp.path(), case.name, case.canonical, case.legacy)?;
+        let error = match GuestRuntime::from_process_env() {
+            Ok(_) => return Err(format!("{} accepted a non-Unicode alias", case.name).into()),
+            Err(error) => error,
+        };
+        assert_eq!(error, format!("{} must be valid UTF-8", case.expected_key));
+        assert_value_free(&error, case.name);
+    }
+
+    // SAFETY: the single test has not started threads and is finished reading
+    // the process environment.
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+    }
+    Ok(())
+}

--- a/crates/guest-agent/tests/zero_web_search_policy.rs
+++ b/crates/guest-agent/tests/zero_web_search_policy.rs
@@ -113,6 +113,7 @@ fn build_runtime(
         paths,
         http,
         workload_containment: None,
+        process_control_endpoint: None,
     })
 }
 

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -9,11 +9,12 @@
 //! descriptors move with `SCM_RIGHTS` and are never inherited through the
 //! sandbox-user launch chain.
 //!
-//! The endpoint is bootstrapped through [`BOOTSTRAP_ENV`]. `vsock-guest`
-//! creates the endpoint name with [`endpoint_name`], binds it with
+//! The endpoint is bootstrapped through [`BOOTSTRAP_ENV`] or its reader-only
+//! canonical alias [`CANONICAL_BOOTSTRAP_ENV`]. `vsock-guest` creates the
+//! endpoint name with [`endpoint_name`], binds it with
 //! [`bind_abstract_listener`], accepts a single control sink connection, and
-//! then drives request/response exchange. `guest-agent` reads the endpoint name
-//! from the environment, connects with [`connect_abstract`], sends a hello
+//! then drives request/response exchange. `guest-agent` resolves the endpoint
+//! name from the environment, connects with [`connect_abstract`], sends a hello
 //! frame, then reads requests and writes responses.
 //!
 //! Two companion placement endpoints are derived from the same operation-local
@@ -88,6 +89,13 @@ pub use transport::{
 /// reads it during startup and connects to that abstract socket. Child agent
 /// CLI processes must not inherit this variable.
 pub const BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
+
+/// Canonical operation-control endpoint alias accepted by guest readers.
+///
+/// `vsock-guest` keeps writing [`BOOTSTRAP_ENV`] until the deployed reader
+/// floor, sandbox drain, rollback window, and legacy-read-zero gates in #28914
+/// are complete.
+pub const CANONICAL_BOOTSTRAP_ENV: &str = "OKOU_PROCESS_CONTROL_ENDPOINT";
 
 /// Maximum request payload size carried by a local control request frame.
 ///

--- a/crates/vsock-guest/tests/connection/exec_control.rs
+++ b/crates/vsock-guest/tests/connection/exec_control.rs
@@ -114,7 +114,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
     let control_nonce = unique_exec_control_nonce(u64::from(target_seq));
     let endpoint = process_control_ipc::endpoint_name(target_seq, &control_nonce);
     let command = format!(
-        "printf '%s' \"$$\" > '{}'; printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60",
+        "printf '%s' \"$$\" > '{}'; if [ \"${{OKOU_PROCESS_CONTROL_ENDPOINT+x}}\" = x ]; then exit 42; fi; printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60",
         pid_path.as_str()
     );
     let (handle, mut host_stream) = start_guest_connection();


### PR DESCRIPTION
## Summary

- add reader-only `OKOU_PROCESS_CONTROL_ENDPOINT` support beside the existing `VM0_PROCESS_CONTROL_ENDPOINT` bootstrap contract
- resolve the two aliases exactly once before workload-containment initialization, then pass the same owned result to containment, active-input enablement, and `ControlHandle`
- fail closed on unequal non-empty dual values, preserve empty-as-absent and non-Unicode startup-error semantics, and emit one bounded value-free source event for successful endpoint resolution
- keep the production `vsock-guest` writer legacy-only and keep both bootstrap aliases out of managed CLI environments

## Scope

This is the reader-only Stage 1 change from #29066 and parent #28914. It does not perform writer cutover, release, runner promotion, sandbox drain, legacy-reader removal, cgroup-endpoint migration, wire-protocol changes, socket-lifecycle changes, active-input behavior changes, or any work from #25722.

Implementation base: `bbb60c70fb46dcc1ca6a15694de0770edba98c95`

## Acceptance criteria

- [x] `process-control-ipc` defines `OKOU_PROCESS_CONTROL_ENDPOINT` as the canonical reader alias while `BOOTSTRAP_ENV` remains exactly `VM0_PROCESS_CONTROL_ENDPOINT`
- [x] absent, empty, legacy-only, canonical-only, equal-dual, and one-empty/one-non-empty states resolve deterministically; unequal non-empty dual values fail closed
- [x] non-Unicode input remains a startup error at the early runtime boundary, including mixed valid/non-Unicode dual states
- [x] `WorkloadContainment::from_process_env`, the guest-agent active-input predicate, and `ControlHandle::spawn` consume the same once-resolved endpoint result
- [x] alias conflict is rejected before workload-containment initialization and before async/control workers start
- [x] source evidence uses only fixed key/source labels (`canonical-only`, `legacy-only`, `dual`), is emitted at most once for a successful endpoint-bearing startup, and never includes endpoint material
- [x] conflict, invalid-encoding, and missing-capability diagnostics never include endpoint values
- [x] both bootstrap aliases remain absent from managed CLI child environments
- [x] the `vsock-guest` production writer remains legacy-only, with a regression that rejects accidental canonical emission
- [x] the two cgroup endpoint contracts, other `VM0_*` keys, wire protocol, socket lifecycle, and active-input semantics are unchanged

## Safety evidence

- the only production environment read is the centralized resolver in `guest-agent/src/run_context.rs`
- the only production process-control bootstrap write remains `env_with_control.push((process_control_ipc::BOOTSTRAP_ENV, endpoint))` in `vsock-guest/src/exec_operation.rs`
- canonical-only process startup reaches the real vsock control sink and active-input path
- the state matrix verifies endpoint ownership, fixed source evidence, empty handling, fail-closed conflict ordering, non-Unicode errors, and value non-disclosure
- the latest scan of 21 open PRs found no file overlap; #29069 briefly overlapped two cleanup-list files, then merged and is included in this branch's base without bringing its resume-session scope into this diff

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p process-control-ipc -p guest-agent -p vsock-guest --tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p process-control-ipc -p guest-agent -p vsock-guest --all-targets --all-features --no-deps -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p process-control-ipc -p guest-agent -p vsock-guest --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_channel process_control_channel_reaches_guest_agent`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection supervised_exec_control_forwards_to_bootstrap_sink`
- `git diff --check origin/main...HEAD`

The full repository suite is left to the PR pipeline as required by the implementation contract.

## Fallbacks

- `guest-agent/src/run_context.rs:process_control_endpoint_from_process_env` — temporarily accepts both aliases so legacy-only runners and reusable sandboxes can start the new guest, while a later canonical writer can roll back safely to this reader floor. Surface: existing runner/sandbox, with the two-hour guest runtime budget plus bounded finalization and the explicit drain evidence below. Remove only after the #28914 reader-floor, drain, rollback-window, and zero-legacy-read gates pass; the writer-cutover and legacy-reader-removal follow-ups remain tracked by #28914. The production writer remains legacy-only in this PR.

Do not remove the legacy reader until #28914 records all of the following:

- the exact deployed runner artifact, embedded guest SHA, and rootfs reader identities have reached the dual-read floor; semver alone is insufficient
- the runner/sandbox drain succeeds, status shows no `active_runs` or `idle_vms`, the old service is inactive and cannot admit work, and no fresh heartbeat appears after the five-minute stale boundary
- zero old identities remain stable for two additional 10-second heartbeat intervals
- the supported rollback window closes
- value-free source evidence shows zero legacy-only reads for the required observation window

Closes #29066
Parent: #28914
