### PR TITLE
revert: composer feedback note editable isolation

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -79,15 +79,6 @@ export const composerRestoredAttachmentValidationEnabled$ = computed(
   },
 );
 
-export const composerNoteEditableIsolationEnabled$ = computed(
-  (get): boolean => {
-    return (
-      get(featureSwitch$)[FeatureSwitchKey.ComposerNoteEditableIsolation] ??
-      false
-    );
-  },
-);
-
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -32,10 +32,7 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
-import {
-  composerNoteEditableIsolationEnabled$,
-  composerSubmitDomReconcileEnabled$,
-} from "../external/feature-switch.ts";
+import { composerSubmitDomReconcileEnabled$ } from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import { sentryLogContext } from "../../lib/sentry-config.ts";
 import { onRef, resetSignal } from "../utils.ts";
@@ -646,7 +643,6 @@ function createFeedbackItemNodeView(
   node: ProseMirrorNode,
   removeFeedback: (id: number) => void,
   localizedUi: Set<() => void>,
-  editableIsolationEnabled: () => boolean,
 ): NodeView {
   const dom = document.createElement("div");
   dom.dataset.feedbackItem = "";
@@ -695,14 +691,6 @@ function createFeedbackItemNodeView(
   contentDOM.setAttribute("aria-multiline", "true");
   noteDom.append(placeholderDom, contentDOM);
   dom.append(quoteDom, noteDom);
-  if (editableIsolationEnabled()) {
-    // Everything around contentDOM is chrome. Keeping it outside the editable
-    // region denies WebKit's editing machinery a reason to restructure it and
-    // keeps the caret from landing between the wrappers (#27787); contentDOM
-    // opts back in as its own editing host.
-    dom.contentEditable = "false";
-    contentDOM.contentEditable = "true";
-  }
 
   let currentNode = node;
   function localize(): void {
@@ -1618,8 +1606,6 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
-  /** Resolved ComposerNoteEditableIsolation switch, set while mounted. */
-  noteEditableIsolation: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1791,9 +1777,6 @@ function createFeedbackItemNode(
             runtime.removeFeedback(id);
           },
           runtime.localizedUi,
-          () => {
-            return runtime.noteEditableIsolation;
-          },
         );
       };
     },
@@ -1957,7 +1940,6 @@ function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
   runtime.blur = () => {};
   runtime.replaceFeedbackItems = () => {};
   runtime.removeFeedback = () => {};
