### PR TITLE
refactor(desktop): dual-read product and platform environment aliases

### DIFF
--- a/turbo/apps/desktop/scripts/desktop-build-config.js
+++ b/turbo/apps/desktop/scripts/desktop-build-config.js
@@ -2,6 +2,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const desktopIdentities = require("../src/desktop-identities.json");
+const {
+  resolveDesktopEnvironmentAlias,
+} = require("./desktop-environment-alias");
 
 const PRODUCTION_PLATFORM_HOSTNAMES = new Set(["app.vm0.ai", "app.okou.ai"]);
 const RUNTIME_CONFIG_PATH = path.resolve(
@@ -32,13 +35,13 @@ function resolveDesktopBuildConfig(options = {}) {
   const fileConfig = readRuntimeConfig();
   const product = desktopProduct(
     options.product?.trim() ||
-      process.env.VM0_DESKTOP_PRODUCT?.trim() ||
+      resolveDesktopEnvironmentAlias("OKOU_DESKTOP_PRODUCT") ||
       fileConfig?.product ||
       "zero",
   );
   const platformUrl = new URL(
     options.platformUrl?.trim() ||
-      process.env.VM0_DESKTOP_PLATFORM_URL?.trim() ||
+      resolveDesktopEnvironmentAlias("OKOU_DESKTOP_PLATFORM_URL") ||
       fileConfig?.platformUrl ||
       desktopIdentities[product].defaultPlatformUrl,
   );

--- a/turbo/apps/desktop/scripts/desktop-environment-alias.d.ts
+++ b/turbo/apps/desktop/scripts/desktop-environment-alias.d.ts
@@ -1,0 +1,7 @@
+export type DesktopEnvironmentAliasKey =
+  | "OKOU_DESKTOP_PLATFORM_URL"
+  | "OKOU_DESKTOP_PRODUCT";
+
+export function resolveDesktopEnvironmentAlias(
+  canonicalKey: DesktopEnvironmentAliasKey,
+): string | undefined;

--- a/turbo/apps/desktop/scripts/desktop-environment-alias.js
+++ b/turbo/apps/desktop/scripts/desktop-environment-alias.js
@@ -1,0 +1,40 @@
+const ENVIRONMENT_ALIASES = {
+  OKOU_DESKTOP_PLATFORM_URL: "VM0_DESKTOP_PLATFORM_URL",
+  OKOU_DESKTOP_PRODUCT: "VM0_DESKTOP_PRODUCT",
+};
+
+function environmentValue(name) {
+  return process.env[name]?.trim() || undefined;
+}
+
+// Repository writers and supported local inputs remain legacy-only during
+// reader Stage 1. Remove the legacy mappings only after #28914 cuts every
+// writer over, preserves the rollback window, and records zero legacy source
+// evidence.
+function resolveDesktopEnvironmentAlias(canonicalKey) {
+  const legacyKey = ENVIRONMENT_ALIASES[canonicalKey];
+  const canonicalValue = environmentValue(canonicalKey);
+  const legacyValue = environmentValue(legacyKey);
+
+  if (!canonicalValue && !legacyValue) {
+    return undefined;
+  }
+  if (canonicalValue && legacyValue && canonicalValue !== legacyValue) {
+    throw new Error(
+      `Desktop environment aliases conflict: key=${canonicalKey} state=conflict`,
+    );
+  }
+
+  const source =
+    canonicalValue && legacyValue
+      ? "dual"
+      : canonicalValue
+        ? "canonical-only"
+        : "legacy-only";
+  console.info(
+    `desktop_environment_alias_source key=${canonicalKey} source=${source}`,
+  );
+  return canonicalValue || legacyValue;
+}
+
+module.exports = { resolveDesktopEnvironmentAlias };

--- a/turbo/apps/desktop/scripts/run-packaged-app.js
+++ b/turbo/apps/desktop/scripts/run-packaged-app.js
@@ -7,10 +7,7 @@ if (process.platform !== "darwin") {
   throw new Error("Packaged desktop dev runs are only supported on macOS.");
 }
 
-const { executablePath } = packagedAppPaths({
-  platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL,
-  product: process.env.VM0_DESKTOP_PRODUCT,
-});
+const { executablePath } = packagedAppPaths();
 
 if (!fs.existsSync(executablePath)) {
   throw new Error(`Packaged app executable was not found at ${executablePath}`);

--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -12,8 +12,6 @@ if (process.platform !== "darwin") {
 
 const { executablePath, mainBundlePath, mcpBundlePath } = packagedAppPaths({
   appBundlePath: process.env.OKOU_DESKTOP_SMOKE_APP_PATH,
-  platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL,
-  product: process.env.VM0_DESKTOP_PRODUCT,
 });
 
 if (!fs.existsSync(executablePath)) {

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DesktopProduct } from "@okouai/api-contracts/contracts/client-headers";
 import type { DesktopUpdateLine } from "@okouai/api-contracts/contracts/desktop-updates";
+import { resolveDesktopEnvironmentAlias } from "../scripts/desktop-environment-alias.js";
 import desktopIdentities from "./desktop-identities.json";
 import { rewriteDesktopServiceHostname } from "./desktop-api-base-url";
 
@@ -123,7 +124,7 @@ function configuredProduct(
 ): DesktopProduct {
   return desktopProduct(
     rawProduct?.trim() ||
-      process.env.VM0_DESKTOP_PRODUCT?.trim() ||
+      resolveDesktopEnvironmentAlias("OKOU_DESKTOP_PRODUCT") ||
       fileConfig?.product ||
       "zero",
   );
@@ -136,10 +137,10 @@ function configuredPlatformUrl(
   if (rawPlatformUrl !== undefined) {
     return rawPlatformUrl;
   }
-  if (process.env.VM0_DESKTOP_PLATFORM_URL?.trim()) {
-    return process.env.VM0_DESKTOP_PLATFORM_URL;
-  }
-  return fileConfig?.platformUrl;
+  return (
+    resolveDesktopEnvironmentAlias("OKOU_DESKTOP_PLATFORM_URL") ||
+    fileConfig?.platformUrl
+  );
 }
 
 function parsePlatformUrl(

--- a/turbo/apps/desktop/src/desktop-environment-alias-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-environment-alias-entry-points.test.ts
@@ -1,0 +1,773 @@
+import { randomUUID } from "node:crypto";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const desktopDirectory = resolve(__dirname, "..");
+const turboDirectory = resolve(desktopDirectory, "../..");
+const temporaryDirectories: string[] = [];
+
+const aliases = {
+  canonicalPlatformUrl: "OKOU_DESKTOP_PLATFORM_URL",
+  canonicalProduct: "OKOU_DESKTOP_PRODUCT",
+  legacyPlatformUrl: "VM0_DESKTOP_PLATFORM_URL",
+  legacyProduct: "VM0_DESKTOP_PRODUCT",
+} as const;
+
+const buildConfigHarnessSource = `
+const { resolveDesktopBuildConfig } = require(process.env.TEST_CONFIG_MODULE);
+
+function optionalValue(prefix) {
+  return process.env[prefix + "_DEFINED"] === "true"
+    ? process.env[prefix + "_VALUE"]
+    : undefined;
+}
+
+const config = resolveDesktopBuildConfig({
+  platformUrl: optionalValue("TEST_PLATFORM_ARGUMENT"),
+  product: optionalValue("TEST_PRODUCT_ARGUMENT"),
+});
+if (
+  config.product !== process.env.TEST_EXPECTED_PRODUCT ||
+  config.platformUrl.toString() !== process.env.TEST_EXPECTED_PLATFORM_URL ||
+  config.identity.displayName !== process.env.TEST_EXPECTED_DISPLAY_NAME
+) {
+  throw new Error("Desktop build configuration changed");
+}
+`;
+
+const installedConfigHarnessSource = `
+import { resolveDesktopConfig } from "./src/config.ts";
+
+function optionalValue(prefix: string): string | undefined {
+  return process.env[prefix + "_DEFINED"] === "true"
+    ? process.env[prefix + "_VALUE"]
+    : undefined;
+}
+
+const config = resolveDesktopConfig(
+  optionalValue("TEST_PLATFORM_ARGUMENT"),
+  optionalValue("TEST_PRODUCT_ARGUMENT"),
+);
+if (
+  config.identity.product !== process.env.TEST_EXPECTED_PRODUCT ||
+  config.platformUrl.toString() !== process.env.TEST_EXPECTED_PLATFORM_URL ||
+  config.environment !== process.env.TEST_EXPECTED_ENVIRONMENT ||
+  config.identity.displayName !== process.env.TEST_EXPECTED_DISPLAY_NAME ||
+  config.sessionPartition !== process.env.TEST_EXPECTED_SESSION_PARTITION
+) {
+  throw new Error("Installed Desktop configuration changed");
+}
+`;
+
+const platformOverrideSource = `
+Object.defineProperty(process, "platform", { value: "darwin" });
+`;
+
+interface AliasValues {
+  readonly canonicalPlatformUrl?: string;
+  readonly canonicalProduct?: string;
+  readonly legacyPlatformUrl?: string;
+  readonly legacyProduct?: string;
+}
+
+interface RuntimeFileConfig {
+  readonly platformUrl: string;
+  readonly product?: "zero" | "okou";
+}
+
+interface SurfaceCase {
+  readonly aliases?: AliasValues;
+  readonly fileConfig?: RuntimeFileConfig;
+  readonly platformArgument?: string;
+  readonly productArgument?: string;
+  readonly expectedProduct: "zero" | "okou";
+  readonly expectedPlatformUrl: string;
+  readonly expectedDisplayName: string;
+}
+
+interface InstalledSurfaceCase extends SurfaceCase {
+  readonly expectedEnvironment: "production" | "staging" | "development";
+}
+
+interface DesktopFixture {
+  readonly desktopDirectory: string;
+  readonly platformOverridePath: string;
+  readonly tracePath: string;
+}
+
+interface EntryPointResult {
+  readonly process: SpawnSyncReturns<string>;
+  readonly trace: string;
+  readonly aliasValues: readonly string[];
+}
+
+function createDesktopFixture(): DesktopFixture {
+  const directory = mkdtempSync(join(tmpdir(), "desktop-env-alias-entry-"));
+  temporaryDirectories.push(directory);
+  const fixtureDesktopDirectory = join(directory, "desktop");
+  const scriptsDirectory = join(fixtureDesktopDirectory, "scripts");
+  const sourceDirectory = join(fixtureDesktopDirectory, "src");
+  mkdirSync(scriptsDirectory, { recursive: true });
+  mkdirSync(sourceDirectory, { recursive: true });
+
+  for (const relativePath of [
+    "scripts/desktop-build-config.js",
+    "scripts/desktop-environment-alias.js",
+    "scripts/packaged-app-paths.js",
+    "scripts/run-packaged-app.js",
+    "scripts/smoke-test-packaged-app.js",
+    "src/config.ts",
+    "src/desktop-api-base-url.ts",
+    "src/desktop-identities.json",
+  ]) {
+    copyFileSync(
+      join(desktopDirectory, relativePath),
+      join(fixtureDesktopDirectory, relativePath),
+    );
+  }
+
+  const platformOverridePath = join(directory, "darwin-platform.cjs");
+  writeFileSync(platformOverridePath, platformOverrideSource);
+  return {
+    desktopDirectory: fixtureDesktopDirectory,
+    platformOverridePath,
+    tracePath: join(directory, "external-side-effects.txt"),
+  };
+}
+
+function writeRuntimeConfig(
+  fixture: DesktopFixture,
+  config: RuntimeFileConfig | undefined,
+): void {
+  if (config) {
+    writeFileSync(
+      join(fixture.desktopDirectory, "desktop-runtime-config.json"),
+      JSON.stringify(config),
+    );
+  }
+}
+
+function applyAliases(
+  environment: NodeJS.ProcessEnv,
+  values: AliasValues | undefined,
+): readonly string[] {
+  if (!values) {
+    return [];
+  }
+
+  const selectedValues: string[] = [];
+  for (const [key, environmentName] of Object.entries(aliases)) {
+    const value = values[key as keyof AliasValues];
+    if (value !== undefined) {
+      environment[environmentName] = value;
+      if (value.trim()) {
+        selectedValues.push(value.trim());
+      }
+    }
+  }
+  return selectedValues;
+}
+
+function baseEnvironment(): NodeJS.ProcessEnv {
+  return process.env.PATH ? { PATH: process.env.PATH } : {};
+}
+
+function surfaceEnvironment(
+  testCase: SurfaceCase,
+  fixture: DesktopFixture,
+): {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly values: readonly string[];
+} {
+  const environment = baseEnvironment();
+  environment.TEST_CONFIG_MODULE = join(
+    fixture.desktopDirectory,
+    "scripts",
+    "desktop-build-config.js",
+  );
+  environment.TEST_EXPECTED_DISPLAY_NAME = testCase.expectedDisplayName;
+  environment.TEST_EXPECTED_PLATFORM_URL = testCase.expectedPlatformUrl;
+  environment.TEST_EXPECTED_PRODUCT = testCase.expectedProduct;
+  environment.TEST_PLATFORM_ARGUMENT_DEFINED = String(
+    testCase.platformArgument !== undefined,
+  );
+  environment.TEST_PLATFORM_ARGUMENT_VALUE = testCase.platformArgument;
+  environment.TEST_PRODUCT_ARGUMENT_DEFINED = String(
+    testCase.productArgument !== undefined,
+  );
+  environment.TEST_PRODUCT_ARGUMENT_VALUE = testCase.productArgument;
+  return {
+    environment,
+    values: applyAliases(environment, testCase.aliases),
+  };
+}
+
+function trace(fixture: DesktopFixture): string {
+  return existsSync(fixture.tracePath)
+    ? readFileSync(fixture.tracePath, "utf8")
+    : "";
+}
+
+function runBuildConfig(testCase: SurfaceCase): EntryPointResult {
+  const fixture = createDesktopFixture();
+  writeRuntimeConfig(fixture, testCase.fileConfig);
+  const { environment, values } = surfaceEnvironment(testCase, fixture);
+  const processResult = spawnSync(
+    process.execPath,
+    ["--eval", buildConfigHarnessSource],
+    { encoding: "utf8", env: environment },
+  );
+  return { process: processResult, trace: trace(fixture), aliasValues: values };
+}
+
+function runInstalledConfig(testCase: InstalledSurfaceCase): EntryPointResult {
+  const fixture = createDesktopFixture();
+  writeRuntimeConfig(fixture, testCase.fileConfig);
+  const harnessPath = join(fixture.desktopDirectory, "installed-config.ts");
+  writeFileSync(harnessPath, installedConfigHarnessSource);
+  const { environment, values } = surfaceEnvironment(testCase, fixture);
+  environment.TEST_EXPECTED_ENVIRONMENT = testCase.expectedEnvironment;
+  environment.TEST_EXPECTED_SESSION_PARTITION = `persist:vm0-desktop-${testCase.expectedEnvironment}`;
+  const processResult = spawnSync(
+    process.execPath,
+    ["--import", "tsx", harnessPath],
+    { cwd: turboDirectory, encoding: "utf8", env: environment },
+  );
+  return { process: processResult, trace: trace(fixture), aliasValues: values };
+}
+
+function preparePackagedApp(
+  fixture: DesktopFixture,
+  appName: string,
+  marker: "selected" | "unexpected",
+): void {
+  const appBundlePath = join(
+    fixture.desktopDirectory,
+    "out",
+    `${appName}-darwin-${process.arch}`,
+    `${appName}.app`,
+  );
+  const executablePath = join(appBundlePath, "Contents", "MacOS", appName);
+  const resourcesPath = join(appBundlePath, "Contents", "Resources");
+  mkdirSync(join(resourcesPath, "app", "dist"), { recursive: true });
+  mkdirSync(join(resourcesPath, "mcp"), { recursive: true });
+  mkdirSync(join(appBundlePath, "Contents", "MacOS"), { recursive: true });
+  writeFileSync(
+    executablePath,
+    `#!${process.execPath}\nrequire("node:fs").appendFileSync(process.env.TEST_TRACE_PATH, "${marker}\\n");\nconsole.log("[smoke-test] desktop main ready");\n`,
+  );
+  chmodSync(executablePath, 0o755);
+  writeFileSync(join(resourcesPath, "app", "dist", "main.js"), "");
+  writeFileSync(join(resourcesPath, "mcp", "index.mjs"), "");
+}
+
+function runWrapper(
+  wrapper: "run-packaged-app.js" | "smoke-test-packaged-app.js",
+  values: AliasValues,
+  expectedAppName: "Zero Computer Use" | "Zero CU Dev" | "Okou" | "Okou Dev",
+): EntryPointResult {
+  const fixture = createDesktopFixture();
+  for (const appName of [
+    "Zero Computer Use",
+    "Zero CU Dev",
+    "Okou",
+    "Okou Dev",
+  ]) {
+    preparePackagedApp(
+      fixture,
+      appName,
+      appName === expectedAppName ? "selected" : "unexpected",
+    );
+  }
+  const environment = baseEnvironment();
+  environment.TEST_TRACE_PATH = fixture.tracePath;
+  const aliasValues = applyAliases(environment, values);
+  const processResult = spawnSync(
+    process.execPath,
+    [
+      "--require",
+      fixture.platformOverridePath,
+      join(fixture.desktopDirectory, "scripts", wrapper),
+    ],
+    { encoding: "utf8", env: environment },
+  );
+  return {
+    process: processResult,
+    trace: trace(fixture),
+    aliasValues,
+  };
+}
+
+function sourceEvents(result: EntryPointResult): readonly string[] {
+  return result.process.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("desktop_environment_alias_source "));
+}
+
+function expectBoundedSourceEvents(
+  result: EntryPointResult,
+  expectedEvents: readonly string[],
+): void {
+  expect(sourceEvents(result)).toStrictEqual(expectedEvents);
+  for (const event of sourceEvents(result)) {
+    expect(event).toMatch(
+      /^desktop_environment_alias_source key=OKOU_DESKTOP_(?:PLATFORM_URL|PRODUCT) source=(?:canonical-only|legacy-only|dual)$/,
+    );
+  }
+}
+
+function expectNoAliasValueDisclosure(result: EntryPointResult): void {
+  const output = result.process.stdout + result.process.stderr;
+  for (const value of result.aliasValues) {
+    expect(output.includes(value)).toBe(false);
+  }
+  expect(output.includes("length=")).toBe(false);
+}
+
+function expectSuccessfulEntryPoint(
+  result: EntryPointResult,
+  expectedEvents: readonly string[],
+): void {
+  expect(result.process.status, result.process.stderr).toBe(0);
+  expectBoundedSourceEvents(result, expectedEvents);
+  expectNoAliasValueDisclosure(result);
+}
+
+function expectConflict(
+  result: EntryPointResult,
+  key: "OKOU_DESKTOP_PLATFORM_URL" | "OKOU_DESKTOP_PRODUCT",
+): void {
+  expect(result.process.status).toBe(1);
+  expect(result.trace).toBe("");
+  expect(result.process.stderr).toContain(
+    `Desktop environment aliases conflict: key=${key} state=conflict`,
+  );
+  expectNoAliasValueDisclosure(result);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Desktop build configuration entry point", () => {
+  it.each([
+    {
+      name: "canonical-only aliases",
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+      ],
+    },
+    {
+      name: "legacy-only aliases",
+      aliases: {
+        legacyProduct: "okou",
+        legacyPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=legacy-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=legacy-only",
+      ],
+    },
+    {
+      name: "trimmed equal dual aliases",
+      aliases: {
+        canonicalProduct: " okou ",
+        legacyProduct: "okou",
+        canonicalPlatformUrl: " https://app.okou.ai ",
+        legacyPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=dual",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=dual",
+      ],
+    },
+    {
+      name: "canonical product and legacy platform URL",
+      aliases: {
+        canonicalProduct: "okou",
+        legacyPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=legacy-only",
+      ],
+    },
+    {
+      name: "legacy product and canonical platform URL",
+      aliases: {
+        legacyProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=legacy-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+      ],
+    },
+  ])("resolves $name independently", ({ aliases: values, events }) => {
+    const result = runBuildConfig({
+      aliases: values,
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+    });
+
+    expectSuccessfulEntryPoint(result, events);
+  });
+
+  it("keeps environment ahead of the runtime file and the file ahead of defaults", () => {
+    const environmentResult = runBuildConfig({
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      fileConfig: {
+        product: "zero",
+        platformUrl: "https://staging-app.omby.ai",
+      },
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+    });
+    expectSuccessfulEntryPoint(environmentResult, [
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+    ]);
+
+    const fileResult = runBuildConfig({
+      aliases: {
+        canonicalProduct: " ",
+        legacyProduct: "\t",
+        canonicalPlatformUrl: " ",
+        legacyPlatformUrl: "\n",
+      },
+      fileConfig: {
+        product: "okou",
+        platformUrl: "https://staging-app.omby.ai",
+      },
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://staging-app.omby.ai/",
+      expectedDisplayName: "Okou Dev",
+    });
+    expectSuccessfulEntryPoint(fileResult, []);
+  });
+
+  it("keeps non-empty explicit options ahead of conflicting aliases", () => {
+    const result = runBuildConfig({
+      aliases: {
+        canonicalProduct: "zero",
+        legacyProduct: "okou",
+        canonicalPlatformUrl: "https://app.vm0.ai",
+        legacyPlatformUrl: "https://staging-app.omby.ai",
+      },
+      productArgument: " okou ",
+      platformArgument: " https://app.okou.ai ",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+    });
+
+    expectSuccessfulEntryPoint(result, []);
+  });
+
+  it("lets trimmed-empty explicit options fall through to aliases", () => {
+    const result = runBuildConfig({
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      productArgument: " ",
+      platformArgument: "\t",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+    });
+
+    expectSuccessfulEntryPoint(result, [
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+    ]);
+  });
+
+  it.each([
+    {
+      key: "OKOU_DESKTOP_PRODUCT" as const,
+      aliases: { canonicalProduct: "okou", legacyProduct: "zero" },
+    },
+    {
+      key: "OKOU_DESKTOP_PLATFORM_URL" as const,
+      aliases: {
+        canonicalPlatformUrl: `https://${randomUUID()}.example`,
+        legacyPlatformUrl: `https://${randomUUID()}.example`,
+      },
+      productArgument: "okou",
+    },
+  ])("fails closed for unequal $key aliases", (testCase) => {
+    const result = runBuildConfig({
+      ...testCase,
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+    });
+
+    expectConflict(result, testCase.key);
+  });
+});
+
+describe("installed Desktop configuration entry point", () => {
+  it.each([
+    {
+      name: "canonical product and legacy platform URL",
+      aliases: {
+        canonicalProduct: "okou",
+        legacyPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=legacy-only",
+      ],
+    },
+    {
+      name: "legacy product and canonical platform URL",
+      aliases: {
+        legacyProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=legacy-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+      ],
+    },
+    {
+      name: "trimmed equal dual aliases",
+      aliases: {
+        canonicalProduct: " okou ",
+        legacyProduct: "okou",
+        canonicalPlatformUrl: " https://app.okou.ai ",
+        legacyPlatformUrl: "https://app.okou.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=dual",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=dual",
+      ],
+    },
+  ])("resolves $name independently", ({ aliases: values, events }) => {
+    const result = runInstalledConfig({
+      aliases: values,
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+
+    expectSuccessfulEntryPoint(result, events);
+  });
+
+  it("keeps environment ahead of the runtime file and the file ahead of defaults", () => {
+    const environmentResult = runInstalledConfig({
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+      fileConfig: {
+        product: "zero",
+        platformUrl: "https://staging-app.omby.ai",
+      },
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+    expectSuccessfulEntryPoint(environmentResult, [
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+    ]);
+
+    const fileResult = runInstalledConfig({
+      fileConfig: {
+        product: "okou",
+        platformUrl: "https://staging-app.omby.ai",
+      },
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://staging-app.omby.ai/",
+      expectedDisplayName: "Okou Dev",
+      expectedEnvironment: "staging",
+    });
+    expectSuccessfulEntryPoint(fileResult, []);
+  });
+
+  it("keeps non-empty arguments ahead of conflicting aliases", () => {
+    const result = runInstalledConfig({
+      aliases: {
+        canonicalProduct: "zero",
+        legacyProduct: "okou",
+        canonicalPlatformUrl: "https://app.vm0.ai",
+        legacyPlatformUrl: "https://staging-app.omby.ai",
+      },
+      productArgument: " okou ",
+      platformArgument: " https://app.okou.ai ",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+
+    expectSuccessfulEntryPoint(result, []);
+  });
+
+  it("lets a trimmed-empty product argument fall through to aliases", () => {
+    const result = runInstalledConfig({
+      aliases: { canonicalProduct: "okou" },
+      productArgument: " ",
+      platformArgument: "https://app.okou.ai",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+
+    expectSuccessfulEntryPoint(result, [
+      "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+    ]);
+  });
+
+  it("keeps a defined-empty platform argument ahead of aliases and the runtime file", () => {
+    const result = runInstalledConfig({
+      aliases: {
+        canonicalPlatformUrl: `https://${randomUUID()}.example`,
+        legacyPlatformUrl: `https://${randomUUID()}.example`,
+      },
+      fileConfig: {
+        product: "zero",
+        platformUrl: "https://staging-app.omby.ai",
+      },
+      productArgument: "okou",
+      platformArgument: "",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+
+    expectSuccessfulEntryPoint(result, []);
+  });
+
+  it.each([
+    {
+      key: "OKOU_DESKTOP_PRODUCT" as const,
+      aliases: { canonicalProduct: "okou", legacyProduct: "zero" },
+      platformArgument: "https://app.okou.ai",
+    },
+    {
+      key: "OKOU_DESKTOP_PLATFORM_URL" as const,
+      aliases: {
+        canonicalPlatformUrl: `https://${randomUUID()}.example`,
+        legacyPlatformUrl: `https://${randomUUID()}.example`,
+      },
+      productArgument: "okou",
+    },
+  ])("fails closed for unequal $key aliases", (testCase) => {
+    const result = runInstalledConfig({
+      ...testCase,
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
+      expectedEnvironment: "production",
+    });
+
+    expectConflict(result, testCase.key);
+  });
+});
+
+describe("packaged Desktop wrapper entry points", () => {
+  it.each([
+    {
+      wrapper: "run-packaged-app.js" as const,
+      aliases: {
+        canonicalProduct: "okou",
+        legacyPlatformUrl: "https://staging-app.omby.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=canonical-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=legacy-only",
+      ],
+    },
+    {
+      wrapper: "smoke-test-packaged-app.js" as const,
+      aliases: {
+        legacyProduct: "okou",
+        canonicalPlatformUrl: "https://staging-app.omby.ai",
+      },
+      events: [
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PRODUCT source=legacy-only",
+        "desktop_environment_alias_source key=OKOU_DESKTOP_PLATFORM_URL source=canonical-only",
+      ],
+    },
+  ])("delegates independent aliases through $wrapper", (testCase) => {
+    const result = runWrapper(testCase.wrapper, testCase.aliases, "Okou Dev");
+
+    expectSuccessfulEntryPoint(result, testCase.events);
+    expect(result.trace).toBe("selected\n");
+  });
+
+  it.each([
+    {
+      wrapper: "run-packaged-app.js" as const,
+      key: "OKOU_DESKTOP_PRODUCT" as const,
+      aliases: {
+        canonicalProduct: "okou",
+        legacyProduct: "zero",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+    },
+    {
+      wrapper: "run-packaged-app.js" as const,
+      key: "OKOU_DESKTOP_PLATFORM_URL" as const,
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: `https://${randomUUID()}.example`,
+        legacyPlatformUrl: `https://${randomUUID()}.example`,
+      },
+    },
+    {
+      wrapper: "smoke-test-packaged-app.js" as const,
+      key: "OKOU_DESKTOP_PRODUCT" as const,
+      aliases: {
+        canonicalProduct: "okou",
+        legacyProduct: "zero",
+        canonicalPlatformUrl: "https://app.okou.ai",
+      },
+    },
+    {
+      wrapper: "smoke-test-packaged-app.js" as const,
+      key: "OKOU_DESKTOP_PLATFORM_URL" as const,
+      aliases: {
+        canonicalProduct: "okou",
+        canonicalPlatformUrl: `https://${randomUUID()}.example`,
+        legacyPlatformUrl: `https://${randomUUID()}.example`,
+      },
+    },
+  ])("rejects $key conflicts before $wrapper side effects", (testCase) => {
+    const result = runWrapper(testCase.wrapper, testCase.aliases, "Okou");
+
+    expectConflict(result, testCase.key);
+  });
+});


### PR DESCRIPTION
## Summary

- add one shared synchronous per-key reader for the canonical Desktop product and platform URL environment aliases while retaining the legacy aliases
- preserve the distinct build-time and installed-runtime precedence rules, including explicit-argument conflict bypass and the installed-runtime defined-empty platform behavior
- make packaged run and smoke wrappers delegate product and platform resolution to the shared reader
- keep the bootstrap import-graph guard explicit by preserving JavaScript/TypeScript import extensions and tracking the shared resolver in its intentional reachable set
- add real Node entry-point coverage for both configuration surfaces and wrapper delegation without mocking internal resolver or configuration modules

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-environment-alias-entry-points.test.ts` (25 tests)
- `pnpm --filter @okouai/desktop exec vitest run src/bootstrap-imports.test.ts` (1 test)
- `pnpm --filter @okouai/desktop exec vitest run src/window-policy.test.ts` (64 tests)
- `pnpm --filter @okouai/desktop run build:electron` (including the bootstrap bundle guard)
- `./.github/scripts/tests/deploy-desktop-workflow-test.sh`
- `./.github/scripts/tests/okou-desktop-artifact-test.sh`
- `node --check` for each changed or added JavaScript reader/wrapper file
- `git diff --check`

The repository writers and documented-input surfaces named by the issue are byte-for-byte unchanged from the PR base and remain legacy-only: `.github/workflows/desktop.yml`, `.github/workflows/release-please.yml`, `.github/scripts/tests`, `turbo/package.json`, `turbo/turbo.json`, and `turbo/apps/desktop/README.md`. A source scan found zero canonical product/platform alias occurrences in those paths. Their legacy occurrence counts and dispatch-baseline object hashes are unchanged: Desktop workflow 19 (`4e5e5b946f7ffef67231bae950b79aa1503c468a`), release workflow 4 (`921d07cb8421e6e3952c6cf77e1aaa7b8782f33e`), package manifest 2 (`cd60a12fad45c8b480730fa22d2681c72abb659f`), Turbo configuration 1 (`03e75832091cd4e9ebdb82fdad4f5dd530b5e5ef`), Desktop README 9 (`3549d9b1f8c911050e9b9cdb49881f74265d57e4`), and workflow contract tests 6 (aggregate `e35926bb4090c01cd5e0a301424f001b4386d14f956f47d718304912fc4ad377`).

## Fallbacks

- **Readers:** `scripts/desktop-environment-alias.js` provides `resolveDesktopEnvironmentAlias`; `scripts/desktop-build-config.js` and `src/config.ts` consume it independently per key; `scripts/run-packaged-app.js` and `scripts/smoke-test-packaged-app.js` delegate rather than converting legacy environment values into higher-precedence explicit arguments.
- **Writers:** `.github/workflows/desktop.yml`, `.github/workflows/release-please.yml`, `.github/scripts/tests`, `turbo/package.json`, `turbo/turbo.json`, and `turbo/apps/desktop/README.md` remain unchanged and legacy-only in this reader stage.
- **Supported inputs:** each product and platform URL reader independently accepts its canonical alias or its legacy alias. Absent and trimmed-empty environment values are absent; equal trimmed dual definitions are accepted; conflicting dual definitions fail closed. A selected higher-precedence explicit argument continues to bypass environment alias resolution.
- **Source evidence:** each accepted environment lookup emits only `desktop_environment_alias_source`, the canonical key, and one bounded source label (`canonical-only`, `legacy-only`, or `dual`). Conflict diagnostics contain only the canonical key and fixed conflict state. No product values, URLs, hostnames, paths, or lengths are emitted.
- **Rollback:** this PR changes readers only, so it can be reverted without changing any repository writer, documented input, runtime schema, identity, default URL, packaged path, or artifact behavior. The unchanged legacy writers continue to work throughout rollback.
- **Later writer cutover:** a separate focused stage under #28914 may switch repository writers and documentation to canonical aliases only after this dual-reader foundation has landed and source evidence is available. That change is intentionally excluded here.
- **Reader-removal gate:** the dual reader must remain through the rollback window. Legacy-reader removal is a separate later change permitted only after canonical writer identity is proven and bounded production source evidence shows zero legacy use; writer cutover alone is not sufficient.

Closes #29103

Refs #28914