### PR TITLE
refactor(desktop): switch notarization api writer to okou aliases

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -66,10 +66,11 @@ ruby -e '
 
   release_text = File.read(ARGV[1])
   promote_text = release_text.split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
+  dollar = 36.chr
   canonical_credentials = {
-    "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" => "$" + "{{ steps.notary-key.outputs.path }}",
-    "OKOU_DESKTOP_NOTARIZE_API_KEY_ID" => "$" + "{{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
-    "OKOU_DESKTOP_NOTARIZE_API_ISSUER" => "$" + "{{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}",
+    "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" => dollar + "{{ steps.notary-key.outputs.path }}",
+    "OKOU_DESKTOP_NOTARIZE_API_KEY_ID" => dollar + "{{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
+    "OKOU_DESKTOP_NOTARIZE_API_ISSUER" => dollar + "{{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}",
   }
   legacy_credentials = [
     "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
@@ -93,9 +94,9 @@ ruby -e '
   notarize_run = notarize_step.fetch("run")
   raise "Desktop app signing must consume the atomic API credential source" unless notarize_run.include?("sign-and-notarize-packaged-app.mjs")
   canonical_notarytool_arguments = [
-    "--key \"$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH\"",
-    "--key-id \"$OKOU_DESKTOP_NOTARIZE_API_KEY_ID\"",
-    "--issuer \"$OKOU_DESKTOP_NOTARIZE_API_ISSUER\"",
+    "--key \"#{dollar}OKOU_DESKTOP_NOTARIZE_API_KEY_PATH\"",
+    "--key-id \"#{dollar}OKOU_DESKTOP_NOTARIZE_API_KEY_ID\"",
+    "--issuer \"#{dollar}OKOU_DESKTOP_NOTARIZE_API_ISSUER\"",
   ]
   raise "Desktop DMG notarization must consume the canonical API credential triple" unless canonical_notarytool_arguments.all? { |argument| notarize_run.include?(argument) }
   raise "Desktop promotion must not rebuild the app" if promote_text.include?("pnpm -F @okouai/desktop build")

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -64,7 +64,40 @@ ruby -e '
   raise "Desktop promotion must address artifacts by release_target" unless download.include?(ARGV[5])
   raise "Desktop promotion must require the Okou app archive" unless download.include?("--require-okou")
 
-  promote_text = File.read(ARGV[1]).split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
+  release_text = File.read(ARGV[1])
+  promote_text = release_text.split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
+  canonical_credentials = {
+    "OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" => "$" + "{{ steps.notary-key.outputs.path }}",
+    "OKOU_DESKTOP_NOTARIZE_API_KEY_ID" => "$" + "{{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
+    "OKOU_DESKTOP_NOTARIZE_API_ISSUER" => "$" + "{{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}",
+  }
+  legacy_credentials = [
+    "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
+    "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
+    "VM0_DESKTOP_NOTARIZE_API_ISSUER",
+  ]
+  credential_steps = promote.fetch("steps").select do |step|
+    environment = step.fetch("env", {})
+    canonical_credentials.keys.any? { |name| environment.key?(name) }
+  end
+  raise "Desktop promotion must define one atomic API credential source" unless credential_steps.length == 1
+  notarize_step = credential_steps.fetch(0)
+  raise "Desktop promotion must bind the canonical API credential triple together" unless notarize_step.fetch("env") == canonical_credentials
+
+  canonical_occurrences_are_exact = canonical_credentials.keys.all? do |name|
+    release_text.scan(name).length == 2
+  end
+  raise "Desktop release workflow must use each canonical API credential alias exactly twice" unless canonical_occurrences_are_exact
+  raise "Desktop release workflow must not use legacy API credential aliases" if legacy_credentials.any? { |name| release_text.include?(name) }
+
+  notarize_run = notarize_step.fetch("run")
+  raise "Desktop app signing must consume the atomic API credential source" unless notarize_run.include?("sign-and-notarize-packaged-app.mjs")
+  canonical_notarytool_arguments = [
+    "--key \"$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH\"",
+    "--key-id \"$OKOU_DESKTOP_NOTARIZE_API_KEY_ID\"",
+    "--issuer \"$OKOU_DESKTOP_NOTARIZE_API_ISSUER\"",
+  ]
+  raise "Desktop DMG notarization must consume the canonical API credential triple" unless canonical_notarytool_arguments.all? { |argument| notarize_run.include?(argument) }
   raise "Desktop promotion must not rebuild the app" if promote_text.include?("pnpm -F @okouai/desktop build")
   raise "Desktop promotion must sign the downloaded app" unless promote_text.include?("sign-and-notarize-packaged-app.mjs")
   raise "Desktop promotion must select a product signing identity" unless promote_text.include?("--product")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -408,9 +408,9 @@ jobs:
       - name: Sign and notarize macOS artifacts
         id: desktop-artifacts
         env:
-          VM0_DESKTOP_NOTARIZE_API_KEY_PATH: ${{ steps.notary-key.outputs.path }}
-          VM0_DESKTOP_NOTARIZE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          VM0_DESKTOP_NOTARIZE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          OKOU_DESKTOP_NOTARIZE_API_KEY_PATH: ${{ steps.notary-key.outputs.path }}
+          OKOU_DESKTOP_NOTARIZE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          OKOU_DESKTOP_NOTARIZE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           create_product_artifacts() {
             local product="$1"
@@ -439,9 +439,9 @@ jobs:
               "${background_args[@]}"
             codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
             xcrun notarytool submit "$dmg_artifact_path" \
-              --key "$VM0_DESKTOP_NOTARIZE_API_KEY_PATH" \
-              --key-id "$VM0_DESKTOP_NOTARIZE_API_KEY_ID" \
-              --issuer "$VM0_DESKTOP_NOTARIZE_API_ISSUER" \
+              --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
+              --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
+              --issuer "$OKOU_DESKTOP_NOTARIZE_API_ISSUER" \
               --wait
             xcrun stapler staple "$dmg_artifact_path"
           }

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -76,8 +76,8 @@ That build creates `Okou.app` with bundle ID and callback scheme
 Local notarized builds use the `notarytool` Keychain profile
 `vm0-desktop-notary` by default. Set `VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE` to
 override the profile and `VM0_DESKTOP_NOTARIZE_KEYCHAIN` to override the
-Keychain path, or set `VM0_DESKTOP_NOTARIZE_API_KEY_PATH`,
-`VM0_DESKTOP_NOTARIZE_API_KEY_ID`, and `VM0_DESKTOP_NOTARIZE_API_ISSUER` to use
+Keychain path, or set `OKOU_DESKTOP_NOTARIZE_API_KEY_PATH`,
+`OKOU_DESKTOP_NOTARIZE_API_KEY_ID`, and `OKOU_DESKTOP_NOTARIZE_API_ISSUER` to use
 an API key file directly.
 
 The helper source lives under `apps/desktop/native/computer-use-helper`. Build

--- a/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-notarize-api-environment.js
@@ -34,10 +34,12 @@ function resolvedOptions(source, values) {
   );
 }
 
