### PR TITLE
refactor(desktop): rename native helper sentry environment keys

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -107,15 +107,15 @@ func nonEmptyEnvironmentValue(_ key: String) -> String? {
 }
 
 func startSentry() {
-    guard let dsn = nonEmptyEnvironmentValue("VM0_DESKTOP_SENTRY_DSN")
+    guard let dsn = nonEmptyEnvironmentValue("OKOU_DESKTOP_SENTRY_DSN")
         ?? nonEmptyEnvironmentValue("SENTRY_DSN_DESKTOP")
     else {
         return
     }
 
-    let releaseName = nonEmptyEnvironmentValue("VM0_DESKTOP_SENTRY_RELEASE")
+    let releaseName = nonEmptyEnvironmentValue("OKOU_DESKTOP_SENTRY_RELEASE")
     let environment =
-        nonEmptyEnvironmentValue("VM0_DESKTOP_SENTRY_ENVIRONMENT") ?? "production"
+        nonEmptyEnvironmentValue("OKOU_DESKTOP_SENTRY_ENVIRONMENT") ?? "production"
 
     SentrySDK.start { options in
         options.dsn = dsn

--- a/turbo/apps/desktop/src/sentry-main.ts
+++ b/turbo/apps/desktop/src/sentry-main.ts
@@ -11,9 +11,9 @@ const sentryEnvironment =
   process.env.SENTRY_ENVIRONMENT ?? __DESKTOP_SENTRY_ENVIRONMENT__;
 
 if (sentryDsn) {
-  process.env.VM0_DESKTOP_SENTRY_DSN = sentryDsn;
-  process.env.VM0_DESKTOP_SENTRY_RELEASE = sentryRelease;
-  process.env.VM0_DESKTOP_SENTRY_ENVIRONMENT = sentryEnvironment;
+  process.env.OKOU_DESKTOP_SENTRY_DSN = sentryDsn;
+  process.env.OKOU_DESKTOP_SENTRY_RELEASE = sentryRelease;
+  process.env.OKOU_DESKTOP_SENTRY_ENVIRONMENT = sentryEnvironment;
 
   Sentry.init({
     dsn: sentryDsn,


### PR DESCRIPTION
## Summary

- Atomically rename the private Electron-to-native-helper Sentry handshake from `VM0_DESKTOP_SENTRY_*` to `OKOU_DESKTOP_SENTRY_*` in its sole producer and consumer.
- Preserve `SENTRY_DSN_DESKTOP`, `SENTRY_ENVIRONMENT`, the helper DSN fallback, trimming, defaults, release value, Sentry configuration, error capture, child spawning, and packaging.
- Leave `src/main.ts`, unrelated Desktop environment keys, releases, and production state unchanged.

## Freshness and overlap gate

- Refreshed from `origin/main` immediately before implementation at `25bffa6b84524c2455394221b260b53383a212f2`.
- Before editing, each legacy spelling had exactly two repository matches: one producer in `turbo/apps/desktop/src/sentry-main.ts` and one consumer in `turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift`; every canonical spelling had zero matches.
- Fully paginated all 21 open PRs after the refreshed `main` snapshot. None changed either scoped production file or contained a selected Sentry key in its available patch. The only remaining Desktop-file overlap was release PR #29070, limited to the Desktop version and changelog metadata.

## Exact post-change search evidence

- `VM0_DESKTOP_SENTRY_(DSN|RELEASE|ENVIRONMENT)`: 0 repository matches.
- `OKOU_DESKTOP_SENTRY_DSN`: 2 matches total, exactly 1 Electron producer and 1 Swift consumer.
- `OKOU_DESKTOP_SENTRY_RELEASE`: 2 matches total, exactly 1 Electron producer and 1 Swift consumer.
- `OKOU_DESKTOP_SENTRY_ENVIRONMENT`: 2 matches total, exactly 1 Electron producer and 1 Swift consumer.
- The changed-file set is exactly the two scoped production files; `git diff --check` passes.

## Same-artifact evidence

- `turbo/apps/desktop/package.json` runs `build:native` and `build:electron` in the same Desktop build from one repository checkout.
- `turbo/apps/desktop/scripts/build-native-helper.js` builds the checked-out Swift package and copies the executable to `native/dist/native/computer-use-helper`.
- `turbo/apps/desktop/forge.config.js` packages that directory through `extraResource` alongside the Electron application bundle.
- `.github/workflows/desktop.yml` verifies both `Contents/Resources/app/dist/main.js` and `Contents/Resources/native/computer-use-helper` in the same packaged application and zip artifact.
- Both one-shot and persistent helper `spawn` calls still omit an explicit `env`, preserving parent-process environment inheritance.

## Verification

- `pnpm exec prettier --write apps/desktop/src/sentry-main.ts` (unchanged, lockfile-pinned Prettier 3.8.1)
- `pnpm -F @okouai/desktop lint`
- `pnpm -F @okouai/desktop check-types`
- `pnpm knip --workspace @okouai/desktop`
- `pnpm -F @okouai/desktop test:native` (command passed; Swift tests are macOS-only and skipped on this Linux runner, so the Desktop PR pipeline provides native build/test coverage)
- Repository-wide exact-key and invariant searches described above
- `git diff --check`

Closes #29086
