### PR TITLE
refactor(runtime): dual-read guest runtime directory environment aliases

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -356,9 +356,17 @@ impl GuestConfigRaw {
     /// contains conflicting values.
     pub fn from_process_env() -> Result<Self, String> {
         let guest_runtime_dir =
-            std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
-                .filter(|value| !value.is_empty())
-                .map(PathBuf::from);
+            guest_contracts::runtime_paths::guest_runtime_dir_env_from_process_env()
+                .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
+        Self::from_process_env_with_guest_runtime_dir(guest_runtime_dir)
+    }
+
+    /// Capture all remaining startup values after the runtime-directory alias
+    /// pair was resolved at the outer single-threaded bootstrap boundary.
+    pub(crate) fn from_process_env_with_guest_runtime_dir(
+        guest_runtime_dir: guest_contracts::runtime_paths::GuestRuntimeDirEnvResolution,
+    ) -> Result<Self, String> {
+        let (guest_runtime_dir, _source) = guest_runtime_dir.into_parts();
 
         let (user_env_file, user_env_file_source) = private_payload_file_env(
             guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -25,12 +25,15 @@
 //!
 //! ## Shared runtime-path rules
 //!
-//! When a command resolves its default runtime path, the non-empty absolute
-//! [`GUEST_RUNTIME_DIR_ENV`](guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV) override
-//! (`VM0_GUEST_RUNTIME_DIR`) wins. Without that override, the path is derived
-//! from [`RUN_ID_ENV`](guest_contracts::env::RUN_ID_ENV) (`OKOU_RUN_ID`) and `HOME` as
-//! [`run_dir_from_env`](guest_contracts::runtime_paths::run_dir_from_env) describes:
-//! `$HOME/.vm0/guest-agent/runs/<run-id>`. A relative override is invalid.
+//! Commands resolve the canonical `OKOU_GUEST_RUNTIME_DIR` and legacy
+//! [`GUEST_RUNTIME_DIR_ENV`](guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+//! (`VM0_GUEST_RUNTIME_DIR`) aliases through one shared contract. Empty values
+//! are absent, one non-empty absolute value is selected, equal dual values are
+//! accepted, and conflicting non-empty values fail closed. Without an
+//! override, [`run_dir_from_env`](guest_contracts::runtime_paths::run_dir_from_env)
+//! derives `$HOME/.vm0/guest-agent/runs/<run-id>` from
+//! [`RUN_ID_ENV`](guest_contracts::env::RUN_ID_ENV) (`OKOU_RUN_ID`) and `HOME`.
+//! A relative override is invalid.
 //!
 //! ## `verify-session-history-identity`
 //!

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1195,6 +1195,7 @@ mod tests {
             guest_contracts::env::USE_MOCK_CODEX_ENV,
             guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
             guest_contracts::env::MOCK_CODEX_PATH_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             process_control_ipc::BOOTSTRAP_ENV,
             process_control_ipc::CANONICAL_BOOTSTRAP_ENV,

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -90,11 +90,7 @@ impl GuestPaths {
     pub fn from_process_env(
         run_id: &str,
     ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
-        let runtime_dir = std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
-            .filter(|value| !value.is_empty())
-            .map(PathBuf::from);
-        let home = std::env::var_os("HOME").map(PathBuf::from);
-        Self::from_captured_env(run_id, runtime_dir.as_deref(), home.as_deref())
+        guest_contracts::runtime_paths::run_dir_from_env(run_id).map(Self::from_runtime_dir)
     }
 
     /// Build paths from values captured during bootstrap without rereading env.
@@ -103,7 +99,7 @@ impl GuestPaths {
         runtime_dir: Option<&Path>,
         process_home: Option<&Path>,
     ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
-        resolve_run_dir_from_captured_env(run_id, runtime_dir, process_home)
+        guest_contracts::runtime_paths::run_dir_from_captured_env(run_id, runtime_dir, process_home)
             .map(Self::from_runtime_dir)
     }
 
@@ -171,24 +167,6 @@ impl GuestPaths {
     pub fn telemetry_sandbox_ops_pos_file(&self) -> &str {
         &self.telemetry_sandbox_ops_pos_file
     }
-}
-
-fn resolve_run_dir_from_captured_env(
-    run_id: &str,
-    runtime_dir: Option<&Path>,
-    process_home: Option<&Path>,
-) -> Result<PathBuf, guest_contracts::runtime_paths::RuntimePathError> {
-    if let Some(runtime_dir) = runtime_dir {
-        if !runtime_dir.is_absolute() {
-            return Err(guest_contracts::runtime_paths::RuntimePathError::InvalidRuntimeDir);
-        }
-        return Ok(runtime_dir.to_path_buf());
-    }
-
-    let home = process_home
-        .filter(|value| !value.as_os_str().is_empty())
-        .ok_or(guest_contracts::runtime_paths::RuntimePathError::MissingHome)?;
-    guest_contracts::runtime_paths::run_dir_for_home(home, run_id)
 }
 
 fn path_to_string(path: PathBuf) -> String {

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -54,15 +54,27 @@ impl GuestRuntime {
     /// process-wide setup and consume runner-owned inputs before returning, so
     /// callers must not retry it in the same process.
     pub fn from_process_env() -> Result<Self, String> {
+        let guest_runtime_dir =
+            guest_contracts::runtime_paths::guest_runtime_dir_env_from_process_env()
+                .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
+        let guest_runtime_dir_source = guest_runtime_dir.source();
         let (process_control_endpoint, process_control_source) =
             process_control_endpoint_from_process_env()?;
         let workload_containment =
             WorkloadContainment::from_process_env(process_control_endpoint.is_some())?;
-        let raw = GuestConfigRaw::from_process_env()?;
+        let raw = GuestConfigRaw::from_process_env_with_guest_runtime_dir(guest_runtime_dir)?;
         raw.require_run_payload_file()?;
         let paths = paths_from_raw(&raw)?;
         guest_common::log::set_system_log_file(paths.system_log_file());
         guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());
+        if let Some(source) = guest_runtime_dir_source {
+            guest_common::log_info!(
+                LOG_TAG,
+                "guest_runtime_dir_env_source key={} source={}",
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+                source.label()
+            );
+        }
         if let Some(source) = process_control_source {
             guest_common::log_info!(
                 LOG_TAG,

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -47,6 +47,18 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     }
 
     let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV)?;
+    let configured_runtime_dir =
+        guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), &run_id)?;
+    unsafe {
+        std::env::set_var(
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            &configured_runtime_dir,
+        );
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &configured_runtime_dir,
+        );
+    }
     let runtime_dir = guest_contracts::runtime_paths::run_dir_from_env(&run_id)?;
     let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
     std::fs::create_dir_all(&user_env_dir)?;
@@ -165,6 +177,8 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
     for key in [
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         guest_contracts::env::USER_ENV_FILE_ENV,
         guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
         guest_contracts::env::RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1037,6 +1037,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::USE_MOCK_CODEX_ENV,
         guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,

--- a/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
@@ -1,0 +1,344 @@
+//! Guest runtime-directory aliases resolve before bootstrap side effects.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use tokio::process::Command;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CHILD_TIMEOUT: Duration = Duration::from_secs(15);
+const SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
+static NEXT_ENDPOINT: AtomicU32 = AtomicU32::new(1);
+
+struct PrivateFiles {
+    user_env_path: PathBuf,
+    run_payload_path: PathBuf,
+}
+
+fn unique_endpoint(label: u8) -> String {
+    let seq = std::process::id().wrapping_add(NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed));
+    let mut nonce = [0_u8; 16];
+    nonce[..4].copy_from_slice(&seq.to_le_bytes());
+    nonce[4] = label;
+    process_control_ipc::endpoint_name(seq, &nonce)
+}
+
+fn write_private_files(runtime_dir: &Path, valid_payload: bool) -> TestResult<PrivateFiles> {
+    let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
+    let user_env_path = user_env_dir.join(guest_contracts::env::USER_ENV_FILENAME);
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::create_dir_all(&run_payload_dir)?;
+    std::fs::write(&user_env_path, br#"{"HOME":"/home/user"}"#)?;
+    if valid_payload {
+        std::fs::write(
+            &run_payload_path,
+            serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+        )?;
+    } else {
+        std::fs::write(&run_payload_path, b"invalid-json")?;
+    }
+    Ok(PrivateFiles {
+        user_env_path,
+        run_payload_path,
+    })
+}
+
+fn guest_agent_command(root: &Path, run_id: &str, private_files: &PrivateFiles) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+    command
+        .env_clear()
+        .env(guest_contracts::env::RUN_ID_ENV, run_id)
+        .env("HOME", root.join("process-home"))
+        .env(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1")
+        .env(guest_contracts::env::API_TOKEN_ENV, "")
+        .env(
+            guest_contracts::env::USER_ENV_FILE_ENV,
+            &private_files.user_env_path,
+        )
+        .env(
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            &private_files.run_payload_path,
+        );
+    command
+}
+
+fn apply_runtime_aliases(command: &mut Command, canonical: Option<&OsStr>, legacy: Option<&OsStr>) {
+    command
+        .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+    if let Some(value) = canonical {
+        command.env(
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            value,
+        );
+    }
+    if let Some(value) = legacy {
+        command.env(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV, value);
+    }
+}
+
+async fn command_output(command: &mut Command, context: &str) -> TestResult<std::process::Output> {
+    Ok(common::command_output_with_timeout(command, CHILD_TIMEOUT, context).await?)
+}
+
+fn source_messages(log: &str) -> Vec<&str> {
+    log.lines()
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .filter(|message| message.starts_with(SOURCE_EVENT))
+        .collect()
+}
+
+fn assert_value_free(text: &str, forbidden: &[&str], context: &str) {
+    for value in forbidden {
+        assert!(
+            !text.contains(value),
+            "{context} exposed guest runtime-directory material"
+        );
+    }
+}
+
+fn assert_listener_idle(listener: &std::os::unix::net::UnixListener, context: &str) -> TestResult {
+    listener.set_nonblocking(true)?;
+    let error = match listener.accept() {
+        Err(error) => error,
+        Ok(_) => {
+            return Err(format!("{context} connected before rejecting runtime aliases").into());
+        }
+    };
+    assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock, "{context}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_uses_shared_runtime_alias_semantics_and_sink_scoped_evidence() -> TestResult {
+    struct Case {
+        name: &'static str,
+        canonical: Option<&'static str>,
+        legacy: Option<&'static str>,
+        source: Option<&'static str>,
+        fallback: bool,
+    }
+
+    let cases = [
+        Case {
+            name: "absent",
+            canonical: None,
+            legacy: None,
+            source: None,
+            fallback: true,
+        },
+        Case {
+            name: "dual-empty",
+            canonical: Some(""),
+            legacy: Some(""),
+            source: None,
+            fallback: true,
+        },
+        Case {
+            name: "canonical-only",
+            canonical: Some("selected"),
+            legacy: None,
+            source: Some("canonical-only"),
+            fallback: false,
+        },
+        Case {
+            name: "legacy-only",
+            canonical: None,
+            legacy: Some("selected"),
+            source: Some("legacy-only"),
+            fallback: false,
+        },
+        Case {
+            name: "equal-dual",
+            canonical: Some("selected"),
+            legacy: Some("selected"),
+            source: Some("dual"),
+            fallback: false,
+        },
+        Case {
+            name: "canonical-empty",
+            canonical: Some(""),
+            legacy: Some("selected"),
+            source: Some("legacy-only"),
+            fallback: false,
+        },
+        Case {
+            name: "legacy-empty",
+            canonical: Some("selected"),
+            legacy: Some(""),
+            source: Some("canonical-only"),
+            fallback: false,
+        },
+    ];
+
+    let root = tempfile::tempdir()?;
+    for case in cases {
+        let run_id = format!("runtime-alias-{}", case.name);
+        let runtime_dir = if case.fallback {
+            guest_contracts::runtime_paths::run_dir_for_home(
+                root.path().join("process-home"),
+                &run_id,
+            )?
+        } else {
+            root.path()
+                .join(format!("{}-runtime-value-must-not-leak", case.name))
+        };
+        let private_files = write_private_files(&runtime_dir, false)?;
+        let mut command = guest_agent_command(root.path(), &run_id, &private_files);
+        let selected = runtime_dir.as_os_str();
+        let canonical = case.canonical.map(|value| {
+            if value.is_empty() {
+                OsStr::new("")
+            } else {
+                selected
+            }
+        });
+        let legacy = case.legacy.map(|value| {
+            if value.is_empty() {
+                OsStr::new("")
+            } else {
+                selected
+            }
+        });
+        apply_runtime_aliases(&mut command, canonical, legacy);
+
+        let output = command_output(
+            &mut command,
+            &format!("{} runtime alias scenario did not finish", case.name),
+        )
+        .await?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(1), "{}: {stderr}", case.name);
+        assert!(
+            stderr.contains("parse VM0_RUN_PAYLOAD_FILE JSON"),
+            "{}: {stderr}",
+            case.name
+        );
+
+        let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+            &runtime_dir,
+        ))?;
+        let messages = source_messages(&log);
+        let expected = case.source.map(|source| {
+            format!(
+                "{SOURCE_EVENT} key={} source={source}",
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
+            )
+        });
+        match expected {
+            Some(expected) => assert_eq!(messages, [expected.as_str()], "{}", case.name),
+            None => assert!(messages.is_empty(), "{}", case.name),
+        }
+        let runtime_marker = format!("{}-runtime-value-must-not-leak", case.name);
+        assert_value_free(&stderr, &[&runtime_marker], case.name);
+        assert_value_free(&log, &[&runtime_marker], case.name);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_rejects_runtime_alias_conflict_before_capabilities_and_private_files()
+-> TestResult {
+    let root = tempfile::tempdir()?;
+    let canonical_dir = root.path().join("canonical-runtime-must-not-leak");
+    let legacy_dir = root.path().join("legacy-runtime-must-not-leak");
+    std::fs::create_dir_all(&legacy_dir)?;
+    let private_files = write_private_files(&canonical_dir, true)?;
+    let process_endpoint = unique_endpoint(1);
+    let workload_endpoint = unique_endpoint(2);
+    let process_listener = process_control_ipc::bind_abstract_listener(&process_endpoint)?;
+    let workload_listener = process_control_ipc::bind_abstract_listener(&workload_endpoint)?;
+    let mut command = guest_agent_command(root.path(), "runtime-conflict", &private_files);
+    apply_runtime_aliases(
+        &mut command,
+        Some(canonical_dir.as_os_str()),
+        Some(legacy_dir.as_os_str()),
+    );
+    command
+        .env(process_control_ipc::BOOTSTRAP_ENV, &process_endpoint)
+        .env(
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+            &workload_endpoint,
+        )
+        .env(
+            guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+            "tool-endpoint-must-not-leak",
+        );
+
+    let output = command_output(
+        &mut command,
+        "guest runtime alias conflict did not fail closed",
+    )
+    .await?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(stderr.contains(
+        "conflicting guest runtime directory environment aliases: \
+         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
+    ));
+    assert_value_free(
+        &stderr,
+        &[
+            "canonical-runtime-must-not-leak",
+            "legacy-runtime-must-not-leak",
+            "tool-endpoint-must-not-leak",
+            &process_endpoint,
+            &workload_endpoint,
+        ],
+        "runtime conflict",
+    );
+    assert_listener_idle(&process_listener, "process-control socket")?;
+    assert_listener_idle(&workload_listener, "workload placement socket")?;
+    assert!(private_files.user_env_path.exists());
+    assert!(private_files.run_payload_path.exists());
+    assert!(!guest_contracts::runtime_paths::system_log_file(&canonical_dir).exists());
+    assert!(!guest_contracts::runtime_paths::system_log_file(&legacy_dir).exists());
+    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&canonical_dir).exists());
+    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&legacy_dir).exists());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_rejects_relative_runtime_alias_before_capability_connection() -> TestResult {
+    let root = tempfile::tempdir()?;
+    let runtime_dir = root.path().join("private-runtime");
+    let private_files = write_private_files(&runtime_dir, true)?;
+    let workload_endpoint = unique_endpoint(3);
+    let workload_listener = process_control_ipc::bind_abstract_listener(&workload_endpoint)?;
+    let mut command = guest_agent_command(root.path(), "relative-runtime", &private_files);
+    apply_runtime_aliases(&mut command, Some(OsStr::new("relative-runtime")), None);
+    command
+        .env(process_control_ipc::BOOTSTRAP_ENV, "process-control")
+        .env(
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+            &workload_endpoint,
+        )
+        .env(
+            guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+            "tool-endpoint",
+        );
+
+    let output = command_output(
+        &mut command,
+        "relative runtime alias did not fail before capability connection",
+    )
+    .await?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(stderr.contains("VM0_GUEST_RUNTIME_DIR must be an absolute path"));
+    assert_listener_idle(&workload_listener, "relative runtime workload socket")?;
+    assert!(private_files.user_env_path.exists());
+    assert!(private_files.run_payload_path.exists());
+    Ok(())
+}

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -629,6 +629,103 @@ async fn export_session_history_sidecar_rejects_symlinked_metadata_without_openi
     Ok(())
 }
 
