### PR TITLE
fix: keep uploaded template preview stable on visibility updates

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
@@ -157,7 +157,6 @@ function createImportedPresentationTemplateResources$(
   importedPresentationTemplates$: Computed<
     Promise<readonly PresentationTemplateSummary[]>
   >,
-  internalDetailVersion$: State<number>,
 ) {
   return computed(
     async (get): Promise<readonly ImportedPresentationTemplateResource[]> => {
@@ -167,7 +166,6 @@ function createImportedPresentationTemplateResources$(
           summary,
           detail$: computed(
             async (get): Promise<PresentationTemplateDetail | null> => {
-              get(internalDetailVersion$);
               const client = get(apiClient$)(presentationTemplatesContract);
               const result = await accept(
                 client.get({ params: { templateId: summary.id } }),
@@ -323,13 +321,11 @@ export function createImportedPresentationTemplateSignals() {
     catalog$,
     deletedPresentationTemplateIds$,
   );
-  const internalDetailVersion$ = state(0);
   const urlRefresh =
     createImportedPresentationTemplateUrlRefreshSignals(catalog$);
   const importedPresentationTemplateResources$ =
     createImportedPresentationTemplateResources$(
       importedPresentationTemplates$,
-      internalDetailVersion$,
     );
   const { internalRequestedTemplateId$, ...detailSignals } =
     createImportedPresentationTemplateDetailSignals(
@@ -384,9 +380,6 @@ export function createImportedPresentationTemplateSignals() {
         [200],
       );
       signal.throwIfAborted();
-      set(internalDetailVersion$, (version) => {
-        return version + 1;
-      });
       set(refreshPresentationTemplates$);
     },
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3990,6 +3990,147 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("keeps loaded uploaded slides mounted while visibility metadata refreshes", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    let template: PresentationTemplateDetail = {
+      id: "ea583da0-6e8c-4ca4-9cb9-3a898c8d1850",
+      title: "Stable preview deck",
+      sourceFilename: "stable-preview-deck.pptx",
+      coverUrl: "https://example.com/stable-preview-cover.png",
+      pageCount: 3,
+      visibility: "private",
+      canManage: true,
+      pageUrls: [
+        "https://example.com/stable-preview-cover.png",
+        "https://example.com/stable-preview-page-2.png",
+        "https://example.com/stable-preview-page-3.png",
+      ],
+      createdAt: "2026-08-21T02:41:59.522Z",
+      updatedAt: "2026-08-21T02:41:59.522Z",
+    };
+    let detailRequestCount = 0;
+    let updateRequestCount = 0;
+    let holdDetailRefresh = false;
+    const detailRefreshRequested = context.mocks.deferred<void>();
+    const releaseDetailRefresh = context.mocks.deferred<void>();
+    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      return respond(200, [presentationTemplateSummary(template)]);
+    });
+    context.mocks.api(
+      presentationTemplatesContract.get,
+      async ({ params, respond }) => {
+        expect(params.templateId).toBe(template.id);
+        detailRequestCount += 1;
+        if (holdDetailRefresh) {
+          detailRefreshRequested.resolve();
+          await releaseDetailRefresh.promise;
+        }
+        return respond(200, template);
+      },
+    );
+    context.mocks.api(
+      presentationTemplatesContract.update,
+      ({ body, params, respond }) => {
+        expect(params.templateId).toBe(template.id);
+        expect(body).toStrictEqual({ visibility: "public" });
+        updateRequestCount += 1;
+        holdDetailRefresh = true;
+        template = {
+          ...template,
+          coverUrl:
+            "https://example.com/stable-preview-cover.png?signature=renewed",
+          visibility: "public",
+          pageUrls: template.pageUrls.map((pageUrl) => {
+            return `${pageUrl}?signature=renewed`;
+          }),
+          updatedAt: "2026-08-21T02:42:59.522Z",
+        };
+        return respond(200, presentationTemplateSummary(template));
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(await screen.findByLabelText("Template"));
+    await user.click(
+      await screen.findByLabelText(
+        "Preview Stable preview deck at current slide",
+      ),
+    );
+    const detailImage = await screen.findByTestId(
+      "Stable preview deck imported detail image preview",
+    );
+    await user.click(screen.getByLabelText("Preview slide 3"));
+    expect(detailImage).toHaveAttribute(
+      "src",
+      "https://example.com/stable-preview-page-3.png",
+    );
+    const thumbnailButtons = [1, 2, 3].map((slideNumber) => {
+      return screen.getByLabelText(`Preview slide ${slideNumber.toString()}`);
+    });
+    const thumbnailImages = thumbnailButtons.map((button) => {
+      const image = button.querySelector("img");
+      if (image === null) {
+        throw new Error("Uploaded template thumbnail image not found");
+      }
+      return image;
+    });
+    const detailRequestCountBeforeUpdate = detailRequestCount;
+    expect(detailRequestCountBeforeUpdate).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("combobox", { name: "Visibility" }));
+    await user.click(screen.getByRole("option", { name: "Workspace" }));
+    await detailRefreshRequested.promise;
+
+    expect(updateRequestCount).toBe(1);
+    expect(
+      screen.getByTestId("Stable preview deck imported detail image preview"),
+    ).toBe(detailImage);
+    expect(detailImage).toHaveAttribute(
+      "src",
+      "https://example.com/stable-preview-page-3.png",
+    );
+    for (const [index, button] of thumbnailButtons.entries()) {
+      expect(
+        screen.getByLabelText(`Preview slide ${(index + 1).toString()}`),
+      ).toBe(button);
+      expect(button.querySelector("img")).toBe(thumbnailImages[index]);
+    }
+
+    releaseDetailRefresh.resolve();
+    await waitFor(() => {
+      expect(detailRequestCount).toBeGreaterThan(
+        detailRequestCountBeforeUpdate,
+      );
+      expect(
+        screen.getByRole("combobox", { name: "Visibility" }),
+      ).toHaveTextContent("Workspace");
+      expect(detailImage).toHaveAttribute(
+        "src",
+        "https://example.com/stable-preview-page-3.png?signature=renewed",
+      );
+    });
+    expect(
+      screen.getByTestId("Stable preview deck imported detail image preview"),
+    ).toBe(detailImage);
+    for (const [index, button] of thumbnailButtons.entries()) {
+      const expectedPageUrl = template.pageUrls[index];
+      if (expectedPageUrl === undefined) {
+        throw new Error("Renewed uploaded template page URL not found");
+      }
+      expect(
+        screen.getByLabelText(`Preview slide ${(index + 1).toString()}`),
+      ).toBe(button);
+      expect(button.querySelector("img")).toBe(thumbnailImages[index]);
+      expect(thumbnailImages[index]).toHaveAttribute("src", expectedPageUrl);
+    }
+  });
+
   it("keeps remaining uploaded cards mounted while delete refresh is pending", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context, { threadId: THREAD_ID });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5739,6 +5739,10 @@ function ImportedPresentationTemplateThumbnails({
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
 }) {
   const { t } = useTranslation();
+  const pageResourceKey = (pageUrl: string) => {
+    const queryStart = pageUrl.indexOf("?");
+    return queryStart === -1 ? pageUrl : pageUrl.slice(0, queryStart);
+  };
   return (
     <div
       className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(96px,1fr))] gap-1.5 lg:grid-cols-8"
@@ -5749,7 +5753,7 @@ function ImportedPresentationTemplateThumbnails({
         const active = index === activeSlideIndex;
         return (
           <button
-            key={pageUrl}
+            key={pageResourceKey(pageUrl)}
             type="button"
             aria-label={t(
               ($) => {
@@ -5800,16 +5804,25 @@ function ImportedPresentationTemplatePreviewPage({
   const detailLoadable = useLoadable(
     signals.template.importedPresentationTemplateDetail$,
   );
+  const lastResolvedDetail = useLastResolved(
+    signals.template.importedPresentationTemplateDetail$,
+  );
   const activeSlideIndexRaw = useGet(
     signals.template.importedPresentationTemplatePreviewSlideIndex$,
   );
   const selectSlide = useSet(
     signals.template.selectImportedPresentationTemplatePreviewSlide$,
   );
+  const currentDetail =
+    detailLoadable.state === "hasData" ? detailLoadable.data : null;
+  const loadedDetail =
+    currentDetail?.id === summary.id
+      ? currentDetail
+      : lastResolvedDetail?.id === summary.id
+        ? lastResolvedDetail
+        : null;
   const detail =
-    detailLoadable.state === "hasData" && detailLoadable.data?.id === summary.id
-      ? detailLoadable.data
-      : null;
+    loadedDetail?.id === summary.id ? { ...loadedDetail, ...summary } : null;
   const activeTemplate = detail === null ? summary : detail;
   const title = activeTemplate.title;
   const pageUrls =


### PR DESCRIPTION
## Summary

- remove the duplicate uploaded-template detail invalidation after visibility updates
- retain the last resolved slide set while refreshed metadata and signed URLs load
- preserve thumbnail DOM identity when only signed URL query parameters change
- cover the pending and completed refresh states with a page-level regression test

## Testing

- `pnpm exec prettier --check apps/platform/src/signals/okou-page/presentation-template-library.ts apps/platform/src/views/okou-page/chat-composer.tsx apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter @okouai/app run check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx -t "(prefetches uploaded decks before picker open and revalidates without blanking|scrubs every uploaded slide and manages an owned template from its detail view|keeps loaded uploaded slides mounted while visibility metadata refreshes|keeps remaining uploaded cards mounted while delete refresh is pending)"`