### PR TITLE
docs(python): define proxy registry unavailability reason contract

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -100,6 +100,14 @@ def block_registry_unavailable(
     flow: http.HTTPFlow,
     unavailable: registry.RegistryUnavailable,
 ) -> None:
+    """Block the flow with a fail-closed 503 response for an unavailable registry.
+
+    The JSON response contains the fixed ``registry_unavailable`` error, the
+    fixed user-visible ``message`` ``Proxy registry is unavailable``, and the
+    ``reason`` copied from ``RegistryUnavailable.reason``. The response message
+    is intentionally distinct from ``RegistryUnavailable.message``, which
+    remains detailed internal failure context.
+    """
     flow_metadata.set_firewall_decision(
         flow.metadata,
         "BLOCK",

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -55,7 +55,21 @@ class _RegistrySnapshot:
 
 @dataclass(frozen=True)
 class RegistryUnavailable:
-    """Current registry file cannot be trusted as an enforcement source."""
+    """Current registry file cannot be trusted as an enforcement source.
+
+    ``reason`` is the stable diagnostic category for the unavailable state:
+
+    - ``stat_failed`` means the registry could not be opened or validated as a
+      regular file, so no file identity was available.
+    - ``read_failed`` means the opened registry could not be read, including a
+      bounded-read failure.
+    - ``parse_failed`` means the bytes could not be decoded or did not have the
+      expected registry shape.
+
+    ``message`` contains detailed internal failure context. The local 503
+    response exposes ``reason`` as its diagnostic category but uses its own
+    fixed user-visible message instead of serializing this internal detail.
+    """
 
     reason: str
     message: str
@@ -458,6 +472,16 @@ def load_registry_state(registry_path: str) -> RegistryState:
     failed key so repeated reads of the same bad bytes do not reparse or
     re-warn. File read errors keep retrying that key, and internal
     compile/eviction errors are allowed to propagate.
+
+    ``stat_failed`` covers failures before a file identity is available, and
+    later calls retry opening the path while the stat warning guard suppresses
+    duplicate warnings. ``read_failed`` covers bounded read errors; its file
+    identity is not stored as a failed key, so the same identity is retried on
+    the next call while ``read_error_key`` only suppresses duplicate warnings.
+    ``parse_failed`` stores the file identity in ``failed_key`` and
+    short-circuits subsequent calls for that identity until the file changes.
+    An unavailable transition clears the previous enforcement snapshot rather
+    than reusing stale registry data.
     """
     path = Path(registry_path)
     path_key = _path_key(path)


### PR DESCRIPTION
## Summary

- Document the complete `RegistryUnavailable.reason` vocabulary and the failure boundary for `stat_failed`, `read_failed`, and `parse_failed`.
- Document category-specific retry and cache behavior, including parse-failure `failed_key` handling.
- Document the local 503 response contract and distinguish its fixed user-visible message from the internal detailed `message`.

## Scope

This is a documentation-only change. Runtime reason values, state transitions, cache behavior, response fields, and enforcement behavior are unchanged. No tests were modified.

## Validation

- `uv run --no-sync python -m pytest tests/test_registry_loading.py tests/test_request_handler_registry_admission.py tests/test_request_handler_api_admission.py`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`

Closes #29143
