### PR TITLE
refactor(desktop): rename packaged smoke app path environment key

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -581,7 +581,7 @@ jobs:
                 ditto "$mounted_app" "$installed_app"
                 VM0_DESKTOP_PRODUCT=okou \
                 VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
-                VM0_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+                OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
                 node apps/desktop/scripts/smoke-test-packaged-app.js
 
                 unzip -q "$zip_artifact_path" -d "$update_dir"
@@ -589,7 +589,7 @@ jobs:
                 ditto "$update_dir/Okou.app" "$installed_app"
                 VM0_DESKTOP_PRODUCT=okou \
                 VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
-                VM0_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+                OKOU_DESKTOP_SMOKE_APP_PATH="$installed_app" \
                 node apps/desktop/scripts/smoke-test-packaged-app.js
               fi
             )

--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -11,7 +11,7 @@ if (process.platform !== "darwin") {
 }
 
 const { executablePath, mainBundlePath, mcpBundlePath } = packagedAppPaths({
-  appBundlePath: process.env.VM0_DESKTOP_SMOKE_APP_PATH,
+  appBundlePath: process.env.OKOU_DESKTOP_SMOKE_APP_PATH,
   platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL,
   product: process.env.VM0_DESKTOP_PRODUCT,
 });


### PR DESCRIPTION
## Summary

- rename both installed-app Desktop smoke writers to `OKOU_DESKTOP_SMOKE_APP_PATH`
- make the packaged-app smoke reader consume only the canonical key while preserving the existing `appBundlePath` pass-through
- keep the private CI subprocess contract atomic within the same `release_target` checkout

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/desktop run lint`
- `pnpm --filter @okouai/desktop run check-types`
- `bash .github/scripts/tests/deploy-desktop-workflow-test.sh`
- `bash .github/scripts/tests/fetch-okou-desktop-artifact-test.sh`
- `bash .github/scripts/tests/okou-desktop-artifact-test.sh`
- exact repository counts: legacy key `0`, canonical key `3`

## Fallbacks

No fallback is introduced. Both writers and the sole reader are renamed atomically in the same `release_target` checkout, so there is no mixed-version state to tolerate. To roll back, revert this commit as a unit.

Closes #29097
Refs #28914