-// The release workflow and documented local-build surface remain legacy-only
-// during reader Stage 1. Remove these aliases only after #28914 atomically
-// cuts the writer and docs over, preserves the rollback window, and records
-// zero legacy-only source evidence.
+// The release workflow and documented local-build surface now use the canonical
+// triple. Keep legacy reads for a unit-revert rollback of that writer/docs
+// change. Remove them only after a signed Desktop release checks out a target
+// containing the canonical writer, records canonical-only source evidence,
+// completes the supported rollback window, and records zero legacy-use evidence
+// under #28914.
 function resolveDesktopNotarizeApiEnvironment() {
   const values = {
     canonical: CREDENTIAL_ALIASES.map((alias) =>


### PR DESCRIPTION
## Summary

- atomically switch the Desktop production notarization writer and both consumer paths to the canonical OKOU credential triple
- update the Desktop documentation and resolver rollout comment while retaining the shared canonical/legacy dual reader
- add focused workflow coverage for canonical identity and counts, an atomic source, zero legacy workflow names, and the unchanged exact release target checkout

## Verification

- replayed the unchanged four-file patch onto repaired main 38fe1374b10ff9a670e70c7cbeb042930de5f1dd; base and merge-base match exactly, and stable patch ID remains 47e8c1bc6e6e8ca71600cfed52ff0823aa8fcec0
- pnpm exec prettier --check apps/desktop
- pnpm --filter @okouai/desktop lint
- pnpm --filter @okouai/desktop run check-types
- pnpm knip --workspace @okouai/desktop
- bash -n .github/scripts/tests/deploy-desktop-workflow-test.sh
- ShellCheck .github/scripts/tests/deploy-desktop-workflow-test.sh
- actionlint .github/workflows/release-please.yml
- bash .github/scripts/tests/deploy-desktop-workflow-test.sh
- pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts src/bootstrap-imports.test.ts src/desktop-environment-alias-entry-points.test.ts
- fully paginated all 24 open PRs immediately before the refreshed push; the two same-workflow changes are confined to the API production job, with zero selected-literal or Desktop semantic overlap outside this PR

## Fallbacks

- the shared resolver retains its canonical/legacy dual reader, fail-fast conflict handling, and value-free source evidence
- the production writer and documented local-build surface now use the canonical aliases, while the promotion job still checks out the exact release target containing the merged reader foundation
- a unit revert of this focused change restores the writer and documentation without changing the retained reader
- reader contraction remains a separate gate after an ordinary signed Desktop release records canonical-only value-free source evidence, the supported rollback window completes, and zero legacy-use evidence is recorded under the parent EPIC

Closes #29104
Refs #28914
