### PR TITLE
refactor(agent-detail): neutralize agent detail and creation vertical

### DIFF
--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import type { TeamComposeItem } from "@okouai/core";
 import { createElement } from "react";
-import { AgentDetailPage } from "../../views/team-page/zero-team-detail-page.tsx";
+import { AgentDetailPage } from "../../views/team-page/agent-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -22,7 +22,7 @@ import { rootSignal$ } from "./root-signal.ts";
 /**
  * Type alias for the factory function returned by `get(apiClient$)`.
  * Useful for shared helper functions that accept the client factory
- * as a parameter (e.g. `createZeroAgent`).
+ * as a parameter (e.g. `createAgent`).
  */
 export type ApiClientFactory = <T extends AppRouter>(
   contract: T,

--- a/turbo/apps/platform/src/signals/okou-page/agents.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agents.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { reloadAgents$ } from "../agent.ts";
 import { apiClient$ } from "../api-client.ts";
-import { createZeroAgent } from "./create-zero-agent.ts";
+import { createAgent } from "./create-agent.ts";
 
 /**
  * Create a sub-agent by composing via the zero agents API.
@@ -17,7 +17,7 @@ export const createSubagent$ = command(
   ) => {
     const createClient = get(apiClient$);
 
-    await createZeroAgent(
+    await createAgent(
       createClient,
       {
         displayName,

--- a/turbo/apps/platform/src/signals/okou-page/create-agent.ts
+++ b/turbo/apps/platform/src/signals/okou-page/create-agent.ts
@@ -7,7 +7,7 @@ import { SEED_INSTRUCTIONS } from "@okouai/core/seed-instructions";
 import type { ApiClientFactory } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 
-interface CreateZeroAgentParams {
+interface CreateAgentParams {
   displayName: string;
   sound?: string;
   avatarUrl?: string;
@@ -15,14 +15,14 @@ interface CreateZeroAgentParams {
 }
 
 /**
- * Create a zero agent and upload seed instructions.
+ * Create an agent and upload seed instructions.
  *
  * Shared between onboarding (lead agent) and sub-agent creation
  * to keep the two flows in sync.
  */
-export async function createZeroAgent(
+export async function createAgent(
   createClient: ApiClientFactory,
-  params: CreateZeroAgentParams,
+  params: CreateAgentParams,
   signal: AbortSignal,
 ): Promise<AgentResponse> {
   // Step 1: Create agent (compose). The API assigns a random preset avatar

--- a/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
@@ -75,7 +75,7 @@ import {
 } from "./components/context-content.tsx";
 import { NetworkContent } from "./components/network-content.tsx";
 import { Markdown } from "../components/markdown.tsx";
-import { ZeroNoPermissionIllustration } from "./components/no-permission-illustration.tsx";
+import { NoPermissionIllustration } from "./components/no-permission-illustration.tsx";
 import { formatAppNumber } from "../../i18n/format.ts";
 
 // ---------------------------------------------------------------------------
@@ -252,7 +252,7 @@ function ActivityNotFound() {
         </span>
       </nav>
       <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
-        <ZeroNoPermissionIllustration />
+        <NoPermissionIllustration />
         <h2 className="text-lg font-semibold text-foreground">
           {t(($) => {
             return $.activity.detail.notFound.title;

--- a/turbo/apps/platform/src/views/okou-page/components/no-permission-illustration.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/no-permission-illustration.tsx
@@ -1,15 +1,15 @@
 import { noPermissionIllustration } from "../platform-assets.ts";
 
-type ZeroNoPermissionIllustrationProps = {
+type NoPermissionIllustrationProps = {
   className?: string;
 };
 
 /**
  * Padlock illustration for restricted access / not-found states (transparent WebP).
  */
-export function ZeroNoPermissionIllustration({
+export function NoPermissionIllustration({
   className = "h-28 w-auto max-w-[200px] object-contain opacity-90",
-}: ZeroNoPermissionIllustrationProps) {
+}: NoPermissionIllustrationProps) {
   return (
     <img
       src={noPermissionIllustration}

--- a/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ZeroUnsavedBar } from "./unsaved-bar.tsx";
 import { TiptapInstructionsEditor } from "./tiptap-instructions-editor.tsx";
 
-interface ZeroInstructionsTabProps {
+interface InstructionsTabProps {
   instructions: AgentInstructions | null;
   loading: boolean;
   fetchError: string | null;
@@ -16,7 +16,7 @@ interface ZeroInstructionsTabProps {
   onBuild: () => void;
 }
 
-export function ZeroInstructionsTab({
+export function InstructionsTab({
   instructions,
   loading,
   fetchError,
@@ -27,7 +27,7 @@ export function ZeroInstructionsTab({
   onEdit,
   onDiscard,
   onBuild,
-}: ZeroInstructionsTabProps) {
+}: InstructionsTabProps) {
   const { t } = useTranslation("agents");
   const rawContent = instructions?.content ?? "";
   const displayContent = editedContent ?? rawContent;

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -48,7 +48,7 @@ import {
   setAgentDemoteConfirmOpen$,
 } from "../../signals/okou-page/settings/settings-tab.ts";
 
-interface ZeroSettingsTabProps {
+interface SettingsTabProps {
   agentId: string;
   displayName: string;
   description: string;
@@ -85,7 +85,7 @@ interface ZeroSettingsTabProps {
   onDelete?: () => Promise<void>;
 }
 
-export function ZeroSettingsTab({
+export function SettingsTab({
   agentId,
   displayName: resolvedAgentName,
   description: initialDescription,
@@ -100,7 +100,7 @@ export function ZeroSettingsTab({
   deleteWorkflows = [],
   deleteCopyTargets = [],
   onCopyWorkflowBeforeDelete,
-}: ZeroSettingsTabProps) {
+}: SettingsTabProps) {
   const { t } = useTranslation("agents");
   const defaults = {
     name: resolvedAgentName,

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -60,7 +60,7 @@ import { testConnectorPermissionDetails } from "../../../mocks/handlers/connecto
 import { mockChatEventRows } from "../../okou-page/__tests__/chat-event-test-helpers.ts";
 
 const context = testContext();
-const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
+const agentId = "c0000000-0000-4000-a000-000000000001";
 const researchAgentId = "a0000000-0000-4000-a000-000000000401";
 const PAGE_LOAD_TIMEOUT_MS = 5000;
 
@@ -427,7 +427,7 @@ function mockTeamAPIs({
   readonly onCustomConnectorUpdate?: () => void;
 } = {}): void {
   context.mocks.data.team([
-    createAgent(zeroAgentId, "Zero"),
+    createAgent(agentId, "Support Agent"),
     createAgent(researchAgentId, "Research Agent"),
   ]);
   context.mocks.data.connectors([
@@ -492,7 +492,7 @@ function mockTeamAPIs({
     return respond(200, { agents: {}, threads: {} });
   });
   context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
-    const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
+    const agent = params.id === agentId ? "Support Agent" : "Research Agent";
     return respond(200, {
       agentId: params.id,
       ownerId: "test-owner-id",
@@ -531,9 +531,9 @@ function mockAgentWorkflowApis(): void {
     }),
     createWorkflowSummary({
       id: "d0000000-0000-4000-a000-000000000703",
-      agentId: zeroAgentId,
-      agentName: "zero",
-      agentDisplayName: "Zero",
+      agentId,
+      agentName: "support-agent",
+      agentDisplayName: "Support Agent",
       displayName: "Support Intake",
       visibility: "public",
     }),
@@ -791,11 +791,11 @@ describe("team page navigation", () => {
     click(buttonByText("Allow", permissionRow));
 
     context.store.set(detachedNavigateTo$, ROUTES.agentDetail, {
-      pathParams: { agentId: zeroAgentId },
+      pathParams: { agentId },
       searchParams: new URLSearchParams(),
     });
 
-    await screen.findByRole("heading", { name: "Zero" });
+    await screen.findByRole("heading", { name: "Support Agent" });
     await waitFor(() => {
       expect(
         screen.queryByText("messages:send-as-user"),
@@ -846,12 +846,14 @@ describe("team page navigation", () => {
     });
 
     context.store.set(detachedNavigateTo$, ROUTES.agentDetail, {
-      pathParams: { agentId: zeroAgentId },
+      pathParams: { agentId },
       searchParams: new URLSearchParams(),
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Zero" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Support Agent" }),
+      ).toBeInTheDocument();
       expect(screen.getByText("@octocat")).toBeInTheDocument();
       expect(screen.getByLabelText("Grant GitHub access")).toBeInTheDocument();
       expect(
@@ -1113,7 +1115,7 @@ describe("team page navigation", () => {
           },
         });
       }
-      const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
+      const agent = params.id === agentId ? "Support Agent" : "Research Agent";
       return respond(200, {
         agentId: params.id,
         ownerId: "test-owner-id",
@@ -1171,9 +1173,9 @@ describe("team page navigation", () => {
           201,
           createWorkflowSummary({
             id: "d0000000-0000-4000-a000-0000000007ff",
-            agentId: zeroAgentId,
-            agentName: "zero",
-            agentDisplayName: "Zero",
+            agentId,
+            agentName: "support-agent",
+            agentDisplayName: "Support Agent",
             displayName: "Sales Research",
             visibility: "private",
           }),
@@ -1196,7 +1198,7 @@ describe("team page navigation", () => {
           },
         });
       }
-      const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
+      const agent = params.id === agentId ? "Support Agent" : "Research Agent";
       return respond(200, {
         agentId: params.id,
         ownerId: "test-owner-id",
@@ -1233,10 +1235,10 @@ describe("team page navigation", () => {
       ).toBeInTheDocument();
     });
 
-    // Copy "Sales Research" onto Zero; leave "Ops Playbook" to be deleted.
+    // Copy "Sales Research" onto Support Agent; leave "Ops Playbook" deleted.
     selectOptionByLabel(
       "Handle workflow Sales Research",
-      /Copy to Zero/,
+      /Copy to Support Agent/,
       deleteDialog,
     );
 
@@ -1247,7 +1249,7 @@ describe("team page navigation", () => {
       expect(copyRequests).toStrictEqual([
         {
           workflowId: "d0000000-0000-4000-a000-000000000701",
-          toAgentId: zeroAgentId,
+          toAgentId: agentId,
         },
       ]);
     });

--- a/turbo/apps/platform/src/views/team-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/agent-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useGet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { ZeroJobDetailPage } from "./zero-job-detail-page.tsx";
+import { JobDetailPage } from "./job-detail-page.tsx";
 import { currentAgentId$ } from "../../signals/agent.ts";
 
 export function AgentDetailPage() {
@@ -8,7 +8,7 @@ export function AgentDetailPage() {
   const agentId = useGet(currentAgentId$);
 
   return agentId ? (
-    <ZeroJobDetailPage />
+    <JobDetailPage />
   ) : (
     <div className="flex flex-1 items-center justify-center text-muted-foreground">
       {t(($) => {

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -39,8 +39,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@okouai/ui";
-import { ZeroInstructionsTab } from "../okou-page/instructions-tab.tsx";
-import { ZeroSettingsTab } from "../okou-page/settings-tab.tsx";
+import { InstructionsTab } from "../okou-page/instructions-tab.tsx";
+import { SettingsTab } from "../okou-page/settings-tab.tsx";
 import { TONE_OPTIONS, type Tone } from "../okou-page/tone-constants.ts";
 import { agentDetail$ } from "../../signals/okou-page/job-detail/detail";
 import {
@@ -81,7 +81,7 @@ import {
 } from "../../signals/agent.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
-import { ZeroNoPermissionIllustration } from "../okou-page/components/no-permission-illustration.tsx";
+import { NoPermissionIllustration } from "../okou-page/components/no-permission-illustration.tsx";
 import { ConnectorCard } from "../okou-page/components/settings/connector-card.tsx";
 import { PermissionsDrawer } from "../okou-page/components/settings/permissions-dialog.tsx";
 import type { PermissionDraftIntent } from "../../signals/okou-page/settings/permission-draft-intent.ts";
@@ -199,7 +199,7 @@ function DetailError({ error, agentId }: { error: string; agentId: string }) {
         <Breadcrumb />
         <main className="flex-1 flex items-center justify-center px-4 sm:px-6 pb-16">
           <div className="flex flex-col items-center text-center gap-4 max-w-sm">
-            <ZeroNoPermissionIllustration className="h-32 w-auto max-w-[220px] object-contain opacity-90" />
+            <NoPermissionIllustration className="h-32 w-auto max-w-[220px] object-contain opacity-90" />
             <div className="space-y-1.5">
               <h2 className="text-lg font-semibold text-foreground">
                 {t(($) => {
@@ -806,7 +806,7 @@ function JobInstructionsTab() {
   const discard = useSet(discardAgentEdit$);
 
   return (
-    <ZeroInstructionsTab
+    <InstructionsTab
       instructions={instructions}
       loading={loading}
       fetchError={fetchError}
@@ -998,7 +998,7 @@ function AgentProfileSettings({
   };
 
   return (
-    <ZeroSettingsTab
+    <SettingsTab
       key={agentId}
       agentId={agentId}
       displayName={displayName}
@@ -1141,7 +1141,7 @@ function useTabVisibility(agentId: string, ownerId: string) {
   };
 }
 
-export function ZeroJobDetailPage() {
+export function JobDetailPage() {
   const { t } = useTranslation("agents");
   const detailLoadable = useLoadable(agentDetail$);
   const error = loadableErrorMessage(


### PR DESCRIPTION
Closes #29152. Part of #26873.

Finishes what #28847 started for the agent detail and agent creation vertical in `apps/platform`: the directory carries the namespace, so the `zero-` prefix is **dropped**, not swapped for `okou-`.

## File renames

| Current | New |
|---|---|
| `views/team-page/zero-job-detail-page.tsx` | `views/team-page/job-detail-page.tsx` |
| `views/team-page/zero-team-detail-page.tsx` | `views/team-page/agent-detail-page.tsx` |
| `signals/okou-page/create-zero-agent.ts` | `signals/okou-page/create-agent.ts` |

`zero-team-detail-page.tsx` already exported `AgentDetailPage`; the file is now named after its export.

## Symbol renames

- `ZeroJobDetailPage` → `JobDetailPage`
- `createZeroAgent` → `createAgent`, `CreateZeroAgentParams` → `CreateAgentParams`
- `ZeroInstructionsTab` → `InstructionsTab`, `ZeroInstructionsTabProps` → `InstructionsTabProps`
- `ZeroSettingsTab` → `SettingsTab`, `ZeroSettingsTabProps` → `SettingsTabProps`
- `ZeroNoPermissionIllustration` → `NoPermissionIllustration`, and its `Props`
- `zeroAgentId` → `agentId` in `views/team-page/__tests__/team-navigation.test.tsx`

Every reference moved in this same commit, including the ones defined in a different directory than they are used (`signals/agents-page/agent-detail-page-setup.ts`, `views/okou-page/activity-detail-page.tsx`).

## Test fixture

The default-agent fixture in `team-navigation.test.tsx` no longer carries the `Zero` name: display name `"Zero"` → `"Support Agent"`, `agentName: "zero"` → `"support-agent"`, and the `findByRole` / `getByRole` heading assertions plus the `/Copy to Zero/` option matcher were updated to match. The file's local `createAgent` helper is untouched and the renamed `createAgent` signal is not imported there, so there is no collision.

Also updated the doc comment in `signals/api-client.ts` that names `createZeroAgent` as an example.

## Out of scope, deliberately left alone

- `zeroHostDomain` in `lib/platform-host.ts` — it mirrors `ZERO_HOST_DOMAIN`, which retires with the VM0-brand host under #26701.
- `job` in `job-detail-page.tsx`. The sibling `job-custom-connectors-section.tsx` already uses that word unprefixed, so `job` is established vocabulary here; `job` → `agent` would be a semantic change, not a rename.
- `ZeroUnsavedBar`, `zeroOnboardingStatus$`, the `zero-card` / `zero-btn-morandi` / `zero-chip` CSS class names, and the `"zero-agent-name"` input id — other verticals of #26873.
- `crates/`, `apps/api`, `packages/`, `CHANGELOG.md`, and migration filenames.

## One judgement call worth flagging

The issue enumerated a single doc comment to update (`signals/api-client.ts:25`). I also updated the docstring directly above the renamed function — `"Create a zero agent and upload seed instructions."` → `"Create an agent …"` — because it describes the symbol being renamed. The neighbouring comment in `agents.ts` that says *"composing via the zero agents API"* refers to the API surface rather than this function, so it is left for the `apps/api` slice.

## Notes

`.claude/skills` and `docs/` were grepped for every path and symbol this slice touches; nothing references them, so there is no repeat of the `feature-switch/SKILL.md` breakage that #28890 had to repair.

Renaming shortened several identifiers, so prettier reflowed one assertion in the test file that previously fit on a single line. That accounts for the diff being slightly larger than the rename count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
