### PR TITLE
feat: enable built-in model fallback for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -99,6 +99,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.SharedChatDatabase]).toBe(false);
     expect(
       staffOrgStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
@@ -131,6 +134,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
+      false,
+    );
     expect(
       otherOrgStates[FeatureSwitchKey.ComposerRestoredAttachmentValidation],
     ).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -365,6 +365,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description: "Select healthy fallback routes for VM0 built-in models.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SharedChatDatabase]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable built-in model provider fallback for staff organizations through the existing static rollout allowlist
- keep the feature disabled for non-staff organizations unless an explicit override enables it
- cover both staff and non-staff states in the feature switch rollout matrix test

## Exclusions

- does not enable the fallback globally
- does not change fallback routing, cooldown behavior, or organization-scoped overrides

## Validation

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm knip --workspace @okouai/core`
- pre-commit repository-wide Knip and type checks
