### PR TITLE
fix(api): let fetch set google drive upload content length

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -62,6 +62,7 @@ import { hostedTextFile } from "./helpers/api-bdd-host-files";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import {
   createConnectorBddApi,
+  mockGoogleDriveArtifactUpload,
   mockGoogleDriveConnectorOAuth,
   mockGoogleDriveFilesList,
 } from "./helpers/api-bdd-connectors";
@@ -3475,6 +3476,34 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     expect(invalidBody.body.error.code).toBe("BAD_REQUEST");
 
     await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
+
+    const uploadRecorder = mockGoogleDriveArtifactUpload({
+      id: "drive-uploaded-file",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-uploaded-file/view",
+    });
+    const synced = await chat.requestSyncThreadArtifact(
+      actor,
+      run.threadId,
+      { runId: run.runId, fileId: csvId },
+      [200],
+    );
+    expect(synced.body).toStrictEqual({
+      id: "drive-uploaded-file",
+      name: "data.csv",
+      webViewLink: "https://drive.google.com/file/d/drive-uploaded-file/view",
+    });
+    expect(uploadRecorder.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-ok",
+    ]);
+    expect(uploadRecorder.folderQueries).toHaveLength(2);
+    expect(uploadRecorder.contentTypeHeaders[0]).toMatch(
+      /^multipart\/related; boundary=vm0-/u,
+    );
+    // Fetch derives this forbidden request header from the Buffer body at the
+    // transport layer. Supplying it explicitly is rejected by instrumented
+    // Node/Undici and would be visible to MSW here.
+    expect(uploadRecorder.contentLengthHeaders).toStrictEqual([null]);
 
     // Drive lists one mirrored file: csv synced, pdf not synced.
     const listRecorder = mockGoogleDriveFilesList(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -471,6 +471,8 @@ export function mockSlackConnectorOAuth(): void {
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
+const GOOGLE_DRIVE_UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files";
 const GOOGLE_OPENID_USERINFO_URL =
   "https://openidconnect.googleapis.com/v1/userinfo";
 
@@ -685,6 +687,56 @@ export function mockGoogleDriveFilesList(
         return new HttpResponse(null, { status: response.status });
       }
       return HttpResponse.json({ files: [...response.files] });
+    }),
+  );
+
+  return recorded;
+}
+
+interface GoogleDriveArtifactUploadRecorder {
+  readonly authorizationHeaders: (string | null)[];
+  readonly contentLengthHeaders: (string | null)[];
+  readonly contentTypeHeaders: (string | null)[];
+  readonly folderQueries: string[];
+}
+
+/**
+ * Google Drive folder and multipart-upload provider boundary. Folder lookups
+ * resolve an existing root and thread folder so the recorder stays focused on
+ * the file upload request.
+ */
+export function mockGoogleDriveArtifactUpload(
+  file: GoogleDriveFileFixture,
+): GoogleDriveArtifactUploadRecorder {
+  const recorded: GoogleDriveArtifactUploadRecorder = {
+    authorizationHeaders: [],
+    contentLengthHeaders: [],
+    contentTypeHeaders: [],
+    folderQueries: [],
+  };
+
+  server.use(
+    http.get(GOOGLE_DRIVE_FILES_URL, ({ request }) => {
+      const query = new URL(request.url).searchParams.get("q") ?? "";
+      recorded.folderQueries.push(query);
+      const rootFolder = query.includes("'root' in parents");
+      return HttpResponse.json({
+        files: [
+          {
+            id: rootFolder
+              ? "drive-artifact-root-folder"
+              : "drive-artifact-thread-folder",
+            name: rootFolder ? "vm0-artifact" : "thread-artifacts",
+          },
+        ],
+      });
+    }),
+    http.post(GOOGLE_DRIVE_UPLOAD_URL, async ({ request }) => {
+      recorded.authorizationHeaders.push(request.headers.get("authorization"));
+      recorded.contentLengthHeaders.push(request.headers.get("content-length"));
+      recorded.contentTypeHeaders.push(request.headers.get("content-type"));
+      await request.arrayBuffer();
+      return HttpResponse.json(file);
     }),
   );
 

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -984,7 +984,6 @@ async function uploadDriveFile(args: {
     headers: {
       Authorization: `Bearer ${args.accessToken}`,
       "Content-Type": `multipart/related; boundary=${boundary}`,
-      "Content-Length": String(body.length),
     },
     body,
   });


### PR DESCRIPTION
## Summary

- let Fetch derive `Content-Length` for Google Drive multipart artifact uploads
- add a route-level regression test covering folder resolution, OAuth authorization, multipart upload, and the absence of an explicit length header

## Root cause

Production Node/Undici rejected the manually supplied `Content-Length` header after the request passed through fetch instrumentation, before Google Drive returned a response. The request body remains a `Buffer`, so Fetch computes the correct wire length automatically.

## Verification

- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "groups run uploads and reports google drive sync status"`
