### PR TITLE
test(desktop): support explicit javascript imports in bootstrap graph guard

### DIFF
--- a/turbo/apps/desktop/src/bootstrap-imports.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-imports.test.ts
@@ -20,6 +20,7 @@ const IGNORED_SPECIFIERS = new Set(["./main.js"]);
 
 const IMPORT_PATTERN =
   /(?:^|\n)import\s+(?<type>type\s+)?(?:[^"']*?|[^"']*?\{[^}]*\}[^"']*?)from\s+["'](?<from>[^"']+)["']|await import\(["'](?<dynamic>[^"']+)["']\)/g;
+const SOURCE_EXTENSION_PATTERN = /\.[cm]?[jt]s$/;
 
 function valueImports(sourceFile: string): readonly string[] {
   const source = readFileSync(join(__dirname, sourceFile), "utf8");
@@ -63,7 +64,12 @@ describe("bootstrap import graph", () => {
         if (specifier.endsWith(".json")) {
           continue;
         }
-        queue.push(`${specifier.replace(/^\.\//, "")}.ts`);
+        const sourceSpecifier = specifier.replace(/^\.\//, "");
+        queue.push(
+          SOURCE_EXTENSION_PATTERN.test(sourceSpecifier)
+            ? sourceSpecifier
+            : `${sourceSpecifier}.ts`,
+        );
       }
     }
 
@@ -71,6 +77,7 @@ describe("bootstrap import graph", () => {
     // Keep the reachable set intentional: growing it means growing the code
     // that must never fail to load.
     expect([...visited].sort()).toEqual([
+      "../scripts/desktop-environment-alias.js",
       "bootstrap-degraded.ts",
       "bootstrap.ts",
       "computer-use-types.ts",


### PR DESCRIPTION
## Summary

- preserve explicit `.js`, `.ts`, `.mjs`, `.cjs`, `.mts`, and `.cts` relative source extensions while the bootstrap import-graph guard continues to resolve extensionless imports to `.ts`
- traverse `../scripts/desktop-environment-alias.js` as a real value-import dependency and add it to the exact intentional reachable set
- retain the existing package allowlist, JSON exclusion, runtime `./main.js` exclusion, and all production Desktop behavior unchanged

## Verification

- `pnpm exec prettier --write apps/desktop/src/bootstrap-imports.test.ts`
- `pnpm --filter @okouai/desktop exec vitest run src/bootstrap-imports.test.ts` (1 test)
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-environment-alias-entry-points.test.ts` (25 tests)
- `pnpm --filter @okouai/desktop run build:electron` (including the real bootstrap bundle guard)
- `pnpm --filter @okouai/desktop lint`
- `pnpm --filter @okouai/desktop check-types`
- `pnpm knip --workspace apps/desktop`
- `git diff --check`

The patch contains one changed source-test file on `main@7dec03fddb922deb901cede8703dde5e7c9e450e`. Production configuration, the shared environment-alias resolver, wrappers, workflows, writers, package scripts, Turbo configuration, and documentation are byte-for-byte unchanged. A fully paginated audit of all 22 open PRs before push found zero target-file, selected-literal, or semantic overlap.

## Fallbacks

- None. This patch changes only source-test traversal for explicit JavaScript and TypeScript module extensions; it does not add, change, or remove a production fallback or deployment phase. The independent product/platform dual-reader compatibility introduced by #29105 remains unchanged and retains the writer-cutover, rollback, source-evidence, and separate reader-removal gates under #28914.

Closes #29107

Refs #29103

Refs #28914
