### PR TITLE
refactor(desktop): dual-read notarization api credential aliases

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -3,6 +3,9 @@ const path = require("node:path");
 
 const packageMetadata = require("./package.json");
 const { resolveDesktopBuildConfig } = require("./scripts/desktop-build-config");
+const {
+  resolveDesktopNotarizeApiEnvironment,
+} = require("./scripts/desktop-notarize-api-environment");
 
 const MINIMUM_MACOS_VERSION = "14.0";
 const DEFAULT_NOTARIZE_KEYCHAIN_PROFILE = "vm0-desktop-notary";
@@ -18,14 +21,6 @@ const codeSigningIdentity =
   process.env.VM0_DESKTOP_SIGNING_IDENTITY ??
   (process.env.CI === "true" ? "-" : DEVELOPER_ID_APPLICATION_IDENTITY);
 
-function requiredEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
-
 function desktopNotarizeOptions() {
   if (process.env.VM0_DESKTOP_NOTARIZE !== "true") {
     return undefined;
@@ -40,18 +35,17 @@ function desktopNotarizeOptions() {
     };
   }
 
-  if (!process.env.VM0_DESKTOP_NOTARIZE_API_KEY_PATH) {
+  if (
+    !process.env.OKOU_DESKTOP_NOTARIZE_API_KEY_PATH &&
+    !process.env.VM0_DESKTOP_NOTARIZE_API_KEY_PATH
+  ) {
     return {
       keychainProfile: DEFAULT_NOTARIZE_KEYCHAIN_PROFILE,
       keychain: DEFAULT_NOTARIZE_KEYCHAIN,
     };
   }
 
-  return {
-    appleApiKey: requiredEnv("VM0_DESKTOP_NOTARIZE_API_KEY_PATH"),
-    appleApiKeyId: requiredEnv("VM0_DESKTOP_NOTARIZE_API_KEY_ID"),
-    appleApiIssuer: requiredEnv("VM0_DESKTOP_NOTARIZE_API_ISSUER"),
-  };
+  return resolveDesktopNotarizeApiEnvironment();
 }
 
 const { identity: desktopIdentity } = resolveDesktopBuildConfig();

--- a/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
@@ -1,0 +1,85 @@
+const CREDENTIAL_ALIASES = [
+  {
+    canonical: "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH",
+    legacy: "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
+    option: "appleApiKey",
+  },
+  {
+    canonical: "OKOU_DESKTOP_NOTARIZE_API_KEY_ID",
+    legacy: "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
+    option: "appleApiKeyId",
+  },
+  {
+    canonical: "OKOU_DESKTOP_NOTARIZE_API_ISSUER",
+    legacy: "VM0_DESKTOP_NOTARIZE_API_ISSUER",
+    option: "appleApiIssuer",
+  },
+];
+
+function presentEnvironmentValue(name) {
+  return process.env[name] || undefined;
+}
+
+function aliasState(values) {
+  return CREDENTIAL_ALIASES.flatMap((alias, index) => [
+    `${alias.canonical}=${values.canonical[index] ? "present" : "absent"}`,
+    `${alias.legacy}=${values.legacy[index] ? "present" : "absent"}`,
+  ]).join(" ");
+}
+
+function resolvedOptions(source, values) {
+  console.info(`desktop_notarize_api_env_source source=${source}`);
+  return Object.fromEntries(
+    CREDENTIAL_ALIASES.map((alias, index) => [alias.option, values[index]]),
+  );
+}
+
+// The release workflow and documented local-build surface remain legacy-only
+// during reader Stage 1. Remove these aliases only after #28914 atomically
+// cuts the writer and docs over, preserves the rollback window, and records
+// zero legacy-only source evidence.
+function resolveDesktopNotarizeApiEnvironment() {
+  const values = {
+    canonical: CREDENTIAL_ALIASES.map((alias) =>
+      presentEnvironmentValue(alias.canonical),
+    ),
+    legacy: CREDENTIAL_ALIASES.map((alias) =>
+      presentEnvironmentValue(alias.legacy),
+    ),
+  };
+  const canonicalCount = values.canonical.filter(Boolean).length;
+  const legacyCount = values.legacy.filter(Boolean).length;
+
+  if (canonicalCount === 0 && legacyCount === 0) {
+    return undefined;
+  }
+  if (canonicalCount === CREDENTIAL_ALIASES.length && legacyCount === 0) {
+    return resolvedOptions("canonical-only", values.canonical);
+  }
+  if (canonicalCount === 0 && legacyCount === CREDENTIAL_ALIASES.length) {
+    return resolvedOptions("legacy-only", values.legacy);
+  }
+  if (
+    canonicalCount === CREDENTIAL_ALIASES.length &&
+    legacyCount === CREDENTIAL_ALIASES.length
+  ) {
+    if (
+      values.canonical.every((value, index) => value === values.legacy[index])
+    ) {
+      return resolvedOptions("dual", values.canonical);
+    }
+    throw new Error(
+      `Desktop notarization API credential aliases conflict: state=conflict ${aliasState(values)}`,
+    );
+  }
+  if (canonicalCount > 0 && legacyCount > 0) {
+    throw new Error(
+      `Desktop notarization API credentials mix canonical and legacy aliases: state=mixed ${aliasState(values)}`,
+    );
+  }
+  throw new Error(
+    `Desktop notarization API credentials are incomplete: state=incomplete ${aliasState(values)}`,
+  );
+}
+
+module.exports = { resolveDesktopNotarizeApiEnvironment };

--- a/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
+++ b/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
@@ -7,6 +7,10 @@ import { fileURLToPath } from "node:url";
 import { notarize } from "@electron/notarize";
 import { sign } from "@electron/osx-sign";
 
+import desktopNotarizeApiEnvironment from "./desktop-notarize-api-environment.js";
+
+const { resolveDesktopNotarizeApiEnvironment } = desktopNotarizeApiEnvironment;
+
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const desktopDirectory = path.resolve(scriptDirectory, "..");
 const packageMetadata = JSON.parse(
@@ -67,6 +71,13 @@ if (
   );
 }
 
+const notarizeOptions = resolveDesktopNotarizeApiEnvironment();
+if (!notarizeOptions) {
+  throw new Error(
+    "Desktop notarization API environment is required: state=absent",
+  );
+}
+
 await sign({
   app: options.appPath,
   batchCodesignCalls: true,
@@ -78,9 +89,5 @@ await sign({
 
 await notarize({
   appPath: options.appPath,
-  appleApiKey: requiredEnvironmentVariable("VM0_DESKTOP_NOTARIZE_API_KEY_PATH"),
-  appleApiKeyId: requiredEnvironmentVariable("VM0_DESKTOP_NOTARIZE_API_KEY_ID"),
-  appleApiIssuer: requiredEnvironmentVariable(
-    "VM0_DESKTOP_NOTARIZE_API_ISSUER",
-  ),
+  ...notarizeOptions,
 });

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -1,0 +1,550 @@
+import { randomUUID } from "node:crypto";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import packageMetadata from "../package.json";
+
+const desktopDirectory = resolve(__dirname, "..");
+const forgeConfigPath = join(desktopDirectory, "forge.config.js");
+const packagedAppScriptPath = join(
+  desktopDirectory,
+  "scripts",
+  "sign-and-notarize-packaged-app.mjs",
+);
+const temporaryDirectories: string[] = [];
+
+const canonicalAliases = {
+  keyPath: "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH",
+  keyId: "OKOU_DESKTOP_NOTARIZE_API_KEY_ID",
+  issuer: "OKOU_DESKTOP_NOTARIZE_API_ISSUER",
+} as const;
+const legacyAliases = {
+  keyPath: "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
+  keyId: "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
+  issuer: "VM0_DESKTOP_NOTARIZE_API_ISSUER",
+} as const;
+const allAliases = [
+  ...Object.values(canonicalAliases),
+  ...Object.values(legacyAliases),
+];
+
+const moduleLoaderSource = `
+import { registerHooks } from "node:module";
+import { pathToFileURL } from "node:url";
+
+const externalModules = new Map([
+  ["@electron/osx-sign", pathToFileURL(process.env.TEST_OSX_SIGN_MODULE).href],
+  ["@electron/notarize", pathToFileURL(process.env.TEST_NOTARIZE_MODULE).href],
+]);
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const replacement = externalModules.get(specifier);
+    if (replacement) {
+      return { shortCircuit: true, url: replacement };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+`;
+
+const osxSignModuleSource = `
+import { appendFileSync } from "node:fs";
+
+export async function sign(options) {
+  appendFileSync(process.env.TEST_TRACE_PATH, "sign\\n");
+  const forgeOptionsAreUnchanged =
+    process.env.TEST_SIGN_KIND === "forge" &&
+    options.app === process.env.TEST_EXPECTED_APP_PATH &&
+    options.batchCodesignCalls === true &&
+    options.identity === "-" &&
+    options.identityValidation === false &&
+    options.platform === "darwin" &&
+    options.timestamp === "none" &&
+    options.version === process.env.TEST_EXPECTED_ELECTRON_VERSION;
+  const helperOptionsAreUnchanged =
+    process.env.TEST_SIGN_KIND === "helper" &&
+    options.app === process.env.TEST_EXPECTED_APP_PATH &&
+    options.batchCodesignCalls === true &&
+    options.identity === process.env.VM0_DESKTOP_SIGNING_IDENTITY &&
+    options.identityValidation === true &&
+    options.platform === "darwin" &&
+    options.timestamp === undefined &&
+    options.version === process.env.TEST_EXPECTED_ELECTRON_VERSION;
+  if (!forgeOptionsAreUnchanged && !helperOptionsAreUnchanged) {
+    throw new Error("Desktop signing options changed");
+  }
+}
+`;
+
+const notarizeModuleSource = `
+import { appendFileSync } from "node:fs";
+
+export async function notarize(options) {
+  appendFileSync(process.env.TEST_TRACE_PATH, "notarize\\n");
+  const appPathIsUnchanged =
+    options.appPath === process.env.TEST_EXPECTED_APP_PATH;
+  const mode = process.env.TEST_NOTARIZE_MODE;
+  let credentialsAreUnchanged = false;
+  if (mode === "api") {
+    const prefix =
+      process.env.TEST_EXPECTED_API_SOURCE === "legacy-only" ? "VM0" : "OKOU";
+    credentialsAreUnchanged =
+      options.appleApiKey ===
+        process.env[prefix + "_DESKTOP_NOTARIZE_API_KEY_PATH"] &&
+      options.appleApiKeyId ===
+        process.env[prefix + "_DESKTOP_NOTARIZE_API_KEY_ID"] &&
+      options.appleApiIssuer ===
+        process.env[prefix + "_DESKTOP_NOTARIZE_API_ISSUER"] &&
+      options.keychainProfile === undefined &&
+      options.keychain === undefined;
+  } else if (mode === "default-keychain") {
+    credentialsAreUnchanged =
+      options.keychainProfile === "vm0-desktop-notary" &&
+      options.keychain === process.env.TEST_EXPECTED_DEFAULT_KEYCHAIN &&
+      options.appleApiKey === undefined &&
+      options.appleApiKeyId === undefined &&
+      options.appleApiIssuer === undefined;
+  } else if (mode === "custom-keychain") {
+    credentialsAreUnchanged =
+      options.keychainProfile ===
+        process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE &&
+      options.keychain === process.env.TEST_EXPECTED_DEFAULT_KEYCHAIN &&
+      options.appleApiKey === undefined &&
+      options.appleApiKeyId === undefined &&
+      options.appleApiIssuer === undefined;
+  }
+  if (!appPathIsUnchanged || !credentialsAreUnchanged) {
+    throw new Error("Desktop notarization options changed");
+  }
+}
+`;
+
+const forgeHarnessSource = `
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const forgeConfig = require(process.env.TEST_FORGE_CONFIG_PATH);
+await forgeConfig.hooks.postPackage({}, {
+  platform: "darwin",
+  outputPaths: [process.env.TEST_OUTPUT_PATH],
+});
+`;
+
+type CredentialCase =
+  | "absent"
+  | "empty"
+  | "canonical-only"
+  | "legacy-only"
+  | "dual"
+  | "conflict"
+  | "mixed"
+  | "incomplete";
+type SuccessfulSource = "canonical-only" | "legacy-only" | "dual";
+
+interface CredentialValues {
+  readonly keyPath: string;
+  readonly keyId: string;
+  readonly issuer: string;
+}
+
+interface TestHarness {
+  readonly directory: string;
+  readonly loaderPath: string;
+  readonly tracePath: string;
+  readonly signModulePath: string;
+  readonly notarizeModulePath: string;
+}
+
+interface EntryPointResult {
+  readonly process: SpawnSyncReturns<string>;
+  readonly trace: string;
+  readonly credentialValues: readonly string[];
+}
+
+function createTestHarness(): TestHarness {
+  const directory = mkdtempSync(join(tmpdir(), "desktop-notarize-entry-"));
+  temporaryDirectories.push(directory);
+  const loaderPath = join(directory, "external-module-loader.mjs");
+  const signModulePath = join(directory, "osx-sign.mjs");
+  const notarizeModulePath = join(directory, "notarize.mjs");
+  writeFileSync(loaderPath, moduleLoaderSource);
+  writeFileSync(signModulePath, osxSignModuleSource);
+  writeFileSync(notarizeModulePath, notarizeModuleSource);
+  return {
+    directory,
+    loaderPath,
+    tracePath: join(directory, "external-side-effects.txt"),
+    signModulePath,
+    notarizeModulePath,
+  };
+}
+
+function credentialValues(directory: string): CredentialValues {
+  return {
+    keyPath: join(directory, randomUUID()),
+    keyId: randomUUID(),
+    issuer: randomUUID(),
+  };
+}
+
+function assignCredentialValues(
+  environment: NodeJS.ProcessEnv,
+  aliases: typeof canonicalAliases | typeof legacyAliases,
+  values: CredentialValues,
+): void {
+  environment[aliases.keyPath] = values.keyPath;
+  environment[aliases.keyId] = values.keyId;
+  environment[aliases.issuer] = values.issuer;
+}
+
+function applyCredentialCase(
+  environment: NodeJS.ProcessEnv,
+  directory: string,
+  credentialCase: CredentialCase,
+): readonly string[] {
+  if (credentialCase === "absent") {
+    return [];
+  }
+  if (credentialCase === "empty") {
+    for (const alias of allAliases) {
+      environment[alias] = "";
+    }
+    return [];
+  }
+
+  const canonical = credentialValues(directory);
+  const legacy =
+    credentialCase === "dual" ? canonical : credentialValues(directory);
+  if (credentialCase === "canonical-only") {
+    assignCredentialValues(environment, canonicalAliases, canonical);
+    for (const alias of Object.values(legacyAliases)) {
+      environment[alias] = "";
+    }
+  } else if (credentialCase === "legacy-only") {
+    assignCredentialValues(environment, legacyAliases, legacy);
+    for (const alias of Object.values(canonicalAliases)) {
+      environment[alias] = "";
+    }
+  } else if (credentialCase === "dual" || credentialCase === "conflict") {
+    assignCredentialValues(environment, canonicalAliases, canonical);
+    assignCredentialValues(environment, legacyAliases, legacy);
+  } else if (credentialCase === "mixed") {
+    environment[canonicalAliases.keyPath] = canonical.keyPath;
+    environment[legacyAliases.keyId] = legacy.keyId;
+    environment[legacyAliases.issuer] = legacy.issuer;
+  } else {
+    environment[canonicalAliases.keyPath] = canonical.keyPath;
+    environment[canonicalAliases.keyId] = canonical.keyId;
+    environment[canonicalAliases.issuer] = "";
+  }
+
+  return allAliases.flatMap((alias) => {
+    const value = environment[alias];
+    return value ? [value] : [];
+  });
+}
+
+function baseEnvironment(harness: TestHarness): NodeJS.ProcessEnv {
+  return {
+    CI: "true",
+    HOME: harness.directory,
+    TEST_EXPECTED_DEFAULT_KEYCHAIN: join(
+      harness.directory,
+      "Library",
+      "Keychains",
+      "login.keychain-db",
+    ),
+    TEST_EXPECTED_ELECTRON_VERSION: packageMetadata.devDependencies.electron,
+    TEST_FORGE_CONFIG_PATH: forgeConfigPath,
+    TEST_NOTARIZE_MODULE: harness.notarizeModulePath,
+    TEST_OSX_SIGN_MODULE: harness.signModulePath,
+    TEST_TRACE_PATH: harness.tracePath,
+  };
+}
+
+function trace(harness: TestHarness): string {
+  return existsSync(harness.tracePath)
+    ? readFileSync(harness.tracePath, "utf8")
+    : "";
+}
+
+function runForge(
+  credentialCase: CredentialCase,
+  options: {
+    readonly notarize?: boolean;
+    readonly source?: SuccessfulSource;
+    readonly keychainMode?: "default-keychain" | "custom-keychain";
+  } = {},
+): EntryPointResult {
+  const harness = createTestHarness();
+  const outputPath = join(harness.directory, "forge-output");
+  const appPath = join(outputPath, "Zero Computer Use.app");
+  mkdirSync(appPath, { recursive: true });
+  const environment = baseEnvironment(harness);
+  environment.TEST_EXPECTED_APP_PATH = appPath;
+  environment.TEST_OUTPUT_PATH = outputPath;
+  environment.TEST_SIGN_KIND = "forge";
+  if (options.notarize !== false) {
+    environment.VM0_DESKTOP_NOTARIZE = "true";
+  }
+  const values = applyCredentialCase(
+    environment,
+    harness.directory,
+    credentialCase,
+  );
+  if (options.source) {
+    environment.TEST_NOTARIZE_MODE = "api";
+    environment.TEST_EXPECTED_API_SOURCE = options.source;
+  }
+  if (options.keychainMode) {
+    environment.TEST_NOTARIZE_MODE = options.keychainMode;
+  }
+  if (options.keychainMode === "custom-keychain") {
+    environment.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE = randomUUID();
+  }
+
+  const processResult = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      harness.loaderPath,
+      "--input-type=module",
+      "--eval",
+      forgeHarnessSource,
+    ],
+    {
+      cwd: desktopDirectory,
+      encoding: "utf8",
+      env: environment,
+    },
+  );
+  return {
+    process: processResult,
+    trace: trace(harness),
+    credentialValues: values,
+  };
+}
+
+function runPackagedAppHelper(
+  credentialCase: CredentialCase,
+  options: { readonly appName?: string; readonly product?: string } = {},
+): EntryPointResult {
+  const harness = createTestHarness();
+  const appPath = join(
+    harness.directory,
+    options.appName ?? "Zero Computer Use.app",
+  );
+  mkdirSync(appPath, { recursive: true });
+  const environment = baseEnvironment(harness);
+  environment.TEST_EXPECTED_APP_PATH = appPath;
+  environment.TEST_SIGN_KIND = "helper";
+  environment.TEST_NOTARIZE_MODE = "api";
+  environment.VM0_DESKTOP_SIGNING_IDENTITY = randomUUID();
+  const values = applyCredentialCase(
+    environment,
+    harness.directory,
+    credentialCase,
+  );
+  if (
+    credentialCase === "canonical-only" ||
+    credentialCase === "legacy-only" ||
+    credentialCase === "dual"
+  ) {
+    environment.TEST_EXPECTED_API_SOURCE = credentialCase;
+  }
+
+  const processResult = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      harness.loaderPath,
+      packagedAppScriptPath,
+      "--app",
+      appPath,
+      "--product",
+      options.product ?? "zero",
+    ],
+    {
+      cwd: desktopDirectory,
+      encoding: "utf8",
+      env: environment,
+    },
+  );
+  return {
+    process: processResult,
+    trace: trace(harness),
+    credentialValues: values,
+  };
+}
+
+function sourceEvents(result: EntryPointResult): readonly string[] {
+  return result.process.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("desktop_notarize_api_env_source "));
+}
+
+function expectNoCredentialDisclosure(result: EntryPointResult): void {
+  const output = result.process.stdout + result.process.stderr;
+  for (const value of result.credentialValues) {
+    expect(output.includes(value)).toBe(false);
+  }
+}
+
+function expectSuccessfulApiEntryPoint(
+  result: EntryPointResult,
+  source: SuccessfulSource,
+): void {
+  expect(result.process.status === 0).toBe(true);
+  expect(result.trace).toBe("sign\nnotarize\n");
+  expect(sourceEvents(result)).toStrictEqual([
+    `desktop_notarize_api_env_source source=${source}`,
+  ]);
+  expectNoCredentialDisclosure(result);
+}
+
+function expectFailedBeforeExternalSideEffects(
+  result: EntryPointResult,
+  state: "absent" | "conflict" | "mixed" | "incomplete",
+): void {
+  expect(result.process.status === 1).toBe(true);
+  expect(result.trace).toBe("");
+  expect(sourceEvents(result)).toStrictEqual([]);
+  expect(result.process.stderr.includes(`state=${state}`)).toBe(true);
+  expectNoCredentialDisclosure(result);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Desktop Forge notarization entry point", () => {
+  it.each([
+    ["canonical-only", "canonical-only"],
+    ["legacy-only", "legacy-only"],
+    ["dual", "dual"],
+  ] as const)(
+    "uses one complete %s API credential set",
+    (credentialCase, source) => {
+      expectSuccessfulApiEntryPoint(
+        runForge(credentialCase, { source }),
+        source,
+      );
+    },
+  );
+
+  it.each([
+    ["conflict", "conflict"],
+    ["mixed", "mixed"],
+    ["incomplete", "incomplete"],
+  ] as const)(
+    "rejects %s API credentials before signing",
+    (credentialCase, state) => {
+      expectFailedBeforeExternalSideEffects(runForge(credentialCase), state);
+    },
+  );
+
+  it.each(["absent", "empty"] as const)(
+    "keeps the default Keychain profile when API aliases are %s",
+    (credentialCase) => {
+      const result = runForge(credentialCase, {
+        keychainMode: "default-keychain",
+      });
+      expect(result.process.status === 0).toBe(true);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(sourceEvents(result)).toStrictEqual([]);
+    },
+  );
+
+  it("keeps a custom Keychain profile ahead of conflicting API aliases", () => {
+    const result = runForge("conflict", {
+      keychainMode: "custom-keychain",
+    });
+    expect(result.process.status === 0).toBe(true);
+    expect(result.trace).toBe("sign\nnotarize\n");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expectNoCredentialDisclosure(result);
+  });
+
+  it("keeps notarization disabled unless the existing toggle is true", () => {
+    const result = runForge("canonical-only", { notarize: false });
+    expect(result.process.status === 0).toBe(true);
+    expect(result.trace).toBe("sign\n");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expectNoCredentialDisclosure(result);
+  });
+});
+
+describe("packaged Desktop signing and notarization entry point", () => {
+  it.each([
+    ["canonical-only", "canonical-only"],
+    ["legacy-only", "legacy-only"],
+    ["dual", "dual"],
+  ] as const)(
+    "uses one complete %s API credential set",
+    (credentialCase, source) => {
+      expectSuccessfulApiEntryPoint(
+        runPackagedAppHelper(credentialCase),
+        source,
+      );
+    },
+  );
+
+  it.each([
+    ["conflict", "conflict"],
+    ["mixed", "mixed"],
+    ["incomplete", "incomplete"],
+    ["absent", "absent"],
+    ["empty", "absent"],
+  ] as const)(
+    "rejects %s API credentials before signing",
+    (credentialCase, state) => {
+      expectFailedBeforeExternalSideEffects(
+        runPackagedAppHelper(credentialCase),
+        state,
+      );
+    },
+  );
+
+  it("preserves packaged app-name validation before external side effects", () => {
+    const result = runPackagedAppHelper("canonical-only", {
+      appName: "Unexpected.app",
+    });
+    expect(result.process.status === 1).toBe(true);
+    expect(result.trace).toBe("");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expect(
+      result.process.stderr.includes(
+        "Expected a Zero Computer Use.app directory",
+      ),
+    ).toBe(true);
+    expectNoCredentialDisclosure(result);
+  });
+
+  it("preserves product validation before external side effects", () => {
+    const result = runPackagedAppHelper("canonical-only", {
+      product: "unexpected",
+    });
+    expect(result.process.status === 1).toBe(true);
+    expect(result.trace).toBe("");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expect(
+      result.process.stderr.includes(
+        "Usage: sign-and-notarize-packaged-app.mjs",
+      ),
+    ).toBe(true);
+    expectNoCredentialDisclosure(result);
+  });
+});


