### PR TITLE
perf(api): warm connector projections before traffic

### DIFF
--- a/.github/scripts/reconcile-api-connector-catalog.sh
+++ b/.github/scripts/reconcile-api-connector-catalog.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: reconcile-api-connector-catalog.sh DEPLOYMENT_URL strict|allow-legacy" >&2
+  exit 2
+fi
+
+deployment_url=${1%/}
+response_mode=$2
+
+if [ -z "$deployment_url" ]; then
+  echo "deployment URL is required" >&2
+  exit 2
+fi
+if [ "$response_mode" != "strict" ] && [ "$response_mode" != "allow-legacy" ]; then
+  echo "response mode must be strict or allow-legacy" >&2
+  exit 2
+fi
+: "${CRON_SECRET:?CRON_SECRET is required}"
+
+headers=(-H "Authorization: Bearer ${CRON_SECRET}")
+if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+  headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+fi
+
+for attempt in 1 2 3; do
+  response=""
+  if ! response=$(curl \
+    --fail-with-body \
+    --show-error \
+    --silent \
+    --max-time 120 \
+    "${headers[@]}" \
+    "${deployment_url}/api/cron/sync-connector-catalog"); then
+    echo "::warning::Connector catalog reconcile request failed (attempt ${attempt}/3)"
+  elif summary=$(jq -ce '
+    if type != "object" then
+      error("response must be an object")
+    else
+      {
+        outcome: (
+          if .outcome == "accepted" or .outcome == "unchanged" or .outcome == "rejected"
+          then .outcome
+          else "invalid-response"
+          end
+        ),
+        catalogCurrent: (.state == "current"),
+        hasActiveCatalog: (.active != null),
+        compatibilityCurrent: (
+          (.filtering | type) == "object" and .filtering.stale == false
+        ),
+        filteredAuthMethodCount: (
+          if (.filtering.filteredAuthMethods | type) == "array"
+          then (.filtering.filteredAuthMethods | length)
+          else null
+          end
+        ),
+        runtimeProjection: (
+          if has("runtimeProjection") | not then
+            "legacy-response"
+          elif (.runtimeProjection | type) != "object" then
+            "invalid-response"
+          elif .runtimeProjection.state == "ready" then
+            "ready"
+          elif
+            .runtimeProjection.state == "not-ready" and
+            (
+              .runtimeProjection.reason == "schema-unavailable" or
+              .runtimeProjection.reason == "projection-not-ready" or
+              .runtimeProjection.reason == "unsupported" or
+              .runtimeProjection.reason == "compatibility-not-ready" or
+              .runtimeProjection.reason == "invalid-compatibility" or
+              .runtimeProjection.reason == "incomplete" or
+              .runtimeProjection.reason == "identity-changed"
+            )
+          then .runtimeProjection.reason
+          else "invalid-response"
+          end
+        )
+      }
+    end
+  ' <<<"$response"); then
+    echo "Connector catalog reconcile: ${summary}"
+
+    if jq -e --arg response_mode "$response_mode" '
+      type == "object" and
+      .state == "current" and
+      .active != null and
+      (.filtering | type) == "object" and
+      .filtering.stale == false and
+      (
+        (
+          has("runtimeProjection") and
+          (.runtimeProjection | type) == "object" and
+          .runtimeProjection.state == "ready"
+        ) or
+        (
+          (has("runtimeProjection") | not) and
+          $response_mode == "allow-legacy"
+        )
+      )
+    ' <<<"$response" >/dev/null; then
+      exit 0
+    fi
+    echo "::warning::Connector catalog is not ready (attempt ${attempt}/3)"
+  else
+    echo "::warning::Connector catalog reconcile returned invalid JSON (attempt ${attempt}/3)"
+  fi
+
+  if [ "$attempt" -lt 3 ]; then
+    sleep 2
+  fi
+done
+
+echo "::error::Connector catalog reconcile did not produce a current ready projection"
+exit 1

--- a/.github/scripts/tests/reconcile-api-connector-catalog-test.sh
+++ b/.github/scripts/tests/reconcile-api-connector-catalog-test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/reconcile-api-connector-catalog.sh"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+fake_bin="${test_dir}/bin"
+mkdir -p "$fake_bin"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+cat >"${fake_bin}/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$MOCK_CURL_ARGS"
+attempt=1
+if [ -f "$MOCK_CURL_COUNT" ]; then
+  attempt=$(( $(cat "$MOCK_CURL_COUNT") + 1 ))
+fi
+printf '%s\n' "$attempt" >"$MOCK_CURL_COUNT"
+response=$(sed -n "${attempt}p" "$MOCK_CURL_RESPONSES")
+if [ -z "$response" ]; then
+  response=$(tail -n 1 "$MOCK_CURL_RESPONSES")
+fi
+if [ "$response" = "__HTTP_FAILURE__" ]; then
+  echo "curl: mock HTTP failure" >&2
+  exit 22
+fi
+printf '%s\n' "$response"
+SH
+
+cat >"${fake_bin}/sleep" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$MOCK_SLEEP_ARGS"
+SH
+
+chmod +x "${fake_bin}/curl" "${fake_bin}/sleep"
+
+ready_response='{"outcome":"unchanged","state":"current","active":{"catalogVersion":"sensitive-version","catalogDigest":"sha256:sensitive-digest"},"filtering":{"capabilityDigest":"sha256:sensitive-capability","stale":false,"filteredAuthMethods":[{"connectorSlug":"sensitive-connector"}]},"runtimeProjection":{"state":"ready"}}'
+legacy_response='{"outcome":"unchanged","state":"current","active":{"catalogVersion":"legacy-version"},"filtering":{"stale":false,"filteredAuthMethods":[]}}'
+not_ready_response='{"outcome":"unchanged","state":"current","active":{"catalogVersion":"sensitive-version"},"filtering":{"stale":false,"filteredAuthMethods":[]},"runtimeProjection":{"state":"not-ready","reason":"incomplete"}}'
+
+run_case() {
+  local name=$1
+  local mode=$2
+  local responses=$3
+  local bypass_secret=${4-sensitive-bypass-secret}
+  local case_dir="${test_dir}/${name}"
+  mkdir -p "$case_dir"
+  printf '%s\n' "$responses" >"${case_dir}/responses"
+  : >"${case_dir}/curl-args"
+  : >"${case_dir}/sleep-args"
+  env \
+    PATH="${fake_bin}:$PATH" \
+    CRON_SECRET="sensitive-cron-secret" \
+    MOCK_CURL_ARGS="${case_dir}/curl-args" \
+    MOCK_CURL_COUNT="${case_dir}/curl-count" \
+    MOCK_CURL_RESPONSES="${case_dir}/responses" \
+    MOCK_SLEEP_ARGS="${case_dir}/sleep-args" \
+    VERCEL_AUTOMATION_BYPASS_SECRET="$bypass_secret" \
+    bash "$script" "https://api-preview.example.test/" "$mode"
+}
+
+strict_output=$(run_case strict-ready strict "$ready_response")
+grep -q 'catalogCurrent.*true' <<<"$strict_output" || fail "strict success did not log current state"
+grep -q 'runtimeProjection.*ready' <<<"$strict_output" || fail "strict success did not log ready state"
+grep -q -- '-H Authorization: Bearer sensitive-cron-secret' "${test_dir}/strict-ready/curl-args" || fail "cron authorization header missing"
+grep -q -- '-H x-vercel-protection-bypass: sensitive-bypass-secret' "${test_dir}/strict-ready/curl-args" || fail "Vercel bypass header missing"
+grep -q 'https://api-preview.example.test/api/cron/sync-connector-catalog' "${test_dir}/strict-ready/curl-args" || fail "exact deployment URL missing"
+
+run_case no-bypass strict "$ready_response" "" >/dev/null
+if grep -q 'x-vercel-protection-bypass' "${test_dir}/no-bypass/curl-args"; then
+  fail "empty Vercel bypass secret added a header"
+fi
+
+if run_case strict-missing strict "$legacy_response" >"${test_dir}/strict-missing.out" 2>&1; then
+  fail "strict mode accepted a missing runtime projection field"
+fi
+[ "$(wc -l <"${test_dir}/strict-missing/sleep-args")" -eq 2 ] || fail "strict exhaustion did not sleep twice"
+
+legacy_output=$(run_case legacy-success allow-legacy "$legacy_response")
+grep -q 'runtimeProjection.*legacy-response' <<<"$legacy_output" || fail "legacy success was not identified"
+
+if run_case legacy-not-ready allow-legacy "$not_ready_response" >"${test_dir}/legacy-not-ready.out" 2>&1; then
+  fail "legacy mode accepted an explicit non-ready response"
+fi
+grep -q 'runtimeProjection.*incomplete' "${test_dir}/legacy-not-ready.out" || fail "bounded non-ready reason was not logged"
+
+recovery_responses=$(printf '%s\n%s\n%s' '__HTTP_FAILURE__' 'not-json' "$ready_response")
+recovery_output=$(run_case recovery strict "$recovery_responses" 2>&1)
+grep -q 'attempt 1/3' <<<"$recovery_output" || fail "HTTP retry was not reported"
+grep -q 'attempt 2/3' <<<"$recovery_output" || fail "invalid JSON retry was not reported"
+[ "$(cat "${test_dir}/recovery/curl-count")" -eq 3 ] || fail "recovery did not use three attempts"
+
+for sensitive in \
+  sensitive-cron-secret \
+  sensitive-bypass-secret \
+  sensitive-version \
+  sensitive-digest \
+  sensitive-capability \
+  sensitive-connector; do
+  if grep -q "$sensitive" <<<"$recovery_output"; then
+    fail "reconcile logs leaked $sensitive"
+  fi
+done
+
+if run_case invalid-mode unsupported "$ready_response" >"${test_dir}/invalid-mode.out" 2>&1; then
+  fail "invalid response mode succeeded"
+fi
+[ ! -s "${test_dir}/invalid-mode/curl-args" ] || fail "invalid mode called curl"
+
+echo "reconcile-api-connector-catalog tests passed"

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -321,6 +321,34 @@ ruby -e '
   rollback_app_step = rollback.fetch("rollback-app").fetch("steps").find { |step| step["id"] == "app" }
   raise "rollback App deployment must use the shared artifact fetcher" unless rollback_app_step.fetch("run").include?(artifact_fetch_helper)
 
+  reconcile_helper = ".github/scripts/reconcile-api-connector-catalog.sh"
+  preview_api_steps = turbo.fetch("deploy-api").fetch("steps")
+  preview_reconcile_index = preview_api_steps.index { |step| step["name"] == "Reconcile preview connector catalog" }
+  preview_alias_index = preview_api_steps.index { |step| step["name"] == "Create API Vercel Alias" }
+  raise "preview connector reconciliation step is missing" unless preview_reconcile_index
+  raise "preview connector reconciliation must run before alias" unless preview_alias_index && preview_reconcile_index < preview_alias_index
+  preview_reconcile = preview_api_steps.fetch(preview_reconcile_index)
+  raise "preview must use the shared strict connector gate" unless preview_reconcile.fetch("run").include?(reconcile_helper) && preview_reconcile.fetch("run").end_with?(" strict")
+
+  rollback_api_steps = rollback.fetch("rollback-api").fetch("steps")
+  rollback_checkout = rollback_api_steps.find { |step| step["uses"].to_s.start_with?("actions/checkout@") }
+  raise "rollback API must fetch full history for target baseline validation" unless rollback_checkout.dig("with", "fetch-depth") == 0
+  rollback_compatibility_index = rollback_api_steps.index { |step| step["name"] == "Verify rollback connector catalog compatibility" }
+  rollback_reconcile_index = rollback_api_steps.index { |step| step["name"] == "Reconcile rollback API connector catalog" }
+  rollback_promote_index = rollback_api_steps.index { |step| step["name"] == "Promote target API deployment" }
+  raise "rollback connector compatibility gate is missing" unless rollback_compatibility_index
+  raise "rollback connector reconcile gate is missing" unless rollback_reconcile_index
+  raise "rollback API promotion is missing" unless rollback_promote_index
+  unless rollback_compatibility_index < rollback_reconcile_index && rollback_reconcile_index < rollback_promote_index
+    raise "rollback API must verify target, reconcile it, then promote it"
+  end
+  rollback_compatibility = rollback_api_steps.fetch(rollback_compatibility_index)
+  raise "rollback compatibility must validate the projection V2 baseline" unless rollback_compatibility.fetch("run").include?("f40d5ea90b2fc4649cd336d083ce9d97573fb9ed")
+  rollback_reconcile = rollback_api_steps.fetch(rollback_reconcile_index)
+  expected_rollback_url = "$" + "{{ needs.resolve-target.outputs.api_deployment_url }}"
+  raise "rollback reconcile must use the resolved target URL" unless rollback_reconcile.fetch("env").fetch("API_DEPLOYMENT_URL") == expected_rollback_url
+  raise "rollback must use the shared legacy-compatible connector gate" unless rollback_reconcile.fetch("run").include?(reconcile_helper) && rollback_reconcile.fetch("run").end_with?(" allow-legacy")
+
   artifact_upload_step = turbo.fetch("deploy-app").fetch("steps").find { |step| step["name"] == "Upload canonical app artifact" }
   artifact_upload_run = artifact_upload_step.fetch("run")
   raise "deploy-app must upload the archived App artifact" unless artifact_upload_run.include?("/dist.tar.gz")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1275,7 +1275,7 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy API Production
+      - name: Stage API Production
         id: deploy
         uses: ./.github/actions/vercel-deploy
         with:
@@ -1289,8 +1289,26 @@ jobs:
             rm -rf .vercel/output
             cp -R turbo/apps/api/.vercel/output .vercel/output
           environment-file: ${{ steps.api-production-env.outputs.file }}
+          skip-domain: "true"
           skip-start: "true"
           skip-finish: "true"
+          skip-setup: "true"
+
+      - name: Reconcile staged API connector catalog
+        shell: bash
+        env:
+          API_DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: bash .github/scripts/reconcile-api-connector-catalog.sh "$API_DEPLOYMENT_URL" strict
+
+      - name: Promote API Production
+        uses: ./.github/actions/vercel-promote
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_API }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
           skip-setup: "true"
 
       - name: Verify production App and API domains

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -357,6 +357,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          fetch-depth: 0
           ref: main
       - uses: ./.github/actions/toolchain-init
 
