### PR TITLE
fix(ably-subscriber): space short-lived token renewals

### DIFF
--- a/crates/ably-subscriber/src/connection/state.rs
+++ b/crates/ably-subscriber/src/connection/state.rs
@@ -62,8 +62,9 @@ impl ConnState {
             return Some(Instant::now());
         }
 
-        let renew_in_ms = (remaining_ms as u128).saturating_sub(margin.as_millis());
-        let renew_in = Duration::from_millis(u64::try_from(renew_in_ms).ok()?);
+        let remaining = Duration::from_millis(u64::try_from(remaining_ms).ok()?);
+        let effective_margin = margin.min(remaining / 2);
+        let renew_in = remaining - effective_margin;
         checked_deadline_after(renew_in)
     }
 
@@ -519,21 +520,6 @@ mod tests {
 
         let renewal_at = ConnState::compute_renewal_at(&token, Duration::from_secs(300))
             .expect("expired tokens should still schedule renewal");
-        assert!(renewal_at <= Instant::now());
-    }
-
-    #[test]
-    fn token_inside_renewal_margin_is_scheduled_immediately() {
-        let token = TokenDetails {
-            token: "tok".to_string(),
-            expires: unix_now_ms() + 60_000,
-            issued: 0,
-            capability: None,
-            client_id: None,
-        };
-
-        let renewal_at = ConnState::compute_renewal_at(&token, Duration::from_secs(300))
-            .expect("tokens inside the renewal margin should schedule renewal");
         assert!(renewal_at <= Instant::now());
     }
 

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -242,6 +242,10 @@ pub struct TimingConfig {
 
     // -- Token renewal -------------------------------------------------------
     /// How early before token expiry to start proactive renewal.
+    ///
+    /// When this exceeds half of a token's remaining lifetime, the effective
+    /// margin is capped at that half-life so the next renewal stays in the
+    /// future while retaining time to renew before expiry.
     pub token_renewal_margin: Duration,
     /// Delay before retrying a failed token renewal.
     pub token_renewal_retry_delay: Duration,

--- a/crates/ably-subscriber/tests/integration/auth_token.rs
+++ b/crates/ably-subscriber/tests/integration/auth_token.rs
@@ -216,6 +216,9 @@ async fn token_renewal() {
 
 #[tokio::test]
 async fn repeated_short_lived_tokens_are_spaced_without_starving_messages() {
+    const SHORT_TOKEN_TTL_MS: i64 = 4_000;
+    const PRE_EXPIRY_RENEWAL_TIMEOUT: Duration = Duration::from_secs(3);
+
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
 
@@ -228,7 +231,11 @@ async fn repeated_short_lived_tokens_are_spaced_without_starving_messages() {
             *calls += 1;
 
             let now = now_ms();
-            let expires = if call == 0 { now } else { now + 2_000 };
+            let expires = if call == 0 {
+                now
+            } else {
+                now + SHORT_TOKEN_TTL_MS
+            };
             let body = serde_json::to_vec(&serde_json::json!({
                 "token": format!("short-lived-token-{call}"),
                 "expires": expires,
@@ -294,7 +301,7 @@ async fn repeated_short_lived_tokens_are_spaced_without_starving_messages() {
     )
     .await;
 
-    tokio::time::timeout(Duration::from_millis(1_500), second_renewal_rx)
+    tokio::time::timeout(PRE_EXPIRY_RENEWAL_TIMEOUT, second_renewal_rx)
         .await
         .expect("short-lived replacement token should renew before expiry")
         .unwrap();

--- a/crates/ably-subscriber/tests/integration/auth_token.rs
+++ b/crates/ably-subscriber/tests/integration/auth_token.rs
@@ -215,6 +215,96 @@ async fn token_renewal() {
 }
 
 #[tokio::test]
+async fn repeated_short_lived_tokens_are_spaced_without_starving_messages() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    let call_count = std::sync::Mutex::new(0u32);
+    let token_mock = http.mock(|when, then| {
+        when.method(POST).path("/keys/testKey.testId/requestToken");
+        then.respond_with(move |_req: &HttpMockRequest| {
+            let mut calls = call_count.lock().unwrap();
+            let call = *calls;
+            *calls += 1;
+
+            let now = now_ms();
+            let expires = if call == 0 { now } else { now + 2_000 };
+            let body = serde_json::to_vec(&serde_json::json!({
+                "token": format!("short-lived-token-{call}"),
+                "expires": expires,
+                "issued": now,
+            }))
+            .unwrap();
+
+            HttpMockResponse::builder()
+                .status(201)
+                .header("content-type", "application/json")
+                .body(body)
+                .build()
+        });
+    });
+
+    let ws_port = ws.port;
+    let (second_renewal_tx, second_renewal_rx) = tokio::sync::oneshot::channel::<()>();
+    let (test_complete_tx, test_complete_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let first_auth = expect_protocol_msg(&mut conn, "first short-token AUTH")
+            .await
+            .unwrap();
+        assert_eq!(first_auth.action, action::AUTH);
+
+        send_message(&mut conn, "ch", "between-renewals", serde_json::json!("ok"))
+            .await
+            .unwrap();
+
+        let second_auth = expect_protocol_msg(&mut conn, "second short-token AUTH")
+            .await
+            .unwrap();
+        assert_eq!(second_auth.action, action::AUTH);
+        second_renewal_tx.send(()).unwrap();
+        wait_for_test_observation(test_complete_rx, "short-token renewal assertions").await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    expect_connected(&mut sub, "Connected event").await.unwrap();
+    let event = expect_event_with_timeout(
+        &mut sub,
+        RECONNECT_EVENT_TIMEOUT,
+        "message between short-token renewals",
+    )
+    .await
+    .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("between-renewals"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    assert_value_stable_for(
+        Duration::from_millis(250),
+        || token_mock.calls(),
+        2,
+        "short-lived replacement token should schedule a future renewal",
+    )
+    .await;
+
+    tokio::time::timeout(Duration::from_millis(1_500), second_renewal_rx)
+        .await
+        .expect("short-lived replacement token should renew before expiry")
+        .unwrap();
+    assert_eq!(token_mock.calls(), 3);
+
+    test_complete_tx.send(()).unwrap();
+    join_server_task(server_task, "mock server").await.unwrap();
+}
+
+#[tokio::test]
 async fn close_during_pending_token_renewal_sends_close() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();


### PR DESCRIPTION
## Summary

- cap the effective proactive renewal margin at half of a token's remaining lifetime
- keep expired tokens immediately due and preserve the configured margin for tokens with at least twice that remaining lifetime
- cover repeated successful short-lived tokens through the public subscription flow, including bounded callback traffic, message delivery, and later pre-expiry renewal

## Compatibility

- no public type, protocol payload, persistence, or runner contract changes
- no new timing configuration or change to renewal failure handling
- receive-loop event priority remains unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p ably-subscriber --all-targets --all-features`
- `cargo doc -p ably-subscriber --all-features --no-deps`
- `cargo test -p ably-subscriber`
- repeated the new exact integration test three times
- repository pre-commit Rust formatting, workspace Clippy, rustdoc, and file-size checks

Closes #29119
