### PR TITLE
refactor(activity): neutralize the activity vertical in platform

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
@@ -7,7 +7,7 @@ import { apiClient$ } from "../api-client.ts";
 import { currentRunId$ } from "./activity-signals.ts";
 import { accept } from "../../lib/accept.ts";
 
-interface ZeroActivityContext {
+interface ActivityContext {
   runId: string;
   context: RunContextResponse | null;
 }
@@ -16,7 +16,7 @@ interface ZeroActivityContext {
  * Run context snapshot fetched from Axiom via the context API.
  * Returns null if context is not available (old runs or ingestion delay).
  */
-export const zeroActivityContext$ = computed(async (get) => {
+export const activityContext$ = computed(async (get) => {
   const runId = get(currentRunId$);
   if (!runId) {
     return null;
@@ -31,10 +31,10 @@ export const zeroActivityContext$ = computed(async (get) => {
     return {
       runId,
       context: null,
-    } satisfies ZeroActivityContext;
+    } satisfies ActivityContext;
   }
   return {
     runId,
     context: result.body,
-  } satisfies ZeroActivityContext;
+  } satisfies ActivityContext;
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -27,7 +27,7 @@ interface RunNetworkLogsPage extends NetworkLogsPage {
   runId: string;
 }
 
-interface ZeroActivityNetworkLogs {
+interface ActivityNetworkLogs {
   runId: string | null;
   networkLogs: NetworkLogEntry[];
   hasMore: boolean;
@@ -136,7 +136,7 @@ const pagination$ = state<PaginationState>({
  * Combined signal for the UI. Merges auto-loaded first page with
  * any extra pages loaded via loadNetworkLogsNextPage$.
  */
-export const zeroActivityNetworkLogs$ = computed(async (get) => {
+export const activityNetworkLogs$ = computed(async (get) => {
   const first = await get(firstPage$);
   if (!first) {
     return {
@@ -144,7 +144,7 @@ export const zeroActivityNetworkLogs$ = computed(async (get) => {
       networkLogs: [] as NetworkLogEntry[],
       hasMore: false,
       loading: false,
-    } satisfies ZeroActivityNetworkLogs;
+    } satisfies ActivityNetworkLogs;
   }
 
   const currentRunId = get(currentRunId$);
@@ -161,7 +161,7 @@ export const zeroActivityNetworkLogs$ = computed(async (get) => {
     networkLogs: [...first.logs, ...extra],
     hasMore,
     loading,
-  } satisfies ZeroActivityNetworkLogs;
+  } satisfies ActivityNetworkLogs;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/activity-page/activity-runner-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-runner-signals.ts
@@ -5,11 +5,11 @@ import type {
   WorkspaceReuseResult,
 } from "@okouai/api-contracts/contracts/webhooks";
 import { apiClient$ } from "../api-client.ts";
-import { currentRunId$, zeroActivityDetail$ } from "./activity-signals.ts";
+import { currentRunId$, activityDetail$ } from "./activity-signals.ts";
 import { accept } from "../../lib/accept.ts";
 import type { LogStatus } from "../okou-page/log-types.ts";
 
-interface ZeroActivityRunner {
+interface ActivityRunner {
   runId: string;
   status: LogStatus;
   runner: {
@@ -18,9 +18,9 @@ interface ZeroActivityRunner {
   };
 }
 
-export const zeroActivityRunner$ = computed(async (get) => {
+export const activityRunner$ = computed(async (get) => {
   const runId = get(currentRunId$);
-  const detail = await get(zeroActivityDetail$);
+  const detail = await get(activityDetail$);
   if (!runId || !detail || detail.id !== runId) {
     return null;
   }
@@ -37,5 +37,5 @@ export const zeroActivityRunner$ = computed(async (get) => {
       sandboxReuseResult: result.body.sandboxReuseResult,
       workspaceReuseResult: result.body.workspaceReuseResult ?? null,
     },
-  } satisfies ZeroActivityRunner;
+  } satisfies ActivityRunner;
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -32,7 +32,7 @@ type AgentEventsClient = InitClientReturn<
   InitClientArgs
 >;
 
-interface ZeroActivityEvents {
+interface ActivityEvents {
   readonly runId: string;
   readonly events: AgentEvent[];
   readonly status: LogStatus;
@@ -46,10 +46,10 @@ type ActivityEventsState =
     }
   | {
       readonly phase: "ready";
-      readonly data: ZeroActivityEvents;
+      readonly data: ActivityEvents;
     };
 
-interface ZeroActivityVisibleGroups {
+interface ActivityVisibleGroups {
   readonly runId: string | null;
   readonly groups: EventGroup[];
   readonly loading: boolean;
@@ -99,7 +99,7 @@ async function fetchAgentEventBatch(
     readonly expectedSequence?: number;
   },
   signal: AbortSignal,
-): Promise<Omit<ZeroActivityEvents, "runId">> {
+): Promise<Omit<ActivityEvents, "runId">> {
   const firstPage = await fetchAgentEventPage(
     client,
     runId,
@@ -152,7 +152,7 @@ async function fetchAgentEventBatch(
 
 const internalActivityEventsState$ = state<ActivityEventsState | null>(null);
 
-export const zeroActivityEvents$ = computed((get) => {
+export const activityEvents$ = computed((get) => {
   const runId = get(currentRunId$);
   const state = get(internalActivityEventsState$);
   if (!runId || state?.phase !== "ready" || state.data.runId !== runId) {
@@ -161,7 +161,7 @@ export const zeroActivityEvents$ = computed((get) => {
   return state.data;
 });
 
-const zeroActivityEventsLoading$ = computed((get) => {
+const activityEventsLoading$ = computed((get) => {
   const runId = get(currentRunId$);
   const state = get(internalActivityEventsState$);
   return state?.phase === "loading" && state.runId === runId;
@@ -190,7 +190,7 @@ function visibleEventSequence(events: readonly AgentEvent[]): number {
   return visibleThrough;
 }
 
-function reachedTerminalEventWatermark(data: ZeroActivityEvents): boolean {
+function reachedTerminalEventWatermark(data: ActivityEvents): boolean {
   return (
     isTerminalStatus(data.status) &&
     data.lastEventSequence !== null &&
@@ -218,8 +218,8 @@ function mergeAgentEvents(
 }
 
 function activityEventsMadeProgress(
-  previous: ZeroActivityEvents,
-  current: ZeroActivityEvents,
+  previous: ActivityEvents,
+  current: ActivityEvents,
 ): boolean {
   return (
     current.events.length !== previous.events.length ||
@@ -253,10 +253,10 @@ export const setupActivityEvents$ = command(
     let current = {
       runId,
       ...initial,
-    } satisfies ZeroActivityEvents;
+    } satisfies ActivityEvents;
     set(internalActivityEventsState$, { phase: "ready", data: current });
 
-    await get(zeroActivityDetail$);
+    await get(activityDetail$);
     signal.throwIfAborted();
     // Allow React to render the initial event history and bind the scroll
     // container before restoring the pre-removal bottom position.
@@ -318,7 +318,7 @@ export const setupActivityEvents$ = command(
   },
 );
 
-export const zeroActivityDetail$ = computed(async (get) => {
+export const activityDetail$ = computed(async (get) => {
   const runId = get(currentRunId$);
   if (!runId) {
     return null;
@@ -335,27 +335,27 @@ export const zeroActivityDetail$ = computed(async (get) => {
 
 const internalStepSearch$ = state("");
 
-export const zeroActivityStepSearch$ = computed((get) => {
+export const activityStepSearch$ = computed((get) => {
   return get(internalStepSearch$);
 });
 
-export const setZeroActivityStepSearch$ = command(({ set }, value: string) => {
+export const setActivityStepSearch$ = command(({ set }, value: string) => {
   set(internalStepSearch$, value);
 });
 
-export const zeroActivityVisibleGroups$ = computed(async (get) => {
+export const activityVisibleGroups$ = computed(async (get) => {
   const runId = get(currentRunId$);
   const [detail, events] = await Promise.all([
-    get(zeroActivityDetail$),
-    get(zeroActivityEvents$),
+    get(activityDetail$),
+    get(activityEvents$),
   ]);
-  const loading = get(zeroActivityEventsLoading$);
+  const loading = get(activityEventsLoading$);
   if (!detail || !events || events.runId !== detail.id) {
     return {
       runId,
       groups: [],
       loading,
-    } satisfies ZeroActivityVisibleGroups;
+    } satisfies ActivityVisibleGroups;
   }
   return {
     runId: detail.id,
@@ -363,7 +363,7 @@ export const zeroActivityVisibleGroups$ = computed(async (get) => {
       framework: detail.framework,
     }),
     loading: false,
-  } satisfies ZeroActivityVisibleGroups;
+  } satisfies ActivityVisibleGroups;
 });
 
 export function formatLogTime(createdAt: string): string {

--- a/turbo/apps/platform/src/signals/okou-page/mobile-breadcrumb.ts
+++ b/turbo/apps/platform/src/signals/okou-page/mobile-breadcrumb.ts
@@ -9,7 +9,7 @@ import {
   currentChatThreadId$,
   currentChatAgentDisplayName$,
 } from "../agent-chat.ts";
-import { zeroActivityDetail$ } from "../activity-page/activity-signals.ts";
+import { activityDetail$ } from "../activity-page/activity-signals.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { currentWorkflowDetail$ } from "../workflows-page/workflows-signals.ts";
@@ -77,7 +77,7 @@ const activityDetailBreadcrumb$ = computed(
     const params = get(pathParams$) as Params;
     const activityRunId = getStringParam(params, "activityRunId");
     if (activityRunId) {
-      const detail = await get(zeroActivityDetail$);
+      const detail = await get(activityDetail$);
       if (detail && detail.id === activityRunId) {
         return {
           section,

--- a/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
@@ -44,11 +44,11 @@ import {
 } from "../../signals/okou-page/log-types.ts";
 import { StatusBadge } from "./components/log-views/status-badge.tsx";
 import {
-  zeroActivityDetail$,
-  zeroActivityEvents$,
-  zeroActivityVisibleGroups$,
-  zeroActivityStepSearch$,
-  setZeroActivityStepSearch$,
+  activityDetail$,
+  activityEvents$,
+  activityVisibleGroups$,
+  activityStepSearch$,
+  setActivityStepSearch$,
   formatLogTime,
   formatDuration,
   currentRunId$,
@@ -60,10 +60,10 @@ import {
 } from "../../signals/activity-page/log-detail-utils";
 import { EventGroupCard } from "./components/log-views/event-group-card.tsx";
 import { StatusDot } from "./components/log-views/status-dot.tsx";
-import { zeroActivityContext$ } from "../../signals/activity-page/activity-context-signals.ts";
-import { zeroActivityRunner$ } from "../../signals/activity-page/activity-runner-signals.ts";
+import { activityContext$ } from "../../signals/activity-page/activity-context-signals.ts";
+import { activityRunner$ } from "../../signals/activity-page/activity-runner-signals.ts";
 import {
-  zeroActivityNetworkLogs$,
+  activityNetworkLogs$,
   loadNetworkLogsNextPage$,
 } from "../../signals/activity-page/activity-network-signals.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -495,9 +495,9 @@ function ActivityStepsContent({
   features: Record<FeatureSwitchKey, boolean> | undefined;
 }) {
   const { t } = useTranslation();
-  const stepSearch = useGet(zeroActivityStepSearch$);
-  const setStepSearch = useSet(setZeroActivityStepSearch$);
-  const visibleGroupsLoadable = useLastLoadable(zeroActivityVisibleGroups$);
+  const stepSearch = useGet(activityStepSearch$);
+  const setStepSearch = useSet(setActivityStepSearch$);
+  const visibleGroupsLoadable = useLastLoadable(activityVisibleGroups$);
   const visibleGroupsData =
     visibleGroupsLoadable.state === "hasData" &&
     visibleGroupsLoadable.data.runId === detail.id
@@ -578,7 +578,7 @@ function ActivityStepsContent({
 
 function ActivityContextTab({ detail }: { detail: LogDetail }) {
   const { t } = useTranslation();
-  const contextLoadable = useLastLoadable(zeroActivityContext$);
+  const contextLoadable = useLastLoadable(activityContext$);
   const modelRoute =
     detail.modelRuntimeProvider && detail.modelRuntimeModel ? (
       <section className="mb-6">
@@ -757,7 +757,7 @@ function RunnerOutcomeRow({
 
 function ActivityRunnerTab({ detailId }: { detailId: string }) {
   const { t } = useTranslation();
-  const runnerLoadable = useLastLoadable(zeroActivityRunner$);
+  const runnerLoadable = useLastLoadable(activityRunner$);
 
   if (
     runnerLoadable.state === "loading" ||
@@ -905,7 +905,7 @@ function ActivityRunnerTab({ detailId }: { detailId: string }) {
 
 function ActivityNetworkTab({ detailId }: { detailId: string }) {
   const { t } = useTranslation();
-  const logsLoadable = useLastLoadable(zeroActivityNetworkLogs$);
+  const logsLoadable = useLastLoadable(activityNetworkLogs$);
   const loadNextPage = useSet(loadNetworkLogsNextPage$);
   const pageSignal = useGet(pageSignal$);
 
@@ -1108,8 +1108,8 @@ function ActivityDetailContent({
 export function ZeroActivityDetailPage() {
   const { t } = useTranslation();
   const currentRunId = useGet(currentRunId$);
-  const detailLoadable = useLastLoadable(zeroActivityDetail$);
-  const eventsLoadable = useLastLoadable(zeroActivityEvents$);
+  const detailLoadable = useLastLoadable(activityDetail$);
+  const eventsLoadable = useLastLoadable(activityEvents$);
   // Resolve agent display name from the detail response
   const detail =
     detailLoadable.state === "hasData" ? detailLoadable.data : null;


### PR DESCRIPTION
Part of #26873. Neutralizes the activity vertical in `apps/platform`.

## What changed

Drops the `zero`/`Zero` prefix from the 14 identifiers defined under `turbo/apps/platform/src/signals/activity-page`, following the convention established by #28847 (`views/zero-page` → `views/okou-page`, prefix stripped from filenames): the directory carries the namespace, symbols do not repeat it. The prefix is dropped, not swapped — `zeroActivityDetail$` becomes `activityDetail$`, not `okouActivityDetail$`.

Signals and derived state:

| Before | After |
| --- | --- |
| `zeroActivityContext$` | `activityContext$` |
| `zeroActivityDetail$` | `activityDetail$` |
| `zeroActivityEvents$` | `activityEvents$` |
| `zeroActivityEventsLoading$` | `activityEventsLoading$` |
| `zeroActivityNetworkLogs$` | `activityNetworkLogs$` |
| `zeroActivityRunner$` | `activityRunner$` |
| `zeroActivityStepSearch$` | `activityStepSearch$` |
| `zeroActivityVisibleGroups$` | `activityVisibleGroups$` |
| `setZeroActivityStepSearch$` | `setActivityStepSearch$` |

Types:

| Before | After |
| --- | --- |
| `ZeroActivityContext` | `ActivityContext` |
| `ZeroActivityEvents` | `ActivityEvents` |
| `ZeroActivityNetworkLogs` | `ActivityNetworkLogs` |
| `ZeroActivityRunner` | `ActivityRunner` |
| `ZeroActivityVisibleGroups` | `ActivityVisibleGroups` |

Each symbol is renamed at its definition and at every reference in the same commit, including the two files outside `signals/activity-page` that import from it (`signals/okou-page/mobile-breadcrumb.ts` and `views/okou-page/activity-detail-page.tsx`).

No files needed renaming — nothing under `signals/activity-page` still carries a `zero-` prefix.

## Verification

- Repo-wide grep confirms no `zeroActivity`/`ZeroActivity` identifiers remain except `ZeroActivityDetailPage`, which is explicitly listed in #29155 (the `okou-page` shell slice) and is deliberately left alone here.
- The bare target names were re-checked against `turbo/apps/platform/src` after the rename. The only near-match is the `ROUTES.activityDetail` route key in `signals/route-paths.ts`, an object property rather than a module binding, so there is no collision.
- `.claude/skills/`, `docs/`, and the root markdown files were grepped for the touched paths and identifiers; nothing references them, so there is no repeat of the `feature-switch/SKILL.md` breakage that #28890 had to repair.
- Prettier (3.8.1, the pinned version) reports all six files clean with no reflow needed.

## Out of scope

- `zeroHostDomain` in `lib/platform-host.ts` — it mirrors `ZERO_HOST_DOMAIN`, which `apps/api/src/lib/env.ts` deliberately retains until the VM0-brand host retires under #26701.
- `ZeroActivityDetailPage` — belongs to #29155.
- `crates/`, `apps/api`, `packages/` — this is an `apps/platform` slice.
- `CHANGELOG.md` and migration filenames — historical records.

Closes #29151
