### PR TITLE
test(runner): rename local-submit child environment keys

### DIFF
--- a/crates/runner/src/cmd/local/submit/tests/interrupt.rs
+++ b/crates/runner/src/cmd/local/submit/tests/interrupt.rs
@@ -11,7 +11,7 @@ use crate::test_fixtures::ignored_child::{
     ignored_child_test_env_guard_enabled, run_ignored_child_test,
 };
 
-const INTERRUPT_CHILD_ENV: &str = "VM0_RUNNER_LOCAL_SUBMIT_INTERRUPT_TEST";
+const INTERRUPT_CHILD_ENV: &str = "OKOU_RUNNER_LOCAL_SUBMIT_INTERRUPT_TEST";
 const INTERRUPT_CHILD_VALUE: &str = "after-job-publication";
 const INTERRUPT_CHILD_TEST: &str =
     "cmd::local::submit::tests::interrupt::sigint_after_job_publication_uses_cancel_cleanup_child";

--- a/crates/runner/src/cmd/local/submit/tests/timezone.rs
+++ b/crates/runner/src/cmd/local/submit/tests/timezone.rs
@@ -6,8 +6,8 @@ use crate::test_fixtures::ignored_child::{
     ignored_child_test_env_guard_enabled, run_ignored_child_test,
 };
 
-const TIMEZONE_CHILD_SCENARIO: &str = "VM0_RUNNER_TIMEZONE_TEST_SCENARIO";
-const TIMEZONE_CHILD_FILE: &str = "VM0_RUNNER_TIMEZONE_TEST_FILE";
+const TIMEZONE_CHILD_SCENARIO: &str = "OKOU_RUNNER_TIMEZONE_TEST_SCENARIO";
+const TIMEZONE_CHILD_FILE: &str = "OKOU_RUNNER_TIMEZONE_TEST_FILE";
 const TIMEZONE_CHILD_TEST: &str =
     "cmd::local::submit::tests::timezone::detect_system_timezone_child";
 const TIMEZONE_FROM_ENV_SCENARIO: &str = "from-env";


### PR DESCRIPTION
## Summary

- atomically rename the three private local-submit child-process environment keys from `VM0_*` to `OKOU_*`
- keep each parent producer, child reader, checkpoint, and ignored-child guard on the same existing constant
- preserve the standard `TZ` input and all local-submit, SIGINT, cleanup, timezone, timeout, path, and test behavior

## Acceptance criteria

1. **Producer and consumer synchronization:** the interrupt parent, post-publication checkpoint, and child guard share `OKOU_RUNNER_LOCAL_SUBMIT_INTERRUPT_TEST`; the timezone parent and child share both canonical scenario and file keys.
2. **Legacy spellings removed:** a repository-wide search returns zero occurrences for all three selected `VM0_*` names.
3. **Interrupt behavior preserved:** the scenario value, checkpoint placement, SIGINT path, cancelled-job cleanup, and ignored-child guard are unchanged.
4. **Timezone behavior preserved:** all five scenarios, temporary-file contents and paths, assertions, and the separate standard `TZ` input are unchanged.
5. **Focused file scope:** only `interrupt.rs` and `timezone.rs` change.
6. **Verification:** Rust formatting, runner tests-target Clippy, and runner tests-target check pass locally. Both focused local-submit test filters were attempted with one build job and test debuginfo disabled, but the 3.8 GiB no-swap host terminated the shared runner test-binary link with exit 137; PR CI is authoritative for execution.
7. **String-only diff:** the final diff is exactly three one-to-one environment-key string replacements with no other behavior change.

## Verification

- `cargo +1.96.0 fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo +1.96.0 clippy --manifest-path crates/Cargo.toml -p runner --tests --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo +1.96.0 check --manifest-path crates/Cargo.toml -p runner --tests --all-features`
- attempted: `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.96.0 test --manifest-path crates/Cargo.toml -p runner 'cmd::local::submit::tests::interrupt::' -- --test-threads=1` (runner test-binary link terminated with exit 137)
- attempted: `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.96.0 test --manifest-path crates/Cargo.toml -p runner 'cmd::local::submit::tests::timezone::' -- --test-threads=1` (runner test-binary link terminated with exit 137)
- final whitelist audit: only the three selected literals change, all legacy spellings are absent, all canonical spellings are present, `TZ` has no changed line, and the current open-PR overlap is empty

Closes #29075

Parent EPIC: #28914
