### PR TITLE
refactor(ci): move e2e and workflow callers off the branded api namespace

### DIFF
--- a/.github/pages/okou-app/_worker.js
+++ b/.github/pages/okou-app/_worker.js
@@ -346,7 +346,7 @@ export default {
       } catch {
         return gatewayResponse(503);
       }
-      const metaUrl = `${origin}/api/okou/shared-threads/${match[1]}/meta`;
+      const metaUrl = `${origin}/api/shared-threads/${match[1]}/meta`;
       let metaResponse;
       try {
         metaResponse = await fetch(metaUrl, {

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -136,7 +136,7 @@ for fragment in (
     "Access-Control-Request-Method: GET",
     "%header{access-control-allow-origin}",
     "%header{access-control-allow-credentials}",
-    "/api/okou/__brand-smoke__",
+    "/api/__brand-smoke__",
     "api-promotion",
 ):
     if fragment not in production_verifier_source:

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -448,7 +448,7 @@ const preview = await requestSharedPage({
 assert.equal(preview.response.status, 200);
 assert.equal(
   preview.observedUrl,
-  `${previewOrigin}/api/okou/shared-threads/${sharedThreadId}/meta`,
+  `${previewOrigin}/api/shared-threads/${sharedThreadId}/meta`,
 );
 assert.equal(
   preview.observedHeaders.get("x-vercel-protection-bypass"),
@@ -485,7 +485,7 @@ const production = await requestSharedPage({
 assert.equal(production.response.status, 200);
 assert.equal(
   production.observedUrl,
-  `https://api.okou.ai/api/okou/shared-threads/${sharedThreadId}/meta`,
+  `https://api.okou.ai/api/shared-threads/${sharedThreadId}/meta`,
 );
 assert.equal(
   production.observedHeaders.get("x-vercel-protection-bypass"),
@@ -539,7 +539,7 @@ const missing = await requestSharedPage({
 assert.equal(missing.response.status, 404);
 assert.equal(
   missing.observedUrl,
-  `https://api.vm0.ai/api/okou/shared-threads/${sharedThreadId}/meta`,
+  `https://api.vm0.ai/api/shared-threads/${sharedThreadId}/meta`,
 );
 assert.equal(
   missing.response.headers.get("cache-control"),

--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -131,23 +131,23 @@ export E2E_API_URL="https://pr-27981-api.vm6.ai/"
 export E2E_API_TOKEN="sensitive-api-token"
 export VERCEL_AUTOMATION_BYPASS_SECRET="sensitive-bypass-secret"
 payload='{"secret":"sensitive-request-payload"}'
-MOCK_CURL_EXPECTED_VERCEL_URL='https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fokou%2Fchat%2Fevents+status%3A429&timeline=past12Hours'
-MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fokou%%2Fchat%%2Fevents+status%%3A%{http_code}&timeline=past12Hours\n'
+MOCK_CURL_EXPECTED_VERCEL_URL='https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fchat%2Fevents+status%3A429&timeline=past12Hours'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fchat%%2Fevents+status%%3A%{http_code}&timeline=past12Hours\n'
 
 MOCK_CURL_MODE=success
-MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events"
-run_request "/api/okou/chat/events" -X POST -d "$payload"
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/chat/events"
+run_request "/api/chat/events" -X POST -d "$payload"
 assert_status 0
 assert_file_equals $'{"ok":true}\n' "$stdout_file"
 assert_file_equals '' "$stderr_file"
 
 MOCK_CURL_MODE=failure
-MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events?cursor=sensitive-query-value"
-run_request "/api/okou/chat/events?cursor=sensitive-query-value" -X POST -d "$payload"
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/chat/events?cursor=sensitive-query-value"
+run_request "/api/chat/events?cursor=sensitive-query-value" -X POST -d "$payload"
 assert_status 22
 assert_file_equals $'{"error":"rate limited"}\n' "$stdout_file"
 assert_file_equals \
-    $'curl: (22) The requested URL returned error: 429\nVercel logs: '"$MOCK_CURL_EXPECTED_VERCEL_URL"$'\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
+    $'curl: (22) The requested URL returned error: 429\nVercel logs: '"$MOCK_CURL_EXPECTED_VERCEL_URL"$'\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/chat/events curl_status=22\n' \
     "$stderr_file"
 assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
 assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -395,8 +395,8 @@ model_defaults_step = bootstrap_steps.find do |step|
 end
 raise "missing runner model policy bootstrap" unless model_defaults_step
 model_defaults_script = model_defaults_step.fetch("run")
-unless model_defaults_script.include?("/api/okou/model-policies") &&
-    model_defaults_script.include?("/api/okou/user-model-preference") &&
+unless model_defaults_script.include?("/api/model-policies") &&
+    model_defaults_script.include?("/api/user-model-preference") &&
     model_defaults_script.include?("deepseek-v4-flash") &&
     model_defaults_script.include?("gpt-5.6-luna") &&
     model_defaults_script.include?('{"selectedModel":null,"serviceTier":null}')
@@ -431,9 +431,9 @@ unless mock_claude_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
 end
 mock_claude_script = File.read(ARGV.fetch(1))
 %w[
-  /api/zero/me/model-providers
-  /api/zero/model-policies
-  /api/zero/feature-switches
+  /api/me/model-providers
+  /api/model-policies
+  /api/feature-switches
   claude-code-oauth-token
   claude-sonnet-4-6
   realAgentInPreview
@@ -458,8 +458,8 @@ raise "missing real Codex account bootstrap" unless codex_step
 codex_script = codex_step.fetch("run")
 %w[
   /api/model-providers
-  /api/okou/model-policies
-  /api/okou/feature-switches
+  /api/model-policies
+  /api/feature-switches
   gpt-5.6-luna
   realAgentInPreview
 ].each do |required_fragment|
@@ -477,8 +477,8 @@ end
 raise "missing real Claude account bootstrap" unless claude_step
 claude_script = claude_step.fetch("run")
 %w[
-  /api/okou/model-policies
-  /api/okou/feature-switches
+  /api/model-policies
+  /api/feature-switches
   realAgentInPreview
   builtInModelProviderFallback
 ].each do |required_fragment|

--- a/.github/scripts/verify-okou-production-domains.sh
+++ b/.github/scripts/verify-okou-production-domains.sh
@@ -73,7 +73,7 @@ verify_api_cors() {
       --header "Access-Control-Request-Method: GET" \
       --output /dev/null \
       --write-out $'%{http_code}\n%header{access-control-allow-origin}\n%header{access-control-allow-credentials}' \
-      "${api_origin}/api/okou/__brand-smoke__"
+      "${api_origin}/api/__brand-smoke__"
   )"
   mapfile -t cors_values <<< "$cors_result"
   if [[ "${cors_values[0]:-}" != "204" ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2580,8 +2580,8 @@ jobs:
             ]
           }')"
 
-          curl -fsS "${headers[@]}" -X PUT -d "$payload" "${E2E_API_URL}/api/okou/model-policies" >/dev/null
-          curl -fsS "${headers[@]}" -X PUT -d '{"selectedModel":null,"serviceTier":null}' "${E2E_API_URL}/api/okou/user-model-preference" >/dev/null
+          curl -fsS "${headers[@]}" -X PUT -d "$payload" "${E2E_API_URL}/api/model-policies" >/dev/null
+          curl -fsS "${headers[@]}" -X PUT -d '{"selectedModel":null,"serviceTier":null}' "${E2E_API_URL}/api/user-model-preference" >/dev/null
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Bootstrap runner mock model provider
@@ -2626,7 +2626,7 @@ jobs:
           provider_id=$(jq -er '.provider.id | select(type == "string" and length > 0)' \
             <<< "$provider_response")
 
-          policies=$(curl -fsS "${headers[@]}" "${api_url}/api/okou/model-policies")
+          policies=$(curl -fsS "${headers[@]}" "${api_url}/api/model-policies")
           policy_payload=$(jq -c --arg providerId "$provider_id" '
             {
               policies: (
@@ -2654,13 +2654,13 @@ jobs:
           curl -fsS "${headers[@]}" \
             -X PUT \
             -d "$policy_payload" \
-            "${api_url}/api/okou/model-policies" \
+            "${api_url}/api/model-policies" \
             >/dev/null
 
           curl -fsS "${headers[@]}" \
             -X POST \
             -d '{"switches":{"realAgentInPreview":true}}' \
-            "${api_url}/api/okou/feature-switches" \
+            "${api_url}/api/feature-switches" \
             | jq -e '.effectiveSwitches.realAgentInPreview == true' \
             >/dev/null
         env:
@@ -2680,7 +2680,7 @@ jobs:
             headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           fi
 
-          policies=$(curl -fsS "${headers[@]}" "${api_url}/api/okou/model-policies")
+          policies=$(curl -fsS "${headers[@]}" "${api_url}/api/model-policies")
           policy_payload=$(jq -c --arg model "$claude_model" '
             {
               policies: (
@@ -2708,13 +2708,13 @@ jobs:
           curl -fsS "${headers[@]}" \
             -X PUT \
             -d "$policy_payload" \
-            "${api_url}/api/okou/model-policies" \
+            "${api_url}/api/model-policies" \
             >/dev/null
 
           curl -fsS "${headers[@]}" \
             -X POST \
             -d '{"switches":{"realAgentInPreview":true,"builtInModelProviderFallback":true}}' \
-            "${api_url}/api/okou/feature-switches" \
+            "${api_url}/api/feature-switches" \
             | jq -e '
                 .effectiveSwitches.realAgentInPreview == true and
                 .effectiveSwitches.builtInModelProviderFallback == true

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -78,7 +78,7 @@ selects the CI-only runner tests.
 Runner BATS files live in `e2e/tests/03-runner`. They share the accounts and
 public device-flow tokens prepared by the runner E2E workflow, then create and
 clean up their own agents, threads, and connector connections through public
-`/api/okou/*` endpoints.
+`/api/*` endpoints.
 
 Name runner BATS files `run-tNN-<behavior>.bats`, using the next unused `NN`.
 The number is a stable file identifier, not an execution order. Test titles

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -189,7 +189,7 @@ runner_e2e_start_checkpointed_chat_run() {
 
 runner_e2e_delete_chat_thread() {
     local thread_id="$1"
-    runner_api_curl "/api/okou/chat-threads/${thread_id}" -X DELETE
+    runner_api_curl "/api/chat-threads/${thread_id}" -X DELETE
 }
 
 runner_e2e_delete_workflow() {

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -78,7 +78,7 @@ runner_chat_event_rows() {
     local page_number
 
     for ((page_number = 1; page_number <= 100; page_number += 1)); do
-        request_path="/api/okou/chat-threads/${thread_id}/event-rows?sinceSeqId=${since_seq_id}&limit=50"
+        request_path="/api/chat-threads/${thread_id}/event-rows?sinceSeqId=${since_seq_id}&limit=50"
         if ((since_seq_id > 0)); then
             request_path+="&sinceEventId=${since_event_id}"
         fi
@@ -283,7 +283,7 @@ runner_chat_send_parts() {
             } + if $captureNetworkBodies then {captureNetworkBodies: true} else {} end')"
     fi
 
-    runner_api_curl "/api/okou/chat/events" -X POST -d "$payload"
+    runner_api_curl "/api/chat/events" -X POST -d "$payload"
 }
 
 runner_wait_for_run() {

--- a/e2e/playwright/runner-mock-claude-bootstrap.bash
+++ b/e2e/playwright/runner-mock-claude-bootstrap.bash
@@ -14,12 +14,12 @@ fi
 provider_response=$(curl -fsS "${headers[@]}" \
     -X POST \
     -d '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}' \
-    "${api_url}/api/zero/me/model-providers")
+    "${api_url}/api/me/model-providers")
 jq -e '.provider.type == "claude-code-oauth-token"' \
     <<<"$provider_response" \
     >/dev/null
 
-policies=$(curl -fsS "${headers[@]}" "${api_url}/api/zero/model-policies")
+policies=$(curl -fsS "${headers[@]}" "${api_url}/api/model-policies")
 policy_payload=$(jq -c '
     {
       policies: (
@@ -47,12 +47,12 @@ policy_payload=$(jq -c '
 curl -fsS "${headers[@]}" \
     -X PUT \
     -d "$policy_payload" \
-    "${api_url}/api/zero/model-policies" \
+    "${api_url}/api/model-policies" \
     >/dev/null
 
 curl -fsS "${headers[@]}" \
     -X POST \
     -d '{"switches":{"realAgentInPreview":false}}' \
-    "${api_url}/api/zero/feature-switches" \
+    "${api_url}/api/feature-switches" \
     | jq -e '.effectiveSwitches.realAgentInPreview == false' \
     >/dev/null

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -289,6 +289,16 @@ export function withApiNamespaceAliases(
  *   holds — is still there. Read a row against the traffic of the loop it
  *   belongs to, not only against its own. This is #28917's call-rate rule
  *   reached from the other direction.
+ *
+ * A production traffic sweep does not see this repository's own CI. E2E runs
+ * against preview deployments, so a row called only by a workflow step or an
+ * `e2e/` helper reads as zero-traffic in `vm0-request-log-prod` and looks
+ * drained when it is not — the next E2E run after its removal is what finds
+ * out. Six rows were held open by CI alone until #29169 moved those callers to
+ * neutral paths. Before removing a row, grep `e2e/`, `.github/scripts/` and
+ * `.github/workflows/` for both of its branded forms; treat a hit as a caller
+ * to repoint in the same commit, not as evidence the row is still owed. That
+ * grep returns nothing today, and this note is here so it stays that way.
  */
 type MigratedBrandedPathTable = Readonly<Record<string, readonly string[]>>;
 


### PR DESCRIPTION
Closes #29169. Part of #26701.

## Why this is not just cleanup

Every drain decision in this epic — #28709, #28716, #28917, #28974, #28916 — measured `vm0-request-log-prod`. E2E runs against preview deployments, so **CI callers never appear in that evidence**. Six compat rows were load-bearing for CI alone (`/api/me/model-providers`, `/api/model-policies`, `/api/feature-switches`, `/api/chat-threads/:id`, `/api/chat-threads/:threadId/event-rows`, `/api/chat/events`): each reads as zero-traffic in a production sweep, and removing one would have 404ed the next E2E run.

This PR moves every CI-side caller onto the neutral path its contract already declares, so that constraint disappears. CI scripts have no drain window — every run uses the current branch's scripts — so the callers and the assertions that read them move in one commit with no staging.

**No compat row is removed here.** The rows retire later on their own evidence.

## Live callers repointed

- `e2e/playwright/runner-mock-claude-bootstrap.bash` — `/api/zero/me/model-providers`, `/api/zero/model-policies` (×2), `/api/zero/feature-switches`
- `e2e/helpers/runner-api.bash` — `/api/okou/chat-threads/:id`
- `e2e/helpers/runner-chat.bash` — `/api/okou/chat-threads/:id/event-rows`, `/api/okou/chat/events`
- `.github/workflows/turbo.yml` — `/api/okou/model-policies` (×4), `/api/okou/user-model-preference`, `/api/okou/feature-switches` (×2)

## Coupled assertions updated in the same commit

`turbo-playwright-runner-workflow-test.sh` and `runner-api-curl-test.sh` assert that the scripts above contain specific path fragments, so they fail the moment a caller moves unless both change together. In `runner-api-curl-test.sh` the percent-encoded Vercel log URLs are derived from the request path, so those fixtures move with it.

## `__brand-smoke__` repointed

`.github/scripts/verify-okou-production-domains.sh` and `deploy-okou-pages-workflow-test.sh` send a CORS preflight to `/api/okou/__brand-smoke__`. No such route exists — the path is only a target for the OPTIONS probe, and CORS is not configured per namespace. Verified against production before and after that all three namespaces answer identically:

```
OPTIONS https://api.okou.ai/api/okou/__brand-smoke__   204  allow-origin: https://app.okou.ai  allow-credentials: true
OPTIONS https://api.okou.ai/api/__brand-smoke__        204  same
OPTIONS https://api.okou.ai/api/zero/__brand-smoke__   204  same
```

## Bug fix: shared-thread link previews were broken in production

`.github/pages/okou-app/_worker.js` built its metadata URL as `${origin}/api/okou/shared-threads/${id}/meta`. That route is not registered: `packages/api-contracts/src/contracts/shared-threads.ts` declares the neutral path, and there is no `shared-threads` row in `MIGRATED_BRANDED_PATHS`. The worker has been getting a 404 for every share link, and the worker turns a 404 meta response into a "Shared conversation not found" page — so **every valid share link rendered as not-found**.

Three tests in `okou-app-worker-test.mjs` asserted the branded URL, so they were green against the broken behaviour.

### Verification against production, with a real shared thread

Created a real shared thread (`7b9dbc79-…`) and queried both forms on both API hosts:

```
GET https://api.vm0.ai/api/shared-threads/7b9dbc79-…/meta        200  {"title":"…","publicBrand":"vm0"}
GET https://api.vm0.ai/api/okou/shared-threads/7b9dbc79-…/meta   404  {"error":"Not found"}
GET https://api.okou.ai/api/shared-threads/7b9dbc79-…/meta       200  {"title":"…","publicBrand":"vm0"}
GET https://api.okou.ai/api/okou/shared-threads/7b9dbc79-…/meta  404  {"error":"Not found"}
```

And the user-visible symptom on the deployed worker, before this change:

```
GET https://app.okou.ai/share/threads/7b9dbc79-…   404
<title>Shared conversation not found | Okou</title>
```

The neutral path returns the real title and brand, so the repointed worker resolves metadata rather than falling through to the not-found page. Scope was kept to the meta URL; nothing else in the worker was changed.

## Recording the gap

`MIGRATED_BRANDED_PATHS` in `turbo/apps/api/src/signals/route-entry.ts` carries the header comment the next drain reads first. Added a paragraph stating that a production traffic sweep does not see CI callers, and that `e2e/`, `.github/scripts/` and `.github/workflows/` must be grepped for a row's branded forms before it is removed.

After this PR that grep returns nothing:

```
$ rg '/api/okou/|/api/zero/' e2e/ .github/
$ echo $?
1
```

## Local verification

`okou-app-worker-test.sh`, `runner-api-curl-test.sh`, `turbo-playwright-runner-workflow-test.sh` and `deploy-okou-pages-workflow-test.sh` all pass locally. The E2E jobs this PR edits run in the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
