### PR TITLE
refactor(python): consolidate model-provider flow metadata setup

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -56,6 +56,47 @@ def make_openai_responses_websocket_response_headers(
     return http.Headers(pairs)
 
 
+def set_model_provider_flow_metadata(
+    flow: http.HTTPFlow,
+    tmp_path: Path,
+    *,
+    host: str,
+    original_url: str,
+    firewall_name: str,
+    proxy_log_path: Path | str | None,
+    run_id: str = "run-abc-123",
+    network_log_path: Path | str | None = None,
+    firewall_action: str = "ALLOW",
+    firewall_billable: object = True,
+    sandbox_token: str | None = None,
+    cli_agent_type: str | None = None,
+    model_usage_provider: str | None = None,
+) -> None:
+    flow.metadata[metadata_keys.SANDBOX_RUN_ID] = run_id
+    flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = str(
+        network_log_path if network_log_path is not None else tmp_path / "network.jsonl"
+    )
+    if proxy_log_path is not None:
+        flow.metadata[metadata_keys.SANDBOX_PROXY_LOG_PATH] = str(proxy_log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
+    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    http_network_log.set_target(
+        flow,
+        url=original_url,
+        host=host,
+        port=flow.request.port,
+    )
+    flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
+    flow.metadata[metadata_keys.SANDBOX_AUTH_KEY] = (
+        "tok-xyz" if sandbox_token is None else sandbox_token
+    )
+    if cli_agent_type is not None:
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
+    if model_usage_provider is not None:
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = model_usage_provider
+
+
 def make_model_provider_flow(
     real_flow: RealFlowFactory,
     tmp_path: Path,
@@ -75,30 +116,21 @@ def make_model_provider_flow(
     model_usage_provider: str | None = None,
 ) -> http.HTTPFlow:
     flow = real_flow(with_response=False, host=host, path=path, method=method)
-    flow.metadata[metadata_keys.SANDBOX_RUN_ID] = run_id
-    flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = str(
-        network_log_path if network_log_path is not None else tmp_path / "network.jsonl"
-    )
-    flow.metadata[metadata_keys.SANDBOX_PROXY_LOG_PATH] = str(
-        proxy_log_path if proxy_log_path is not None else tmp_path / "proxy.jsonl"
-    )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
-    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
-    http_network_log.set_target(
+    set_model_provider_flow_metadata(
         flow,
-        url=original_url,
+        tmp_path,
         host=host,
-        port=flow.request.port,
+        original_url=original_url,
+        firewall_name=firewall_name,
+        proxy_log_path=(proxy_log_path if proxy_log_path is not None else tmp_path / "proxy.jsonl"),
+        run_id=run_id,
+        network_log_path=network_log_path,
+        firewall_action=firewall_action,
+        firewall_billable=firewall_billable,
+        sandbox_token=sandbox_token,
+        cli_agent_type=cli_agent_type,
+        model_usage_provider=model_usage_provider,
     )
-    flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
-    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
-    flow.metadata[metadata_keys.SANDBOX_AUTH_KEY] = (
-        "tok-xyz" if sandbox_token is None else sandbox_token
-    )
-    if cli_agent_type is not None:
-        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
-    if model_usage_provider is not None:
-        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = model_usage_provider
     return flow
 
 

--- a/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
@@ -10,10 +10,9 @@ from pathlib import Path
 import brotli
 import zstandard
 
-import flow_metadata_keys as metadata_keys
-import http_network_log
 import mitm_addon
 import usage
+from tests.model_provider_flow_helpers import set_model_provider_flow_metadata
 
 
 @dataclass(frozen=True)
@@ -324,54 +323,6 @@ def run_response(flow, usage_webhook_api):
     return webhook
 
 
-def set_common_model_metadata(
-    flow,
-    tmp_path: Path,
-    *,
-    billable: bool = True,
-    proxy_log_path: Path | None = None,
-    run_id: str = "run-abc-123",
-) -> None:
-    flow.metadata[metadata_keys.SANDBOX_RUN_ID] = run_id
-    flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
-    if proxy_log_path is not None:
-        flow.metadata[metadata_keys.SANDBOX_PROXY_LOG_PATH] = str(proxy_log_path)
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = billable
-    flow.metadata[metadata_keys.SANDBOX_AUTH_KEY] = "tok-xyz"
-
-
-def set_model_provider_metadata(
-    flow,
-    tmp_path: Path,
-    provider_case: ModelProviderJsonCase,
-    *,
-    billable: bool = True,
-    observable: bool = True,
-    proxy_log_path: Path | None = None,
-    run_id: str = "run-abc-123",
-) -> None:
-    set_common_model_metadata(
-        flow,
-        tmp_path,
-        billable=billable,
-        proxy_log_path=proxy_log_path,
-        run_id=run_id,
-    )
-    flow.metadata[metadata_keys.ORIGINAL_URL] = provider_case.original_url
-    http_network_log.set_target(
-        flow,
-        url=provider_case.original_url,
-        host=provider_case.host,
-        port=flow.request.port,
-    )
-    flow.metadata[metadata_keys.FIREWALL_NAME] = provider_case.firewall_name
-    if observable:
-        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = provider_case.model
-    if provider_case.cli_agent_type is not None:
-        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = provider_case.cli_agent_type
-
-
 def model_provider_flow(
     real_flow,
     tmp_path: Path,
@@ -383,13 +334,16 @@ def model_provider_flow(
     run_id: str = "run-abc-123",
 ):
     flow = real_flow(with_response=False, host=provider_case.host)
-    set_model_provider_metadata(
+    set_model_provider_flow_metadata(
         flow,
         tmp_path,
-        provider_case,
-        billable=billable,
-        observable=observable,
+        host=provider_case.host,
+        original_url=provider_case.original_url,
+        firewall_name=provider_case.firewall_name,
         proxy_log_path=proxy_log_path,
         run_id=run_id,
+        firewall_billable=billable,
+        cli_agent_type=provider_case.cli_agent_type,
+        model_usage_provider=provider_case.model if observable else None,
     )
     return flow

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -19,7 +19,10 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
-from tests.model_provider_flow_helpers import model_usage_source_entries
+from tests.model_provider_flow_helpers import (
+    model_usage_source_entries,
+    set_model_provider_flow_metadata,
+)
 from tests.model_provider_response_helpers import (
     ANTHROPIC_JSON_CASE,
     CODEX_OAUTH_RESPONSES_CASE,
@@ -32,7 +35,6 @@ from tests.model_provider_response_helpers import (
     model_provider_flow,
     model_provider_json_case_id,
     run_response,
-    set_common_model_metadata,
     standard_success_payload,
 )
 from tests.stream_buffer_helpers import set_response_stream_buffer
@@ -726,13 +728,13 @@ class TestModelProviderJsonFallback:
     @pytest.mark.parametrize("firewall_name", [None, 42])
     def test_json_fallback_skips_malformed_firewall_name(self, tmp_path, real_flow, firewall_name):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        set_common_model_metadata(flow, tmp_path)
-        flow.metadata[metadata_keys.ORIGINAL_URL] = ANTHROPIC_JSON_CASE.original_url
-        http_network_log.set_target(
+        set_model_provider_flow_metadata(
             flow,
-            url=ANTHROPIC_JSON_CASE.original_url,
+            tmp_path,
             host=ANTHROPIC_JSON_CASE.host,
-            port=flow.request.port,
+            original_url=ANTHROPIC_JSON_CASE.original_url,
+            firewall_name=ANTHROPIC_JSON_CASE.firewall_name,
+            proxy_log_path=None,
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
         body = standard_success_payload(ANTHROPIC_JSON_CASE)


### PR DESCRIPTION
## Summary

- add one typed helper that owns model-provider flow metadata and network-target setup for existing flows
- delegate both general and JSON response flow fixtures to the shared owner
- preserve the general helper's default proxy-log path and the JSON helper's explicit omission behavior
- seed the malformed-firewall fixture through the shared contract before overwriting the field under test

## Scope

This is a test-helper-only refactor. It does not change mitm-addon runtime behavior, APIs, persisted data, protocols, dependencies, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused model-provider JSON, chat-completions, usage-idempotency, and WebSocket pytest run: 193 passed
- `uv run --no-sync python -m pytest tests/`: 6605 passed

Closes #29116
