### PR TITLE
test(desktop): rename packaged smoke-test child environment key

### DIFF
--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -88,7 +88,7 @@ console.log(
 );
 
 const child = spawn(executablePath, [], {
-  env: { ...process.env, VM0_DESKTOP_SMOKE_TEST: "1" },
+  env: { ...process.env, OKOU_DESKTOP_SMOKE_TEST: "1" },
   stdio: ["ignore", "pipe", "pipe"],
 });
 

--- a/turbo/apps/desktop/src/desktop-smoke-test.test.ts
+++ b/turbo/apps/desktop/src/desktop-smoke-test.test.ts
@@ -4,13 +4,13 @@ import { isDesktopSmokeTestEnabled } from "./desktop-smoke-test";
 
 describe("isDesktopSmokeTestEnabled", () => {
   it("enables smoke test mode only when the flag is exactly 1", () => {
-    expect(isDesktopSmokeTestEnabled({ VM0_DESKTOP_SMOKE_TEST: "1" })).toBe(
+    expect(isDesktopSmokeTestEnabled({ OKOU_DESKTOP_SMOKE_TEST: "1" })).toBe(
       true,
     );
-    expect(isDesktopSmokeTestEnabled({ VM0_DESKTOP_SMOKE_TEST: "true" })).toBe(
+    expect(isDesktopSmokeTestEnabled({ OKOU_DESKTOP_SMOKE_TEST: "true" })).toBe(
       false,
     );
-    expect(isDesktopSmokeTestEnabled({ VM0_DESKTOP_SMOKE_TEST: "" })).toBe(
+    expect(isDesktopSmokeTestEnabled({ OKOU_DESKTOP_SMOKE_TEST: "" })).toBe(
       false,
     );
     expect(isDesktopSmokeTestEnabled({})).toBe(false);

--- a/turbo/apps/desktop/src/desktop-smoke-test.ts
+++ b/turbo/apps/desktop/src/desktop-smoke-test.ts
@@ -1,4 +1,4 @@
-const DESKTOP_SMOKE_TEST_ENV = "VM0_DESKTOP_SMOKE_TEST";
+const DESKTOP_SMOKE_TEST_ENV = "OKOU_DESKTOP_SMOKE_TEST";
 
 export const DESKTOP_SMOKE_TEST_READY_MARKER =
   "[smoke-test] desktop main ready";


### PR DESCRIPTION
## Summary

- atomically rename the packaged Desktop smoke-test child-process environment key from `VM0_DESKTOP_SMOKE_TEST` to `OKOU_DESKTOP_SMOKE_TEST`
- update the parent spawn writer, packaged-process helper constant, and focused test fixtures in the same commit
- preserve exact `"1"` enablement semantics, inherited environment handling, zero-migration suppression, packaged smoke verification, and exit behavior
- leave `main.ts` and every other Desktop environment contract unchanged

## Acceptance criteria

- the packaged smoke harness writes only `OKOU_DESKTOP_SMOKE_TEST=1`
- the helper reads only `OKOU_DESKTOP_SMOKE_TEST`, with true/false/empty/missing coverage preserved
- the repository contains no remaining `VM0_DESKTOP_SMOKE_TEST` occurrence
- the complete diff is limited to the three issue-approved files and contains only five one-to-one string replacements

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-smoke-test.test.ts`
- final whitelist audit: 3 changed files, 5 canonical occurrences, 0 legacy occurrences, 0 `main.ts` diff, and 0 overlap across the current first 100 open PRs

Closes #29078

Parent EPIC: #28914
