### PR TITLE
feat: add auth v2 organization continuation

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -46,11 +46,13 @@ export interface MockedMembership {
 }
 
 export interface MockedClientSession {
+  currentTask?: { readonly key: string };
   id: string;
   status?: string;
   user?: {
     fullName?: string | null;
     imageUrl?: string;
+    organizationMemberships?: MockedMembership[];
     primaryEmailAddress?: { emailAddress: string } | null;
   };
 }
@@ -304,6 +306,9 @@ export function mockUser(
         user: {
           fullName: user.fullName,
           imageUrl: user.imageUrl,
+          get organizationMemberships() {
+            return internalMockedMemberships;
+          },
           primaryEmailAddress: user.email ? { emailAddress: user.email } : null,
         },
       },
@@ -852,9 +857,14 @@ interface MockedSetActiveParams {
   session?: string | null;
   navigate?: (params: {
     session: {
+      readonly id: string;
+      readonly status: string;
       currentTask?: {
-        key: "choose-organization" | "reset-password" | "setup-mfa";
+        key: string;
       };
+      readonly user: {
+        readonly organizationMemberships: MockedMembership[];
+      } | null;
     };
     decorateUrl: (url: string) => string;
   }) => void | Promise<unknown>;
@@ -864,8 +874,30 @@ async function defaultSetActiveImpl(
   params: MockedSetActiveParams,
 ): Promise<void> {
   let navigatedTo: string | null = params.redirectUrl ?? null;
+  const selectedSession = internalMockedClientSessions.find((session) => {
+    return session.id === params.session;
+  });
+  const activeSession = internalMockedClientSessions.find((session) => {
+    return session.status === "pending" || session.status === "active";
+  });
+  const sourceSession = selectedSession ?? activeSession;
+  const session = {
+    id: sourceSession?.id ?? params.session ?? "test-session-id",
+    ...(!params.organization && sourceSession?.currentTask
+      ? { currentTask: sourceSession.currentTask }
+      : {}),
+    status: params.organization
+      ? "active"
+      : (sourceSession?.status ?? "active"),
+    user: {
+      organizationMemberships:
+        sourceSession?.user?.organizationMemberships ??
+        internalMockedUser?.organizationMemberships ??
+        [],
+    },
+  };
   await params.navigate?.({
-    session: {},
+    session,
     decorateUrl: (url) => {
       navigatedTo = defaultBuildUrlWithAuthImpl(url);
       return navigatedTo;
@@ -903,6 +935,19 @@ export const mockedClerk = {
     }
     if (internalMockedClerkSessionSignedOut) {
       return null;
+    }
+    const recoverableSession = internalMockedClientSessions.find((session) => {
+      return session.status === "pending";
+    });
+    if (recoverableSession) {
+      return {
+        ...recoverableSession,
+        get lastActiveOrganizationId() {
+          return internalMockedOrganization?.id ?? null;
+        },
+        getToken: sessionGetToken,
+        touch: sessionTouch,
+      };
     }
     return {
       id: "test-session-id",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1044,6 +1044,24 @@
     },
     "toggleTheme": "Design wechseln",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "Die Anmeldung konnte nicht abgeschlossen werden. Starte erneut und versuche es noch einmal.",
+        "activationErrorTitle": "Anmeldung konnte nicht abgeschlossen werden",
+        "chooseOrganizationDescription": "Wähle eine Organisation aus, um mit {{brandName}} fortzufahren.",
+        "chooseOrganizationTitle": "Organisation auswählen",
+        "completeDescription": "Du wirst zu {{brandName}} weitergeleitet.",
+        "completeTitle": "Anmeldung abgeschlossen",
+        "loadingDescription": "Es wird geprüft, welcher Schritt für dein Konto als Nächstes erforderlich ist.",
+        "loadingTitle": "Anmeldung wird abgeschlossen",
+        "noOrganizationsDescription": "Für dieses Konto ist keine Organisation verfügbar. Bitte einen Organisationsadministrator um Zugriff und starte dann erneut.",
+        "noOrganizationsTitle": "Keine Organisation verfügbar",
+        "recoveryAction": "Neu starten",
+        "secondFactorDescription": "Diese Anmeldung erfordert einen zusätzlichen Bestätigungsschritt, den diese Seite nicht unterstützt. Starte erneut, um eine andere Anmeldemethode zu verwenden.",
+        "secondFactorTitle": "Zusätzliche Bestätigung erforderlich",
+        "selectOrganization": "Mit {{organizationName}} fortfahren",
+        "unsupportedDescription": "Dein Konto hat einen Authentifizierungsschritt zurückgegeben, den diese Seite nicht unterstützt. Starte erneut, um eine andere Anmeldemethode zu verwenden.",
+        "unsupportedTitle": "Anmeldeschritt nicht verfügbar"
+      },
       "signIn": {
         "action": "Aktuelle Anmeldung verwenden",
         "title": "Bei {{brandName}} anmelden"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1044,6 +1044,24 @@
     },
     "toggleTheme": "Toggle theme",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "We couldn't finish signing you in. Start over and try again.",
+        "activationErrorTitle": "Sign-in couldn't be completed",
+        "chooseOrganizationDescription": "Choose an organization to continue to {{brandName}}.",
+        "chooseOrganizationTitle": "Choose an organization",
+        "completeDescription": "Taking you to {{brandName}}.",
+        "completeTitle": "Sign-in complete",
+        "loadingDescription": "Checking what your account needs next.",
+        "loadingTitle": "Finishing sign-in",
+        "noOrganizationsDescription": "This account doesn't have an organization available. Ask an organization administrator for access, then start over.",
+        "noOrganizationsTitle": "No organization available",
+        "recoveryAction": "Start over",
+        "secondFactorDescription": "This sign-in requires an additional verification step that this page doesn't support. Start over to try another sign-in method.",
+        "secondFactorTitle": "Additional verification required",
+        "selectOrganization": "Continue with {{organizationName}}",
+        "unsupportedDescription": "Your account returned an authentication step that this page doesn't support. Start over to try another sign-in method.",
+        "unsupportedTitle": "Sign-in step unavailable"
+      },
       "signIn": {
         "action": "Use current sign-in",
         "title": "Sign in to {{brandName}}"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1063,6 +1063,24 @@
     },
     "toggleTheme": "Cambiar tema",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "No pudimos completar el inicio de sesión. Vuelve a empezar e inténtalo de nuevo.",
+        "activationErrorTitle": "No se pudo completar el inicio de sesión",
+        "chooseOrganizationDescription": "Elige una organización para continuar a {{brandName}}.",
+        "chooseOrganizationTitle": "Elige una organización",
+        "completeDescription": "Te estamos llevando a {{brandName}}.",
+        "completeTitle": "Inicio de sesión completado",
+        "loadingDescription": "Estamos comprobando qué necesita tu cuenta a continuación.",
+        "loadingTitle": "Finalizando el inicio de sesión",
+        "noOrganizationsDescription": "Esta cuenta no tiene ninguna organización disponible. Pide acceso a un administrador de la organización y vuelve a empezar.",
+        "noOrganizationsTitle": "No hay ninguna organización disponible",
+        "recoveryAction": "Volver a empezar",
+        "secondFactorDescription": "Este inicio de sesión requiere un paso de verificación adicional que esta página no admite. Vuelve a empezar para probar otro método de inicio de sesión.",
+        "secondFactorTitle": "Se requiere verificación adicional",
+        "selectOrganization": "Continuar con {{organizationName}}",
+        "unsupportedDescription": "Tu cuenta devolvió un paso de autenticación que esta página no admite. Vuelve a empezar para probar otro método de inicio de sesión.",
+        "unsupportedTitle": "Paso de inicio de sesión no disponible"
+      },
       "signIn": {
         "action": "Usar el inicio de sesión actual",
         "title": "Iniciar sesión en {{brandName}}"

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1063,6 +1063,24 @@
     },
     "toggleTheme": "Changer de thème",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "Nous n'avons pas pu terminer la connexion. Recommencez et réessayez.",
+        "activationErrorTitle": "La connexion n'a pas pu être terminée",
+        "chooseOrganizationDescription": "Choisissez une organisation pour continuer vers {{brandName}}.",
+        "chooseOrganizationTitle": "Choisir une organisation",
+        "completeDescription": "Redirection vers {{brandName}}.",
+        "completeTitle": "Connexion terminée",
+        "loadingDescription": "Vérification de la prochaine étape requise pour votre compte.",
+        "loadingTitle": "Finalisation de la connexion",
+        "noOrganizationsDescription": "Aucune organisation n'est disponible pour ce compte. Demandez l'accès à un administrateur de l'organisation, puis recommencez.",
+        "noOrganizationsTitle": "Aucune organisation disponible",
+        "recoveryAction": "Recommencer",
+        "secondFactorDescription": "Cette connexion nécessite une étape de vérification supplémentaire que cette page ne prend pas en charge. Recommencez pour essayer une autre méthode de connexion.",
+        "secondFactorTitle": "Vérification supplémentaire requise",
+        "selectOrganization": "Continuer avec {{organizationName}}",
+        "unsupportedDescription": "Votre compte a renvoyé une étape d'authentification que cette page ne prend pas en charge. Recommencez pour essayer une autre méthode de connexion.",
+        "unsupportedTitle": "Étape de connexion indisponible"
+      },
       "signIn": {
         "action": "Utiliser la connexion actuelle",
         "title": "Se connecter à {{brandName}}"

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1044,6 +1044,24 @@
     },
     "toggleTheme": "थीम टॉगल करें",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "हम आपका साइन-इन पूरा नहीं कर सके। फिर से शुरू करके दोबारा कोशिश करें।",
+        "activationErrorTitle": "साइन-इन पूरा नहीं हो सका",
+        "chooseOrganizationDescription": "{{brandName}} पर जारी रखने के लिए कोई संगठन चुनें।",
+        "chooseOrganizationTitle": "कोई संगठन चुनें",
+        "completeDescription": "आपको {{brandName}} पर ले जाया जा रहा है।",
+        "completeTitle": "साइन-इन पूरा हुआ",
+        "loadingDescription": "जाँचा जा रहा है कि आपके खाते के लिए आगे क्या आवश्यक है।",
+        "loadingTitle": "साइन-इन पूरा किया जा रहा है",
+        "noOrganizationsDescription": "इस खाते के लिए कोई संगठन उपलब्ध नहीं है। संगठन व्यवस्थापक से पहुँच माँगें, फिर दोबारा शुरू करें।",
+        "noOrganizationsTitle": "कोई संगठन उपलब्ध नहीं है",
+        "recoveryAction": "फिर से शुरू करें",
+        "secondFactorDescription": "इस साइन-इन के लिए एक अतिरिक्त सत्यापन चरण आवश्यक है, जिसका यह पेज समर्थन नहीं करता। कोई दूसरी साइन-इन विधि आज़माने के लिए फिर से शुरू करें।",
+        "secondFactorTitle": "अतिरिक्त सत्यापन आवश्यक है",
+        "selectOrganization": "{{organizationName}} के साथ जारी रखें",
+        "unsupportedDescription": "आपके खाते ने ऐसा प्रमाणीकरण चरण लौटाया है, जिसका यह पेज समर्थन नहीं करता। कोई दूसरी साइन-इन विधि आज़माने के लिए फिर से शुरू करें।",
+        "unsupportedTitle": "साइन-इन चरण उपलब्ध नहीं है"
+      },
       "signIn": {
         "action": "मौजूदा साइन-इन का उपयोग करें",
         "title": "{{brandName}} में साइन इन करें"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1043,6 +1043,24 @@
     },
     "toggleTheme": "Beralih tema",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "Kami tidak dapat menyelesaikan proses masuk. Mulai lagi dan coba kembali.",
