### PR TITLE
fix(platform): open the image annotation editor from any surface

### DIFF
--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -17,6 +17,7 @@ import {
   isStandalonePwa,
   setupKeyboardDismissGesture,
 } from "../lib/keyboard-dismiss-gesture.ts";
+import { ImageAnnotationEditor } from "./okou-page/image-annotation-editor.tsx";
 import { IN_VITEST } from "../env.ts";
 import "./css/index.css";
 
@@ -75,6 +76,10 @@ export const setupRouter = (
           </VM0ClerkProvider>
           <InspectLogFileInput />
           <ForceUpgradeDialog />
+          {/* The lightbox is mounted by three different pages, and opening the
+              editor closes it — so the editor lives at the root instead, or it
+              would only exist on whichever page happened to mount it. */}
+          <ImageAnnotationEditor />
         </ErrorBoundary>
         <AppToaster />
       </StoreProvider>

--- a/turbo/apps/platform/src/views/okou-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/agent-chat-page.tsx
@@ -26,8 +26,6 @@ import { ZeroChatComposer } from "./chat-composer.tsx";
 import { StartCards } from "./start-cards.tsx";
 import { GrowthEntryHeader } from "./growth-entry.tsx";
 import { AttachmentLightbox } from "./attachment-chips.tsx";
-import { ImageAnnotationEditor } from "./image-annotation-editor.tsx";
-import { annotationSessionActive$ } from "../../signals/okou-page/image-annotation.ts";
 import { chatPageTaglineIndex$ } from "../../signals/okou-page/chat-page.ts";
 import { agentChatComposerSignals$ } from "../../signals/okou-page/agent-composer-signals.ts";
 import { subscribeComputerUseHostsChangedRef$ } from "../../signals/okou-page/computer-use-hosts.ts";
@@ -356,7 +354,6 @@ export function AgentChatPage() {
   );
 
   const lightboxUrl = useGet(attachmentLightboxUrl$);
-  const annotationSessionActive = useGet(annotationSessionActive$);
 
   const handleInputChange = (value: string) => {
     setInput(value);
@@ -391,9 +388,6 @@ export function AgentChatPage() {
       <PersonalClaudeCodeDeviceAuthDialog />
       <PersonalCodexDeviceAuthDialog />
       {lightboxUrl && <AttachmentLightbox />}
-      {/* Mounted beside the viewer rather than inside it: opening the editor
-          closes the lightbox, so nesting would unmount the editor immediately. */}
-      {annotationSessionActive && <ImageAnnotationEditor />}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -1275,8 +1275,14 @@ function ArtifactPreviewDialogActions({
         <Button
           type="button"
           variant="quiet"
-          size="sm"
+          size="icon-sm"
           data-testid="artifact-dialog-annotate"
+          aria-label={t(($) => {
+            return $.artifacts.annotation.open;
+          })}
+          title={t(($) => {
+            return $.artifacts.annotation.open;
+          })}
           onClick={() => {
             // The editor owns the whole surface while it is open, so the
             // read-only viewer steps aside rather than stacking behind it.
@@ -1284,10 +1290,7 @@ function ArtifactPreviewDialogActions({
             closeLightboxWithDialogExit(rootSignal);
           }}
         >
-          <Pencil size={16} />
-          {t(($) => {
-            return $.artifacts.annotation.open;
-          })}
+          <Pencil size={18} />
         </Button>
       )}
       {showShare && (

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -48,6 +48,7 @@ import {
   type AnnotationInk,
   type AnnotationPoint,
   type AnnotationStroke,
+  type AnnotationTarget,
   type AnnotationTool,
 } from "../../signals/okou-page/image-annotation.ts";
 import { useResolvedAttachmentUrl } from "./attachment-resource.ts";
@@ -719,13 +720,27 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
   );
 }
 
+/**
+ * Mounted at the app root, so it must not touch page-scoped state until a
+ * session actually exists — `useResolvedAttachmentUrl` reads the resolver that
+ * belongs to the current page, and reaching for it before any page is set up
+ * throws. Splitting the surface into its own component keeps that read behind
+ * the session check.
+ */
 export function ImageAnnotationEditor() {
   const target = useGet(annotationSessionTarget$);
+  if (!target) {
+    return null;
+  }
+  return <AnnotationSurface target={target} />;
+}
+
+function AnnotationSurface({ target }: { target: AnnotationTarget }) {
   const annotation = useGet(annotationDraft$);
   const selectedId = useGet(annotationSelectedMarkId$);
-  const resolvedUrl = useResolvedAttachmentUrl(target?.url ?? "");
+  const resolvedUrl = useResolvedAttachmentUrl(target.url);
 
-  if (!target || resolvedUrl === null) {
+  if (resolvedUrl === null) {
     return null;
   }
 
@@ -735,7 +750,7 @@ export function ImageAnnotationEditor() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
+      className="zero-app fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
       data-testid="image-annotation-editor"
     >
       <div className="flex h-[min(700px,90vh)] w-[min(980px,94vw)] min-h-0 flex-col overflow-hidden rounded-2xl bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]">


### PR DESCRIPTION
Follow-up to #28976, from dogfooding feedback.

## Clicking Annotate closed the lightbox and did nothing

`AttachmentLightbox` is mounted by three pages — `agent-chat-page`, `chat-thread-page` and `artifact-catalog-page` — but I mounted `ImageAnnotationEditor` in only one of them. Inside an actual thread the button opened the session and closed the viewer against a component that was never rendered, so the screen just went back to the composer.

Rather than adding the third copy, the editor now mounts **once at the app root** next to the other global dialogs, which removes the class of bug. Two consequences handled here:

- it renders outside `.zero-app`, so the overlay carries that class itself for the scoped custom properties
- it must not touch page-scoped state before a session exists — `useResolvedAttachmentUrl` reads the resolver owned by the current page, and reaching for it at root level throws. The surface moved into its own component so that read stays behind the session check.

The existing tests now pass *only* because of the root mount, so they lock the behaviour in.

## The entry is icon-only

`Annotate` showed a pencil plus a text label while every neighbouring action (share, download, split view, fullscreen, close) is icon-only. It is now an `icon-sm` quiet button with the label on `aria-label` and `title`.

## Verification

- `pnpm check-types` — both the production and tests configs
- `pnpm -F @okouai/app lint` — clean
- `vitest`: `image-annotation` (4), plus `attachment-chips` + `chat-draft` (76) as regression cover

Still not exercised outside tests: the flatten itself and the two-file send shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)