### PR DESCRIPTION
## Summary

- add one shared synchronous resolver for the Desktop notarization API credential triple, with atomic canonical-only, legacy-only, equal-dual, absent, conflict, mixed, and incomplete handling
- preserve Forge's notarization toggle, custom Keychain precedence, default Keychain fallback, signing options, and both readers' existing product/app validation and notarization arguments
- exercise the real Forge hook and packaged-app helper process entry points with real temporary filesystem boundaries while replacing only external Apple signing and notarization modules

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` — 20 tests passed
- rebased onto `origin/main@421c50efb1593716ff76d367da2067ed1af5b6b9`, then reran focused Prettier, Desktop lint, Desktop type checking, and the entry-point test
- fully paginated 22 open PRs and 393 changed-file patches before push; no selected-key, reader-file, resolver-file, or semantic overlap was found
- `.github/workflows/release-please.yml` and `turbo/apps/desktop/README.md` are byte-for-byte identical to current `origin/main`; the production writer remains legacy-only for the complete triple, and the workflow contains no canonical triple writer
- all unrelated Desktop environment contracts in the two readers remain unchanged

## Fallbacks

- `turbo/apps/desktop/scripts/desktop-notarize-api-environment.js:resolveDesktopNotarizeApiEnvironment` is the bounded Stage 1 compatibility reader shared by `turbo/apps/desktop/forge.config.js` and `turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs`. It protects the supported local-build/release surface while `.github/workflows/release-please.yml` remains the legacy-only production writer and `turbo/apps/desktop/README.md` remains the legacy-only documented local input. The fixed `desktop_notarize_api_env_source` event records only `canonical-only`, `legacy-only`, or `dual`. Rollback remains safe because this stage adds canonical reads without changing legacy inputs or the writer. Under #28914, a later focused change must cut the production writer and documentation over together as one atomic triple after the reader floor is established; the dual reader must remain through the supported rollback window, and legacy reading may be removed only in a separate PR after canonical writer identity and value-free source evidence prove zero legacy production use.

Closes #29099
Refs #28914
