### PR TITLE
feat(auth): add advanced v2 sign-in strategies

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -310,6 +310,11 @@ function clearMockedAuth() {
   internalMockedGoogleOneTapCredential = null;
   internalMockedGoogleOneTapCallback = null;
   Reflect.deleteProperty(globalThis, "google");
+  for (const script of document.querySelectorAll(
+    "script[data-auth-v2-google-one-tap]",
+  )) {
+    script.remove();
+  }
   mockedGoogleOneTap.cancel.mockReset();
   mockedGoogleOneTap.initialize.mockReset();
   mockedGoogleOneTap.initialize.mockImplementation(

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -54,6 +54,12 @@ export interface MockedClientSession {
   };
 }
 
+export interface MockedAuthV2Capabilities {
+  readonly googleOAuth?: boolean;
+  readonly googleOneTapClientId?: string | null;
+  readonly passkey?: boolean;
+}
+
 export type MockedSignInFactor =
   | { readonly strategy: "password" }
   | {
@@ -61,6 +67,7 @@ export type MockedSignInFactor =
       readonly safeIdentifier: string;
       readonly strategy: "email_code" | "reset_password_email_code";
     }
+  | { readonly strategy: "oauth_google" | "passkey" }
   | { readonly strategy: string };
 
 export interface MockedSignInResourceState {
@@ -101,6 +108,11 @@ let internalMockedOrganization: {
 let internalMockedInvitations: MockedInvitation[] = [];
 let internalMockedMemberships: MockedMembership[] = [{ id: "org_default" }];
 let internalMockedClientSessions: MockedClientSession[] = [];
+let internalMockedAuthV2Capabilities: Required<MockedAuthV2Capabilities> = {
+  googleOAuth: false,
+  googleOneTapClientId: null,
+  passkey: false,
+};
 let internalMockedClerkLoadOptions: MockedClerkLoadOptions = {};
 let internalMockedClerkLoaded = true;
 let internalMockedClerkSessionTransitioning = false;
@@ -118,6 +130,16 @@ export function mockSignInResource(state: MockedSignInResourceState): void {
     isTransferable: state.isTransferable ?? false,
     status: state.status,
     supportedFirstFactors: state.supportedFirstFactors ?? null,
+  };
+}
+
+export function mockAuthV2Capabilities(
+  capabilities: MockedAuthV2Capabilities,
+): void {
+  internalMockedAuthV2Capabilities = {
+    googleOAuth: capabilities.googleOAuth ?? false,
+    googleOneTapClientId: capabilities.googleOneTapClientId ?? null,
+    passkey: capabilities.passkey ?? false,
   };
 }
 
@@ -189,6 +211,62 @@ export function mockUser(
   internalMockedSession = session;
 }
 
+interface MockedGoogleOneTapInitializeOptions {
+  readonly callback: (response: { readonly credential?: string }) => void;
+  readonly client_id: string;
+}
+
+type MockedGoogleOneTapMomentCallback = (notification: {
+  isDismissedMoment(): boolean;
+  isNotDisplayed(): boolean;
+  isSkippedMoment(): boolean;
+}) => void;
+
+let internalMockedGoogleOneTapCredential: string | null = null;
+let internalMockedGoogleOneTapCallback:
+  | MockedGoogleOneTapInitializeOptions["callback"]
+  | null = null;
+
+function defaultGoogleOneTapInitializeImpl(
+  options: MockedGoogleOneTapInitializeOptions,
+): void {
+  internalMockedGoogleOneTapCallback = options.callback;
+}
+
+function defaultGoogleOneTapPromptImpl(
+  callback: MockedGoogleOneTapMomentCallback,
+): void {
+  if (internalMockedGoogleOneTapCredential) {
+    internalMockedGoogleOneTapCallback?.({
+      credential: internalMockedGoogleOneTapCredential,
+    });
+    return;
+  }
+  callback({
+    isDismissedMoment: () => false,
+    isNotDisplayed: () => true,
+    isSkippedMoment: () => false,
+  });
+}
+
+export const mockedGoogleOneTap = {
+  cancel: vi.fn<() => void>(),
+  initialize: vi.fn<typeof defaultGoogleOneTapInitializeImpl>(
+    defaultGoogleOneTapInitializeImpl,
+  ),
+  prompt: vi.fn<typeof defaultGoogleOneTapPromptImpl>(
+    defaultGoogleOneTapPromptImpl,
+  ),
+};
+
+export function mockGoogleOneTapCredential(credential: string | null): void {
+  internalMockedGoogleOneTapCredential = credential;
+  Object.defineProperty(globalThis, "google", {
+    configurable: true,
+    value: { accounts: { id: mockedGoogleOneTap } },
+  });
+}
+
 /**
  * Configure organization-related mock state for testing org selection.
  */
@@ -224,6 +302,21 @@ function clearMockedAuth() {
   internalMockedInvitations = [];
   internalMockedMemberships = [{ id: "org_default" }];
   internalMockedClientSessions = [];
+  internalMockedAuthV2Capabilities = {
+    googleOAuth: false,
+    googleOneTapClientId: null,
+    passkey: false,
+  };
+  internalMockedGoogleOneTapCredential = null;
+  internalMockedGoogleOneTapCallback = null;
+  Reflect.deleteProperty(globalThis, "google");
+  mockedGoogleOneTap.cancel.mockReset();
+  mockedGoogleOneTap.initialize.mockReset();
+  mockedGoogleOneTap.initialize.mockImplementation(
+    defaultGoogleOneTapInitializeImpl,
+  );
+  mockedGoogleOneTap.prompt.mockReset();
+  mockedGoogleOneTap.prompt.mockImplementation(defaultGoogleOneTapPromptImpl);
   internalMockedClerkLoadOptions = {};
   internalMockedClerkLoaded = true;
   internalMockedClerkSessionTransitioning = false;
@@ -265,6 +358,18 @@ function clearMockedAuth() {
   mockedClerk.signInFutureReset.mockImplementation(
     defaultSignInFutureResetImpl,
   );
+  mockedClerk.signInAuthenticateWithPasskey.mockReset();
+  mockedClerk.signInAuthenticateWithPasskey.mockImplementation(
+    defaultSignInResourceOperationImpl,
+  );
+  mockedClerk.signInAuthenticateWithRedirect.mockReset();
+  mockedClerk.signInAuthenticateWithRedirect.mockImplementation(
+    defaultSignInAuthenticateWithRedirectImpl,
+  );
+  mockedClerk.handleRedirectCallback.mockReset();
+  mockedClerk.handleRedirectCallback.mockImplementation(
+    defaultHandleRedirectCallbackImpl,
+  );
   mockedClerk.buildUrlWithAuth.mockReset();
   mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
   mockedClerk.buildUserProfileUrl.mockReset();
@@ -301,8 +406,10 @@ const defaultSessionTouchImpl: SessionTouchImpl = () => {
 const sessionTouch = vi.fn<SessionTouchImpl>(defaultSessionTouchImpl);
 interface MockedSignInCreateParams {
   readonly identifier?: string;
+  readonly signUpIfMissing?: boolean;
   readonly strategy?: string;
   readonly ticket?: string;
+  readonly token?: string;
 }
 
 function defaultClientSignInCreateImpl(params: MockedSignInCreateParams) {
@@ -329,6 +436,52 @@ const signInPrepareFirstFactor = vi.fn<
 const signInAttemptFirstFactor = vi.fn<
   typeof defaultSignInResourceOperationImpl
 >(defaultSignInResourceOperationImpl);
+const signInAuthenticateWithPasskey = vi.fn<
+  typeof defaultSignInResourceOperationImpl
+>(defaultSignInResourceOperationImpl);
+
+interface MockedSignInAuthenticateWithRedirectParams {
+  readonly continueSignIn?: boolean;
+  readonly continueSignUp?: boolean;
+  readonly redirectUrl: string;
+  readonly redirectUrlComplete: string;
+  readonly strategy: string;
+}
+
+function defaultSignInAuthenticateWithRedirectImpl(
+  _params: MockedSignInAuthenticateWithRedirectParams,
+) {
+  return Promise.resolve();
+}
+
+const signInAuthenticateWithRedirect = vi.fn<
+  typeof defaultSignInAuthenticateWithRedirectImpl
+>(defaultSignInAuthenticateWithRedirectImpl);
+
+interface MockedHandleRedirectCallbackParams {
+  readonly continueSignUpUrl?: string | null;
+  readonly firstFactorUrl?: string;
+  readonly reloadResource?: "signIn" | "signUp";
+  readonly resetPasswordUrl?: string;
+  readonly secondFactorUrl?: string;
+  readonly signInFallbackRedirectUrl?: string | null;
+  readonly signInForceRedirectUrl?: string | null;
+  readonly signInUrl?: string;
+  readonly signUpUrl?: string;
+  readonly transferable?: boolean;
+  readonly verifyEmailAddressUrl?: string | null;
+  readonly verifyPhoneNumberUrl?: string | null;
+}
+
+function defaultHandleRedirectCallbackImpl(
+  _params?: MockedHandleRedirectCallbackParams,
+) {
+  return Promise.resolve();
+}
+
+const handleRedirectCallback = vi.fn<typeof defaultHandleRedirectCallbackImpl>(
+  defaultHandleRedirectCallbackImpl,
+);
 const signInResetPassword = vi.fn<typeof defaultSignInResourceOperationImpl>(
   defaultSignInResourceOperationImpl,
 );
@@ -354,6 +507,8 @@ const mockedClientSignIn = {
   create: clientSignInCreate,
   prepareFirstFactor: signInPrepareFirstFactor,
   attemptFirstFactor: signInAttemptFirstFactor,
+  authenticateWithPasskey: signInAuthenticateWithPasskey,
+  authenticateWithRedirect: signInAuthenticateWithRedirect,
   resetPassword: signInResetPassword,
   __internal_future: {
     get isTransferable() {
@@ -480,14 +635,46 @@ export const mockedClerk = {
   clientSignInCreate,
   signInPrepareFirstFactor,
   signInAttemptFirstFactor,
+  signInAuthenticateWithPasskey,
+  signInAuthenticateWithRedirect,
   signInResetPassword,
   signInFutureReset,
   client: {
     get sessions() {
       return internalMockedClientSessions;
     },
+    get signedInSessions() {
+      return internalMockedClientSessions.filter((session) => {
+        return (
+          (session.status === "active" || session.status === "pending") &&
+          session.user !== undefined
+        );
+      });
+    },
     signIn: mockedClientSignIn,
   },
+  get __internal_environment() {
+    return {
+      displayConfig: {
+        googleOneTapClientId:
+          internalMockedAuthV2Capabilities.googleOneTapClientId ?? undefined,
+      },
+      userSettings: {
+        attributes: {
+          passkey: {
+            enabled: internalMockedAuthV2Capabilities.passkey,
+            used_for_first_factor: internalMockedAuthV2Capabilities.passkey,
+          },
+        },
+        authenticatableSocialStrategies:
+          internalMockedAuthV2Capabilities.googleOAuth ? ["oauth_google"] : [],
+        passkeySettings: {
+          show_sign_in_button: internalMockedAuthV2Capabilities.passkey,
+        },
+      },
+    };
+  },
+  handleRedirectCallback,
   signOut: vi.fn(() => {
     return Promise.resolve();
   }),

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -11,26 +11,29 @@ import {
   createAuthV2SignInSignals,
   type AuthV2SignInSignals,
 } from "./auth-v2/sign-in-flow.ts";
+import { AUTH_V2_OAUTH_CALLBACK_PATH } from "./auth-v2/sign-in-external-strategies.ts";
+import { resolveAuthV2PlatformContext } from "./auth-v2/platform-context.ts";
 import { updateDocumentTitle$ } from "./document-title.ts";
 import { updatePage$ } from "./react-router.ts";
-
-// Redirect, brand, and attribution policy intentionally live outside the
-// flow. The parallel redirect track can replace this resolver without changing
-// Clerk operations or activation ownership.
-function resolveAuthV2SignInRedirectUrl(): string {
-  return "/";
-}
+import { ROUTES } from "./route-paths.ts";
 
 function setupAuthV2Page(mode: AuthV2PageMode) {
   return command(async ({ set }, signal: AbortSignal) => {
-    const authBrand = resolveAuthBrandContext();
+    let authBrand: ReturnType<typeof resolveAuthBrandContext>;
     let signInSignals: AuthV2SignInSignals | null = null;
     if (mode === "sign-in") {
+      const platformContext = resolveAuthV2PlatformContext(mode);
+      authBrand = platformContext.authBrand;
       signInSignals = createAuthV2SignInSignals({
-        resolveRedirectUrl: resolveAuthV2SignInRedirectUrl,
+        isBaseRoute: location.pathname === ROUTES.signInV2,
+        isOAuthCallbackRoute:
+          location.pathname ===
+          `${ROUTES.signInV2}${AUTH_V2_OAUTH_CALLBACK_PATH}`,
+        navigation: platformContext.navigation,
       });
       set(updatePage$, createElement(AuthV2Page, { mode, signInSignals }));
     } else {
+      authBrand = resolveAuthBrandContext();
       set(updatePage$, createElement(AuthV2Page, { mode }));
     }
     set(

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
@@ -18,7 +18,6 @@ export interface AuthV2ExternalCapabilities {
 export interface AuthV2ExistingAccount {
   readonly displayName: string;
   readonly identifier: string | null;
-  readonly imageUrl: string | null;
   readonly sessionId: string;
 }
 
@@ -92,6 +91,9 @@ function loadGoogleIdentityApi(
   const cleanup = (): void => {
     script.removeEventListener("load", handleLoad);
     script.removeEventListener("error", handleError);
+    if (!googleIdentityApi()) {
+      script.remove();
+    }
   };
 
   script.addEventListener("load", handleLoad, { once: true });
@@ -162,7 +164,6 @@ export function discoverAuthV2ExistingAccounts(
     return {
       displayName,
       identifier: emailAddress,
-      imageUrl: session.user.imageUrl || null,
       sessionId: session.id,
     };
   });

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
@@ -1,0 +1,234 @@
+import type { Clerk } from "@clerk/clerk-js";
+import type { SignInResource } from "@clerk/react/types";
+
+import { createDeferredPromise, settle, withCleanup } from "../utils.ts";
+import type { AuthV2Navigation } from "./navigation.ts";
+
+const GOOGLE_IDENTITY_SCRIPT_URL = "https://accounts.google.com/gsi/client";
+const GOOGLE_OAUTH_STRATEGY = "oauth_google" as const;
+
+export const AUTH_V2_OAUTH_CALLBACK_PATH = "/sso-callback";
+
+export interface AuthV2ExternalCapabilities {
+  readonly googleOAuth: boolean;
+  readonly googleOneTapClientId: string | null;
+  readonly passkey: boolean;
+}
+
+export interface AuthV2ExistingAccount {
+  readonly displayName: string;
+  readonly identifier: string | null;
+  readonly imageUrl: string | null;
+  readonly sessionId: string;
+}
+
+interface GoogleCredentialResponse {
+  readonly credential?: string;
+}
+
+interface GooglePromptMomentNotification {
+  isDismissedMoment(): boolean;
+  isNotDisplayed(): boolean;
+  isSkippedMoment(): boolean;
+}
+
+interface GoogleIdentityApi {
+  cancel(): void;
+  initialize(options: {
+    readonly auto_select: boolean;
+    readonly callback: (response: GoogleCredentialResponse) => void;
+    readonly cancel_on_tap_outside: boolean;
+    readonly client_id: string;
+    readonly itp_support: boolean;
+  }): void;
+  prompt(
+    callback: (notification: GooglePromptMomentNotification) => void,
+  ): void;
+}
+
+interface GoogleIdentityServices {
+  readonly accounts?: {
+    readonly id?: GoogleIdentityApi;
+  };
+}
+
+type GoogleWindow = Window & { readonly google?: GoogleIdentityServices };
+
+function googleIdentityApi(): GoogleIdentityApi | null {
+  return (window as GoogleWindow).google?.accounts?.id ?? null;
+}
+
+function loadGoogleIdentityApi(
+  signal: AbortSignal,
+): Promise<GoogleIdentityApi> {
+  signal.throwIfAborted();
+  const loadedApi = googleIdentityApi();
+  if (loadedApi) {
+    return Promise.resolve(loadedApi);
+  }
+
+  const existingScript = document.querySelector<HTMLScriptElement>(
+    "script[data-auth-v2-google-one-tap]",
+  );
+  const script = existingScript ?? document.createElement("script");
+  if (!existingScript) {
+    script.async = true;
+    script.dataset.authV2GoogleOneTap = "true";
+    script.src = GOOGLE_IDENTITY_SCRIPT_URL;
+  }
+
+  const deferred = createDeferredPromise<GoogleIdentityApi>(signal);
+  const handleLoad = (): void => {
+    const api = googleIdentityApi();
+    if (api) {
+      deferred.resolve(api);
+      return;
+    }
+    deferred.reject(new Error("Google Identity Services did not initialize"));
+  };
+  const handleError = (): void => {
+    deferred.reject(new Error("Google Identity Services could not be loaded"));
+  };
+  const cleanup = (): void => {
+    script.removeEventListener("load", handleLoad);
+    script.removeEventListener("error", handleError);
+  };
+
+  script.addEventListener("load", handleLoad, { once: true });
+  script.addEventListener("error", handleError, { once: true });
+  if (!existingScript) {
+    document.head.appendChild(script);
+  }
+  return withCleanup(deferred.promise, cleanup);
+}
+
+async function startGoogleOneTapPrompt(
+  api: GoogleIdentityApi,
+  clientId: string,
+  finish: (credential: string | null) => void,
+  signal: AbortSignal,
+): Promise<void> {
+  await Promise.resolve();
+  signal.throwIfAborted();
+  api.initialize({
+    auto_select: false,
+    callback: (response) => {
+      finish(response.credential ?? null);
+    },
+    cancel_on_tap_outside: true,
+    client_id: clientId,
+    itp_support: true,
+  });
+  api.prompt((notification) => {
+    if (
+      notification.isDismissedMoment() ||
+      notification.isNotDisplayed() ||
+      notification.isSkippedMoment()
+    ) {
+      finish(null);
+    }
+  });
+}
+
+export function discoverAuthV2ExternalCapabilities(
+  clerk: Clerk,
+): AuthV2ExternalCapabilities {
+  const environment = clerk.__internal_environment;
+  const settings = environment?.userSettings;
+  const googleOAuth =
+    settings?.authenticatableSocialStrategies.includes(GOOGLE_OAUTH_STRATEGY) ??
+    false;
+  const passkeyAttribute = settings?.attributes.passkey;
+  const passkey =
+    passkeyAttribute?.enabled === true &&
+    passkeyAttribute.used_for_first_factor === true &&
+    settings?.passkeySettings.show_sign_in_button === true;
+  const googleOneTapClientId = googleOAuth
+    ? (environment?.displayConfig.googleOneTapClientId ?? null)
+    : null;
+  return { googleOAuth, googleOneTapClientId, passkey };
+}
+
+export function discoverAuthV2ExistingAccounts(
+  clerk: Clerk,
+): readonly AuthV2ExistingAccount[] {
+  return (clerk.client?.signedInSessions ?? []).map((session) => {
+    const emailAddress = session.user.primaryEmailAddress?.emailAddress ?? null;
+    const displayName =
+      session.user.fullName ??
+      emailAddress ??
+      session.user.username ??
+      "Account";
+    return {
+      displayName,
+      identifier: emailAddress,
+      imageUrl: session.user.imageUrl || null,
+      sessionId: session.id,
+    };
+  });
+}
+
+export function startAuthV2GoogleOAuth(
+  resource: SignInResource,
+  navigation: AuthV2Navigation,
+): Promise<void> {
+  return resource.authenticateWithRedirect({
+    continueSignIn: true,
+    continueSignUp: false,
+    redirectUrl: navigation.href("sign-in", AUTH_V2_OAUTH_CALLBACK_PATH),
+    redirectUrlComplete: navigation.completionRedirectUrl,
+    strategy: GOOGLE_OAUTH_STRATEGY,
+  });
+}
+
+export async function recoverAuthV2GoogleOAuth(
+  clerk: Clerk,
+  navigation: AuthV2Navigation,
+): Promise<string | null> {
+  await clerk.handleRedirectCallback({
+    continueSignUpUrl: null,
+    firstFactorUrl: navigation.href("sign-in", "/factor-one"),
+    reloadResource: "signIn",
+    resetPasswordUrl: navigation.href("sign-in", "/reset-password"),
+    secondFactorUrl: navigation.href("sign-in", "/factor-two"),
+    signInFallbackRedirectUrl: navigation.completionRedirectUrl,
+    signInForceRedirectUrl: navigation.completionRedirectUrl,
+    signInUrl: navigation.href("sign-in"),
+    signUpUrl: navigation.href("sign-up"),
+    transferable: false,
+    verifyEmailAddressUrl: null,
+    verifyPhoneNumberUrl: null,
+  });
+
+  const resource = clerk.client?.signIn;
+  return resource?.status === "complete" ? resource.createdSessionId : null;
+}
+
+export async function requestGoogleOneTapCredential(
+  clientId: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const api = await loadGoogleIdentityApi(signal);
+  signal.throwIfAborted();
+  const credential = createDeferredPromise<string | null>(signal);
+  const finish = (value: string | null): void => {
+    if (!credential.settled()) {
+      credential.resolve(value);
+    }
+  };
+  const handleAbort = (): void => {
+    api.cancel();
+  };
+  signal.addEventListener("abort", handleAbort, { once: true });
+
+  const prompt = await settle(
+    startGoogleOneTapPrompt(api, clientId, finish, signal),
+    signal,
+  );
+  if (!prompt.ok && !credential.settled()) {
+    credential.reject(prompt.error);
+  }
+  return withCleanup(credential.promise, () => {
+    signal.removeEventListener("abort", handleAbort);
+  });
+}

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -14,8 +14,7 @@ import {
 } from "ccstate";
 
 import { clerk$ } from "../auth.ts";
-import { pageSignal$ } from "../page-signal.ts";
-import { onRef, settle, withCleanup } from "../utils.ts";
+import { settle, withCleanup } from "../utils.ts";
 import {
   discoverAuthV2ExistingAccounts,
   discoverAuthV2ExternalCapabilities,
@@ -124,10 +123,6 @@ export interface AuthV2SignInSignals {
   readonly code$: Computed<string>;
   readonly confirmPassword$: Computed<string>;
   readonly error$: Computed<AuthV2SignInError | null>;
-  readonly googleOneTapLifecycleRef$: Command<
-    (() => void) | undefined,
-    [HTMLDivElement | null]
-  >;
   readonly identifier$: Computed<string>;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
   readonly newPassword$: Computed<string>;
@@ -312,28 +307,33 @@ function normalizeClerkError(
   error: unknown,
   fallbackField: AuthV2SignInErrorField,
 ): AuthV2SignInError {
-  if (isRecord(error) && Array.isArray(error.errors)) {
-    const firstError = error.errors.find(isRecord);
-    if (firstError) {
-      const clerkCode = stringProperty(firstError, "code");
-      const message =
-        stringProperty(firstError, "longMessage") ??
-        stringProperty(firstError, "message");
-      const code =
-        clerkCode === "passkey_retrieval_cancelled"
-          ? "passkey-cancelled"
-          : clerkCode === "passkey_not_supported" ||
-              clerkCode === "passkey_pa_not_supported"
-            ? "passkey-unavailable"
-            : "clerk";
-      return {
-        code,
-        field: clerkErrorField(firstError, fallbackField),
-        ...(message ? { message } : {}),
-      };
-    }
+  if (!isRecord(error)) {
+    return { code: "unknown", field: fallbackField };
   }
-  return { code: "unknown", field: fallbackField };
+  const apiError = Array.isArray(error.errors)
+    ? error.errors.find(isRecord)
+    : null;
+  const normalizedError = apiError ?? error;
+  const clerkCode = stringProperty(normalizedError, "code");
+  if (!apiError && !clerkCode) {
+    return { code: "unknown", field: fallbackField };
+  }
+  const message =
+    stringProperty(normalizedError, "longMessage") ??
+    stringProperty(normalizedError, "message");
+  const code =
+    clerkCode === "passkey_retrieval_cancelled" ||
+    clerkCode === "passkey_operation_aborted"
+      ? "passkey-cancelled"
+      : clerkCode === "passkey_not_supported" ||
+          clerkCode === "passkey_pa_not_supported"
+        ? "passkey-unavailable"
+        : "clerk";
+  return {
+    code,
+    field: clerkErrorField(normalizedError, fallbackField),
+    ...(message ? { message } : {}),
+  };
 }
 
 function selectedFactorForSnapshot(
@@ -1174,17 +1174,13 @@ export function createAuthV2SignInSignals(
     applyResource$,
     dependencies,
   );
-  const googleOneTapLifecycleRef$ = onRef(
-    command(
-      async (
-        { get, set },
-        _element: HTMLDivElement,
-        signal: AbortSignal,
-      ): Promise<void> => {
-        await set(runGoogleOneTap$, get(pageSignal$));
-        signal.throwIfAborted();
-      },
-    ),
+  const initializeWithExternalStrategies$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      await set(initialize$, signal);
+      signal.throwIfAborted();
+      await set(runGoogleOneTap$, signal);
+      signal.throwIfAborted();
+    },
   );
   return {
     ...formCommands,
@@ -1197,11 +1193,10 @@ export function createAuthV2SignInSignals(
     error$: computed((get) => {
       return get(atoms.error$);
     }),
-    googleOneTapLifecycleRef$,
     identifier$: computed((get) => {
       return get(atoms.identifier$);
     }),
-    initialize$,
+    initialize$: initializeWithExternalStrategies$,
     newPassword$: computed((get) => {
       return get(atoms.newPassword$);
     }),

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -14,7 +14,18 @@ import {
 } from "ccstate";
 
 import { clerk$ } from "../auth.ts";
-import { settle, withCleanup } from "../utils.ts";
+import { pageSignal$ } from "../page-signal.ts";
+import { onRef, settle, withCleanup } from "../utils.ts";
+import {
+  discoverAuthV2ExistingAccounts,
+  discoverAuthV2ExternalCapabilities,
+  type AuthV2ExistingAccount,
+  type AuthV2ExternalCapabilities,
+  recoverAuthV2GoogleOAuth,
+  requestGoogleOneTapCredential,
+  startAuthV2GoogleOAuth,
+} from "./sign-in-external-strategies.ts";
+import type { AuthV2Navigation } from "./navigation.ts";
 
 export type AuthV2SignInFactor =
   | {
@@ -32,9 +43,19 @@ export type AuthV2SignInFactor =
       readonly id: string;
       readonly kind: "password-reset";
       readonly safeIdentifier: string;
+    }
+  | {
+      readonly id: "oauth:oauth_google";
+      readonly kind: "oauth";
+      readonly strategy: "oauth_google";
+    }
+  | {
+      readonly id: "passkey";
+      readonly kind: "passkey";
     };
 
 export type AuthV2SignInStep =
+  | "choose-session"
   | "identifier"
   | "choose-factor"
   | "password"
@@ -51,6 +72,7 @@ export type AuthV2SignInUnknownReason =
 export type AuthV2SignInState =
   | { readonly status: "loading" }
   | {
+      readonly accounts: readonly AuthV2ExistingAccount[];
       readonly factors: readonly AuthV2SignInFactor[];
       readonly selectedFactor: AuthV2SignInFactor | null;
       readonly status: "incomplete";
@@ -72,7 +94,12 @@ export type AuthV2SignInErrorField =
   | "password";
 
 export interface AuthV2SignInError {
-  readonly code: "clerk" | "password-mismatch" | "unknown";
+  readonly code:
+    | "clerk"
+    | "passkey-cancelled"
+    | "passkey-unavailable"
+    | "password-mismatch"
+    | "unknown";
   readonly field: AuthV2SignInErrorField;
   readonly message?: string;
 }
@@ -82,10 +109,13 @@ interface SignInResourceSnapshot {
   readonly createdSessionId: string | null;
   readonly factors: readonly AuthV2SignInFactor[];
   readonly transferable: boolean;
+  readonly unknownFactorStrategies: readonly string[];
 }
 
 export interface AuthV2SignInFlowDependencies {
-  readonly resolveRedirectUrl: () => string;
+  readonly isBaseRoute: boolean;
+  readonly isOAuthCallbackRoute: boolean;
+  readonly navigation: AuthV2Navigation;
 }
 
 export interface AuthV2SignInSignals {
@@ -94,6 +124,10 @@ export interface AuthV2SignInSignals {
   readonly code$: Computed<string>;
   readonly confirmPassword$: Computed<string>;
   readonly error$: Computed<AuthV2SignInError | null>;
+  readonly googleOneTapLifecycleRef$: Command<
+    (() => void) | undefined,
+    [HTMLDivElement | null]
+  >;
   readonly identifier$: Computed<string>;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
   readonly newPassword$: Computed<string>;
@@ -101,6 +135,7 @@ export interface AuthV2SignInSignals {
   readonly resendCode$: Command<Promise<void>, [AbortSignal]>;
   readonly restart$: Command<void, []>;
   readonly selectFactor$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly selectSession$: Command<Promise<void>, [string, AbortSignal]>;
   readonly setCode$: Command<void, [string]>;
   readonly setConfirmPassword$: Command<void, [string]>;
   readonly setIdentifier$: Command<void, [string]>;
@@ -108,15 +143,18 @@ export interface AuthV2SignInSignals {
   readonly setPassword$: Command<void, [string]>;
   readonly state$: Computed<AuthV2SignInState>;
   readonly submit$: Command<Promise<void>, [AbortSignal]>;
+  readonly useAnotherAccount$: Command<void, []>;
 }
 
-type CoalescedOperation = "resource";
+type CoalescedOperation = "one-tap" | "resource";
 type AuthV2SignInUnknownState = Extract<
   AuthV2SignInState,
   { status: "unknown" }
 >;
 
 interface SignInFlowAtoms {
+  readonly accounts$: State<readonly AuthV2ExistingAccount[]>;
+  readonly capabilities$: State<AuthV2ExternalCapabilities>;
   readonly code$: State<string>;
   readonly confirmPassword$: State<string>;
   readonly editIdentifier$: State<boolean>;
@@ -128,6 +166,7 @@ interface SignInFlowAtoms {
   readonly selectedFactor$: State<AuthV2SignInFactor | null>;
   readonly snapshot$: State<SignInResourceSnapshot | null>;
   readonly state$: Computed<AuthV2SignInState>;
+  readonly useAnotherAccount$: State<boolean>;
 }
 
 interface SignInFlowRuntime {
@@ -145,52 +184,95 @@ type ApplySignInResourceCommand = Command<
   [SignInResource, AbortSignal]
 >;
 
+function emptyExternalCapabilities(): AuthV2ExternalCapabilities {
+  return {
+    googleOAuth: false,
+    googleOneTapClientId: null,
+    passkey: false,
+  };
+}
+
+interface FactorDiscovery {
+  readonly factors: readonly AuthV2SignInFactor[];
+  readonly unknownStrategies: readonly string[];
+}
+
 function discoverFactors(
   factors: readonly SignInFirstFactor[] | null,
-): readonly AuthV2SignInFactor[] {
+): FactorDiscovery {
   if (!factors) {
-    return [];
+    return { factors: [], unknownStrategies: [] };
   }
 
-  return factors.flatMap((factor): AuthV2SignInFactor[] => {
+  const discovered: AuthV2SignInFactor[] = [];
+  const unknownStrategies: string[] = [];
+  for (const factor of factors) {
     if (factor.strategy === "password") {
-      return [{ id: "password", kind: "password" }];
+      discovered.push({ id: "password", kind: "password" });
+    } else if (factor.strategy === "email_code") {
+      discovered.push({
+        emailAddressId: factor.emailAddressId,
+        id: `email-code:${factor.emailAddressId}`,
+        kind: "email-code",
+        safeIdentifier: factor.safeIdentifier,
+      });
+    } else if (factor.strategy === "reset_password_email_code") {
+      discovered.push({
+        emailAddressId: factor.emailAddressId,
+        id: `password-reset:${factor.emailAddressId}`,
+        kind: "password-reset",
+        safeIdentifier: factor.safeIdentifier,
+      });
+    } else if (factor.strategy === "oauth_google") {
+      discovered.push({
+        id: "oauth:oauth_google",
+        kind: "oauth",
+        strategy: "oauth_google",
+      });
+    } else if (factor.strategy === "passkey") {
+      discovered.push({ id: "passkey", kind: "passkey" });
+    } else {
+      unknownStrategies.push(factor.strategy);
     }
-    if (factor.strategy === "email_code") {
-      return [
-        {
-          emailAddressId: factor.emailAddressId,
-          id: `email-code:${factor.emailAddressId}`,
-          kind: "email-code",
-          safeIdentifier: factor.safeIdentifier,
-        },
-      ];
-    }
-    if (factor.strategy === "reset_password_email_code") {
-      return [
-        {
-          emailAddressId: factor.emailAddressId,
-          id: `password-reset:${factor.emailAddressId}`,
-          kind: "password-reset",
-          safeIdentifier: factor.safeIdentifier,
-        },
-      ];
-    }
-    return [];
-  });
+  }
+  return { factors: discovered, unknownStrategies };
+}
+
+function entryFactors(
+  capabilities: AuthV2ExternalCapabilities,
+): readonly AuthV2SignInFactor[] {
+  const factors: AuthV2SignInFactor[] = [];
+  if (capabilities.googleOAuth) {
+    factors.push({
+      id: "oauth:oauth_google",
+      kind: "oauth",
+      strategy: "oauth_google",
+    });
+  }
+  if (capabilities.passkey) {
+    factors.push({ id: "passkey", kind: "passkey" });
+  }
+  return factors;
 }
 
 function snapshotSignInResource(
   resource: SignInResource,
+  capabilities: AuthV2ExternalCapabilities,
 ): SignInResourceSnapshot {
   // The legacy resource is the stable low-level API used by this app. Clerk
   // exposes transferability on its future view, so keep that SDK detail
   // isolated in this adapter rather than leaking it into the flow or view.
+  const discovered = discoverFactors(resource.supportedFirstFactors);
+  const factors =
+    resource.status === "needs_identifier" || resource.status === null
+      ? entryFactors(capabilities)
+      : discovered.factors;
   return {
     clerkStatus: resource.status,
     createdSessionId: resource.createdSessionId,
-    factors: discoverFactors(resource.supportedFirstFactors),
+    factors,
     transferable: resource.__internal_future.isTransferable,
+    unknownFactorStrategies: discovered.unknownStrategies,
   };
 }
 
@@ -233,11 +315,19 @@ function normalizeClerkError(
   if (isRecord(error) && Array.isArray(error.errors)) {
     const firstError = error.errors.find(isRecord);
     if (firstError) {
+      const clerkCode = stringProperty(firstError, "code");
       const message =
         stringProperty(firstError, "longMessage") ??
         stringProperty(firstError, "message");
+      const code =
+        clerkCode === "passkey_retrieval_cancelled"
+          ? "passkey-cancelled"
+          : clerkCode === "passkey_not_supported" ||
+              clerkCode === "passkey_pa_not_supported"
+            ? "passkey-unavailable"
+            : "clerk";
       return {
-        code: "clerk",
+        code,
         field: clerkErrorField(firstError, fallbackField),
         ...(message ? { message } : {}),
       };
@@ -270,10 +360,12 @@ export const clerkSignInResource$ = computed(async (get) => {
 
 function incompleteState(
   snapshot: SignInResourceSnapshot,
+  accounts: readonly AuthV2ExistingAccount[],
   step: AuthV2SignInStep,
   selectedFactor: AuthV2SignInFactor | null = null,
 ): AuthV2SignInState {
   return {
+    accounts,
     factors: snapshot.factors,
     selectedFactor,
     status: "incomplete",
@@ -281,14 +373,35 @@ function incompleteState(
   };
 }
 
+interface DeriveSignInFlowOptions {
+  readonly accounts: readonly AuthV2ExistingAccount[];
+  readonly editIdentifier: boolean;
+  readonly fatalState: AuthV2SignInUnknownState | null;
+  readonly selectedFactor: AuthV2SignInFactor | null;
+  readonly useAnotherAccount: boolean;
+}
+
+function stepForSelectedFactor(
+  factor: AuthV2SignInFactor | null,
+): AuthV2SignInStep {
+  if (factor?.kind === "password") {
+    return "password";
+  }
+  if (factor?.kind === "email-code") {
+    return "email-code";
+  }
+  if (factor?.kind === "password-reset") {
+    return "password-reset-code";
+  }
+  return "choose-factor";
+}
+
 function deriveSignInFlowState(
   snapshot: SignInResourceSnapshot | null,
-  selectedFactor: AuthV2SignInFactor | null,
-  editIdentifier: boolean,
-  fatalState: AuthV2SignInUnknownState | null,
+  options: DeriveSignInFlowOptions,
 ): AuthV2SignInState {
-  if (fatalState) {
-    return fatalState;
+  if (options.fatalState) {
+    return options.fatalState;
   }
   if (!snapshot) {
     return { status: "loading" };
@@ -297,33 +410,49 @@ function deriveSignInFlowState(
     return { status: "transfer" };
   }
   if (
-    editIdentifier ||
+    options.editIdentifier ||
     snapshot.clerkStatus === "needs_identifier" ||
     snapshot.clerkStatus === null
   ) {
-    return incompleteState(snapshot, "identifier");
+    return incompleteState(
+      snapshot,
+      options.accounts,
+      !options.editIdentifier &&
+        !options.useAnotherAccount &&
+        options.accounts.length > 0
+        ? "choose-session"
+        : "identifier",
+    );
   }
   if (snapshot.clerkStatus === "needs_first_factor") {
-    if (snapshot.factors.length === 0) {
+    if (
+      snapshot.factors.length === 0 ||
+      snapshot.unknownFactorStrategies.length > 0
+    ) {
       return {
         clerkStatus: snapshot.clerkStatus,
         reason: "unsupported-factor",
         status: "unknown",
       };
     }
-    const currentFactor = selectedFactorForSnapshot(snapshot, selectedFactor);
-    const step =
-      currentFactor?.kind === "password"
-        ? "password"
-        : currentFactor?.kind === "email-code"
-          ? "email-code"
-          : currentFactor?.kind === "password-reset"
-            ? "password-reset-code"
-            : "choose-factor";
-    return incompleteState(snapshot, step, currentFactor);
+    const currentFactor = selectedFactorForSnapshot(
+      snapshot,
+      options.selectedFactor,
+    );
+    return incompleteState(
+      snapshot,
+      options.accounts,
+      stepForSelectedFactor(currentFactor),
+      currentFactor,
+    );
   }
   if (snapshot.clerkStatus === "needs_new_password") {
-    return incompleteState(snapshot, "new-password", selectedFactor);
+    return incompleteState(
+      snapshot,
+      options.accounts,
+      "new-password",
+      options.selectedFactor,
+    );
   }
   if (snapshot.clerkStatus === "complete") {
     return snapshot.createdSessionId
@@ -342,6 +471,10 @@ function deriveSignInFlowState(
 }
 
 function createSignInFlowAtoms(): SignInFlowAtoms {
+  const accounts$ = state<readonly AuthV2ExistingAccount[]>([]);
+  const capabilities$ = state<AuthV2ExternalCapabilities>(
+    emptyExternalCapabilities(),
+  );
   const snapshot$ = state<SignInResourceSnapshot | null>(null);
   const selectedFactor$ = state<AuthV2SignInFactor | null>(null);
   const editIdentifier$ = state(false);
@@ -352,15 +485,19 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
   const code$ = state("");
   const newPassword$ = state("");
   const confirmPassword$ = state("");
+  const useAnotherAccount$ = state(false);
   const state$ = computed((get) => {
-    return deriveSignInFlowState(
-      get(snapshot$),
-      get(selectedFactor$),
-      get(editIdentifier$),
-      get(fatalState$),
-    );
+    return deriveSignInFlowState(get(snapshot$), {
+      accounts: get(accounts$),
+      editIdentifier: get(editIdentifier$),
+      fatalState: get(fatalState$),
+      selectedFactor: get(selectedFactor$),
+      useAnotherAccount: get(useAnotherAccount$),
+    });
   });
   return {
+    accounts$,
+    capabilities$,
     code$,
     confirmPassword$,
     editIdentifier$,
@@ -372,6 +509,7 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
     selectedFactor$,
     snapshot$,
     state$,
+    useAnotherAccount$,
   };
 }
 
@@ -392,6 +530,7 @@ function createResourceCommands(
   runtime: SignInFlowRuntime,
   dependencies: AuthV2SignInFlowDependencies,
 ): {
+  readonly activateSession$: Command<Promise<void>, [string, AbortSignal]>;
   readonly applyResource$: ApplySignInResourceCommand;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
 } {
@@ -432,7 +571,7 @@ function createResourceCommands(
         performActivation$,
         clerk,
         sessionId,
-        dependencies.resolveRedirectUrl(),
+        dependencies.navigation.completionRedirectUrl,
         signal,
       );
       const trackedActivation = withCleanup(activationPromise, () => {
@@ -448,11 +587,14 @@ function createResourceCommands(
 
   const applyResource$ = command(
     async (
-      { set },
+      { get, set },
       resource: SignInResource,
       signal: AbortSignal,
     ): Promise<void> => {
-      const snapshot = snapshotSignInResource(resource);
+      const snapshot = snapshotSignInResource(
+        resource,
+        get(atoms.capabilities$),
+      );
       set(atoms.snapshot$, snapshot);
       set(atoms.fatalState$, null);
       if (
@@ -478,13 +620,37 @@ function createResourceCommands(
 
   const initialize$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      const resource = await get(clerkSignInResource$);
+      const clerk = await get(clerk$);
       signal.throwIfAborted();
-      await set(applyResource$, resource, signal);
+      if (!clerk.client) {
+        throw new Error(
+          "Loaded Clerk instance did not provide a client resource",
+        );
+      }
+      set(atoms.capabilities$, discoverAuthV2ExternalCapabilities(clerk));
+
+      if (dependencies.isOAuthCallbackRoute) {
+        const recovery = await settle(
+          recoverAuthV2GoogleOAuth(clerk, dependencies.navigation),
+          signal,
+        );
+        if (!recovery.ok) {
+          set(atoms.error$, normalizeClerkError(recovery.error, "general"));
+        } else if (recovery.value) {
+          // handleRedirectCallback activates completed OAuth sessions itself.
+          // Remember that ownership boundary so applyResource$ cannot activate
+          // the same session a second time after the callback reload.
+          set(runtime.activatedSessionId$, recovery.value);
+        }
+      }
+
+      signal.throwIfAborted();
+      set(atoms.accounts$, discoverAuthV2ExistingAccounts(clerk));
+      await set(applyResource$, clerk.client.signIn, signal);
       signal.throwIfAborted();
     },
   );
-  return { applyResource$, initialize$ };
+  return { activateSession$, applyResource$, initialize$ };
 }
 
 function createCoalescedOperation$<Key extends CoalescedOperation>(
@@ -601,7 +767,10 @@ function createSubmitOperation$(
 }
 
 function factorPreparation(
-  factor: Exclude<AuthV2SignInFactor, { kind: "password" }>,
+  factor: Extract<
+    AuthV2SignInFactor,
+    { kind: "email-code" | "password-reset" }
+  >,
 ): PrepareFirstFactorParams {
   return {
     emailAddressId: factor.emailAddressId,
@@ -614,6 +783,7 @@ function createFactorSelectionCommand(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
   applyResource$: ApplySignInResourceCommand,
+  dependencies: AuthV2SignInFlowDependencies,
 ): Command<Promise<void>, [string, AbortSignal]> {
   const prepareFactorOperation$ = command(
     async (
@@ -636,16 +806,43 @@ function createFactorSelectionCommand(
 
       set(atoms.error$, null);
       set(atoms.code$, "");
-      if (
-        factor.kind === "password" ||
-        get(runtime.preparedFactorId$) === factor.id
-      ) {
+      if (factor.kind === "password") {
         set(atoms.selectedFactor$, factor);
         return;
       }
 
       const resource = await get(clerkSignInResource$);
       signal.throwIfAborted();
+      if (factor.kind === "oauth") {
+        const redirect = await settle(
+          startAuthV2GoogleOAuth(resource, dependencies.navigation),
+          signal,
+        );
+        if (!redirect.ok) {
+          set(atoms.error$, normalizeClerkError(redirect.error, "general"));
+        }
+        return;
+      }
+      if (factor.kind === "passkey") {
+        const authentication = await settle(
+          resource.authenticateWithPasskey({ flow: "discoverable" }),
+          signal,
+        );
+        if (!authentication.ok) {
+          set(
+            atoms.error$,
+            normalizeClerkError(authentication.error, "general"),
+          );
+          return;
+        }
+        await set(applyResource$, authentication.value, signal);
+        signal.throwIfAborted();
+        return;
+      }
+      if (get(runtime.preparedFactorId$) === factor.id) {
+        set(atoms.selectedFactor$, factor);
+        return;
+      }
       const prepared = await settle(
         resource.prepareFirstFactor(factorPreparation(factor)),
         signal,
@@ -692,6 +889,161 @@ function createFactorSelectionCommand(
   );
 }
 
+function createSessionSelectionCommand(
+  atoms: SignInFlowAtoms,
+  runtime: SignInFlowRuntime,
+  activateSession$: Command<Promise<void>, [string, AbortSignal]>,
+): Command<Promise<void>, [string, AbortSignal]> {
+  const selectSessionOperation$ = command(
+    async (
+      { get, set },
+      sessionId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const account = get(atoms.accounts$).find((candidate) => {
+        return candidate.sessionId === sessionId;
+      });
+      if (!account) {
+        set(atoms.fatalState$, {
+          clerkStatus: get(atoms.snapshot$)?.clerkStatus ?? null,
+          reason: "missing-session",
+          status: "unknown",
+        });
+        return;
+      }
+
+      set(atoms.error$, null);
+      const activation = await settle(
+        set(activateSession$, account.sessionId, signal),
+        signal,
+      );
+      if (!activation.ok) {
+        set(atoms.error$, normalizeClerkError(activation.error, "general"));
+      }
+    },
+  );
+
+  return command(
+    async (
+      { get, set },
+      sessionId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const current = get(runtime.inFlight$).get("resource");
+      if (current) {
+        await current;
+        signal.throwIfAborted();
+        return;
+      }
+      const operation = set(selectSessionOperation$, sessionId, signal);
+      set(runtime.inFlight$, (operations) => {
+        return new Map(operations).set("resource", operation);
+      });
+      await withCleanup(operation, () => {
+        set(runtime.inFlight$, (operations) => {
+          if (operations.get("resource") !== operation) {
+            return operations;
+          }
+          const remaining = new Map(operations);
+          remaining.delete("resource");
+          return remaining;
+        });
+      });
+      signal.throwIfAborted();
+    },
+  );
+}
+
+function createGoogleOneTapCommand(
+  atoms: SignInFlowAtoms,
+  runtime: SignInFlowRuntime,
+  applyResource$: ApplySignInResourceCommand,
+  dependencies: AuthV2SignInFlowDependencies,
+): Command<Promise<void>, [AbortSignal]> {
+  const exchangeCredentialOperation$ = command(
+    async (
+      { get, set },
+      credential: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const resource = await get(clerkSignInResource$);
+      signal.throwIfAborted();
+      set(atoms.error$, null);
+      const exchange = await settle(
+        resource.create({
+          signUpIfMissing: false,
+          strategy: "google_one_tap",
+          token: credential,
+        }),
+        signal,
+      );
+      if (!exchange.ok) {
+        set(atoms.error$, normalizeClerkError(exchange.error, "general"));
+        return;
+      }
+      await set(applyResource$, exchange.value, signal);
+      signal.throwIfAborted();
+    },
+  );
+  const exchangeCredential$ = command(
+    async (
+      { get, set },
+      credential: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const current = get(runtime.inFlight$).get("resource");
+      if (current) {
+        await current;
+        signal.throwIfAborted();
+        return;
+      }
+      const operation = set(exchangeCredentialOperation$, credential, signal);
+      set(runtime.inFlight$, (operations) => {
+        return new Map(operations).set("resource", operation);
+      });
+      await withCleanup(operation, () => {
+        set(runtime.inFlight$, (operations) => {
+          if (operations.get("resource") !== operation) {
+            return operations;
+          }
+          const remaining = new Map(operations);
+          remaining.delete("resource");
+          return remaining;
+        });
+      });
+      signal.throwIfAborted();
+    },
+  );
+  const promptOperation$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      if (!dependencies.isBaseRoute) {
+        return;
+      }
+      const clerk = await get(clerk$);
+      signal.throwIfAborted();
+      const clientId =
+        discoverAuthV2ExternalCapabilities(clerk).googleOneTapClientId;
+      if (!clientId) {
+        return;
+      }
+      const credential = await settle(
+        requestGoogleOneTapCredential(clientId, signal),
+        signal,
+      );
+      if (!credential.ok) {
+        set(atoms.error$, normalizeClerkError(credential.error, "general"));
+        return;
+      }
+      if (!credential.value) {
+        return;
+      }
+      await set(exchangeCredential$, credential.value, signal);
+      signal.throwIfAborted();
+    },
+  );
+  return createCoalescedOperation$(runtime, "one-tap", promptOperation$);
+}
+
 function createResendCodeOperation$(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
@@ -699,7 +1051,10 @@ function createResendCodeOperation$(
 ): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const factor = get(atoms.selectedFactor$);
-    if (!factor || factor.kind === "password") {
+    if (
+      !factor ||
+      (factor.kind !== "email-code" && factor.kind !== "password-reset")
+    ) {
       return;
     }
 
@@ -732,18 +1087,20 @@ function createFormCommands(
   });
   const backToIdentifier$ = command(({ set }) => {
     set(atoms.editIdentifier$, true);
+    set(atoms.useAnotherAccount$, true);
     set(atoms.selectedFactor$, null);
     set(atoms.code$, "");
     set(atoms.password$, "");
     set(atoms.error$, null);
   });
-  const restart$ = command(({ set }) => {
+  const restart$ = command(({ get, set }) => {
     set(runtime.preparedFactorId$, null);
     set(atoms.snapshot$, {
       clerkStatus: "needs_identifier",
       createdSessionId: null,
-      factors: [],
+      factors: entryFactors(get(atoms.capabilities$)),
       transferable: false,
+      unknownFactorStrategies: [],
     });
     set(atoms.selectedFactor$, null);
     set(atoms.editIdentifier$, false);
@@ -754,6 +1111,11 @@ function createFormCommands(
     set(atoms.code$, "");
     set(atoms.newPassword$, "");
     set(atoms.confirmPassword$, "");
+    set(atoms.useAnotherAccount$, true);
+  });
+  const useAnotherAccount$ = command(({ set }) => {
+    set(atoms.useAnotherAccount$, true);
+    set(atoms.error$, null);
   });
   const setIdentifier$ = command(({ set }, value: string) => {
     set(atoms.identifier$, value);
@@ -784,6 +1146,7 @@ function createFormCommands(
     setIdentifier$,
     setNewPassword$,
     setPassword$,
+    useAnotherAccount$,
   };
 }
 
@@ -792,11 +1155,8 @@ export function createAuthV2SignInSignals(
 ): AuthV2SignInSignals {
   const atoms = createSignInFlowAtoms();
   const runtime = createSignInFlowRuntime();
-  const { applyResource$, initialize$ } = createResourceCommands(
-    atoms,
-    runtime,
-    dependencies,
-  );
+  const { activateSession$, applyResource$, initialize$ } =
+    createResourceCommands(atoms, runtime, dependencies);
   const submitOperation$ = createSubmitOperation$(
     atoms,
     runtime,
@@ -808,6 +1168,24 @@ export function createAuthV2SignInSignals(
     applyResource$,
   );
   const formCommands = createFormCommands(atoms, runtime);
+  const runGoogleOneTap$ = createGoogleOneTapCommand(
+    atoms,
+    runtime,
+    applyResource$,
+    dependencies,
+  );
+  const googleOneTapLifecycleRef$ = onRef(
+    command(
+      async (
+        { get, set },
+        _element: HTMLDivElement,
+        signal: AbortSignal,
+      ): Promise<void> => {
+        await set(runGoogleOneTap$, get(pageSignal$));
+        signal.throwIfAborted();
+      },
+    ),
+  );
   return {
     ...formCommands,
     code$: computed((get) => {
@@ -819,6 +1197,7 @@ export function createAuthV2SignInSignals(
     error$: computed((get) => {
       return get(atoms.error$);
     }),
+    googleOneTapLifecycleRef$,
     identifier$: computed((get) => {
       return get(atoms.identifier$);
     }),
@@ -834,7 +1213,17 @@ export function createAuthV2SignInSignals(
       "resource",
       resendCodeOperation$,
     ),
-    selectFactor$: createFactorSelectionCommand(atoms, runtime, applyResource$),
+    selectFactor$: createFactorSelectionCommand(
+      atoms,
+      runtime,
+      applyResource$,
+      dependencies,
+    ),
+    selectSession$: createSessionSelectionCommand(
+      atoms,
+      runtime,
+      activateSession$,
+    ),
     state$: atoms.state$,
     submit$: createCoalescedOperation$(runtime, "resource", submitOperation$),
   };

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -70,7 +70,9 @@ describe("auth v2 presentation", () => {
     expect(screen.getByRole("main")).toContainElement(heading);
     expect(
       screen.getByRole("region", { name: "Sign in to VM0" }),
-    ).toHaveAccessibleDescription("Welcome back! Please sign in to continue");
+    ).toHaveAccessibleDescription(
+      "Select the account with which you wish to continue.",
+    );
     expect(linkByLabel("Go to VM0 home")).toHaveAttribute("href", "/");
 
     const announcer = screen.getByTestId("auth-v2-announcer");

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -12,8 +12,12 @@ import {
   queryAllByRoleFast,
 } from "../../../../__tests__/page-helper.ts";
 import {
+  mockAuthV2Capabilities,
+  mockedGoogleOneTap,
   mockedClerk,
+  mockGoogleOneTapCredential,
   mockSignInResource,
+  type MockedClientSession,
   type MockedSignInFactor,
   type MockedSignInResourceState,
 } from "../../../../__tests__/mock-auth.ts";
@@ -42,6 +46,14 @@ function passwordResetFactor(): MockedSignInFactor {
   };
 }
 
+function googleOAuthFactor(): MockedSignInFactor {
+  return { strategy: "oauth_google" };
+}
+
+function passkeyFactor(): MockedSignInFactor {
+  return { strategy: "passkey" };
+}
+
 function currentSignInResource() {
   return mockedClerk.client.signIn;
 }
@@ -51,14 +63,28 @@ function moveSignInTo(state: MockedSignInResourceState) {
   return currentSignInResource();
 }
 
-function setupSignInPage(state: MockedSignInResourceState): void {
+interface SetupSignInPageOptions {
+  readonly url?: string;
+  readonly user?: {
+    readonly clientSessions: MockedClientSession[];
+    readonly email?: string;
+    readonly fullName: string;
+    readonly id: string;
+  } | null;
+}
+
+function setupSignInPage(
+  state: MockedSignInResourceState,
+  options: SetupSignInPageOptions = {},
+): void {
   mockSignInResource(state);
-  context.mocks.browser.url("https://app.vm0.ai/v2/sign-in");
+  const url = new URL(options.url ?? "https://app.vm0.ai/v2/sign-in");
+  context.mocks.browser.url(url.toString());
   detachedSetupPage({
     context,
-    path: "/v2/sign-in",
+    path: `${url.pathname}${url.search}${url.hash}`,
     session: null,
-    user: null,
+    user: options.user ?? null,
   });
 }
 
@@ -177,9 +203,267 @@ describe("auth v2 sign-in flow", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: "/",
+      redirectUrl: "https://app.vm0.ai",
       session: "session_password",
     });
+  });
+
+  it("hands Google OAuth to Clerk once with typed callback and completion URLs", async () => {
+    const redirectUrl = "https://app.okou.ai/onboarding?source=oauth";
+    const authSearch = new URLSearchParams({
+      redirect_url: redirectUrl,
+      utm_campaign: "oauth",
+    });
+    const authHash = "#/?step=start";
+    mockAuthV2Capabilities({ googleOAuth: true });
+    setupSignInPage(
+      { status: "needs_identifier" },
+      {
+        url: `https://app.vm0.ai/v2/sign-in?${authSearch.toString()}${authHash}`,
+      },
+    );
+
+    const google = await waitForRoleElement("button", "Continue with Google");
+    fireEvent.click(google);
+    fireEvent.click(google);
+
+    await waitFor(() => {
+      expect(mockedClerk.signInAuthenticateWithRedirect).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+    expect(mockedClerk.signInAuthenticateWithRedirect).toHaveBeenCalledWith({
+      continueSignIn: true,
+      continueSignUp: false,
+      redirectUrl: `/v2/sign-in/sso-callback?${authSearch.toString()}${authHash}`,
+      redirectUrlComplete: redirectUrl,
+      strategy: "oauth_google",
+    });
+  });
+
+  it("recovers a Google OAuth callback reload without activating twice", async () => {
+    const redirectUrl = "https://app.okou.ai/onboarding?source=callback";
+    mockSignInResource({
+      createdSessionId: "session_oauth",
+      status: "complete",
+    });
+    mockedClerk.setActive.mockResolvedValue(undefined);
+    mockedClerk.handleRedirectCallback.mockImplementation(async (params) => {
+      await mockedClerk.setActive({
+        redirectUrl: params?.signInForceRedirectUrl ?? undefined,
+        session: "session_oauth",
+      });
+    });
+
+    setupSignInPage(
+      {
+        createdSessionId: "session_oauth",
+        status: "complete",
+      },
+      {
+        url: `https://app.vm0.ai/v2/sign-in/sso-callback?redirect_url=${encodeURIComponent(redirectUrl)}`,
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockedClerk.handleRedirectCallback).toHaveBeenCalledTimes(1);
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.handleRedirectCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        firstFactorUrl: expect.stringContaining("/v2/sign-in/factor-one"),
+        reloadResource: "signIn",
+        signInFallbackRedirectUrl: redirectUrl,
+        signInForceRedirectUrl: redirectUrl,
+        transferable: false,
+      }),
+    );
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      redirectUrl,
+      session: "session_oauth",
+    });
+  });
+
+  it("exchanges one Google One Tap credential only on the exact base route", async () => {
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential("google-one-tap-token");
+    mockedClerk.clientSignInCreate.mockImplementation((params) => {
+      if (params.strategy === "google_one_tap") {
+        return Promise.resolve(
+          moveSignInTo({
+            createdSessionId: "session_one_tap",
+            status: "complete",
+          }),
+        );
+      }
+      return Promise.resolve(currentSignInResource());
+    });
+
+    setupSignInPage({ status: "needs_identifier" });
+
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+        signUpIfMissing: false,
+        strategy: "google_one_tap",
+        token: "google-one-tap-token",
+      });
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedGoogleOneTap.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auto_select: false,
+        client_id: "google-client-id",
+      }),
+    );
+  });
+
+  it("does not start Google One Tap on a nested sign-in route", async () => {
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential("google-one-tap-token");
+
+    setupSignInPage(
+      { status: "needs_identifier" },
+      { url: "https://app.vm0.ai/v2/sign-in/factor-one" },
+    );
+
+    await expect(
+      screen.findByLabelText("Email address or username"),
+    ).resolves.toBeVisible();
+    expect(mockedGoogleOneTap.initialize).not.toHaveBeenCalled();
+    expect(mockedGoogleOneTap.prompt).not.toHaveBeenCalled();
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      clerkError: {
+        errors: [{ code: "passkey_retrieval_cancelled" }],
+      },
+      expectedMessage: "Passkey verification was cancelled or timed out.",
+      name: "user cancellation",
+    },
+    {
+      clerkError: {
+        errors: [{ code: "passkey_not_supported" }],
+      },
+      expectedMessage: "Passkeys are not supported on this device.",
+      name: "an unavailable device",
+    },
+    {
+      clerkError: {
+        errors: [
+          {
+            code: "passkey_verification_failed",
+            longMessage: "Your passkey could not be verified.",
+          },
+        ],
+      },
+      expectedMessage: "Your passkey could not be verified.",
+      name: "a verification error",
+    },
+  ])("keeps another enabled method available after $name", async (testCase) => {
+    mockAuthV2Capabilities({ googleOAuth: true, passkey: true });
+    mockedClerk.signInAuthenticateWithPasskey.mockRejectedValue(
+      testCase.clerkError,
+    );
+    setupSignInPage({
+      status: "needs_first_factor",
+      supportedFirstFactors: [googleOAuthFactor(), passkeyFactor()],
+    });
+
+    const passkey = await waitForRoleElement(
+      "button",
+      "Sign in with your passkey",
+    );
+    fireEvent.click(passkey);
+    fireEvent.click(passkey);
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      testCase.expectedMessage,
+    );
+    expect(mockedClerk.signInAuthenticateWithPasskey).toHaveBeenCalledTimes(1);
+    const google = await waitForRoleElement("button", "Continue with Google");
+    expect(google).toBeVisible();
+    expect(passkey).toBeVisible();
+
+    fireEvent.click(google);
+    await waitFor(() => {
+      expect(mockedClerk.signInAuthenticateWithRedirect).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+  });
+
+  it("selects an existing Clerk account once and can fall back to a new sign-in", async () => {
+    const activation = createDeferredPromise<void>(context.signal);
+    mockedClerk.setActive.mockImplementation(() => {
+      return activation.promise;
+    });
+    setupSignInPage(
+      { status: "needs_identifier" },
+      {
+        user: {
+          clientSessions: [
+            {
+              id: "session_ada",
+              status: "active",
+              user: {
+                fullName: "Ada Lovelace",
+                primaryEmailAddress: { emailAddress: "ada@example.com" },
+              },
+            },
+            {
+              id: "session_grace",
+              status: "active",
+              user: {
+                fullName: "Grace Hopper",
+                primaryEmailAddress: { emailAddress: "grace@example.com" },
+              },
+            },
+          ],
+          email: "ada@example.com",
+          fullName: "Ada Lovelace",
+          id: "user_ada",
+        },
+      },
+    );
+
+    await expect(
+      screen.findByRole("heading", { name: "Choose an account" }),
+    ).resolves.toBeVisible();
+    const adaAccount = queryAllByRoleFast("button").find((candidate) => {
+      return candidate.textContent?.includes("Ada Lovelace");
+    });
+    if (!adaAccount) {
+      throw new Error("Ada Lovelace account button not found");
+    }
+    fireEvent.click(adaAccount);
+    fireEvent.click(adaAccount);
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      redirectUrl: "https://app.vm0.ai",
+      session: "session_ada",
+    });
+
+    await act(async () => {
+      activation.resolve(undefined);
+      await activation.promise;
+    });
+    fireEvent.click(await waitForRoleElement("button", "Add account"));
+
+    await expect(
+      screen.findByLabelText("Email address or username"),
+    ).resolves.toBeVisible();
   });
 
   it("prepares and resends one email code per concurrent user action", async () => {
@@ -328,6 +612,7 @@ describe("auth v2 sign-in flow", () => {
     await expect(
       screen.findByTestId("clerk-sign-in"),
     ).resolves.toBeInTheDocument();
+    expect(screen.getByTestId("clerk-google-one-tap")).toBeInTheDocument();
 
     act(() => {
       window.history.back();
@@ -337,6 +622,9 @@ describe("auth v2 sign-in flow", () => {
     );
 
     await expect(screen.findByLabelText("Password")).resolves.toHaveValue("");
+    expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
+    expect(document.querySelector('[class*="cl-"]')).not.toBeInTheDocument();
   });
 
   it("runs the password-reset code and new-password sequence", async () => {
@@ -451,7 +739,7 @@ describe("auth v2 sign-in flow", () => {
       name: "an unsupported factor set",
       state: {
         status: "needs_first_factor",
-        supportedFirstFactors: [{ strategy: "oauth_google" }],
+        supportedFirstFactors: [{ strategy: "oauth_github" }],
       },
     },
     {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -116,6 +116,13 @@ async function waitForRoleElement(
   return element;
 }
 
+function createStalledGoogleOneTapScript(): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.dataset.authV2GoogleOneTap = "true";
+  document.head.appendChild(script);
+  return script;
+}
+
 async function submitIdentifier(
   identifier: string,
   factors: readonly MockedSignInFactor[],
@@ -341,29 +348,81 @@ describe("auth v2 sign-in flow", () => {
     expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
   });
 
+  it("retries Google One Tap after a script failure and back navigation", async () => {
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    const failedScript = createStalledGoogleOneTapScript();
+    setupSignInPage({ status: "needs_identifier" });
+
+    // Script loading is a browser resource boundary and cannot be triggered
+    // through a rendered control, so dispatch its terminal event directly.
+    await screen.findByLabelText("Email address or username");
+    fireEvent.error(failedScript);
+
+    await waitFor(() => {
+      expect(failedScript).not.toBeInTheDocument();
+    });
+    await expect(screen.findByRole("alert")).resolves.toBeVisible();
+
+    fireEvent.click(await waitForRoleElement("link", "Use current sign-in"));
+    await expect(
+      screen.findByTestId("clerk-sign-in"),
+    ).resolves.toBeInTheDocument();
+
+    const retryScript = createStalledGoogleOneTapScript();
+    act(() => {
+      window.history.back();
+    });
+    await screen.findByLabelText("Email address or username");
+    expect(retryScript).not.toBe(failedScript);
+
+    mockGoogleOneTapCredential("retry-google-one-tap-token");
+    mockedClerk.clientSignInCreate.mockImplementation((params) => {
+      if (params.strategy === "google_one_tap") {
+        return Promise.resolve(
+          moveSignInTo({
+            createdSessionId: "session_one_tap_retry",
+            status: "complete",
+          }),
+        );
+      }
+      return Promise.resolve(currentSignInResource());
+    });
+    fireEvent.load(retryScript);
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+        signUpIfMissing: false,
+        strategy: "google_one_tap",
+        token: "retry-google-one-tap-token",
+      });
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it.each([
     {
       clerkError: {
-        errors: [{ code: "passkey_retrieval_cancelled" }],
+        code: "passkey_retrieval_cancelled",
+        message: "The passkey request was cancelled.",
       },
-      expectedMessage: "Passkey verification was cancelled or timed out.",
+      expectedMessage: "The passkey request was cancelled.",
       name: "user cancellation",
     },
     {
       clerkError: {
-        errors: [{ code: "passkey_not_supported" }],
+        code: "passkey_not_supported",
+        message: "This device does not support passkeys.",
       },
-      expectedMessage: "Passkeys are not supported on this device.",
+      expectedMessage: "This device does not support passkeys.",
       name: "an unavailable device",
     },
     {
       clerkError: {
-        errors: [
-          {
-            code: "passkey_verification_failed",
-            longMessage: "Your passkey could not be verified.",
-          },
-        ],
+        code: "passkey_retrieval_failed",
+        message: "Your passkey could not be verified.",
       },
       expectedMessage: "Your passkey could not be verified.",
       name: "a verification error",

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@okouai/ui";
-import { useGet } from "ccstate-react";
+import { useGet, useSet } from "ccstate-react";
 
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
@@ -15,6 +15,7 @@ export function AuthV2SignInCard({
 }) {
   const copy = useAuthV2SignInCopy();
   const flowState = useGet(signals.state$);
+  const googleOneTapLifecycleRef = useSet(signals.googleOneTapLifecycleRef$);
   const description = signInCardDescription(flowState, copy);
   return (
     <AuthV2Shell
@@ -23,7 +24,7 @@ export function AuthV2SignInCard({
       focusKey="sign-in"
       title={copy.signInTitle}
     >
-      <div className="space-y-4">
+      <div className="space-y-4" ref={googleOneTapLifecycleRef}>
         <SignInCardContent copy={copy} signals={signals} state={flowState} />
         <div className="flex justify-center">
           <Button asChild size="sm" variant="link">

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@okouai/ui";
-import { useGet, useSet } from "ccstate-react";
+import { useGet } from "ccstate-react";
 
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
@@ -15,7 +15,6 @@ export function AuthV2SignInCard({
 }) {
   const copy = useAuthV2SignInCopy();
   const flowState = useGet(signals.state$);
-  const googleOneTapLifecycleRef = useSet(signals.googleOneTapLifecycleRef$);
   const description = signInCardDescription(flowState, copy);
   return (
     <AuthV2Shell
@@ -24,7 +23,7 @@ export function AuthV2SignInCard({
       focusKey="sign-in"
       title={copy.signInTitle}
     >
-      <div className="space-y-4" ref={googleOneTapLifecycleRef}>
+      <div className="space-y-4">
         <SignInCardContent copy={copy} signals={signals} state={flowState} />
         <div className="flex justify-center">
           <Button asChild size="sm" variant="link">

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -97,18 +97,55 @@ function SubmitButton({
   );
 }
 
-function IdentifierStep({ copy, signals }: SignInStepProps) {
+function IdentifierStep({
+  copy,
+  signals,
+  state,
+}: SignInStepProps & { readonly state: IncompleteSignInState }) {
   const identifier = useGet(signals.identifier$);
   const pageSignal = useGet(pageSignal$);
   const setIdentifier = useSet(signals.setIdentifier$);
   const [submitLoadable, submit] = useLoadableSet(signals.submit$);
+  const [selectLoadable, selectFactor] = useLoadableSet(signals.selectFactor$);
+  const externalFactors = state.factors.filter((factor) => {
+    return factor.kind === "oauth" || factor.kind === "passkey";
+  });
+  const operationPending =
+    submitLoadable.state === "loading" || selectLoadable.state === "loading";
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign in");
   };
+  const handleSelectFactor = (factorId: string): void => {
+    detach(
+      selectFactor(factorId, pageSignal),
+      Reason.DomCallback,
+      "select auth v2 sign in factor",
+    );
+  };
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
       <FlowErrorAlert copy={copy} signals={signals} />
+      {externalFactors.length > 0 ? (
+        <div className="space-y-2">
+          {externalFactors.map((factor) => {
+            return (
+              <Button
+                className="w-full"
+                disabled={operationPending}
+                key={factor.id}
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  handleSelectFactor(factor.id);
+                }}
+              >
+                {signInFactorLabel(factor, copy)}
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
       <TextField
         autoComplete="username"
         inputMode="email"
@@ -119,9 +156,72 @@ function IdentifierStep({ copy, signals }: SignInStepProps) {
       />
       <SubmitButton
         busy={submitLoadable.state === "loading"}
+        disabled={operationPending}
         label={copy.continue}
       />
     </form>
+  );
+}
+
+function ChooseSessionStep({
+  copy,
+  signals,
+  state,
+}: SignInStepProps & { readonly state: IncompleteSignInState }) {
+  const pageSignal = useGet(pageSignal$);
+  const useAnotherAccount = useSet(signals.useAnotherAccount$);
+  const [selectionLoadable, selectSession] = useLoadableSet(
+    signals.selectSession$,
+  );
+  const selectAccount = (sessionId: string): void => {
+    detach(
+      selectSession(sessionId, pageSignal),
+      Reason.DomCallback,
+      "select existing auth v2 session",
+    );
+  };
+  return (
+    <div className="space-y-4">
+      <FlowErrorAlert copy={copy} signals={signals} />
+      <h2 className="text-base font-medium text-foreground">
+        {copy.chooseAccountTitle}
+      </h2>
+      <div className="space-y-2">
+        {state.accounts.map((account) => {
+          return (
+            <Button
+              className="h-auto w-full justify-start py-3"
+              disabled={selectionLoadable.state === "loading"}
+              key={account.sessionId}
+              type="button"
+              variant="outline"
+              onClick={() => {
+                selectAccount(account.sessionId);
+              }}
+            >
+              <span className="min-w-0 text-left">
+                <span className="block truncate">{account.displayName}</span>
+                {account.identifier &&
+                account.identifier !== account.displayName ? (
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {account.identifier}
+                  </span>
+                ) : null}
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+      <Button
+        className="w-full"
+        disabled={selectionLoadable.state === "loading"}
+        type="button"
+        variant="ghost"
+        onClick={useAnotherAccount}
+      >
+        {copy.addAccount}
+      </Button>
+    </div>
   );
 }
 
@@ -265,7 +365,9 @@ function CodeStep({
   const operationPending = submitting || resending;
   const selectedFactor = state.selectedFactor;
   const safeIdentifier =
-    selectedFactor && selectedFactor.kind !== "password"
+    selectedFactor &&
+    (selectedFactor.kind === "email-code" ||
+      selectedFactor.kind === "password-reset")
       ? selectedFactor.safeIdentifier
       : null;
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
@@ -450,8 +552,11 @@ export function SignInCardContent({
   if (state.status === "unknown") {
     return <UnknownStep copy={copy} signals={signals} />;
   }
+  if (state.step === "choose-session") {
+    return <ChooseSessionStep copy={copy} signals={signals} state={state} />;
+  }
   if (state.step === "identifier") {
-    return <IdentifierStep copy={copy} signals={signals} />;
+    return <IdentifierStep copy={copy} signals={signals} state={state} />;
   }
   if (state.step === "choose-factor") {
     return <ChooseFactorStep copy={copy} signals={signals} state={state} />;

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
@@ -13,11 +13,15 @@ import { getClerkLocalization } from "../../auth/clerk-localization.ts";
 
 const CLERK_APPLICATION_NAME = "{{applicationName}}";
 const CLERK_IDENTIFIER = "{{identifier}}";
+const CLERK_PROVIDER = "{{provider|titleize}}";
 
 type ClerkLocalization = ReturnType<typeof getClerkLocalization>;
 
 export interface AuthV2SignInCopy {
+  readonly addAccount: string;
   readonly back: string;
+  readonly chooseAccountSubtitle: string;
+  readonly chooseAccountTitle: string;
   readonly chooseMethodSubtitle: string;
   readonly chooseMethodTitle: string;
   readonly codeLabel: string;
@@ -30,6 +34,7 @@ export interface AuthV2SignInCopy {
   readonly emailCodeSubtitle: string;
   readonly emailCodeTitle: string;
   readonly forgotPassword: string;
+  readonly googleMethod: string;
   readonly identifierLabel: string;
   readonly legacySignIn: string;
   readonly loading: string;
@@ -45,6 +50,9 @@ export interface AuthV2SignInCopy {
   readonly passwordResetMethod: string;
   readonly passwordSubtitle: string;
   readonly passwordTitle: string;
+  readonly passkeyCancelled: string;
+  readonly passkeyMethod: string;
+  readonly passkeyUnavailable: string;
   readonly resendCode: string;
   readonly resetPassword: string;
   readonly resetPasswordCodeSubtitle: string;
@@ -156,6 +164,50 @@ function methodCopy(localization: ClerkLocalization) {
     passwordMethod: localizedString(
       methods?.blockButton__password,
       fallback?.blockButton__password,
+    ),
+    passkeyMethod: localizedString(
+      methods?.blockButton__passkey,
+      fallback?.blockButton__passkey,
+    ),
+    googleMethod: replaceClerkVariable(
+      localizedString(
+        localization.socialButtonsBlockButton,
+        enUS.socialButtonsBlockButton,
+      ),
+      CLERK_PROVIDER,
+      "Google",
+    ),
+  };
+}
+
+function accountCopy(localization: ClerkLocalization) {
+  const accountSwitcher = localization.signIn?.accountSwitcher;
+  const fallback = enUS.signIn?.accountSwitcher;
+  return {
+    addAccount: localizedString(
+      accountSwitcher?.action__addAccount,
+      fallback?.action__addAccount,
+    ),
+    chooseAccountSubtitle: localizedString(
+      accountSwitcher?.subtitle,
+      fallback?.subtitle,
+    ),
+    chooseAccountTitle: localizedString(
+      accountSwitcher?.title,
+      fallback?.title,
+    ),
+  };
+}
+
+function passkeyErrorCopy(localization: ClerkLocalization) {
+  return {
+    passkeyCancelled: localizedString(
+      localization.unstable__errors?.passkey_retrieval_cancelled,
+      enUS.unstable__errors?.passkey_retrieval_cancelled,
+    ),
+    passkeyUnavailable: localizedString(
+      localization.unstable__errors?.passkey_not_supported,
+      enUS.unstable__errors?.passkey_not_supported,
     ),
   };
 }
@@ -272,12 +324,14 @@ export function useAuthV2SignInCopy(): AuthV2SignInCopy {
   return {
     ...formCopy(localization),
     ...startCopy(localization),
+    ...accountCopy(localization),
     ...methodCopy(localization),
     ...passwordCopy(localization),
     ...emailCodeCopy(localization, authBrand.brandName),
     ...resetPasswordCopy(localization),
     ...resetCodeCopy(localization),
     ...terminalCopy(localization, authBrand.brandName),
+    ...passkeyErrorCopy(localization),
     ...translatedCopy,
   };
 }
@@ -288,6 +342,12 @@ export function signInErrorMessage(
 ): string {
   if (error.code === "password-mismatch") {
     return copy.passwordMismatch;
+  }
+  if (error.code === "passkey-cancelled") {
+    return error.message ?? copy.passkeyCancelled;
+  }
+  if (error.code === "passkey-unavailable") {
+    return error.message ?? copy.passkeyUnavailable;
   }
   return error.message ?? copy.unknownError;
 }
@@ -310,6 +370,9 @@ export function signInCardDescription(
   }
   if (flowState.step === "choose-factor") {
     return copy.chooseMethodSubtitle;
+  }
+  if (flowState.step === "choose-session") {
+    return copy.chooseAccountSubtitle;
   }
   if (flowState.step === "password") {
     return copy.passwordSubtitle;
@@ -335,6 +398,12 @@ export function signInFactorLabel(
   }
   if (factor.kind === "password-reset") {
     return copy.passwordResetMethod;
+  }
+  if (factor.kind === "oauth") {
+    return copy.googleMethod;
+  }
+  if (factor.kind === "passkey") {
+    return copy.passkeyMethod;
   }
   return replaceClerkVariable(
     copy.emailCodeMethod,


### PR DESCRIPTION
## Summary

- add Clerk-returned existing-session account selection to the vm0-owned Auth v2 sign-in flow
- add Google OAuth redirect handoff and callback recovery, plus sign-in-only Google One Tap gated to the exact `/v2/sign-in` route
- discover and authenticate passkeys with cancellation, unavailable-device, error, and enabled-method fallback handling
- preserve coalesced Clerk resource operations, exactly-once session activation, and the typed Auth v2 platform/navigation contract

## Verification

- `pnpm vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx src/views/auth/__tests__/auth-page.test.tsx src/signals/auth-v2/navigation.test.ts src/signals/auth-v2/platform-context.test.ts` (62 tests)
- `pnpm exec tsc -p tsconfig.production.json --noEmit`
- `pnpm exec tsc -p tsconfig.tests.json --noEmit`
- targeted ESLint and Oxlint for the touched Auth v2 modules and tests
- Prettier check with the lockfile-pinned version

## Scope

- does not redirect production authentication traffic to `/v2`
- does not remove or change the v1 `/sign-in` or `/sign-up` pages
- does not implement Auth v2 sign-up, continuation/organization selection, second-factor UI, analytics, or rollout

Refs #28927
