### PR TITLE
test(ci): drop drained zero output tombstones from web-api-env action test

### DIFF
--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -6,12 +6,15 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ACTION="${REPO_ROOT}/.github/actions/web-api-env/action.yml"
 EXPECTED_BUILD_COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse --verify HEAD)"
 TEMP_DIRS=()
-# ZERO_ keys whose readers are still live: apps/api reads both in lib/env.ts,
-# host.service.ts resolves the VM0-brand host from them, and turbo.json still
-# lists them. The deployment must not emit either name, because a rendered value
-# would feed the last remaining OKOU_ENV_FALLBACKS entry (OKOU_HOST_SCHEME) and
-# make its drain evidence false. They retire with the VM0-brand host under
-# #26701, together with these assertions.
+# These are not retired names. Their readers are live: lib/env.ts defines both,
+# host.service.ts resolves the VM0-brand hosted-site host from them,
+# artifact-preview.service.ts accepts the domain, and turbo.json still lists
+# them. The action no longer sources either name and must not start again: an
+# emitted value would restore the retired repo-variable source for live brand
+# configuration, and for ZERO_HOST_SCHEME it would additionally feed the last
+# remaining OKOU_ENV_FALLBACKS entry (OKOU_HOST_SCHEME) and falsify its drain
+# evidence. Both retire with the VM0-brand host under #26701, and these
+# assertions retire with them.
 ZERO_KEYS_WITH_LIVE_READERS=(
   ZERO_HOST_DOMAIN
   ZERO_HOST_SCHEME

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -6,21 +6,15 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ACTION="${REPO_ROOT}/.github/actions/web-api-env/action.yml"
 EXPECTED_BUILD_COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse --verify HEAD)"
 TEMP_DIRS=()