+#[tokio::test]
+async fn default_identity_path_dual_reads_runtime_aliases_without_protocol_output() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let history = br#"{"type":"system"}"#;
+    let session_id = "runtime-alias-default-path";
+    let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
+    std::fs::write(&history_path, history)?;
+    let identity = SessionHistoryIdentity::new(
+        SessionHistoryFramework::ClaudeCode,
+        session_id_hash(session_id),
+        SessionHistoryRefKind::Blob,
+        sha256_hex(history),
+        history.len() as u64,
+        history_source,
+    )?;
+
+    for (name, canonical, legacy) in [
+        ("canonical-only", true, false),
+        ("legacy-only", false, true),
+        ("equal-dual", true, true),
+    ] {
+        let runtime_dir = dir.path().join(name);
+        let metadata_path =
+            guest_contracts::runtime_paths::final_session_history_identity_file(&runtime_dir);
+        guest_contracts::runtime_paths::write_private(&metadata_path, identity.to_json_vec()?)?;
+        let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+        command
+            .env_clear()
+            .env(
+                guest_contracts::env::RUN_ID_ENV,
+                "not/validated/when/runtime-dir-is-set",
+            )
+            .arg("verify-session-history-identity");
+        if canonical {
+            command.env(
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            );
+        }
+        if legacy {
+            command.env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            );
+        }
+
+        let output = common::command_output_with_timeout(
+            &mut command,
+            SESSION_HISTORY_HELPER_TIMEOUT,
+            &format!("{name} default identity-path helper exceeded its completion budget"),
+        )
+        .await?;
+        assert!(
+            output.status.success(),
+            "{name}: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stdout.is_empty(), "{name} changed stdout");
+        assert!(output.stderr.is_empty(), "{name} changed stderr");
+    }
+
+    let canonical_dir = dir.path().join("canonical-must-not-leak");
+    let legacy_dir = dir.path().join("legacy-must-not-leak");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+    command
+        .env_clear()
+        .env(guest_contracts::env::RUN_ID_ENV, "run-id")
+        .env(
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            &canonical_dir,
+        )
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &legacy_dir,
+        )
+        .arg("verify-session-history-identity");
+    let output = common::command_output_with_timeout(
+        &mut command,
+        SESSION_HISTORY_HELPER_TIMEOUT,
+        "conflicting default identity-path aliases exceeded their completion budget",
+    )
+    .await?;
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(
+        "conflicting guest runtime directory environment aliases: \
+         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
+    ));
+    assert!(!stderr.contains("canonical-must-not-leak"));
+    assert!(!stderr.contains("legacy-must-not-leak"));
+    assert!(!stderr.contains("guest_runtime_dir_env_source"));
+
+    Ok(())
+}
+
 fn write_metadata(
     dir: &Path,
     name: &str,

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -5,6 +5,7 @@
 //! so both sides agree on the same filesystem layout.
 
 use std::env;
+use std::ffi::OsString;
 use std::fs::File;
 #[cfg(not(unix))]
 use std::fs::{self, OpenOptions};
@@ -14,7 +15,7 @@ use std::path::Component;
 use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
-use std::ffi::{CString, OsStr, OsString};
+use std::ffi::{CString, OsStr};
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 #[cfg(unix)]
@@ -26,6 +27,15 @@ use uuid::Uuid;
 /// When set to a non-empty absolute path, this value is used as the run
 /// directory directly instead of deriving one from `HOME` and a run id.
 pub const GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
+/// Canonical reader alias for [`GUEST_RUNTIME_DIR_ENV`].
+///
+/// This bounded fallback lets new embedded readers accept the five legacy-only
+/// writers on the existing runner and reusable-sandbox surface, where a claim
+/// can live for the two-hour guest runtime budget plus bounded finalization.
+/// Remove the legacy branch only after #28914 records the exact-artifact reader
+/// floor, service and reusable-sandbox drain, rollback window, and
+/// legacy-read-zero gates.
+pub const CANONICAL_GUEST_RUNTIME_DIR_ENV: &str = "OKOU_GUEST_RUNTIME_DIR";
 /// Fixed fallback path used when a storage manifest exceeds the stdin limit.
 pub const STORAGE_MANIFEST_PATH: &str = "/tmp/storage-manifest.json";
 const DEFAULT_RUNTIME_PARENT: &str = ".vm0/guest-agent/runs";
@@ -45,6 +55,8 @@ pub enum RuntimePathError {
     MissingHome,
     /// `VM0_GUEST_RUNTIME_DIR` was set to a relative path.
     InvalidRuntimeDir,
+    /// Both runtime-directory aliases were non-empty and unequal.
+    ConflictingRuntimeDirEnvAliases,
 }
 
 impl std::fmt::Display for RuntimePathError {
@@ -56,6 +68,12 @@ impl std::fmt::Display for RuntimePathError {
             Self::InvalidRuntimeDir => {
                 f.write_str("VM0_GUEST_RUNTIME_DIR must be an absolute path")
             }
+            Self::ConflictingRuntimeDirEnvAliases => write!(
+                f,
+                "conflicting guest runtime directory environment aliases: canonical_key={} \
+                 legacy_key={} state=conflict",
+                CANONICAL_GUEST_RUNTIME_DIR_ENV, GUEST_RUNTIME_DIR_ENV
+            ),
         }
     }
 }
