### PR TITLE
perf(python): skip irrelevant websocket client parsing

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1572,17 +1572,27 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     if not flow_metadata.run_id(flow.metadata):
         return
     if getattr(message, "from_client", False):
-        body = message.content.encode() if isinstance(message.content, str) else message.content
-        event = usage.inspect_openai_responses_client_event_json(body)
-        model_provider_failure.observe_websocket_client_event(
-            flow,
-            request_kind=event.request_kind,
-            is_prewarm=event.is_prewarm,
-        )
-        if not model_websocket_usage.is_enabled(flow):
+        failure_client_enabled = model_provider_failure.should_observe_websocket_client_event(flow)
+        usage_enabled = model_websocket_usage.is_enabled(flow)
+        usage_client_enabled = model_websocket_usage.should_observe_client_event(flow)
+        if not failure_client_enabled and not usage_enabled:
             return
-        codex_output_timing.observe_client_event(flow, event.event_type, message.timestamp)
-        model_websocket_usage.observe_client_event(flow, event)
+        body = message.content.encode() if isinstance(message.content, str) else message.content
+        if not failure_client_enabled and not usage_client_enabled:
+            event = usage.inspect_openai_responses_event_json(body)
+            codex_output_timing.observe_client_event(flow, event.event_type, message.timestamp)
+            return
+        event = usage.inspect_openai_responses_client_event_json(body)
+        if failure_client_enabled:
+            model_provider_failure.observe_websocket_client_event(
+                flow,
+                request_kind=event.request_kind,
+                is_prewarm=event.is_prewarm,
+            )
+        if usage_enabled:
+            codex_output_timing.observe_client_event(flow, event.event_type, message.timestamp)
+        if usage_client_enabled:
+            model_websocket_usage.observe_client_event(flow, event)
         return
     body = message.content.encode() if isinstance(message.content, str) else message.content
     failure_enabled = model_provider_failure.should_observe_websocket_server_event(flow)

