### PR TITLE
test(guest-agent): rename process-containment fixture environment keys

### DIFF
--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -70,9 +70,9 @@ const MEMORY_OOM_GROUP_FILE: &str = "memory.oom.group";
 const PIDS_MAX_FILE: &str = "pids.max";
 const CODEX_AUTH_FILENAME: &str = "auth.json";
 #[cfg(debug_assertions)]
-const TEST_CONTAINMENT_ROOT_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_ROOT";
+const TEST_CONTAINMENT_ROOT_ENV: &str = "OKOU_TEST_PROCESS_CONTAINMENT_ROOT";
 #[cfg(debug_assertions)]
-const TEST_CONTAINMENT_CURRENT_GROUP_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP";
+const TEST_CONTAINMENT_CURRENT_GROUP_ENV: &str = "OKOU_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV: &str = "VM0_TEST_CODEX_HOME_DIR";
 const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -857,8 +857,8 @@ fn run_helper_with_current_group_and_codex_home(
 ) -> Result<Output, Box<dyn std::error::Error>> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
         .env_clear()
-        .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
-        .env("VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP", current_group)
+        .env("OKOU_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
+        .env("OKOU_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP", current_group)
         .env("VM0_TEST_CODEX_HOME_DIR", codex_home)
         .arg("prepare-for-reuse")
         .stdin(Stdio::piped())
@@ -882,9 +882,9 @@ fn run_helper_with_bind_mount(
     let home = tempfile::tempdir()?;
     let mut child = Command::new("/usr/bin/unshare")
         .env_clear()
-        .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
+        .env("OKOU_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
         .env(
-            "VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP",
+            "OKOU_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP",
             "/vm0-exec/exec-current/workload",
         )
         .env("VM0_TEST_CODEX_HOME_DIR", home.path().join(".codex"))


### PR DESCRIPTION
## Summary

- Atomically rename the two private Guest Agent process-containment fixture environment keys from `VM0_*` to `OKOU_*`.
- Update both `#[cfg(debug_assertions)]` reader constants and all four subprocess writers across the direct Guest Agent and `/usr/bin/unshare` helper paths.
- Preserve optional `var_os` behavior, non-Unicode path handling, cgroup validation, fixture paths, bind mounts, and all reuse-preparation behavior.

## Verification

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy -p guest-agent --all-targets --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 cargo check -p guest-agent --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-agent --test reuse_preparation_helper` (31 passed)
- Repository-wide fixed-string search: zero occurrences of `VM0_TEST_PROCESS_CONTAINMENT_ROOT` and `VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP`.

The complete diff is limited to six one-to-one environment-key string replacements in the two contracted Guest Agent files.

Closes #29080
Refs #28914