### PR TITLE
feat(auth): add v2 sign-up flow

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,3 +1,4 @@
+import type { PasswordValidation } from "@clerk/react/types";
 import { vi } from "vitest";
 import { replaceState } from "../signals/location.ts";
 
@@ -171,7 +172,7 @@ let internalMockedSignUpConfiguration: Required<MockedSignUpConfiguration> = {
   privacyPolicyUrl: "https://vm0.ai/privacy",
   termsUrl: "https://vm0.ai/terms",
 };
-let internalMockedPasswordValidation = {
+let internalMockedPasswordValidation: PasswordValidation = {
   complexity: {},
   strength: undefined,
 };
@@ -222,7 +223,7 @@ export function mockSignUpConfiguration(
 }
 
 export function mockSignUpPasswordValidation(
-  validation: typeof internalMockedPasswordValidation,
+  validation: PasswordValidation,
 ): void {
   internalMockedPasswordValidation = validation;
 }
@@ -662,9 +663,7 @@ const signUpAttemptEmailAddressVerification = vi.fn<
 >(defaultSignUpResourceOperationImpl);
 
 interface MockedPasswordValidationCallbacks {
-  readonly onValidation?: (
-    validation: typeof internalMockedPasswordValidation,
-  ) => void;
+  readonly onValidation?: (validation: PasswordValidation) => void;
 }
 
 function defaultSignUpValidatePasswordImpl(

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -70,6 +70,31 @@ export interface MockedSignInResourceState {
   readonly supportedFirstFactors?: readonly MockedSignInFactor[] | null;
 }
 
+export interface MockedSignUpResourceState {
+  readonly createdSessionId?: string | null;
+  readonly emailAddress?: string | null;
+  readonly emailVerificationExpireAt?: Date | null;
+  readonly emailVerificationStatus?: string | null;
+  readonly emailVerificationStrategy?: string | null;
+  readonly firstName?: string | null;
+  readonly hasPassword?: boolean;
+  readonly isTransferable?: boolean;
+  readonly lastName?: string | null;
+  readonly legalAcceptedAt?: number | null;
+  readonly missingFields?: readonly string[];
+  readonly optionalFields?: readonly string[];
+  readonly requiredFields?: readonly string[];
+  readonly status: string | null;
+  readonly unverifiedFields?: readonly string[];
+}
+
+interface MockedSignUpConfiguration {
+  readonly captchaEnabled?: boolean;
+  readonly captchaWidgetType?: "invisible" | "smart" | null;
+  readonly privacyPolicyUrl?: string;
+  readonly termsUrl?: string;
+}
+
 interface MockedUser {
   id: string;
   fullName: string;
@@ -111,6 +136,33 @@ let internalMockedSignInResourceState: Required<MockedSignInResourceState> = {
   status: "needs_identifier",
   supportedFirstFactors: null,
 };
+let internalMockedSignUpResourceState: Required<MockedSignUpResourceState> = {
+  createdSessionId: null,
+  emailAddress: null,
+  emailVerificationExpireAt: null,
+  emailVerificationStatus: null,
+  emailVerificationStrategy: null,
+  firstName: null,
+  hasPassword: false,
+  isTransferable: false,
+  lastName: null,
+  legalAcceptedAt: null,
+  missingFields: ["email_address", "password"],
+  optionalFields: ["first_name", "last_name"],
+  requiredFields: ["email_address", "password"],
+  status: null,
+  unverifiedFields: [],
+};
+let internalMockedSignUpConfiguration: Required<MockedSignUpConfiguration> = {
+  captchaEnabled: false,
+  captchaWidgetType: null,
+  privacyPolicyUrl: "https://vm0.ai/privacy",
+  termsUrl: "https://vm0.ai/terms",
+};
+let internalMockedPasswordValidation = {
+  complexity: {},
+  strength: undefined,
+};
 
 export function mockSignInResource(state: MockedSignInResourceState): void {
   internalMockedSignInResourceState = {
@@ -119,6 +171,48 @@ export function mockSignInResource(state: MockedSignInResourceState): void {
     status: state.status,
     supportedFirstFactors: state.supportedFirstFactors ?? null,
   };
+}
+
+export function mockSignUpResource(state: MockedSignUpResourceState): void {
+  internalMockedSignUpResourceState = {
+    createdSessionId: state.createdSessionId ?? null,
+    emailAddress: state.emailAddress ?? null,
+    emailVerificationExpireAt: state.emailVerificationExpireAt ?? null,
+    emailVerificationStatus: state.emailVerificationStatus ?? null,
+    emailVerificationStrategy: state.emailVerificationStrategy ?? null,
+    firstName: state.firstName ?? null,
+    hasPassword: state.hasPassword ?? false,
+    isTransferable: state.isTransferable ?? false,
+    lastName: state.lastName ?? null,
+    legalAcceptedAt: state.legalAcceptedAt ?? null,
+    missingFields:
+      state.missingFields ??
+      (state.status === null ? ["email_address", "password"] : []),
+    optionalFields: state.optionalFields ?? ["first_name", "last_name"],
+    requiredFields: state.requiredFields ?? ["email_address", "password"],
+    status: state.status,
+    unverifiedFields: state.unverifiedFields ?? [],
+  };
+}
+
+export function mockSignUpConfiguration(
+  configuration: MockedSignUpConfiguration,
+): void {
+  internalMockedSignUpConfiguration = {
+    captchaEnabled: configuration.captchaEnabled ?? false,
+    captchaWidgetType:
+      configuration.captchaWidgetType ??
+      (configuration.captchaEnabled ? "smart" : null),
+    privacyPolicyUrl:
+      configuration.privacyPolicyUrl ?? "https://vm0.ai/privacy",
+    termsUrl: configuration.termsUrl ?? "https://vm0.ai/terms",
+  };
+}
+
+export function mockSignUpPasswordValidation(
+  validation: typeof internalMockedPasswordValidation,
+): void {
+  internalMockedPasswordValidation = validation;
 }
 
 export function mockClerkLoaded(loaded: boolean): void {
@@ -229,6 +323,9 @@ function clearMockedAuth() {
   internalMockedClerkSessionTransitioning = false;
   internalMockedClerkSessionSignedOut = false;
   mockSignInResource({ status: "needs_identifier" });
+  mockSignUpResource({ status: null });
+  mockSignUpConfiguration({});
+  mockSignUpPasswordValidation({ complexity: {}, strength: undefined });
   clerkListeners.length = 0;
   mockedClerk.on = defaultClerkStatusOn;
   mockedClerk.signOut.mockReset();
@@ -264,6 +361,30 @@ function clearMockedAuth() {
   mockedClerk.signInFutureReset.mockReset();
   mockedClerk.signInFutureReset.mockImplementation(
     defaultSignInFutureResetImpl,
+  );
+  mockedClerk.clientSignUpCreate.mockReset();
+  mockedClerk.clientSignUpCreate.mockImplementation(
+    defaultSignUpResourceOperationImpl,
+  );
+  mockedClerk.signUpUpdate.mockReset();
+  mockedClerk.signUpUpdate.mockImplementation(
+    defaultSignUpResourceOperationImpl,
+  );
+  mockedClerk.signUpPrepareEmailAddressVerification.mockReset();
+  mockedClerk.signUpPrepareEmailAddressVerification.mockImplementation(
+    defaultSignUpResourceOperationImpl,
+  );
+  mockedClerk.signUpAttemptEmailAddressVerification.mockReset();
+  mockedClerk.signUpAttemptEmailAddressVerification.mockImplementation(
+    defaultSignUpResourceOperationImpl,
+  );
+  mockedClerk.signUpValidatePassword.mockReset();
+  mockedClerk.signUpValidatePassword.mockImplementation(
+    defaultSignUpValidatePasswordImpl,
+  );
+  mockedClerk.signUpFutureReset.mockReset();
+  mockedClerk.signUpFutureReset.mockImplementation(
+    defaultSignUpFutureResetImpl,
   );
   mockedClerk.buildUrlWithAuth.mockReset();
   mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
@@ -360,6 +481,109 @@ const mockedClientSignIn = {
       return internalMockedSignInResourceState.isTransferable;
     },
     reset: signInFutureReset,
+  },
+};
+
+function defaultSignUpResourceOperationImpl(_params?: unknown) {
+  return Promise.resolve(mockedClientSignUp);
+}
+
+const clientSignUpCreate = vi.fn<typeof defaultSignUpResourceOperationImpl>(
+  defaultSignUpResourceOperationImpl,
+);
+const signUpUpdate = vi.fn<typeof defaultSignUpResourceOperationImpl>(
+  defaultSignUpResourceOperationImpl,
+);
+const signUpPrepareEmailAddressVerification = vi.fn<
+  typeof defaultSignUpResourceOperationImpl
+>(defaultSignUpResourceOperationImpl);
+const signUpAttemptEmailAddressVerification = vi.fn<
+  typeof defaultSignUpResourceOperationImpl
+>(defaultSignUpResourceOperationImpl);
+
+interface MockedPasswordValidationCallbacks {
+  readonly onValidation?: (
+    validation: typeof internalMockedPasswordValidation,
+  ) => void;
+}
+
+function defaultSignUpValidatePasswordImpl(
+  _password: string,
+  callbacks?: MockedPasswordValidationCallbacks,
+): void {
+  callbacks?.onValidation?.(internalMockedPasswordValidation);
+}
+
+const signUpValidatePassword = vi.fn<typeof defaultSignUpValidatePasswordImpl>(
+  defaultSignUpValidatePasswordImpl,
+);
+
+function defaultSignUpFutureResetImpl() {
+  mockSignUpResource({ status: null });
+  return Promise.resolve({ error: null });
+}
+
+const signUpFutureReset = vi.fn<typeof defaultSignUpFutureResetImpl>(
+  defaultSignUpFutureResetImpl,
+);
+
+const mockedClientSignUp = {
+  get status() {
+    return internalMockedSignUpResourceState.status;
+  },
+  get requiredFields() {
+    return internalMockedSignUpResourceState.requiredFields;
+  },
+  get optionalFields() {
+    return internalMockedSignUpResourceState.optionalFields;
+  },
+  get missingFields() {
+    return internalMockedSignUpResourceState.missingFields;
+  },
+  get unverifiedFields() {
+    return internalMockedSignUpResourceState.unverifiedFields;
+  },
+  get emailAddress() {
+    return internalMockedSignUpResourceState.emailAddress;
+  },
+  get firstName() {
+    return internalMockedSignUpResourceState.firstName;
+  },
+  get lastName() {
+    return internalMockedSignUpResourceState.lastName;
+  },
+  get hasPassword() {
+    return internalMockedSignUpResourceState.hasPassword;
+  },
+  get legalAcceptedAt() {
+    return internalMockedSignUpResourceState.legalAcceptedAt;
+  },
+  get createdSessionId() {
+    return internalMockedSignUpResourceState.createdSessionId;
+  },
+  create: clientSignUpCreate,
+  update: signUpUpdate,
+  prepareEmailAddressVerification: signUpPrepareEmailAddressVerification,
+  attemptEmailAddressVerification: signUpAttemptEmailAddressVerification,
+  validatePassword: signUpValidatePassword,
+  verifications: {
+    emailAddress: {
+      get status() {
+        return internalMockedSignUpResourceState.emailVerificationStatus;
+      },
+      get strategy() {
+        return internalMockedSignUpResourceState.emailVerificationStrategy;
+      },
+      get expireAt() {
+        return internalMockedSignUpResourceState.emailVerificationExpireAt;
+      },
+    },
+  },
+  __internal_future: {
+    get isTransferable() {
+      return internalMockedSignUpResourceState.isTransferable;
+    },
+    reset: signUpFutureReset,
   },
 };
 const defaultBuildUrlWithAuthImpl = (to: string) => {
@@ -482,11 +706,39 @@ export const mockedClerk = {
   signInAttemptFirstFactor,
   signInResetPassword,
   signInFutureReset,
+  clientSignUpCreate,
+  signUpUpdate,
+  signUpPrepareEmailAddressVerification,
+  signUpAttemptEmailAddressVerification,
+  signUpValidatePassword,
+  signUpFutureReset,
   client: {
     get sessions() {
       return internalMockedClientSessions;
     },
     signIn: mockedClientSignIn,
+    signUp: mockedClientSignUp,
+  },
+  __internal_environment: {
+    displayConfig: {
+      get captchaWidgetType() {
+        return internalMockedSignUpConfiguration.captchaWidgetType;
+      },
+      get captchaPublicKey() {
+        return internalMockedSignUpConfiguration.captchaEnabled
+          ? "test-captcha-key"
+          : null;
+      },
+      get captchaPublicKeyInvisible() {
+        return null;
+      },
+      get privacyPolicyUrl() {
+        return internalMockedSignUpConfiguration.privacyPolicyUrl;
+      },
+      get termsUrl() {
+        return internalMockedSignUpConfiguration.termsUrl;
+      },
+    },
   },
   signOut: vi.fn(() => {
     return Promise.resolve();

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1050,7 +1050,10 @@
       },
       "signUp": {
         "action": "Aktuelle Registrierung verwenden",
-        "description": "Die neue Registrierungsoberfläche ist noch nicht verfügbar.",
+        "captchaExpired": "Die Bot-Verifizierung ist abgelaufen. Versuche es erneut.",
+        "codeExpired": "Dieser Bestätigungscode ist abgelaufen. Fordere einen neuen Code an.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} s)",
         "title": "Ihr {{brandName}}-Konto erstellen"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1050,7 +1050,10 @@
       },
       "signUp": {
         "action": "Use current sign-up",
-        "description": "The new sign-up experience is not ready yet.",
+        "captchaExpired": "Bot verification expired. Try again.",
+        "codeExpired": "This verification code has expired. Request a new code.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}}s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}}s)",
         "title": "Create your {{brandName}} account"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1069,7 +1069,11 @@
       },
       "signUp": {
         "action": "Usar el registro actual",
-        "description": "La nueva experiencia de registro aún no está disponible.",
+        "captchaExpired": "La verificación de bots ha caducado. Inténtalo de nuevo.",
+        "codeExpired": "Este código de verificación ha caducado. Solicita uno nuevo.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_many": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} s)",
         "title": "Crea tu cuenta de {{brandName}}"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1069,7 +1069,11 @@
       },
       "signUp": {
         "action": "Utiliser l'inscription actuelle",
-        "description": "La nouvelle expérience d'inscription n'est pas encore disponible.",
+        "captchaExpired": "La vérification anti-robot a expiré. Réessayez.",
+        "codeExpired": "Ce code de vérification a expiré. Demandez-en un nouveau.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_many": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} s)",
         "title": "Créer votre compte {{brandName}}"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1050,7 +1050,10 @@
       },
       "signUp": {
         "action": "मौजूदा साइन-अप का उपयोग करें",
-        "description": "नया साइन-अप अनुभव अभी उपलब्ध नहीं है।",
+        "captchaExpired": "बॉट सत्यापन की समय-सीमा समाप्त हो गई है। फिर से कोशिश करें।",
+        "codeExpired": "यह सत्यापन कोड समाप्त हो गया है। नया कोड माँगें।",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} सेकंड)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} सेकंड)",
         "title": "अपना {{brandName}} खाता बनाएं"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1049,7 +1049,9 @@
       },
       "signUp": {
         "action": "Gunakan pendaftaran saat ini",
-        "description": "Pengalaman pendaftaran baru belum tersedia.",
+        "captchaExpired": "Verifikasi bot telah kedaluwarsa. Coba lagi.",
+        "codeExpired": "Kode verifikasi ini telah kedaluwarsa. Minta kode baru.",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} dtk)",
         "title": "Buat akun {{brandName}} Anda"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1069,7 +1069,11 @@
       },
       "signUp": {
         "action": "Usa la registrazione attuale",
-        "description": "La nuova esperienza di registrazione non è ancora disponibile.",
+        "captchaExpired": "La verifica anti-bot è scaduta. Riprova.",
+        "codeExpired": "Questo codice di verifica è scaduto. Richiedine uno nuovo.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_many": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} s)",
         "title": "Crea il tuo account {{brandName}}"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1049,7 +1049,9 @@
       },
       "signUp": {
         "action": "現在のサインアップを使用",
-        "description": "新しいサインアップ画面はまだ利用できません。",
+        "captchaExpired": "ボット確認の有効期限が切れました。もう一度お試しください。",
+        "codeExpired": "この確認コードは期限切れです。新しいコードをリクエストしてください。",
+        "resendCodeCooldown_other": "{{resendCode}}（{{count}}秒）",
         "title": "{{brandName}} アカウントを作成"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1049,7 +1049,9 @@
       },
       "signUp": {
         "action": "현재 회원가입 사용",
-        "description": "새 회원가입 화면은 아직 사용할 수 없습니다.",
+        "captchaExpired": "봇 인증이 만료되었습니다. 다시 시도하세요.",
+        "codeExpired": "이 인증 코드는 만료되었습니다. 새 코드를 요청하세요.",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}}초)",
         "title": "{{brandName}} 계정 만들기"
       }
     }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1069,7 +1069,11 @@
       },
       "signUp": {
         "action": "Usar o cadastro atual",
-        "description": "A nova experiência de cadastro ainda não está disponível.",
+        "captchaExpired": "A verificação contra bots expirou. Tente novamente.",
+        "codeExpired": "Este código de verificação expirou. Solicite um novo código.",
+        "resendCodeCooldown_one": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_many": "{{resendCode}} ({{count}} s)",
+        "resendCodeCooldown_other": "{{resendCode}} ({{count}} s)",
         "title": "Criar sua conta do {{brandName}}"
       }
     }

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -6,11 +6,15 @@ import {
   type AuthV2PageMode,
 } from "../views/auth-v2/auth-v2-page.tsx";
 import { hideAppSkeleton$ } from "./app-skeleton.ts";
