### PR TITLE
chore: update socialkit feature switch maintainer

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -109,7 +109,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
   },
   [FeatureSwitchKey.ManagedSocialKit]: {
-    maintainer: "lancy@vm0.ai",
+    maintainer: "liangyou@vm0.ai",
     description: "Enable vm0-managed SocialKit data and analysis operations",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,


### PR DESCRIPTION
## Summary

- assign the managed SocialKit feature switch to `liangyou@vm0.ai`

## Scope

- metadata-only change
- does not change the switch key, default state, staff rollout, CLI visibility, capability gating, or API enforcement

## Validation

- `pnpm prettier --check packages/core/src/feature-switch.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core test` (205 tests passed)
- pre-commit Prettier, Knip, repository type checks, file-size check, and commitlint
