### PR TITLE
refactor(runner): remove legacy idle status mirror

### DIFF
--- a/.github/scripts/tests/vm0-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-runner-status-collect-test.sh
@@ -143,10 +143,6 @@ test_aggregates_current_legacy_and_future_statuses() {
   "idle_sandboxes": [
     {"sandbox_id": "$uuid_a", "reuse_key": "overlap"},
     {"sandbox_id": "$uuid_d", "reuse_key": "idle"}
-  ],
-  "idle_vms": [
-    {"sandbox_id": "$uuid_a", "reuse_key": "overlap"},
-    {"sandbox_id": "$uuid_d", "reuse_key": "idle"}
   ]
 }
 EOF

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -62,29 +62,13 @@ pub struct IdleSandbox {
     pub sandbox_id: SandboxId,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct RunnerStatus {
     mode: RunnerMode,
     max_concurrent: usize,
     active_runs: Vec<ActiveRun>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     idle_sandboxes: Vec<IdleSandbox>,
-    proxy_port: Option<u16>,
-    dns_port: Option<u16>,
-    started_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-#[derive(Serialize)]
-struct RunnerStatusWire<'a> {
-    mode: RunnerMode,
-    max_concurrent: usize,
-    active_runs: &'a [ActiveRun],
-    #[serde(skip_serializing_if = "borrowed_slice_is_empty")]
-    idle_sandboxes: &'a [IdleSandbox],
-    // Compatibility for previous runner tools during rollout. Remove after
-    // the collector and rollback gates recorded in #28926 are satisfied.
-    #[serde(rename = "idle_vms", skip_serializing_if = "borrowed_slice_is_empty")]
-    legacy_idle_sandboxes: &'a [IdleSandbox],
     #[serde(skip_serializing_if = "Option::is_none")]
     proxy_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,22 +77,6 @@ struct RunnerStatusWire<'a> {
     started_at: DateTime<Utc>,
     #[serde(serialize_with = "serialize_iso")]
     updated_at: DateTime<Utc>,
-}
-
-impl RunnerStatus {
-    fn wire(&self) -> RunnerStatusWire<'_> {
-        RunnerStatusWire {
-            mode: self.mode,
-            max_concurrent: self.max_concurrent,
-            active_runs: &self.active_runs,
-            idle_sandboxes: &self.idle_sandboxes,
-            legacy_idle_sandboxes: &self.idle_sandboxes,
-            proxy_port: self.proxy_port,
-            dns_port: self.dns_port,
-            started_at: self.started_at,
-            updated_at: self.updated_at,
-        }
-    }
 }
 
 struct StatusSnapshot {
@@ -130,10 +98,6 @@ struct StatusWriteGate {
 /// Serialize as ISO 8601 with millisecond precision, matching JS `Date.toISOString()`.
 fn serialize_iso<S: serde::Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
     s.serialize_str(&dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
-}
-
-fn borrowed_slice_is_empty<T>(value: &&[T]) -> bool {
-    value.is_empty()
 }
 
 /// Thread-safe status tracker that persists state to a JSON file atomically.
@@ -444,7 +408,7 @@ impl StatusTracker {
 
     /// Publish an owned snapshot through same-directory atomic replacement.
     async fn persist_snapshot(&self, snapshot: StatusSnapshot) {
-        let json = match serde_json::to_string_pretty(&snapshot.status.wire()) {
+        let json = match serde_json::to_string_pretty(&snapshot.status) {
             Ok(j) => j,
             Err(e) => {
                 warn!(error = %e, "failed to serialize status");
@@ -897,7 +861,7 @@ mod tests {
         );
 
         let status = read_status(&path);
-        assert_eq!(status["idle_sandboxes"], status["idle_vms"]);
+        assert!(status.get("idle_vms").is_none());
         let sandboxes = status["idle_sandboxes"].as_array().unwrap();
         assert_eq!(sandboxes.len(), 2);
         assert_eq!(sandboxes[0]["reuse_key"], "sess-1");
@@ -1093,10 +1057,6 @@ mod tests {
         assert!(
             status.get("idle_sandboxes").is_none(),
             "empty idle_sandboxes should be omitted from JSON"
-        );
-        assert!(
-            status.get("idle_vms").is_none(),
-            "empty legacy idle_vms should be omitted from JSON"
         );
     }
 }

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -167,6 +167,12 @@ status writer, and the independently deployed host monitoring collector scans
 every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
+Current status writers publish `idle_sandboxes` only and omit the field when
+the collection is empty. Current maintenance readers and the host monitoring
+collector prefer `idle_sandboxes` by key presence and fall back to `idle_vms`
+only for retained legacy status files. They never concatenate both fields.
+`idle_vms` is read-only historical compatibility, not a current writer field.
+
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and
 registry at startup, and keeps them in its version-specific base directory.


### PR DESCRIPTION
## Summary

- stop mirroring `idle_sandboxes` into the deprecated `idle_vms` runner status field
- serialize `RunnerStatus` directly while preserving legacy-only reader fallback in the runner and host collector
- update the collector fixture and deployment compatibility documentation for the canonical-only writer contract

## Compatibility

- The canonical writer was deployed in runner `0.171.9` and `0.171.10`; the `0.171.10` release and prod-3/prod-4/prod-11 collector provisioning completed successfully in [the release workflow](https://github.com/vm0-ai/vm0/actions/runs/32735737965).
- Immediate rollback to `0.171.9` remains compatible with canonical-only status files.
- Readers still prefer `idle_sandboxes` by key presence and fall back to `idle_vms` for retained historical files. This PR intentionally does not remove that read compatibility.

## Testing

- `cargo test -p runner status::tests`
- `cargo test -p runner status_file::tests`
- `.github/scripts/tests/vm0-runner-status-collect-test.sh`
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps`
- `pnpm prettier --check --ignore-unknown ../docs/deployment-compatibility.md ../.github/scripts/tests/vm0-runner-status-collect-test.sh`
- `shellcheck .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `scripts/check-file-size.sh` for all changed files

`cargo test -p runner` completed with 3,284 passed, 21 ignored, and one unrelated local non-root failure in `proxy::process::tests::initial_start_retries_an_occupied_selected_port`. The retry reaches the fake mitmdump fixture, but its `/proc/$$/environ` copy is read-only and cannot be overwritten; both affected status test suites and the collector integration test pass.

Closes #28926

Parent: #28900