@@ -100,29 +118,145 @@ pub fn run_dir_for_home(
         .join(run_id))
 }
 
-/// Resolve the runtime directory from process environment.
-///
-/// A non-empty absolute `VM0_GUEST_RUNTIME_DIR` wins and is returned as the
-/// complete runtime directory. In that override branch, `run_id` is not
-/// validated and is not appended. Empty overrides are ignored, relative
-/// overrides return [`RuntimePathError::InvalidRuntimeDir`], and fallback
-/// resolution uses `HOME` plus [`run_dir_for_home`].
-pub fn run_dir_from_env(run_id: &str) -> Result<PathBuf, RuntimePathError> {
-    if let Some(path) = env::var_os(GUEST_RUNTIME_DIR_ENV)
-        && !path.is_empty()
-    {
-        let path = PathBuf::from(path);
-        if !path.is_absolute() {
-            return Err(RuntimePathError::InvalidRuntimeDir);
+/// Value-free provenance for a selected guest runtime-directory override.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GuestRuntimeDirEnvSource {
+    /// Only `OKOU_GUEST_RUNTIME_DIR` supplied a non-empty value.
+    CanonicalOnly,
+    /// Only `VM0_GUEST_RUNTIME_DIR` supplied a non-empty value.
+    LegacyOnly,
+    /// Both aliases supplied the same non-empty value.
+    Dual,
+}
+
+impl GuestRuntimeDirEnvSource {
+    /// Fixed label used by bounded source evidence.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::CanonicalOnly => "canonical-only",
+            Self::LegacyOnly => "legacy-only",
+            Self::Dual => "dual",
         }
-        return Ok(path);
+    }
+}
+
+/// One value-preserving resolution of the guest runtime-directory aliases.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuestRuntimeDirEnvResolution {
+    runtime_dir: Option<PathBuf>,
+    source: Option<GuestRuntimeDirEnvSource>,
+}
+
+impl GuestRuntimeDirEnvResolution {
+    /// Selected non-empty absolute override, if either alias supplied one.
+    pub fn runtime_dir(&self) -> Option<&Path> {
+        self.runtime_dir.as_deref()
     }
 
-    let home = env::var_os("HOME").ok_or(RuntimePathError::MissingHome)?;
-    if home.is_empty() {
-        return Err(RuntimePathError::MissingHome);
+    /// Value-free source for the selected override.
+    pub fn source(&self) -> Option<GuestRuntimeDirEnvSource> {
+        self.source
     }
+
+    /// Consume the resolution into its owned path and source.
+    pub fn into_parts(self) -> (Option<PathBuf>, Option<GuestRuntimeDirEnvSource>) {
+        (self.runtime_dir, self.source)
+    }
+}
+
+/// Resolve canonical and legacy guest runtime-directory aliases without
+/// converting their values to UTF-8.
+///
+/// Empty values are absent. One non-empty value wins, equal non-empty values
+/// resolve once, and unequal non-empty values fail closed without exposing
+/// either path.
+pub fn resolve_guest_runtime_dir_env(
+    canonical: Option<OsString>,
+    legacy: Option<OsString>,
+) -> Result<GuestRuntimeDirEnvResolution, RuntimePathError> {
+    let canonical = canonical.filter(|value| !value.is_empty());
+    let legacy = legacy.filter(|value| !value.is_empty());
+
+    let (runtime_dir, source) = match (canonical, legacy) {
+        (None, None) => (None, None),
+        (Some(runtime_dir), None) => (
+            Some(PathBuf::from(runtime_dir)),
+            Some(GuestRuntimeDirEnvSource::CanonicalOnly),
+        ),
+        (None, Some(runtime_dir)) => (
+            Some(PathBuf::from(runtime_dir)),
+            Some(GuestRuntimeDirEnvSource::LegacyOnly),
+        ),
+        (Some(canonical), Some(legacy)) if canonical == legacy => (
+            Some(PathBuf::from(canonical)),
+            Some(GuestRuntimeDirEnvSource::Dual),
+        ),
+        (Some(_), Some(_)) => {
+            return Err(RuntimePathError::ConflictingRuntimeDirEnvAliases);
+        }
+    };
+
+    if runtime_dir
+        .as_deref()
+        .is_some_and(|runtime_dir| !runtime_dir.is_absolute())
+    {
+        return Err(RuntimePathError::InvalidRuntimeDir);
+    }
+
+    Ok(GuestRuntimeDirEnvResolution {
+        runtime_dir,
+        source,
+    })
+}
+
+/// Capture and resolve both guest runtime-directory aliases exactly once.
+pub fn guest_runtime_dir_env_from_process_env()
+-> Result<GuestRuntimeDirEnvResolution, RuntimePathError> {
+    resolve_guest_runtime_dir_env(
+        env::var_os(CANONICAL_GUEST_RUNTIME_DIR_ENV),
+        env::var_os(GUEST_RUNTIME_DIR_ENV),
+    )
+}
+
+/// Resolve a complete run directory from already captured values.
+pub fn run_dir_from_captured_env(
+    run_id: &str,
+    runtime_dir: Option<&Path>,
+    process_home: Option<&Path>,
+) -> Result<PathBuf, RuntimePathError> {
+    if let Some(runtime_dir) = runtime_dir {
+        if !runtime_dir.is_absolute() {
+            return Err(RuntimePathError::InvalidRuntimeDir);
+        }
+        return Ok(runtime_dir.to_path_buf());
+    }
+
+    let home = process_home
+        .filter(|value| !value.as_os_str().is_empty())
+        .ok_or(RuntimePathError::MissingHome)?;
     run_dir_for_home(home, run_id)
+}
+
+/// Resolve the process runtime directory and return value-free alias source.
+pub fn run_dir_from_env_with_source(
+    run_id: &str,
+) -> Result<(PathBuf, Option<GuestRuntimeDirEnvSource>), RuntimePathError> {
+    let resolution = guest_runtime_dir_env_from_process_env()?;
+    let home = env::var_os("HOME").map(PathBuf::from);
+    let run_dir = run_dir_from_captured_env(run_id, resolution.runtime_dir(), home.as_deref())?;
+    Ok((run_dir, resolution.source()))
+}
+
+/// Resolve the runtime directory from process environment.
+///
+/// A non-empty absolute canonical or legacy override wins and is returned as
+/// the complete runtime directory. In that override branch, `run_id` is not
+/// validated and is not appended. Empty overrides are ignored, relative
+/// overrides return [`RuntimePathError::InvalidRuntimeDir`], conflicting
+/// non-empty aliases fail closed, and fallback resolution uses `HOME` plus
+/// [`run_dir_for_home`].
+pub fn run_dir_from_env(run_id: &str) -> Result<PathBuf, RuntimePathError> {
+    run_dir_from_env_with_source(run_id).map(|(run_dir, _source)| run_dir)
 }
 
 fn file(run_dir: impl AsRef<Path>, name: &str) -> PathBuf {
@@ -1210,7 +1344,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     use std::os::fd::FromRawFd;
     #[cfg(unix)]
-    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
@@ -1263,18 +1397,117 @@ mod tests {
     }
 
     #[test]
-    fn env_runtime_dir_wins_without_run_id_segment() {
-        let temp = tempfile::tempdir().unwrap();
-        unsafe {
-            env::set_var(GUEST_RUNTIME_DIR_ENV, temp.path());
+    fn guest_runtime_dir_aliases_preserve_paths_and_source() {
+        assert_eq!(GUEST_RUNTIME_DIR_ENV, "VM0_GUEST_RUNTIME_DIR");
+        assert_eq!(CANONICAL_GUEST_RUNTIME_DIR_ENV, "OKOU_GUEST_RUNTIME_DIR");
+
+        let success_cases = [
+            ("absent", None, None, None, None),
+            ("both-empty", Some(""), Some(""), None, None),
+            (
+                "canonical-only",
+                Some("/canonical"),
+                None,
+                Some("/canonical"),
+                Some(GuestRuntimeDirEnvSource::CanonicalOnly),
+            ),
+            (
+                "legacy-only",
+                None,
+                Some("/legacy"),
+                Some("/legacy"),
+                Some(GuestRuntimeDirEnvSource::LegacyOnly),
+            ),
+            (
+                "equal-dual",
+                Some("/shared"),
+                Some("/shared"),
+                Some("/shared"),
+                Some(GuestRuntimeDirEnvSource::Dual),
+            ),
+            (
+                "canonical-empty",
+                Some(""),
+                Some("/legacy"),
+                Some("/legacy"),
+                Some(GuestRuntimeDirEnvSource::LegacyOnly),
+            ),
+            (
+                "legacy-empty",
+                Some("/canonical"),
+                Some(""),
+                Some("/canonical"),
+                Some(GuestRuntimeDirEnvSource::CanonicalOnly),
+            ),
+        ];
+
+        for (name, canonical, legacy, expected_path, expected_source) in success_cases {
+            let resolution = resolve_guest_runtime_dir_env(
+                canonical.map(OsString::from),
+                legacy.map(OsString::from),
+            )
+            .unwrap();
+            assert_eq!(
+                resolution.runtime_dir(),
+                expected_path.map(Path::new),
+                "{name} selected the wrong path"
+            );
+            assert_eq!(
+                resolution.source(),
+                expected_source,
+                "{name} selected the wrong source"
+            );
         }
 
-        let dir = run_dir_from_env("not/validated/when/env/is/set").unwrap();
+        let error = resolve_guest_runtime_dir_env(
+            Some(OsString::from("/canonical-must-not-leak")),
+            Some(OsString::from("/legacy-must-not-leak")),
+        )
+        .unwrap_err();
+        assert_eq!(error, RuntimePathError::ConflictingRuntimeDirEnvAliases);
+        let diagnostic = error.to_string();
+        assert_eq!(
+            diagnostic,
+            "conflicting guest runtime directory environment aliases: \
+             canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR \
+             state=conflict"
+        );
+        assert!(!diagnostic.contains("must-not-leak"));
+    }
 
-        assert_eq!(dir, temp.path());
-        unsafe {
-            env::remove_var(GUEST_RUNTIME_DIR_ENV);
+    #[test]
+    fn guest_runtime_dir_aliases_preserve_non_unicode_and_fallback_contract() {
+        #[cfg(unix)]
+        {
+            let absolute = PathBuf::from(OsString::from_vec(vec![b'/', b'r', b'u', b'n', 0xff]));
+            let resolution =
+                resolve_guest_runtime_dir_env(Some(absolute.as_os_str().to_owned()), None).unwrap();
+            assert_eq!(resolution.runtime_dir(), Some(absolute.as_path()));
+
+            let home = PathBuf::from(OsString::from_vec(vec![b'/', b'h', b'o', b'm', b'e', 0xfe]));
+            let fallback = run_dir_from_captured_env("run-123", None, Some(&home)).unwrap();
+            assert_eq!(fallback, home.join(DEFAULT_RUNTIME_PARENT).join("run-123"));
         }
+
+        let override_dir = run_dir_from_captured_env(
+            "not/validated/when/env/is/set",
+            Some(Path::new("/runtime")),
+            None,
+        )
+        .unwrap();
+        assert_eq!(override_dir, Path::new("/runtime"));
+        assert_eq!(
+            run_dir_from_captured_env(
+                "run-123",
+                Some(Path::new("relative-runtime")),
+                Some(Path::new("/home/vm0")),
+            ),
+            Err(RuntimePathError::InvalidRuntimeDir)
+        );
+        assert_eq!(
+            resolve_guest_runtime_dir_env(Some(OsString::from("relative-runtime")), None),
+            Err(RuntimePathError::InvalidRuntimeDir)
+        );
     }
 
     #[test]

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -53,10 +53,18 @@ fn install_runtime_log_paths() -> Result<(), String> {
         ));
     }
 
-    let run_dir = runtime_paths::run_dir_from_env(&run_id)
+    let (run_dir, source) = runtime_paths::run_dir_from_env_with_source(&run_id)
         .map_err(|error| format!("failed to resolve guest-download runtime paths: {error}"))?;
     guest_common::log::set_system_log_file(runtime_paths::system_log_file(&run_dir));
     guest_common::telemetry::set_sandbox_ops_log_file(runtime_paths::sandbox_ops_log_file(run_dir));
+    if let Some(source) = source {
+        log_info!(
+            LOG_TAG,
+            "guest_runtime_dir_env_source key={} source={}",
+            runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            source.label()
+        );
+    }
     Ok(())
 }
 

--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -50,6 +50,7 @@ impl BinaryLoggingFixture {
         let mut command = guest_download_command();
         command
             .env(guest_contracts::env::RUN_ID_ENV, &self.run_id)
+            .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
             .env(
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &self.logs.runtime_dir,
@@ -100,7 +101,11 @@ impl BinaryLoggingFixture {
 }
 
 pub(super) fn guest_download_command() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_guest-download"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-download"));
+    command
+        .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+    command
 }
 
 pub(super) fn sandbox_ops(content: &str) -> Result<Vec<Value>, String> {

--- a/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
+++ b/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
@@ -3,6 +3,39 @@ use super::{
     assert_single_download_total_success, guest_download_command, process,
 };
 use crate::support::{unique_run_id, write_manifest};
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
+const SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
+
+fn apply_runtime_aliases(
+    command: &mut std::process::Command,
+    canonical: Option<&OsStr>,
+    legacy: Option<&OsStr>,
+) {
+    command
+        .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+    if let Some(value) = canonical {
+        command.env(
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            value,
+        );
+    }
+    if let Some(value) = legacy {
+        command.env(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV, value);
+    }
+}
+
+fn source_messages(log: &str) -> Vec<&str> {
+    log.lines()
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .filter(|message| message.starts_with(SOURCE_EVENT))
+        .collect()
+}
 
 #[test]
 fn binary_writes_system_log_to_explicit_runtime_path() {
@@ -23,6 +56,11 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
         "unexpected system log: {content:?}"
     );
     assert_eq!(content.matches("Download completed").count(), 1);
+    assert_eq!(
+        source_messages(&content),
+        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=legacy-only"]
+    );
+    assert!(!content.contains(fixture.logs.runtime_dir.to_string_lossy().as_ref()));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("[INFO] [sandbox:download] Download completed"));
@@ -30,6 +68,182 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
     assert_default_zero_task_attribution(&actions);
     let ops = fixture.ops_entries().unwrap();
     assert_single_download_total_success(&ops, true);
+}
+
+#[test]
+fn binary_dual_reads_runtime_aliases_with_value_free_sink_scoped_evidence() {
+    for (name, canonical, legacy, expected_source) in [
+        ("canonical-only", true, false, "canonical-only"),
+        ("legacy-only", false, true, "legacy-only"),
+        ("equal-dual", true, true, "dual"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest(&dir, &[], None).unwrap();
+        let runtime_dir = dir.path().join(format!("{name}-must-not-leak"));
+        let mut command = guest_download_command();
+        command
+            .arg(&manifest_path)
+            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id")
+            .env("HOME", dir.path().join("unused-home"));
+        apply_runtime_aliases(
+            &mut command,
+            canonical.then_some(runtime_dir.as_os_str()),
+            legacy.then_some(runtime_dir.as_os_str()),
+        );
+
+        let output = process::run(&mut command).unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+            &runtime_dir,
+        ))
+        .unwrap();
+        let expected = format!(
+            "{SOURCE_EVENT} key={} source={expected_source}",
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
+        );
+        assert_eq!(source_messages(&log), [expected.as_str()], "{name}");
+        assert!(!log.contains("must-not-leak"), "{name}");
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("must-not-leak"),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn binary_treats_empty_runtime_alias_as_absent() {
+    for (name, canonical_empty) in [("canonical-empty", true), ("legacy-empty", false)] {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_manifest(&dir, &[], None).unwrap();
+        let runtime_dir = dir.path().join(format!("{name}-runtime"));
+        let mut command = guest_download_command();
+        command
+            .arg(&manifest_path)
+            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id")
+            .env("HOME", dir.path().join("unused-home"));
+        let empty = OsStr::new("");
+        apply_runtime_aliases(
+            &mut command,
+            Some(if canonical_empty {
+                empty
+            } else {
+                runtime_dir.as_os_str()
+            }),
+            Some(if canonical_empty {
+                runtime_dir.as_os_str()
+            } else {
+                empty
+            }),
+        );
+
+        let output = process::run(&mut command).unwrap();
+        assert!(
+            output.status.success(),
+            "{name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+            &runtime_dir,
+        ))
+        .unwrap();
+        let expected_source = if canonical_empty {
+            "legacy-only"
+        } else {
+            "canonical-only"
+        };
+        let expected = format!(
+            "{SOURCE_EVENT} key={} source={expected_source}",
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
+        );
+        assert_eq!(source_messages(&log), [expected.as_str()], "{name}");
+    }
+}
+
+#[test]
+fn binary_rejects_runtime_alias_conflict_without_path_or_log_side_effects() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let canonical_dir = dir.path().join("canonical-must-not-leak");
+    let legacy_dir = dir.path().join("legacy-must-not-leak");
+    let mut command = guest_download_command();
+    command
+        .arg(&manifest_path)
+        .env(guest_contracts::env::RUN_ID_ENV, "run-id")
+        .env("HOME", dir.path().join("home"));
+    apply_runtime_aliases(
+        &mut command,
+        Some(canonical_dir.as_os_str()),
+        Some(legacy_dir.as_os_str()),
+    );
+
+    let output = process::run(&mut command).unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(
+        "conflicting guest runtime directory environment aliases: \
+         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
+    ));
+    assert!(!stderr.contains("canonical-must-not-leak"));
+    assert!(!stderr.contains("legacy-must-not-leak"));
+    assert!(!guest_contracts::runtime_paths::system_log_file(canonical_dir).exists());
+    assert!(!guest_contracts::runtime_paths::system_log_file(legacy_dir).exists());
+    assert!(manifest_path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn binary_accepts_non_unicode_runtime_override_and_home_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let override_manifest = write_manifest(&dir, &[], None).unwrap();
+    let override_dir = dir
+        .path()
+        .join(OsString::from_vec(b"override-\xff".to_vec()));
+    let mut override_command = guest_download_command();
+    override_command
+        .arg(&override_manifest)
+        .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id");
+    apply_runtime_aliases(&mut override_command, Some(override_dir.as_os_str()), None);
+    let override_output = process::run(&mut override_command).unwrap();
+    assert!(
+        override_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&override_output.stderr)
+    );
+    let override_log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+        &override_dir,
+    ))
+    .unwrap();
+    assert_eq!(
+        source_messages(&override_log),
+        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=canonical-only"]
+    );
+
+    let fallback_manifest = write_manifest(&dir, &[], None).unwrap();
+    let home = dir.path().join(OsString::from_vec(b"home-\xfe".to_vec()));
+    let run_id = unique_run_id("non-unicode-home");
+    let fallback_dir = guest_contracts::runtime_paths::run_dir_for_home(&home, &run_id).unwrap();
+    let mut fallback_command = guest_download_command();
+    fallback_command
+        .arg(&fallback_manifest)
+        .env(guest_contracts::env::RUN_ID_ENV, &run_id)
+        .env("HOME", &home);
+    apply_runtime_aliases(&mut fallback_command, None, None);
+    let fallback_output = process::run(&mut fallback_command).unwrap();
+    assert!(
+        fallback_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&fallback_output.stderr)
+    );
+    let fallback_log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+        fallback_dir,
+    ))
+    .unwrap();
+    assert!(source_messages(&fallback_log).is_empty());
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -263,6 +263,11 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
             call.env_keys,
             vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
         );
