### PR TITLE
refactor(feishu): require public brand in oauth state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -432,6 +432,7 @@ function legacyFeishuAppOAuthState(args: {
   readonly installationId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly publicBrand: PublicBrand;
 }): string {
   const encodedPayload = Buffer.from(
     JSON.stringify({
@@ -2432,6 +2433,7 @@ describe("Feishu integration", () => {
           installationId,
           orgId: requireValue(member.orgId, "Expected an organization"),
           userId: member.userId,
+          publicBrand: "vm0",
         }),
       })}`,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
@@ -1,0 +1,113 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oauth";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { mockNow } from "../../../lib/time";
+import { feishuOauthRoutes } from "../feishu-oauth";
+
+const context = testContext();
+const NOW = Date.parse("2026-08-25T00:00:00.000Z");
+const NOW_SECONDS = Math.floor(NOW / 1000);
+const SECRET = "a".repeat(64);
+
+function oauthClient() {
+  return setupApp({ context, routes: feishuOauthRoutes })(feishuOauthContract);
+}
+
+function statePayload(): Readonly<Record<string, unknown>> {
+  return {
+    installationId: randomUUID(),
+    orgId: `org_${randomUUID()}`,
+    userId: `user_${randomUUID()}`,
+    callbackTarget: "app",
+    timestamp: NOW_SECONDS,
+  };
+}
+
+function signedState(
+  payload: Readonly<Record<string, unknown>>,
+  secret = SECRET,
+): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  const signature = createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest("base64url");
+  return `${encodedPayload}.${signature}`;
+}
+
+async function expectConnectError(state: string, error: string): Promise<void> {
+  const response = await accept(
+    oauthClient().connect({ query: { state } }),
+    [400],
+  );
+  expect(response.body.error).toBe(error);
+}
+
+describe("Feishu OAuth state", () => {
+  beforeEach(() => {
+    mockEnv("SECRETS_ENCRYPTION_KEY", SECRET);
+    mockNow(NOW);
+  });
+
+  it.each(["vm0", "okou"] as const)(
+    "passes an explicit %s public brand to installation validation",
+    async (publicBrand) => {
+      await expectConnectError(
+        signedState({ ...statePayload(), publicBrand }),
+        "Feishu bot not found",
+      );
+    },
+  );
+
+  it.each([
+    {
+      kind: "omitted",
+      payload: statePayload(),
+    },
+    {
+      kind: "malformed",
+      payload: { ...statePayload(), publicBrand: null },
+    },
+    {
+      kind: "invalid",
+      payload: { ...statePayload(), publicBrand: "zero" },
+    },
+  ])("rejects an $kind public brand", async ({ payload }) => {
+    await expectConnectError(
+      signedState(payload),
+      "Invalid or expired connect state",
+    );
+  });
+
+  it("preserves the 10-minute expiration boundary", async () => {
+    await expectConnectError(
+      signedState({
+        ...statePayload(),
+        publicBrand: "vm0",
+        timestamp: NOW_SECONDS - 10 * 60,
+      }),
+      "Feishu bot not found",
+    );
+    await expectConnectError(
+      signedState({
+        ...statePayload(),
+        publicBrand: "vm0",
+        timestamp: NOW_SECONDS - 10 * 60 - 1,
+      }),
+      "Invalid or expired connect state",
+    );
+  });
+
+  it("rejects a state signed with a different secret", async () => {
+    await expectConnectError(
+      signedState({ ...statePayload(), publicBrand: "vm0" }, "b".repeat(64)),
+      "Invalid or expired connect state",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
+++ b/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
@@ -19,10 +19,7 @@ const feishuOAuthStateSchema = z.object({
   userId: z.string().min(1),
   callbackTarget: z.literal("app").optional(),
   oauthRedirectTarget: z.literal("app").optional(),
-  // A supported rollback can still omit publicBrand for VM0. Remove this
-  // default after the explicit writer deploys, its 10-minute max age drains,
-  // and every supported rollback target emits publicBrand (#27660).
-  publicBrand: publicBrandSchema.default("vm0"),
+  publicBrand: publicBrandSchema,
   timestamp: z.number().int(),
 });
 


### PR DESCRIPTION
## Summary

- require every signed Feishu OAuth state to contain a valid explicit `publicBrand`
- keep the existing VM0 and Okou writers unchanged, while making the legacy callback test fixture emit explicit VM0 state
- cover explicit VM0 and Okou acceptance plus fail-closed handling for omitted, malformed, invalid, expired, and incorrectly signed state

## Rollout decision and bounded risk

Feishu is still in limited rollout. This change intentionally removes the reader fallback before the pre-#28804 rollback target `api-v1.479.2` leaves the production rollback dashboard.

During deployment skew or an emergency rollback, an old writer may briefly create a VM0 OAuth state without `publicBrand` that the new strict reader rejects. Feishu OAuth state has a 10-minute maximum age, so the impact is bounded to a small number of in-flight authorization attempts; an affected grey-rollout user can restart authorization. Existing installations, persisted connections, completed OAuth grants, and message data are unaffected, and no persisted user data is lost.

The limited-rollout decision and this bounded retry risk are explicitly accepted. Keep #27660 open until the PR is merged and the deployment is verified.

## Verification

- lockfile-pinned Prettier 3.8.1 check for all changed files
- `pnpm --filter api run lint`
- `pnpm --filter api run check-types`
- `pnpm knip --workspace api`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/feishu-oauth-state.test.ts` (7 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts -t "connects the current Feishu user through signed OAuth state|preserves Okou through signed Feishu and persisted connector state"` (2 passed)

Refs #27660
Refs #27750