+        "activationErrorTitle": "Proses masuk tidak dapat diselesaikan",
+        "chooseOrganizationDescription": "Pilih organisasi untuk melanjutkan ke {{brandName}}.",
+        "chooseOrganizationTitle": "Pilih organisasi",
+        "completeDescription": "Mengarahkan Anda ke {{brandName}}.",
+        "completeTitle": "Proses masuk selesai",
+        "loadingDescription": "Memeriksa langkah berikutnya yang diperlukan akun Anda.",
+        "loadingTitle": "Menyelesaikan proses masuk",
+        "noOrganizationsDescription": "Akun ini tidak memiliki organisasi yang tersedia. Minta akses kepada administrator organisasi, lalu mulai lagi.",
+        "noOrganizationsTitle": "Tidak ada organisasi yang tersedia",
+        "recoveryAction": "Mulai lagi",
+        "secondFactorDescription": "Proses masuk ini memerlukan langkah verifikasi tambahan yang tidak didukung halaman ini. Mulai lagi untuk mencoba metode masuk lain.",
+        "secondFactorTitle": "Verifikasi tambahan diperlukan",
+        "selectOrganization": "Lanjutkan dengan {{organizationName}}",
+        "unsupportedDescription": "Akun Anda mengembalikan langkah autentikasi yang tidak didukung halaman ini. Mulai lagi untuk mencoba metode masuk lain.",
+        "unsupportedTitle": "Langkah masuk tidak tersedia"
+      },
       "signIn": {
         "action": "Gunakan proses masuk saat ini",
         "title": "Masuk ke {{brandName}}"

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1063,6 +1063,24 @@
     },
     "toggleTheme": "Cambia tema",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "Non è stato possibile completare l'accesso. Ricomincia e riprova.",
+        "activationErrorTitle": "Impossibile completare l'accesso",
+        "chooseOrganizationDescription": "Scegli un'organizzazione per continuare su {{brandName}}.",
+        "chooseOrganizationTitle": "Scegli un'organizzazione",
+        "completeDescription": "Ti stiamo portando su {{brandName}}.",
+        "completeTitle": "Accesso completato",
+        "loadingDescription": "Stiamo verificando il prossimo passaggio richiesto dal tuo account.",
+        "loadingTitle": "Completamento dell'accesso",
+        "noOrganizationsDescription": "Questo account non dispone di organizzazioni. Chiedi l'accesso a un amministratore dell'organizzazione, quindi ricomincia.",
+        "noOrganizationsTitle": "Nessuna organizzazione disponibile",
+        "recoveryAction": "Ricomincia",
+        "secondFactorDescription": "Questo accesso richiede un ulteriore passaggio di verifica non supportato da questa pagina. Ricomincia per provare un altro metodo di accesso.",
+        "secondFactorTitle": "È richiesta un'ulteriore verifica",
+        "selectOrganization": "Continua con {{organizationName}}",
+        "unsupportedDescription": "Il tuo account ha restituito un passaggio di autenticazione non supportato da questa pagina. Ricomincia per provare un altro metodo di accesso.",
+        "unsupportedTitle": "Passaggio di accesso non disponibile"
+      },
       "signIn": {
         "action": "Usa l'accesso attuale",
         "title": "Accedi a {{brandName}}"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1043,6 +1043,24 @@
     },
     "toggleTheme": "テーマの切り替え",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "サインインを完了できませんでした。最初からやり直してください。",
+        "activationErrorTitle": "サインインを完了できませんでした",
+        "chooseOrganizationDescription": "{{brandName}} に進む組織を選択してください。",
+        "chooseOrganizationTitle": "組織を選択",
+        "completeDescription": "{{brandName}} に移動しています。",
+        "completeTitle": "サインイン完了",
+        "loadingDescription": "アカウントに必要な次の手順を確認しています。",
+        "loadingTitle": "サインインを完了しています",
+        "noOrganizationsDescription": "このアカウントで利用できる組織がありません。組織の管理者にアクセスを依頼してから、最初からやり直してください。",
+        "noOrganizationsTitle": "利用できる組織がありません",
+        "recoveryAction": "最初からやり直す",
+        "secondFactorDescription": "このサインインには、このページでサポートされていない追加の確認手順が必要です。別のサインイン方法を試すには、最初からやり直してください。",
+        "secondFactorTitle": "追加の確認が必要です",
+        "selectOrganization": "{{organizationName}} で続行",
+        "unsupportedDescription": "このページでサポートされていない認証手順がアカウントから返されました。別のサインイン方法を試すには、最初からやり直してください。",
+        "unsupportedTitle": "サインイン手順を利用できません"
+      },
       "signIn": {
         "action": "現在のサインインを使用",
         "title": "{{brandName}} にサインイン"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1043,6 +1043,24 @@
     },
     "toggleTheme": "테마 전환",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "로그인을 완료할 수 없습니다. 처음부터 다시 시도하세요.",