-MIGRATED_ZERO_OUTPUT_KEYS=(
+# ZERO_ keys whose readers are still live: apps/api reads both in lib/env.ts,
+# host.service.ts resolves the VM0-brand host from them, and turbo.json still
+# lists them. The deployment must not emit either name, because a rendered value
+# would feed the last remaining OKOU_ENV_FALLBACKS entry (OKOU_HOST_SCHEME) and
+# make its drain evidence false. They retire with the VM0-brand host under
+# #26701, together with these assertions.
+ZERO_KEYS_WITH_LIVE_READERS=(
   ZERO_HOST_DOMAIN
   ZERO_HOST_SCHEME
-  ZERO_PRICE_PRO
-  ZERO_PRICE_TEAM
-  ZERO_PRICE_USAGE_PACK_PLAN_PRO
-  ZERO_PRICE_USAGE_PACK_PLAN_TEAM
-  ZERO_PRICE_USAGE_PACK_20
-  ZERO_PRICE_USAGE_PACK_50
-  ZERO_PRICE_USAGE_PACK_100
-  ZERO_PRICE_USAGE_PACK_200
-  ZERO_PRICE_CUSTOM_CREDITS
-  ZERO_PRICE_CUSTOM_CREDIT_UNIT
-  ZERO_PRICE_CONCURRENCY
-  ZERO_ONE_TIME_CAMPAIGN
 )
 GITHUB_APP_VAR_SUFFIXES=(
   SLUG
@@ -126,10 +120,10 @@ assert_preview_job_ref_aliases_absent() {
   assert_env_key_absent "$env_file" VM0_PREVIEW_JOB_REF
 }
 
-assert_migrated_zero_outputs_absent() {
+assert_zero_keys_with_live_readers_absent() {
   local env_file="$1"
   local key
-  for key in "${MIGRATED_ZERO_OUTPUT_KEYS[@]}"; do
+  for key in "${ZERO_KEYS_WITH_LIVE_READERS[@]}"; do
     assert_env_key_absent "$env_file" "$key"
   done
 }
@@ -437,7 +431,7 @@ success_output="$(run_action "$(build_doppler_secrets_json)" "$success_dir" 2>&1
 success_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${success_dir}/github-output")"
 assert_contains "$success_output" "Rendered"
 assert_no_fixture_secret_values "$success_output"
-assert_migrated_zero_outputs_absent "$success_env_file"
+assert_zero_keys_with_live_readers_absent "$success_env_file"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
@@ -533,7 +527,7 @@ empty_output="$(run_action "$(build_doppler_secrets_json)" "$empty_dir" api prev
 empty_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_dir}/github-output")"
 assert_contains "$empty_output" "Rendered"
 assert_no_fixture_secret_values "$empty_output"
-assert_migrated_zero_outputs_absent "$empty_env_file"
+assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -548,7 +542,7 @@ production_web_output="$(run_action "$(build_doppler_secrets_json)" "$production
 production_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${production_web_dir}/github-output")"
 assert_contains "$production_web_output" "Rendered"
 assert_no_fixture_secret_values "$production_web_output"
-assert_migrated_zero_outputs_absent "$production_web_env_file"
+assert_zero_keys_with_live_readers_absent "$production_web_env_file"
 assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
 assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
@@ -573,7 +567,7 @@ production_api_output="$(run_action "$(build_doppler_secrets_json)" "$production
 production_api_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${production_api_dir}/github-output")"
 assert_contains "$production_api_output" "Rendered"
 assert_no_fixture_secret_values "$production_api_output"
-assert_migrated_zero_outputs_absent "$production_api_env_file"
+assert_zero_keys_with_live_readers_absent "$production_api_env_file"
 assert_env_value "$production_api_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
 assert_env_value "$production_api_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"


### PR DESCRIPTION
Closes #29174. Part of #26701.

## What changed

`MIGRATED_ZERO_OUTPUT_KEYS` in `.github/scripts/tests/web-api-env-action-test.sh` held fourteen keys asserted absent from the rendered env. Twelve are removed, two are kept, and the array plus its helper are renamed to describe what is actually left.

## Why twelve go

`docs/fallback.md` section 1: a negative test asserting that removed behavior stays removed is a tombstone, and it is deleted together with the old code. The criterion is whether the old code is gone, not whether traffic drained.

All twelve — `ZERO_PRICE_PRO`, `ZERO_PRICE_TEAM`, `ZERO_PRICE_USAGE_PACK_PLAN_PRO`, `ZERO_PRICE_USAGE_PACK_PLAN_TEAM`, `ZERO_PRICE_USAGE_PACK_20/50/100/200`, `ZERO_PRICE_CUSTOM_CREDITS`, `ZERO_PRICE_CUSTOM_CREDIT_UNIT`, `ZERO_PRICE_CONCURRENCY`, `ZERO_ONE_TIME_CAMPAIGN` — appear in no file in this repository except that test. None is listed in `turbo/turbo.json`, and `.github/actions/web-api-env/action.yml` contains zero occurrences of `ZERO_` at all. There is no reader left for an emitted value to reach, so the assertions pin the absence of code that no longer exists.

The positive assertions covering the `OKOU_PRICE_*` replacements are untouched and are what actually provides coverage.

## Why two stay

`ZERO_HOST_DOMAIN` and `ZERO_HOST_SCHEME` are not tombstones. Their readers are live:

- `turbo/apps/api/src/lib/env.ts:106` defines `ZERO_HOST_SCHEME` in the schema
- `turbo/apps/api/src/lib/env.ts:183` — `OKOU_HOST_SCHEME: "ZERO_HOST_SCHEME"` is the last remaining `OKOU_ENV_FALLBACKS` entry
- `turbo/apps/api/src/signals/services/host.service.ts:221` reads it
- `turbo/turbo.json` still lists both

The writer is gone while the readers remain, so these two assertions pin a currently-reachable state: if the action started emitting the legacy names again, the fallback path would be fed and its drain evidence would be false. `env.ts:93` records that these readers retire with the VM0-brand host under #26701, not with the rest of the `ZERO_*` variables — and these two assertions retire with them.

## Rename

With two entries left, `MIGRATED_ZERO_OUTPUT_KEYS` was actively misleading: the survivors are precisely the keys that have *not* finished migrating. The array is now `ZERO_KEYS_WITH_LIVE_READERS`, the helper is `assert_zero_keys_with_live_readers_absent`, and all four call sites are updated. A comment above the array records the reason so the next reader does not have to re-derive it.

## Unchanged on purpose

- The general guard at line 354 (`repo_var|repo_secret|add_(var|secret) … "?ZERO_`) stays. It is not keyed to a retired name — it forbids the action reading *any* `ZERO_`-named repo variable or secret, preventing a new legacy read rather than restating an old deletion.
- No reader of the two kept keys is touched, and `OKOU_ENV_FALLBACKS` in `lib/env.ts` is untouched. Those go with the brand-host retirement.
- Other `ZERO_` strings elsewhere in the repo (reverse assertions, fixtures, history) are deliberately left alone.

## Verification

`bash .github/scripts/tests/web-api-env-action-test.sh` passes. The script is self-contained and asserts against the real `.github/actions/web-api-env/action.yml` rather than a fixture; CI runs it through the `.github/scripts/tests/*.sh` loop in `security.yml`.