-import { resolveAuthBrandContext } from "./auth.ts";
+import { resolveAuthV2PlatformContext } from "./auth-v2/platform-context.ts";
 import {
   createAuthV2SignInSignals,
   type AuthV2SignInSignals,
 } from "./auth-v2/sign-in-flow.ts";
+import {
+  createAuthV2SignUpSignals,
+  type AuthV2SignUpSignals,
+} from "./auth-v2/sign-up-flow.ts";
 import { updateDocumentTitle$ } from "./document-title.ts";
 import { updatePage$ } from "./react-router.ts";
 
@@ -23,15 +27,35 @@ function resolveAuthV2SignInRedirectUrl(): string {
 
 function setupAuthV2Page(mode: AuthV2PageMode) {
   return command(async ({ set }, signal: AbortSignal) => {
-    const authBrand = resolveAuthBrandContext();
+    const platformContext = resolveAuthV2PlatformContext(mode);
     let signInSignals: AuthV2SignInSignals | null = null;
+    let signUpSignals: AuthV2SignUpSignals | null = null;
     if (mode === "sign-in") {
       signInSignals = createAuthV2SignInSignals({
         resolveRedirectUrl: resolveAuthV2SignInRedirectUrl,
       });
-      set(updatePage$, createElement(AuthV2Page, { mode, signInSignals }));
+      set(
+        updatePage$,
+        createElement(AuthV2Page, {
+          mode,
+          platformContext,
+          signInSignals,
+        }),
+      );
     } else {
-      set(updatePage$, createElement(AuthV2Page, { mode }));
+      signUpSignals = createAuthV2SignUpSignals({
+        resolveRedirectUrl: () => {
+          return platformContext.navigation.completionRedirectUrl;
+        },
+      });
+      set(
+        updatePage$,
+        createElement(AuthV2Page, {
+          mode,
+          platformContext,
+          signUpSignals,
+        }),
+      );
     }
     set(
       updateDocumentTitle$,
@@ -42,12 +66,14 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
         : i18n.t(($) => {
             return $.auth.documentTitles.signUp;
           }),
-      authBrand.brandName,
+      platformContext.authBrand.brandName,
     );
     await set(hideAppSkeleton$, signal);
     signal.throwIfAborted();
     if (signInSignals) {
       await set(signInSignals.initialize$, signal);
+    } else if (signUpSignals) {
+      await set(signUpSignals.initialize$, signal);
     }
   });
 }

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -18,7 +18,7 @@ import { now } from "../../lib/time.ts";
 import { clerk$ } from "../auth.ts";
 import { locale$ } from "../locale.ts";
 import { logger } from "../log.ts";
-import { onRef, settle, withCleanup } from "../utils.ts";
+import { createDeferredPromise, onRef, settle, withCleanup } from "../utils.ts";
 
 const L = logger("AuthV2SignUp");
 
@@ -368,6 +368,22 @@ function passwordValidationFailed(validation: PasswordValidation): boolean {
     Object.values(validation.complexity ?? {}).some(Boolean) ||
     validation.strength?.state === "fail"
   );
+}
+
+function validatePassword(
+  resource: SignUpResource,
+  password: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const validation = createDeferredPromise<boolean>(signal);
+  resource.validatePassword(password, {
+    onValidation: (result) => {
+      if (!validation.settled()) {
+        validation.resolve(passwordValidationFailed(result));
+      }
+    },
+  });
+  return validation.promise;
 }
 
 function hasDetailsToCollect(snapshot: SignUpResourceSnapshot): boolean {
@@ -925,12 +941,12 @@ function createSubmitOperation(
     }
     const password = get(atoms.password$);
     if (snapshot.fields.password !== "hidden" && password) {
-      let invalidPassword = false;
-      resource.validatePassword(password, {
-        onValidation: (validation) => {
-          invalidPassword = passwordValidationFailed(validation);
-        },
-      });
+      const invalidPassword = await validatePassword(
+        resource,
+        password,
+        signal,
+      );
+      signal.throwIfAborted();
       if (invalidPassword) {
         set(atoms.error$, {
           code: "password-invalid",

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -1,0 +1,1192 @@
+import type { Clerk } from "@clerk/clerk-js";
+import type {
+  PasswordValidation,
+  SignUpCreateParams,
+  SignUpField,
+  SignUpResource,
+} from "@clerk/react/types";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
+
+import { now } from "../../lib/time.ts";
+import { clerk$ } from "../auth.ts";
+import { locale$ } from "../locale.ts";
+import { logger } from "../log.ts";
+import { onRef, settle, withCleanup } from "../utils.ts";
+
+const L = logger("AuthV2SignUp");
+
+export const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS = 30;
+const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS =
+  AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS * 1000;
+
+const SUPPORTED_SIGN_UP_FIELDS = [
+  "email_address",
+  "first_name",
+  "last_name",
+  "legal_accepted",
+  "password",
+] as const satisfies readonly SignUpField[];
+
+type SupportedSignUpField = (typeof SUPPORTED_SIGN_UP_FIELDS)[number];
+type FieldRequirement = "hidden" | "optional" | "required";
+
+export interface AuthV2SignUpFields {
+  readonly emailAddress: FieldRequirement;
+  readonly firstName: FieldRequirement;
+  readonly lastName: FieldRequirement;
+  readonly password: FieldRequirement;
+}
+
+export interface AuthV2SignUpLegalConfig {
+  readonly privacyPolicyUrl: string | null;
+  readonly required: boolean;
+  readonly termsUrl: string | null;
+}
+
+export type AuthV2SignUpVerificationState =
+  | "expired"
+  | "prepare-failed"
+  | "preparing"
+  | "ready";
+
+export type AuthV2SignUpCaptchaState =
+  | "blocked"
+  | "error"
+  | "expired"
+  | "idle"
+  | "loading";
+
+export type AuthV2SignUpUnknownReason =
+  | "activation-failed"
+  | "missing-legal-configuration"
+  | "missing-session"
+  | "unsupported-field"
+  | "unsupported-status";
+
+export type AuthV2SignUpState =
+  | { readonly status: "loading" }
+  | {
+      readonly captchaEnabled: boolean;
+      readonly fields: AuthV2SignUpFields;
+      readonly legal: AuthV2SignUpLegalConfig;
+      readonly status: "incomplete";
+      readonly step: "details";
+    }
+  | {
+      readonly emailAddress: string;
+      readonly status: "incomplete";
+      readonly step: "email-code";
+      readonly verification: AuthV2SignUpVerificationState;
+    }
+  | { readonly status: "complete" }
+  | { readonly status: "transfer" }
+  | {
+      readonly clerkStatus: string | null;
+      readonly reason: AuthV2SignUpUnknownReason;
+      readonly status: "unknown";
+    };
+
+export type AuthV2SignUpErrorField =
+  | "captcha"
+  | "code"
+  | "email-address"
+  | "first-name"
+  | "general"
+  | "last-name"
+  | "legal"
+  | "password";
+
+export interface AuthV2SignUpError {
+  readonly clerkCode?: string;
+  readonly code: "clerk" | "legal-required" | "password-invalid" | "unknown";
+  readonly field: AuthV2SignUpErrorField;
+  readonly message?: string;
+}
+
+export interface AuthV2SignUpFlowDependencies {
+  readonly resolveRedirectUrl: () => string;
+}
+
+export interface AuthV2SignUpSignals {
+  readonly backToDetails$: Command<void, []>;
+  readonly captchaRef$: ReturnType<typeof onRef<HTMLDivElement>>;
+  readonly captchaState$: Computed<AuthV2SignUpCaptchaState>;
+  readonly code$: Computed<string>;
+  readonly emailAddress$: Computed<string>;
+  readonly error$: Computed<AuthV2SignUpError | null>;
+  readonly firstName$: Computed<string>;
+  readonly initialize$: Command<Promise<void>, [AbortSignal]>;
+  readonly lastName$: Computed<string>;
+  readonly legalAccepted$: Computed<boolean>;
+  readonly password$: Computed<string>;
+  readonly resendCode$: Command<Promise<void>, [AbortSignal]>;
+  readonly resendCoolingDown$: Computed<boolean>;
+  readonly restart$: Command<Promise<void>, [AbortSignal]>;
+  readonly setCode$: Command<void, [string]>;
+  readonly setEmailAddress$: Command<void, [string]>;
+  readonly setFirstName$: Command<void, [string]>;
+  readonly setLastName$: Command<void, [string]>;
+  readonly setLegalAccepted$: Command<void, [boolean]>;
+  readonly setPassword$: Command<void, [string]>;
+  readonly state$: Computed<AuthV2SignUpState>;
+  readonly submit$: Command<Promise<void>, [AbortSignal]>;
+}
+
+interface SignUpConfiguration {
+  readonly captchaEnabled: boolean;
+  readonly privacyPolicyUrl: string | null;
+  readonly termsUrl: string | null;
+}
+
+interface SignUpVerificationSnapshot {
+  readonly expireAtMs: number | null;
+  readonly status: string | null;
+  readonly strategy: string | null;
+}
+
+interface SignUpResourceSnapshot {
+  readonly captchaEnabled: boolean;
+  readonly clerkStatus: string | null;
+  readonly createdSessionId: string | null;
+  readonly emailAddress: string | null;
+  readonly fields: AuthV2SignUpFields;
+  readonly legal: AuthV2SignUpLegalConfig;
+  readonly missingFields: readonly SignUpField[];
+  readonly transferable: boolean;
+  readonly unsupportedFields: readonly SignUpField[];
+  readonly unverifiedEmailAddress: boolean;
+  readonly verification: SignUpVerificationSnapshot;
+}
+
+type AuthV2SignUpUnknownState = Extract<
+  AuthV2SignUpState,
+  { status: "unknown" }
+>;
+
+interface SignUpFlowAtoms {
+  readonly captchaPending$: State<boolean>;
+  readonly captchaState$: State<AuthV2SignUpCaptchaState>;
+  readonly code$: State<string>;
+  readonly editDetails$: State<boolean>;
+  readonly emailAddress$: State<string>;
+  readonly error$: State<AuthV2SignUpError | null>;
+  readonly fatalState$: State<AuthV2SignUpUnknownState | null>;
+  readonly firstName$: State<string>;
+  readonly lastName$: State<string>;
+  readonly legalAccepted$: State<boolean>;
+  readonly password$: State<string>;
+  readonly preparationState$: State<"failed" | "idle" | "preparing">;
+  readonly resendCoolingDown$: State<boolean>;
+  readonly snapshot$: State<SignUpResourceSnapshot | null>;
+  readonly state$: Computed<AuthV2SignUpState>;
+  readonly verificationExpired$: State<boolean>;
+}
+
+interface SignUpFlowRuntime {
+  readonly activatedSessionId$: State<string | null>;
+  readonly activation$: State<{
+    readonly promise: Promise<void>;
+    readonly sessionId: string;
+  } | null>;
+  readonly automaticPreparationAttempted$: State<boolean>;
+  readonly cooldownTimer$: State<number | null>;
+  readonly expiryTimer$: State<number | null>;
+  readonly inFlight$: State<Promise<void> | null>;
+}
+
+type ApplySignUpResourceCommand = Command<
+  Promise<void>,
+  [SignUpResource, AbortSignal]
+>;
+
+function fieldRequirement(
+  field: SupportedSignUpField,
+  requiredFields: ReadonlySet<SignUpField>,
+  optionalFields: ReadonlySet<SignUpField>,
+): FieldRequirement {
+  if (requiredFields.has(field)) {
+    return "required";
+  }
+  return optionalFields.has(field) ? "optional" : "hidden";
+}
+
+function signUpFields(resource: SignUpResource): AuthV2SignUpFields {
+  const requiredFields = new Set(resource.requiredFields);
+  const optionalFields = new Set(resource.optionalFields);
+  return {
+    emailAddress: fieldRequirement(
+      "email_address",
+      requiredFields,
+      optionalFields,
+    ),
+    firstName: fieldRequirement("first_name", requiredFields, optionalFields),
+    lastName: fieldRequirement("last_name", requiredFields, optionalFields),
+    password: resource.hasPassword
+      ? "hidden"
+      : fieldRequirement("password", requiredFields, optionalFields),
+  };
+}
+
+function unsupportedSignUpFields(
+  resource: SignUpResource,
+): readonly SignUpField[] {
+  const supportedFields = new Set<SignUpField>(SUPPORTED_SIGN_UP_FIELDS);
+  return [...resource.requiredFields, ...resource.missingFields].filter(
+    (field, index, fields) => {
+      return !supportedFields.has(field) && fields.indexOf(field) === index;
+    },
+  );
+}
+
+function snapshotSignUpResource(
+  resource: SignUpResource,
+  configuration: SignUpConfiguration,
+): SignUpResourceSnapshot {
+  const verification = resource.verifications.emailAddress;
+  const legalRequired =
+    resource.requiredFields.includes("legal_accepted") &&
+    resource.missingFields.includes("legal_accepted");
+  return {
+    captchaEnabled: configuration.captchaEnabled,
+    clerkStatus: resource.status,
+    createdSessionId: resource.createdSessionId,
+    emailAddress: resource.emailAddress,
+    fields: signUpFields(resource),
+    legal: {
+      privacyPolicyUrl: configuration.privacyPolicyUrl,
+      required: legalRequired,
+      termsUrl: configuration.termsUrl,
+    },
+    missingFields: [...resource.missingFields],
+    transferable: resource.__internal_future.isTransferable,
+    unsupportedFields: unsupportedSignUpFields(resource),
+    unverifiedEmailAddress: resource.unverifiedFields.includes("email_address"),
+    verification: {
+      expireAtMs: verification.expireAt?.getTime() ?? null,
+      status: verification.status,
+      strategy: verification.strategy,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringProperty(
+  value: Record<string, unknown>,
+  property: string,
+): string | undefined {
+  const candidate = value[property];
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : undefined;
+}
+
+function clerkErrorField(
+  error: Record<string, unknown>,
+  fallbackField: AuthV2SignUpErrorField,
+): AuthV2SignUpErrorField {
+  const meta = error.meta;
+  const parameter = isRecord(meta) ? stringProperty(meta, "paramName") : null;
+  if (parameter === "email_address" || parameter === "emailAddress") {
+    return "email-address";
+  }
+  if (parameter === "first_name" || parameter === "firstName") {
+    return "first-name";
+  }
+  if (parameter === "last_name" || parameter === "lastName") {
+    return "last-name";
+  }
+  if (parameter === "legal_accepted" || parameter === "legalAccepted") {
+    return "legal";
+  }
+  if (parameter === "password") {
+    return "password";
+  }
+  if (parameter === "code") {
+    return "code";
+  }
+  if (parameter === "captcha") {
+    return "captcha";
+  }
+  return fallbackField;
+}
+
+function normalizeClerkError(
+  error: unknown,
+  fallbackField: AuthV2SignUpErrorField,
+): AuthV2SignUpError {
+  if (isRecord(error) && Array.isArray(error.errors)) {
+    const firstError = error.errors.find(isRecord);
+    if (firstError) {
+      const message =
+        stringProperty(firstError, "longMessage") ??
+        stringProperty(firstError, "message");
+      const clerkCode = stringProperty(firstError, "code");
+      return {
+        ...(clerkCode ? { clerkCode } : {}),
+        code: "clerk",
+        field: clerkErrorField(firstError, fallbackField),
+        ...(message ? { message } : {}),
+      };
+    }
+  }
+  return { code: "unknown", field: fallbackField };
+}
+
+function isExpiredError(error: AuthV2SignUpError): boolean {
+  const code = error.clerkCode?.toLowerCase();
+  return (
+    code?.includes("expired") === true || code?.includes("timeout") === true
+  );
+}
+
+function captchaFailureState(
+  error: AuthV2SignUpError,
+): AuthV2SignUpCaptchaState | null {
+  const code = error.clerkCode?.toLowerCase();
+  if (!code?.includes("captcha")) {
+    return error.field === "captcha" ? "error" : null;
+  }
+  return code.includes("expired") ||
+    code.includes("timeout") ||
+    code === "captcha_invalid"
+    ? "expired"
+    : "error";
+}
+
+function passwordValidationFailed(validation: PasswordValidation): boolean {
+  return (
+    Object.values(validation.complexity ?? {}).some(Boolean) ||
+    validation.strength?.state === "fail"
+  );
+}
+
+function hasDetailsToCollect(snapshot: SignUpResourceSnapshot): boolean {
+  return snapshot.clerkStatus === null || snapshot.missingFields.length > 0;
+}
+
+function unknownSignUpState(
+  snapshot: SignUpResourceSnapshot,
+  reason: AuthV2SignUpUnknownReason,
+): AuthV2SignUpUnknownState {
+  return { clerkStatus: snapshot.clerkStatus, reason, status: "unknown" };
+}
+
+function hasMissingLegalConfiguration(
+  snapshot: SignUpResourceSnapshot,
+): boolean {
+  return (
+    snapshot.legal.required &&
+    !snapshot.legal.termsUrl &&
+    !snapshot.legal.privacyPolicyUrl
+  );
+}
+
+function verificationState(
+  snapshot: SignUpResourceSnapshot,
+  preparationState: "failed" | "idle" | "preparing",
+  verificationExpired: boolean,
+): AuthV2SignUpVerificationState {
+  if (verificationExpired || snapshot.verification.status === "expired") {
+    return "expired";
+  }
+  if (preparationState === "preparing") {
+    return "preparing";
+  }
+  return preparationState === "failed" ? "prepare-failed" : "ready";
+}
+
+function incompleteSignUpState(
+  snapshot: SignUpResourceSnapshot,
+  editDetails: boolean,
+  preparationState: "failed" | "idle" | "preparing",
+  verificationExpired: boolean,
+): AuthV2SignUpState {
+  if (
+    (editDetails || !snapshot.unverifiedEmailAddress) &&
+    (editDetails || hasDetailsToCollect(snapshot))
+  ) {
+    return {
+      captchaEnabled: snapshot.captchaEnabled,
+      fields: snapshot.fields,
+      legal: snapshot.legal,
+      status: "incomplete",
+      step: "details",
+    };
+  }
+  if (snapshot.unverifiedEmailAddress && snapshot.emailAddress) {
+    return {
+      emailAddress: snapshot.emailAddress,
+      status: "incomplete",
+      step: "email-code",
+      verification: verificationState(
+        snapshot,
+        preparationState,
+        verificationExpired,
+      ),
+    };
+  }
+  return unknownSignUpState(snapshot, "unsupported-status");
+}
+
+function deriveSignUpFlowState(
+  snapshot: SignUpResourceSnapshot | null,
+  editDetails: boolean,
+  preparationState: "failed" | "idle" | "preparing",
+  verificationExpired: boolean,
+  fatalState: AuthV2SignUpUnknownState | null,
+): AuthV2SignUpState {
+  if (fatalState) {
+    return fatalState;
+  }
+  if (!snapshot) {
+    return { status: "loading" };
+  }
+  if (snapshot.transferable) {
+    return { status: "transfer" };
+  }
+  if (snapshot.unsupportedFields.length > 0) {
+    return unknownSignUpState(snapshot, "unsupported-field");
+  }
+  if (hasMissingLegalConfiguration(snapshot)) {
+    return unknownSignUpState(snapshot, "missing-legal-configuration");
+  }
+  if (snapshot.clerkStatus === "complete") {
+    return snapshot.createdSessionId
+      ? { status: "complete" }
+      : unknownSignUpState(snapshot, "missing-session");
+  }
+  if (
+    snapshot.clerkStatus !== null &&
+    snapshot.clerkStatus !== "missing_requirements"
+  ) {
+    return unknownSignUpState(snapshot, "unsupported-status");
+  }
+  return incompleteSignUpState(
+    snapshot,
+    editDetails,
+    preparationState,
+    verificationExpired,
+  );
+}
+
+function createSignUpFlowAtoms(): SignUpFlowAtoms {
+  const snapshot$ = state<SignUpResourceSnapshot | null>(null);
+  const editDetails$ = state(false);
+  const preparationState$ = state<"failed" | "idle" | "preparing">("idle");
+  const verificationExpired$ = state(false);
+  const fatalState$ = state<AuthV2SignUpUnknownState | null>(null);
+  const error$ = state<AuthV2SignUpError | null>(null);
+  const emailAddress$ = state("");
+  const password$ = state("");
+  const firstName$ = state("");
+  const lastName$ = state("");
+  const legalAccepted$ = state(false);
+  const code$ = state("");
+  const captchaState$ = state<AuthV2SignUpCaptchaState>("idle");
+  const captchaPending$ = state(false);
+  const resendCoolingDown$ = state(false);
+  const state$ = computed((get) => {
+    return deriveSignUpFlowState(
+      get(snapshot$),
+      get(editDetails$),
+      get(preparationState$),
+      get(verificationExpired$),
+      get(fatalState$),
+    );
+  });
+  return {
+    captchaPending$,
+    captchaState$,
+    code$,
+    editDetails$,
+    emailAddress$,
+    error$,
+    fatalState$,
+    firstName$,
+    lastName$,
+    legalAccepted$,
+    password$,
+    preparationState$,
+    resendCoolingDown$,
+    snapshot$,
+    state$,
+    verificationExpired$,
+  };
+}
+
+function createSignUpFlowRuntime(): SignUpFlowRuntime {
+  return {
+    activatedSessionId$: state<string | null>(null),
+    activation$: state<{
+      readonly promise: Promise<void>;
+      readonly sessionId: string;
+    } | null>(null),
+    automaticPreparationAttempted$: state(false),
+    cooldownTimer$: state<number | null>(null),
+    expiryTimer$: state<number | null>(null),
+    inFlight$: state<Promise<void> | null>(null),
+  };
+}
+
+export const clerkSignUpResource$ = computed(async (get) => {
+  const clerk = await get(clerk$);
+  if (!clerk.client) {
+    throw new Error("Loaded Clerk instance did not provide a client resource");
+  }
+  return clerk.client.signUp;
+});
+
+const clerkSignUpConfiguration$ = computed(async (get) => {
+  const clerk = await get(clerk$);
+  const displayConfig = clerk.__internal_environment?.displayConfig;
+  if (!displayConfig) {
+    throw new Error(
+      "Loaded Clerk instance did not provide display configuration",
+    );
+  }
+  return {
+    captchaEnabled:
+      displayConfig.captchaWidgetType !== null &&
+      (displayConfig.captchaPublicKey !== null ||
+        displayConfig.captchaPublicKeyInvisible !== null),
+    privacyPolicyUrl: displayConfig.privacyPolicyUrl || null,
+    termsUrl: displayConfig.termsUrl || null,
+  } satisfies SignUpConfiguration;
+});
+
+function clearTimer(
+  timer: number | null,
+  setTimer: (timer: number | null) => void,
+): void {
+  if (timer !== null) {
+    window.clearTimeout(timer);
+    setTimer(null);
+  }
+}
+
+function createScheduleExpiryCommand(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+): Command<void, [number | null, AbortSignal]> {
+  const markExpired$ = command(({ set }) => {
+    set(atoms.verificationExpired$, true);
+    set(runtime.expiryTimer$, null);
+  });
+  return command(
+    ({ get, set }, expireAtMs: number | null, signal: AbortSignal): void => {
+      clearTimer(get(runtime.expiryTimer$), (timer) => {
+        set(runtime.expiryTimer$, timer);
+      });
+      set(atoms.verificationExpired$, false);
+      if (expireAtMs === null) {
+        return;
+      }
+      const delay = Math.max(0, expireAtMs - now());
+      if (delay === 0) {
+        set(markExpired$);
+        return;
+      }
+      const timer = window.setTimeout(() => {
+        set(markExpired$);
+      }, delay);
+      set(runtime.expiryTimer$, timer);
+      signal.addEventListener(
+        "abort",
+        () => {
+          if (get(runtime.expiryTimer$) === timer) {
+            window.clearTimeout(timer);
+            set(runtime.expiryTimer$, null);
+          }
+        },
+        { once: true },
+      );
+    },
+  );
+}
+
+function createStartCooldownCommand(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+): Command<void, [AbortSignal]> {
+  const finishCooldown$ = command(({ set }) => {
+    set(atoms.resendCoolingDown$, false);
+    set(runtime.cooldownTimer$, null);
+  });
+  return command(({ get, set }, signal: AbortSignal): void => {
+    clearTimer(get(runtime.cooldownTimer$), (timer) => {
+      set(runtime.cooldownTimer$, timer);
+    });
+    set(atoms.resendCoolingDown$, true);
+    const timer = window.setTimeout(() => {
+      set(finishCooldown$);
+    }, AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS);
+    set(runtime.cooldownTimer$, timer);
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (get(runtime.cooldownTimer$) === timer) {
+          window.clearTimeout(timer);
+          set(runtime.cooldownTimer$, null);
+        }
+      },
+      { once: true },
+    );
+  });
+}
+
+function createActivateSessionCommand(
+  runtime: SignUpFlowRuntime,
+  dependencies: AuthV2SignUpFlowDependencies,
+): Command<Promise<void>, [string, AbortSignal]> {
+  const performActivation$ = command(
+    async (
+      { set },
+      clerk: Clerk,
+      sessionId: string,
+      redirectUrl: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await clerk.setActive({ redirectUrl, session: sessionId });
+      signal.throwIfAborted();
+      set(runtime.activatedSessionId$, sessionId);
+    },
+  );
+  return command(
+    async (
+      { get, set },
+      sessionId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (get(runtime.activatedSessionId$) === sessionId) {
+        return;
+      }
+      const activeActivation = get(runtime.activation$);
+      if (activeActivation) {
+        await activeActivation.promise;
+        signal.throwIfAborted();
+        if (get(runtime.activatedSessionId$) === sessionId) {
+          return;
+        }
+      }
+
+      const clerk = await get(clerk$);
+      signal.throwIfAborted();
+      const activationPromise = set(
+        performActivation$,
+        clerk,
+        sessionId,
+        dependencies.resolveRedirectUrl(),
+        signal,
+      );
+      const trackedActivation = withCleanup(activationPromise, () => {
+        set(runtime.activation$, (current) => {
+          return current?.sessionId === sessionId ? null : current;
+        });
+      });
+      set(runtime.activation$, { promise: trackedActivation, sessionId });
+      await trackedActivation;
+      signal.throwIfAborted();
+    },
+  );
+}
+
+function createResourceCommands(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+  dependencies: AuthV2SignUpFlowDependencies,
+): {
+  readonly applyResource$: ApplySignUpResourceCommand;
+  readonly initialize$: Command<Promise<void>, [AbortSignal]>;
+  readonly prepareEmailVerification$: Command<
+    Promise<void>,
+    [SignUpResource, boolean, AbortSignal]
+  >;
+} {
+  const scheduleExpiry$ = createScheduleExpiryCommand(atoms, runtime);
+  const startCooldown$ = createStartCooldownCommand(atoms, runtime);
+  const activateSession$ = createActivateSessionCommand(runtime, dependencies);
+
+  const applyResource$ = command(
+    async (
+      { get, set },
+      resource: SignUpResource,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const configuration = await get(clerkSignUpConfiguration$);
+      signal.throwIfAborted();
+      const snapshot = snapshotSignUpResource(resource, configuration);
+      set(atoms.snapshot$, snapshot);
+      set(atoms.fatalState$, null);
+      set(scheduleExpiry$, snapshot.verification.expireAtMs, signal);
+      if (
+        snapshot.transferable ||
+        snapshot.clerkStatus !== "complete" ||
+        !snapshot.createdSessionId
+      ) {
+        return;
+      }
+      const activation = await settle(
+        set(activateSession$, snapshot.createdSessionId, signal),
+        signal,
+      );
+      if (!activation.ok) {
+        L.error("Auth v2 sign-up activation failed", snapshot.clerkStatus);
+        set(atoms.fatalState$, {
+          clerkStatus: snapshot.clerkStatus,
+          reason: "activation-failed",
+          status: "unknown",
+        });
+      }
+    },
+  );
+
+  const prepareEmailVerification$ = command(
+    async (
+      { get, set },
+      resource: SignUpResource,
+      automatic: boolean,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const snapshot = get(atoms.snapshot$);
+      const flowState = get(atoms.state$);
+      if (
+        flowState.status !== "incomplete" ||
+        flowState.step !== "email-code" ||
+        !snapshot?.unverifiedEmailAddress ||
+        snapshot.verification.strategy === "email_code" ||
+        snapshot.verification.status === "expired"
+      ) {
+        return;
+      }
+      if (automatic && get(runtime.automaticPreparationAttempted$)) {
+        return;
+      }
+      if (automatic) {
+        set(runtime.automaticPreparationAttempted$, true);
+      }
+      set(atoms.preparationState$, "preparing");
+      set(atoms.error$, null);
+      const prepared = await settle(
+        resource.prepareEmailAddressVerification({ strategy: "email_code" }),
+        signal,
+      );
+      if (!prepared.ok) {
+        const error = normalizeClerkError(prepared.error, "code");
+        L.warn(
+          "Auth v2 sign-up email preparation failed",
+          error.clerkCode ?? error.code,
+        );
+        set(atoms.preparationState$, "failed");
+        set(atoms.error$, error);
+        return;
+      }
+      set(atoms.preparationState$, "idle");
+      set(atoms.verificationExpired$, false);
+      await set(applyResource$, prepared.value, signal);
+      signal.throwIfAborted();
+      set(startCooldown$, signal);
+    },
+  );
+
+  const initialize$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      const resource = await get(clerkSignUpResource$);
+      signal.throwIfAborted();
+      set(atoms.emailAddress$, resource.emailAddress ?? "");
+      set(atoms.firstName$, resource.firstName ?? "");
+      set(atoms.lastName$, resource.lastName ?? "");
+      set(atoms.legalAccepted$, resource.legalAcceptedAt !== null);
+      await set(applyResource$, resource, signal);
+      signal.throwIfAborted();
+      await set(prepareEmailVerification$, resource, true, signal);
+      signal.throwIfAborted();
+    },
+  );
+
+  return { applyResource$, initialize$, prepareEmailVerification$ };
+}
+
+function createCoalescedOperation(
+  runtime: SignUpFlowRuntime,
+  operation$: Command<Promise<void>, [AbortSignal]>,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const current = get(runtime.inFlight$);
+    if (current) {
+      await current;
+      signal.throwIfAborted();
+      return;
+    }
+    const operation = set(operation$, signal);
+    set(runtime.inFlight$, operation);
+    await withCleanup(operation, () => {
+      set(runtime.inFlight$, (active) => {
+        return active === operation ? null : active;
+      });
+    });
+    signal.throwIfAborted();
+  });
+}
+
+function signUpParams(
+  snapshot: SignUpResourceSnapshot,
+  fields: {
+    readonly emailAddress: string;
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly legalAccepted: boolean;
+    readonly password: string;
+  },
+  locale: string,
+): SignUpCreateParams {
+  const params: SignUpCreateParams = { locale };
+  const emailAddress = fields.emailAddress.trim();
+  const firstName = fields.firstName.trim();
+  const lastName = fields.lastName.trim();
+  if (snapshot.fields.emailAddress !== "hidden" && emailAddress) {
+    params.emailAddress = emailAddress;
+  }
+  if (snapshot.fields.password !== "hidden" && fields.password) {
+    params.password = fields.password;
+  }
+  if (snapshot.fields.firstName !== "hidden" && firstName) {
+    params.firstName = firstName;
+  }
+  if (snapshot.fields.lastName !== "hidden" && lastName) {
+    params.lastName = lastName;
+  }
+  if (snapshot.legal.required) {
+    params.legalAccepted = fields.legalAccepted;
+  }
+  return params;
+}
+
+function createSubmitOperation(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+  applyResource$: ApplySignUpResourceCommand,
+  prepareEmailVerification$: Command<
+    Promise<void>,
+    [SignUpResource, boolean, AbortSignal]
+  >,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const flowState = get(atoms.state$);
+    if (flowState.status !== "incomplete") {
+      return;
+    }
+    const resource = await get(clerkSignUpResource$);
+    signal.throwIfAborted();
+    set(atoms.error$, null);
+
+    if (flowState.step === "email-code") {
+      if (flowState.verification !== "ready") {
+        return;
+      }
+      const code = get(atoms.code$).trim();
+      if (!code) {
+        return;
+      }
+      const attempted = await settle(
+        resource.attemptEmailAddressVerification({ code }),
+        signal,
+      );
+      if (!attempted.ok) {
+        const error = normalizeClerkError(attempted.error, "code");
+        if (isExpiredError(error)) {
+          set(atoms.verificationExpired$, true);
+        }
+        set(atoms.error$, error);
+        return;
+      }
+      set(atoms.code$, "");
+      await set(applyResource$, attempted.value, signal);
+      signal.throwIfAborted();
+      return;
+    }
+
+    const snapshot = get(atoms.snapshot$);
+    if (!snapshot) {
+      return;
+    }
+    if (snapshot.legal.required && !get(atoms.legalAccepted$)) {
+      set(atoms.error$, { code: "legal-required", field: "legal" });
+      return;
+    }
+    const password = get(atoms.password$);
+    if (snapshot.fields.password !== "hidden" && password) {
+      let invalidPassword = false;
+      resource.validatePassword(password, {
+        onValidation: (validation) => {
+          invalidPassword = passwordValidationFailed(validation);
+        },
+      });
+      if (invalidPassword) {
+        set(atoms.error$, {
+          code: "password-invalid",
+          field: "password",
+        });
+        return;
+      }
+    }
+
+    const locale = get(locale$);
+    const params = signUpParams(
+      snapshot,
+      {
+        emailAddress: get(atoms.emailAddress$),
+        firstName: get(atoms.firstName$),
+        lastName: get(atoms.lastName$),
+        legalAccepted: get(atoms.legalAccepted$),
+        password,
+      },
+      locale,
+    );
+    set(runtime.automaticPreparationAttempted$, false);
+    set(atoms.preparationState$, "idle");
+    set(atoms.verificationExpired$, false);
+    set(atoms.captchaPending$, snapshot.captchaEnabled);
+    set(atoms.captchaState$, snapshot.captchaEnabled ? "loading" : "idle");
+    const request =
+      snapshot.clerkStatus === null
+        ? resource.create(params)
+        : resource.update(params);
+    const submitted = await settle(request, signal);
+    set(atoms.captchaPending$, false);
+    if (!submitted.ok) {
+      const error = normalizeClerkError(submitted.error, "general");
+      const captchaState = captchaFailureState(error);
+      if (captchaState) {
+        set(atoms.captchaState$, captchaState);
+      } else {
+        set(atoms.captchaState$, "idle");
+      }
+      set(atoms.error$, error);
+      return;
+    }
+    set(atoms.captchaState$, "idle");
+    set(atoms.editDetails$, false);
+    await set(applyResource$, submitted.value, signal);
+    signal.throwIfAborted();
+    await set(prepareEmailVerification$, submitted.value, true, signal);
+    signal.throwIfAborted();
+  });
+}
+
+function createResendOperation(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+  applyResource$: ApplySignUpResourceCommand,
+): Command<Promise<void>, [AbortSignal]> {
+  const startCooldown$ = createStartCooldownCommand(atoms, runtime);
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const flowState = get(atoms.state$);
+    if (
+      flowState.status !== "incomplete" ||
+      flowState.step !== "email-code" ||
+      (get(atoms.resendCoolingDown$) && flowState.verification !== "expired")
+    ) {
+      return;
+    }
+    const resource = await get(clerkSignUpResource$);
+    signal.throwIfAborted();
+    set(atoms.error$, null);
+    set(atoms.preparationState$, "preparing");
+    const prepared = await settle(
+      resource.prepareEmailAddressVerification({ strategy: "email_code" }),
+      signal,
+    );
+    if (!prepared.ok) {
+      const error = normalizeClerkError(prepared.error, "code");
+      set(atoms.preparationState$, "failed");
+      set(atoms.error$, error);
+      return;
+    }
+    set(atoms.preparationState$, "idle");
+    set(atoms.verificationExpired$, false);
+    set(atoms.code$, "");
+    await set(applyResource$, prepared.value, signal);
+    signal.throwIfAborted();
+    set(startCooldown$, signal);
+  });
+}
+
+function createRestartOperation(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+  applyResource$: ApplySignUpResourceCommand,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const resource = await get(clerkSignUpResource$);
+    signal.throwIfAborted();
+    const reset = await settle(resource.__internal_future.reset(), signal);
+    if (!reset.ok || reset.value.error) {
+      const error = normalizeClerkError(
+        reset.ok ? reset.value.error : reset.error,
+        "general",
+      );
+      set(atoms.error$, error);
+      return;
+    }
+    set(runtime.automaticPreparationAttempted$, false);
+    set(atoms.editDetails$, false);
+    set(atoms.fatalState$, null);
+    set(atoms.error$, null);
+    set(atoms.emailAddress$, "");
+    set(atoms.password$, "");
+    set(atoms.firstName$, "");
+    set(atoms.lastName$, "");
+    set(atoms.legalAccepted$, false);
+    set(atoms.code$, "");
+    set(atoms.preparationState$, "idle");
+    set(atoms.verificationExpired$, false);
+    set(atoms.captchaState$, "idle");
+    await set(applyResource$, resource, signal);
+    signal.throwIfAborted();
+  });
+}
+
+function createFormCommands(atoms: SignUpFlowAtoms) {
+  const backToDetails$ = command(({ set }) => {
+    set(atoms.editDetails$, true);
+    set(atoms.code$, "");
+    set(atoms.error$, null);
+    set(atoms.preparationState$, "idle");
+  });
+  const setEmailAddress$ = command(({ set }, value: string) => {
+    set(atoms.emailAddress$, value);
+    set(atoms.error$, null);
+  });
+  const setPassword$ = command(({ set }, value: string) => {
+    set(atoms.password$, value);
+    set(atoms.error$, null);
+  });
+  const setFirstName$ = command(({ set }, value: string) => {
+    set(atoms.firstName$, value);
+    set(atoms.error$, null);
+  });
+  const setLastName$ = command(({ set }, value: string) => {
+    set(atoms.lastName$, value);
+    set(atoms.error$, null);
+  });
+  const setLegalAccepted$ = command(({ set }, value: boolean) => {
+    set(atoms.legalAccepted$, value);
+    set(atoms.error$, null);
+  });
+  const setCode$ = command(({ set }, value: string) => {
+    set(atoms.code$, value);
+    set(atoms.error$, null);
+  });
+  return {
+    backToDetails$,
+    setCode$,
+    setEmailAddress$,
+    setFirstName$,
+    setLastName$,
+    setLegalAccepted$,
+    setPassword$,
+  };
+}
+
+function createCaptchaRef(atoms: SignUpFlowAtoms) {
+  return onRef(
+    command(
+      ({ get, set }, element: HTMLDivElement, signal: AbortSignal): void => {
+        const syncCaptchaState = (): void => {
+          if (!get(atoms.captchaPending$)) {
+            return;
+          }
+          set(
+            atoms.captchaState$,
+            element.dataset.clInteractive === "true" ? "blocked" : "loading",
+          );
+        };
+        const observer = new MutationObserver(syncCaptchaState);
+        observer.observe(element, {
+          attributeFilter: ["data-cl-interactive"],
+          attributes: true,
+        });
+        syncCaptchaState();
+        signal.addEventListener(
+          "abort",
+          () => {
+            observer.disconnect();
+          },
+          { once: true },
+        );
+      },
+    ),
+  );
+}
+
+export function createAuthV2SignUpSignals(
+  dependencies: AuthV2SignUpFlowDependencies,
+): AuthV2SignUpSignals {
+  const atoms = createSignUpFlowAtoms();
+  const runtime = createSignUpFlowRuntime();
+  const { applyResource$, initialize$, prepareEmailVerification$ } =
+    createResourceCommands(atoms, runtime, dependencies);
+  const submitOperation$ = createSubmitOperation(
+    atoms,
+    runtime,
+    applyResource$,
+    prepareEmailVerification$,
+  );
+  const resendOperation$ = createResendOperation(
+    atoms,
+    runtime,
+    applyResource$,
+  );
+  const restartOperation$ = createRestartOperation(
+    atoms,
+    runtime,
+    applyResource$,
+  );
+  const formCommands = createFormCommands(atoms);
+  return {
+    ...formCommands,
+    captchaRef$: createCaptchaRef(atoms),
+    captchaState$: computed((get) => {
+      return get(atoms.captchaState$);
+    }),
+    code$: computed((get) => {
+      return get(atoms.code$);
+    }),
+    emailAddress$: computed((get) => {
+      return get(atoms.emailAddress$);
+    }),
+    error$: computed((get) => {
+      return get(atoms.error$);
+    }),
+    firstName$: computed((get) => {
+      return get(atoms.firstName$);
+    }),
+    initialize$,
+    lastName$: computed((get) => {
+      return get(atoms.lastName$);
+    }),
+    legalAccepted$: computed((get) => {
+      return get(atoms.legalAccepted$);
+    }),
+    password$: computed((get) => {
+      return get(atoms.password$);
+    }),
+    resendCode$: createCoalescedOperation(runtime, resendOperation$),
+    resendCoolingDown$: computed((get) => {
+      return get(atoms.resendCoolingDown$);
+    }),
+    restart$: createCoalescedOperation(runtime, restartOperation$),
+    state$: atoms.state$,
+    submit$: createCoalescedOperation(runtime, submitOperation$),
+  };
+}

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -179,11 +179,11 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.signUpV2,
-    setup: setupSignUpV2Page$,
+    setup: setupPageWrapper(setupSignUpV2Page$),
   },
   {
     path: ROUTES.signUpV2CatchAll,
-    setup: setupSignUpV2Page$,
+    setup: setupPageWrapper(setupSignUpV2Page$),
   },
 
   // --- New routes ---

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -126,9 +126,7 @@ describe("auth v2 presentation", () => {
     });
     expect(
       screen.getByRole("region", { name: "Okou アカウントを作成" }),
-    ).toHaveAccessibleDescription(
-      "新しいサインアップ画面はまだ利用できません。",
-    );
+    ).toHaveAccessibleDescription("ようこそ！始めるには詳細を入力してください");
     expect(linkByLabel("Okou のホームに移動")).toHaveAttribute("href", "/");
     expect(linkByText("現在のサインアップを使用")).toHaveAttribute(
       "href",

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
@@ -1,63 +1,35 @@
-import { Button } from "@okouai/ui";
-import { useTranslation } from "react-i18next";
 import type { AuthV2SignInSignals } from "../../signals/auth-v2/sign-in-flow.ts";
-import { resolveAuthBrandContext } from "../../signals/auth.ts";
-import { ROUTES } from "../../signals/route-paths.ts";
+import type { AuthV2PlatformContext } from "../../signals/auth-v2/platform-context.ts";
+import type { AuthV2SignUpSignals } from "../../signals/auth-v2/sign-up-flow.ts";
 import { AuthShell } from "../auth/auth-shell.tsx";
-import { Link } from "../router/link.tsx";
-import { AuthV2Shell } from "./auth-v2-shell.tsx";
 import { AuthV2SignInCard } from "./sign-in/sign-in-card.tsx";
+import { AuthV2SignUpCard } from "./sign-up/sign-up-card.tsx";
 
 export type AuthV2PageMode = "sign-in" | "sign-up";
 
 type AuthV2PageProps =
   | {
       readonly mode: "sign-in";
+      readonly platformContext: AuthV2PlatformContext;
       readonly signInSignals: AuthV2SignInSignals;
     }
-  | { readonly mode: "sign-up" };
+  | {
+      readonly mode: "sign-up";
+      readonly platformContext: AuthV2PlatformContext;
+      readonly signUpSignals: AuthV2SignUpSignals;
+    };
 
 export function AuthV2Page(props: AuthV2PageProps) {
-  const { t } = useTranslation();
-  const authBrand = resolveAuthBrandContext();
-  const title = t(
-    ($) => {
-      return $.auth.v2.signUp.title;
-    },
-    { brandName: authBrand.brandName },
-  );
-  const description = t(($) => {
-    return $.auth.v2.signUp.description;
-  });
-  const action = t(($) => {
-    return $.auth.v2.signUp.action;
-  });
-
   return (
-    <AuthShell authBrand={authBrand} variant="v2">
+    <AuthShell authBrand={props.platformContext.authBrand} variant="v2">
       {props.mode === "sign-in" ? (
         <AuthV2SignInCard signals={props.signInSignals} />
       ) : (
-        <AuthV2Shell
-          description={description}
-          focusKey={props.mode}
-          title={title}
-        >
-          <Button
-            asChild
-            className="h-9 w-full bg-foreground text-background hover:bg-foreground-hover active:bg-foreground-pressed"
-          >
-            <Link
-              pathname={ROUTES.signUp}
-              options={{
-                hash: location.hash,
-                searchParams: new URLSearchParams(location.search),
-              }}
-            >
-              {action}
-            </Link>
-          </Button>
-        </AuthV2Shell>
+        <AuthV2SignUpCard
+          authBrand={props.platformContext.authBrand}
+          navigation={props.platformContext.navigation}
+          signals={props.signUpSignals}
+        />
       )}
     </AuthShell>
   );

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -1,3 +1,4 @@
+import type { PasswordValidation } from "@clerk/react/types";
 import {
   act,
   fireEvent,
@@ -343,6 +344,52 @@ describe("auth v2 sign-up flow", () => {
         expect.objectContaining({ legalAccepted: true }),
       );
     });
+  });
+
+  it("waits for Clerk's delayed password-strength result before creating", async () => {
+    let finishValidation:
+      | ((validation: PasswordValidation) => void)
+      | undefined;
+    mockedClerk.signUpValidatePassword.mockImplementation(
+      (_password, callbacks) => {
+        finishValidation = callbacks?.onValidation;
+      },
+    );
+    setupSignUpPage({ status: null });
+    const { emailInput } = await fillRequiredDetails();
+
+    fireEvent.submit(containingForm(emailInput));
+
+    await waitFor(() => {
+      expect(mockedClerk.signUpValidatePassword).toHaveBeenCalledWith(
+        "valid-password",
+        expect.objectContaining({ onValidation: expect.any(Function) }),
+      );
+    });
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
+
+    act(() => {
+      finishValidation?.({
+        complexity: {},
+        strength: {
+          keys: ["min_zxcvbn_strength"],
+          result: {
+            calcTime: 0,
+            feedback: { suggestions: [], warning: null },
+            guesses: 0,
+            guessesLog10: 0,
+            password: "valid-password",
+            score: 0,
+          },
+          state: "fail",
+        },
+      });
+    });
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Your password is not strong enough.",
+    );
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
   });
 
   it("shows expired verification recovery and lets the user edit the email before preparing once", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -1,0 +1,502 @@
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { now } from "../../../../lib/time.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../../__tests__/page-helper.ts";
+import {
+  mockedClerk,
+  mockSignUpConfiguration,
+  mockSignUpPasswordValidation,
+  mockSignUpResource,
+  type MockedSignUpResourceState,
+} from "../../../../__tests__/mock-auth.ts";
+import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../../signals/utils.ts";
+
+const context = testContext();
+
+function currentSignUpResource() {
+  return mockedClerk.client.signUp;
+}
+
+function moveSignUpTo(state: MockedSignUpResourceState) {
+  mockSignUpResource(state);
+  return currentSignUpResource();
+}
+
+function moveSignUpToAsync(
+  state: MockedSignUpResourceState,
+): Promise<ReturnType<typeof currentSignUpResource>> {
+  return Promise.resolve(moveSignUpTo(state));
+}
+
+function setupSignUpPage(
+  state: MockedSignUpResourceState,
+  options: { readonly path?: string; readonly url?: string } = {},
+): void {
+  const path = options.path ?? "/v2/sign-up";
+  mockSignUpResource(state);
+  context.mocks.browser.url(options.url ?? `https://app.vm0.ai${path}`);
+  detachedSetupPage({
+    context,
+    path,
+    session: null,
+    user: null,
+  });
+}
+
+function containingForm(element: HTMLElement): HTMLFormElement {
+  const form = element.closest("form");
+  if (!(form instanceof HTMLFormElement)) {
+    throw new Error("Expected element to be inside a form");
+  }
+  return form;
+}
+
+function roleElement(role: "button" | "link", name: string) {
+  return queryAllByRoleFast(role).find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
+}
+
+async function waitForRoleElement(
+  role: "button" | "link",
+  name: string,
+): Promise<HTMLElement> {
+  await waitFor(() => {
+    expect(roleElement(role, name)).toBeDefined();
+  });
+  const element = roleElement(role, name);
+  if (!element) {
+    throw new Error(`Expected ${role} named ${name}`);
+  }
+  return element;
+}
+
+function readyEmailVerificationState(
+  overrides: Partial<MockedSignUpResourceState> = {},
+): MockedSignUpResourceState {
+  return {
+    emailAddress: "person@example.com",
+    emailVerificationExpireAt: new Date(now() + 10 * 60 * 1000),
+    emailVerificationStatus: "unverified",
+    emailVerificationStrategy: "email_code",
+    hasPassword: true,
+    missingFields: [],
+    status: "missing_requirements",
+    unverifiedFields: ["email_address"],
+    ...overrides,
+  };
+}
+
+async function fillRequiredDetails(): Promise<{
+  readonly emailInput: HTMLElement;
+  readonly passwordInput: HTMLElement;
+}> {
+  const emailInput = await screen.findByLabelText("Email address");
+  const passwordInput = screen.getByLabelText("Password");
+  fireEvent.change(emailInput, { target: { value: "person@example.com" } });
+  fireEvent.change(passwordInput, { target: { value: "valid-password" } });
+  return { emailInput, passwordInput };
+}
+
+describe("auth v2 sign-up flow", () => {
+  it("shows loading on the base route until the low-level Clerk resource is ready", async () => {
+    const clerkLoad = createDeferredPromise<void>(context.signal);
+    mockedClerk.load.mockImplementation(() => {
+      return clerkLoad.promise;
+    });
+
+    setupSignUpPage({ status: null });
+
+    const signUpCard = await screen.findByTestId("app-auth-v2");
+    expect(within(signUpCard).getByRole("status")).toHaveTextContent(
+      "Loading authentication",
+    );
+
+    await act(async () => {
+      clerkLoad.resolve(undefined);
+      await clerkLoad.promise;
+    });
+
+    await expect(
+      screen.findByLabelText("Email address"),
+    ).resolves.toBeVisible();
+  });
+
+  it("recovers a prepared progressive sign-up on a nested refresh without sending another code", async () => {
+    setupSignUpPage(readyEmailVerificationState(), {
+      path: "/v2/sign-up/verify-email-address",
+    });
+
+    await expect(
+      screen.findByLabelText("Verification code"),
+    ).resolves.toBeVisible();
+    expect(
+      mockedClerk.signUpPrepareEmailAddressVerification,
+    ).not.toHaveBeenCalled();
+    expect(screen.getByText("person@example.com")).toBeVisible();
+  });
+
+  it("collects Clerk-exposed fields, validates the password, coalesces creation, and prepares exactly once", async () => {
+    const create = createDeferredPromise<
+      ReturnType<typeof currentSignUpResource>
+    >(context.signal);
+    mockedClerk.clientSignUpCreate.mockImplementation(() => {
+      return create.promise;
+    });
+    mockedClerk.signUpPrepareEmailAddressVerification.mockImplementation(() => {
+      return moveSignUpToAsync(readyEmailVerificationState());
+    });
+
+    setupSignUpPage({ status: null });
+    const { emailInput } = await fillRequiredDetails();
+    const firstNameInput = screen.getByLabelText(/First name/);
+    const lastNameInput = screen.getByLabelText(/Last name/);
+    fireEvent.change(firstNameInput, { target: { value: "Ada" } });
+    fireEvent.change(lastNameInput, { target: { value: "Lovelace" } });
+    const form = containingForm(emailInput);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignUpCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.signUpValidatePassword).toHaveBeenCalledWith(
+      "valid-password",
+      expect.objectContaining({ onValidation: expect.any(Function) }),
+    );
+    expect(mockedClerk.clientSignUpCreate).toHaveBeenCalledWith({
+      emailAddress: "person@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      locale: "en-US",
+      password: "valid-password",
+    });
+
+    await act(async () => {
+      create.resolve(
+        moveSignUpTo(
+          readyEmailVerificationState({
+            emailVerificationExpireAt: null,
+            emailVerificationStatus: null,
+            emailVerificationStrategy: null,
+          }),
+        ),
+      );
+      await create.promise;
+    });
+
+    await waitFor(() => {
+      expect(
+        mockedClerk.signUpPrepareEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      mockedClerk.signUpPrepareEmailAddressVerification,
+    ).toHaveBeenCalledWith({ strategy: "email_code" });
+    await expect(
+      screen.findByLabelText("Verification code"),
+    ).resolves.toBeVisible();
+  });
+
+  it("coalesces resend and code attempts, applies cooldown, preserves attribution, and activates once", async () => {
+    const resend = createDeferredPromise<
+      ReturnType<typeof currentSignUpResource>
+    >(context.signal);
+    const attempt = createDeferredPromise<
+      ReturnType<typeof currentSignUpResource>
+    >(context.signal);
+    mockedClerk.signUpPrepareEmailAddressVerification.mockImplementation(() => {
+      return resend.promise;
+    });
+    mockedClerk.signUpAttemptEmailAddressVerification.mockImplementation(() => {
+      return attempt.promise;
+    });
+    const path =
+      "/v2/sign-up/verify-email-address?gclid=click-123&utm_campaign=summer";
+    setupSignUpPage(readyEmailVerificationState(), {
+      path,
+      url: `https://app.vm0.ai${path}`,
+    });
+
+    await screen.findByLabelText("Verification code");
+    const resendButton = await waitForRoleElement(
+      "button",
+      "Didn't receive a code? Resend",
+    );
+    fireEvent.click(resendButton);
+    fireEvent.click(resendButton);
+
+    await waitFor(() => {
+      expect(
+        mockedClerk.signUpPrepareEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      resend.resolve(moveSignUpTo(readyEmailVerificationState()));
+      await resend.promise;
+    });
+
+    const cooldownButton = await waitForRoleElement(
+      "button",
+      "Didn't receive a code? Resend (30s)",
+    );
+    expect(cooldownButton).toBeDisabled();
+    const readyCodeInput = await screen.findByLabelText("Verification code");
+    fireEvent.change(readyCodeInput, { target: { value: "123456" } });
+    const form = containingForm(readyCodeInput);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(
+        mockedClerk.signUpAttemptEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      mockedClerk.signUpAttemptEmailAddressVerification,
+    ).toHaveBeenCalledWith({ code: "123456" });
+
+    await act(async () => {
+      attempt.resolve(
+        moveSignUpTo({
+          createdSessionId: "session_sign_up",
+          hasPassword: true,
+          status: "complete",
+        }),
+      );
+      await attempt.promise;
+    });
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    const activation = mockedClerk.setActive.mock.calls[0]?.[0];
+    expect(activation?.session).toBe("session_sign_up");
+    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    expect(redirectUrl.pathname).toBe("/onboarding");
+    expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");
+  });
+
+  it("requires configured legal consent and rejects Clerk-invalid passwords", async () => {
+    const user = userEvent.setup();
+    mockSignUpConfiguration({
+      privacyPolicyUrl: "https://vm0.ai/legal/privacy",
+      termsUrl: "https://vm0.ai/legal/terms",
+    });
+    setupSignUpPage({
+      missingFields: ["email_address", "password", "legal_accepted"],
+      requiredFields: ["email_address", "password", "legal_accepted"],
+      status: null,
+    });
+    const { emailInput } = await fillRequiredDetails();
+    expect(roleElement("link", "Terms of Service")).toHaveAttribute(
+      "href",
+      "https://vm0.ai/legal/terms",
+    );
+    expect(roleElement("link", "Privacy Policy")).toHaveAttribute(
+      "href",
+      "https://vm0.ai/legal/privacy",
+    );
+
+    const form = containingForm(emailInput);
+    fireEvent.submit(form);
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Please read and accept the terms to continue",
+    );
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
+
+    const legalConsent = screen.getByRole("checkbox");
+    await user.click(legalConsent);
+    await waitFor(() => {
+      expect(legalConsent).toBeChecked();
+    });
+    mockSignUpPasswordValidation({
+      complexity: { min_length: true },
+      strength: undefined,
+    });
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Your password is not strong enough.",
+      );
+    });
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
+
+    mockSignUpPasswordValidation({ complexity: {}, strength: undefined });
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(mockedClerk.clientSignUpCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ legalAccepted: true }),
+      );
+    });
+  });
+
+  it("shows expired verification recovery and lets the user edit the email before preparing once", async () => {
+    setupSignUpPage(
+      readyEmailVerificationState({
+        emailVerificationExpireAt: new Date(now() - 1000),
+        emailVerificationStatus: "expired",
+      }),
+    );
+
+    const editEmail = await waitForRoleElement("button", "Edit email address");
+    expect(screen.getByRole("alert")).toBeVisible();
+    await expect(
+      waitForRoleElement("button", "Didn't receive a code? Resend"),
+    ).resolves.toBeEnabled();
+    fireEvent.click(editEmail);
+
+    const emailInput = await screen.findByLabelText("Email address");
+    expect(emailInput).toHaveValue("person@example.com");
+    expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
+    fireEvent.change(emailInput, {
+      target: { value: "updated@example.com" },
+    });
+    mockedClerk.signUpUpdate.mockImplementation(() => {
+      return moveSignUpToAsync(
+        readyEmailVerificationState({
+          emailAddress: "updated@example.com",
+          emailVerificationExpireAt: null,
+          emailVerificationStatus: null,
+          emailVerificationStrategy: null,
+        }),
+      );
+    });
+    mockedClerk.signUpPrepareEmailAddressVerification.mockImplementation(() => {
+      return moveSignUpToAsync(
+        readyEmailVerificationState({ emailAddress: "updated@example.com" }),
+      );
+    });
+    fireEvent.submit(containingForm(emailInput));
+
+    await waitFor(() => {
+      expect(mockedClerk.signUpUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ emailAddress: "updated@example.com" }),
+      );
+      expect(
+        mockedClerk.signUpPrepareEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+    });
+    await expect(
+      screen.findByText("updated@example.com"),
+    ).resolves.toBeVisible();
+  });
+
+  it("surfaces Turnstile loading, blocked, expired, and retry states", async () => {
+    const create = createDeferredPromise<
+      ReturnType<typeof currentSignUpResource>
+    >(context.signal);
+    mockSignUpConfiguration({ captchaEnabled: true });
+    mockedClerk.clientSignUpCreate.mockImplementation(() => {
+      return create.promise;
+    });
+    setupSignUpPage({ status: null });
+    const { emailInput } = await fillRequiredDetails();
+    const captcha = document.querySelector("#clerk-captcha");
+    expect(captcha).toBeInstanceOf(HTMLDivElement);
+    fireEvent.submit(containingForm(emailInput));
+
+    await expect(screen.findByText("Loading…")).resolves.toBeVisible();
+    if (!(captcha instanceof HTMLDivElement)) {
+      throw new Error("Expected the Clerk CAPTCHA host");
+    }
+    captcha.dataset.clInteractive = "true";
+    await waitFor(() => {
+      expect(screen.getByText("Verifying your request")).toBeVisible();
+    });
+
+    await act(async () => {
+      create.reject({
+        errors: [
+          {
+            code: "captcha_invalid",
+            longMessage: "Bot validation expired.",
+            meta: { paramName: "captcha" },
+          },
+        ],
+      });
+      await expect(create.promise).rejects.toBeDefined();
+    });
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Bot validation expired.",
+    );
+    mockedClerk.clientSignUpCreate.mockImplementation(() => {
+      return moveSignUpToAsync({
+        createdSessionId: "session_captcha",
+        hasPassword: true,
+        status: "complete",
+      });
+    });
+    fireEvent.click(await waitForRoleElement("button", "Try again"));
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignUpCreate).toHaveBeenCalledTimes(2);
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it.each([
+    {
+      name: "a transferable identity",
+      state: readyEmailVerificationState({
+        emailVerificationExpireAt: null,
+        emailVerificationStatus: null,
+        emailVerificationStrategy: null,
+        isTransferable: true,
+      }),
+      title: "Sign in",
+    },
+    {
+      name: "an unsupported required field",
+      state: {
+        missingFields: ["phone_number"],
+        requiredFields: ["phone_number"],
+        status: "missing_requirements",
+      },
+      title: "Access restricted",
+    },
+    {
+      name: "a completed attempt without a session",
+      state: { status: "complete" },
+      title: "Access restricted",
+    },
+  ])(
+    "renders explicit transfer or recovery UI for $name",
+    async ({ state, title }) => {
+      const redirectUrl = "https://app.okou.ai/onboarding?source=sign-up";
+      setupSignUpPage(state, {
+        path: `/v2/sign-up?redirect_url=${encodeURIComponent(redirectUrl)}`,
+      });
+
+      await expect(
+        screen.findByRole(title === "Sign in" ? "link" : "heading", {
+          name: title,
+        }),
+      ).resolves.toBeVisible();
+      const signIn = roleElement("link", "Sign in");
+      expect(signIn).toHaveAttribute(
+        "href",
+        expect.stringContaining("redirect_url="),
+      );
+      expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
+      expect(
+        mockedClerk.signUpPrepareEmailAddressVerification,
+      ).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-card.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@okouai/ui";
+import { useGet } from "ccstate-react";
+
+import type { AuthV2Navigation } from "../../../signals/auth-v2/navigation.ts";
+import type { AuthV2SignUpSignals } from "../../../signals/auth-v2/sign-up-flow.ts";
+import type { AuthBrandContext } from "../../../signals/auth.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
+import { Link } from "../../router/link.tsx";
+import { AuthV2Shell } from "../auth-v2-shell.tsx";
+import { SignUpCardContent, SignUpSwitch } from "./sign-up-content.tsx";
+import { signUpCardDescription, useAuthV2SignUpCopy } from "./sign-up-copy.ts";
+
+export function AuthV2SignUpCard({
+  authBrand,
+  navigation,
+  signals,
+}: {
+  readonly authBrand: AuthBrandContext;
+  readonly navigation: AuthV2Navigation;
+  readonly signals: AuthV2SignUpSignals;
+}) {
+  const copy = useAuthV2SignUpCopy(authBrand.brandName);
+  const flowState = useGet(signals.state$);
+  const description = signUpCardDescription(flowState, copy);
+  const signInHref = navigation.href("sign-in");
+  return (
+    <AuthV2Shell
+      announcement={description}
+      description={description}
+      focusKey="sign-up"
+      title={copy.signUpTitle}
+    >
+      <div className="space-y-4">
+        <SignUpCardContent
+          copy={copy}
+          signInHref={signInHref}
+          signals={signals}
+          state={flowState}
+        />
+        {flowState.status === "incomplete" ? (
+          <SignUpSwitch copy={copy} signInHref={signInHref} />
+        ) : null}
+        <div className="flex justify-center">
+          <Button asChild size="sm" variant="link">
+            <Link
+              options={{
+                hash: location.hash,
+                searchParams: new URLSearchParams(location.search),
+              }}
+              pathname={ROUTES.signUp}
+            >
+              {copy.legacySignUp}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </AuthV2Shell>
+  );
+}

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
@@ -1,0 +1,615 @@
+import { Button, Checkbox, Input } from "@okouai/ui";
+import { Alert, AlertDescription } from "@okouai/ui/components/ui/alert";
+import { useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Loader2 } from "lucide-react";
+import type { FormEvent, ReactNode } from "react";
+
+import type {
+  AuthV2SignUpErrorField,
+  AuthV2SignUpFields,
+  AuthV2SignUpLegalConfig,
+  AuthV2SignUpSignals,
+  AuthV2SignUpState,
+} from "../../../signals/auth-v2/sign-up-flow.ts";
+import { pageSignal$ } from "../../../signals/page-signal.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
+import { Link } from "../../router/link.tsx";
+import {
+  type AuthV2SignUpCopy,
+  resendCodeLabel,
+  signUpErrorMessage,
+} from "./sign-up-copy.ts";
+
+type IncompleteSignUpState = Extract<
+  AuthV2SignUpState,
+  { status: "incomplete" }
+>;
+
+interface SignUpStepProps {
+  readonly copy: AuthV2SignUpCopy;
+  readonly signInHref: string;
+  readonly signals: AuthV2SignUpSignals;
+}
+
+function TextField({
+  autoComplete,
+  errorField,
+  inputMode,
+  label,
+  name,
+  onChange,
+  optionalLabel,
+  required,
+  type = "text",
+  value,
+}: {
+  readonly autoComplete: string;
+  readonly errorField: AuthV2SignUpErrorField | null;
+  readonly inputMode?: "email" | "numeric";
+  readonly label: string;
+  readonly name: string;
+  readonly onChange: (value: string) => void;
+  readonly optionalLabel?: string;
+  readonly required: boolean;
+  readonly type?: "email" | "password" | "text";
+  readonly value: string;
+}) {
+  const id = `auth-v2-sign-up-${name}`;
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium text-foreground" htmlFor={id}>
+        {label}
+        {!required && optionalLabel ? (
+          <span className="ml-1 font-normal text-muted-foreground">
+            ({optionalLabel})
+          </span>
+        ) : null}
+      </label>
+      <Input
+        aria-invalid={errorField === name}
+        autoComplete={autoComplete}
+        id={id}
+        inputMode={inputMode}
+        name={name}
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+        required={required}
+        type={type}
+        value={value}
+      />
+    </div>
+  );
+}
+
+function FlowErrorAlert({ copy, signals }: SignUpStepProps) {
+  const error = useGet(signals.error$);
+  if (!error || error.field === "captcha") {
+    return null;
+  }
+  return (
+    <Alert variant="destructive">
+      <AlertDescription>{signUpErrorMessage(error, copy)}</AlertDescription>
+    </Alert>
+  );
+}
+
+function SubmitButton({
+  busy,
+  disabled = busy,
+  label,
+}: {
+  readonly busy: boolean;
+  readonly disabled?: boolean;
+  readonly label: string;
+}) {
+  return (
+    <Button className="w-full" disabled={disabled} type="submit">
+      {busy ? <Loader2 className="animate-spin" aria-hidden="true" /> : null}
+      {label}
+    </Button>
+  );
+}
+
+function signInLinkOptions(signInHref: string) {
+  const url = new URL(signInHref, location.origin);
+  return {
+    hash: url.hash,
+    searchParams: url.searchParams,
+  };
+}
+
+function SignInLink({
+  children,
+  className,
+  signInHref,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly signInHref: string;
+}) {
+  return (
+    <Link
+      className={className}
+      options={signInLinkOptions(signInHref)}
+      pathname={ROUTES.signInV2}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function legalTemplate(
+  legal: AuthV2SignUpLegalConfig,
+  copy: AuthV2SignUpCopy,
+): string {
+  if (legal.termsUrl && legal.privacyPolicyUrl) {
+    return copy.legalTermsAndPrivacy;
+  }
+  return legal.termsUrl ? copy.legalTermsOnly : copy.legalPrivacyOnly;
+}
+
+function LegalConsentText({
+  copy,
+  legal,
+}: {
+  readonly copy: AuthV2SignUpCopy;
+  readonly legal: AuthV2SignUpLegalConfig;
+}) {
+  const template = legalTemplate(legal, copy);
+  const tokenPattern =
+    /{{\s*(termsOfServiceLink|privacyPolicyLink)\s*\|\|\s*link\((["'])(.*?)\2\)\s*}}/g;
+  const content: ReactNode[] = [];
+  let cursor = 0;
+  for (const match of template.matchAll(tokenPattern)) {
+    const index = match.index;
+    const token = match[1];
+    const label = match[3];
+    if (index === undefined || !token || !label) {
+      continue;
+    }
+    if (index > cursor) {
+      content.push(template.slice(cursor, index));
+    }
+    const href =
+      token === "termsOfServiceLink" ? legal.termsUrl : legal.privacyPolicyUrl;
+    if (href) {
+      content.push(
+        <a
+          className="font-medium underline underline-offset-4"
+          href={href}
+          key={`${token}-${index}`}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {label}
+        </a>,
+      );
+    } else {
+      content.push(label);
+    }
+    cursor = index + match[0].length;
+  }
+  if (cursor < template.length) {
+    content.push(template.slice(cursor));
+  }
+  return content;
+}
+
+function FieldList({
+  copy,
+  fields,
+  signals,
+}: {
+  readonly copy: AuthV2SignUpCopy;
+  readonly fields: AuthV2SignUpFields;
+  readonly signals: AuthV2SignUpSignals;
+}) {
+  const emailAddress = useGet(signals.emailAddress$);
+  const password = useGet(signals.password$);
+  const firstName = useGet(signals.firstName$);
+  const lastName = useGet(signals.lastName$);
+  const error = useGet(signals.error$);
+  const errorField = error?.field ?? null;
+  const setEmailAddress = useSet(signals.setEmailAddress$);
+  const setPassword = useSet(signals.setPassword$);
+  const setFirstName = useSet(signals.setFirstName$);
+  const setLastName = useSet(signals.setLastName$);
+  return (
+    <>
+      {fields.emailAddress !== "hidden" ? (
+        <TextField
+          autoComplete="email"
+          errorField={errorField}
+          inputMode="email"
+          label={copy.emailAddressLabel}
+          name="email-address"
+          onChange={setEmailAddress}
+          optionalLabel={copy.optional}
+          required={fields.emailAddress === "required"}
+          type="email"
+          value={emailAddress}
+        />
+      ) : null}
+      {fields.password !== "hidden" ? (
+        <TextField
+          autoComplete="new-password"
+          errorField={errorField}
+          label={copy.passwordLabel}
+          name="password"
+          onChange={setPassword}
+          optionalLabel={copy.optional}
+          required={fields.password === "required"}
+          type="password"
+          value={password}
+        />
+      ) : null}
+      {fields.firstName !== "hidden" ? (
+        <TextField
+          autoComplete="given-name"
+          errorField={errorField}
+          label={copy.firstNameLabel}
+          name="first-name"
+          onChange={setFirstName}
+          optionalLabel={copy.optional}
+          required={fields.firstName === "required"}
+          value={firstName}
+        />
+      ) : null}
+      {fields.lastName !== "hidden" ? (
+        <TextField
+          autoComplete="family-name"
+          errorField={errorField}
+          label={copy.lastNameLabel}
+          name="last-name"
+          onChange={setLastName}
+          optionalLabel={copy.optional}
+          required={fields.lastName === "required"}
+          value={lastName}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function CaptchaStatus({ copy, signals }: SignUpStepProps) {
+  const captchaState = useGet(signals.captchaState$);
+  const error = useGet(signals.error$);
+  if (captchaState === "idle") {
+    return null;
+  }
+  if (captchaState === "error" || captchaState === "expired") {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>
+          {error?.message ??
+            (captchaState === "expired"
+              ? copy.captchaExpired
+              : copy.captchaError)}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <div
+      className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm text-muted-foreground"
+      role="status"
+    >
+      <Loader2 className="mt-0.5 size-4 animate-spin" aria-hidden="true" />
+      <span>
+        <span className="block font-medium text-foreground">
+          {captchaState === "blocked" ? copy.captchaTitle : copy.captchaLoading}
+        </span>
+        {captchaState === "blocked" ? (
+          <span className="block">{copy.captchaSubtitle}</span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function DetailsStep({
+  copy,
+  signInHref,
+  signals,
+  state,
+}: SignUpStepProps & {
+  readonly state: Extract<IncompleteSignUpState, { step: "details" }>;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const legalAccepted = useGet(signals.legalAccepted$);
+  const captchaState = useGet(signals.captchaState$);
+  const error = useGet(signals.error$);
+  const setLegalAccepted = useSet(signals.setLegalAccepted$);
+  const captchaRef = useSet(signals.captchaRef$);
+  const [submitLoadable, submit] = useLoadableSet(signals.submit$);
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign up");
+  };
+  const retrying = captchaState === "error" || captchaState === "expired";
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <FlowErrorAlert copy={copy} signals={signals} signInHref={signInHref} />
+      <FieldList copy={copy} fields={state.fields} signals={signals} />
+      {state.legal.required ? (
+        <label className="flex cursor-pointer items-start gap-2 text-sm text-muted-foreground">
+          <Checkbox
+            aria-invalid={error?.field === "legal" ? true : undefined}
+            checked={legalAccepted}
+            className="mt-0.5"
+            onCheckedChange={(checked) => {
+              setLegalAccepted(checked === true);
+            }}
+          />
+          <span>
+            <LegalConsentText copy={copy} legal={state.legal} />
+          </span>
+        </label>
+      ) : null}
+      {state.captchaEnabled ? (
+        <div
+          data-cl-size="flexible"
+          data-cl-theme="auto"
+          id="clerk-captcha"
+          ref={captchaRef}
+        />
+      ) : null}
+      <CaptchaStatus copy={copy} signals={signals} signInHref={signInHref} />
+      <SubmitButton
+        busy={submitLoadable.state === "loading"}
+        label={retrying ? copy.retry : copy.continue}
+      />
+    </form>
+  );
+}
+
+function EmailCodeStep({
+  copy,
+  signInHref,
+  signals,
+  state,
+}: SignUpStepProps & {
+  readonly state: Extract<IncompleteSignUpState, { step: "email-code" }>;
+}) {
+  const code = useGet(signals.code$);
+  const error = useGet(signals.error$);
+  const coolingDown = useGet(signals.resendCoolingDown$);
+  const pageSignal = useGet(pageSignal$);
+  const setCode = useSet(signals.setCode$);
+  const backToDetails = useSet(signals.backToDetails$);
+  const [submitLoadable, submit] = useLoadableSet(signals.submit$);
+  const [resendLoadable, resendCode] = useLoadableSet(signals.resendCode$);
+  const preparing = state.verification === "preparing";
+  const prepareFailed = state.verification === "prepare-failed";
+  const expired = state.verification === "expired";
+  const submitting = submitLoadable.state === "loading";
+  const resending = resendLoadable.state === "loading";
+  const operationPending = preparing || submitting || resending;
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    detach(submit(pageSignal), Reason.DomCallback, "verify auth v2 sign up");
+  };
+  const handleResend = (): void => {
+    detach(
+      resendCode(pageSignal),
+      Reason.DomCallback,
+      "resend auth v2 sign up code",
+    );
+  };
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <FlowErrorAlert copy={copy} signals={signals} signInHref={signInHref} />
+      <div className="space-y-1 text-center">
+        <h2 className="text-base font-medium text-foreground">
+          {copy.emailCodeTitle}
+        </h2>
+        <p className="text-sm text-muted-foreground">{state.emailAddress}</p>
+      </div>
+      {preparing ? (
+        <div
+          className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+          role="status"
+        >
+          <Loader2 className="animate-spin" aria-hidden="true" />
+          {copy.loading}
+        </div>
+      ) : null}
+      {expired ? (
+        <Alert variant="destructive">
+          <AlertDescription>{copy.codeExpired}</AlertDescription>
+        </Alert>
+      ) : null}
+      {!preparing && !prepareFailed ? (
+        <TextField
+          autoComplete="one-time-code"
+          errorField={error?.field ?? null}
+          inputMode="numeric"
+          label={copy.codeLabel}
+          name="code"
+          onChange={setCode}
+          required
+          value={code}
+        />
+      ) : null}
+      {!preparing && !prepareFailed ? (
+        <SubmitButton
+          busy={submitting}
+          disabled={operationPending || expired}
+          label={copy.verify}
+        />
+      ) : null}
+      <Button
+        className="h-auto w-full"
+        disabled={operationPending || (coolingDown && !expired)}
+        type="button"
+        variant={prepareFailed || expired ? "outline" : "link"}
+        onClick={handleResend}
+      >
+        {resending ? (
+          <Loader2 className="animate-spin" aria-hidden="true" />
+        ) : null}
+        {prepareFailed ? copy.retry : resendCodeLabel(coolingDown, copy)}
+      </Button>
+      <Button
+        className="w-full"
+        disabled={operationPending}
+        type="button"
+        variant="ghost"
+        onClick={backToDetails}
+      >
+        {copy.editEmailAddress || copy.back}
+      </Button>
+    </form>
+  );
+}
+
+function LoadingStep({ copy }: { readonly copy: AuthV2SignUpCopy }) {
+  return (
+    <div
+      className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground"
+      role="status"
+    >
+      <Loader2 className="animate-spin" aria-hidden="true" />
+      <span>{copy.loading}</span>
+    </div>
+  );
+}
+
+function CompleteStep({ copy }: { readonly copy: AuthV2SignUpCopy }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 py-8 text-center"
+      role="status"
+    >
+      <Loader2
+        className="animate-spin text-muted-foreground"
+        aria-hidden="true"
+      />
+      <h2 className="text-base font-medium text-foreground">
+        {copy.completeTitle}
+      </h2>
+    </div>
+  );
+}
+
+function TransferStep({ copy, signInHref, signals }: SignUpStepProps) {
+  const pageSignal = useGet(pageSignal$);
+  const [restartLoadable, restart] = useLoadableSet(signals.restart$);
+  return (
+    <div className="space-y-3">
+      <Button className="w-full" asChild>
+        <SignInLink signInHref={signInHref}>{copy.signIn}</SignInLink>
+      </Button>
+      <Button
+        className="w-full"
+        disabled={restartLoadable.state === "loading"}
+        type="button"
+        variant="ghost"
+        onClick={() => {
+          detach(
+            restart(pageSignal),
+            Reason.DomCallback,
+            "restart auth v2 sign up",
+          );
+        }}
+      >
+        {copy.restart}
+      </Button>
+    </div>
+  );
+}
+
+function UnknownStep({ copy, signInHref, signals }: SignUpStepProps) {
+  const pageSignal = useGet(pageSignal$);
+  const [restartLoadable, restart] = useLoadableSet(signals.restart$);
+  return (
+    <div className="space-y-4 text-center">
+      <h2 className="text-base font-medium text-foreground">
+        {copy.unknownTitle}
+      </h2>
+      <Button
+        className="w-full"
+        disabled={restartLoadable.state === "loading"}
+        type="button"
+        variant="outline"
+        onClick={() => {
+          detach(
+            restart(pageSignal),
+            Reason.DomCallback,
+            "restart unknown auth v2 sign up",
+          );
+        }}
+      >
+        {copy.restart}
+      </Button>
+      <Button className="w-full" asChild variant="ghost">
+        <SignInLink signInHref={signInHref}>{copy.signIn}</SignInLink>
+      </Button>
+    </div>
+  );
+}
+
+export function SignUpCardContent({
+  copy,
+  signInHref,
+  signals,
+  state,
+}: SignUpStepProps & { readonly state: AuthV2SignUpState }) {
+  if (state.status === "loading") {
+    return <LoadingStep copy={copy} />;
+  }
+  if (state.status === "complete") {
+    return <CompleteStep copy={copy} />;
+  }
+  if (state.status === "transfer") {
+    return (
+      <TransferStep copy={copy} signInHref={signInHref} signals={signals} />
+    );
+  }
+  if (state.status === "unknown") {
+    return (
+      <UnknownStep copy={copy} signInHref={signInHref} signals={signals} />
+    );
+  }
+  if (state.step === "email-code") {
+    return (
+      <EmailCodeStep
+        copy={copy}
+        signInHref={signInHref}
+        signals={signals}
+        state={state}
+      />
+    );
+  }
+  return (
+    <DetailsStep
+      copy={copy}
+      signInHref={signInHref}
+      signals={signals}
+      state={state}
+    />
+  );
+}
+
+export function SignUpSwitch({
+  copy,
+  signInHref,
+}: {
+  readonly copy: AuthV2SignUpCopy;
+  readonly signInHref: string;
+}) {
+  return (
+    <p className="text-center text-sm text-muted-foreground">
+      {copy.alreadyHaveAccount}{" "}
+      <SignInLink
+        className="font-medium text-foreground underline underline-offset-4"
+        signInHref={signInHref}
+      >
+        {copy.signIn}
+      </SignInLink>
+    </p>
+  );
+}

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-copy.ts
@@ -1,0 +1,306 @@
+import { enUS } from "@clerk/localizations";
+import { useGet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+
+import {
+  AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS,
+  type AuthV2SignUpError,
+  type AuthV2SignUpState,
+} from "../../../signals/auth-v2/sign-up-flow.ts";
+import type { AuthBrandContext } from "../../../signals/auth.ts";
+import { locale$ } from "../../../signals/locale.ts";
+import { getClerkLocalization } from "../../auth/clerk-localization.ts";
+
+type ClerkLocalization = ReturnType<typeof getClerkLocalization>;
+
+export interface AuthV2SignUpCopy {
+  readonly alreadyHaveAccount: string;
+  readonly back: string;
+  readonly captchaError: string;
+  readonly captchaExpired: string;
+  readonly captchaLoading: string;
+  readonly captchaSubtitle: string;
+  readonly captchaTitle: string;
+  readonly codeExpired: string;
+  readonly codeLabel: string;
+  readonly completeSubtitle: string;
+  readonly completeTitle: string;
+  readonly continue: string;
+  readonly description: string;
+  readonly editEmailAddress: string;
+  readonly emailAddressLabel: string;
+  readonly emailCodeSubtitle: string;
+  readonly emailCodeTitle: string;
+  readonly firstNameLabel: string;
+  readonly lastNameLabel: string;
+  readonly legacySignUp: string;
+  readonly legalPrivacyOnly: string;
+  readonly legalRequired: string;
+  readonly legalTermsAndPrivacy: string;
+  readonly legalTermsOnly: string;
+  readonly loading: string;
+  readonly optional: string;
+  readonly passwordInvalid: string;
+  readonly passwordLabel: string;
+  readonly resendCode: string;
+  readonly resendCodeCooldown: string;
+  readonly restart: string;
+  readonly retry: string;
+  readonly signIn: string;
+  readonly signUpTitle: string;
+  readonly unknownError: string;
+  readonly unknownMessage: string;
+  readonly unknownTitle: string;
+  readonly verify: string;
+}
+
+function localizedString(value: unknown, fallback: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return typeof fallback === "string" ? fallback : "";
+}
+
+function formCopy(localization: ClerkLocalization) {
+  return {
+    back: localizedString(localization.backButton, enUS.backButton),
+    codeLabel: localizedString(
+      localization.signUp?.emailCode?.formTitle,
+      enUS.signUp?.emailCode?.formTitle,
+    ),
+    continue: localizedString(
+      localization.formButtonPrimary,
+      enUS.formButtonPrimary,
+    ),
+    editEmailAddress: localizedString(
+      localization.identityPreviewEditButton__emailAddress,
+      enUS.identityPreviewEditButton__emailAddress,
+    ),
+    emailAddressLabel: localizedString(
+      localization.formFieldLabel__emailAddress,
+      enUS.formFieldLabel__emailAddress,
+    ),
+    firstNameLabel: localizedString(
+      localization.formFieldLabel__firstName,
+      enUS.formFieldLabel__firstName,
+    ),
+    lastNameLabel: localizedString(
+      localization.formFieldLabel__lastName,
+      enUS.formFieldLabel__lastName,
+    ),
+    optional: localizedString(
+      localization.formFieldHintText__optional,
+      enUS.formFieldHintText__optional,
+    ),
+    passwordLabel: localizedString(
+      localization.formFieldLabel__password,
+      enUS.formFieldLabel__password,
+    ),
+    verify: localizedString(
+      localization.formButtonPrimary__verify,
+      enUS.formButtonPrimary__verify,
+    ),
+  };
+}
+
+function startCopy(localization: ClerkLocalization) {
+  const start = localization.signUp?.start;
+  const fallback = enUS.signUp?.start;
+  return {
+    alreadyHaveAccount: localizedString(
+      start?.actionText,
+      fallback?.actionText,
+    ),
+    description: localizedString(start?.subtitle, fallback?.subtitle),
+    signIn: localizedString(start?.actionLink, fallback?.actionLink),
+  };
+}
+
+function emailCodeCopy(localization: ClerkLocalization) {
+  const emailCode = localization.signUp?.emailCode;
+  const fallback = enUS.signUp?.emailCode;
+  return {
+    emailCodeSubtitle: localizedString(emailCode?.subtitle, fallback?.subtitle),
+    emailCodeTitle: localizedString(emailCode?.title, fallback?.title),
+    resendCode: localizedString(
+      emailCode?.resendButton,
+      fallback?.resendButton,
+    ),
+  };
+}
+
+function legalCopy(localization: ClerkLocalization) {
+  const legal = localization.signUp?.legalConsent;
+  const fallback = enUS.signUp?.legalConsent;
+  return {
+    legalPrivacyOnly: localizedString(
+      legal?.checkbox?.label__onlyPrivacyPolicy,
+      fallback?.checkbox?.label__onlyPrivacyPolicy,
+    ),
+    legalRequired: localizedString(
+      legal?.continue?.subtitle,
+      fallback?.continue?.subtitle,
+    ),
+    legalTermsAndPrivacy: localizedString(
+      legal?.checkbox?.label__termsOfServiceAndPrivacyPolicy,
+      fallback?.checkbox?.label__termsOfServiceAndPrivacyPolicy,
+    ),
+    legalTermsOnly: localizedString(
+      legal?.checkbox?.label__onlyTermsOfService,
+      fallback?.checkbox?.label__onlyTermsOfService,
+    ),
+  };
+}
+
+function captchaCopy(localization: ClerkLocalization) {
+  const protectCheck = localization.signUp?.protectCheck;
+  const fallbackProtectCheck = enUS.signUp?.protectCheck;
+  return {
+    captchaError: localizedString(
+      localization.unstable__errors?.captcha_unavailable,
+      enUS.unstable__errors?.captcha_unavailable,
+    ),
+    captchaLoading: localizedString(
+      protectCheck?.loading,
+      fallbackProtectCheck?.loading,
+    ),
+    captchaSubtitle: localizedString(
+      protectCheck?.subtitle,
+      fallbackProtectCheck?.subtitle,
+    ),
+    captchaTitle: localizedString(
+      protectCheck?.title,
+      fallbackProtectCheck?.title,
+    ),
+    retry: localizedString(
+      protectCheck?.retryButton,
+      fallbackProtectCheck?.retryButton,
+    ),
+  };
+}
+
+function completionCopy(localization: ClerkLocalization) {
+  return {
+    completeSubtitle: localizedString(
+      localization.signUp?.emailLink?.loading?.title,
+      enUS.signUp?.emailLink?.loading?.title,
+    ),
+    completeTitle: localizedString(
+      localization.signUp?.emailLink?.verified?.title,
+      enUS.signUp?.emailLink?.verified?.title,
+    ),
+    passwordInvalid: localizedString(
+      localization.unstable__errors?.form_password_not_strong_enough,
+      enUS.unstable__errors?.form_password_not_strong_enough,
+    ),
+  };
+}
+
+function recoveryCopy(localization: ClerkLocalization) {
+  const restrictedAccess = localization.signUp?.restrictedAccess;
+  const fallbackRestrictedAccess = enUS.signUp?.restrictedAccess;
+  return {
+    restart: localizedString(
+      localization.footerActionLink__useAnotherMethod,
+      enUS.footerActionLink__useAnotherMethod,
+    ),
+    unknownError: localizedString(
+      localization.unstable__errors?.action_blocked,
+      enUS.unstable__errors?.action_blocked,
+    ),
+    unknownMessage: localizedString(
+      restrictedAccess?.subtitle,
+      fallbackRestrictedAccess?.subtitle,
+    ),
+    unknownTitle: localizedString(
+      restrictedAccess?.title,
+      fallbackRestrictedAccess?.title,
+    ),
+  };
+}
+
+export function useAuthV2SignUpCopy(
+  brandName: AuthBrandContext["brandName"],
+): AuthV2SignUpCopy {
+  const { t } = useTranslation();
+  const locale = useGet(locale$);
+  const localization = getClerkLocalization(brandName, locale, t);
+  return {
+    ...formCopy(localization),
+    ...startCopy(localization),
+    ...emailCodeCopy(localization),
+    ...legalCopy(localization),
+    ...captchaCopy(localization),
+    ...completionCopy(localization),
+    ...recoveryCopy(localization),
+    captchaExpired: t(($) => {
+      return $.auth.v2.signUp.captchaExpired;
+    }),
+    codeExpired: t(($) => {
+      return $.auth.v2.signUp.codeExpired;
+    }),
+    legacySignUp: t(($) => {
+      return $.auth.v2.signUp.action;
+    }),
+    loading: t(($) => {
+      return $.auth.loading;
+    }),
+    resendCodeCooldown: t(
+      ($) => {
+        return $.auth.v2.signUp.resendCodeCooldown;
+      },
+      {
+        count: AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS,
+        resendCode: emailCodeCopy(localization).resendCode,
+      },
+    ),
+    signUpTitle: t(
+      ($) => {
+        return $.auth.v2.signUp.title;
+      },
+      { brandName },
+    ),
+  };
+}
+
+export function signUpErrorMessage(
+  error: AuthV2SignUpError,
+  copy: AuthV2SignUpCopy,
+): string {
+  if (error.code === "legal-required") {
+    return copy.legalRequired;
+  }
+  if (error.code === "password-invalid") {
+    return copy.passwordInvalid;
+  }
+  return error.message ?? copy.unknownError;
+}
+
+export function signUpCardDescription(
+  flowState: AuthV2SignUpState,
+  copy: AuthV2SignUpCopy,
+): string {
+  if (flowState.status === "loading") {
+    return copy.loading;
+  }
+  if (flowState.status === "complete") {
+    return copy.completeSubtitle;
+  }
+  if (flowState.status === "transfer") {
+    return copy.alreadyHaveAccount;
+  }
+  if (flowState.status === "unknown") {
+    return copy.unknownMessage;
+  }
+  if (flowState.step === "email-code") {
+    return copy.emailCodeSubtitle;
+  }
+  return copy.description;
+}
+
+export function resendCodeLabel(
+  coolingDown: boolean,
+  copy: AuthV2SignUpCopy,
+): string {
+  return coolingDown ? copy.resendCodeCooldown : copy.resendCode;
+}

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -30,8 +30,10 @@ function okouBrandLink(): HTMLElement {
   return link;
 }
 
-function authV2ActionLink(): HTMLAnchorElement {
-  const link = screen.getByTestId("app-auth-v2").querySelector("a");
+function authV2ActionLink(name: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
   if (!(link instanceof HTMLAnchorElement)) {
     throw new Error("Auth v2 action link not found");
   }
@@ -403,7 +405,7 @@ describe("app auth pages", () => {
     expect(
       screen.getByRole("heading", { name: routeCase.heading }),
     ).toBeVisible();
-    const actionLink = authV2ActionLink();
+    const actionLink = authV2ActionLink(routeCase.action);
     expect(actionLink).toHaveTextContent(routeCase.action);
     expect(actionLink).toHaveAttribute("href", routeCase.legacyPath);
     expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
@@ -427,7 +429,7 @@ describe("app auth pages", () => {
     expect(
       screen.getByRole("heading", { name: "Sign in to Okou" }),
     ).toBeVisible();
-    const continueLink = authV2ActionLink();
+    const continueLink = authV2ActionLink("Use current sign-in");
     expect(continueLink).toHaveAttribute(
       "href",
       `/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}${hash}`,


### PR DESCRIPTION
## Summary

- add the vm0-owned native sign-up flow for `/v2/sign-up` and nested refresh routes using lower-level Clerk resources
- support Clerk-driven email/password fields, optional names, validation, legal consent, email-code verification recovery, resend cooldown, and Turnstile states
- coalesce duplicate operations, fail closed on unsupported states, activate the created session once, and preserve typed branding, redirect, attribution, satellite, and sign-in-switching context
- keep Google OAuth sign-up, production traffic rollout, and v1 auth removal out of this change

## Testing

- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- bounded non-platform, platform, and API TypeScript checks
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx --pool=threads --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx --pool=threads --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx --pool=threads --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/signals/auth-v2/platform-context.test.ts --pool=threads --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/signals/auth-v2/navigation.test.ts --pool=threads --maxWorkers=1`

## Remaining parity gaps

- external strategies remain for the planned OAuth, One Tap, and Passkey wave across both auth modes
- cross-flow continuation/task states, broader diagnostics, live browser parity evidence, production routing, and v1 removal remain outside this focused slice

Part of #28927