### PR TITLE
refactor(api): dual-write codex service-tier environment aliases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6143,7 +6143,10 @@ describe("CHAT-02: model-first provider policies", () => {
     const environment = claimEnvironment(fastClaim.claim);
     expect(fastClaim.claim.cliAgentType).toBe("codex");
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-sol");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBe("fast");
+    expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(environment.VM0_CODEX_SERVICE_TIER).toBe(
+      environment.OKOU_CODEX_SERVICE_TIER,
+    );
     expect(environment.OPENAI_API_KEY).toBeTruthy();
     expect(environment.CHATGPT_ACCESS_TOKEN).toBeUndefined();
     await cancelChatRun(actor, fast.runId, fastClaim.sandboxHeaders);
@@ -6247,6 +6250,7 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     const standardEnvironment = claimEnvironment(standardClaim);
     expect(standardEnvironment.OPENAI_MODEL).toBe("gpt-5.6-luna");
+    expect(standardEnvironment.OKOU_CODEX_SERVICE_TIER).toBeUndefined();
     expect(standardEnvironment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     await cancelChatRun(actor, standard.runId);
 
@@ -6339,7 +6343,10 @@ describe("CHAT-02: model-first provider policies", () => {
       modelProviderSecretPlaceholder("openai-api-key", "OPENAI_API_KEY"),
     );
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-luna");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBe("fast");
+    expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(environment.VM0_CODEX_SERVICE_TIER).toBe(
+      environment.OKOU_CODEX_SERVICE_TIER,
+    );
     expect(
       (await readThreadProjection(actor, first.threadId)).serviceTier,
     ).toBe("priority");

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4409,7 +4409,10 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const fastRunId = await pollSlackRun(runnerGroup);
     const fastClaim = await runs.claimRunnerJob(fastRunId);
     expect(fastClaim.cliAgentType).toBe("codex");
-    expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBe("fast");
+    expect(fastClaim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBe(
+      fastClaim.environment?.OKOU_CODEX_SERVICE_TIER,
+    );
     const fastOkouToken = fastClaim.environment?.OKOU_TOKEN;
     if (!fastOkouToken) {
       throw new Error("Expected the Slack Fast run to expose OKOU_TOKEN");
@@ -5539,7 +5542,10 @@ describe("INT-02: Telegram integration", () => {
     );
     const claim = await runs.claimRunnerJob(runId);
     expect(claim.cliAgentType).toBe("codex");
-    expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBe("fast");
+    expect(claim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
+    expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBe(
+      claim.environment?.OKOU_CODEX_SERVICE_TIER,
+    );
     const okouToken = claim.environment?.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the Telegram Fast run to expose OKOU_TOKEN");

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -571,7 +571,10 @@ function buildAgentRunPlatformEnvironment(args: {
         }
       : {}),
     ...(args.codexServiceTier
-      ? { VM0_CODEX_SERVICE_TIER: args.codexServiceTier }
+      ? {
+          OKOU_CODEX_SERVICE_TIER: args.codexServiceTier,
+          VM0_CODEX_SERVICE_TIER: args.codexServiceTier,
+        }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary

- emit equal `OKOU_CODEX_SERVICE_TIER` and retained `VM0_CODEX_SERVICE_TIER` entries from the same validated fast-tier value in the existing trusted `platformEnvironment`
- strengthen the existing chat, Slack, and Telegram claim assertions to prove equal dual values for fast runs and absence of both aliases for a standard run
- preserve the legacy alias, guest reader, fast-mode settings, model and credential behavior, validation, transport, and rollback compatibility

## Base and overlap evidence

- refreshed and rebased on exact `main@c31a72a0c68e5435179097d73e498b60b6de0bd4` immediately before commit
- final patch is exactly three API files, 21 additions and 5 deletions
- audited all 30 open PRs at the final base:
  - #29167 touches `agent-runs-create.service.ts` only at the disjoint agent prompt line near 409; this PR changes the environment builder near 573
  - #29053 and #29068 touch `chat-events.bdd.test.ts` only in website-template assertions near 9800; this PR changes Codex claim assertions near 6143-6348
  - fully paginated the 185-file #25722 file list and found no selected-file overlap
- a production-source repository search finds the alias writer only in `buildAgentRunPlatformEnvironment`

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/agent-runs-create.service.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec knip --workspace api`
- `git diff --check`

The focused chat BDD invocation reached both selected cases, but each stopped in the unchanged shared runner-claim setup at `claimChatRun -> api.claimRunnerJob` with `404 Job not found in queue`, before the changed assertions at lines 6146 and 6346 executed. No new alias assertion failed. Per repository policy, PR CI is authoritative for this environment-dependent coverage; no queue, harness, or local-service changes are included.

Refs #28914

Closes #29158
