### PR TITLE
perf(ci): scope rust checks for mitm-addon-only changes

### DIFF
--- a/.github/scripts/mitm-addon-only-changed.sh
+++ b/.github/scripts/mitm-addon-only-changed.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: mitm-addon-only-changed.sh <base-ref>" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BASE_REF=$1
+
+if ! BASE_COMMIT=$(git -C "$REPO_ROOT" rev-parse --verify "${BASE_REF}^{commit}" 2>/dev/null); then
+  echo "Invalid base ref: ${BASE_REF}" >&2
+  exit 2
+fi
+
+mapfile -d '' -t changed_files < <(
+  git -C "$REPO_ROOT" diff --no-renames --name-only -z "$BASE_COMMIT" HEAD --
+)
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  echo "No changed files" >&2
+  exit 1
+fi
+
+for changed_file in "${changed_files[@]}"; do
+  case "$changed_file" in
+    crates/runner/mitm-addon/*) ;;
+    *)
+      echo "Non-addon path changed: ${changed_file}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Only mitm-addon paths changed" >&2

--- a/.github/scripts/mitm-addon-only-changed.sh
+++ b/.github/scripts/mitm-addon-only-changed.sh
@@ -15,9 +15,21 @@ if ! BASE_COMMIT=$(git -C "$REPO_ROOT" rev-parse --verify "${BASE_REF}^{commit}"
   exit 2
 fi
 
-mapfile -d '' -t changed_files < <(
-  git -C "$REPO_ROOT" diff --no-renames --name-only -z "$BASE_COMMIT" HEAD --
-)
+if ! changed_files_file=$(mktemp); then
+  echo "Failed to create changed-files buffer" >&2
+  exit 2
+fi
+trap 'rm -f "$changed_files_file"' EXIT
+
+if ! git -C "$REPO_ROOT" diff --no-renames --name-only -z "$BASE_COMMIT" HEAD -- \
+  > "$changed_files_file"; then
+  echo "Failed to inspect changed files" >&2
+  exit 2
+fi
+if ! mapfile -d '' -t changed_files < "$changed_files_file"; then
+  echo "Failed to read changed files" >&2
+  exit 2
+fi
 
 if [ "${#changed_files[@]}" -eq 0 ]; then
   echo "No changed files" >&2

--- a/.github/scripts/mitm-addon-only-changed.sh
+++ b/.github/scripts/mitm-addon-only-changed.sh
@@ -28,7 +28,7 @@ for changed_file in "${changed_files[@]}"; do
   case "$changed_file" in
     crates/runner/mitm-addon/*) ;;
     *)
-      echo "Non-addon path changed: ${changed_file}" >&2
+      echo "Change set includes paths outside mitm-addon" >&2
       exit 1
       ;;
   esac

--- a/.github/scripts/tests/mitm-addon-ci-selection-test.sh
+++ b/.github/scripts/tests/mitm-addon-ci-selection-test.sh
@@ -134,6 +134,13 @@ assert_status 1 "$rename_base" "cross-boundary rename"
 
 assert_status 2 does-not-exist "invalid base ref"
 
+diff_error_base=$(git -C "$repo" rev-parse HEAD^)
+diff_error_tree=$(git -C "$repo" rev-parse "${diff_error_base}^{tree}")
+diff_error_object="${repo}/.git/objects/${diff_error_tree:0:2}/${diff_error_tree:2}"
+[ -f "$diff_error_object" ] || fail "diff failure fixture must use a loose tree object"
+rm -f -- "$diff_error_object"
+assert_status 2 "$diff_error_base" "Git diff failure"
+
 crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
 security_json=$(yq -o=json '.' "$SECURITY_WORKFLOW")
 

--- a/.github/scripts/tests/mitm-addon-ci-selection-test.sh
+++ b/.github/scripts/tests/mitm-addon-ci-selection-test.sh
@@ -154,9 +154,10 @@ jq -e '
     .id == "detect" and
     (.run | contains(".github/scripts/mitm-addon-only-changed.sh \"$BASE_REF\"")) and
     (.run | contains("mitm-addon-only-changed=true")) and
-    (.run | contains("mitm-addon-only-changed=false"))
+    (.run | contains("mitm-addon-only-changed=false")) and
+    (.run | contains("exit \"$mitm_addon_only_rc\""))
   )
-' <<<"$crates_json" >/dev/null || fail "detect must map classifier statuses to explicit outputs"
+' <<<"$crates_json" >/dev/null || fail "detect must map classifier statuses and propagate errors"
 
 jq -e '
   .jobs.check.if == "needs.detect.outputs.any-changed == '\''true'\''"

--- a/.github/scripts/tests/mitm-addon-ci-selection-test.sh
+++ b/.github/scripts/tests/mitm-addon-ci-selection-test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLASSIFIER="${SCRIPT_DIR}/mitm-addon-only-changed.sh"
+CRATES_WORKFLOW="${REPO_ROOT}/.github/workflows/crates.yml"
+SECURITY_WORKFLOW="${REPO_ROOT}/.github/workflows/security.yml"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+for command in git jq yq; do
+  command -v "$command" >/dev/null || fail "$command is required"
+done
+
+repo="${TEST_ROOT}/repo"
+mkdir -p \
+  "${repo}/.github/scripts" \
+  "${repo}/.github/workflows" \
+  "${repo}/crates/runner/mitm-addon/src" \
+  "${repo}/crates/runner/mitm-addon/tests" \
+  "${repo}/crates/runner/src"
+cp "$CLASSIFIER" "${repo}/.github/scripts/mitm-addon-only-changed.sh"
+chmod +x "${repo}/.github/scripts/mitm-addon-only-changed.sh"
+
+printf 'name: crates\n' > "${repo}/.github/workflows/crates.yml"
+printf '[workspace]\n' > "${repo}/crates/Cargo.toml"
+printf 'fn main() {}\n' > "${repo}/crates/runner/build.rs"
+printf 'fn main() {}\n' > "${repo}/crates/runner/src/main.rs"
+printf 'print("addon")\n' > "${repo}/crates/runner/mitm-addon/src/addon.py"
+printf 'print("rename")\n' > "${repo}/crates/runner/mitm-addon/src/rename.py"
+printf 'def test_addon(): pass\n' > "${repo}/crates/runner/mitm-addon/tests/test_addon.py"
+printf '[project]\nname = "addon"\n' > "${repo}/crates/runner/mitm-addon/pyproject.toml"
+printf 'version = 1\n' > "${repo}/crates/runner/mitm-addon/uv.lock"
+
+git -C "$repo" init -q
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+git -C "$repo" add --all
+git -C "$repo" commit -qm baseline
+
+run_classifier() {
+  local base_ref=$1
+  (
+    cd "$repo"
+    .github/scripts/mitm-addon-only-changed.sh "$base_ref"
+  )
+}
+
+assert_status() {
+  local expected=$1 base_ref=$2 label=$3 output status
+  if output=$(run_classifier "$base_ref" 2>&1); then
+    status=0
+  else
+    status=$?
+  fi
+  if [ "$status" -ne "$expected" ]; then
+    fail "${label}: expected status ${expected}, got ${status}: ${output}"
+  fi
+}
+
+commit_change() {
+  local path=$1 label=$2
+  printf '\n# %s\n' "$label" >> "${repo}/${path}"
+  git -C "$repo" add -- "$path"
+  git -C "$repo" commit -qm "$label"
+}
+
+assert_path_status() {
+  local expected=$1 path=$2 label=$3 base_ref
+  base_ref=$(git -C "$repo" rev-parse HEAD)
+  commit_change "$path" "$label"
+  assert_status "$expected" "$base_ref" "$label"
+}
+
+empty_base=$(git -C "$repo" rev-parse HEAD)
+assert_status 1 "$empty_base" "empty change set"
+
+assert_path_status 0 \
+  crates/runner/mitm-addon/src/addon.py \
+  "addon source"
+assert_path_status 0 \
+  crates/runner/mitm-addon/tests/test_addon.py \
+  "addon tests"
+assert_path_status 0 \
+  crates/runner/mitm-addon/pyproject.toml \
+  "addon project configuration"
+assert_path_status 0 \
+  crates/runner/mitm-addon/uv.lock \
+  "addon lockfile"
+
+assert_path_status 1 crates/runner/src/main.rs "runner Rust source"
+assert_path_status 1 crates/runner/build.rs "runner build script"
+assert_path_status 1 crates/Cargo.toml "Cargo workspace configuration"
+assert_path_status 1 .github/workflows/crates.yml "shared workflow"
+
+mixed_base=$(git -C "$repo" rev-parse HEAD)
+printf '\n# mixed addon\n' >> "${repo}/crates/runner/mitm-addon/src/addon.py"
+printf '\n// mixed Rust\n' >> "${repo}/crates/runner/src/main.rs"
+git -C "$repo" add -- \
+  crates/runner/mitm-addon/src/addon.py \
+  crates/runner/src/main.rs
+git -C "$repo" commit -qm "mixed addon and Rust"
+assert_status 1 "$mixed_base" "mixed addon and Rust"
+
+rename_base=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" mv \
+  crates/runner/mitm-addon/src/rename.py \
+  crates/runner/src/rename.py
+git -C "$repo" commit -qm "cross-boundary rename"
+assert_status 1 "$rename_base" "cross-boundary rename"
+
+assert_status 2 does-not-exist "invalid base ref"
+
+crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
+security_json=$(yq -o=json '.' "$SECURITY_WORKFLOW")
+
+jq -e '
+  .jobs.detect.outputs["mitm-addon-only-changed"] ==
+    "${{ steps.detect.outputs.mitm-addon-only-changed }}"
+' <<<"$crates_json" >/dev/null || fail "detect must publish addon-only classification"
+
+jq -e '
+  any(.jobs.detect.steps[];
+    .id == "detect" and
+    (.run | contains(".github/scripts/mitm-addon-only-changed.sh \"$BASE_REF\"")) and
+    (.run | contains("mitm-addon-only-changed=true")) and
+    (.run | contains("mitm-addon-only-changed=false"))
+  )
+' <<<"$crates_json" >/dev/null || fail "detect must map classifier statuses to explicit outputs"
+
+jq -e '
+  .jobs.check.if == "needs.detect.outputs.any-changed == '\''true'\''"
+' <<<"$crates_json" >/dev/null || fail "check job must remain selected for addon-only changes"
+
+for step_name in "Check formatting" "Run clippy" "Build documentation"; do
+  jq -e --arg step_name "$step_name" '
+    any(.jobs.check.steps[];
+      .name == $step_name and
+      .if == "needs.detect.outputs.mitm-addon-only-changed != '\''true'\''"
+    )
+  ' <<<"$crates_json" >/dev/null || fail "${step_name} must skip only for explicit addon-only changes"
+done
+
+jq -e '
+  any(.jobs.check.steps[];
+    .name == "Check runner and mitm-addon version contract" and
+    .if == "needs.detect.outputs.mitm-addon-only-changed == '\''true'\''" and
+    (.run | contains("cargo test -p runner --bin runner")) and
+    (.run | contains("deps::tests::mitmproxy_version_contract_matches_python_runtime_and_tests")) and
+    (.run | contains("--exact"))
+  )
+' <<<"$crates_json" >/dev/null || fail "addon-only check must run the focused runner contract"
+
+jq -e '
+  (.jobs.coverage.if | contains("needs.detect.outputs.any-changed == '\''true'\''")) and
+  (.jobs.coverage.if | contains("needs.detect.outputs.mitm-addon-only-changed != '\''true'\''"))
+' <<<"$crates_json" >/dev/null || fail "coverage must fail closed and skip only addon-only changes"
+
+jq -e '
+  (.jobs["mitm-addon-test"].if | contains("needs.detect.outputs.any-changed == '\''true'\''")) and
+  (.jobs["mitm-addon-test"].if | contains("mitm-addon-only-changed") | not)
+' <<<"$crates_json" >/dev/null || fail "addon Python checks must remain selected independently"
+
+jq -e '
+  (.jobs["runner-build"].if | contains("crates-runner-consumer-needed")) and
+  (.jobs["runner-build"].if | contains("mitm-addon-only-changed") | not)
+' <<<"$crates_json" >/dev/null || fail "runner build selection must not use addon-only classification"
+
+jq -e '
+  any(.jobs["ci-gate-crates"].steps[];
+    .name == "Validate CI results" and
+    (.run | contains("check_result \"check\" \"${{ needs.check.result }}\" \"true\"")) and
+    (.run | contains("check_result \"coverage\" \"${{ needs.coverage.result }}\" \"true\""))
+  )
+' <<<"$crates_json" >/dev/null || fail "Crates gate must accept relevance-based check and coverage skips"
+
+jq -e '
+  any(.jobs.actionlint.steps[];
+    .name == "Run workflow script tests" and
+    (.run | contains(".github/scripts/mitm-addon-only-changed.sh")) and
+    (.run | contains(".github/scripts/tests/mitm-addon-ci-selection-test.sh"))
+  )
+' <<<"$security_json" >/dev/null || fail "Security CI must ShellCheck the addon CI scripts"
+
+echo "mitm-addon-ci-selection-test: ok"

--- a/.github/scripts/tests/mitm-addon-ci-selection-test.sh
+++ b/.github/scripts/tests/mitm-addon-ci-selection-test.sh
@@ -174,13 +174,15 @@ done
 
 jq -e '
   any(.jobs.check.steps[];
-    .name == "Check runner and mitm-addon version contract" and
+    .name == "Check runner and mitm-addon contracts" and
     .if == "needs.detect.outputs.mitm-addon-only-changed == '\''true'\''" and
     (.run | contains("cargo test -p runner --bin runner")) and
     (.run | contains("deps::tests::mitmproxy_version_contract_matches_python_runtime_and_tests")) and
+    (.run | contains("proxy::process::tests::embedded_addon_reads_runner_token_environment")) and
+    (.run | contains("proxy::process::tests::addon_scripts_are_embedded")) and
     (.run | contains("--exact"))
   )
-' <<<"$crates_json" >/dev/null || fail "addon-only check must run the focused runner contract"
+' <<<"$crates_json" >/dev/null || fail "addon-only check must run the focused runner contracts"
 
 jq -e '
   (.jobs.coverage.if | contains("needs.detect.outputs.any-changed == '\''true'\''")) and

--- a/.github/scripts/tests/mitm-addon-ci-selection-test.sh
+++ b/.github/scripts/tests/mitm-addon-ci-selection-test.sh
@@ -99,6 +99,23 @@ assert_path_status 1 crates/runner/build.rs "runner build script"
 assert_path_status 1 crates/Cargo.toml "Cargo workspace configuration"
 assert_path_status 1 .github/workflows/crates.yml "shared workflow"
 
+untrusted_base=$(git -C "$repo" rev-parse HEAD)
+untrusted_path=$'.github/workflows/untrusted\n::warning::forged-command.yml'
+printf 'name: untrusted\n' > "${repo}/${untrusted_path}"
+git -C "$repo" add -- "$untrusted_path"
+git -C "$repo" commit -qm "untrusted path"
+if untrusted_output=$(run_classifier "$untrusted_base" 2>&1); then
+  untrusted_status=0
+else
+  untrusted_status=$?
+fi
+if [ "$untrusted_status" -ne 1 ]; then
+  fail "untrusted path: expected status 1, got ${untrusted_status}: ${untrusted_output}"
+fi
+if [[ "$untrusted_output" == *"::warning::forged-command"* ]]; then
+  fail "untrusted path must not be emitted into workflow logs"
+fi
+
 mixed_base=$(git -C "$repo" rev-parse HEAD)
 printf '\n# mixed addon\n' >> "${repo}/crates/runner/mitm-addon/src/addon.py"
 printf '\n// mixed Rust\n' >> "${repo}/crates/runner/src/main.rs"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -64,6 +64,7 @@ jobs:
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
+      mitm-addon-only-changed: ${{ steps.detect.outputs.mitm-addon-only-changed }}
       mitm-addon-test-inputs-changed: ${{ steps.detect.outputs.mitm-addon-test-inputs-changed }}
       mitm-addon-pricing-seed-changed: ${{ steps.detect.outputs.mitm-addon-pricing-seed-changed }}
       runner-firewall-contract-inputs-changed: ${{ steps.detect.outputs.runner-firewall-contract-inputs-changed }}
@@ -119,6 +120,16 @@ jobs:
           check_crate runner
           check_crate nbd-cow
           check_crate vsock-test
+
+          mitm_addon_only_rc=0
+          .github/scripts/mitm-addon-only-changed.sh "$BASE_REF" && mitm_addon_only_rc=0 || mitm_addon_only_rc=$?
+          if [ "$mitm_addon_only_rc" -eq 0 ]; then
+            echo "mitm-addon-only-changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$mitm_addon_only_rc" -eq 1 ]; then
+            echo "mitm-addon-only-changed=false" >> "$GITHUB_OUTPUT"
+          else
+            exit "$mitm_addon_only_rc"
+          fi
 
           # Aggregate: true if any crate or CI config changed
           if grep -q "=true" "$GITHUB_OUTPUT"; then
@@ -312,11 +323,13 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
+        if: needs.detect.outputs.mitm-addon-only-changed != 'true'
         run: |
           cd crates
           cargo fmt --all -- --check
 
       - name: Run clippy
+        if: needs.detect.outputs.mitm-addon-only-changed != 'true'
         run: |
           cd crates
           cargo clippy --all-targets --all-features
@@ -330,9 +343,18 @@ jobs:
           cargo clippy -p vsock-guest --release --no-default-features --all-targets
 
       - name: Build documentation
+        if: needs.detect.outputs.mitm-addon-only-changed != 'true'
         run: |
           cd crates
           cargo doc --workspace --all-features --no-deps
+
+      - name: Check runner and mitm-addon version contract
+        if: needs.detect.outputs.mitm-addon-only-changed == 'true'
+        run: |
+          cd crates
+          cargo test -p runner --bin runner \
+            deps::tests::mitmproxy_version_contract_matches_python_runtime_and_tests -- \
+            --exact
 
       - name: Run ably-subscriber smoke test
         if: |
@@ -411,7 +433,9 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
-    if: needs.detect.outputs.any-changed == 'true'
+    if: |
+      needs.detect.outputs.any-changed == 'true' &&
+      needs.detect.outputs.mitm-addon-only-changed != 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -348,12 +348,18 @@ jobs:
           cd crates
           cargo doc --workspace --all-features --no-deps
 
-      - name: Check runner and mitm-addon version contract
+      - name: Check runner and mitm-addon contracts
         if: needs.detect.outputs.mitm-addon-only-changed == 'true'
         run: |
           cd crates
           cargo test -p runner --bin runner \
             deps::tests::mitmproxy_version_contract_matches_python_runtime_and_tests -- \
+            --exact
+          cargo test -p runner --bin runner \
+            proxy::process::tests::embedded_addon_reads_runner_token_environment -- \
+            --exact
+          cargo test -p runner --bin runner \
+            proxy::process::tests::addon_scripts_are_embedded -- \
             --exact
 
       - name: Run ably-subscriber smoke test

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -256,6 +256,7 @@ jobs:
             .github/scripts/download-verified.sh \
             .github/scripts/fetch-okou-desktop-artifact.sh \
             .github/scripts/list-okou-pages-preview-pr-numbers.sh \
+            .github/scripts/mitm-addon-only-changed.sh \
             .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
@@ -285,6 +286,7 @@ jobs:
             .github/scripts/tests/download-verified-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/list-okou-pages-preview-pr-numbers-test.sh \
+            .github/scripts/tests/mitm-addon-ci-selection-test.sh \
             .github/scripts/tests/neon-credential-mask-test.sh \
             .github/scripts/tests/neon-connection-string-ssl-test.sh \
             .github/scripts/tests/okou-desktop-artifact-test.sh \


### PR DESCRIPTION
## Summary

- classify non-empty `mitm-addon`-only diffs independently from the existing runner change signal
- keep runner image, behavior, E2E, Python, and focused runner/addon cross-language validation selected
- retain the mitmproxy version, runner-token environment, and embedded addon file-set contracts
- skip broad workspace Rust format, Clippy, documentation, and coverage only after an explicit addon-only classification
- propagate changed-file buffer and `git diff` failures instead of converting them into a boolean classification
- avoid emitting untrusted changed paths into GitHub Actions logs
- cover addon source/test/config, Rust, Cargo, workflow, mixed, rename, empty, invalid-base, Git diff failure, and workflow-command-shaped filename scenarios against the production classifier

## Expected CI impact

The representative addon-only merge-group run spent 178 seconds in broad Rust `check` and 289 seconds in Rust `coverage`, or 467 runner-seconds in aggregate. Runner behavior completed 71 seconds after coverage in that run, so the evidence supports capacity savings but not a wall-time reduction for that specific run.

This PR intentionally takes the broad path because it changes shared workflow inputs. A later natural addon-only run is required to measure post-merge wall time.

## Validation

- `PATH="/workspaces/vm6/codex-work/tools/bin:$PATH" bash .github/scripts/tests/mitm-addon-ci-selection-test.sh`
- `bash -n .github/scripts/mitm-addon-only-changed.sh .github/scripts/tests/mitm-addon-ci-selection-test.sh`
- `shellcheck .github/scripts/mitm-addon-only-changed.sh .github/scripts/tests/mitm-addon-ci-selection-test.sh`
- `PATH="/workspaces/vm6/codex-work/tools/bin:$PATH" .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml .github/workflows/security.yml`
- `actionlint v1.7.12`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `bash .github/scripts/tests/runner-image-context-test.sh`
- `bash .github/scripts/tests/checkout-depth-test.sh`
- `cargo test -p runner --bin runner deps::tests::mitmproxy_version_contract_matches_python_runtime_and_tests -- --exact`
- `cargo test -p runner --bin runner proxy::process::tests::embedded_addon_reads_runner_token_environment -- --exact`
- `cargo test -p runner --bin runner proxy::process::tests::addon_scripts_are_embedded -- --exact`
- `lefthook run pre-commit`

## Scope

No runtime, deployment, API, database, persisted-state, or addon embedding contract changes. This does not split the addon from the runner or reuse artifacts from another unmerged queue entry.

Closes #29019

Parent context: #29016