+        "activationErrorTitle": "로그인을 완료할 수 없음",
+        "chooseOrganizationDescription": "{{brandName}}에서 계속하려면 조직을 선택하세요.",
+        "chooseOrganizationTitle": "조직 선택",
+        "completeDescription": "{{brandName}}(으)로 이동하고 있습니다.",
+        "completeTitle": "로그인 완료",
+        "loadingDescription": "계정에 필요한 다음 단계를 확인하고 있습니다.",
+        "loadingTitle": "로그인 마무리 중",
+        "noOrganizationsDescription": "이 계정에서 사용할 수 있는 조직이 없습니다. 조직 관리자에게 액세스를 요청한 후 처음부터 다시 시작하세요.",
+        "noOrganizationsTitle": "사용 가능한 조직 없음",
+        "recoveryAction": "처음부터 다시 시작",
+        "secondFactorDescription": "이 로그인에는 이 페이지에서 지원하지 않는 추가 확인 단계가 필요합니다. 다른 로그인 방법을 사용하려면 처음부터 다시 시작하세요.",
+        "secondFactorTitle": "추가 확인 필요",
+        "selectOrganization": "{{organizationName}}(으)로 계속",
+        "unsupportedDescription": "계정에서 이 페이지가 지원하지 않는 인증 단계를 반환했습니다. 다른 로그인 방법을 사용하려면 처음부터 다시 시작하세요.",
+        "unsupportedTitle": "로그인 단계를 사용할 수 없음"
+      },
       "signIn": {
         "action": "현재 로그인 사용",
         "title": "{{brandName}}에 로그인"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1063,6 +1063,24 @@
     },
     "toggleTheme": "Alternar tema",
     "v2": {
+      "continuation": {
+        "activationErrorDescription": "Não foi possível concluir seu login. Comece novamente e tente outra vez.",
+        "activationErrorTitle": "Não foi possível concluir o login",
+        "chooseOrganizationDescription": "Escolha uma organização para continuar no {{brandName}}.",
+        "chooseOrganizationTitle": "Escolha uma organização",
+        "completeDescription": "Levando você ao {{brandName}}.",
+        "completeTitle": "Login concluído",
+        "loadingDescription": "Verificando o que sua conta precisa fazer a seguir.",
+        "loadingTitle": "Finalizando o login",
+        "noOrganizationsDescription": "Esta conta não tem uma organização disponível. Peça acesso a um administrador da organização e comece novamente.",
+        "noOrganizationsTitle": "Nenhuma organização disponível",
+        "recoveryAction": "Começar novamente",
+        "secondFactorDescription": "Este login exige uma etapa adicional de verificação que esta página não oferece. Comece novamente para tentar outro método de login.",
+        "secondFactorTitle": "Verificação adicional necessária",
+        "selectOrganization": "Continuar com {{organizationName}}",
+        "unsupportedDescription": "Sua conta retornou uma etapa de autenticação que esta página não oferece. Comece novamente para tentar outro método de login.",
+        "unsupportedTitle": "Etapa de login indisponível"
+      },
       "signIn": {
         "action": "Usar o login atual",
         "title": "Entrar no {{brandName}}"

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -6,6 +6,10 @@ import {
   type AuthV2PageMode,
 } from "../views/auth-v2/auth-v2-page.tsx";
 import { hideAppSkeleton$ } from "./app-skeleton.ts";
+import {
+  createAuthV2ContinuationSignals,
+  isAuthV2ContinuationLocation,
+} from "./auth-v2/continuation.ts";
 import { resolveAuthV2PlatformContext } from "./auth-v2/platform-context.ts";
 import {
   createAuthV2SignInSignals,
@@ -22,12 +26,21 @@ import { updatePage$ } from "./react-router.ts";
 import { ROUTES } from "./route-paths.ts";
 
 function setupAuthV2Page(mode: AuthV2PageMode) {
-  return command(async ({ set }, signal: AbortSignal) => {
+  return command(async ({ get, set }, signal: AbortSignal) => {
     const platformContext = resolveAuthV2PlatformContext(mode);
+    const continuationSignals = createAuthV2ContinuationSignals({
+      isContinuationRoute: isAuthV2ContinuationLocation(
+        location.pathname,
+        location.hash,
+      ),
+      mode,
+      navigation: platformContext.navigation,
+    });
     let signInSignals: AuthV2SignInSignals | null = null;
     let signUpSignals: AuthV2SignUpSignals | null = null;
     if (mode === "sign-in") {
       signInSignals = createAuthV2SignInSignals({
+        continuation: continuationSignals,
         isBaseRoute: location.pathname === ROUTES.signInV2,
         isOAuthCallbackRoute:
           location.pathname ===
@@ -38,24 +51,24 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
         updatePage$,
         createElement(AuthV2Page, {
           mode,
+          continuationSignals,
           platformContext,
           signInSignals,
         }),
       );
     } else {
       signUpSignals = createAuthV2SignUpSignals({
+        continuation: continuationSignals,
         isOAuthCallbackRoute:
           location.pathname ===
           `${ROUTES.signUpV2}${AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH}`,
         navigation: platformContext.navigation,
-        resolveRedirectUrl: () => {
-          return platformContext.navigation.completionRedirectUrl;
-        },
       });
       set(
         updatePage$,
         createElement(AuthV2Page, {
           mode,
+          continuationSignals,
           platformContext,
           signUpSignals,
         }),
@@ -74,6 +87,11 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
     );
     await set(hideAppSkeleton$, signal);
     signal.throwIfAborted();
+    await set(continuationSignals.initialize$, signal);
+    signal.throwIfAborted();
+    if (get(continuationSignals.state$).status !== "inactive") {
+      return;
+    }
     if (signInSignals) {
       await set(signInSignals.initialize$, signal);
     } else if (signUpSignals) {

--- a/turbo/apps/platform/src/signals/auth-v2/continuation.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/continuation.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type MockedMembership,
+  mockedClerk,
+} from "../../__tests__/mock-auth.ts";
+import { setupPage } from "../../__tests__/page-helper.ts";
+import { testContext } from "../__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../utils.ts";
+import {
+  createAuthV2ContinuationSignals,
+  isAuthV2ContinuationLocation,
+  type AuthV2ContinuationSignals,
+} from "./continuation.ts";
+import type { AuthV2RouteMode } from "./navigation.ts";
+import { resolveAuthV2PlatformContext } from "./platform-context.ts";
+
+const context = testContext();
+
+function membership(id: string, name: string): MockedMembership {
+  return {
+    id: `membership_${id}`,
+    organization: { id, name },
+    role: "org:member",
+  };
+}
+
+async function setupContinuation(options: {
+  readonly memberships?: MockedMembership[];
+  readonly mode?: AuthV2RouteMode;
+  readonly path?: string;
+  readonly taskKey?: string;
+}): Promise<AuthV2ContinuationSignals> {
+  const path = options.path ?? "/v2/sign-in/tasks/choose-organization";
+  const memberships = options.memberships ?? [];
+  context.mocks.browser.url(`https://app.vm0.ai${path}`);
+  await setupPage({
+    context,
+    org: { activeOrg: null, memberships },
+    path,
+    session: { token: "test-token" },
+    user: {
+      clientSessions: options.taskKey
+        ? [
+            {
+              currentTask: { key: options.taskKey },
+              id: "session_pending",
+              status: "pending",
+              user: {
+                fullName: "Test User",
+                organizationMemberships: memberships,
+              },
+            },
+          ]
+        : [],
+      fullName: "Test User",
+      id: "user_test",
+    },
+    withoutRender: true,
+  });
+  const mode = options.mode ?? "sign-in";
+  const platformContext = resolveAuthV2PlatformContext(mode);
+  return createAuthV2ContinuationSignals({
+    isContinuationRoute: isAuthV2ContinuationLocation(
+      location.pathname,
+      location.hash,
+    ),
+    mode,
+    navigation: platformContext.navigation,
+  });
+}
+
+async function initialize(signals: AuthV2ContinuationSignals): Promise<void> {
+  await context.store.set(signals.initialize$, context.signal);
+}
+
+describe("auth v2 continuation recovery", () => {
+  it("recognizes pathname and Clerk hash task refresh routes", () => {
+    expect(
+      isAuthV2ContinuationLocation("/v2/sign-in/tasks/choose-organization", ""),
+    ).toBe(true);
+    expect(
+      isAuthV2ContinuationLocation(
+        "/v2/sign-in",
+        "#/tasks/choose-organization?attempt=1",
+      ),
+    ).toBe(true);
+    expect(isAuthV2ContinuationLocation("/v2/sign-in/factor-one", "")).toBe(
+      false,
+    );
+  });
+
+  it("recovers a pending organization task with existing memberships only", async () => {
+    const memberships = [
+      membership("org_alpha", "Alpha Company"),
+      membership("org_beta", "Beta Studio"),
+    ];
+    const signals = await setupContinuation({
+      memberships,
+      taskKey: "choose-organization",
+    });
+
+    expect(context.store.get(signals.state$)).toStrictEqual({
+      status: "loading",
+    });
+    await initialize(signals);
+
+    expect(context.store.get(signals.state$)).toStrictEqual({
+      organizations: [
+        { id: "org_alpha", name: "Alpha Company" },
+        { id: "org_beta", name: "Beta Studio" },
+      ],
+      selectingOrganizationId: null,
+      status: "incomplete",
+      task: "choose-organization",
+    });
+  });
+
+  it("coalesces duplicate membership selection and redirects once", async () => {
+    const memberships = [
+      membership("org_alpha", "Alpha Company"),
+      membership("org_beta", "Beta Studio"),
+    ];
+    const signals = await setupContinuation({
+      memberships,
+      path: `/v2/sign-in/tasks/choose-organization?redirect_url=${encodeURIComponent("https://app.vm0.ai/agents")}`,
+      taskKey: "choose-organization",
+    });
+    await initialize(signals);
+    const activation = createDeferredPromise<void>(context.signal);
+    mockedClerk.setActive.mockImplementation(async (params) => {
+      await activation.promise;
+      await params.navigate?.({
+        decorateUrl: (url) => {
+          return url;
+        },
+        session: {
+          id: "session_pending",
+          status: "active",
+          user: { organizationMemberships: memberships },
+        },
+      });
+    });
+
+    const firstSelection = context.store.set(
+      signals.selectOrganization$,
+      "org_beta",
+      context.signal,
+    );
+    const duplicateSelection = context.store.set(
+      signals.selectOrganization$,
+      "org_beta",
+      context.signal,
+    );
+    await vi.waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      navigate: expect.any(Function),
+      organization: "org_beta",
+    });
+
+    activation.resolve();
+    await Promise.all([firstSelection, duplicateSelection]);
+
+    await vi.waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(location.pathname).toBe("/agents");
+    expect(context.store.get(signals.state$)).toStrictEqual({
+      status: "complete",
+    });
+  });
+});
+
+describe("auth v2 continuation route ownership", () => {
+  it("keeps a completed sign-up task on the nested sign-up route", async () => {
+    const signals = await setupContinuation({
+      mode: "sign-up",
+      path: "/v2/sign-up",
+    });
+    await initialize(signals);
+    const memberships = [membership("org_alpha", "Alpha Company")];
+    mockedClerk.setActive.mockImplementation(async (params) => {
+      await params.navigate?.({
+        decorateUrl: (url) => {
+          return url;
+        },
+        session: {
+          currentTask: { key: "choose-organization" },
+          id: "session_sign_up",
+          status: "pending",
+          user: { organizationMemberships: memberships },
+        },
+      });
+    });
+
+    await context.store.set(
+      signals.completeSession$,
+      "session_sign_up",
+      context.signal,
+    );
+
+    expect(location.pathname).toBe("/v2/sign-up/tasks/choose-organization");
+    expect(context.store.get(signals.state$)).toStrictEqual({
+      organizations: [{ id: "org_alpha", name: "Alpha Company" }],
+      selectingOrganizationId: null,
+      status: "incomplete",
+      task: "choose-organization",
+    });
+  });
+});
+
+describe("auth v2 continuation terminal states", () => {
+  it("coalesces duplicate completed-session activation", async () => {
+    const signals = await setupContinuation({ path: "/v2/sign-in" });
+    await initialize(signals);
+    const activation = createDeferredPromise<void>(context.signal);
+    mockedClerk.setActive.mockImplementation(async (params) => {
+      await activation.promise;
+      await params.navigate?.({
+        decorateUrl: (url) => {
+          return url;
+        },
+        session: {
+          id: "session_complete",
+          status: "active",
+          user: { organizationMemberships: [] },
+        },
+      });
+    });
+
+    const firstCompletion = context.store.set(
+      signals.completeSession$,
+      "session_complete",
+      context.signal,
+    );
+    const duplicateCompletion = context.store.set(
+      signals.completeSession$,
+      "session_complete",
+      context.signal,
+    );
+    await vi.waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+
+    activation.resolve();
+    await Promise.all([firstCompletion, duplicateCompletion]);
+
+    expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    expect(location.pathname).toBe("/");
+  });
+
+  it.each([
+    { expectedReason: "unsupported-task", taskKey: "reset-password" },
+    { expectedReason: "second-factor", taskKey: "setup-mfa" },
+    { expectedReason: "unknown-task", taskKey: "future-task" },
+  ] as const)(
+    "fails closed for the $taskKey task",
+    async ({ expectedReason, taskKey }) => {
+      const signals = await setupContinuation({ taskKey });
+
+      await initialize(signals);
+
+      expect(context.store.get(signals.state$)).toStrictEqual({
+        reason: expectedReason,
+        status: "unknown",
+      });
+      expect(mockedClerk.setActive).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed when forced selection has no existing membership", async () => {
+    const signals = await setupContinuation({
+      memberships: [],
+      taskKey: "choose-organization",
+    });
+
+    await initialize(signals);
+
+    expect(context.store.get(signals.state$)).toStrictEqual({
+      reason: "no-organizations",
+      status: "failure",
+    });
+  });
+
+  it("surfaces session activation failure without retrying", async () => {
+    const sessionSignals = await setupContinuation({ path: "/v2/sign-in" });
+    await initialize(sessionSignals);
+    mockedClerk.setActive.mockRejectedValueOnce(
+      new Error("sensitive session activation response"),
+    );
+
+    await context.store.set(
+      sessionSignals.completeSession$,
+      "session_private",
+      context.signal,
+    );
+
+    expect(context.store.get(sessionSignals.state$)).toStrictEqual({
+      reason: "activation-failed",
+      status: "failure",
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces organization activation failure without retrying", async () => {
+    const memberships = [membership("org_alpha", "Alpha Company")];
+    const organizationSignals = await setupContinuation({
+      memberships,
+      taskKey: "choose-organization",
+    });
+    await initialize(organizationSignals);
+    mockedClerk.setActive.mockRejectedValueOnce(
+      new Error("sensitive organization activation response"),
+    );
+
+    await context.store.set(
+      organizationSignals.selectOrganization$,
+      "org_alpha",
+      context.signal,
+    );
+
+    expect(context.store.get(organizationSignals.state$)).toStrictEqual({
+      reason: "organization-activation-failed",
+      status: "failure",
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo/apps/platform/src/signals/auth-v2/continuation.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/continuation.ts
@@ -1,0 +1,463 @@
+import type { Clerk } from "@clerk/clerk-js";
+import type {
+  SessionResource,
+  SignedInSessionResource,
+} from "@clerk/react/types";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
+
+import { clerk$ } from "../auth.ts";
+import { ROUTES } from "../route-paths.ts";
+import { settle, withCleanup } from "../utils.ts";
+import type { AuthV2Navigation, AuthV2RouteMode } from "./navigation.ts";
+
+export const AUTH_V2_CHOOSE_ORGANIZATION_PATH = "/tasks/choose-organization";
+
+export interface AuthV2ContinuationOrganization {
+  readonly id: string;
+  readonly name: string;
+}
+
+export type AuthV2ContinuationFailureReason =
+  | "activation-failed"
+  | "missing-session"
+  | "no-organizations"
+  | "organization-activation-failed"
+  | "session-unavailable";
+
+export type AuthV2ContinuationUnknownReason =
+  | "second-factor"
+  | "unknown-task"
+  | "unsupported-task";
+
+export type AuthV2ContinuationState =
+  | { readonly status: "loading" }
+  | { readonly status: "inactive" }
+  | { readonly status: "recovering" }
+  | {
+      readonly organizations: readonly AuthV2ContinuationOrganization[];
+      readonly selectingOrganizationId: string | null;
+      readonly status: "incomplete";
+      readonly task: "choose-organization";
+    }
+  | { readonly status: "complete" }
+  | {
+      readonly reason: AuthV2ContinuationFailureReason;
+      readonly status: "failure";
+    }
+  | {
+      readonly reason: AuthV2ContinuationUnknownReason;
+      readonly status: "unknown";
+    };
+
+export interface AuthV2ContinuationSignals {
+  readonly completeSession$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly failClosed$: Command<void, [AuthV2ContinuationUnknownReason]>;
+  readonly initialize$: Command<Promise<void>, [AbortSignal]>;
+  readonly recover$: Command<Promise<void>, [AbortSignal]>;
+  readonly restart$: Command<Promise<void>, [AbortSignal]>;
+  readonly selectOrganization$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly state$: Computed<AuthV2ContinuationState>;
+}
+
+export type AuthV2ContinuationFlowHandoff = Pick<
+  AuthV2ContinuationSignals,
+  "completeSession$" | "failClosed$" | "recover$"
+>;
+
+export interface AuthV2ContinuationDependencies {
+  readonly isContinuationRoute: boolean;
+  readonly mode: AuthV2RouteMode;
+  readonly navigation: AuthV2Navigation;
+}
+
+type ContinuationSessionSource = "organization" | "recovery" | "session";
+type DecorateUrl = (url: string) => string;
+
+interface ContinuationAtoms {
+  readonly sessionId$: State<string | null>;
+  readonly state$: State<AuthV2ContinuationState>;
+}
+
+interface ContinuationRuntime {
+  readonly activatedOrganizationId$: State<string | null>;
+  readonly handledSessionId$: State<string | null>;
+  readonly inFlight$: State<Promise<void> | null>;
+  readonly redirected$: State<boolean>;
+  readonly taskNavigated$: State<boolean>;
+}
+
+type ApplySessionCommand = Command<
+  void,
+  [SessionResource, ContinuationSessionSource, DecorateUrl]
+>;
+
+function taskKey(
+  session: SessionResource,
+): { readonly kind: "none" } | { readonly key: string; readonly kind: "key" } {
+  const task: unknown = session.currentTask;
+  if (task === undefined || task === null) {
+    return { kind: "none" };
+  }
+  if (typeof task !== "object" || !("key" in task)) {
+    return { key: "", kind: "key" };
+  }
+  const key: unknown = task.key;
+  return { key: typeof key === "string" ? key : "", kind: "key" };
+}
+
+function availableOrganizations(
+  session: SessionResource,
+): readonly AuthV2ContinuationOrganization[] {
+  const organizations: AuthV2ContinuationOrganization[] = [];
+  const seenOrganizationIds = new Set<string>();
+  for (const membership of session.user?.organizationMemberships ?? []) {
+    const { id, name } = membership.organization;
+    if (!seenOrganizationIds.has(id)) {
+      seenOrganizationIds.add(id);
+      organizations.push({ id, name });
+    }
+  }
+  return organizations;
+}
+
+function createContinuationAtoms(): ContinuationAtoms {
+  return {
+    sessionId$: state<string | null>(null),
+    state$: state<AuthV2ContinuationState>({ status: "loading" }),
+  };
+}
+
+function createContinuationRuntime(): ContinuationRuntime {
+  return {
+    activatedOrganizationId$: state<string | null>(null),
+    handledSessionId$: state<string | null>(null),
+    inFlight$: state<Promise<void> | null>(null),
+    redirected$: state(false),
+    taskNavigated$: state(false),
+  };
+}
+
+function createApplySessionCommand(
+  atoms: ContinuationAtoms,
+  runtime: ContinuationRuntime,
+  dependencies: AuthV2ContinuationDependencies,
+): ApplySessionCommand {
+  const redirect$ = command(({ get, set }, destination: string): void => {
+    if (get(runtime.redirected$)) {
+      return;
+    }
+    set(runtime.redirected$, true);
+    window.location.href = destination;
+  });
+  const navigateToTask$ = command(({ get, set }, destination: string): void => {
+    if (get(runtime.taskNavigated$)) {
+      return;
+    }
+    set(runtime.taskNavigated$, true);
+    window.location.href = destination;
+  });
+
+  return command(
+    (
+      { set },
+      session: SessionResource,
+      source: ContinuationSessionSource,
+      decorateUrl: DecorateUrl,
+    ): void => {
+      set(atoms.sessionId$, session.id);
+      const currentTask = taskKey(session);
+      if (currentTask.kind === "key") {
+        if (currentTask.key === "choose-organization") {
+          if (source === "organization") {
+            set(atoms.state$, {
+              reason: "organization-activation-failed",
+              status: "failure",
+            });
+            return;
+          }
+          const organizations = availableOrganizations(session);
+          if (organizations.length === 0) {
+            set(atoms.state$, {
+              reason: "no-organizations",
+              status: "failure",
+            });
+            return;
+          }
+          set(atoms.state$, {
+            organizations,
+            selectingOrganizationId: null,
+            status: "incomplete",
+            task: "choose-organization",
+          });
+          if (!dependencies.isContinuationRoute) {
+            set(
+              navigateToTask$,
+              decorateUrl(
+                dependencies.navigation.href(
+                  dependencies.mode,
+                  AUTH_V2_CHOOSE_ORGANIZATION_PATH,
+                ),
+              ),
+            );
+          }
+          return;
+        }
+        set(atoms.state$, {
+          reason:
+            currentTask.key === "setup-mfa"
+              ? "second-factor"
+              : currentTask.key === "reset-password"
+                ? "unsupported-task"
+                : "unknown-task",
+          status: "unknown",
+        });
+        return;
+      }
+
+      if (session.status === "active") {
+        set(atoms.state$, { status: "complete" });
+        set(
+          redirect$,
+          decorateUrl(dependencies.navigation.completionRedirectUrl),
+        );
+        return;
+      }
+      if (session.status === "pending") {
+        set(atoms.state$, { reason: "unknown-task", status: "unknown" });
+        return;
+      }
+      set(atoms.state$, {
+        reason: "session-unavailable",
+        status: "failure",
+      });
+    },
+  );
+}
+
+function findRecoverableSession(clerk: Clerk): SignedInSessionResource | null {
+  const activeSession = clerk.session;
+  if (
+    activeSession?.status === "active" ||
+    activeSession?.status === "pending"
+  ) {
+    return activeSession;
+  }
+  return null;
+}
+
+function createRecoveryCommand(
+  atoms: ContinuationAtoms,
+  applySession$: ApplySessionCommand,
+  dependencies: AuthV2ContinuationDependencies,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    set(atoms.state$, { status: "recovering" });
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const session = findRecoverableSession(clerk);
+    const hasPendingContinuation =
+      session?.status === "pending" ||
+      (session ? taskKey(session).kind === "key" : false);
+    if (!dependencies.isContinuationRoute && !hasPendingContinuation) {
+      set(atoms.state$, { status: "inactive" });
+      return;
+    }
+    if (!session) {
+      set(atoms.state$, { reason: "missing-session", status: "failure" });
+      return;
+    }
+    set(applySession$, session, "recovery", clerk.buildUrlWithAuth.bind(clerk));
+  });
+}
+
+function createCoalescedOperation(
+  runtime: ContinuationRuntime,
+  operation$: Command<Promise<void>, [string, AbortSignal]>,
+): Command<Promise<void>, [string, AbortSignal]> {
+  return command(
+    async ({ get, set }, value: string, signal: AbortSignal): Promise<void> => {
+      const current = get(runtime.inFlight$);
+      if (current) {
+        await current;
+        signal.throwIfAborted();
+        return;
+      }
+      const operation = set(operation$, value, signal);
+      const trackedOperation = withCleanup(operation, () => {
+        set(runtime.inFlight$, null);
+      });
+      set(runtime.inFlight$, trackedOperation);
+      await trackedOperation;
+      signal.throwIfAborted();
+    },
+  );
+}
+
+function createCompleteSessionCommand(
+  atoms: ContinuationAtoms,
+  runtime: ContinuationRuntime,
+  applySession$: ApplySessionCommand,
+): Command<Promise<void>, [string, AbortSignal]> {
+  const activateSession$ = command(
+    async (
+      { get, set },
+      sessionId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (get(runtime.handledSessionId$) === sessionId) {
+        return;
+      }
+      set(runtime.handledSessionId$, sessionId);
+      set(atoms.sessionId$, sessionId);
+      set(atoms.state$, { status: "recovering" });
+      const clerk = await get(clerk$);
+      signal.throwIfAborted();
+      const activation = await settle(
+        clerk.setActive({
+          navigate: ({ decorateUrl, session }) => {
+            set(applySession$, session, "session", decorateUrl);
+          },
+          session: sessionId,
+        }),
+        signal,
+      );
+      if (!activation.ok) {
+        set(atoms.state$, {
+          reason: "activation-failed",
+          status: "failure",
+        });
+        return;
+      }
+    },
+  );
+  return createCoalescedOperation(runtime, activateSession$);
+}
+
+function createSelectOrganizationCommand(
+  atoms: ContinuationAtoms,
+  runtime: ContinuationRuntime,
+  applySession$: ApplySessionCommand,
+): Command<Promise<void>, [string, AbortSignal]> {
+  const activateOrganization$ = command(
+    async (
+      { get, set },
+      organizationId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (get(runtime.activatedOrganizationId$) === organizationId) {
+        return;
+      }
+      const continuationState = get(atoms.state$);
+      if (
+        continuationState.status !== "incomplete" ||
+        !continuationState.organizations.some((organization) => {
+          return organization.id === organizationId;
+        })
+      ) {
+        return;
+      }
+      set(atoms.state$, {
+        ...continuationState,
+        selectingOrganizationId: organizationId,
+      });
+      const clerk = await get(clerk$);
+      signal.throwIfAborted();
+      const activation = await settle(
+        clerk.setActive({
+          navigate: ({ decorateUrl, session }) => {
+            set(applySession$, session, "organization", decorateUrl);
+          },
+          organization: organizationId,
+        }),
+        signal,
+      );
+      if (!activation.ok) {
+        set(atoms.state$, {
+          reason: "organization-activation-failed",
+          status: "failure",
+        });
+        return;
+      }
+      set(runtime.activatedOrganizationId$, organizationId);
+    },
+  );
+  return createCoalescedOperation(runtime, activateOrganization$);
+}
+
+function createRestartCommand(
+  atoms: ContinuationAtoms,
+  runtime: ContinuationRuntime,
+  dependencies: AuthV2ContinuationDependencies,
+): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get }, signal: AbortSignal): Promise<void> => {
+    const current = get(runtime.inFlight$);
+    if (current) {
+      await current;
+      signal.throwIfAborted();
+      return;
+    }
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const sessionId = get(atoms.sessionId$);
+    if (sessionId) {
+      const signedOut = await settle(clerk.signOut({ sessionId }), signal);
+      if (!signedOut.ok) {
+        return;
+      }
+    }
+    window.location.href = dependencies.navigation.href(dependencies.mode);
+  });
+}
+
+export function isAuthV2ContinuationLocation(
+  pathname: string,
+  hash: string,
+): boolean {
+  const pathPrefixes = [
+    `${ROUTES.signInV2}/tasks/`,
+    `${ROUTES.signUpV2}/tasks/`,
+  ];
+  const hashPath = hash.startsWith("#") ? hash.slice(1) : hash;
+  return (
+    pathPrefixes.some((prefix) => {
+      return pathname.startsWith(prefix);
+    }) || hashPath.startsWith("/tasks/")
+  );
+}
+
+export function createAuthV2ContinuationSignals(
+  dependencies: AuthV2ContinuationDependencies,
+): AuthV2ContinuationSignals {
+  const atoms = createContinuationAtoms();
+  const runtime = createContinuationRuntime();
+  const applySession$ = createApplySessionCommand(atoms, runtime, dependencies);
+  const recover$ = createRecoveryCommand(atoms, applySession$, dependencies);
+  return {
+    completeSession$: createCompleteSessionCommand(
+      atoms,
+      runtime,
+      applySession$,
+    ),
+    failClosed$: command(({ set }, reason) => {
+      set(atoms.state$, { reason, status: "unknown" });
+    }),
+    initialize$: recover$,
+    recover$,
+    restart$: createRestartCommand(atoms, runtime, dependencies),
+    selectOrganization$: createSelectOrganizationCommand(
+      atoms,
+      runtime,
+      applySession$,
+    ),
+    state$: computed((get) => {
+      return get(atoms.state$);
+    }),
+  };
+}

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -1,4 +1,3 @@
-import type { Clerk } from "@clerk/clerk-js";
 import type {
   PrepareFirstFactorParams,
   SignInFirstFactor,
@@ -24,6 +23,7 @@ import {
   requestGoogleOneTapCredential,
   startAuthV2GoogleOAuth,
 } from "./sign-in-external-strategies.ts";
+import type { AuthV2ContinuationFlowHandoff } from "./continuation.ts";
 import type { AuthV2Navigation } from "./navigation.ts";
 
 export type AuthV2SignInFactor =
@@ -63,7 +63,6 @@ export type AuthV2SignInStep =
   | "new-password";
 
 export type AuthV2SignInUnknownReason =
-  | "activation-failed"
   | "missing-session"
   | "unsupported-factor"
   | "unsupported-status";
@@ -112,6 +111,7 @@ interface SignInResourceSnapshot {
 }
 
 export interface AuthV2SignInFlowDependencies {
+  readonly continuation: AuthV2ContinuationFlowHandoff;
   readonly isBaseRoute: boolean;
   readonly isOAuthCallbackRoute: boolean;
   readonly navigation: AuthV2Navigation;
@@ -165,11 +165,7 @@ interface SignInFlowAtoms {
 }
 
 interface SignInFlowRuntime {
-  readonly activatedSessionId$: State<string | null>;
-  readonly activation$: State<{
-    readonly promise: Promise<void>;
-    readonly sessionId: string;
-  } | null>;
+  readonly handledSessionId$: State<string | null>;
   readonly inFlight$: State<ReadonlyMap<CoalescedOperation, Promise<void>>>;
   readonly preparedFactorId$: State<string | null>;
 }
@@ -515,11 +511,7 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
 
 function createSignInFlowRuntime(): SignInFlowRuntime {
   return {
-    activatedSessionId$: state<string | null>(null),
-    activation$: state<{
-      readonly promise: Promise<void>;
-      readonly sessionId: string;
-    } | null>(null),
+    handledSessionId$: state<string | null>(null),
     inFlight$: state<ReadonlyMap<CoalescedOperation, Promise<void>>>(new Map()),
     preparedFactorId$: state<string | null>(null),
   };
@@ -530,61 +522,9 @@ function createResourceCommands(
   runtime: SignInFlowRuntime,
   dependencies: AuthV2SignInFlowDependencies,
 ): {
-  readonly activateSession$: Command<Promise<void>, [string, AbortSignal]>;
   readonly applyResource$: ApplySignInResourceCommand;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
 } {
-  const performActivation$ = command(
-    async (
-      { set },
-      clerk: Clerk,
-      sessionId: string,
-      redirectUrl: string,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      await clerk.setActive({ redirectUrl, session: sessionId });
-      signal.throwIfAborted();
-      set(runtime.activatedSessionId$, sessionId);
-    },
-  );
-  const activateSession$ = command(
-    async (
-      { get, set },
-      sessionId: string,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      if (get(runtime.activatedSessionId$) === sessionId) {
-        return;
-      }
-      const activeActivation = get(runtime.activation$);
-      if (activeActivation) {
-        await activeActivation.promise;
-        signal.throwIfAborted();
-        if (get(runtime.activatedSessionId$) === sessionId) {
-          return;
-        }
-      }
-
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
-      const activationPromise = set(
-        performActivation$,
-        clerk,
-        sessionId,
-        dependencies.navigation.completionRedirectUrl,
-        signal,
-      );
-      const trackedActivation = withCleanup(activationPromise, () => {
-        set(runtime.activation$, (current) => {
-          return current?.sessionId === sessionId ? null : current;
-        });
-      });
-      set(runtime.activation$, { promise: trackedActivation, sessionId });
-      await trackedActivation;
-      signal.throwIfAborted();
-    },
-  );
-
   const applyResource$ = command(
     async (
       { get, set },
@@ -597,6 +537,10 @@ function createResourceCommands(
       );
       set(atoms.snapshot$, snapshot);
       set(atoms.fatalState$, null);
+      if (snapshot.clerkStatus === "needs_second_factor") {
+        set(dependencies.continuation.failClosed$, "second-factor");
+        return;
+      }
       if (
         snapshot.transferable ||
         snapshot.clerkStatus !== "complete" ||
@@ -604,17 +548,16 @@ function createResourceCommands(
       ) {
         return;
       }
-      const activation = await settle(
-        set(activateSession$, snapshot.createdSessionId, signal),
+      if (get(runtime.handledSessionId$) === snapshot.createdSessionId) {
+        return;
+      }
+      await set(
+        dependencies.continuation.completeSession$,
+        snapshot.createdSessionId,
         signal,
       );
-      if (!activation.ok) {
-        set(atoms.fatalState$, {
-          clerkStatus: snapshot.clerkStatus,
-          reason: "activation-failed",
-          status: "unknown",
-        });
-      }
+      signal.throwIfAborted();
+      set(runtime.handledSessionId$, snapshot.createdSessionId);
     },
   );
 
@@ -638,9 +581,11 @@ function createResourceCommands(
           set(atoms.error$, normalizeClerkError(recovery.error, "general"));
         } else if (recovery.value) {
           // handleRedirectCallback activates completed OAuth sessions itself.
-          // Remember that ownership boundary so applyResource$ cannot activate
-          // the same session a second time after the callback reload.
-          set(runtime.activatedSessionId$, recovery.value);
+          // Remember that ownership boundary so applyResource$ cannot hand the
+          // same session to the continuation controller a second time.
+          set(runtime.handledSessionId$, recovery.value);
+          await set(dependencies.continuation.recover$, signal);
+          signal.throwIfAborted();
         }
       }
 
@@ -650,7 +595,7 @@ function createResourceCommands(
       signal.throwIfAborted();
     },
   );
-  return { activateSession$, applyResource$, initialize$ };
+  return { applyResource$, initialize$ };
 }
 
 function createCoalescedOperation$<Key extends CoalescedOperation>(
@@ -892,7 +837,7 @@ function createFactorSelectionCommand(
 function createSessionSelectionCommand(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
-  activateSession$: Command<Promise<void>, [string, AbortSignal]>,
+  completeSession$: Command<Promise<void>, [string, AbortSignal]>,
 ): Command<Promise<void>, [string, AbortSignal]> {
   const selectSessionOperation$ = command(
     async (
@@ -914,7 +859,7 @@ function createSessionSelectionCommand(
 
       set(atoms.error$, null);
       const activation = await settle(
-        set(activateSession$, account.sessionId, signal),
+        set(completeSession$, account.sessionId, signal),
         signal,
       );
       if (!activation.ok) {
@@ -1155,8 +1100,11 @@ export function createAuthV2SignInSignals(
 ): AuthV2SignInSignals {
   const atoms = createSignInFlowAtoms();
   const runtime = createSignInFlowRuntime();
-  const { activateSession$, applyResource$, initialize$ } =
-    createResourceCommands(atoms, runtime, dependencies);
+  const { applyResource$, initialize$ } = createResourceCommands(
+    atoms,
+    runtime,
+    dependencies,
+  );
   const submitOperation$ = createSubmitOperation$(
     atoms,
     runtime,
@@ -1217,7 +1165,7 @@ export function createAuthV2SignInSignals(
     selectSession$: createSessionSelectionCommand(
       atoms,
       runtime,
-      activateSession$,
+      dependencies.continuation.completeSession$,
     ),
     state$: atoms.state$,
     submit$: createCoalescedOperation$(runtime, "resource", submitOperation$),

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -1,4 +1,3 @@
-import type { Clerk } from "@clerk/clerk-js";
 import type {
   PasswordValidation,
   SignUpCreateParams,
@@ -19,6 +18,7 @@ import { clerk$ } from "../auth.ts";
 import { locale$ } from "../locale.ts";
 import { logger } from "../log.ts";
 import { createDeferredPromise, onRef, settle, withCleanup } from "../utils.ts";
+import type { AuthV2ContinuationFlowHandoff } from "./continuation.ts";
 import type { AuthV2Navigation } from "./navigation.ts";
 import {
   discoverAuthV2SignUpExternalCapabilities,
@@ -70,7 +70,6 @@ export type AuthV2SignUpCaptchaState =
   | "loading";
 
 export type AuthV2SignUpUnknownReason =
-  | "activation-failed"
   | "missing-legal-configuration"
   | "missing-session"
   | "unsupported-field"
@@ -117,9 +116,12 @@ export interface AuthV2SignUpError {
 }
 
 export interface AuthV2SignUpFlowDependencies {
+  readonly continuation: Pick<
+    AuthV2ContinuationFlowHandoff,
+    "completeSession$"
+  >;
   readonly isOAuthCallbackRoute: boolean;
   readonly navigation: AuthV2Navigation;
-  readonly resolveRedirectUrl: () => string;
 }
 
 export interface AuthV2SignUpSignals {
@@ -201,11 +203,6 @@ interface SignUpFlowAtoms {
 }
 
 interface SignUpFlowRuntime {
-  readonly activatedSessionId$: State<string | null>;
-  readonly activation$: State<{
-    readonly promise: Promise<void>;
-    readonly sessionId: string;
-  } | null>;
   readonly automaticPreparationAttempted$: State<boolean>;
   readonly cooldownTimer$: State<number | null>;
   readonly expiryTimer$: State<number | null>;
@@ -216,10 +213,6 @@ type ApplySignUpResourceCommand = Command<
   Promise<void>,
   [SignUpResource, AbortSignal]
 >;
-type CompleteSignUpSessionCommand = Command<
-  Promise<void>,
-  [string, string | null, AbortSignal]
->;
 type PrepareEmailVerificationCommand = Command<
   Promise<void>,
   [SignUpResource, boolean, AbortSignal]
@@ -227,7 +220,6 @@ type PrepareEmailVerificationCommand = Command<
 
 interface SignUpResourceCommands {
   readonly applyResource$: ApplySignUpResourceCommand;
-  readonly completeSession$: CompleteSignUpSessionCommand;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
   readonly prepareEmailVerification$: PrepareEmailVerificationCommand;
 }
@@ -570,11 +562,6 @@ function createSignUpFlowAtoms(): SignUpFlowAtoms {
 
 function createSignUpFlowRuntime(): SignUpFlowRuntime {
   return {
-    activatedSessionId$: state<string | null>(null),
-    activation$: state<{
-      readonly promise: Promise<void>;
-      readonly sessionId: string;
-    } | null>(null),
     automaticPreparationAttempted$: state(false),
     cooldownTimer$: state<number | null>(null),
     expiryTimer$: state<number | null>(null),
@@ -688,96 +675,10 @@ function createStartCooldownCommand(
   });
 }
 
-function createActivateSessionCommand(
-  runtime: SignUpFlowRuntime,
-  dependencies: AuthV2SignUpFlowDependencies,
-): Command<Promise<void>, [string, AbortSignal]> {
-  const performActivation$ = command(
-    async (
-      { set },
-      clerk: Clerk,
-      sessionId: string,
-      redirectUrl: string,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      await clerk.setActive({ redirectUrl, session: sessionId });
-      signal.throwIfAborted();
-      set(runtime.activatedSessionId$, sessionId);
-    },
-  );
-  return command(
-    async (
-      { get, set },
-      sessionId: string,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      if (get(runtime.activatedSessionId$) === sessionId) {
-        return;
-      }
-      const activeActivation = get(runtime.activation$);
-      if (activeActivation) {
-        await activeActivation.promise;
-        signal.throwIfAborted();
-        if (get(runtime.activatedSessionId$) === sessionId) {
-          return;
-        }
-      }
-
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
-      const activationPromise = set(
-        performActivation$,
-        clerk,
-        sessionId,
-        dependencies.resolveRedirectUrl(),
-        signal,
-      );
-      const trackedActivation = withCleanup(activationPromise, () => {
-        set(runtime.activation$, (current) => {
-          return current?.sessionId === sessionId ? null : current;
-        });
-      });
-      set(runtime.activation$, { promise: trackedActivation, sessionId });
-      await trackedActivation;
-      signal.throwIfAborted();
-    },
-  );
-}
-
-function createCompleteSessionCommand(
-  atoms: SignUpFlowAtoms,
-  runtime: SignUpFlowRuntime,
-  dependencies: AuthV2SignUpFlowDependencies,
-): CompleteSignUpSessionCommand {
-  const activateSession$ = createActivateSessionCommand(runtime, dependencies);
-  return command(
-    async (
-      { set },
-      sessionId: string,
-      clerkStatus: string | null,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      const activation = await settle(
-        set(activateSession$, sessionId, signal),
-        signal,
-      );
-      if (!activation.ok) {
-        L.error("Auth v2 sign-up activation failed", clerkStatus);
-        set(atoms.fatalState$, {
-          clerkStatus,
-          reason: "activation-failed",
-          status: "unknown",
-        });
-      }
-    },
-  );
-}
-
 function createInitializeCommand(
   atoms: SignUpFlowAtoms,
   dependencies: AuthV2SignUpFlowDependencies,
   applyResource$: ApplySignUpResourceCommand,
-  completeSession$: CompleteSignUpSessionCommand,
   prepareEmailVerification$: PrepareEmailVerificationCommand,
 ): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
@@ -836,7 +737,11 @@ function createInitializeCommand(
     set(atoms.lastName$, resource.lastName ?? "");
     set(atoms.legalAccepted$, resource.legalAcceptedAt !== null);
     if (recoveredSessionId) {
-      await set(completeSession$, recoveredSessionId, "complete", signal);
+      await set(
+        dependencies.continuation.completeSession$,
+        recoveredSessionId,
+        signal,
+      );
       signal.throwIfAborted();
       return;
     }
@@ -854,11 +759,6 @@ function createResourceCommands(
 ): SignUpResourceCommands {
   const scheduleExpiry$ = createScheduleExpiryCommand(atoms, runtime);
   const startCooldown$ = createStartCooldownCommand(atoms, runtime);
-  const completeSession$ = createCompleteSessionCommand(
-    atoms,
-    runtime,
-    dependencies,
-  );
 
   const applyResource$ = command(
     async (
@@ -880,9 +780,8 @@ function createResourceCommands(
         return;
       }
       await set(
-        completeSession$,
+        dependencies.continuation.completeSession$,
         snapshot.createdSessionId,
-        snapshot.clerkStatus,
         signal,
       );
       signal.throwIfAborted();
@@ -941,13 +840,11 @@ function createResourceCommands(
     atoms,
     dependencies,
     applyResource$,
-    completeSession$,
     prepareEmailVerification$,
   );
 
   return {
     applyResource$,
-    completeSession$,
     initialize$,
     prepareEmailVerification$,
   };

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
@@ -1,13 +1,19 @@
+import { useGet } from "ccstate-react";
+
+import type { AuthV2ContinuationSignals } from "../../signals/auth-v2/continuation.ts";
 import type { AuthV2SignInSignals } from "../../signals/auth-v2/sign-in-flow.ts";
 import type { AuthV2PlatformContext } from "../../signals/auth-v2/platform-context.ts";
 import type { AuthV2SignUpSignals } from "../../signals/auth-v2/sign-up-flow.ts";
 import { AuthShell } from "../auth/auth-shell.tsx";
+import { AuthV2ContinuationCard } from "./continuation/continuation-card.tsx";
 import { AuthV2SignInCard } from "./sign-in/sign-in-card.tsx";
 import { AuthV2SignUpCard } from "./sign-up/sign-up-card.tsx";
 
 export type AuthV2PageMode = "sign-in" | "sign-up";
 
-type AuthV2PageProps =
+type AuthV2PageProps = {
+  readonly continuationSignals: AuthV2ContinuationSignals;
+} & (
   | {
       readonly mode: "sign-in";
       readonly platformContext: AuthV2PlatformContext;
@@ -17,12 +23,20 @@ type AuthV2PageProps =
       readonly mode: "sign-up";
       readonly platformContext: AuthV2PlatformContext;
       readonly signUpSignals: AuthV2SignUpSignals;
-    };
+    }
+);
 
 export function AuthV2Page(props: AuthV2PageProps) {
+  const continuationState = useGet(props.continuationSignals.state$);
   return (
     <AuthShell authBrand={props.platformContext.authBrand} variant="v2">
-      {props.mode === "sign-in" ? (
+      {continuationState.status !== "inactive" ? (
+        <AuthV2ContinuationCard
+          authBrand={props.platformContext.authBrand}
+          signals={props.continuationSignals}
+          state={continuationState}
+        />
+      ) : props.mode === "sign-in" ? (
         <AuthV2SignInCard signals={props.signInSignals} />
       ) : (
         <AuthV2SignUpCard

--- a/turbo/apps/platform/src/views/auth-v2/continuation/__tests__/continuation-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/__tests__/continuation-card.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  type MockedMembership,
+  mockedClerk,
+  mockSignInResource,
+} from "../../../../__tests__/mock-auth.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../../__tests__/page-helper.ts";
+import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function membership(id: string, name: string): MockedMembership {
+  return {
+    id: `membership_${id}`,
+    organization: { id, name },
+    role: "org:member",
+  };
+}
+
+function buttonNamed(name: string): HTMLElement | undefined {
+  return queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
+}
+
+async function waitForButton(name: string): Promise<HTMLElement> {
+  await waitFor(() => {
+    expect(buttonNamed(name)).toBeDefined();
+  });
+  const button = buttonNamed(name);
+  if (!button) {
+    throw new Error(`Expected button named ${name}`);
+  }
+  return button;
+}
+
+function setupTaskPage(options: {
+  readonly memberships?: MockedMembership[];
+  readonly taskKey: string;
+  readonly url?: string;
+}): void {
+  const memberships = options.memberships ?? [];
+  const url = new URL(
+    options.url ?? "https://app.vm0.ai/v2/sign-in/tasks/choose-organization",
+  );
+  context.mocks.browser.url(url.toString());
+  detachedSetupPage({
+    context,
+    org: { activeOrg: null, memberships },
+    path: `${url.pathname}${url.search}${url.hash}`,
+    session: { token: "test-token" },
+    user: {
+      clientSessions: [
+        {
+          currentTask: { key: options.taskKey },
+          id: "session_pending",
+          status: "pending",
+          user: {
+            fullName: "Test User",
+            organizationMemberships: memberships,
+          },
+        },
+      ],
+      fullName: "Test User",
+      id: "user_test",
+    },
+  });
+}
+
+describe("auth v2 continuation card", () => {
+  it("recovers forced selection, switches membership once, and exposes no organization management", async () => {
+    const memberships = [
+      membership("org_alpha", "Alpha Company"),
+      membership("org_beta", "Beta Studio"),
+    ];
+    setupTaskPage({
+      memberships,
+      taskKey: "choose-organization",
+      url: `https://app.vm0.ai/v2/sign-in/tasks/choose-organization?redirect_url=${encodeURIComponent("https://app.vm0.ai/agents")}`,
+    });
+
+    const beta = await waitForButton("Continue with Beta Studio");
+    expect(buttonNamed("Continue with Alpha Company")).toBeVisible();
+    expect(screen.queryByText(/create organization/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invitation/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/manage organization/i)).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("membership_org_alpha");
+    expect(document.body).not.toHaveTextContent("org_beta");
+
+    fireEvent.click(beta);
+    fireEvent.click(beta);
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.setActive).toHaveBeenCalledWith({
+      navigate: expect.any(Function),
+      organization: "org_beta",
+    });
+    await waitFor(() => {
+      expect(location.pathname).toBe("/agents");
+    });
+  });
+
+  it("shows a sanitized recovery path after organization activation failure", async () => {
+    setupTaskPage({
+      memberships: [membership("org_private", "Private Workspace")],
+      taskKey: "choose-organization",
+    });
+    mockedClerk.setActive.mockRejectedValue(
+      new Error("token=secret membership_private https://sensitive.example"),
+    );
+
+    fireEvent.click(await waitForButton("Continue with Private Workspace"));
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "Sign-in couldn't be completed",
+      }),
+    ).resolves.toBeVisible();
+    expect(buttonNamed("Start over")).toBeVisible();
+    expect(document.body).not.toHaveTextContent("token=secret");
+    expect(document.body).not.toHaveTextContent("membership_private");
+    expect(document.body).not.toHaveTextContent("sensitive.example");
+  });
+
+  it("does not offer organization creation when no membership is available", async () => {
+    setupTaskPage({ memberships: [], taskKey: "choose-organization" });
+
+    await expect(
+      screen.findByRole("heading", { name: "No organization available" }),
+    ).resolves.toBeVisible();
+    expect(buttonNamed("Start over")).toBeVisible();
+    expect(
+      queryAllByRoleFast("button").some((button) => {
+        return /create/i.test(button.textContent ?? "");
+      }),
+    ).toBeFalsy();
+  });
+
+  it.each([
+    {
+      description: "an unsupported continuation",
+      expectedTitle: "Sign-in step unavailable",
+      taskKey: "reset-password",
+    },
+    {
+      description: "an unknown task",
+      expectedTitle: "Sign-in step unavailable",
+      taskKey: "future-sensitive-task",
+    },
+    {
+      description: "a returned second-factor task",
+      expectedTitle: "Additional verification required",
+      taskKey: "setup-mfa",
+    },
+  ])("fails closed for $description", async ({ expectedTitle, taskKey }) => {
+    setupTaskPage({ taskKey });
+
+    await expect(
+      screen.findByRole("heading", { name: expectedTitle }),
+    ).resolves.toBeVisible();
+    expect(buttonNamed("Start over")).toBeVisible();
+    expect(document.body).not.toHaveTextContent(taskKey);
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Clerk returns a second-factor sign-in status", async () => {
+    mockSignInResource({ status: "needs_second_factor" });
+    context.mocks.browser.url("https://app.vm0.ai/v2/sign-in/factor-two");
+    detachedSetupPage({
+      context,
+      path: "/v2/sign-in/factor-two",
+      session: null,
+      user: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "Additional verification required",
+      }),
+    ).resolves.toBeVisible();
+    expect(buttonNamed("Start over")).toBeVisible();
+  });
+});

--- a/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
@@ -1,0 +1,182 @@
+import { Button } from "@okouai/ui";
+import { useGet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Loader2 } from "lucide-react";
+
+import type {
+  AuthV2ContinuationSignals,
+  AuthV2ContinuationState,
+} from "../../../signals/auth-v2/continuation.ts";
+import type { AuthBrandContext } from "../../../signals/auth.ts";
+import { pageSignal$ } from "../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
+import { AuthV2Shell } from "../auth-v2-shell.tsx";
+import {
+  type AuthV2ContinuationCopy,
+  useAuthV2ContinuationCopy,
+} from "./continuation-copy.ts";
+
+function continuationHeading(
+  state: AuthV2ContinuationState,
+  copy: AuthV2ContinuationCopy,
+): { readonly description: string; readonly title: string } {
+  if (state.status === "incomplete") {
+    return {
+      description: copy.chooseOrganizationDescription,
+      title: copy.chooseOrganizationTitle,
+    };
+  }
+  if (state.status === "complete") {
+    return {
+      description: copy.completeDescription,
+      title: copy.completeTitle,
+    };
+  }
+  if (state.status === "failure" && state.reason === "no-organizations") {
+    return {
+      description: copy.noOrganizationsDescription,
+      title: copy.noOrganizationsTitle,
+    };
+  }
+  if (state.status === "failure") {
+    return {
+      description: copy.activationErrorDescription,
+      title: copy.activationErrorTitle,
+    };
+  }
+  if (state.status === "unknown" && state.reason === "second-factor") {
+    return {
+      description: copy.secondFactorDescription,
+      title: copy.secondFactorTitle,
+    };
+  }
+  if (state.status === "unknown") {
+    return {
+      description: copy.unsupportedDescription,
+      title: copy.unsupportedTitle,
+    };
+  }
+  return {
+    description: copy.loadingDescription,
+    title: copy.loadingTitle,
+  };
+}
+
+function LoadingContent({ label }: { readonly label: string }) {
+  return (
+    <div className="flex justify-center py-2" role="status">
+      <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+function OrganizationContent({
+  copy,
+  signals,
+  state,
+}: {
+  readonly copy: AuthV2ContinuationCopy;
+  readonly signals: AuthV2ContinuationSignals;
+  readonly state: Extract<AuthV2ContinuationState, { status: "incomplete" }>;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [selectionLoadable, selectOrganization] = useLoadableSet(
+    signals.selectOrganization$,
+  );
+  const selectionPending = selectionLoadable.state === "loading";
+  return (
+    <div className="space-y-2">
+      {state.organizations.map((organization) => {
+        const selected =
+          state.selectingOrganizationId === organization.id && selectionPending;
+        return (
+          <Button
+            className="w-full justify-start"
+            disabled={selectionPending}
+            key={organization.id}
+            onClick={() => {
+              detach(
+                selectOrganization(organization.id, pageSignal),
+                Reason.DomCallback,
+                "select auth v2 organization",
+              );
+            }}
+            type="button"
+            variant="outline"
+          >
+            {selected ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : null}
+            {copy.selectOrganization(organization.name)}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecoveryContent({
+  copy,
+  signals,
+}: {
+  readonly copy: AuthV2ContinuationCopy;
+  readonly signals: AuthV2ContinuationSignals;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [restartLoadable, restart] = useLoadableSet(signals.restart$);
+  const restarting = restartLoadable.state === "loading";
+  return (
+    <Button
+      className="w-full"
+      disabled={restarting}
+      onClick={() => {
+        detach(
+          restart(pageSignal),
+          Reason.DomCallback,
+          "restart auth v2 after continuation failure",
+        );
+      }}
+      type="button"
+    >
+      {restarting ? (
+        <Loader2 className="animate-spin" aria-hidden="true" />
+      ) : null}
+      {copy.recoveryAction}
+    </Button>
+  );
+}
+
+export function AuthV2ContinuationCard({
+  authBrand,
+  signals,
+  state,
+}: {
+  readonly authBrand: AuthBrandContext;
+  readonly signals: AuthV2ContinuationSignals;
+  readonly state: AuthV2ContinuationState;
+}) {
+  const copy = useAuthV2ContinuationCopy(authBrand.brandName);
+  if (state.status === "inactive") {
+    return null;
+  }
+  const heading = continuationHeading(state, copy);
+  const content =
+    state.status === "incomplete" ? (
+      <OrganizationContent copy={copy} signals={signals} state={state} />
+    ) : state.status === "failure" || state.status === "unknown" ? (
+      <RecoveryContent copy={copy} signals={signals} />
+    ) : (
+      <LoadingContent label={heading.description} />
+    );
+  return (
+    <AuthV2Shell
+      announcement={heading.description}
+      description={heading.description}
+      focusKey={`continuation-${state.status}`}
+      title={heading.title}
+    >
+      {content}
+    </AuthV2Shell>
+  );
+}

--- a/turbo/apps/platform/src/views/auth-v2/continuation/continuation-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/continuation-copy.ts
@@ -1,0 +1,89 @@
+import { useTranslation } from "react-i18next";
+
+import type { AuthBrandContext } from "../../../signals/auth.ts";
+
+export interface AuthV2ContinuationCopy {
+  readonly activationErrorDescription: string;
+  readonly activationErrorTitle: string;
+  readonly chooseOrganizationDescription: string;
+  readonly chooseOrganizationTitle: string;
+  readonly completeDescription: string;
+  readonly completeTitle: string;
+  readonly loadingDescription: string;
+  readonly loadingTitle: string;
+  readonly noOrganizationsDescription: string;
+  readonly noOrganizationsTitle: string;
+  readonly recoveryAction: string;
+  readonly secondFactorDescription: string;
+  readonly secondFactorTitle: string;
+  readonly selectOrganization: (organizationName: string) => string;
+  readonly unsupportedDescription: string;
+  readonly unsupportedTitle: string;
+}
+
+export function useAuthV2ContinuationCopy(
+  brandName: AuthBrandContext["brandName"],
+): AuthV2ContinuationCopy {
+  const { t } = useTranslation();
+  return {
+    activationErrorDescription: t(($) => {
+      return $.auth.v2.continuation.activationErrorDescription;
+    }),
+    activationErrorTitle: t(($) => {
+      return $.auth.v2.continuation.activationErrorTitle;
+    }),
+    chooseOrganizationDescription: t(
+      ($) => {
+        return $.auth.v2.continuation.chooseOrganizationDescription;
+      },
+      { brandName },
+    ),
+    chooseOrganizationTitle: t(($) => {
+      return $.auth.v2.continuation.chooseOrganizationTitle;
+    }),
+    completeDescription: t(
+      ($) => {
+        return $.auth.v2.continuation.completeDescription;
+      },
+      { brandName },
+    ),
+    completeTitle: t(($) => {
+      return $.auth.v2.continuation.completeTitle;
+    }),
+    loadingDescription: t(($) => {
+      return $.auth.v2.continuation.loadingDescription;
+    }),
+    loadingTitle: t(($) => {
+      return $.auth.v2.continuation.loadingTitle;
+    }),
+    noOrganizationsDescription: t(($) => {
+      return $.auth.v2.continuation.noOrganizationsDescription;
+    }),
+    noOrganizationsTitle: t(($) => {
+      return $.auth.v2.continuation.noOrganizationsTitle;
+    }),
+    recoveryAction: t(($) => {
+      return $.auth.v2.continuation.recoveryAction;
+    }),
+    secondFactorDescription: t(($) => {
+      return $.auth.v2.continuation.secondFactorDescription;
+    }),
+    secondFactorTitle: t(($) => {
+      return $.auth.v2.continuation.secondFactorTitle;
+    }),
+    selectOrganization: (organizationName) => {
+      return t(
+        ($) => {
+          return $.auth.v2.continuation.selectOrganization;
+        },
+        { organizationName },
+      );
+    },
+    unsupportedDescription: t(($) => {
+      return $.auth.v2.continuation.unsupportedDescription;
+    }),
+    unsupportedTitle: t(($) => {
+      return $.auth.v2.continuation.unsupportedTitle;
+    }),
+  };
+}

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -154,7 +154,9 @@ describe("auth v2 sign-in flow", () => {
 
     const signInCard = await screen.findByTestId("app-auth-v2");
     const loadingState = within(signInCard).getByRole("status");
-    expect(loadingState).toHaveTextContent("Loading authentication");
+    expect(loadingState).toHaveTextContent(
+      "Checking what your account needs next.",
+    );
 
     await act(async () => {
       clerkLoad.resolve(undefined);
@@ -210,7 +212,7 @@ describe("auth v2 sign-in flow", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: "https://app.vm0.ai",
+      navigate: expect.any(Function),
       session: "session_password",
     });
   });
@@ -460,10 +462,20 @@ describe("auth v2 sign-in flow", () => {
     });
   });
 
-  it("selects an existing Clerk account once and can fall back to a new sign-in", async () => {
+  it("selects an existing Clerk account once", async () => {
     const activation = createDeferredPromise<void>(context.signal);
-    mockedClerk.setActive.mockImplementation(() => {
-      return activation.promise;
+    mockedClerk.setActive.mockImplementation(async (params) => {
+      await activation.promise;
+      await params.navigate?.({
+        decorateUrl: (url) => {
+          return url;
+        },
+        session: {
+          id: "session_ada",
+          status: "active",
+          user: { organizationMemberships: [] },
+        },
+      });
     });
     setupSignInPage(
       { status: "needs_identifier" },
@@ -510,7 +522,7 @@ describe("auth v2 sign-in flow", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: "https://app.vm0.ai",
+      navigate: expect.any(Function),
       session: "session_ada",
     });
 
@@ -518,6 +530,30 @@ describe("auth v2 sign-in flow", () => {
       activation.resolve(undefined);
       await activation.promise;
     });
+  });
+
+  it("can fall back from existing Clerk accounts to a new sign-in", async () => {
+    setupSignInPage(
+      { status: "needs_identifier" },
+      {
+        user: {
+          clientSessions: [
+            {
+              id: "session_ada",
+              status: "active",
+              user: {
+                fullName: "Ada Lovelace",
+                primaryEmailAddress: { emailAddress: "ada@example.com" },
+              },
+            },
+          ],
+          email: "ada@example.com",
+          fullName: "Ada Lovelace",
+          id: "user_ada",
+        },
+      },
+    );
+
     fireEvent.click(await waitForRoleElement("button", "Add account"));
 
     await expect(
@@ -790,10 +826,6 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it.each([
-    {
-      name: "an unsupported Clerk status",
-      state: { status: "needs_second_factor" },
-    },
     {
       name: "an unsupported factor set",
       state: {

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -124,7 +124,7 @@ describe("auth v2 sign-up flow", () => {
 
     const signUpCard = await screen.findByTestId("app-auth-v2");
     expect(within(signUpCard).getByRole("status")).toHaveTextContent(
-      "Loading authentication",
+      "Checking what your account needs next.",
     );
 
     await act(async () => {
@@ -235,7 +235,7 @@ describe("auth v2 sign-up flow", () => {
     });
   });
 
-  it("recovers a completed Google callback through the existing activation seam exactly once", async () => {
+  it("hands a completed Google callback to continuation exactly once", async () => {
     const path = "/v2/sign-up/sso-callback?gclid=click-123&utm_campaign=summer";
     setupSignUpPage(
       {
@@ -252,11 +252,11 @@ describe("auth v2 sign-up flow", () => {
     });
     expect(mockedClerk.handleRedirectCallback).not.toHaveBeenCalled();
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: expect.stringContaining("/onboarding"),
+      navigate: expect.any(Function),
       session: "session_google_sign_up",
     });
-    const activation = mockedClerk.setActive.mock.calls[0]?.[0];
-    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    const redirectUrl = new URL(location.href);
+    expect(redirectUrl.pathname).toBe("/onboarding");
     expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
     expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");
   });
@@ -292,11 +292,11 @@ describe("auth v2 sign-up flow", () => {
       transfer: true,
     });
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: expect.stringContaining("/onboarding"),
+      navigate: expect.any(Function),
       session: "session_existing_google",
     });
-    const activation = mockedClerk.setActive.mock.calls[0]?.[0];
-    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    const redirectUrl = new URL(location.href);
+    expect(redirectUrl.pathname).toBe("/onboarding");
     expect(redirectUrl.searchParams.get("gclid")).toBe("existing-123");
     expect(redirectUrl.searchParams.get("utm_campaign")).toBe("transfer");
   });
@@ -329,9 +329,11 @@ describe("auth v2 sign-up flow", () => {
     });
     expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
     expect(mockedClerk.setActive).toHaveBeenCalledWith({
-      redirectUrl: "https://app.vm0.ai",
+      navigate: expect.any(Function),
       session: "session_recovered_transfer",
     });
+    expect(location.origin).toBe("https://app.vm0.ai");
+    expect(location.pathname).toBe("/");
   });
 
   it("replaces an unrelated sign-in resource before transferring an existing Google identity", async () => {
@@ -370,7 +372,7 @@ describe("auth v2 sign-up flow", () => {
         transfer: true,
       });
       expect(mockedClerk.setActive).toHaveBeenCalledWith({
-        redirectUrl: "https://app.vm0.ai",
+        navigate: expect.any(Function),
         session: "session_existing_google",
       });
     });
@@ -594,8 +596,11 @@ describe("auth v2 sign-up flow", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
     const activation = mockedClerk.setActive.mock.calls[0]?.[0];
-    expect(activation?.session).toBe("session_sign_up");
-    const redirectUrl = new URL(activation?.redirectUrl ?? "");
+    expect(activation).toStrictEqual({
+      navigate: expect.any(Function),
+      session: "session_sign_up",
+    });
+    const redirectUrl = new URL(location.href);
     expect(redirectUrl.pathname).toBe("/onboarding");
     expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
     expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -1,11 +1,14 @@
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
-import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import {
+  type MockedMembership,
+  mockedClerk,
+} from "../../../__tests__/mock-auth.ts";
 import { PRESENTATION_ONBOARDING_URL } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import type { SupportedLocale } from "../../../i18n/resources.ts";
 import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
@@ -38,6 +41,47 @@ function authV2ActionLink(name: string): HTMLAnchorElement {
     throw new Error("Auth v2 action link not found");
   }
   return link;
+}
+
+function authV2Button(name: string): HTMLButtonElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("Auth v2 button not found");
+  }
+  return button;
+}
+
+function setupChooseOrganizationPage(
+  path: string,
+  organization: { readonly id: string; readonly name: string },
+): void {
+  const membership: MockedMembership = {
+    id: `membership_${organization.id}`,
+    organization,
+    role: "org:member",
+  };
+  detachedSetupPage({
+    context,
+    org: { activeOrg: null, memberships: [membership] },
+    path,
+    user: {
+      clientSessions: [
+        {
+          currentTask: { key: "choose-organization" },
+          id: "session_pending",
+          status: "pending",
+          user: {
+            fullName: "Test User",
+            organizationMemberships: [membership],
+          },
+        },
+      ],
+      fullName: "Test User",
+      id: "test-user-123",
+    },
+  });
 }
 
 function disableUrlCanParse(): void {
@@ -376,13 +420,6 @@ describe("app auth pages", () => {
       path: "/v2/sign-in",
     },
     {
-      action: "Use current sign-in",
-      documentTitle: "Sign in | VM0",
-      heading: "Sign in to VM0",
-      legacyPath: "/sign-in",
-      path: "/v2/sign-in/tasks/choose-organization",
-    },
-    {
       action: "Use current sign-up",
       documentTitle: "Sign up | VM0",
       heading: "Create your VM0 account",
@@ -401,10 +438,10 @@ describe("app auth pages", () => {
 
     detachedSetupPage({ context, path: routeCase.path });
 
-    await expect(screen.findByTestId("app-auth-v2")).resolves.toBeVisible();
-    expect(
-      screen.getByRole("heading", { name: routeCase.heading }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("region", { name: routeCase.heading }),
+    ).resolves.toBeVisible();
+    expect(screen.getByTestId("app-auth-v2")).toBeVisible();
     const actionLink = authV2ActionLink(routeCase.action);
     expect(actionLink).toHaveTextContent(routeCase.action);
     expect(actionLink).toHaveAttribute("href", routeCase.legacyPath);
@@ -417,22 +454,45 @@ describe("app auth pages", () => {
     expect(document.title).toBe(routeCase.documentTitle);
   });
 
-  it("preserves branded auth intent when leaving the v2 scaffold", async () => {
+  it("recovers forced organization selection on a nested v2 task route", async () => {
+    const path = "/v2/sign-in/tasks/choose-organization";
+    setBrowserUrl(`https://app.vm0.ai${path}`);
+
+    setupChooseOrganizationPage(path, {
+      id: "org_route",
+      name: "Route Organization",
+    });
+
+    await expect(
+      screen.findByRole("region", { name: "Choose an organization" }),
+    ).resolves.toBeVisible();
+    expect(authV2Button("Continue with Route Organization")).toBeVisible();
+    expect(
+      queryAllByRoleFast("link").some((candidate) => {
+        return candidate.textContent?.trim() === "Use current sign-in";
+      }),
+    ).toBeFalsy();
+    expect(screen.queryByText(/create organization/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
+    expect(document.title).toBe("Sign in | VM0");
+  });
+
+  it("preserves branded auth intent through v2 continuation", async () => {
     const redirectUrl = "https://app.okou.ai/onboarding?source=auth-v2";
     const hash = "#/?step=identifier";
     const path = `/v2/sign-in/tasks/choose-organization?redirect_url=${encodeURIComponent(redirectUrl)}${hash}`;
     setBrowserUrl(`https://app.vm0.ai${path}`);
 
-    detachedSetupPage({ context, path });
+    setupChooseOrganizationPage(path, {
+      id: "org_okou",
+      name: "Okou Organization",
+    });
 
-    await expect(screen.findByTestId("app-auth-v2")).resolves.toBeVisible();
-    expect(
-      screen.getByRole("heading", { name: "Sign in to Okou" }),
-    ).toBeVisible();
-    const continueLink = authV2ActionLink("Use current sign-in");
-    expect(continueLink).toHaveAttribute(
-      "href",
-      `/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}${hash}`,
+    await expect(
+      screen.findByRole("region", { name: "Choose an organization" }),
+    ).resolves.toBeVisible();
+    expect(document.body).toHaveTextContent(
+      "Choose an organization to continue to Okou.",
     );
     expect(document.title).toBe("Sign in | Okou");
     expect(okouBrandLink()).toHaveAttribute("href", "https://app.okou.ai");
@@ -440,6 +500,12 @@ describe("app auth pages", () => {
       "data-clerk-sign-in-start-title",
       "Sign in to Okou",
     );
+
+    fireEvent.click(authV2Button("Continue with Okou Organization"));
+
+    await waitFor(() => {
+      expect(location.href).toBe(redirectUrl);
+    });
   });
 
   it("renders the app-hosted sign-in route with an allowed redirect URL", async () => {


### PR DESCRIPTION
## Summary

- Add a vm0-owned Auth v2 continuation state machine based on Clerk 6.25.8 session status and `currentTask` resources, including loading, refresh recovery, incomplete, complete, failure, and fail-closed unknown states.
- Hand completed sign-in/sign-up session IDs to the continuation controller, activate each session once, and handle forced organization selection from existing memberships only before following the existing allowed redirect policy.
- Add sanitized recovery UI for missing/failed activation, unsupported or unknown tasks, and returned second-factor states. The UI contains no organization creation, invitation, management, Clerk prebuilt component, or `.cl-*` selector.
- Preserve multi-session account selection, nested `/v2` task refreshes, VM0/Okou context, and sign-in/sign-up route ownership without routing production traffic to `/v2`.

Part of #28927.

## Scope boundaries

- No changes to existing `/sign-in` or `/sign-up` behavior or production routing.
- No Google sign-up callback classification, sign-up external-strategy module, or Clerk transfer handoff changes; those remain owned by #29109.
- No organization creation, invitations, organization management, or global analytics/diagnostics.

## Dependency reconciliation with #29109

Google sign-up PR #29109 merged into `main` at `e3682a7a1832c7dd82b265b7aaeb782d43375dc0`. This branch is rebased onto that commit, and the expected overlap has been reconciled in:

- `turbo/apps/platform/src/__tests__/mock-auth.ts`
- `turbo/apps/platform/src/signals/auth-v2-page-setup.ts`
- `turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts`
- `turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx`

The reconciled seam preserves #29109's Google callback classification and existing-identity resource-transfer recovery. Both native and recovered Google completions now hand only a completed session ID to continuation, which remains the sole owner of final `setActive`, task interpretation, organization activation, and allowed navigation. No sibling-owned Google sign-up file is changed outside the four shared integration files above.

## Shared integration files

Follow-on Auth v2 work should account for these shared files when rebasing:

- `turbo/apps/platform/src/__tests__/mock-auth.ts`
- `turbo/apps/platform/src/i18n/locales/de-DE/common.json`
- `turbo/apps/platform/src/i18n/locales/en-US/common.json`
- `turbo/apps/platform/src/i18n/locales/es-ES/common.json`
- `turbo/apps/platform/src/i18n/locales/fr-FR/common.json`
- `turbo/apps/platform/src/i18n/locales/hi-IN/common.json`
- `turbo/apps/platform/src/i18n/locales/id-ID/common.json`
- `turbo/apps/platform/src/i18n/locales/it-IT/common.json`
- `turbo/apps/platform/src/i18n/locales/ja-JP/common.json`
- `turbo/apps/platform/src/i18n/locales/ko-KR/common.json`
- `turbo/apps/platform/src/i18n/locales/pt-BR/common.json`
- `turbo/apps/platform/src/signals/auth-v2-page-setup.ts`
- `turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts`
- `turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts`
- `turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx`
- `turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx`
- `turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx`

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm knip`
- `pnpm exec tsc -p apps/platform/tsconfig.production.json --noEmit`
- `pnpm exec tsc -p apps/platform/tsconfig.tests.json --noEmit`
- `src/signals/auth-v2/continuation.test.ts` (11 tests)
- `src/signals/auth-v2/navigation.test.ts` (6 tests)
- `src/signals/auth-v2/platform-context.test.ts` (5 tests)
- `src/signals/auth-v2/sign-up-external-strategies.test.ts` (6 tests)
- `src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx` (3 tests)
- `src/views/auth-v2/continuation/__tests__/continuation-card.test.tsx` (7 tests)
- `src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` (20 tests)
- `src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx` (21 tests)\n- `src/views/auth/__tests__/auth-page.test.tsx` (29 tests)

All 79 focused Auth v2 tests passed with Vitest's single-thread pool and a bounded Node heap. The full local Vitest suite and local dev server were intentionally not run; PR CI is the integration gate.