@@ -380,6 +381,30 @@ jobs:
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
             text: "*Production* ⏪ rolling API back to `${{ needs.resolve-target.outputs.target_commit }}`..."
+
+      # The first rollout of #29091 can select retained deployments whose cron
+      # response predates runtimeProjection. Projection V2 already awaits the
+      # same reconciliation before returning. Remove this baseline and legacy
+      # response mode after every retained rollback target contains #29091.
+      - name: Verify rollback connector catalog compatibility
+        shell: bash
+        env:
+          TARGET_COMMIT: ${{ needs.resolve-target.outputs.target_commit }}
+        run: |
+          set -euo pipefail
+          projection_v2_baseline=f40d5ea90b2fc4649cd336d083ce9d97573fb9ed
+          if ! git merge-base --is-ancestor "$projection_v2_baseline" "$TARGET_COMMIT"; then
+            echo "::error::Rollback target predates connector runtime projection V2: ${TARGET_COMMIT}"
+            exit 1
+          fi
+
+      - name: Reconcile rollback API connector catalog
+        shell: bash
+        env:
+          API_DEPLOYMENT_URL: ${{ needs.resolve-target.outputs.api_deployment_url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: bash .github/scripts/reconcile-api-connector-catalog.sh "$API_DEPLOYMENT_URL" allow-legacy
 
       - name: Promote target API deployment
         uses: ./.github/actions/vercel-promote

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1141,53 +1141,7 @@ jobs:
           API_DEPLOYMENT_URL: ${{ steps.api-deploy.outputs.url }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: |
-          set -euo pipefail
-
-          response=""
-          for attempt in 1 2 3; do
-            if ! response=$(curl \
-              --fail-with-body \
-              --show-error \
-              --silent \
-              --max-time 120 \
-              -H "Authorization: Bearer ${CRON_SECRET}" \
-              -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \
-              "${API_DEPLOYMENT_URL}/api/cron/sync-connector-catalog"); then
-              echo "::warning::Connector catalog reconcile request failed (attempt ${attempt}/3)"
-            elif summary=$(jq -c '{
-              outcome,
-              state,
-              active,
-              lastAttempt,
-              filtering: {
-                capabilityDigest: .filtering.capabilityDigest,
-                evaluatedAt: .filtering.evaluatedAt,
-                stale: .filtering.stale,
-                filteredAuthMethodCount: (.filtering.filteredAuthMethods | length)
-              }
-            }' <<< "$response"); then
-              echo "Connector catalog reconcile: ${summary}"
-
-              if jq -e '
-                .state == "current"
-                and .active != null
-                and .filtering.stale == false
-              ' <<< "$response" >/dev/null; then
-                exit 0
-              fi
-              echo "::warning::Connector catalog is not ready (attempt ${attempt}/3)"
-            else
-              echo "::warning::Connector catalog reconcile returned invalid JSON (attempt ${attempt}/3)"
-            fi
-
-            if [ "$attempt" -lt 3 ]; then
-              sleep 2
-            fi
-          done
-
-          echo "::error::Connector catalog reconcile did not produce a current accepted snapshot"
-          exit 1
+        run: bash .github/scripts/reconcile-api-connector-catalog.sh "$API_DEPLOYMENT_URL" strict
 
       - name: Create API Vercel Alias
         id: api-alias

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -133,7 +133,7 @@ describe("release-please API deployment graph", () => {
     );
   });
 
-  it("builds the API before migrations and deploys it afterward", () => {
+  it("builds and migrates the API before staged reconciliation and promotion", () => {
     const workflow = readText(".github/workflows/release-please.yml");
     const promoteApiProductionJob = workflowJobBlock(
       workflow,
@@ -161,7 +161,16 @@ describe("release-please API deployment graph", () => {
       "- name: Initialize API deployment toolchain",
     );
     const deploymentStep = promoteApiProductionJob.indexOf(
-      "- name: Deploy API Production",
+      "- name: Stage API Production",
+    );
+    const reconciliationStep = promoteApiProductionJob.indexOf(
+      "- name: Reconcile staged API connector catalog",
+    );
+    const promotionStep = promoteApiProductionJob.indexOf(
+      "- name: Promote API Production",
+    );
+    const domainVerificationStep = promoteApiProductionJob.indexOf(
+      "- name: Verify production App and API domains",
     );
 
     expect(promoteApiProductionJob).toContain(
@@ -175,6 +184,9 @@ describe("release-please API deployment graph", () => {
     ).toHaveLength(1);
     expect(
       promoteApiProductionJob.match(/\.\/\.github\/actions\/vercel-deploy/g),
+    ).toHaveLength(1);
+    expect(
+      promoteApiProductionJob.match(/\.\/\.github\/actions\/vercel-promote/g),
     ).toHaveLength(1);
     expect(
       promoteApiProductionJob.match(/pnpm --dir turbo\/apps\/api build/g),
@@ -197,7 +209,24 @@ describe("release-please API deployment graph", () => {
     expect(migrationStep).toBeGreaterThan(deploymentToolchainStep);
     expect(migrationStep).toBeGreaterThan(migrationSmokeStep);
     expect(deploymentStep).toBeGreaterThan(migrationStep);
+    expect(reconciliationStep).toBeGreaterThan(deploymentStep);
+    expect(promotionStep).toBeGreaterThan(reconciliationStep);
+    expect(domainVerificationStep).toBeGreaterThan(promotionStep);
     expect(promoteApiProductionJob).toContain('prebuilt: "true"');
+    expect(
+      promoteApiProductionJob.slice(deploymentStep, reconciliationStep),
+    ).toContain('skip-domain: "true"');
+    expect(
+      promoteApiProductionJob.slice(reconciliationStep, promotionStep),
+    ).toContain(
+      'bash .github/scripts/reconcile-api-connector-catalog.sh "$API_DEPLOYMENT_URL" strict',
+    );
+    expect(
+      promoteApiProductionJob.slice(reconciliationStep, promotionStep),
+    ).toContain(`API_DEPLOYMENT_URL: \${{ steps.deploy.outputs.url }}`);
+    expect(
+      promoteApiProductionJob.slice(promotionStep, domainVerificationStep),
+    ).toContain(`deployment-url: \${{ steps.deploy.outputs.url }}`);
     expect(promoteApiProductionJob).toContain('skip-setup: "true"');
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -49,8 +49,10 @@ import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   apiTestConnectorCatalogValidationAuthority,
+  clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements,
   deleteApiTestConnectorCatalogCompatibility,
   deleteApiTestConnectorCatalogCompatibilityEvaluation,
+  deleteApiTestConnectorCatalogRuntimeProjectionRow,
   deleteApiTestConnectorCatalogRuntimeProjectionSet,
   expireApiTestConnectorCatalogRuntimeProjectionAuthority,
   invalidateApiTestConnectorCatalogCompatibility,
@@ -60,6 +62,7 @@ import {
   readApiTestConnectorCatalogRuntimeProjectionAuthority,
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogStoredBytes,
+  setApiTestConnectorCatalogRuntimeProjectionIdentityReplacements,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
 import {
@@ -1668,6 +1671,7 @@ describe("connector catalog valid lifecycle", () => {
         stale: false,
         filteredAuthMethods: [],
       },
+      runtimeProjection: { state: "ready" },
     });
     await expect(
       readApiTestConnectorCatalogValidationAuthority(),
@@ -1687,7 +1691,11 @@ describe("connector catalog valid lifecycle", () => {
 
     const callsBeforeStatus = context.mocks.s3.send.mock.calls.length;
     expect((await readStatus()).body).toStrictEqual(
-      (({ outcome: _outcome, ...status }) => {
+      (({
+        outcome: _outcome,
+        runtimeProjection: _runtimeProjection,
+        ...status
+      }) => {
         return status;
       })(acceptedFirst.body),
     );
@@ -1711,6 +1719,7 @@ describe("connector catalog valid lifecycle", () => {
         stale: false,
         filteredAuthMethods: [],
       },
+      runtimeProjection: { state: "ready" },
     });
     expect(context.mocks.s3.send.mock.calls.length - callsBeforeUnchanged).toBe(
       1,
@@ -1729,6 +1738,17 @@ describe("connector catalog valid lifecycle", () => {
       connectorSlugs: [first.connectorSlug],
     });
 
+    await deleteApiTestConnectorCatalogRuntimeProjectionRow(
+      first.connectorSlug,
+    );
+    mockNow(new Date("2026-07-15T08:01:30.000Z"));
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "unchanged",
+      state: "current",
+      active: { catalogVersion: first.version },
+      runtimeProjection: { state: "ready" },
+    });
+
     await expireApiTestConnectorCatalogRuntimeProjectionAuthority();
     await expect(
       readApiTestConnectorCatalogRuntimeProjectionAuthority(),
@@ -1741,6 +1761,7 @@ describe("connector catalog valid lifecycle", () => {
       outcome: "unchanged",
       state: "current",
       active: { catalogVersion: first.version },
+      runtimeProjection: { state: "ready" },
     });
     await expect(
       readApiTestConnectorCatalogRuntimeProjectionAuthority(),
@@ -1788,6 +1809,33 @@ describe("connector catalog valid lifecycle", () => {
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(
       callsBeforePublicCatalog,
     );
+  });
+
+  it("reports a bounded non-ready result when projection identity changes after reconciliation", async () => {
+    configureSource();
+    const release = buildRelease({ version: "2026-07-15.3" });
+    serveObjects(catalogObjects([release], release));
+    expect((await syncCatalog()).body.runtimeProjection).toStrictEqual({
+      state: "ready",
+    });
+
+    setApiTestConnectorCatalogRuntimeProjectionIdentityReplacements([
+      `api-test-readiness-replacement-${randomUUID()}`,
+    ]);
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    });
+    mockNow(new Date("2026-07-15T08:01:00.000Z"));
+    expect((await syncCatalog()).body.runtimeProjection).toStrictEqual({
+      state: "not-ready",
+      reason: "incomplete",
+    });
+
+    clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    mockNow(new Date("2026-07-15T08:02:00.000Z"));
+    expect((await syncCatalog()).body.runtimeProjection).toStrictEqual({
+      state: "ready",
+    });
   });
 
   it("serves every public catalog surface from accepted database state", async () => {
@@ -6961,7 +7009,11 @@ describe("connector catalog rejection and latest-valid retention", () => {
 
     const callsBeforeStatus = context.mocks.s3.send.mock.calls.length;
     expect((await readStatus()).body).toStrictEqual(
-      (({ outcome: _outcome, ...status }) => {
+      (({
+        outcome: _outcome,
+        runtimeProjection: _runtimeProjection,
+        ...status
+      }) => {
         return status;
       })(rejected.body),
     );

--- a/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
@@ -2,9 +2,13 @@ import { cronConnectorCatalogContract } from "@okouai/api-contracts/contracts/cr
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
+import { db$ } from "../external/db";
 import { reconcileConnectorCatalogCompatibility$ } from "../services/connector-catalog-compatibility.service";
 import { connectorCatalogDiagnostics$ } from "../services/connector-catalog-diagnostics.service";
-import { reconcileConnectorCatalogRuntimeProjection$ } from "../services/connector-catalog-runtime-projection.service";
+import {
+  readConnectorCatalogRuntimeProjectionReadiness,
+  reconcileConnectorCatalogRuntimeProjection$,
+} from "../services/connector-catalog-runtime-projection.service";
 import { syncConnectorCatalog$ } from "../services/connector-catalog-sync.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
@@ -18,11 +22,19 @@ const syncConnectorCatalogRoute$ = command(
     await set(reconcileConnectorCatalogCompatibility$, signal);
     await set(reconcileConnectorCatalogRuntimeProjection$, signal);
     const diagnostics = await set(connectorCatalogDiagnostics$, signal);
+    const runtimeProjection =
+      await readConnectorCatalogRuntimeProjectionReadiness({
+        db: get(db$),
+        active: diagnostics.active,
+        capabilityDigest: diagnostics.filtering.capabilityDigest,
+      });
+    signal.throwIfAborted();
     return {
       status: 200 as const,
       body: {
         outcome: result.outcome,
         ...diagnostics,
+        runtimeProjection,
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 
 import { CONNECTOR_CATALOG_MAX_RAW_BYTES } from "@okouai/api-contracts/contracts/connector-catalog";
+import type {
+  ConnectorCatalogRuntimeProjectionReadiness,
+  ConnectorCatalogRuntimeProjectionReadinessReason,
+} from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import {
   connectorCatalogActiveSnapshot,
@@ -468,6 +472,64 @@ export async function readConnectorCatalogRuntimeProjectionIdentity(
   db: ReadonlyDb,
 ): Promise<ConnectorCatalogRuntimeProjectionIdentityRead> {
   return await readProjectionIdentity(db);
+}
+
+function connectorCatalogRuntimeProjectionReadinessReason(
+  reason: Extract<
+    ConnectorCatalogRuntimeProjectionIdentityRead,
+    { readonly kind: "fallback" }
+  >["reason"],
+): ConnectorCatalogRuntimeProjectionReadinessReason {
+  switch (reason) {
+    case "schema_unavailable": {
+      return "schema-unavailable";
+    }
+    case "not_ready": {
+      return "projection-not-ready";
+    }
+    case "unsupported": {
+      return "unsupported";
+    }
+    case "compatibility_not_ready": {
+      return "compatibility-not-ready";
+    }
+    case "invalid_compatibility": {
+      return "invalid-compatibility";
+    }
+  }
+}
+
+export async function readConnectorCatalogRuntimeProjectionReadiness(args: {
+  readonly db: ReadonlyDb;
+  readonly active: {
+    readonly catalogVersion: string;
+    readonly catalogDigest: string;
+  } | null;
+  readonly capabilityDigest: string;
+}): Promise<ConnectorCatalogRuntimeProjectionReadiness> {
+  const result = await readProjectionIdentity(args.db);
+  if (result.kind === "fallback") {
+    return {
+      state: "not-ready",
+      reason: connectorCatalogRuntimeProjectionReadinessReason(result.reason),
+    };
+  }
+  const identity = result.projection.identity;
+  if (
+    args.active === null ||
+    identity.catalogVersion !== args.active.catalogVersion ||
+    identity.catalogDigest !== args.active.catalogDigest ||
+    identity.capabilityDigest !== args.capabilityDigest
+  ) {
+    return { state: "not-ready", reason: "identity-changed" };
+  }
+  const actualCount = await countConnectorCatalogRuntimeProjectionRows({
+    db: args.db,
+    identity,
+  });
+  return actualCount === identity.connectorCount
+    ? { state: "ready" }
+    : { state: "not-ready", reason: "incomplete" };
 }
 
 function projectionIdentityWhere(

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -80,7 +80,7 @@ type ConnectorCatalogRawSyncStatus = Omit<
 >;
 type ConnectorCatalogRawSyncResponse = Omit<
   ConnectorCatalogSyncResponse,
-  "filtering" | "credentialStorage"
+  "filtering" | "credentialStorage" | "runtimeProjection"
 >;
 
 interface SyncStateSnapshot {

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
@@ -51,6 +51,25 @@ export const connectorCredentialStorageReadinessSchema = z.object({
   unresolvedBridgeCredentials: z.number().int().nonnegative(),
 });
 
+export const connectorCatalogRuntimeProjectionReadinessReasonSchema = z.enum([
+  "schema-unavailable",
+  "projection-not-ready",
+  "unsupported",
+  "compatibility-not-ready",
+  "invalid-compatibility",
+  "incomplete",
+  "identity-changed",
+]);
+
+export const connectorCatalogRuntimeProjectionReadinessSchema =
+  z.discriminatedUnion("state", [
+    z.object({ state: z.literal("ready") }),
+    z.object({
+      state: z.literal("not-ready"),
+      reason: connectorCatalogRuntimeProjectionReadinessReasonSchema,
+    }),
+  ]);
+
 export const connectorCatalogDiagnosticsSchema = z.object({
   state: z.enum(["never-synced", "current", "stale"]),
   active: z
@@ -100,6 +119,12 @@ export type ConnectorCatalogFilteringStatus = z.infer<
 >;
 export type ConnectorCredentialStorageReadiness = z.infer<
   typeof connectorCredentialStorageReadinessSchema
+>;
+export type ConnectorCatalogRuntimeProjectionReadinessReason = z.infer<
+  typeof connectorCatalogRuntimeProjectionReadinessReasonSchema
+>;
+export type ConnectorCatalogRuntimeProjectionReadiness = z.infer<
+  typeof connectorCatalogRuntimeProjectionReadinessSchema
 >;
 export type ConnectorCatalogDiagnostics = z.infer<
   typeof connectorCatalogDiagnosticsSchema

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { connectorCatalogDiagnosticsSchema } from "./connector-catalog-diagnostics";
+import {
+  connectorCatalogDiagnosticsSchema,
+  connectorCatalogRuntimeProjectionReadinessSchema,
+} from "./connector-catalog-diagnostics";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -219,6 +222,7 @@ const cronSyncSkillsResponseSchema = z.object({
 const connectorCatalogSyncResponseSchema =
   connectorCatalogDiagnosticsSchema.extend({
     outcome: z.enum(["accepted", "unchanged", "rejected"]),
+    runtimeProjection: connectorCatalogRuntimeProjectionReadinessSchema,
   });
 
 export type ConnectorCatalogSyncResponse = z.infer<


### PR DESCRIPTION
## Summary

- expose a bounded runtime-projection readiness result from the connector catalog cron response
- share one strict readiness/retry/log-redaction gate across preview, production release, and rollback
- stage production API artifacts without moving traffic, reconcile the exact deployment URL, then promote the same artifact without rebuilding
- reconcile rollback targets before promotion, with a temporary missing-field compatibility path restricted to the runtime projection V2 baseline

## Behavior and rollout

The gate now requires a current catalog, non-stale executable compatibility, and a complete exact-generation runtime projection. A catalog identity race or incomplete set returns a bounded non-ready result and consumes another retry instead of being promoted.

Normal release ordering is now migration -> staged Vercel production deployment -> exact-URL reconciliation -> promotion -> production-domain verification. Gate failure leaves the existing production deployment serving.

Retained rollback deployments created before this response field may omit it only when the target descends from runtime projection V2 commit `f40d5ea90b2fc4649cd336d083ce9d97573fb9ed`; explicit non-ready responses still fail. The workflow comment records when to remove this compatibility branch.

## Explicit exclusions

- no database migration or new persisted representation
- no change to authenticated connector catalog diagnostics
- no removal or weakening of the complete accepted-catalog fallback
- no full scan/repair of intact-count malformed or digest-mismatched projection payloads

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts src/__tests__/release-please-config.test.ts` (118 tests)
- `cd turbo && pnpm knip --workspace api`
- `cd turbo && pnpm knip --workspace @okouai/api-contracts`
- `cd turbo && pnpm -F api build`
- `bash .github/scripts/tests/reconcile-api-connector-catalog-test.sh`
- pre-commit full Turbo Knip and `pnpm check-types`

The local image does not provide Ruby or ShellCheck, so the existing rollback workflow parser and workflow shell-compatibility test could not complete locally; CI remains responsible for those checks.

Closes #29091

Parent context: #28275
