### PR TITLE
fix(composer): rebuild the quote block on native prosemirror machinery

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -73,6 +73,12 @@ export const composerRestoredAttachmentValidationEnabled$ = computed(
   },
 );
 
+export const composerFlatFeedbackNoteEnabled$ = computed((get): boolean => {
+  return (
+    get(featureSwitch$)[FeatureSwitchKey.ComposerFlatFeedbackNote] ?? false
+  );
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -27,6 +27,7 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { composerFlatFeedbackNoteEnabled$ } from "../external/feature-switch.ts";
 import { onRef, resetSignal } from "../utils.ts";
 import type { DraftInputSyncTarget, DraftSignals } from "./chat-draft.ts";
 import {
@@ -526,14 +527,13 @@ function createComposerIcon(
   return icon;
 }
 
-function createFeedbackItemNodeView(
-  node: ProseMirrorNode,
-  removeFeedback: (id: number) => void,
-  localizedUi: Set<() => void>,
-): NodeView {
-  const dom = document.createElement("div");
-  dom.dataset.feedbackItem = "";
+interface FeedbackQuoteChip {
+  readonly quoteDom: HTMLDivElement;
+  readonly quoteText: HTMLSpanElement;
+  readonly removeButton: HTMLButtonElement;
+}
 
+function createFeedbackQuoteChip(): FeedbackQuoteChip {
   const quoteDom = document.createElement("div");
   quoteDom.className = "flex";
   quoteDom.contentEditable = "false";
@@ -565,6 +565,18 @@ function createFeedbackItemNodeView(
   );
   quoteChip.append(quoteIconContainer, quoteText, removeButton);
   quoteDom.append(quoteChip);
+  return { quoteDom, quoteText, removeButton };
+}
+
+function createFeedbackItemNodeView(
+  node: ProseMirrorNode,
+  removeFeedback: (id: number) => void,
+  localizedUi: Set<() => void>,
+): NodeView {
+  const dom = document.createElement("div");
+  dom.dataset.feedbackItem = "";
+
+  const { quoteDom, quoteText, removeButton } = createFeedbackQuoteChip();
 
   const noteDom = document.createElement("div");
   const placeholderDom = document.createElement("span");
@@ -642,6 +654,155 @@ function createFeedbackItemNodeView(
       localizedUi.delete(localize);
     },
   };
+}
+
+/**
+ * The flat quote block: the node view's dom IS the content element, so every
+ * mutation anywhere in the block is visible to ProseMirror and its default
+ * dirty-node redraw self-heals any damage the browser causes (#27787). The
+ * quote chip and the placeholder are not part of this view at all — they are
+ * a widget decoration, which ProseMirror renders non-editable, preserves
+ * across redraws, and skips when re-parsing the DOM.
+ */
+function createFlatFeedbackItemNodeView(
+  node: ProseMirrorNode,
+  localizedUi: Set<() => void>,
+): NodeView {
+  const dom = document.createElement("div");
+  dom.dataset.feedbackItem = "";
+  dom.dataset.feedbackNote = "";
+  dom.setAttribute("role", "textbox");
+  dom.setAttribute("aria-multiline", "true");
+
+  let currentNode = node;
+  function localize(): void {
+    dom.setAttribute(
+      "aria-label",
+      i18n.t(($) => {
+        return $.chat.feedback.placeholder;
+      }),
+    );
+  }
+  function render(nextNode: ProseMirrorNode): void {
+    const { showDivider, fill } = feedbackItemNodeAttributes(nextNode);
+    // The chrome widget occupies the first 38px (chip row plus gap), so the
+    // note area of a filled item keeps its 96px: 38 + 96 = 134.
+    const className =
+      "flex flex-col gap-1.5 pb-1.5 text-[0.9375rem] leading-snug " +
+      "text-foreground outline-none [&_p]:m-0 [&_p]:px-1 " +
+      "[&_p:nth-of-type(1)]:pt-1 [&_p:last-of-type]:pb-1" +
+      `${fill ? " min-h-[134px]" : ""}${
+        showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
+      }`;
+    if (dom.className !== className) {
+      dom.className = className;
+    }
+  }
+  localizedUi.add(localize);
+  localize();
+  render(currentNode);
+
+  return {
+    dom,
+    contentDOM: dom,
+    update(nextNode) {
+      if (nextNode.type !== currentNode.type) {
+        return false;
+      }
+      currentNode = nextNode;
+      render(nextNode);
+      return true;
+    },
+    destroy() {
+      localizedUi.delete(localize);
+    },
+  };
+}
+
+function buildFeedbackItemChrome(
+  quote: string,
+  showPlaceholder: boolean,
+  onRemove: () => void,
+): HTMLElement {
+  const { quoteDom, quoteText, removeButton } = createFeedbackQuoteChip();
+  quoteText.textContent = quote;
+  const removeLabel = i18n.t(($) => {
+    return $.chat.feedback.remove;
+  });
+  removeButton.setAttribute("aria-label", removeLabel);
+  removeButton.title = removeLabel;
+  removeButton.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+  });
+  removeButton.addEventListener("click", onRemove);
+  if (showPlaceholder) {
+    quoteDom.classList.add("relative");
+    const placeholder = document.createElement("span");
+    // The chip row is 32px plus the item's 6px gap; the first paragraph adds
+    // 4px of top padding, so the placeholder sits at 42px over its text.
+    placeholder.className =
+      "pointer-events-none absolute left-1 top-[42px] w-max " +
+      "text-[0.9375rem] leading-snug text-muted-foreground/40";
+    placeholder.setAttribute("aria-hidden", "true");
+    placeholder.textContent = i18n.t(($) => {
+      return $.chat.feedback.placeholder;
+    });
+    quoteDom.append(placeholder);
+  }
+  return quoteDom;
+}
+
+function buildFeedbackChromeDecorations(
+  doc: ProseMirrorNode,
+  runtime: WorkflowComposerRuntime,
+): DecorationSet {
+  const decorations: Decoration[] = [];
+  let position = 0;
+  for (let index = 0; index < doc.childCount; index++) {
+    const child = doc.child(index);
+    const childPosition = position;
+    position += child.nodeSize;
+    if (child.type.name !== FEEDBACK_ITEM_NODE_NAME) {
+      continue;
+    }
+    const { feedbackId, quote } = feedbackItemNodeAttributes(child);
+    const showPlaceholder = nodeText(child).length === 0;
+    decorations.push(
+      Decoration.widget(
+        childPosition + 1,
+        () => {
+          return buildFeedbackItemChrome(quote, showPlaceholder, () => {
+            runtime.removeFeedback(feedbackId);
+          });
+        },
+        {
+          // The key carries everything the DOM is built from, so the widget
+          // is only recreated when its content actually changes.
+          key: `feedback-chrome-${feedbackId}-${showPlaceholder ? "empty" : "filled"}-${i18n.language}`,
+          side: -2,
+          ignoreSelection: true,
+          stopEvent: () => {
+            return true;
+          },
+        },
+      ),
+    );
+  }
+  return DecorationSet.create(doc, decorations);
+}
+
+function createFeedbackChromePlugin(runtime: WorkflowComposerRuntime): Plugin {
+  return new Plugin({
+    key: new PluginKey("feedbackItemChrome"),
+    props: {
+      decorations(state) {
+        if (!runtime.flatFeedbackNote) {
+          return DecorationSet.empty;
+        }
+        return buildFeedbackChromeDecorations(state.doc, runtime);
+      },
+    },
+  });
 }
 
 function templateAttachmentNodeAttributes(
@@ -1493,6 +1654,8 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
+  /** Resolved ComposerFlatFeedbackNote switch, set while mounted. */
+  flatFeedbackNote: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1658,6 +1821,9 @@ function createFeedbackItemNode(
     },
     addNodeView() {
       return ({ node }) => {
+        if (runtime.flatFeedbackNote) {
+          return createFlatFeedbackItemNodeView(node, runtime.localizedUi);
+        }
         return createFeedbackItemNodeView(
           node,
           (id) => {
@@ -1666,6 +1832,9 @@ function createFeedbackItemNode(
           runtime.localizedUi,
         );
       };
+    },
+    addProseMirrorPlugins() {
+      return [createFeedbackChromePlugin(runtime)];
     },
   });
 }
@@ -1818,6 +1987,11 @@ function refreshWorkflowComposerLocalization(
   for (const localize of runtime.localizedUi) {
     localize();
   }
+  // The feedback chrome widgets carry their language in the decoration key;
+  // an empty transaction makes the view re-read decorations in the new one.
+  if (editor.isInitialized) {
+    editor.view.dispatch(editor.state.tr);
+  }
 }
 
 function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
@@ -1827,6 +2001,7 @@ function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
   runtime.blur = () => {};
   runtime.replaceFeedbackItems = () => {};
   runtime.removeFeedback = () => {};
+  runtime.flatFeedbackNote = false;
 }
 
 function applyWorkflowNames(editor: Editor, names: readonly string[]): void {
@@ -2043,6 +2218,7 @@ function createMountEditorCommand({
       runtime.removeFeedback = (id) => {
         set(feedback.signals.remove$, id);
       };
+      runtime.flatFeedbackNote = get(composerFlatFeedbackNoteEnabled$);
       configureMountedWorkflowEditor(editor, singleLineOnMobile);
       setWorkflowComposerDocument(
         editor,
@@ -2453,6 +2629,7 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
+    flatFeedbackNote: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1505,6 +1505,207 @@ describe("chat inline feedback", () => {
     expect(sentPrompts[0]).toContain("补充具体日期");
   });
 
+  async function setupFlatFeedbackNoteThread(caseName: string): Promise<{
+    readonly assistantReply: string;
+    readonly sentMessages: RunCreateCapture[];
+  }> {
+    const assistantReply = "The rollout dates are unclear in this summary.";
+    const sentMessages: RunCreateCapture[] = [];
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: `msg-feedback-flat-${caseName}-user`,
+          role: "user",
+          content: "Review this launch summary",
+          runId: `run-feedback-flat-${caseName}`,
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: `msg-feedback-flat-${caseName}-assistant`,
+          role: "assistant",
+          content: assistantReply,
+          runId: `run-feedback-flat-${caseName}`,
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
+    });
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerFlatFeedbackNote]: true,
+      },
+    });
+    await findComposerEditor();
+    return { assistantReply, sentMessages };
+  }
+
+  it("renders the flat quote block and submits typed text with the flat note switch enabled", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { assistantReply, sentMessages } =
+      await setupFlatFeedbackNoteThread("submit");
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const note = await findFeedbackNote();
+    // The flat block is its own content element: no nested note wrapper.
+    expect(note.dataset.feedbackItem).toBe("");
+    expect(note.querySelector("[data-feedback-note]")).toBeNull();
+    // The chrome widget carries the quote chip and the empty-note placeholder.
+    expect(note).toHaveTextContent(assistantReply);
+    expect(note).toHaveTextContent("What should change about this?");
+
+    await user.click(note);
+    pastePlainText(note, "Make the dates explicit");
+    await waitFor(() => {
+      expect(note).toHaveTextContent("Make the dates explicit");
+    });
+    await waitFor(() => {
+      expect(note).not.toHaveTextContent("What should change about this?");
+    });
+
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(sentMessages).toHaveLength(1);
+    });
+    expect(sentMessages[0]?.prompt).toContain("Make the dates explicit");
+    expect(sentMessages[0]?.prompt).toContain(assistantReply);
+  });
+
+  it("stays editable after the flat quote block is damaged in place", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { assistantReply, sentMessages } =
+      await setupFlatFeedbackNoteThread("damage");
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const note = await findFeedbackNote();
+    await user.click(note);
+    pastePlainText(note, "Make the dates");
+    await waitFor(() => {
+      expect(note).toHaveTextContent("Make the dates");
+    });
+
+    // Damage the block the way the traced WebKit collapse does, with the DOM
+    // observer live: the paragraph disappears and a bare <br> replaces it.
+    for (const paragraph of Array.from(note.querySelectorAll(":scope > p"))) {
+      paragraph.remove();
+    }
+    note.append(document.createElement("br"));
+
+    // ProseMirror sees the damage (nothing ignores it) and redraws the block
+    // into a consistent, editable state instead of a silent divergence.
+    await waitFor(() => {
+      expect(note.querySelector(":scope > p")).not.toBeNull();
+    });
+
+    await user.click(note);
+    pastePlainText(note, "typed after damage");
+    await waitFor(() => {
+      expect(note).toHaveTextContent("typed after damage");
+    });
+
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(sentMessages).toHaveLength(1);
+    });
+    expect(sentMessages[0]?.prompt).toContain("typed after damage");
+  });
+
+  it("keeps dropping input after the legacy note wrappers collapse", async () => {
+    // Control for the flat-note tests: with the switch off, the legacy
+    // structure swallows the traced WebKit collapse (wrapper removed, <br>
+    // left behind) and silently drops everything typed afterwards — the
+    // #27787 failure the flat block exists to remove.
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+    const sentMessages: RunCreateCapture[] = [];
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-flat-control-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-flat-control",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-flat-control-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-flat-control",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
+    });
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerFlatFeedbackNote]: false,
+      },
+    });
+    await findComposerEditor();
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const note = await findFeedbackNote();
+    await user.click(note);
+    pastePlainText(note, "Make the dates");
+    await waitFor(() => {
+      expect(note).toHaveTextContent("Make the dates");
+    });
+
+    const item = note.closest("[data-feedback-item]");
+    const wrapper = note.parentElement;
+    if (!(item instanceof HTMLElement) || !(wrapper instanceof HTMLElement)) {
+      throw new Error("Legacy feedback structure not found");
+    }
+    wrapper.remove();
+    item.append(document.createElement("br"));
+    await waitFor(() => {
+      expect(document.querySelector("[data-feedback-note]")).toBeNull();
+    });
+
+    // Later typing lands in the collapsed block; the legacy ignoreMutation
+    // discards it, so it never reaches the document or the submission.
+    item.append(document.createTextNode(" typed after damage"));
+
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(sentMessages).toHaveLength(1);
+    });
+    expect(sentMessages[0]?.prompt).toContain("Make the dates");
+    expect(sentMessages[0]?.prompt).not.toContain("typed after damage");
+  });
+
+  it("removes the flat quote block from its widget chrome button", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { assistantReply } = await setupFlatFeedbackNoteThread("remove");
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const note = await findFeedbackNote();
+    await user.click(within(note).getByLabelText("Remove feedback"));
+    await waitFor(() => {
+      expect(document.querySelector("[data-feedback-item]")).toBeNull();
+    });
+  });
+
   it("waits until mouseup before showing the inline feedback toolbar", async () => {
     const assistantReply = "The rollout dates are unclear in this summary.";
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -165,6 +165,7 @@ describe("getAllFeatureStates", () => {
     expect(
       bingjieStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(true);
+    expect(bingjieStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(true);
 
     const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
@@ -173,6 +174,9 @@ describe("getAllFeatureStates", () => {
     expect(
       otherStaffStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(false);
+    expect(otherStaffStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
+      false,
+    );
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -83,4 +83,5 @@ export enum FeatureSwitchKey {
   SharedChatDatabase = "sharedChatDatabase",
   ComposerImageAnnotation = "composerImageAnnotation",
   ComposerRestoredAttachmentValidation = "composerRestoredAttachmentValidation",
+  ComposerFlatFeedbackNote = "composerFlatFeedbackNote",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -388,6 +388,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
+  [FeatureSwitchKey.ComposerFlatFeedbackNote]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Rebuild the composer quote block on ProseMirror's native machinery: the note content element is the block itself and the quote chip is a widget decoration, removing the editable wrapper elements and the custom mutation filtering that let WebKit damage go unnoticed.",
+    enabled: false,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

The quote block rewritten the way ProseMirror expects it to be built — per the direction on #27787: not another patch, but making the block itself correct.

**What was wrong with the block.** Its node view wrapped the content element in editable anonymous divs (`noteDom`, the placeholder) and overrode `ignoreMutation` to discard every mutation outside `contentDOM`. That pairing produced the whole failure family:

- WebKit's delete-and-prune editing primitive removes the "emptied" anonymous editable wrappers during an IME composition (desktop-Safari traced); the ignore rule swallows the removal record; ProseMirror never repairs; everything typed afterwards is visible on screen but silently missing from submissions.
- A mid-composition Backspace can land the caret in the wrapper gap, which ProseMirror resolves into the **previous** quote's note.

**The rebuilt block** (behind the new `composerFlatFeedbackNote` switch, default off, `bingjie@vm0.ai` only):

- The node view's `dom` **is** the content element. No wrappers, no custom `ignoreMutation` — every mutation anywhere in the block is visible, and ProseMirror's own dirty-node redraw self-heals any damage. There is no "gap" for a caret to land in.
- The quote chip and the empty-note placeholder move into a **widget decoration**: ProseMirror renders it `contenteditable="false"`, preserves it across redraws, and skips it when re-parsing the DOM (`WidgetViewDesc.parseRule` → ignore). The widget's `stopEvent` keeps chip clicks out of editing, and its key (`feedbackId` + emptiness + language) recreates the DOM only when its content changes; a language change re-reads decorations via an empty transaction.
- One editing host throughout — the IME input-context binding defect that falsified the nested-host attempt (#29037, reverted in the base PR) cannot occur, and the `closest('[contenteditable="false"]')` event-routing heuristics are unaffected.

With the switch off, the legacy node view renders byte-for-byte as before. `blockResyncTargets` now accepts the flat block carrying `data-feedback-note` on itself, so the `composerSubmitDomReconcile` switch keeps working in both modes.

## Verification

- core feature-switch tests — 25 passed (new switch asserted Bingjie-only)
- `chat-inline-feedback.test.tsx` — **36 passed**: 32 existing legacy tests untouched, plus
  - flat structure renders, placeholder shows/hides, typed text reaches the submission
  - **damage self-heal**: with the DOM observer live, the block's paragraph is removed and a bare `<br>` inserted (the traced WebKit collapse shape); the block must return to a consistent editable state and text typed afterwards must reach the submission — verified red when a broad `ignoreMutation` is temporarily reintroduced
  - the chip's remove button (widget-owned) removes the block
  - control documenting the bug: same collapse under the legacy structure silently drops post-collapse input
- `chat-run-queue.test.tsx` — 32 passed
- `pnpm run lint` (apps/platform) exit 0; both `check-types` clean; `pnpm knip` exit 0

## Dogfood checklist (the two field symptoms)

- quote → compose pinyin — first keystroke must join the composition (the #29037 defect), and composing to the point that previously collapsed the box must no longer lose the tail on send
- two quotes → Backspace mid-composition — caret must stay in the second note
- chip remove button, placeholder, divider/fill layout, drag-select across the block, Enter-to-send from inside the note

## Merge order

Based on #29125 (the revert of the falsified nested-host attempt); merge that first and this retargets to `main` automatically. #29015 (repair + telemetry) stays open as an independent safety net; whether it is still wanted can be decided after this dogfoods.

Related to #27787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)