### PR TITLE
fix(cli): name the actual default video model in help text

### DIFF
--- a/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
@@ -377,8 +377,10 @@ describe("okou generate lister", () => {
     expect(text).not.toContain("No ready video generation connectors found.");
     expect(text).toContain("Built-in command:");
     expect(text).toContain("Built-in video generation");
+    // Spelled out rather than derived from the catalog, so moving the default
+    // has to be a deliberate edit here instead of silently rewriting the help.
     expect(text).toContain(
-      "Models: dreamina-seedance-2.0-fast (default), dreamina-seedance-2.5, dreamina-seedance-2.0, dreamina-seedance-2.0-mini, seedance-1.5-pro, minimax-h3, veo3.1-fast, kling-v3-4k",
+      "Models: dreamina-seedance-2.5, dreamina-seedance-2.0 (default), dreamina-seedance-2.0-fast, dreamina-seedance-2.0-mini, seedance-1.5-pro, veo3.1-fast, kling-v3-4k, minimax-h3",
     );
     expect(text).toContain("Use: okou generate video --provider built-in -h");
     expect(text).toContain(

--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -474,4 +474,27 @@ describe("okou generate video command", () => {
     expect(stderr).toContain("okou upgrade pro");
     expect(generationRequests).toBe(0);
   });
+
+  it("names the catalog default as the model an omitted --model falls back to", () => {
+    // The help used to spell the default out by hand, and kept naming
+    // seedance 2.0 fast for a while after the catalog moved off it.
+    let help = "";
+    videoCommand.configureOutput({
+      writeOut: (text: string) => {
+        help += text;
+      },
+    });
+    videoCommand.outputHelp();
+    videoCommand.configureOutput({
+      writeOut: (text: string) => {
+        process.stdout.write(text);
+      },
+    });
+
+    const collapsed = help.replace(/\s+/g, " ");
+    expect(collapsed).toContain(
+      "Omitting --model uses the caller's selected video model, falling back to dreamina-seedance-2.0 ",
+    );
+    expect(collapsed).not.toContain("dreamina-seedance-2.0-fast (default)");
+  });
 });

--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -493,7 +493,7 @@ describe("okou generate video command", () => {
 
     const collapsed = help.replace(/\s+/g, " ");
     expect(collapsed).toContain(
-      "Omitting --model uses the caller's selected video model, falling back to dreamina-seedance-2.0 ",
+      "Omitting --model generates with dreamina-seedance-2.0 ",
     );
     expect(collapsed).not.toContain("dreamina-seedance-2.0-fast (default)");
   });

--- a/turbo/apps/cli/src/commands/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/generate/lib/lister.ts
@@ -10,6 +10,20 @@ import {
 } from "../../shared/billing-capabilities";
 import { planUpgradeUrl } from "../../shared/billing-links";
 import { getOkouAgentId } from "../../../lib/okou-env";
+import {
+  DEFAULT_VIDEO_MODEL,
+  VIDEO_MODEL_CONFIGS,
+  VIDEO_MODELS,
+} from "@okouai/core/video-model-catalog";
+
+/**
+ * Derived from the catalog so the summary cannot keep marking a model the
+ * default after the catalog stops using it.
+ */
+const BUILT_IN_VIDEO_MODEL_SUMMARY = VIDEO_MODELS.map((model) => {
+  const { alias } = VIDEO_MODEL_CONFIGS[model];
+  return model === DEFAULT_VIDEO_MODEL ? `${alias} (default)` : alias;
+}).join(", ");
 
 type ConnectorGenerationType =
   | "audio"
@@ -224,8 +238,7 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
   video: {
     label: "Built-in video generation",
     command: "okou generate video --provider built-in -h",
-    models:
-      "dreamina-seedance-2.0-fast (default), dreamina-seedance-2.5, dreamina-seedance-2.0, dreamina-seedance-2.0-mini, seedance-1.5-pro, minimax-h3, veo3.1-fast, kling-v3-4k",
+    models: BUILT_IN_VIDEO_MODEL_SUMMARY,
   },
   presentation: {
     label: "Built-in presentation generation",

--- a/turbo/apps/cli/src/commands/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/video-generate.ts
@@ -8,6 +8,7 @@ import {
   findVideoTemplate,
   listVideoTemplates,
 } from "@okouai/core/resource-registry";
+import { DEFAULT_VIDEO_MODEL_ALIAS } from "@okouai/core/video-model-catalog";
 import { formatRegistryListing } from "./resource-listing";
 import { createVideoTemplateAuthoringPacket } from "./video-template-authoring";
 import {
@@ -454,13 +455,15 @@ Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful video generation
   - Uses MiniMax, BytePlus ModelArk, and fal.ai video models with configured usage pricing
+  - Omitting --model uses the caller's selected video model, falling back to
+    ${DEFAULT_VIDEO_MODEL_ALIAS}
 
 Models:
   - Dreamina Seedance 2.5: dreamina-seedance-2.5. Supports 4s-30s,
     480p/720p/1080p, optional audio, up to 30 image references, and up to
     10 video and 10 audio references, plus first/last frames.
   - Dreamina Seedance 2.0: dreamina-seedance-2.0,
-    dreamina-seedance-2.0-fast (default), dreamina-seedance-2.0-mini.
+    dreamina-seedance-2.0-fast, dreamina-seedance-2.0-mini.
     Supports 4s-15s,
     480p/720p, seed, optional audio, image references, and first/last
     frames. The full model also supports 1080p; the full and Mini models

--- a/turbo/apps/cli/src/commands/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/video-generate.ts
@@ -455,8 +455,7 @@ Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful video generation
   - Uses MiniMax, BytePlus ModelArk, and fal.ai video models with configured usage pricing
-  - Omitting --model uses the caller's selected video model, falling back to
-    ${DEFAULT_VIDEO_MODEL_ALIAS}
+  - Omitting --model generates with ${DEFAULT_VIDEO_MODEL_ALIAS}
 
 Models:
   - Dreamina Seedance 2.5: dreamina-seedance-2.5. Supports 4s-30s,

--- a/turbo/packages/core/src/video-model-catalog.ts
+++ b/turbo/packages/core/src/video-model-catalog.ts
@@ -380,6 +380,14 @@ export const VIDEO_MODEL_ALIASES = {
  */
 export const DEFAULT_VIDEO_MODEL =
   "dreamina-seedance-2-0-260128" satisfies VideoModel;
+
+/**
+ * What help text names when it points at the default. Derived rather than
+ * spelled out again, because a hand-written copy keeps naming the previous
+ * default after this one moves.
+ */
+export const DEFAULT_VIDEO_MODEL_ALIAS =
+  VIDEO_MODEL_CONFIGS[DEFAULT_VIDEO_MODEL].alias;
 export const DEFAULT_VIDEO_ASPECT_RATIO = "16:9" satisfies VideoAspectRatio;
 export const DEFAULT_VIDEO_DURATION = "8s" satisfies VideoDuration;
 


### PR DESCRIPTION
## Problem

Two pieces of CLI help still marked `dreamina-seedance-2.0-fast` as the default video model:

- `okou generate video` (provider listing) — `Models: dreamina-seedance-2.0-fast (default), ...`
- `okou generate video -h` — `Dreamina Seedance 2.0: ..., dreamina-seedance-2.0-fast (default), ...`

That stopped being true in #29045, which moved `DEFAULT_VIDEO_MODEL` from `dreamina-seedance-2-0-fast-260128` to `dreamina-seedance-2-0-260128` — the fast model is `public: false`, so a private default left every picker row unmarked while runs quietly used it.

Both help strings were hand-written copies of the catalog, so they did not move with it. Anyone reading the CLI help is told the wrong model, and passing `--model dreamina-seedance-2.0-fast` "to keep the default" now silently changes the model and the price tier.

## Change

- Export `DEFAULT_VIDEO_MODEL_ALIAS` from the catalog, next to `DEFAULT_VIDEO_MODEL`.
- The provider listing builds its model summary from `VIDEO_MODELS` and marks whichever entry the catalog defaults to, instead of a literal string.
- `okou generate video -h` drops the hard-coded `(default)` marker from the Seedance 2.0 prose and gains one note interpolated from the alias.

Help output after the change:

```
Notes:
  ...
  - Omitting --model generates with dreamina-seedance-2.0

Models:
  - Dreamina Seedance 2.0: dreamina-seedance-2.0,
    dreamina-seedance-2.0-fast, dreamina-seedance-2.0-mini. ...
```

```
Models: dreamina-seedance-2.5, dreamina-seedance-2.0 (default), dreamina-seedance-2.0-fast, dreamina-seedance-2.0-mini, seedance-1.5-pro, veo3.1-fast, kling-v3-4k, minimax-h3
```

The note states the catalog default plainly rather than describing the thread/member pin chain in `video-io-generate.ts`. That chain only applies behind `FeatureSwitchKey.VideoModelSelection`, which is `enabled: false` and staff-org-only, so GA readers cannot reach or set it from the CLI. The PR that takes the switch to GA can document it then.

## Tests

Both help texts are now asserted against a spelled-out expectation, so moving the default has to be a deliberate edit to the test rather than a silent rewrite of what users are told:

- `lister.test.ts` — updated to the derived summary.
- `video.test.ts` — new case asserting `okou generate video -h` names the catalog default and no longer marks the fast model as default.

No behavior change: the CLI already sent `model: undefined` when the flag was omitted and let the server resolve it. Only the text changes.

Verified locally: `vitest run` on both CLI test files (34 passed), `tsc --noEmit` for `apps/cli` and `packages/core`, `oxlint` on the changed files, `prettier --write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
