### PR TITLE
chore(composer): open the note editable isolation switch to the staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -128,6 +128,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ComposerNoteEditableIsolation]).toBe(
+      true,
+    );
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -162,6 +165,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ComposerNoteEditableIsolation]).toBe(
+      false,
+    );
   });
 
   it("should enable Bingjie-only composer switches only for Bingjie", () => {
@@ -174,9 +180,6 @@ describe("getAllFeatureStates", () => {
     expect(
       bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(true);
-    expect(bingjieStates[FeatureSwitchKey.ComposerNoteEditableIsolation]).toBe(
-      true,
-    );
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -187,9 +190,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(
       otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
-    ).toBe(false);
-    expect(
-      otherStaffStates[FeatureSwitchKey.ComposerNoteEditableIsolation],
     ).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -400,7 +400,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Keep the feedback note's wrapper elements outside the editable flow, with the note content opting back in as its own editing host, so WebKit's editing machinery can neither restructure the wrappers during an IME composition nor land the caret between them.",
     enabled: false,
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

`ComposerNoteEditableIsolation` landed in #29037 gated to a single email hash (`fnv1a("bingjie@vm0.ai")`). This moves it one rollout step up to the whole staff org so the team can dogfood the fix for the feedback-note collapse (#27787).

```diff
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
```

`enabled: false` is unchanged, so nothing outside the staff org is affected. The org hash **supersedes** the email hash rather than joining it — the staff org already covers the maintainer, so keeping both would leave a dead identity path.

Per `.claude/skills/feature-switch`, `enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` is the standard staff-only tier, matching `Lab`, `Banking`, `ManagedSocialKit`, and `MorningBrief`.

## What the switch does

With it on, the feedback-item node view marks its `dom` `contenteditable="false"` and opts `contentDOM` back in as its own editing host, so WebKit's editing machinery can neither prune the note wrappers mid-IME-composition nor land the caret between them.

## Test changes

The two `ComposerNoteEditableIsolation` assertions in `should enable Bingjie-only composer switches only for Bingjie` are **deleted** rather than flipped: the switch is no longer Bingjie-only, so those assertions described configuration that no longer exists. Per `docs/fallback.md` §1, an outdated assertion is removed together with the config it covered instead of being kept as a tombstone.

Coverage moves to `should reflect the current staff org rollout matrix`, which asserts it on both sides (staff org `true`, non-staff org `false`) alongside every other org-gated switch.

## Rollout risk worth naming

#29015 (collapse detection, zero-loss reattachment, and collapse telemetry) is **still open**. Until it lands, `createFeedbackItemNodeView` keeps main's `ignoreMutation`, which discards every mutation outside `contentDOM` — including the record for WebKit tearing the wrappers out.

So for anyone in the staff org who hits a collapse anyway, the failure stays silent: no repair, no log, no signal. That is not a regression (it is today's behavior for everyone), but it does mean **absence of reports is not evidence the prevention works**. Verify positively — reproduce the collapse with the switch off, then confirm it stops with it on — rather than inferring success from silence.

## Verification

- `pnpm exec prettier --write <changed files>` — clean
- `pnpm --filter @okouai/core run check-types` — clean
- `pnpm --filter @okouai/core run lint` — exit 0
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed

Related to #27787. Follows #29037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)