### PR TITLE
refactor(desktop): rename unsigned-build signing bypass environment key

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -43,7 +43,7 @@ ruby -e '
   raise "deploy-desktop must use a SHA-addressed R2 prefix" unless artifact_step.fetch("run").include?(ARGV[6])
 
   build_step = deploy.fetch("steps").find { |step| step["name"] == "Build canonical unsigned Desktop app" }
-  raise "canonical Desktop build must skip signing" unless build_step.fetch("env").fetch("VM0_DESKTOP_SKIP_SIGNING") == "true"
+  raise "canonical Desktop build must skip signing" unless build_step.fetch("env").fetch("OKOU_DESKTOP_SKIP_SIGNING") == "true"
   raise "canonical Desktop build must package Okou" unless build_step.fetch("run").include?("Okou.app")
   raise "canonical Okou build must target app.okou.ai" unless build_step.fetch("run").include?("VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai")
 

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -110,7 +110,7 @@ if bash "$verify_script" "$unsafe_dir" "$commit_sha" "$desktop_version" >/dev/nu
   exit 1
 fi
 
-VM0_DESKTOP_SKIP_SIGNING=true node - "$repo_root" <<'NODE'
+OKOU_DESKTOP_SKIP_SIGNING=true node - "$repo_root" <<'NODE'
 const path = require("node:path");
 
 const repoRoot = process.argv[2];
@@ -134,7 +134,7 @@ forgeConfig.hooks
   });
 NODE
 
-VM0_DESKTOP_SKIP_SIGNING=true \
+OKOU_DESKTOP_SKIP_SIGNING=true \
 VM0_DESKTOP_PRODUCT=okou \
 VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
 node - "$repo_root" <<'NODE'

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -649,7 +649,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT_DESKTOP: ${{ vars.SENTRY_PROJECT_DESKTOP }}
           SENTRY_ENVIRONMENT: production
-          VM0_DESKTOP_SKIP_SIGNING: "true"
+          OKOU_DESKTOP_SKIP_SIGNING: "true"
         working-directory: turbo
         run: |
           cleanup_runtime_config() {

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -61,7 +61,7 @@ const osxNotarize = desktopNotarizeOptions();
 async function signPackagedDarwinApps(_forgeConfig, packageResult) {
   if (
     packageResult.platform !== "darwin" ||
-    process.env.VM0_DESKTOP_SKIP_SIGNING === "true"
+    process.env.OKOU_DESKTOP_SKIP_SIGNING === "true"
   ) {
     return;
   }


### PR DESCRIPTION
## Summary

- Rename the private unsigned Desktop build handshake from `VM0_DESKTOP_SKIP_SIGNING` to `OKOU_DESKTOP_SKIP_SIGNING`.
- Update the canonical workflow writer, sole Forge reader, both artifact-test fixture writers, and the workflow-structure assertion atomically.
- Preserve exact `true` semantics, Darwin gating, signing and notarization behavior, workflow commands and checkout, and artifact identity.

Closes #29088
Refs #28914

## Contract evidence

- Refreshed `origin/main` before editing at `25bffa6b84524c2455394221b260b53383a212f2`; a complete tracked-file exact-key search found exactly five legacy occurrences across the four scoped files and zero canonical occurrences.
- Fully paginated every file list for all 22 then-open PRs, including the 185-file PR #25722; none overlapped the four scoped files.
- While validation ran, `main` advanced to `8011fe5283f6d570e911284c67ec47a9acc89302`. None of the four scoped files changed, the same five legacy occurrences remained, and this branch was fast-forwarded to that current baseline before commit.
- The PR head has zero `VM0_DESKTOP_SKIP_SIGNING` occurrences and exactly five `OKOU_DESKTOP_SKIP_SIGNING` occurrences in the intended writer, reader, two fixture writers, and assertion.
- The `deploy-desktop` job checks out its event SHA without a `ref` override, then runs the canonical build from that checkout. The workflow writer and `forge.config.js` reader therefore come from the same repository revision.
- The complete diff is four files and exactly five one-to-one string replacements (5 insertions, 5 deletions); no fallback or unrelated environment-key change is present.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm exec prettier --check apps/desktop/forge.config.js ../.github/workflows/desktop.yml`
- `pnpm -F @okouai/desktop lint`
- `pnpm -F @okouai/desktop check-types`
- `bash .github/scripts/tests/deploy-desktop-workflow-test.sh`
- `bash .github/scripts/tests/okou-desktop-artifact-test.sh`

No full local Vitest suite or local development server was run; PR CI is authoritative.