+        assert!(
+            !call.env_keys.iter().any(|key| {
+                key == guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
+            })
+        );
         assert!(!call.sudo);
         assert!(call.stdin_bytes.is_none());
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -454,6 +454,7 @@ fn build_env_json_required_keys() {
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
+    assert!(!env.contains_key(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV));
     assert!(!env.contains_key("VM0_PROMPT"));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
@@ -779,6 +780,10 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
             .get(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
+    );
+    assert!(
+        !bootstrap_env
+            .contains_key(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
     );
     assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -75,9 +75,10 @@ fn guest_download_env_contains_run_identity_values() {
     let context = minimal_context();
     let run_id = context.run_id.to_string();
     let runtime_dir = guest_runtime_dir(context.run_id).unwrap();
+    let env = guest_download_env(&run_id, &runtime_dir);
 
     assert_eq!(
-        guest_download_env(&run_id, &runtime_dir),
+        env,
         [
             (guest_contracts::env::RUN_ID_ENV, run_id.as_str()),
             (
@@ -86,6 +87,9 @@ fn guest_download_env_contains_run_identity_values() {
             ),
         ]
     );
+    assert!(!env.iter().any(|(key, _)| {
+        *key == guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
+    }));
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -386,6 +386,10 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     let exec_calls = sandbox.exec_calls();
     assert_eq!(exec_calls.len(), 3);
     assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
+    assert_eq!(
+        exec_calls[0].env_keys,
+        vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
+    );
     assert!(exec_calls[1].cmd.contains("rm -f --"));
     assert!(exec_calls[1].cmd.contains("/session-history-sidecar"));
     assert!(exec_calls[2].sudo);

--- a/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
+++ b/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
@@ -83,6 +83,7 @@ fn guest_storage_manifest_runs_fixed_argv_env_and_stdin() {
 [ "$1" = "--manifest-stdin" ]
 [ "$OKOU_RUN_ID" = "run-1" ]
 [ "$VM0_GUEST_RUNTIME_DIR" = "/run/vm0/runs/run-1" ]
+[ "${OKOU_GUEST_RUNTIME_DIR+x}" != x ]
 [ "$(cat)" = '{"storages":[]}' ]
 printf 'applied\n'
 printf 'helper stderr\n' >&2


### PR DESCRIPTION
## Summary

- add `OKOU_GUEST_RUNTIME_DIR` as a canonical reader alias while keeping `GUEST_RUNTIME_DIR_ENV` exactly `VM0_GUEST_RUNTIME_DIR`
- resolve canonical and legacy values once through a shared, value-preserving `OsString`/`PathBuf` contract used by normal Guest Agent startup, runner-only Guest Agent helpers, and `guest-download`
- fail closed on unequal non-empty aliases before containment capabilities, private payloads, filesystem/logging effects, or async runtime construction, then emit bounded value-free source evidence only after run-scoped log sinks exist
- keep all five production writers legacy-only and prove managed CLI non-exposure plus writer identity with focused regressions

Closes #29092

Parent: #28914

## Acceptance evidence

- `guest-contracts::runtime_paths` preserves `GUEST_RUNTIME_DIR_ENV = "VM0_GUEST_RUNTIME_DIR"`, defines `CANONICAL_GUEST_RUNTIME_DIR_ENV = "OKOU_GUEST_RUNTIME_DIR"`, and owns the only alias resolver.
- Resolver coverage includes absent, both-empty, canonical-only, legacy-only, empty/non-empty, equal dual, unequal dual, relative, non-Unicode absolute override, non-Unicode `HOME`, override run-id bypass, and unchanged fallback layout/validation.
- Normal `GuestRuntime::from_process_env` captures the pair before process-control or cgroup resolution and carries the owned `PathBuf` into `GuestConfigRaw` and `GuestPaths` without rereading process globals.
- A real `guest-agent` child-process boundary test proves conflict does not connect process-control or workload-containment sockets, receive a descriptor, consume/remove either private payload file, or create either run-scoped log file.
- Normal Guest Agent and `guest-download` each emit at most one `guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=<canonical-only|legacy-only|dual>` message after both log sinks are installed; conflict diagnostics and source evidence disclose no path value or bytes.
- Runner-only helper coverage proves canonical-only, legacy-only, equal-dual, and conflict behavior while preserving successful stdout/stderr and the existing default-path protocol.
- A managed CLI child test starts from equal bootstrap aliases and proves neither alias reaches the child environment.
- Writer regressions keep normal runner bootstrap, final-identity verification, runner storage download, workspace-promotion sidecar export, and root `vsock-guest` guest-download spawning on the legacy key only; no production writer file changes in this diff.
- The diff does not change runtime layout, `HOME` fallback, private payload behavior, storage/session-history/workspace semantics, guest-download transport, process-control/cgroup contracts, release/deployment state, or #25722 Cloudflare Access work.

## Fallbacks

- `crates/guest-contracts/src/runtime_paths.rs:{resolve_guest_runtime_dir_env,guest_runtime_dir_env_from_process_env,run_dir_from_env_with_source}` introduces one bounded reader fallback: a new embedded guest accepts the canonical `OKOU_GUEST_RUNTIME_DIR` alias and the retained legacy `VM0_GUEST_RUNTIME_DIR` spelling, treats empty as absent, accepts equal dual values, and fails closed on unequal non-empty values. Surface: existing runner and reusable sandbox -> embedded guest readers. Existing claims can remain live for the two-hour guest runtime budget plus bounded finalization.
- Reader surfaces using that single contract are `crates/guest-agent/src/run_context.rs:GuestRuntime::from_process_env` with `crates/guest-agent/src/env.rs:GuestConfigRaw` and `crates/guest-agent/src/paths.rs:GuestPaths`, all three runner-only Guest Agent helpers through `GuestPaths::from_process_env`, and `crates/guest-download/src/main.rs:install_runtime_log_paths`.
- The five retained legacy-only writers are `crates/runner/src/executor/env.rs` (normal bootstrap), `crates/runner/src/executor/agent_run.rs` (final-identity verification), `crates/runner/src/executor/storage.rs` (storage download), `crates/runner/src/workspace_promotion.rs` (session-history sidecar export), and `crates/vsock-guest/src/guest_storage_manifest.rs` (root guest-download spawn). They continue to emit only `VM0_GUEST_RUNTIME_DIR`; this PR does not switch or dual-write them.
- Reader-floor gate: release and record the exact deployed runner artifact, embedded Guest Agent binary, embedded `guest-download` binary, and rootfs identities containing this reader floor. A version or semver floor alone is insufficient.
- Drain gate: every pre-floor service and reusable sandbox must drain successfully; `status.json` must show zero `active_runs` and zero `idle_vms`/sandboxes; the service must be inactive and unable to admit work; no pre-floor heartbeat may remain fresh after five minutes; and zero must remain stable for two additional ten-second heartbeat periods.
- Rollback remains safe during the bounded window because the five old writers feed this dual reader and a later canonical-writer rollback returns to the retained legacy spelling. A canonical writer must not ship before the exact-artifact reader floor and drain gates pass.
- Source evidence is emitted only by normal Guest Agent and `guest-download`, after their run-scoped sinks exist, and contains only the canonical key name plus `canonical-only`, `legacy-only`, or `dual`. Helper-command legacy use is instead bounded by exact canonical-writer identity, the reader floor, and the service/sandbox drain.
- Remove the legacy reader and its compatibility tests only in the separate #28914 contraction after all five writers are canonical-only, the supported rollback window has closed, value-free evidence proves legacy-read zero, and the exact-artifact floor plus service/reusable-sandbox drain remain satisfied.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --no-deps -p guest-contracts -p guest-agent -p guest-download -p vsock-guest --all-targets -- -D warnings`
- `cargo check -p guest-contracts -p guest-agent -p guest-download -p runner -p vsock-guest`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p guest-contracts -p guest-agent -p guest-download -p runner -p vsock-guest`
- `cargo test -p guest-contracts guest_runtime_dir_aliases --lib`
- `cargo test -p guest-agent --test guest_runtime_dir_env_aliases`
- `cargo test -p guest-agent --test session_history_identity_helper default_identity_path_dual_reads_runtime_aliases_without_protocol_output`
- `cargo test -p guest-agent --test cli_child_env execute_cli_injects_user_env_without_runner_owned_bootstrap_env`
- `cargo test -p guest-download --test integration binary_logging::runtime_paths`
- `cargo test -p vsock-guest guest_storage_manifest_runs_fixed_argv_env_and_stdin`

The local Rust 1.98 host also exposed pre-existing current-`main` Clippy diagnostics in `vsock-proto`/`runner`; the runner test binary then exceeded the local linker memory limit. The PR pipeline's pinned `vm0-toolchain-rust:20260622` jobs remain the authority for the focused runner writer tests and full affected-crate validation.
