### PR TITLE
refactor(shell): neutralize the remaining okou-page shell symbols in platform

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -412,7 +412,7 @@ When the operation does not need to be tied to the page lifecycle and only needs
 **Example 1: Cancel button for file upload** (`chat-draft.ts`)
 
 ```typescript
-function createChatAttachment(file: File): ZeroChatAttachment {
+function createChatAttachment(file: File): ChatAttachment {
   const resetSignal$ = resetSignal();
 
   // Explicit cancel: no new task started, just abort the current upload
@@ -911,7 +911,7 @@ export const setupChatPage$ = command(
 
     set(
       updatePage$,
-      createElement(ZeroChatThreadPage, { key: threadId, thread }),
+      createElement(ChatThreadPage, { key: threadId, thread }),
     );
     // ...
     await set(thread.loadMessages$, signal);
@@ -924,7 +924,7 @@ No manual cache needed — ccstate `computed` memoizes the last result. As long 
 **Step 5 — Components consume via props:**
 
 ```typescript
-export function ZeroChatThreadPage({ thread }: { thread: ChatThreadSignals }) {
+export function ChatThreadPage({ thread }: { thread: ChatThreadSignals }) {
   const messagesLoadable = useLastLoadable(thread.messages$);
   const setScrollContainer = useSet(thread.setScrollContainer$);
   // ... pass thread down to children ...

--- a/docs/react-commit.md
+++ b/docs/react-commit.md
@@ -177,7 +177,7 @@ commit. The following approaches all overcount in current React builds:
 
 In one chat sample, the `WeakMap` technique reported 76 sidebar executions.
 The React Performance track for the same trace showed no execution spans for
-`SidebarLayout`, `ZeroSidebar`, or `ChatThreadsContent`; the only visible
+`SidebarLayout`, `Sidebar`, or `ChatThreadsContent`; the only visible
 sidebar update initiator was one `ChatThreadItem`. Use the root hook for exact
 commit boundaries and React Performance tracks or a deliberately placed React
 `Profiler` for component attribution.
@@ -513,7 +513,7 @@ The component track gives a more accurate region picture than Fiber traversal:
 
 | Region            | Observed component work                                                                                               |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Visible sidebar   | One direct `ChatThreadItem` update; no spans for `SidebarLayout`, `ZeroSidebar`, or `ChatThreadsContent`              |
+| Visible sidebar   | One direct `ChatThreadItem` update; no spans for `SidebarLayout`, `Sidebar`, or `ChatThreadsContent`                  |
 | Hidden sidebar UI | Five direct `AgentListDialog` updates while the dialog was closed                                                     |
 | Message list      | Four direct `ChatThreadContent` updates; `ChatThreadMessagesMain` and `ChatThreadMessageGroups` each executed 8 times |
 | Composer          | Four direct `ChatThreadComposer` updates; its main leaf slots executed 11 times                                       |
@@ -559,7 +559,7 @@ the composer model hook of the time immediately wrapped it in new
 `modelSelection` and `modelPicker` objects. That responsibility now sits on the
 composer signals themselves: `ComposerModelPickerSlotBase` reads
 `signals.model.modelSelection$` directly. The composer entry point — a single
-hook at the time, now the `ZeroChatComposer` component in
+hook at the time, now the `ChatComposer` component in
 `turbo/apps/platform/src/views/okou-page/chat-composer.tsx` — also recreates its
 event handlers and passes them through every composer leaf. This makes otherwise
 unrelated run and message transitions re-execute the closed picker and editor
@@ -864,7 +864,7 @@ component span time. The larger issue is that `ChatThreadComposer` pulled the
 whole composer into the same Fiber, so send, queue, model, connector,
 attachment, dialog, and editor subscriptions all shared one render boundary.
 That fan-in has since been split: `ChatThreadComposer` renders
-`ZeroChatComposer`, which renders `ComposerSurface`, and each concern now
+`ChatComposer`, which renders `ComposerSurface`, and each concern now
 subscribes inside its own slot component — `ComposerInputSlot`,
 `ComposerModelPickerSlot`, `ComposerConnectorsSlot`, `ComposerAttachments`,
 and `ComposerSendControl`.

--- a/turbo/apps/platform/src/lib/__tests__/static-assets.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/static-assets.test.ts
@@ -160,9 +160,9 @@ describe("static asset object keys", () => {
         return match[1]!;
       });
     });
