### PR TITLE
test(runner): isolate dry-run workspace gc from host discovery

### DIFF
--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -420,7 +420,16 @@ async fn gc_workspace_orphans_dry_run_preserves() {
         .set_times(FileTimes::new().set_modified(old_time))
         .unwrap();
 
-    let summary = gc_workspace_orphans(&home, true).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        true,
+    )
+    .await
+    .unwrap();
 
     assert!(workspace.exists(), "dry-run should NOT delete");
     assert!(


### PR DESCRIPTION
## Summary

- isolate the workspace GC dry-run scenario from live host process discovery
- keep real lock candidate discovery, flock ownership, filesystem traversal, age gating, accounting, and preservation behavior under test
- preserve production fail-closed cleanup behavior unchanged

## Problem

`gc_workspace_orphans_dry_run_preserves` called the top-level workspace GC entry point even though the scenario only verifies dry-run accounting and preservation. The entry point intentionally returns an empty summary when live process discovery is uncertain, so concurrent CI process churn could make the expected workspace count intermittently report zero.

The scenario now calls the existing candidate-processing seam with explicit complete discovery state. Its temporary workspace and lock still go through the real production candidate, locking, parsing, filesystem, age, size, and dry-run paths.

## Exclusions

- no production runner behavior changes
- no retries, sleeps, timeouts, skipped tests, or weakened assertions
- no API, protocol, persisted state, migration, or deployment compatibility changes

## Validation

- `cargo fmt --all --check`
- exact dry-run scenario: 50 consecutive passing runs
- `cargo test -p runner --bin runner --all-features cmd::gc::workspaces::tests::` (33 passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- pre-commit hooks: workspace Cargo formatting, Clippy, documentation, file-size check, and commitlint
- full runner binary attempt: target scenario passed; 3,284 tests passed and one unrelated local non-root proxy fixture failed because its retry cannot overwrite a read-only `/proc/.../environ` copy

Closes #29085