--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -415,6 +415,12 @@ def observe_websocket_client_event(
     flow_state.pending_intent = "prewarm" if is_prewarm else "normal"
 
 
+def should_observe_websocket_client_event(flow: http.HTTPFlow) -> bool:
+    """Return whether an admitted failure state still needs client evidence."""
+    flow_state = _websocket_flow_state(flow)
+    return flow_state is not None and not flow_state.websocket_ambiguous
+
+
 def should_observe_websocket_server_event(flow: http.HTTPFlow) -> bool:
     """Return whether an admitted failure state still needs server evidence."""
     flow_state = _websocket_flow_state(flow)

--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -114,6 +114,14 @@ def _retain_ignored_response_id(
     return True
 
 
+def should_observe_client_event(flow: http.HTTPFlow) -> bool:
+    """Return whether prewarm correlation still needs client evidence."""
+    state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
+    return (
+        is_enabled(flow) and isinstance(state, _OpenAIResponsesPrewarmState) and not state.ambiguous
+    )
+
+
 def observe_client_event(
     flow: http.HTTPFlow,
     event: usage.OpenAIResponsesClientEvent,

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -13,6 +13,7 @@ from mitmproxy import http
 import codex_output_timing
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import model_provider_failure
 import openai_responses_events
 import usage
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
@@ -20,6 +21,7 @@ from tests.model_provider_flow_helpers import make_openai_responses_websocket_fl
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
     capture_deferred_websocket_trims,
+    capture_openai_responses_extractor_feeds,
     feed_websocket_server_message,
     set_websocket_message,
 )
@@ -362,6 +364,57 @@ def test_websocket_event_type_is_probed_once(
             sys.setprofile(previous_profile)
 
     assert probe_calls == 1
+
+
+def test_ambiguous_client_correlations_keep_timing_without_full_parse(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    model_provider_failure.admit_flow(flow)
+    full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
+    probe_code = json_probe.probe_top_level_string_field.__code__
+    probe_calls = 0
+
+    def count_probe(frame: FrameType, event: str, _arg: object) -> None:
+        nonlocal probe_calls
+        if event == "call" and frame.f_code is probe_code:
+            probe_calls += 1
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed_client_event(flow, b"not-json")
+        assert full_body_feeds.count(b"not-json") == 1
+        full_body_feeds.clear()
+
+        previous_profile = sys.getprofile()
+        sys.setprofile(count_probe)
+        try:
+            _feed_client_event(
+                flow,
+                _event("response.create"),
+                received_at=1_700_000_000.125,
+            )
+        finally:
+            sys.setprofile(previous_profile)
+
+        feed_websocket_server_message(flow, _event("response.created"))
+        feed_websocket_server_message(flow, _event("response.output_item.added"))
+
+    assert probe_calls == 1
+    assert full_body_feeds == []
+    assert [
+        operation["action_type"]
+        for operation in _operations(_timing_requests(usage_webhook_server))
+    ] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+    ]
 
 
 def test_eviction_and_reset_release_retained_buffered_report(

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1672,6 +1672,7 @@ def test_websocket_failure_only_flow_uses_one_parse_per_server_frame(
     mitm_addon.responseheaders(flow)
     assert not model_websocket_usage.is_enabled(flow)
     full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
+    client_frame = b'{"type":"response.create"}'
     created_frame = b'{"type":"response.created","response":{"id":"failure-only"}}'
     failed_frame = (
         b'{"type":"response.failed","response":{"id":"failure-only",'
@@ -1683,7 +1684,7 @@ def test_websocket_failure_only_flow_uses_one_parse_per_server_frame(
         set_websocket_message(
             flow,
             from_client=True,
-            content=b'{"type":"response.create"}',
+            content=client_frame,
         )
         mitm_addon.websocket_message(flow)
         set_websocket_message(flow, from_client=False, content=created_frame)
@@ -1692,6 +1693,7 @@ def test_websocket_failure_only_flow_uses_one_parse_per_server_frame(
         mitm_addon.websocket_message(flow)
         mitm_addon.websocket_end(flow)
 
+    assert full_body_feeds.count(client_frame) == 1
     assert full_body_feeds.count(created_frame) == 1
     assert full_body_feeds.count(failed_frame) == 1
     assert _reported_payloads(model_provider_failure_api) == [

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -73,6 +73,7 @@ class TestModelProviderWebSocketPrewarmUsage:
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
+        client_frame = json.dumps({"type": "response.create", "generate": False}).encode()
         dense_terminal = (
             b'{"type":"'
             + terminal_event.encode()
@@ -83,10 +84,8 @@ class TestModelProviderWebSocketPrewarmUsage:
         )
 
         with self._usage_webhook_api() as webhook:
-            feed_websocket_client_message(
-                flow,
-                json.dumps({"type": "response.create", "generate": False}).encode(),
-            )
+            feed_websocket_client_message(flow, client_frame)
+            assert full_body_feeds.count(client_frame) == 1
             feed_websocket_server_message(
                 flow,
                 _openai_websocket_created_frame("dense-prewarm"),

--- a/crates/runner/mitm-addon/tests/test_websocket_retention.py
+++ b/crates/runner/mitm-addon/tests/test_websocket_retention.py
@@ -17,6 +17,7 @@ from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
     append_websocket_message,
     capture_deferred_websocket_trims,
+    capture_openai_responses_extractor_feeds,
     openai_websocket_usage_frame,
     run_deferred_websocket_trims,
 )
@@ -267,10 +268,12 @@ class TestRegisteredWebSocketRetention:
         self,
         real_flow,
         deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+        monkeypatch: pytest.MonkeyPatch,
         from_client: bool,
     ):
         flow = real_flow(with_response=False, host="example.com")
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
+        full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
         message_count = 32
         message_size = 4096
         total_bytes = 0
@@ -291,6 +294,7 @@ class TestRegisteredWebSocketRetention:
 
             assert flow.websocket.messages == messages_before_trim
             assert len(deferred_websocket_trim_scheduler) == 1
+            assert full_body_feeds == []
 
             run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 


### PR DESCRIPTION
## Summary

- gate Responses WebSocket client inspection on active failure, prewarm, and output-timing demand
- skip body conversion and parsing for ordinary registered flows, and keep only the bounded event-type probe after correlation becomes ambiguous
- cover non-model, active prewarm, failure-only, and timing-only client-frame paths through the public hook

## Scope

Server-frame shared inspection, WebSocket retention ordering, provider protocols, and persisted or cross-service contracts are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_websocket_retention.py tests/test_model_provider_websocket_prewarm.py tests/test_model_provider_failure_reporting.py tests/test_model_provider_websocket_source_reporting.py tests/test_codex_output_timing.py` (`153 passed`)
- `uv run --no-sync python -m pytest tests/` (`6606 passed`)

Closes #29118