-  runtime.noteEditableIsolation = false;
 }
 
 function applyWorkflowNames(editor: Editor, names: readonly string[]): void {
@@ -2174,9 +2156,6 @@ function createMountEditorCommand({
       runtime.removeFeedback = (id) => {
         set(feedback.signals.remove$, id);
       };
-      runtime.noteEditableIsolation = get(
-        composerNoteEditableIsolationEnabled$,
-      );
       configureMountedWorkflowEditor(editor, singleLineOnMobile);
       setWorkflowComposerDocument(
         editor,
@@ -2587,7 +2566,6 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
-    noteEditableIsolation: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1692,65 +1692,6 @@ describe("chat inline feedback", () => {
     });
   });
 
-  it("keeps the note editable and submits typed text with editable isolation enabled", async () => {
-    const user = userEvent.setup({ delay: null });
-    const assistantReply = "The rollout dates are unclear in this summary.";
-    const sentMessages: RunCreateCapture[] = [];
-
-    mockChatLifecycle(context, {
-      threadId: FEEDBACK_THREAD_ID,
-      threadTitle: "Feedback review",
-      chatEvents: [
-        {
-          id: "msg-feedback-isolation-user",
-          role: "user",
-          content: "Review this launch summary",
-          runId: "run-feedback-isolation",
-          createdAt: "2026-06-09T10:00:00Z",
-        },
-        {
-          id: "msg-feedback-isolation-assistant",
-          role: "assistant",
-          content: assistantReply,
-          runId: "run-feedback-isolation",
-          createdAt: "2026-06-09T10:01:00Z",
-        },
-      ],
-      onRunCreate: (body) => {
-        sentMessages.push(body);
-      },
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${FEEDBACK_THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerNoteEditableIsolation]: true,
-      },
-    });
-
-    await findComposerEditor();
-    selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Quote"));
-
-    const feedbackComment = await findFeedbackNote();
-    const [feedbackItem] = await findFeedbackItems(1);
-    expect(feedbackItem?.getAttribute("contenteditable")).toBe("false");
-    expect(feedbackComment.getAttribute("contenteditable")).toBe("true");
-
-    await user.click(feedbackComment);
-    pastePlainText(feedbackComment, "Make the dates explicit");
-    await waitFor(() => {
-      expect(feedbackComment).toHaveTextContent("Make the dates explicit");
-    });
-
-    await user.click(screen.getByLabelText("Send"));
-    await waitFor(() => {
-      expect(sentMessages).toHaveLength(1);
-    });
-    expect(sentMessages[0]?.prompt).toContain("Make the dates explicit");
-  });
-
   it("waits until mouseup before showing the inline feedback toolbar", async () => {
     const assistantReply = "The rollout dates are unclear in this summary.";
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -174,9 +174,6 @@ describe("getAllFeatureStates", () => {
     expect(
       bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(true);
-    expect(bingjieStates[FeatureSwitchKey.ComposerNoteEditableIsolation]).toBe(
-      true,
-    );
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -187,9 +184,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(
       otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
-    ).toBe(false);
-    expect(
-      otherStaffStates[FeatureSwitchKey.ComposerNoteEditableIsolation],
     ).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -84,5 +84,4 @@ export enum FeatureSwitchKey {
   ComposerSubmitDomReconcile = "composerSubmitDomReconcile",
   ComposerImageAnnotation = "composerImageAnnotation",
   ComposerRestoredAttachmentValidation = "composerRestoredAttachmentValidation",
-  ComposerNoteEditableIsolation = "composerNoteEditableIsolation",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -395,13 +395,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
-  [FeatureSwitchKey.ComposerNoteEditableIsolation]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Keep the feedback note's wrapper elements outside the editable flow, with the note content opting back in as its own editing host, so WebKit's editing machinery can neither restructure the wrappers during an IME composition nor land the caret between them.",
-    enabled: false,
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
-  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Reverts #29037 (`composerNoteEditableIsolation`), falsified in dogfood on the first day.

## Why

The switch promoted the feedback note's `contentDOM` to its own editing host (`dom` `contenteditable=false`, `contentDOM` `contenteditable=true`). Two structural conflicts surfaced:

1. **IME input-context binding.** The IME binds to the focused editing host, but ProseMirror focuses the outer host (`view.dom`) everywhere, leaving the selection in the inner host while focus sits outside. The first keystroke of a composition resolves that ambiguity literally: typing "zai" into the quote note inserts a bare "z" before "ai" starts composing. Fixing this would mean patching focus handoff on every entry path against ProseMirror's single-host assumptions, and every programmatic `contentDOM.focus()` fires a `blur` on `view.dom` that cascades through the editor's focus state.
2. **Event-routing heuristics.** The composer classifies "events owned by node-view controls" via `closest('[contenteditable="false"]')`. With the node view root non-editable, keys and pastes inside the note match that check too — on desktop, Enter inside the note falls through to ProseMirror (newline) instead of the send shortcut, and paste bypasses `insertPromptMarkdown`.

Per the falsified-fix convention (#28494), the switch and its gated code are removed rather than left dark.

## What stays / what's next

- #29015 (collapse detection, zero-loss reattachment, telemetry) is unaffected by this revert and remains the working mitigation for #27787.
- The structural cure will be redesigned **without a nested editing host**: flatten the note so `contentDOM` is the node view root itself, with the quote chip as a `contenteditable="false"` child guarded by a parse-ignore rule and the placeholder as a decoration. That shape removes the anonymous editable wrappers (what WebKit prunes) while keeping one editing host (no IME binding issue).

## Verification

- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx` — 32 passed
- `pnpm --filter @okouai/core run check-types`, `pnpm --filter @okouai/app run check-types` — clean
- `apps/platform` `pnpm run lint` — exit 0

Related to #27787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)