### PR TITLE
feat(auth): add v2 google sign-up

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,4 +1,4 @@
-import type { PasswordValidation } from "@clerk/react/types";
+import type { ClerkAPIError, PasswordValidation } from "@clerk/react/types";
 import { vi } from "vitest";
 import { replaceState } from "../signals/location.ts";
 
@@ -81,6 +81,8 @@ export interface MockedSignInResourceState {
 export interface MockedSignUpResourceState {
   readonly createdSessionId?: string | null;
   readonly emailAddress?: string | null;
+  readonly externalAccountError?: ClerkAPIError | null;
+  readonly externalAccountStatus?: string | null;
   readonly emailVerificationExpireAt?: Date | null;
   readonly emailVerificationStatus?: string | null;
   readonly emailVerificationStrategy?: string | null;
@@ -152,6 +154,8 @@ let internalMockedSignInResourceState: Required<MockedSignInResourceState> = {
 let internalMockedSignUpResourceState: Required<MockedSignUpResourceState> = {
   createdSessionId: null,
   emailAddress: null,
+  externalAccountError: null,
+  externalAccountStatus: null,
   emailVerificationExpireAt: null,
   emailVerificationStatus: null,
   emailVerificationStrategy: null,
@@ -190,6 +194,8 @@ export function mockSignUpResource(state: MockedSignUpResourceState): void {
   internalMockedSignUpResourceState = {
     createdSessionId: state.createdSessionId ?? null,
     emailAddress: state.emailAddress ?? null,
+    externalAccountError: state.externalAccountError ?? null,
+    externalAccountStatus: state.externalAccountStatus ?? null,
     emailVerificationExpireAt: state.emailVerificationExpireAt ?? null,
     emailVerificationStatus: state.emailVerificationStatus ?? null,
     emailVerificationStrategy: state.emailVerificationStrategy ?? null,
@@ -485,6 +491,14 @@ function clearMockedAuth() {
   mockedClerk.signUpFutureReset.mockImplementation(
     defaultSignUpFutureResetImpl,
   );
+  mockedClerk.signUpReload.mockReset();
+  mockedClerk.signUpReload.mockImplementation(
+    defaultSignUpResourceOperationImpl,
+  );
+  mockedClerk.signUpAuthenticateWithRedirect.mockReset();
+  mockedClerk.signUpAuthenticateWithRedirect.mockImplementation(
+    defaultSignUpAuthenticateWithRedirectImpl,
+  );
   mockedClerk.signInAuthenticateWithPasskey.mockReset();
   mockedClerk.signInAuthenticateWithPasskey.mockImplementation(
     defaultSignInResourceOperationImpl,
@@ -537,6 +551,7 @@ interface MockedSignInCreateParams {
   readonly strategy?: string;
   readonly ticket?: string;
   readonly token?: string;
+  readonly transfer?: boolean;
 }
 
 function defaultClientSignInCreateImpl(params: MockedSignInCreateParams) {
@@ -594,6 +609,8 @@ interface MockedHandleRedirectCallbackParams {
   readonly signInFallbackRedirectUrl?: string | null;
   readonly signInForceRedirectUrl?: string | null;
   readonly signInUrl?: string;
+  readonly signUpFallbackRedirectUrl?: string | null;
+  readonly signUpForceRedirectUrl?: string | null;
   readonly signUpUrl?: string;
   readonly transferable?: boolean;
   readonly verifyEmailAddressUrl?: string | null;
@@ -661,6 +678,9 @@ const signUpPrepareEmailAddressVerification = vi.fn<
 const signUpAttemptEmailAddressVerification = vi.fn<
   typeof defaultSignUpResourceOperationImpl
 >(defaultSignUpResourceOperationImpl);
+const signUpReload = vi.fn<typeof defaultSignUpResourceOperationImpl>(
+  defaultSignUpResourceOperationImpl,
+);
 
 interface MockedPasswordValidationCallbacks {
   readonly onValidation?: (validation: PasswordValidation) => void;
@@ -686,7 +706,27 @@ const signUpFutureReset = vi.fn<typeof defaultSignUpFutureResetImpl>(
   defaultSignUpFutureResetImpl,
 );
 
+interface MockedSignUpAuthenticateWithRedirectParams {
+  readonly continueSignIn?: boolean;
+  readonly continueSignUp?: boolean;
+  readonly legalAccepted?: boolean;
+  readonly redirectUrl: string;
+  readonly redirectUrlComplete: string;
+  readonly strategy: string;
+}
+
+function defaultSignUpAuthenticateWithRedirectImpl(
+  _params: MockedSignUpAuthenticateWithRedirectParams,
+) {
+  return Promise.resolve();
+}
+
+const signUpAuthenticateWithRedirect = vi.fn<
+  typeof defaultSignUpAuthenticateWithRedirectImpl
+>(defaultSignUpAuthenticateWithRedirectImpl);
+
 const mockedClientSignUp = {
+  reload: signUpReload,
   get status() {
     return internalMockedSignUpResourceState.status;
   },
@@ -724,6 +764,7 @@ const mockedClientSignUp = {
   update: signUpUpdate,
   prepareEmailAddressVerification: signUpPrepareEmailAddressVerification,
   attemptEmailAddressVerification: signUpAttemptEmailAddressVerification,
+  authenticateWithRedirect: signUpAuthenticateWithRedirect,
   validatePassword: signUpValidatePassword,
   verifications: {
     emailAddress: {
@@ -735,6 +776,14 @@ const mockedClientSignUp = {
       },
       get expireAt() {
         return internalMockedSignUpResourceState.emailVerificationExpireAt;
+      },
+    },
+    externalAccount: {
+      get error() {
+        return internalMockedSignUpResourceState.externalAccountError;
+      },
+      get status() {
+        return internalMockedSignUpResourceState.externalAccountStatus;
       },
     },
   },
@@ -873,6 +922,8 @@ export const mockedClerk = {
   signUpAttemptEmailAddressVerification,
   signUpValidatePassword,
   signUpFutureReset,
+  signUpReload,
+  signUpAuthenticateWithRedirect,
   client: {
     get sessions() {
       return internalMockedClientSessions;

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -73,6 +73,7 @@ export type MockedSignInFactor =
 
 export interface MockedSignInResourceState {
   readonly createdSessionId?: string | null;
+  readonly identifier?: string | null;
   readonly isTransferable?: boolean;
   readonly status: string | null;
   readonly supportedFirstFactors?: readonly MockedSignInFactor[] | null;
@@ -147,6 +148,7 @@ let internalMockedClerkSessionTransitioning = false;
 let internalMockedClerkSessionSignedOut = false;
 let internalMockedSignInResourceState: Required<MockedSignInResourceState> = {
   createdSessionId: null,
+  identifier: null,
   isTransferable: false,
   status: "needs_identifier",
   supportedFirstFactors: null,
@@ -184,6 +186,7 @@ let internalMockedPasswordValidation: PasswordValidation = {
 export function mockSignInResource(state: MockedSignInResourceState): void {
   internalMockedSignInResourceState = {
     createdSessionId: state.createdSessionId ?? null,
+    identifier: state.identifier ?? null,
     isTransferable: state.isTransferable ?? false,
     status: state.status,
     supportedFirstFactors: state.supportedFirstFactors ?? null,
@@ -639,6 +642,9 @@ const signInFutureReset = vi.fn<typeof defaultSignInFutureResetImpl>(
 );
 
 const mockedClientSignIn = {
+  get identifier() {
+    return internalMockedSignInResourceState.identifier;
+  },
   get status() {
     return internalMockedSignInResourceState.status;
   },

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -16,6 +16,7 @@ import {
   createAuthV2SignUpSignals,
   type AuthV2SignUpSignals,
 } from "./auth-v2/sign-up-flow.ts";
+import { AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH } from "./auth-v2/sign-up-external-strategies.ts";
 import { updateDocumentTitle$ } from "./document-title.ts";
 import { updatePage$ } from "./react-router.ts";
 import { ROUTES } from "./route-paths.ts";
@@ -43,6 +44,10 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
       );
     } else {
       signUpSignals = createAuthV2SignUpSignals({
+        isOAuthCallbackRoute:
+          location.pathname ===
+          `${ROUTES.signUpV2}${AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH}`,
+        navigation: platformContext.navigation,
         resolveRedirectUrl: () => {
           return platformContext.navigation.completionRedirectUrl;
         },

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.test.ts
@@ -130,6 +130,7 @@ describe("Auth v2 sign-up external strategy transfer", () => {
 
   it("transfers an existing identity once and reuses its state after callback reload", async () => {
     mockSignUpResource({
+      emailAddress: "person@example.com",
       externalAccountError: {
         code: "external_account_exists",
         message: "Account already exists",
@@ -141,6 +142,7 @@ describe("Auth v2 sign-up external strategy transfer", () => {
     mockedClerk.clientSignInCreate.mockImplementation(() => {
       mockSignInResource({
         createdSessionId: "session_existing_identity",
+        identifier: "person@example.com",
         status: "complete",
       });
       return Promise.resolve(mockedClerk.client.signIn);
@@ -167,6 +169,7 @@ describe("Auth v2 sign-up external strategy transfer", () => {
 describe("Auth v2 sign-up external strategy recovery", () => {
   it("returns incomplete transfer and callback error states to the flow", async () => {
     mockSignUpResource({
+      emailAddress: "person@example.com",
       externalAccountError: {
         code: "external_account_exists",
         message: "Account already exists",
@@ -177,6 +180,7 @@ describe("Auth v2 sign-up external strategy recovery", () => {
     });
     mockedClerk.clientSignInCreate.mockImplementation(() => {
       mockSignInResource({
+        identifier: "person@example.com",
         status: "needs_first_factor",
         supportedFirstFactors: [{ strategy: "password" }],
       });

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.test.ts
@@ -1,0 +1,206 @@
+import type { Clerk } from "@clerk/clerk-js";
+import type { SignUpResource } from "@clerk/react/types";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearMockedAuthOnAbort,
+  mockAuthV2Capabilities,
+  mockedClerk,
+  mockSignInResource,
+  mockSignUpResource,
+} from "../../__tests__/mock-auth.ts";
+import { testContext } from "../__tests__/test-helpers.ts";
+import { resolveAuthV2PlatformContext } from "./platform-context.ts";
+import {
+  discoverAuthV2SignUpExternalCapabilities,
+  recoverAuthV2GoogleSignUp,
+  resolveAuthV2SignUpTransferState,
+  startAuthV2GoogleSignUp,
+} from "./sign-up-external-strategies.ts";
+
+const context = testContext();
+
+function clerk(): Clerk {
+  return mockedClerk as unknown as Clerk;
+}
+
+function signUpResource(): SignUpResource {
+  return mockedClerk.client.signUp as unknown as SignUpResource;
+}
+
+beforeEach(() => {
+  clearMockedAuthOnAbort(context.signal);
+});
+
+describe("Auth v2 sign-up external strategy handoff", () => {
+  it("discovers Google from the current Clerk environment and resource", () => {
+    mockAuthV2Capabilities({ googleOAuth: false });
+    expect(
+      discoverAuthV2SignUpExternalCapabilities(clerk(), signUpResource()),
+    ).toStrictEqual({ googleOAuth: false });
+
+    mockAuthV2Capabilities({ googleOAuth: true });
+    expect(
+      discoverAuthV2SignUpExternalCapabilities(clerk(), signUpResource()),
+    ).toStrictEqual({ googleOAuth: true });
+    expect(
+      discoverAuthV2SignUpExternalCapabilities(
+        clerk(),
+        {} as unknown as SignUpResource,
+      ),
+    ).toStrictEqual({ googleOAuth: false });
+  });
+
+  it("hands Google sign-up to Clerk with the dedicated callback and attributed completion", async () => {
+    context.mocks.browser.url(
+      "https://app.vm0.ai/v2/sign-up?gclid=click-123&utm_campaign=summer#/start?step=oauth",
+    );
+    const { navigation } = resolveAuthV2PlatformContext("sign-up");
+
+    await startAuthV2GoogleSignUp(signUpResource(), navigation, false);
+
+    expect(mockedClerk.signUpAuthenticateWithRedirect).toHaveBeenCalledTimes(1);
+    const params =
+      mockedClerk.signUpAuthenticateWithRedirect.mock.calls[0]?.[0];
+    expect(params).toMatchObject({
+      continueSignIn: false,
+      continueSignUp: false,
+      redirectUrlComplete: navigation.completionRedirectUrl,
+      strategy: "oauth_google",
+    });
+    expect(params).not.toHaveProperty("legalAccepted");
+    const callbackUrl = new URL(params?.redirectUrl ?? "", location.origin);
+    expect(callbackUrl.pathname).toBe("/v2/sign-up/sso-callback");
+    expect(callbackUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(callbackUrl.searchParams.get("utm_campaign")).toBe("summer");
+    expect(callbackUrl.hash).toBe("#/start?step=oauth");
+    const completionUrl = new URL(params?.redirectUrlComplete ?? "");
+    expect(completionUrl.pathname).toBe("/onboarding");
+    expect(completionUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(completionUrl.searchParams.get("utm_campaign")).toBe("summer");
+  });
+});
+
+describe("Auth v2 sign-up external strategy transfer", () => {
+  it("maps transferred sign-in states without activating or navigating", () => {
+    expect(
+      resolveAuthV2SignUpTransferState({
+        createdSessionId: "session_transfer",
+        status: "complete",
+      }),
+    ).toStrictEqual({
+      sessionId: "session_transfer",
+      status: "complete",
+    });
+    expect(
+      resolveAuthV2SignUpTransferState({
+        createdSessionId: null,
+        status: "needs_first_factor",
+      }),
+    ).toStrictEqual({ status: "sign-in", stepPath: "/factor-one" });
+    expect(
+      resolveAuthV2SignUpTransferState({
+        createdSessionId: null,
+        status: "needs_second_factor",
+      }),
+    ).toStrictEqual({ status: "sign-in", stepPath: "/factor-two" });
+    expect(
+      resolveAuthV2SignUpTransferState({
+        createdSessionId: null,
+        status: "needs_new_password",
+      }),
+    ).toStrictEqual({ status: "sign-in", stepPath: "/reset-password" });
+  });
+
+  it("reloads a completed Google sign-up without taking activation ownership", async () => {
+    mockSignUpResource({
+      createdSessionId: "session_google_sign_up",
+      externalAccountStatus: "verified",
+      status: "complete",
+    });
+
+    const recovery = await recoverAuthV2GoogleSignUp(clerk());
+
+    expect(recovery.status).toBe("sign-up");
+    expect(mockedClerk.signUpReload).toHaveBeenCalledTimes(1);
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+    expect(mockedClerk.handleRedirectCallback).not.toHaveBeenCalled();
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+  });
+
+  it("transfers an existing identity once and reuses its state after callback reload", async () => {
+    mockSignUpResource({
+      externalAccountError: {
+        code: "external_account_exists",
+        message: "Account already exists",
+      },
+      externalAccountStatus: "transferable",
+      isTransferable: true,
+      status: "missing_requirements",
+    });
+    mockedClerk.clientSignInCreate.mockImplementation(() => {
+      mockSignInResource({
+        createdSessionId: "session_existing_identity",
+        status: "complete",
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+
+    await expect(recoverAuthV2GoogleSignUp(clerk())).resolves.toMatchObject({
+      sessionId: "session_existing_identity",
+      status: "complete",
+    });
+    await expect(recoverAuthV2GoogleSignUp(clerk())).resolves.toMatchObject({
+      sessionId: "session_existing_identity",
+      status: "complete",
+    });
+
+    expect(mockedClerk.clientSignInCreate).toHaveBeenCalledTimes(1);
+    expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+      transfer: true,
+    });
+    expect(mockedClerk.signUpReload).toHaveBeenCalledTimes(2);
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+  });
+});
+
+describe("Auth v2 sign-up external strategy recovery", () => {
+  it("returns incomplete transfer and callback error states to the flow", async () => {
+    mockSignUpResource({
+      externalAccountError: {
+        code: "external_account_exists",
+        message: "Account already exists",
+      },
+      externalAccountStatus: "transferable",
+      isTransferable: true,
+      status: "missing_requirements",
+    });
+    mockedClerk.clientSignInCreate.mockImplementation(() => {
+      mockSignInResource({
+        status: "needs_first_factor",
+        supportedFirstFactors: [{ strategy: "password" }],
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+
+    await expect(recoverAuthV2GoogleSignUp(clerk())).resolves.toMatchObject({
+      status: "sign-in",
+      stepPath: "/factor-one",
+    });
+
+    mockSignInResource({ status: "needs_identifier" });
+    mockSignUpResource({
+      externalAccountError: {
+        code: "oauth_callback_error",
+        longMessage: "Google sign-up was cancelled.",
+        message: "OAuth callback failed",
+      },
+      externalAccountStatus: "failed",
+      status: null,
+    });
+    await expect(recoverAuthV2GoogleSignUp(clerk())).resolves.toMatchObject({
+      error: { code: "oauth_callback_error" },
+      status: "error",
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.ts
@@ -71,8 +71,22 @@ export function resolveAuthV2SignUpTransferState(
   };
 }
 
-function hasTransferProgress(resource: SignInResource): boolean {
-  return resource.status !== null && resource.status !== "needs_identifier";
+function normalizeEmailIdentifier(identifier: string | null): string | null {
+  const normalized = identifier?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function hasMatchingTransferProgress(
+  signUp: SignUpResource,
+  signIn: SignInResource,
+): boolean {
+  const signUpIdentifier = normalizeEmailIdentifier(signUp.emailAddress);
+  return (
+    signIn.status !== null &&
+    signIn.status !== "needs_identifier" &&
+    signUpIdentifier !== null &&
+    normalizeEmailIdentifier(signIn.identifier) === signUpIdentifier
+  );
 }
 
 export function discoverAuthV2SignUpExternalCapabilities(
@@ -119,7 +133,7 @@ export async function recoverAuthV2GoogleSignUp(
     externalAccount.status === "transferable" &&
     externalAccount.error?.code === "external_account_exists"
   ) {
-    const signIn = hasTransferProgress(client.signIn)
+    const signIn = hasMatchingTransferProgress(signUp, client.signIn)
       ? client.signIn
       : await client.signIn.create({ transfer: true });
     const transfer = resolveAuthV2SignUpTransferState(signIn);

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-external-strategies.ts
@@ -1,0 +1,159 @@
+import type { Clerk } from "@clerk/clerk-js";
+import type {
+  ClerkAPIError,
+  SignInResource,
+  SignUpResource,
+} from "@clerk/react/types";
+
+import type { AuthV2Navigation, AuthV2StepPath } from "./navigation.ts";
+
+const GOOGLE_OAUTH_STRATEGY = "oauth_google" as const;
+
+export const AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH = "/sso-callback";
+
+export interface AuthV2SignUpExternalCapabilities {
+  readonly googleOAuth: boolean;
+}
+
+export type AuthV2SignUpTransferState =
+  | { readonly sessionId: string; readonly status: "complete" }
+  | {
+      readonly status: "sign-in";
+      readonly stepPath: AuthV2StepPath | null;
+    };
+
+export type AuthV2SignUpOAuthRecovery =
+  | {
+      readonly resource: SignUpResource;
+      readonly status: "sign-up";
+    }
+  | {
+      readonly resource: SignUpResource;
+      readonly sessionId: string;
+      readonly status: "complete";
+    }
+  | {
+      readonly resource: SignInResource;
+      readonly signUpResource: SignUpResource;
+      readonly status: "sign-in";
+      readonly stepPath: AuthV2StepPath | null;
+    }
+  | {
+      readonly error: ClerkAPIError;
+      readonly resource: SignUpResource;
+      readonly status: "error";
+    };
+
+function transferSignInStepPath(
+  status: SignInResource["status"],
+): AuthV2StepPath | null {
+  if (status === "needs_first_factor") {
+    return "/factor-one";
+  }
+  if (status === "needs_new_password") {
+    return "/reset-password";
+  }
+  return status === "needs_second_factor" ? "/factor-two" : null;
+}
+
+export function resolveAuthV2SignUpTransferState(
+  resource: Pick<SignInResource, "createdSessionId" | "status">,
+): AuthV2SignUpTransferState {
+  if (resource.status === "complete" && resource.createdSessionId) {
+    return {
+      sessionId: resource.createdSessionId,
+      status: "complete",
+    };
+  }
+  return {
+    status: "sign-in",
+    stepPath: transferSignInStepPath(resource.status),
+  };
+}
+
+function hasTransferProgress(resource: SignInResource): boolean {
+  return resource.status !== null && resource.status !== "needs_identifier";
+}
+
+export function discoverAuthV2SignUpExternalCapabilities(
+  clerk: Clerk,
+  resource: SignUpResource,
+): AuthV2SignUpExternalCapabilities {
+  const strategies =
+    clerk.__internal_environment?.userSettings.authenticatableSocialStrategies;
+  return {
+    googleOAuth:
+      strategies?.includes(GOOGLE_OAUTH_STRATEGY) === true &&
+      typeof resource.authenticateWithRedirect === "function",
+  };
+}
+
+export function startAuthV2GoogleSignUp(
+  resource: SignUpResource,
+  navigation: AuthV2Navigation,
+  legalAccepted: boolean,
+): Promise<void> {
+  return resource.authenticateWithRedirect({
+    continueSignIn: false,
+    continueSignUp: false,
+    ...(legalAccepted ? { legalAccepted: true } : {}),
+    redirectUrl: navigation.href(
+      "sign-up",
+      AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH,
+    ),
+    redirectUrlComplete: navigation.completionRedirectUrl,
+    strategy: GOOGLE_OAUTH_STRATEGY,
+  });
+}
+
+export async function recoverAuthV2GoogleSignUp(
+  clerk: Clerk,
+): Promise<AuthV2SignUpOAuthRecovery> {
+  const client = clerk.client;
+  if (!client) {
+    throw new Error("Loaded Clerk instance did not provide a client resource");
+  }
+  const signUp = await client.signUp.reload();
+  const externalAccount = signUp.verifications.externalAccount;
+  if (
+    externalAccount.status === "transferable" &&
+    externalAccount.error?.code === "external_account_exists"
+  ) {
+    const signIn = hasTransferProgress(client.signIn)
+      ? client.signIn
+      : await client.signIn.create({ transfer: true });
+    const transfer = resolveAuthV2SignUpTransferState(signIn);
+    return transfer.status === "complete"
+      ? {
+          resource: signUp,
+          sessionId: transfer.sessionId,
+          status: "complete",
+        }
+      : {
+          resource: signIn,
+          signUpResource: signUp,
+          status: "sign-in",
+          stepPath: transfer.stepPath,
+        };
+  }
+
+  const existingSessionId =
+    externalAccount.error?.code === "identifier_already_signed_in"
+      ? externalAccount.error.meta?.sessionId
+      : null;
+  if (existingSessionId) {
+    return {
+      resource: signUp,
+      sessionId: existingSessionId,
+      status: "complete",
+    };
+  }
+  if (externalAccount.error) {
+    return {
+      error: externalAccount.error,
+      resource: signUp,
+      status: "error",
+    };
+  }
+  return { resource: signUp, status: "sign-up" };
+}

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -19,6 +19,12 @@ import { clerk$ } from "../auth.ts";
 import { locale$ } from "../locale.ts";
 import { logger } from "../log.ts";
 import { createDeferredPromise, onRef, settle, withCleanup } from "../utils.ts";
+import type { AuthV2Navigation } from "./navigation.ts";
+import {
+  discoverAuthV2SignUpExternalCapabilities,
+  recoverAuthV2GoogleSignUp,
+  startAuthV2GoogleSignUp,
+} from "./sign-up-external-strategies.ts";
 
 const L = logger("AuthV2SignUp");
 
@@ -111,6 +117,8 @@ export interface AuthV2SignUpError {
 }
 
 export interface AuthV2SignUpFlowDependencies {
+  readonly isOAuthCallbackRoute: boolean;
+  readonly navigation: AuthV2Navigation;
   readonly resolveRedirectUrl: () => string;
 }
 
@@ -122,6 +130,7 @@ export interface AuthV2SignUpSignals {
   readonly emailAddress$: Computed<string>;
   readonly error$: Computed<AuthV2SignUpError | null>;
   readonly firstName$: Computed<string>;
+  readonly googleOAuthAvailable$: Computed<boolean>;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
   readonly lastName$: Computed<string>;
   readonly legalAccepted$: Computed<boolean>;
@@ -136,6 +145,7 @@ export interface AuthV2SignUpSignals {
   readonly setLegalAccepted$: Command<void, [boolean]>;
   readonly setPassword$: Command<void, [string]>;
   readonly state$: Computed<AuthV2SignUpState>;
+  readonly startGoogleOAuth$: Command<Promise<void>, [AbortSignal]>;
   readonly submit$: Command<Promise<void>, [AbortSignal]>;
 }
 
@@ -179,6 +189,7 @@ interface SignUpFlowAtoms {
   readonly error$: State<AuthV2SignUpError | null>;
   readonly fatalState$: State<AuthV2SignUpUnknownState | null>;
   readonly firstName$: State<string>;
+  readonly googleOAuthAvailable$: State<boolean>;
   readonly lastName$: State<string>;
   readonly legalAccepted$: State<boolean>;
   readonly password$: State<string>;
@@ -205,6 +216,21 @@ type ApplySignUpResourceCommand = Command<
   Promise<void>,
   [SignUpResource, AbortSignal]
 >;
+type CompleteSignUpSessionCommand = Command<
+  Promise<void>,
+  [string, string | null, AbortSignal]
+>;
+type PrepareEmailVerificationCommand = Command<
+  Promise<void>,
+  [SignUpResource, boolean, AbortSignal]
+>;
+
+interface SignUpResourceCommands {
+  readonly applyResource$: ApplySignUpResourceCommand;
+  readonly completeSession$: CompleteSignUpSessionCommand;
+  readonly initialize$: Command<Promise<void>, [AbortSignal]>;
+  readonly prepareEmailVerification$: PrepareEmailVerificationCommand;
+}
 
 function fieldRequirement(
   field: SupportedSignUpField,
@@ -505,6 +531,7 @@ function createSignUpFlowAtoms(): SignUpFlowAtoms {
   const emailAddress$ = state("");
   const password$ = state("");
   const firstName$ = state("");
+  const googleOAuthAvailable$ = state(false);
   const lastName$ = state("");
   const legalAccepted$ = state(false);
   const code$ = state("");
@@ -529,6 +556,7 @@ function createSignUpFlowAtoms(): SignUpFlowAtoms {
     error$,
     fatalState$,
     firstName$,
+    googleOAuthAvailable$,
     lastName$,
     legalAccepted$,
     password$,
@@ -716,21 +744,121 @@ function createActivateSessionCommand(
   );
 }
 
+function createCompleteSessionCommand(
+  atoms: SignUpFlowAtoms,
+  runtime: SignUpFlowRuntime,
+  dependencies: AuthV2SignUpFlowDependencies,
+): CompleteSignUpSessionCommand {
+  const activateSession$ = createActivateSessionCommand(runtime, dependencies);
+  return command(
+    async (
+      { set },
+      sessionId: string,
+      clerkStatus: string | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const activation = await settle(
+        set(activateSession$, sessionId, signal),
+        signal,
+      );
+      if (!activation.ok) {
+        L.error("Auth v2 sign-up activation failed", clerkStatus);
+        set(atoms.fatalState$, {
+          clerkStatus,
+          reason: "activation-failed",
+          status: "unknown",
+        });
+      }
+    },
+  );
+}
+
+function createInitializeCommand(
+  atoms: SignUpFlowAtoms,
+  dependencies: AuthV2SignUpFlowDependencies,
+  applyResource$: ApplySignUpResourceCommand,
+  completeSession$: CompleteSignUpSessionCommand,
+  prepareEmailVerification$: PrepareEmailVerificationCommand,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    if (!clerk.client) {
+      throw new Error(
+        "Loaded Clerk instance did not provide a client resource",
+      );
+    }
+    let resource = clerk.client.signUp;
+    let recoveredSessionId: string | null = null;
+    if (dependencies.isOAuthCallbackRoute) {
+      set(atoms.error$, null);
+      const recovery = await settle(recoverAuthV2GoogleSignUp(clerk), signal);
+      if (recovery.ok) {
+        if (recovery.value.status === "sign-in") {
+          window.location.assign(
+            dependencies.navigation.href(
+              "sign-in",
+              recovery.value.stepPath ?? undefined,
+            ),
+          );
+          return;
+        }
+        resource = recovery.value.resource;
+        if (recovery.value.status === "complete") {
+          recoveredSessionId = recovery.value.sessionId;
+        } else if (recovery.value.status === "error") {
+          const error = normalizeClerkError(
+            { errors: [recovery.value.error] },
+            "general",
+          );
+          L.warn(
+            "Auth v2 Google sign-up callback returned an error",
+            error.clerkCode ?? error.code,
+          );
+          set(atoms.error$, error);
+        }
+      } else {
+        const error = normalizeClerkError(recovery.error, "general");
+        L.warn(
+          "Auth v2 Google sign-up callback recovery failed",
+          error.clerkCode ?? error.code,
+        );
+        set(atoms.error$, error);
+        resource = clerk.client.signUp;
+      }
+    }
+    set(
+      atoms.googleOAuthAvailable$,
+      discoverAuthV2SignUpExternalCapabilities(clerk, resource).googleOAuth,
+    );
+    set(atoms.emailAddress$, resource.emailAddress ?? "");
+    set(atoms.firstName$, resource.firstName ?? "");
+    set(atoms.lastName$, resource.lastName ?? "");
+    set(atoms.legalAccepted$, resource.legalAcceptedAt !== null);
+    if (recoveredSessionId) {
+      await set(completeSession$, recoveredSessionId, "complete", signal);
+      signal.throwIfAborted();
+      return;
+    }
+    await set(applyResource$, resource, signal);
+    signal.throwIfAborted();
+    await set(prepareEmailVerification$, resource, true, signal);
+    signal.throwIfAborted();
+  });
+}
+
 function createResourceCommands(
   atoms: SignUpFlowAtoms,
   runtime: SignUpFlowRuntime,
   dependencies: AuthV2SignUpFlowDependencies,
-): {
-  readonly applyResource$: ApplySignUpResourceCommand;
-  readonly initialize$: Command<Promise<void>, [AbortSignal]>;
-  readonly prepareEmailVerification$: Command<
-    Promise<void>,
-    [SignUpResource, boolean, AbortSignal]
-  >;
-} {
+): SignUpResourceCommands {
   const scheduleExpiry$ = createScheduleExpiryCommand(atoms, runtime);
   const startCooldown$ = createStartCooldownCommand(atoms, runtime);
-  const activateSession$ = createActivateSessionCommand(runtime, dependencies);
+  const completeSession$ = createCompleteSessionCommand(
+    atoms,
+    runtime,
+    dependencies,
+  );
 
   const applyResource$ = command(
     async (
@@ -751,18 +879,13 @@ function createResourceCommands(
       ) {
         return;
       }
-      const activation = await settle(
-        set(activateSession$, snapshot.createdSessionId, signal),
+      await set(
+        completeSession$,
+        snapshot.createdSessionId,
+        snapshot.clerkStatus,
         signal,
       );
-      if (!activation.ok) {
-        L.error("Auth v2 sign-up activation failed", snapshot.clerkStatus);
-        set(atoms.fatalState$, {
-          clerkStatus: snapshot.clerkStatus,
-          reason: "activation-failed",
-          status: "unknown",
-        });
-      }
+      signal.throwIfAborted();
     },
   );
 
@@ -814,22 +937,20 @@ function createResourceCommands(
     },
   );
 
-  const initialize$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      const resource = await get(clerkSignUpResource$);
-      signal.throwIfAborted();
-      set(atoms.emailAddress$, resource.emailAddress ?? "");
-      set(atoms.firstName$, resource.firstName ?? "");
-      set(atoms.lastName$, resource.lastName ?? "");
-      set(atoms.legalAccepted$, resource.legalAcceptedAt !== null);
-      await set(applyResource$, resource, signal);
-      signal.throwIfAborted();
-      await set(prepareEmailVerification$, resource, true, signal);
-      signal.throwIfAborted();
-    },
+  const initialize$ = createInitializeCommand(
+    atoms,
+    dependencies,
+    applyResource$,
+    completeSession$,
+    prepareEmailVerification$,
   );
 
-  return { applyResource$, initialize$, prepareEmailVerification$ };
+  return {
+    applyResource$,
+    completeSession$,
+    initialize$,
+    prepareEmailVerification$,
+  };
 }
 
 function createCoalescedOperation(
@@ -851,6 +972,60 @@ function createCoalescedOperation(
       });
     });
     signal.throwIfAborted();
+  });
+}
+
+function createGoogleOAuthOperation(
+  atoms: SignUpFlowAtoms,
+  dependencies: AuthV2SignUpFlowDependencies,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    if (!clerk.client) {
+      throw new Error(
+        "Loaded Clerk instance did not provide a client resource",
+      );
+    }
+    const resource = clerk.client.signUp;
+    const capabilities = discoverAuthV2SignUpExternalCapabilities(
+      clerk,
+      resource,
+    );
+    set(atoms.googleOAuthAvailable$, capabilities.googleOAuth);
+    if (!capabilities.googleOAuth) {
+      set(atoms.error$, { code: "unknown", field: "general" });
+      return;
+    }
+
+    const flowState = get(atoms.state$);
+    const snapshot = get(atoms.snapshot$);
+    if (
+      !snapshot ||
+      flowState.status !== "incomplete" ||
+      flowState.step !== "details"
+    ) {
+      return;
+    }
+    const legalAccepted = get(atoms.legalAccepted$);
+    if (snapshot.legal.required && !legalAccepted) {
+      set(atoms.error$, { code: "legal-required", field: "legal" });
+      return;
+    }
+
+    set(atoms.error$, null);
+    const started = await settle(
+      startAuthV2GoogleSignUp(resource, dependencies.navigation, legalAccepted),
+      signal,
+    );
+    if (!started.ok) {
+      const error = normalizeClerkError(started.error, "general");
+      L.warn(
+        "Auth v2 Google sign-up redirect failed",
+        error.clerkCode ?? error.code,
+      );
+      set(atoms.error$, error);
+    }
   });
 }
 
@@ -1168,6 +1343,7 @@ export function createAuthV2SignUpSignals(
     runtime,
     applyResource$,
   );
+  const googleOAuthOperation$ = createGoogleOAuthOperation(atoms, dependencies);
   const formCommands = createFormCommands(atoms);
   return {
     ...formCommands,
@@ -1187,7 +1363,10 @@ export function createAuthV2SignUpSignals(
     firstName$: computed((get) => {
       return get(atoms.firstName$);
     }),
-    initialize$,
+    googleOAuthAvailable$: computed((get) => {
+      return get(atoms.googleOAuthAvailable$);
+    }),
+    initialize$: createCoalescedOperation(runtime, initialize$),
     lastName$: computed((get) => {
       return get(atoms.lastName$);
     }),
@@ -1203,6 +1382,7 @@ export function createAuthV2SignUpSignals(
     }),
     restart$: createCoalescedOperation(runtime, restartOperation$),
     state$: atoms.state$,
+    startGoogleOAuth$: createCoalescedOperation(runtime, googleOAuthOperation$),
     submit$: createCoalescedOperation(runtime, submitOperation$),
   };
 }

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -304,10 +304,12 @@ describe("auth v2 sign-up flow", () => {
   it("reuses an in-progress transfer on callback reload without another transfer operation", async () => {
     mockSignInResource({
       createdSessionId: "session_recovered_transfer",
+      identifier: "person@example.com",
       status: "complete",
     });
     setupSignUpPage(
       {
+        emailAddress: "person@example.com",
         externalAccountError: {
           code: "external_account_exists",
           message: "Account already exists",
@@ -330,6 +332,51 @@ describe("auth v2 sign-up flow", () => {
       redirectUrl: "https://app.vm0.ai",
       session: "session_recovered_transfer",
     });
+  });
+
+  it("replaces an unrelated sign-in resource before transferring an existing Google identity", async () => {
+    mockSignInResource({
+      createdSessionId: "session_unrelated",
+      identifier: "other@example.com",
+      status: "complete",
+    });
+    mockedClerk.clientSignInCreate.mockImplementation(() => {
+      mockSignInResource({
+        createdSessionId: "session_existing_google",
+        identifier: "person@example.com",
+        status: "complete",
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+    setupSignUpPage(
+      {
+        emailAddress: "person@example.com",
+        externalAccountError: {
+          code: "external_account_exists",
+          message: "Account already exists",
+        },
+        externalAccountStatus: "transferable",
+        isTransferable: true,
+        status: "missing_requirements",
+      },
+      {
+        path: "/v2/sign-up/sso-callback",
+        url: "https://app.vm0.ai/v2/sign-up/sso-callback",
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+        transfer: true,
+      });
+      expect(mockedClerk.setActive).toHaveBeenCalledWith({
+        redirectUrl: "https://app.vm0.ai",
+        session: "session_existing_google",
+      });
+    });
+    expect(mockedClerk.setActive).not.toHaveBeenCalledWith(
+      expect.objectContaining({ session: "session_unrelated" }),
+    );
   });
 
   it("hands an incomplete existing-identity transfer to the attributed v2 sign-in step", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -15,7 +15,9 @@ import {
   queryAllByRoleFast,
 } from "../../../../__tests__/page-helper.ts";
 import {
+  mockAuthV2Capabilities,
   mockedClerk,
+  mockSignInResource,
   mockSignUpConfiguration,
   mockSignUpPasswordValidation,
   mockSignUpResource,
@@ -133,6 +135,266 @@ describe("auth v2 sign-up flow", () => {
     await expect(
       screen.findByLabelText("Email address"),
     ).resolves.toBeVisible();
+  });
+
+  it("hides Google when the current Clerk environment does not support it", async () => {
+    setupSignUpPage({ status: null });
+
+    await screen.findByLabelText("Email address");
+    expect(roleElement("button", "Continue with Google")).toBeUndefined();
+    expect(
+      document.querySelector("script[data-auth-v2-google-one-tap]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows supported Google sign-up without starting One Tap", async () => {
+    mockAuthV2Capabilities({ googleOAuth: true });
+    setupSignUpPage({ status: null });
+
+    await expect(
+      waitForRoleElement("button", "Continue with Google"),
+    ).resolves.toBeVisible();
+    expect(
+      document.querySelector("script[data-auth-v2-google-one-tap]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("coalesces Google handoff and preserves safe campaign attribution", async () => {
+    const redirect = createDeferredPromise<void>(context.signal);
+    mockedClerk.signUpAuthenticateWithRedirect.mockImplementation(() => {
+      return redirect.promise;
+    });
+    mockAuthV2Capabilities({ googleOAuth: true });
+    const untrustedRedirect = "https://app.okou.ai.evil.example/steal";
+    const path = `/v2/sign-up?gclid=click-123&utm_campaign=summer&redirect_url=${encodeURIComponent(untrustedRedirect)}#/start?step=oauth`;
+    setupSignUpPage(
+      { status: null },
+      {
+        path,
+        url: `https://app.vm0.ai${path}`,
+      },
+    );
+
+    const google = await waitForRoleElement("button", "Continue with Google");
+    fireEvent.click(google);
+    fireEvent.click(google);
+
+    await waitFor(() => {
+      expect(mockedClerk.signUpAuthenticateWithRedirect).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+    const handoff =
+      mockedClerk.signUpAuthenticateWithRedirect.mock.calls[0]?.[0];
+    expect(handoff).toMatchObject({
+      continueSignIn: false,
+      continueSignUp: false,
+      strategy: "oauth_google",
+    });
+    const callbackUrl = new URL(handoff?.redirectUrl ?? "", location.origin);
+    const completionUrl = new URL(handoff?.redirectUrlComplete ?? "");
+    expect(callbackUrl.pathname).toBe("/v2/sign-up/sso-callback");
+    expect(callbackUrl.searchParams.get("redirect_url")).toBe(
+      completionUrl.toString(),
+    );
+    expect(callbackUrl.hash).toBe("#/start?step=oauth");
+    expect(completionUrl.origin).toBe("https://app.vm0.ai");
+    expect(completionUrl.pathname).toBe("/onboarding");
+    expect(completionUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(completionUrl.searchParams.get("utm_campaign")).toBe("summer");
+    expect(completionUrl.toString()).not.toContain("evil.example");
+
+    await act(async () => {
+      redirect.resolve(undefined);
+      await redirect.promise;
+    });
+  });
+
+  it("requires legal consent before Google handoff and forwards acceptance", async () => {
+    const user = userEvent.setup();
+    mockAuthV2Capabilities({ googleOAuth: true });
+    setupSignUpPage({
+      missingFields: ["email_address", "password", "legal_accepted"],
+      requiredFields: ["email_address", "password", "legal_accepted"],
+      status: null,
+    });
+
+    const google = await waitForRoleElement("button", "Continue with Google");
+    await user.click(google);
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Please read and accept the terms to continue",
+    );
+    expect(mockedClerk.signUpAuthenticateWithRedirect).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(google);
+    await waitFor(() => {
+      expect(mockedClerk.signUpAuthenticateWithRedirect).toHaveBeenCalledWith(
+        expect.objectContaining({ legalAccepted: true }),
+      );
+    });
+  });
+
+  it("recovers a completed Google callback through the existing activation seam exactly once", async () => {
+    const path = "/v2/sign-up/sso-callback?gclid=click-123&utm_campaign=summer";
+    setupSignUpPage(
+      {
+        createdSessionId: "session_google_sign_up",
+        externalAccountStatus: "verified",
+        status: "complete",
+      },
+      { path, url: `https://app.vm0.ai${path}` },
+    );
+
+    await waitFor(() => {
+      expect(mockedClerk.signUpReload).toHaveBeenCalledTimes(1);
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.handleRedirectCallback).not.toHaveBeenCalled();
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      redirectUrl: expect.stringContaining("/onboarding"),
+      session: "session_google_sign_up",
+    });
+    const activation = mockedClerk.setActive.mock.calls[0]?.[0];
+    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");
+  });
+
+  it("transfers an existing Google identity and activates it once through the same completion seam", async () => {
+    mockedClerk.clientSignInCreate.mockImplementation(() => {
+      mockSignInResource({
+        createdSessionId: "session_existing_google",
+        status: "complete",
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+    const path =
+      "/v2/sign-up/sso-callback?gclid=existing-123&utm_campaign=transfer";
+    setupSignUpPage(
+      {
+        externalAccountError: {
+          code: "external_account_exists",
+          message: "Account already exists",
+        },
+        externalAccountStatus: "transferable",
+        isTransferable: true,
+        status: "missing_requirements",
+      },
+      { path, url: `https://app.vm0.ai${path}` },
+    );
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledTimes(1);
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+      transfer: true,
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      redirectUrl: expect.stringContaining("/onboarding"),
+      session: "session_existing_google",
+    });
+    const activation = mockedClerk.setActive.mock.calls[0]?.[0];
+    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    expect(redirectUrl.searchParams.get("gclid")).toBe("existing-123");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("transfer");
+  });
+
+  it("reuses an in-progress transfer on callback reload without another transfer operation", async () => {
+    mockSignInResource({
+      createdSessionId: "session_recovered_transfer",
+      status: "complete",
+    });
+    setupSignUpPage(
+      {
+        externalAccountError: {
+          code: "external_account_exists",
+          message: "Account already exists",
+        },
+        externalAccountStatus: "transferable",
+        isTransferable: true,
+        status: "missing_requirements",
+      },
+      {
+        path: "/v2/sign-up/sso-callback",
+        url: "https://app.vm0.ai/v2/sign-up/sso-callback",
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      redirectUrl: "https://app.vm0.ai",
+      session: "session_recovered_transfer",
+    });
+  });
+
+  it("hands an incomplete existing-identity transfer to the attributed v2 sign-in step", async () => {
+    const assigned = context.mocks.browser.locationAssign();
+    mockedClerk.clientSignInCreate.mockImplementation(() => {
+      mockSignInResource({
+        status: "needs_first_factor",
+        supportedFirstFactors: [{ strategy: "password" }],
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+    const redirectUrl = "https://app.okou.ai/onboarding?source=transfer";
+    const path = `/v2/sign-up/sso-callback?utm_campaign=transfer&redirect_url=${encodeURIComponent(redirectUrl)}#/callback?attempt=1`;
+    setupSignUpPage(
+      {
+        externalAccountError: {
+          code: "external_account_exists",
+          message: "Account already exists",
+        },
+        externalAccountStatus: "transferable",
+        isTransferable: true,
+        status: "missing_requirements",
+      },
+      { path, url: `https://app.vm0.ai${path}` },
+    );
+
+    await waitFor(() => {
+      expect(assigned.calls).toHaveLength(1);
+    });
+    const destination = new URL(assigned.calls[0] ?? "", location.origin);
+    expect(destination.pathname).toBe("/v2/sign-in/factor-one");
+    expect(destination.searchParams.get("redirect_url")).toBe(redirectUrl);
+    expect(destination.searchParams.get("utm_campaign")).toBe("transfer");
+    expect(destination.hash).toBe("#/callback?attempt=1");
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a cancelled Google callback and leaves sign-up retryable", async () => {
+    mockAuthV2Capabilities({ googleOAuth: true });
+    setupSignUpPage(
+      {
+        externalAccountError: {
+          code: "oauth_callback_error",
+          longMessage: "Google sign-up was cancelled.",
+          message: "OAuth callback failed",
+        },
+        externalAccountStatus: "failed",
+        status: null,
+      },
+      {
+        path: "/v2/sign-up/sso-callback",
+        url: "https://app.vm0.ai/v2/sign-up/sso-callback",
+      },
+    );
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Google sign-up was cancelled.",
+    );
+    fireEvent.click(await waitForRoleElement("button", "Continue with Google"));
+    await waitFor(() => {
+      expect(mockedClerk.signUpAuthenticateWithRedirect).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
   });
 
   it("recovers a prepared progressive sign-up on a nested refresh without sending another code", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
@@ -320,19 +320,46 @@ function DetailsStep({
 }) {
   const pageSignal = useGet(pageSignal$);
   const legalAccepted = useGet(signals.legalAccepted$);
+  const googleOAuthAvailable = useGet(signals.googleOAuthAvailable$);
   const captchaState = useGet(signals.captchaState$);
   const error = useGet(signals.error$);
   const setLegalAccepted = useSet(signals.setLegalAccepted$);
   const captchaRef = useSet(signals.captchaRef$);
   const [submitLoadable, submit] = useLoadableSet(signals.submit$);
+  const [googleOAuthLoadable, startGoogleOAuth] = useLoadableSet(
+    signals.startGoogleOAuth$,
+  );
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign up");
   };
   const retrying = captchaState === "error" || captchaState === "expired";
+  const operationPending =
+    submitLoadable.state === "loading" ||
+    googleOAuthLoadable.state === "loading";
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
       <FlowErrorAlert copy={copy} signals={signals} signInHref={signInHref} />
+      {googleOAuthAvailable ? (
+        <Button
+          className="w-full"
+          disabled={operationPending}
+          type="button"
+          variant="outline"
+          onClick={() => {
+            detach(
+              startGoogleOAuth(pageSignal),
+              Reason.DomCallback,
+              "start auth v2 Google sign up",
+            );
+          }}
+        >
+          {googleOAuthLoadable.state === "loading" ? (
+            <Loader2 className="animate-spin" aria-hidden="true" />
+          ) : null}
+          {copy.googleMethod}
+        </Button>
+      ) : null}
       <FieldList copy={copy} fields={state.fields} signals={signals} />
       {state.legal.required ? (
         <label className="flex cursor-pointer items-start gap-2 text-sm text-muted-foreground">
@@ -360,6 +387,7 @@ function DetailsStep({
       <CaptchaStatus copy={copy} signals={signals} signInHref={signInHref} />
       <SubmitButton
         busy={submitLoadable.state === "loading"}
+        disabled={operationPending}
         label={retrying ? copy.retry : copy.continue}
       />
     </form>

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-copy.ts
@@ -13,6 +13,8 @@ import { getClerkLocalization } from "../../auth/clerk-localization.ts";
 
 type ClerkLocalization = ReturnType<typeof getClerkLocalization>;
 
+const CLERK_PROVIDER = "{{provider|titleize}}";
+
 export interface AuthV2SignUpCopy {
   readonly alreadyHaveAccount: string;
   readonly back: string;
@@ -32,6 +34,7 @@ export interface AuthV2SignUpCopy {
   readonly emailCodeSubtitle: string;
   readonly emailCodeTitle: string;
   readonly firstNameLabel: string;
+  readonly googleMethod: string;
   readonly lastNameLabel: string;
   readonly legacySignUp: string;
   readonly legalPrivacyOnly: string;
@@ -113,6 +116,15 @@ function startCopy(localization: ClerkLocalization) {
     ),
     description: localizedString(start?.subtitle, fallback?.subtitle),
     signIn: localizedString(start?.actionLink, fallback?.actionLink),
+  };
+}
+
+function externalMethodCopy(localization: ClerkLocalization) {
+  return {
+    googleMethod: localizedString(
+      localization.socialButtonsBlockButton,
+      enUS.socialButtonsBlockButton,
+    ).replaceAll(CLERK_PROVIDER, "Google"),
   };
 }
 
@@ -228,6 +240,7 @@ export function useAuthV2SignUpCopy(
   return {
     ...formCopy(localization),
     ...startCopy(localization),
+    ...externalMethodCopy(localization),
     ...emailCodeCopy(localization),
     ...legalCopy(localization),
     ...captchaCopy(localization),


### PR DESCRIPTION
## Summary

- expose Google sign-up only when the current Clerk environment advertises `oauth_google` and the live sign-up resource supports redirect authentication
- add lower-level Clerk OAuth handoff plus dedicated `/v2/sign-up/sso-callback` recovery, including reload-safe existing-identity transfer into the existing v2 sign-in factor routes
- preserve the existing allowed-redirect policy, query/hash context, satellite/brand behavior, campaign attribution, and sign-up onboarding completion URL
- coalesce repeated handoff/recovery operations and pass completed OAuth or transfer sessions through the existing sign-up completion seam for exactly-once activation

## Completion ownership

- the new external-strategy module does not call `setActive` or own final navigation
- completed OAuth and transfer results enter the isolated `createCompleteSessionCommand` seam in `sign-up-flow.ts`, which wraps the already-landed activation path and can be replaced cleanly by the continuation controller
- incomplete transfers move into the existing attributed `/v2/sign-in` factor route without adding sign-in strategy behavior

## Shared integration files

- `turbo/apps/platform/src/signals/auth-v2-page-setup.ts`: identify only the dedicated sign-up OAuth callback route and pass existing navigation context
- `turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts`: connect capability, handoff, callback recovery, transfer, and the isolated completion seam
- `turbo/apps/platform/src/__tests__/mock-auth.ts`: extend the shared Clerk test resource with redirect/reload/transfer fixtures

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --log-order grouped`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/signals/auth-v2/sign-up-external-strategies.test.ts` (6 tests)
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx` (20 tests)

## Scope boundaries

- no Clerk prebuilt auth components or `.cl-*` selectors
- no Google One Tap on sign-up; base-route-only sign-in One Tap remains unchanged
- no continuation/task UI, organization selection/membership behavior, second-factor implementation, or global analytics/diagnostics
- no changes to sign-in external strategies, legacy `/sign-in` or `/sign-up`, or production routing

Part of #28927
