### PR TITLE
refactor(api): dual-write preview job reference aliases

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -253,6 +253,7 @@ runs:
             add_secret ARTIFACT_PREVIEW_WAF_SECRET ARTIFACT_PREVIEW_WAF_SECRET
           fi
           if [[ "$INPUT_ENVIRONMENT" == "preview" && -n "$INPUT_JOB_REF" ]]; then
+            add_env OKOU_PREVIEW_JOB_REF "$INPUT_JOB_REF"
             add_env VM0_PREVIEW_JOB_REF "$INPUT_JOB_REF"
           fi
           if [[ -n "$atom_url" ]]; then

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -96,6 +96,36 @@ assert_env_key_absent() {
   fi
 }
 
+assert_env_key_count() {
+  local env_file="$1"
+  local key="$2"
+  local expected="$3"
+  local count
+  count="$(awk -F= -v key="$key" '$1 == key { count++ } END { print count + 0 }' "$env_file")"
+  if [[ "$count" != "$expected" ]]; then
+    fail "expected ${key} exactly ${expected} time(s) in ${env_file}"
+  fi
+}
+
+assert_env_values_equal() {
+  local env_file="$1"
+  local first_key="$2"
+  local second_key="$3"
+  local first_value
+  local second_value
+  first_value="$(awk -F= -v key="$first_key" '$1 == key { sub(/^[^=]*=/, ""); print }' "$env_file")"
+  second_value="$(awk -F= -v key="$second_key" '$1 == key { sub(/^[^=]*=/, ""); print }' "$env_file")"
+  if [[ "$first_value" != "$second_value" ]]; then
+    fail "expected ${first_key} and ${second_key} values to be equal"
+  fi
+}
+
+assert_preview_job_ref_aliases_absent() {
+  local env_file="$1"
+  assert_env_key_absent "$env_file" OKOU_PREVIEW_JOB_REF
+  assert_env_key_absent "$env_file" VM0_PREVIEW_JOB_REF
+}
+
 assert_migrated_zero_outputs_absent() {
   local env_file="$1"
   local key
@@ -259,6 +289,7 @@ run_action() {
   local branded_config="${6:-canonical}"
   local github_app_vars_json="${7:-}"
   local github_app_secrets_json="${8:-}"
+  local input_job_ref="${9-pr-123}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
   local repo_vars_json
@@ -290,7 +321,7 @@ run_action() {
     INPUT_APP="$input_app" \
     INPUT_ENVIRONMENT="$input_environment" \
     INPUT_DATABASE_URL="postgres://preview-db" \
-    INPUT_JOB_REF="pr-123" \
+    INPUT_JOB_REF="$input_job_ref" \
     INPUT_WEB_URL="https://pr-123-www.vm0.test" \
     INPUT_APP_URL="https://pr-123-app.vm0.test" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
@@ -438,7 +469,11 @@ assert_env_value "$success_env_file" UNSPLASH_ACCESS_KEY "github-unsplash-access
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
 assert_env_value "$success_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
+assert_env_key_count "$success_env_file" OKOU_PREVIEW_JOB_REF 1
+assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
+assert_env_value "$success_env_file" OKOU_PREVIEW_JOB_REF "pr-123"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
+assert_env_values_equal "$success_env_file" OKOU_PREVIEW_JOB_REF VM0_PREVIEW_JOB_REF
 assert_env_value "$success_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
@@ -477,6 +512,20 @@ assert_env_absent_value "$success_env_file" "github-slack-client-secret"
 assert_env_absent_value "$success_env_file" "github-posthog-key"
 assert_env_absent_value "$success_env_file" "github-cloudflare-browser-rendering-token"
 assert_env_absent_value "$success_env_file" "github-artifact-preview-waf-secret"
+
+preview_web_dir="$(mktemp -d)"
+TEMP_DIRS+=("$preview_web_dir")
+preview_web_output="$(run_action "$(build_doppler_secrets_json)" "$preview_web_dir" web preview 2>&1)"
+preview_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${preview_web_dir}/github-output")"
+assert_contains "$preview_web_output" "Rendered"
+assert_preview_job_ref_aliases_absent "$preview_web_env_file"
+
+empty_job_ref_dir="$(mktemp -d)"
+TEMP_DIRS+=("$empty_job_ref_dir")
+empty_job_ref_output="$(run_action "$(build_doppler_secrets_json)" "$empty_job_ref_dir" api preview "https://static.vm0.io/okou-cli/test-sha/package.tgz" canonical "" "" "" 2>&1)"
+empty_job_ref_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_job_ref_dir}/github-output")"
+assert_contains "$empty_job_ref_output" "Rendered"
+assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -551,6 +600,7 @@ assert_env_value "$production_api_env_file" STRIPE_WEBHOOK_SECRET "github-stripe
 assert_env_value "$production_api_env_file" STRIPE_AUTOMATION_WEBHOOK_SECRET "github-stripe-automation-webhook-secret"
 assert_env_absent_value "$production_api_env_file" "doppler-stripe-billing-webhook-secret"
 assert_env_absent_value "$production_api_env_file" "doppler-stripe-automation-webhook-secret"
+assert_preview_job_ref_aliases_absent "$production_api_env_file"
 
 missing_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_dir")

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -16,10 +16,12 @@ type PreviewJobRefAliasState =
   | "legacy-only"
   | "dual";
 
-// The preview deployment action intentionally remains legacy-only during this
-// reader-expansion stage. Remove the legacy alias only after #28914 completes
-// writer cutover, retires pre-reader rollback targets, and observes zero
-// legacy-only resolutions through the supported rollback window.
+// The preview deployment action intentionally emits equal-dual aliases so old
+// API rollback targets keep the legacy input while current APIs exercise the
+// canonical reader. Cut the writer to canonical-only only after every eligible
+// API can read the canonical key; remove the legacy reader separately after
+// bounded evidence shows zero legacy-only or dual resolutions through the
+// supported rollback window.
 function resolveStripePreviewJobRef(): string | null {
   if (env("ENV") !== "preview") {
     return null;


### PR DESCRIPTION
## Summary

- emit `OKOU_PREVIEW_JOB_REF` and `VM0_PREVIEW_JOB_REF` exactly once from the same non-empty `INPUT_JOB_REF` for preview API deployments
- preserve non-API, non-preview, and empty-input absence behavior with focused action contract coverage
- update only the centralized reader rollout comment for the equal-dual writer stage and later contraction gates

## Testing

- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `bash -n .github/scripts/tests/web-api-env-action-test.sh`
- `pnpm dlx shellcheck .github/scripts/tests/web-api-env-action-test.sh`
- `pnpm dlx prettier@3.8.1 --check .github/actions/web-api-env/action.yml turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts`
- `git diff --check origin/main...HEAD`

## Fallbacks

Revert this PR to restore the previous legacy-only `VM0_PREVIEW_JOB_REF` writer. Current APIs and eligible rollback APIs continue to accept that legacy-only state, so rollback requires no data migration, secret change, repository configuration change, or deployment-topology change.

Closes #29135
Parent EPIC: #28914