-    const zeroPageKeys = objectKeys.filter((key) => {
+    const pageKeys = objectKeys.filter((key) => {
       return key.startsWith("views/zero-page/");
     });
-    expect(zeroPageKeys).toHaveLength(31);
+    expect(pageKeys).toHaveLength(31);
   });
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { ZeroActivityDetailPage } from "../../views/okou-page/activity-detail-page.tsx";
+import { ActivityDetailPage } from "../../views/okou-page/activity-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
@@ -13,7 +13,7 @@ export const setupActivityDetailPage$ = command(
     const runId = get(currentRunId$);
     set(
       updatePage$,
-      createElement(ZeroActivityDetailPage, { key: runId }),
+      createElement(ActivityDetailPage, { key: runId }),
       "sidebar",
     );
     set(

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { ZeroChatThreadPage } from "../../views/okou-page/chat-thread-page.tsx";
+import { ChatThreadPage } from "../../views/okou-page/chat-thread-page.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
@@ -59,7 +59,7 @@ const internalSetupChatPage$ = command(
       throw new Error("threadId is required to load chat page");
     }
 
-    set(updatePage$, createElement(ZeroChatThreadPage), "sidebar");
+    set(updatePage$, createElement(ChatThreadPage), "sidebar");
 
     set(captureNavigationTiming$);
 

--- a/turbo/apps/platform/src/signals/chat-page/flatten-annotated-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/flatten-annotated-attachments.ts
@@ -3,7 +3,7 @@ import { settle } from "../utils.ts";
 import type { ResolvedAttachFile } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   uploadFileToStorage$,
-  type ZeroChatAttachment,
+  type ChatAttachment,
 } from "../okou-page/chat-draft.ts";
 import {
   describeAnnotation,
@@ -13,7 +13,7 @@ import { flattenAnnotatedImage } from "../okou-page/flatten-annotated-image.ts";
 import { composerImageAnnotationEnabled$ } from "../external/feature-switch.ts";
 
 interface AttachmentToFlatten {
-  readonly attachment: ZeroChatAttachment;
+  readonly attachment: ChatAttachment;
   readonly info: { id: string; url: string; contentType: string };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -1,10 +1,7 @@
 import { command } from "ccstate";
 import type { ResolvedAttachFile } from "@okouai/api-contracts/contracts/chat-threads";
 import { getModelImageInputSupport } from "@okouai/api-contracts/contracts/model-providers";
-import type {
-  DraftSignals,
-  ZeroChatAttachment,
-} from "../okou-page/chat-draft.ts";
+import type { DraftSignals, ChatAttachment } from "../okou-page/chat-draft.ts";
 import { i18n } from "../../i18n/index.ts";
 import { flattenAnnotatedAttachments$ } from "./flatten-annotated-attachments.ts";
 
@@ -37,7 +34,7 @@ interface AttachmentFileInfo {
 }
 
 interface ResolvedDraftAttachment {
-  attachment: ZeroChatAttachment;
+  attachment: ChatAttachment;
   info: AttachmentFileInfo;
 }
 
@@ -78,7 +75,7 @@ export function shouldExcludeVisualAttachmentsForModel(
 }
 
 export function collectSuccessfulAttachmentInfos(
-  attachments: readonly ZeroChatAttachment[],
+  attachments: readonly ChatAttachment[],
   results: readonly PromiseSettledResult<AttachmentFileInfo | null>[],
 ): ResolvedDraftAttachment[] {
   return results.flatMap((result, index) => {
@@ -92,7 +89,7 @@ export function collectSuccessfulAttachmentInfos(
 }
 
 function attachmentUploadFailureMessage(
-  attachments: readonly ZeroChatAttachment[],
+  attachments: readonly ChatAttachment[],
   results: readonly PromiseSettledResult<AttachmentFileInfo | null>[],
 ): string | null {
   const failedFilenames = results.flatMap((result, index) => {

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -330,7 +330,7 @@ export const uploadFileToStorage$ = command(
   },
 );
 
-export interface ZeroChatAttachment {
+export interface ChatAttachment {
   filename: string;
   contentType: string;
   size: number;
@@ -353,7 +353,7 @@ export interface ZeroChatAttachment {
   setAnnotation$: Command<void, [ImageAnnotation | null]>;
 }
 
-function createChatAttachment(file: File): ZeroChatAttachment {
+function createChatAttachment(file: File): ChatAttachment {
   const contentType = inferUploadContentType(file);
   const internalAnnotation$ = state<ImageAnnotation | null>(null);
   const annotation$ = computed((get) => {
@@ -430,7 +430,7 @@ export interface DraftSignals {
     void,
     [GenerationTemplateRequest | undefined]
   >;
-  attachments$: Computed<ZeroChatAttachment[]>;
+  attachments$: Computed<ChatAttachment[]>;
   attachmentUploadsReady$: Computed<boolean>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
   /**
@@ -442,7 +442,7 @@ export interface DraftSignals {
     Promise<boolean>,
     [PersistedAttachment[], AbortSignal]
   >;
-  removeAttachment$: Command<void, [ZeroChatAttachment]>;
+  removeAttachment$: Command<void, [ChatAttachment]>;
   dragOver$: Computed<boolean>;
   setDragOver$: Command<void, [boolean]>;
   /** Reset all draft state (input, template, attachments). Called after send. */
@@ -459,7 +459,7 @@ interface DraftSeed {
   content: string;
   userMessage: UserMessageDocument | null;
   generationTemplate: GenerationTemplateRequest | undefined;
-  attachments: ZeroChatAttachment[];
+  attachments: ChatAttachment[];
 }
 
 export interface DraftInputSyncTarget {
@@ -468,7 +468,7 @@ export interface DraftInputSyncTarget {
 }
 
 /**
- * Reconstructs a ZeroChatAttachment from persisted attachment metadata.
+ * Reconstructs a ChatAttachment from persisted attachment metadata.
  *
  * The persisted id is an externally managed reference: the artifact is stored
  * per user, so a saved draft, a forwarded message, or a pasted chat payload can
@@ -480,7 +480,7 @@ export interface DraftInputSyncTarget {
  */
 export function createRestoredAttachment(
   persisted: PersistedAttachment,
-): ZeroChatAttachment {
+): ChatAttachment {
   const internalAnnotation$ = state<ImageAnnotation | null>(
     persisted.annotation ?? null,
   );
@@ -517,7 +517,7 @@ export function createRestoredAttachment(
   const cancel$ = command(() => {
     // no-op: already uploaded, nothing to cancel
   });
-  // upload$ accepts a signal parameter to match the ZeroChatAttachment interface.
+  // upload$ accepts a signal parameter to match the ChatAttachment interface.
   // The file is already uploaded, so this is a no-op.
   const upload$ = command((_visitor, _signal: AbortSignal): Promise<void> => {
     return Promise.resolve();
@@ -652,12 +652,12 @@ function createDraftDocumentSignals() {
  * is the only state the user can act on.
  */
 function createPruneUnavailableAttachments(
-  internalAttachments$: State<ZeroChatAttachment[]>,
-): Command<Promise<boolean>, [readonly ZeroChatAttachment[], AbortSignal]> {
+  internalAttachments$: State<ChatAttachment[]>,
+): Command<Promise<boolean>, [readonly ChatAttachment[], AbortSignal]> {
   return command(
     async (
       { get, set },
-      candidates: readonly ZeroChatAttachment[],
+      candidates: readonly ChatAttachment[],
       signal: AbortSignal,
     ): Promise<boolean> => {
       if (candidates.length === 0) {
@@ -702,11 +702,11 @@ function createDraftLifecycleSignals({
   draftInput: ReturnType<typeof createDraftInputSignals>;
   draftDocument: ReturnType<typeof createDraftDocumentSignals>;
   internalGenerationTemplate$: State<GenerationTemplateRequest | undefined>;
-  internalAttachments$: State<ZeroChatAttachment[]>;
+  internalAttachments$: State<ChatAttachment[]>;
   internalDragOver$: State<boolean>;
   pruneUnavailableAttachments$: Command<
     Promise<boolean>,
-    [readonly ZeroChatAttachment[], AbortSignal]
+    [readonly ChatAttachment[], AbortSignal]
   >;
 }) {
   const clear$ = command(({ get, set }) => {
@@ -754,7 +754,7 @@ export function createDraftSignals(): DraftSignals {
   const internalGenerationTemplate$ = state<
     GenerationTemplateRequest | undefined
   >(undefined);
-  const internalAttachments$ = state<ZeroChatAttachment[]>([]);
+  const internalAttachments$ = state<ChatAttachment[]>([]);
   const internalDragOver$ = state(false);
 
   const generationTemplate$ = computed((get) => {
@@ -822,16 +822,14 @@ export function createDraftSignals(): DraftSignals {
     },
   );
 
-  const removeAttachment$ = command(
-    ({ set }, attachment: ZeroChatAttachment) => {
-      set(attachment.cancel$);
-      set(internalAttachments$, (prev) => {
-        return prev.filter((a) => {
-          return a !== attachment;
-        });
+  const removeAttachment$ = command(({ set }, attachment: ChatAttachment) => {
+    set(attachment.cancel$);
+    set(internalAttachments$, (prev) => {
+      return prev.filter((a) => {
+        return a !== attachment;
       });
-    },
-  );
+    });
+  });
 
   const dragOver$ = computed((get) => {
     return get(internalDragOver$);

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -18,7 +18,7 @@ import {
   imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/okou-page/components/model-provider-picker.tsx";
-import type { DraftSignals, ZeroChatAttachment } from "./chat-draft.ts";
+import type { DraftSignals, ChatAttachment } from "./chat-draft.ts";
 import { createComposerFeedbackModel } from "./chat-feedback.ts";
 import type { ChatEvent } from "../chat-page/chat-event-types.ts";
 import {
@@ -133,11 +133,11 @@ interface ComposerWorkflowSignals extends ComposerWorkflowEditorSignals {
 interface ComposerDraftSignals {
   readonly seed$: DraftSignals["seed$"];
   readonly setDraftInput$: Command<void, [string]>;
-  readonly attachments$: Computed<ZeroChatAttachment[]>;
+  readonly attachments$: Computed<ChatAttachment[]>;
   readonly attachmentUploadsReady$: Computed<boolean>;
   readonly uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
   readonly restoreAttachments$: DraftSignals["restoreAttachments$"];
-  readonly removeAttachment$: Command<void, [ZeroChatAttachment]>;
+  readonly removeAttachment$: Command<void, [ChatAttachment]>;
   readonly dragOver$: Computed<boolean>;
   readonly setDragOver$: Command<void, [boolean]>;
   readonly composerFileInput$: Computed<HTMLElement | null>;
@@ -371,7 +371,7 @@ function composerTemplateSignals(
 
 function hasVisibleAttachment(
   selection: ModelProviderSelection | null,
-  attachments: readonly ZeroChatAttachment[],
+  attachments: readonly ChatAttachment[],
   imageRecognitionEnabled: boolean,
 ): boolean {
   if (

--- a/turbo/apps/platform/src/signals/okou-page/ideation-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/ideation-page-setup.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { ZeroIdeationPage } from "../../views/okou-page/ideation-page.tsx";
+import { IdeationPage } from "../../views/okou-page/ideation-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
@@ -10,7 +10,7 @@ import { i18n } from "../../i18n/index.ts";
 
 export const setupIdeationPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ZeroIdeationPage), "sidebar");
+    set(updatePage$, createElement(IdeationPage), "sidebar");
     set(
       updateDocumentTitle$,
       i18n.t(

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -126,7 +126,7 @@ export const setSessionListCollapsed$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// Manage section collapse state (ZeroSidebar) — persisted in localStorage
+// Manage section collapse state (Sidebar) — persisted in localStorage
 // ---------------------------------------------------------------------------
 const {
   get$: manageSectionCollapsedRaw$,

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { toast } from "@okouai/ui/components/ui/sonner";
-import { ZeroWorksPage } from "../../views/okou-page/works-page.tsx";
+import { WorksPage } from "../../views/okou-page/works-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
@@ -44,7 +44,7 @@ const initWorksRedirect$ = command(({ get, set }) => {
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(resetAgentPhoneConnectUi$);
   set(setAgentPhoneConnectDialogOpen$, false);
-  set(updatePage$, createElement(ZeroWorksPage), "sidebar");
+  set(updatePage$, createElement(WorksPage), "sidebar");
   set(
     updateDocumentTitle$,
     i18n.t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings-page.test.tsx
@@ -15,7 +15,7 @@ const context = testContext();
 const ZERO_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const SUPPORT_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
 
-function zeroAgent(): TeamComposeItem {
+function agent(): TeamComposeItem {
   return {
     id: ZERO_AGENT_ID,
     displayName: null,
@@ -38,7 +38,7 @@ function supportAgent(): TeamComposeItem {
 }
 
 function setupTelegramPage(): void {
-  context.mocks.data.team([zeroAgent(), supportAgent()]);
+  context.mocks.data.team([agent(), supportAgent()]);
   detachedSetupPage({
     context,
     path: "/settings/telegram",

--- a/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/activity-detail-page.tsx
@@ -321,7 +321,7 @@ export function ActivityHeaderCard({
                 return $.activity.detail.fields.status;
               })}
             </span>
-            <StatusBadge status={status} zeroStyle />
+            <StatusBadge status={status} shellStyle />
           </div>
           <span
             className="w-px h-3.5 shrink-0 bg-border self-center"
@@ -1105,7 +1105,7 @@ function ActivityDetailContent({
   );
 }
 
-export function ZeroActivityDetailPage() {
+export function ActivityDetailPage() {
   const { t } = useTranslation();
   const currentRunId = useGet(currentRunId$);
   const detailLoadable = useLastLoadable(zeroActivityDetail$);

--- a/turbo/apps/platform/src/views/okou-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/agent-chat-page.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../signals/okou-page/pinned-agents.ts";
 
 import { detach, Reason } from "../../signals/utils.ts";
-import { ZeroChatComposer } from "./chat-composer.tsx";
+import { ChatComposer } from "./chat-composer.tsx";
 import { StartCards } from "./start-cards.tsx";
 import { GrowthEntryHeader } from "./growth-entry.tsx";
 import { AttachmentLightbox } from "./attachment-chips.tsx";
@@ -383,7 +383,7 @@ export function AgentChatPage() {
             </div>
           </div>
 
-          <ZeroChatComposer signals={composerSignals} />
+          <ChatComposer signals={composerSignals} />
 
           <StartCards onSelectPrompt={handleInputChange} />
         </div>

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -25,7 +25,7 @@ import type {
   ChatThreadArtifactFile,
   ChatThreadArtifactRun,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import type { ZeroChatAttachment } from "../../signals/okou-page/chat-draft";
+import type { ChatAttachment } from "../../signals/okou-page/chat-draft";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -1771,7 +1771,7 @@ function AttachmentChip({
   attachment,
   onRemove,
 }: {
-  attachment: ZeroChatAttachment;
+  attachment: ChatAttachment;
   onRemove: () => void;
 }) {
   const { t } = useTranslation();
@@ -1867,8 +1867,8 @@ export function AttachmentChips({
   attachments,
   onRemove,
 }: {
-  attachments: ZeroChatAttachment[];
-  onRemove: (attachment: ZeroChatAttachment) => void;
+  attachments: ChatAttachment[];
+  onRemove: (attachment: ChatAttachment) => void;
 }) {
   return (
     <div className="flex flex-wrap gap-2 px-4 pt-3">

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -287,7 +287,7 @@ function isHappyDomTestEnvironment(): boolean {
 // Props
 // ---------------------------------------------------------------------------
 
-interface ZeroChatComposerProps {
+interface ChatComposerProps {
   readonly signals: ComposerSignals;
   readonly showPendingItems?: boolean;
 }
@@ -10109,10 +10109,10 @@ function ComposerSurface({
   );
 }
 
-export function ZeroChatComposer({
+export function ChatComposer({
   signals,
   showPendingItems = true,
-}: ZeroChatComposerProps) {
+}: ChatComposerProps) {
   return (
     <ComposerSurface signals={signals} showPendingItems={showPendingItems} />
   );

--- a/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
@@ -35,7 +35,7 @@ import {
   setChatListQuery$,
 } from "../../signals/okou-page/sidebar-state.ts";
 import { toast } from "@okouai/ui/components/ui/sonner";
-import { ZeroChatComposer } from "./chat-composer.tsx";
+import { ChatComposer } from "./chat-composer.tsx";
 import { assistantName$ } from "../../signals/branding.ts";
 import { AgentAvatarImg } from "./sidebar-shared.tsx";
 
@@ -195,7 +195,7 @@ function ForwardComposerSurface({
 }) {
   return (
     <div className="w-full min-w-0 p-5" data-chat-composer>
-      <ZeroChatComposer signals={composer} showPendingItems={false} />
+      <ChatComposer signals={composer} showPendingItems={false} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -261,7 +261,7 @@ import {
   type ChatThreadEmojiItem,
 } from "../../signals/chat-page/chat-thread-emoji.ts";
 import { openRenameChatThreadDialogForThreadId$ } from "../../signals/chat-page/chat-thread-rename.ts";
-import { ZeroChatComposer } from "./chat-composer.tsx";
+import { ChatComposer } from "./chat-composer.tsx";
 import {
   ModelProviderPicker,
   type ModelProviderSelection,
@@ -2821,7 +2821,7 @@ function HeaderAutomationSidebar({
 }
 
 // ---------------------------------------------------------------------------
-// ZeroSessionChatPage — real conversation backed by agent runs
+// SessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
 function ChatThread({
@@ -2915,7 +2915,7 @@ function ThreadAutomationsSidebarSlot({
   return <HeaderAutomationSidebar thread={thread} onClose={close} />;
 }
 
-export function ZeroChatThreadPage() {
+export function ChatThreadPage() {
   const activeThreadSidebar = useGet(activeThreadSidebar$);
   const leftPane = useGet(currentLeftPane$);
   const rightPane = useGet(currentRightPane$);
@@ -4773,7 +4773,7 @@ function ChatThreadComposer({ thread }: { thread: ChatPanelSignals }) {
         )}
       >
         <div className="mx-auto max-w-[900px]">
-          <ZeroChatComposer signals={thread.composer} />
+          <ChatComposer signals={thread.composer} />
           <ActiveGoalObjectiveDialog threadId={thread.threadId} />
           <PersonalClaudeCodeDeviceAuthDialog />
           <PersonalCodexDeviceAuthDialog />

--- a/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
@@ -17,8 +17,8 @@ interface StatusBadgeConfig {
 
 interface StatusBadgeProps {
   status: LogStatus;
-  /** When true, use Zero app pill style (cool gray) */
-  zeroStyle?: boolean;
+  /** When true, use the app shell pill style (cool gray) */
+  shellStyle?: boolean;
 }
 
 function getStatusLabel(status: LogStatus): string {
@@ -101,7 +101,7 @@ function getStatusConfig(): Record<LogStatus, StatusBadgeConfig> {
   };
 }
 
-export function StatusBadge({ status, zeroStyle }: StatusBadgeProps) {
+export function StatusBadge({ status, shellStyle }: StatusBadgeProps) {
   const statusConfig = getStatusConfig();
   const config = statusConfig[status];
   const Icon = config.icon;
@@ -111,7 +111,7 @@ export function StatusBadge({ status, zeroStyle }: StatusBadgeProps) {
       data-testid="status-badge"
       data-status={status}
       className={
-        zeroStyle
+        shellStyle
           ? "zero-pill inline-flex items-center gap-1.5 rounded-lg border px-1.5 py-1 text-xs font-medium"
           : "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
       }

--- a/turbo/apps/platform/src/views/okou-page/ideation-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/ideation-page.tsx
@@ -22,7 +22,7 @@ import {
   type IdeationCatalogCopy,
 } from "./ideation-localization.ts";
 
-export function ZeroIdeationPage() {
+export function IdeationPage() {
   const { t } = useTranslation("agents");
   const brandName = useGet(brandName$);
   const features = useLastResolved(featureSwitch$);

--- a/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
@@ -1,6 +1,6 @@
 import type { AgentInstructions } from "../../signals/okou-page/agent-types.ts";
 import { useTranslation } from "react-i18next";
-import { ZeroUnsavedBar } from "./unsaved-bar.tsx";
+import { UnsavedBar } from "./unsaved-bar.tsx";
 import { TiptapInstructionsEditor } from "./tiptap-instructions-editor.tsx";
 
 interface ZeroInstructionsTabProps {
@@ -104,7 +104,7 @@ export function ZeroInstructionsTab({
       )}
 
       {(isDirty || isBuilding) && (
-        <ZeroUnsavedBar
+        <UnsavedBar
           onDiscard={onDiscard}
           onSave={onBuild}
           saving={isBuilding}

--- a/turbo/apps/platform/src/views/okou-page/platform-assets.ts
+++ b/turbo/apps/platform/src/views/okou-page/platform-assets.ts
@@ -1,40 +1,40 @@
 import { platformStaticAssetUrl } from "../../lib/static-assets.ts";
 
-function zeroPageAssetUrl(path: string): string {
+function pageAssetUrl(path: string): string {
   return platformStaticAssetUrl(`views/zero-page/${path.replace(/^\/+/u, "")}`);
 }
 
 export function avatarSvgAssetUrl(filename: string): string {
-  return zeroPageAssetUrl(`assets/avatar-svg/${filename}`);
+  return pageAssetUrl(`assets/avatar-svg/${filename}`);
 }
 
-export const emptyArtifactImg = zeroPageAssetUrl("assets/empty-artifact.webp");
-export const emptyChatImg = zeroPageAssetUrl("assets/empty-chat.webp");
-export const emptyAutomationsImg = zeroPageAssetUrl(
+export const emptyArtifactImg = pageAssetUrl("assets/empty-artifact.webp");
+export const emptyChatImg = pageAssetUrl("assets/empty-chat.webp");
+export const emptyAutomationsImg = pageAssetUrl(
   "assets/empty-automations-fe7f603eaa3c.webp",
 );
-export const emptyWorkflowImg = zeroPageAssetUrl(
+export const emptyWorkflowImg = pageAssetUrl(
   "assets/empty-workflow-96e709d12911.webp",
 );
-export const emptyUsageImg = zeroPageAssetUrl(
+export const emptyUsageImg = pageAssetUrl(
   "assets/empty-usage-a1f6d48793ba.webp",
 );
-export const emptySearchImg = zeroPageAssetUrl(
+export const emptySearchImg = pageAssetUrl(
   "assets/empty-search-b4e60a8e07b8.webp",
 );
-export const computerUseIllustrationImg = zeroPageAssetUrl(
+export const computerUseIllustrationImg = pageAssetUrl(
   "assets/computer-use-illustration-eecea534a3ac.png?v=568fa471",
 );
-export const noConnectorImg = zeroPageAssetUrl("assets/no-connector.webp");
-export const noPermissionIllustration = zeroPageAssetUrl(
+export const noConnectorImg = pageAssetUrl("assets/no-connector.webp");
+export const noPermissionIllustration = pageAssetUrl(
   "assets/no-permission-illustration.webp",
 );
-export const planFreeImg = zeroPageAssetUrl(
+export const planFreeImg = pageAssetUrl(
   "components/org-manage/assets/plan-free.webp",
 );
-export const planProImg = zeroPageAssetUrl(
+export const planProImg = pageAssetUrl(
   "components/org-manage/assets/plan-pro.webp",
 );
-export const planTeamImg = zeroPageAssetUrl(
+export const planTeamImg = pageAssetUrl(
   "components/org-manage/assets/plan-team.webp",
 );

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -27,7 +27,7 @@ import {
 } from "@okouai/ui/components/ui/alert";
 import { type Tone, TONE_OPTIONS } from "./tone-constants.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { ZeroUnsavedBar } from "./unsaved-bar.tsx";
+import { UnsavedBar } from "./unsaved-bar.tsx";
 import type { Command } from "ccstate";
 import { InlineSettingsRow } from "./components/inline-settings-row.tsx";
 import {
@@ -464,7 +464,7 @@ export function ZeroSettingsTab({
       </div>
 
       {isSettingsDirty && (
-        <ZeroUnsavedBar
+        <UnsavedBar
           onDiscard={handleResetSettings}
           onSave={handleSaveSettings}
           saving={saving}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -10,7 +10,7 @@ import { Menu, Package, Share2, UserPlus } from "lucide-react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { Button, cn } from "@okouai/ui";
-import { ZeroSidebar } from "./sidebar.tsx";
+import { Sidebar } from "./sidebar.tsx";
 import { AutomationMenuButton } from "./chat-thread-page.tsx";
 import { currentChatAgent$ } from "../../signals/agent-chat.ts";
 import {
@@ -342,7 +342,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       <CreditPurchaseConfirmDialog />
       <SubscriptionPurchaseConfirmDialog />
       <QueueDrawer />
-      <ZeroSidebar />
+      <Sidebar />
       <div
         data-sidebar-expanded={expanded || undefined}
         className="zero-pwa-fixed-cover fixed inset-0 z-30 bg-black/40 hidden data-[sidebar-expanded]:max-md:block"

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -872,7 +872,7 @@ function ThreeColumnNav() {
   );
 }
 
-export function ZeroSidebar() {
+export function Sidebar() {
   const features = useLastResolved(featureSwitch$);
   const threeColumnNav = features?.[FeatureSwitchKey.ThreeColumnNav] ?? false;
   if (threeColumnNav) {

--- a/turbo/apps/platform/src/views/okou-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/thread-sidebar.tsx
@@ -409,7 +409,7 @@ export function ThreadSidebarSlot({
       return <ThreadArtifactDetail thread={thread} source={target.source} />;
     }
     case "automations": {
-      // Rendered by ZeroChatThreadPage directly: the automations body lives in
+      // Rendered by ChatThreadPage directly: the automations body lives in
       // the page module and importing it here would create an import cycle.
       return null;
     }

--- a/turbo/apps/platform/src/views/okou-page/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/unsaved-bar.tsx
@@ -2,7 +2,7 @@ import { createPortal } from "react-dom";
 import { Pencil, Loader2 } from "lucide-react";
 import { Button } from "@okouai/ui";
 
-interface ZeroUnsavedBarProps {
+interface UnsavedBarProps {
   onDiscard: () => void;
   onSave: () => void;
   saving: boolean;
@@ -11,14 +11,14 @@ interface ZeroUnsavedBarProps {
   saveLabel?: string;
 }
 
-export function ZeroUnsavedBar({
+export function UnsavedBar({
   onDiscard,
   onSave,
   saving,
   message = "You have unsaved changes",
   discardLabel = "Discard",
   saveLabel = "Save",
-}: ZeroUnsavedBarProps) {
+}: UnsavedBarProps) {
   const bar = (
     <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4">
       <div

--- a/turbo/apps/platform/src/views/okou-page/works-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/works-page.tsx
@@ -892,7 +892,7 @@ function StrapiCard() {
   );
 }
 
-export function ZeroWorksPage() {
+export function WorksPage() {
   const { t } = useTranslation();
   const assistantName = useGet(assistantName$);
   const features = useGet(featureSwitch$);

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -231,7 +231,7 @@ import {
 } from "../components/detail-page-layout.tsx";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { TiptapInstructionsEditor } from "../okou-page/tiptap-instructions-editor.tsx";
-import { ZeroUnsavedBar } from "../okou-page/unsaved-bar.tsx";
+import { UnsavedBar } from "../okou-page/unsaved-bar.tsx";
 import { InlineSettingsRow } from "../okou-page/components/inline-settings-row.tsx";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
@@ -2065,7 +2065,7 @@ function WorkflowMetadataForm({
         />
       </form>
       {detail.canManage && dirty ? (
-        <ZeroUnsavedBar onDiscard={resetForm} onSave={save} saving={saving} />
+        <UnsavedBar onDiscard={resetForm} onSave={save} saving={saving} />
       ) : null}
     </>
   );
@@ -3037,7 +3037,7 @@ function WorkflowSelectedFileEditor({
         />
       )}
       {detail.canManage && dirty ? (
-        <ZeroUnsavedBar
+        <UnsavedBar
           saving={saving}
           onDiscard={() => {
             setDraftState(null);

--- a/turbo/docs/react.md
+++ b/turbo/docs/react.md
@@ -14,11 +14,11 @@ Dense `renderWithHooksAgain` samples in a CPU profile indicate that a component 
 
 ### Problem
 
-A parent component (e.g. `ZeroSidebar`) subscribes to multiple async signals at the top level simultaneously:
+A parent component (e.g. `Sidebar`) subscribes to multiple async signals at the top level simultaneously:
 
 ```tsx
 // ❌ Every time an async signal resolves, the entire large component re-renders
-export function ZeroSidebar() {
+export function Sidebar() {
   const displayNameLoadable = useLastLoadable(currentChatAgentDisplayName$);
   const subagentsLoadable = useLastLoadable(subagents$);
   const defaultDisplayName = useLastResolved(defaultAgentName$);
@@ -62,7 +62,7 @@ function SidebarNavContent() {
   // ...renders nav content
 }
 
-export function ZeroSidebar() {
+export function Sidebar() {
   // Zero async subscriptions — renders exactly once on page load
   return (
     <VM0ClerkProvider>
@@ -115,7 +115,7 @@ A parent component subscribes to async signals and then passes the resolved valu
 
 ```tsx
 // ❌ Parent takes on subscriptions it doesn't own; re-renders on every async update
-export function ZeroSidebar() {
+export function Sidebar() {
   const displayName  = useLastResolved(currentChatAgentDisplayName$);
   const subagents    = useLastResolved(subagents$);
   const savingPinned = ...; // from useLoadableSet
@@ -163,7 +163,7 @@ export function getTestRenderCount() {
   return _renderCount;
 }
 
-export function ZeroSidebar() {
+export function Sidebar() {
   _renderCount++;
   // ...
 }

--- a/turbo/scripts/analyze-batching.mjs
+++ b/turbo/scripts/analyze-batching.mjs
@@ -14,7 +14,7 @@
  * (all within the same React batch), not N separate work loops.
  *
  * Usage:
- *   node scripts/analyze-batching.mjs <file.cpuprofile> [--component ZeroSidebar]
+ *   node scripts/analyze-batching.mjs <file.cpuprofile> [--component Sidebar]
  */
 
 import { readFileSync } from "fs";

--- a/turbo/scripts/analyze-rewind-cause.mjs
+++ b/turbo/scripts/analyze-rewind-cause.mjs
@@ -16,7 +16,7 @@
  * finding it stale — this is the actual cause.
  *
  * Usage:
- *   node scripts/analyze-rewind-cause.mjs <file.cpuprofile> [--component ZeroSidebar]
+ *   node scripts/analyze-rewind-cause.mjs <file.cpuprofile> [--component Sidebar]
  */
 
 import { readFileSync } from "fs";

--- a/turbo/scripts/dump-rewind-chains.mjs
+++ b/turbo/scripts/dump-rewind-chains.mjs
@@ -7,7 +7,7 @@
  * path without guessing.
  *
  * Usage:
- *   node scripts/dump-rewind-chains.mjs <file.cpuprofile> --component ZeroSidebar [--max 5]
+ *   node scripts/dump-rewind-chains.mjs <file.cpuprofile> --component Sidebar [--max 5]
  */
 
 import { readFileSync } from "fs";
@@ -21,7 +21,7 @@ if (!file) {
   process.exit(1);
 }
 
-let filterComponent = "ZeroSidebar";
+let filterComponent = "Sidebar";
 let maxChains = 10;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--component" && args[i + 1]) filterComponent = args[++i];


### PR DESCRIPTION
Part of #26873. Closes #29155.

Finishes what #28847 started: `views/okou-page` carries the namespace, so the symbols inside it should not repeat it. The prefix is **dropped**, not swapped — `ZeroSidebar` becomes `Sidebar`, not `OkouSidebar`.

## Renamed

Chat surface:

| Before | After | Sites |
| --- | --- | --- |
| `ZeroChatComposer` | `ChatComposer` | 7 |
| `ZeroChatComposerProps` | `ChatComposerProps` | 2 |
| `ZeroChatThreadPage` | `ChatThreadPage` | 4 |
| `ZeroChatAttachment` | `ChatAttachment` | 29 |
| `ZeroSessionChatPage` | `SessionChatPage` | 1 (comment only) |

Shell:

| Before | After | Sites |
| --- | --- | --- |
| `ZeroSidebar` | `Sidebar` | 4 |
| `ZeroUnsavedBar` | `UnsavedBar` | 8 |
| `ZeroUnsavedBarProps` | `UnsavedBarProps` | 2 |
| `ZeroWorksPage` | `WorksPage` | 3 |
| `ZeroIdeationPage` | `IdeationPage` | 3 |
| `ZeroActivityDetailPage` | `ActivityDetailPage` | 3 |
| `zeroAgent` | `agent` | 2 |
| `zeroPageAssetUrl` | `pageAssetUrl` | 14 |
| `zeroStyle` | `shellStyle` | 4 |
| `zeroPageKeys` | `pageKeys` | 2 |

Every symbol on the issue's list was still present on `main` at the time of the rebase, so nothing was dropped for having landed in a sibling slice.

Several symbols are defined in one directory and referenced from another (`ZeroChatAttachment` spans `views/okou-page`, `signals/okou-page` and `signals/chat-page`; the four `*Page` components are referenced from their `signals/*-page-setup.ts` files; `ZeroUnsavedBar` is also used by `views/workflows-page`). All references move in this same commit.

## `zeroStyle` → `shellStyle`

The issue left this one to the call site. It is not a style object — it is a boolean prop on `StatusBadge` (`components/log-views/status-badge.tsx`) that selects the app-shell pill styling, used once from `activity-detail-page.tsx`. `shellStyle` was the closer of the two suggested names. Its doc comment moved from "use Zero app pill style" to "use the app shell pill style".

## Documentation and profiling scripts

The issue asked for a `.claude/skills` and `docs/` grep. Four live references turned up in those two trees, plus five more outside them that the same reasoning covers. All are updated, so grepping a documented symbol still lands on real code:

- `.claude/skills/ccstate/SKILL.md` (3) — ccstate teaching examples that quote real symbols and name real files (`chat-draft.ts`, `chat-page-setup.ts`).
- `docs/react-commit.md` (4) — includes a present-tense pointer that spells out the file path ("now the `ZeroChatComposer` component in `turbo/apps/platform/src/views/okou-page/chat-composer.tsx`"). The two `ZeroSidebar` sites at lines 180 and 516 record a profiling observation, but they are our own prose and a hand-authored table using component names to orient the reader, not pasted tool output — the trace did not change, only the name of the thing observed — so they are renamed too. A second `ZeroChatComposer` site at line 867 (same present-tense description of current architecture) is renamed alongside line 562. The markdown table at line 516 is re-padded to keep its column alignment.
- `turbo/docs/react.md` (5) — reads as pedagogical, but the code blocks quote the real sidebar's real signals (`subagents$`, `slackOrgScopeMismatch$`, `currentChatAgentDisplayName$`), so `ZeroSidebar` there is a live reference.
- `turbo/scripts/{analyze-rewind-cause,analyze-batching,dump-rewind-chains}.mjs` (4) — usage examples, and one **functional** default: `dump-rewind-chains.mjs` had `let filterComponent = "ZeroSidebar"`, which would have silently matched nothing after this rename.

## Notes for review

- **A second `UnsavedBar` already exists.** `views/okou-page/components/org-manage/unsaved-bar.tsx` exports a component named `UnsavedBar`; this PR renames `ZeroUnsavedBar` to the same bare name. They are separate modules with different portal targets (`#root` vs `#settings-dialog-content`) and no file imports both, so this compiles and the issue's target name is taken as written — but the two are near-duplicates and the collision is worth a follow-up, either a merge or a more specific name for one of them.
- **`ZERO_AGENT_ID` is left alone.** It sits next to the renamed `zeroAgent` fixture in `telegram-settings-page.test.tsx` but is not on the issue's list.
- **The diff is larger than the rename count.** Shortening identifiers lets prettier pull previously wrapped imports and JSX back onto one line, most visibly in `platform-assets.ts` and `resolve-draft-attachments.ts`.
- **`views/zero-page/` string literals are deliberately untouched** in `platform-assets.ts` and `static-assets.test.ts`. Those are published `static.vm0.io` asset paths, not source paths; changing them would 404.
- **`zeroHostDomain` is untouched**, per the issue — it mirrors `ZERO_HOST_DOMAIN`, which retires with the VM0-brand host under #26701.

## Verification

- `pnpm turbo run check-types --filter=@okouai/app` — passes.
- `pnpm turbo run lint --filter=@okouai/app` — 0 errors (44 pre-existing `vitest/require-mock-type-parameters` warnings, untouched by this PR).
- `pnpm prettier --check` — clean across the touched `turbo/` files.
- Case-insensitive repo-wide grep for all fifteen old identifiers returns nothing outside `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
