### PR TITLE
refactor(desktop): dual-read signing identity aliases

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -6,6 +6,9 @@ const { resolveDesktopBuildConfig } = require("./scripts/desktop-build-config");
 const {
   resolveDesktopNotarizeApiEnvironment,
 } = require("./scripts/desktop-notarize-api-environment");
+const {
+  resolveDesktopSigningIdentityEnvironment,
+} = require("./scripts/desktop-signing-identity-environment");
 
 const MINIMUM_MACOS_VERSION = "14.0";
 const DEFAULT_NOTARIZE_KEYCHAIN_PROFILE = "vm0-desktop-notary";
@@ -18,7 +21,7 @@ const DEFAULT_NOTARIZE_KEYCHAIN = path.join(
 const DEVELOPER_ID_APPLICATION_IDENTITY =
   "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)";
 const codeSigningIdentity =
-  process.env.VM0_DESKTOP_SIGNING_IDENTITY ??
+  resolveDesktopSigningIdentityEnvironment() ??
   (process.env.CI === "true" ? "-" : DEVELOPER_ID_APPLICATION_IDENTITY);
 
 function desktopNotarizeOptions() {

--- a/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
@@ -1,0 +1,36 @@
+const CANONICAL_SIGNING_IDENTITY = "OKOU_DESKTOP_SIGNING_IDENTITY";
+const LEGACY_SIGNING_IDENTITY = "VM0_DESKTOP_SIGNING_IDENTITY";
+
+// The production release workflow remains legacy-only during this reader
+// stage. Remove the legacy alias only after an ordinary signed Desktop release
+// proves legacy-only evidence from both readers, a later writer cutover records
+// canonical-only production evidence, and the supported rollback window plus
+// zero legacy-use gate complete under #28914.
+function resolveDesktopSigningIdentityEnvironment() {
+  const canonicalValue = process.env[CANONICAL_SIGNING_IDENTITY];
+  const legacyValue = process.env[LEGACY_SIGNING_IDENTITY];
+  const canonicalPresent = canonicalValue !== undefined;
+  const legacyPresent = legacyValue !== undefined;
+
+  if (!canonicalPresent && !legacyPresent) {
+    return undefined;
+  }
+  if (canonicalPresent && legacyPresent && canonicalValue !== legacyValue) {
+    throw new Error(
+      `Desktop signing identity environment aliases conflict: canonical_key=${CANONICAL_SIGNING_IDENTITY} legacy_key=${LEGACY_SIGNING_IDENTITY} state=conflict`,
+    );
+  }
+
+  const source =
+    canonicalPresent && legacyPresent
+      ? "dual"
+      : canonicalPresent
+        ? "canonical-only"
+        : "legacy-only";
+  console.info(
+    `desktop_signing_identity_env_source key=${CANONICAL_SIGNING_IDENTITY} source=${source}`,
+  );
+  return canonicalPresent ? canonicalValue : legacyValue;
+}
+
+module.exports = { resolveDesktopSigningIdentityEnvironment };

--- a/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
+++ b/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
@@ -8,8 +8,11 @@ import { notarize } from "@electron/notarize";
 import { sign } from "@electron/osx-sign";
 
 import desktopNotarizeApiEnvironment from "./desktop-notarize-api-environment.js";
+import desktopSigningIdentityEnvironment from "./desktop-signing-identity-environment.js";
 
 const { resolveDesktopNotarizeApiEnvironment } = desktopNotarizeApiEnvironment;
+const { resolveDesktopSigningIdentityEnvironment } =
+  desktopSigningIdentityEnvironment;
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const desktopDirectory = path.resolve(scriptDirectory, "..");
@@ -23,8 +26,7 @@ const desktopIdentities = JSON.parse(
   ),
 );
 
-function requiredEnvironmentVariable(name) {
-  const value = process.env[name];
+function requiredEnvironmentVariable(name, value) {
   if (!value) {
     throw new Error(`${name} is required`);
   }
@@ -81,7 +83,10 @@ if (!notarizeOptions) {
 await sign({
   app: options.appPath,
   batchCodesignCalls: true,
-  identity: requiredEnvironmentVariable("VM0_DESKTOP_SIGNING_IDENTITY"),
+  identity: requiredEnvironmentVariable(
+    "VM0_DESKTOP_SIGNING_IDENTITY",
+    resolveDesktopSigningIdentityEnvironment(),
+  ),
   identityValidation: true,
   platform: "darwin",
   version: packageMetadata.devDependencies.electron,

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -37,6 +37,10 @@ const allAliases = [
   ...Object.values(canonicalAliases),
   ...Object.values(legacyAliases),
 ];
+const canonicalSigningIdentityAlias = "OKOU_DESKTOP_SIGNING_IDENTITY";
+const legacySigningIdentityAlias = "VM0_DESKTOP_SIGNING_IDENTITY";
+const developerIdApplicationIdentity =
+  "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)";
 
 const moduleLoaderSource = `
 import { registerHooks } from "node:module";
@@ -63,25 +67,19 @@ import { appendFileSync } from "node:fs";
 
 export async function sign(options) {
   appendFileSync(process.env.TEST_TRACE_PATH, "sign\\n");
-  const forgeOptionsAreUnchanged =
-    process.env.TEST_SIGN_KIND === "forge" &&
+  const signingOptionsAreUnchanged =
     options.app === process.env.TEST_EXPECTED_APP_PATH &&
     options.batchCodesignCalls === true &&
-    options.identity === "-" &&
-    options.identityValidation === false &&
+    options.identity === process.env.TEST_EXPECTED_SIGNING_IDENTITY &&
+    options.identityValidation ===
+      (process.env.TEST_EXPECTED_IDENTITY_VALIDATION === "true") &&
     options.platform === "darwin" &&
-    options.timestamp === "none" &&
+    options.timestamp ===
+      (process.env.TEST_EXPECTED_SIGNING_TIMESTAMP === "none"
+        ? "none"
+        : undefined) &&
     options.version === process.env.TEST_EXPECTED_ELECTRON_VERSION;
-  const helperOptionsAreUnchanged =
-    process.env.TEST_SIGN_KIND === "helper" &&
-    options.app === process.env.TEST_EXPECTED_APP_PATH &&
-    options.batchCodesignCalls === true &&
-    options.identity === process.env.VM0_DESKTOP_SIGNING_IDENTITY &&
-    options.identityValidation === true &&
-    options.platform === "darwin" &&
-    options.timestamp === undefined &&
-    options.version === process.env.TEST_EXPECTED_ELECTRON_VERSION;
-  if (!forgeOptionsAreUnchanged && !helperOptionsAreUnchanged) {
+  if (!signingOptionsAreUnchanged) {
     throw new Error("Desktop signing options changed");
   }
 }
@@ -152,6 +150,11 @@ type CredentialCase =
   | "incomplete";
 type SuccessfulSource = "canonical-only" | "legacy-only" | "dual";
 
+interface SigningIdentityInput {
+  readonly canonical?: string;
+  readonly legacy?: string;
+}
+
 interface CredentialValues {
   readonly keyPath: string;
   readonly keyId: string;
@@ -169,7 +172,7 @@ interface TestHarness {
 interface EntryPointResult {
   readonly process: SpawnSyncReturns<string>;
   readonly trace: string;
-  readonly credentialValues: readonly string[];
+  readonly sensitiveValues: readonly string[];
 }
 
 function createTestHarness(): TestHarness {
@@ -255,6 +258,21 @@ function applyCredentialCase(
   });
 }
 
+function applySigningIdentityInput(
+  environment: NodeJS.ProcessEnv,
+  input: SigningIdentityInput,
+): readonly string[] {
+  if (input.canonical !== undefined) {
+    environment[canonicalSigningIdentityAlias] = input.canonical;
+  }
+  if (input.legacy !== undefined) {
+    environment[legacySigningIdentityAlias] = input.legacy;
+  }
+  return [input.canonical, input.legacy].filter((value): value is string =>
+    Boolean(value),
+  );
+}
+
 function baseEnvironment(harness: TestHarness): NodeJS.ProcessEnv {
   return {
     CI: "true",
@@ -285,6 +303,8 @@ function runForge(
     readonly notarize?: boolean;
     readonly source?: SuccessfulSource;
     readonly keychainMode?: "default-keychain" | "custom-keychain";
+    readonly signingIdentity?: SigningIdentityInput;
+    readonly ci?: boolean;
   } = {},
 ): EntryPointResult {
   const harness = createTestHarness();
@@ -292,17 +312,34 @@ function runForge(
   const appPath = join(outputPath, "Zero Computer Use.app");
   mkdirSync(appPath, { recursive: true });
   const environment = baseEnvironment(harness);
+  if (options.ci === false) {
+    delete environment.CI;
+  }
   environment.TEST_EXPECTED_APP_PATH = appPath;
   environment.TEST_OUTPUT_PATH = outputPath;
-  environment.TEST_SIGN_KIND = "forge";
   if (options.notarize !== false) {
     environment.VM0_DESKTOP_NOTARIZE = "true";
   }
-  const values = applyCredentialCase(
+  const credentialValues = applyCredentialCase(
     environment,
     harness.directory,
     credentialCase,
   );
+  const signingIdentity = options.signingIdentity ?? {};
+  const signingIdentityValues = applySigningIdentityInput(
+    environment,
+    signingIdentity,
+  );
+  const configuredSigningIdentity =
+    signingIdentity.canonical ?? signingIdentity.legacy;
+  const expectedSigningIdentity =
+    configuredSigningIdentity ??
+    (environment.CI === "true" ? "-" : developerIdApplicationIdentity);
+  environment.TEST_EXPECTED_SIGNING_IDENTITY = expectedSigningIdentity;
+  environment.TEST_EXPECTED_IDENTITY_VALIDATION =
+    expectedSigningIdentity === "-" ? "false" : "true";
+  environment.TEST_EXPECTED_SIGNING_TIMESTAMP =
+    expectedSigningIdentity === "-" ? "none" : "absent";
   if (options.source) {
     environment.TEST_NOTARIZE_MODE = "api";
     environment.TEST_EXPECTED_API_SOURCE = options.source;
@@ -332,13 +369,17 @@ function runForge(
   return {
     process: processResult,
     trace: trace(harness),
-    credentialValues: values,
+    sensitiveValues: [...credentialValues, ...signingIdentityValues],
   };
 }
 
 function runPackagedAppHelper(
   credentialCase: CredentialCase,
-  options: { readonly appName?: string; readonly product?: string } = {},
+  options: {
+    readonly appName?: string;
+    readonly product?: string;
+    readonly signingIdentity?: SigningIdentityInput;
+  } = {},
 ): EntryPointResult {
   const harness = createTestHarness();
   const appPath = join(
@@ -348,14 +389,26 @@ function runPackagedAppHelper(
   mkdirSync(appPath, { recursive: true });
   const environment = baseEnvironment(harness);
   environment.TEST_EXPECTED_APP_PATH = appPath;
-  environment.TEST_SIGN_KIND = "helper";
   environment.TEST_NOTARIZE_MODE = "api";
-  environment.VM0_DESKTOP_SIGNING_IDENTITY = randomUUID();
-  const values = applyCredentialCase(
+  const credentialValues = applyCredentialCase(
     environment,
     harness.directory,
     credentialCase,
   );
+  const signingIdentity = options.signingIdentity ?? {
+    legacy: ` ${randomUUID()} `,
+  };
+  const signingIdentityValues = applySigningIdentityInput(
+    environment,
+    signingIdentity,
+  );
+  const expectedSigningIdentity =
+    signingIdentity.canonical ?? signingIdentity.legacy;
+  if (expectedSigningIdentity !== undefined) {
+    environment.TEST_EXPECTED_SIGNING_IDENTITY = expectedSigningIdentity;
+  }
+  environment.TEST_EXPECTED_IDENTITY_VALIDATION = "true";
+  environment.TEST_EXPECTED_SIGNING_TIMESTAMP = "absent";
   if (
     credentialCase === "canonical-only" ||
     credentialCase === "legacy-only" ||
@@ -384,7 +437,7 @@ function runPackagedAppHelper(
   return {
     process: processResult,
     trace: trace(harness),
-    credentialValues: values,
+    sensitiveValues: [...credentialValues, ...signingIdentityValues],
   };
 }
 
@@ -394,11 +447,33 @@ function sourceEvents(result: EntryPointResult): readonly string[] {
     .filter((line) => line.startsWith("desktop_notarize_api_env_source "));
 }
 
-function expectNoCredentialDisclosure(result: EntryPointResult): void {
+function signingIdentitySourceEvents(
+  result: EntryPointResult,
+): readonly string[] {
+  return result.process.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("desktop_signing_identity_env_source "));
+}
+
+function expectSigningIdentitySource(
+  result: EntryPointResult,
+  source: SuccessfulSource | undefined,
+): void {
+  expect(signingIdentitySourceEvents(result)).toStrictEqual(
+    source
+      ? [
+          `desktop_signing_identity_env_source key=${canonicalSigningIdentityAlias} source=${source}`,
+        ]
+      : [],
+  );
+}
+
+function expectNoSensitiveValueDisclosure(result: EntryPointResult): void {
   const output = result.process.stdout + result.process.stderr;
-  for (const value of result.credentialValues) {
+  for (const value of result.sensitiveValues) {
     expect(output.includes(value)).toBe(false);
   }
+  expect(output.includes("length=")).toBe(false);
 }
 
 function expectSuccessfulApiEntryPoint(
@@ -410,7 +485,7 @@ function expectSuccessfulApiEntryPoint(
   expect(sourceEvents(result)).toStrictEqual([
     `desktop_notarize_api_env_source source=${source}`,
   ]);
-  expectNoCredentialDisclosure(result);
+  expectNoSensitiveValueDisclosure(result);
 }
 
 function expectFailedBeforeExternalSideEffects(
@@ -421,7 +496,7 @@ function expectFailedBeforeExternalSideEffects(
   expect(result.trace).toBe("");
   expect(sourceEvents(result)).toStrictEqual([]);
   expect(result.process.stderr.includes(`state=${state}`)).toBe(true);
-  expectNoCredentialDisclosure(result);
+  expectNoSensitiveValueDisclosure(result);
 }
 
 afterEach(() => {
@@ -475,7 +550,7 @@ describe("Desktop Forge notarization entry point", () => {
     expect(result.process.status === 0).toBe(true);
     expect(result.trace).toBe("sign\nnotarize\n");
     expect(sourceEvents(result)).toStrictEqual([]);
-    expectNoCredentialDisclosure(result);
+    expectNoSensitiveValueDisclosure(result);
   });
 
   it("keeps notarization disabled unless the existing toggle is true", () => {
@@ -483,7 +558,87 @@ describe("Desktop Forge notarization entry point", () => {
     expect(result.process.status === 0).toBe(true);
     expect(result.trace).toBe("sign\n");
     expect(sourceEvents(result)).toStrictEqual([]);
-    expectNoCredentialDisclosure(result);
+    expectNoSensitiveValueDisclosure(result);
+  });
+});
+
+describe("Desktop Forge signing identity entry point", () => {
+  const sharedIdentity = ` ${randomUUID()} `;
+
+  it.each([
+    ["canonical-only", { canonical: sharedIdentity }, "canonical-only"],
+    ["legacy-only", { legacy: sharedIdentity }, "legacy-only"],
+    [
+      "byte-equal dual",
+      { canonical: sharedIdentity, legacy: sharedIdentity },
+      "dual",
+    ],
+  ] as const)(
+    "passes the %s identity through unchanged",
+    (_, input, source) => {
+      const result = runForge("absent", {
+        notarize: false,
+        signingIdentity: input,
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\n");
+      expectSigningIdentitySource(result, source);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it.each([
+    ["CI", true],
+    ["local", false],
+  ] as const)(
+    "keeps the existing %s fallback when both aliases are absent",
+    (_, ci) => {
+      const result = runForge("absent", {
+        ci,
+        notarize: false,
+        signingIdentity: {},
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\n");
+      expectSigningIdentitySource(result, undefined);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it.each([
+    ["canonical-only", { canonical: "" }, "canonical-only"],
+    ["legacy-only", { legacy: "" }, "legacy-only"],
+    ["byte-equal dual", { canonical: "", legacy: "" }, "dual"],
+  ] as const)(
+    "does not replace an explicit-empty %s identity",
+    (_, input, source) => {
+      const result = runForge("absent", {
+        notarize: false,
+        signingIdentity: input,
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\n");
+      expectSigningIdentitySource(result, source);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it("rejects conflicting aliases before signing", () => {
+    const result = runForge("absent", {
+      notarize: false,
+      signingIdentity: { canonical: "", legacy: ` ${randomUUID()} ` },
+    });
+
+    expect(result.process.status).toBe(1);
+    expect(result.trace).toBe("");
+    expectSigningIdentitySource(result, undefined);
+    expect(result.process.stderr).toContain(
+      `Desktop signing identity environment aliases conflict: canonical_key=${canonicalSigningIdentityAlias} legacy_key=${legacySigningIdentityAlias} state=conflict`,
+    );
+    expectNoSensitiveValueDisclosure(result);
   });
 });
 
@@ -530,7 +685,7 @@ describe("packaged Desktop signing and notarization entry point", () => {
         "Expected a Zero Computer Use.app directory",
       ),
     ).toBe(true);
-    expectNoCredentialDisclosure(result);
+    expectNoSensitiveValueDisclosure(result);
   });
 
   it("preserves product validation before external side effects", () => {
@@ -545,6 +700,82 @@ describe("packaged Desktop signing and notarization entry point", () => {
         "Usage: sign-and-notarize-packaged-app.mjs",
       ),
     ).toBe(true);
-    expectNoCredentialDisclosure(result);
+    expectNoSensitiveValueDisclosure(result);
+  });
+});
+
+describe("packaged Desktop signing identity entry point", () => {
+  const sharedIdentity = ` ${randomUUID()} `;
+
+  it.each([
+    ["canonical-only", { canonical: sharedIdentity }, "canonical-only"],
+    ["legacy-only", { legacy: sharedIdentity }, "legacy-only"],
+    [
+      "byte-equal dual",
+      { canonical: sharedIdentity, legacy: sharedIdentity },
+      "dual",
+    ],
+  ] as const)(
+    "passes the %s identity through unchanged",
+    (_, input, source) => {
+      const result = runPackagedAppHelper("canonical-only", {
+        signingIdentity: input,
+      });
+
+      expectSuccessfulApiEntryPoint(result, "canonical-only");
+      expectSigningIdentitySource(result, source);
+    },
+  );
+
+  it("keeps the existing required-variable failure when both aliases are absent", () => {
+    const result = runPackagedAppHelper("canonical-only", {
+      signingIdentity: {},
+    });
+
+    expect(result.process.status).toBe(1);
+    expect(result.trace).toBe("");
+    expect(sourceEvents(result)).toStrictEqual([
+      "desktop_notarize_api_env_source source=canonical-only",
+    ]);
+    expectSigningIdentitySource(result, undefined);
+    expect(result.process.stderr).toContain(
+      "VM0_DESKTOP_SIGNING_IDENTITY is required",
+    );
+    expectNoSensitiveValueDisclosure(result);
+  });
+
+  it.each([
+    ["canonical-only", { canonical: "" }, "canonical-only"],
+    ["legacy-only", { legacy: "" }, "legacy-only"],
+    ["byte-equal dual", { canonical: "", legacy: "" }, "dual"],
+  ] as const)(
+    "keeps the existing required-variable failure for an explicit-empty %s identity",
+    (_, input, source) => {
+      const result = runPackagedAppHelper("canonical-only", {
+        signingIdentity: input,
+      });
+
+      expect(result.process.status).toBe(1);
+      expect(result.trace).toBe("");
+      expectSigningIdentitySource(result, source);
+      expect(result.process.stderr).toContain(
+        "VM0_DESKTOP_SIGNING_IDENTITY is required",
+      );
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it("rejects conflicting aliases before signing or notarization", () => {
+    const result = runPackagedAppHelper("canonical-only", {
+      signingIdentity: { canonical: "", legacy: ` ${randomUUID()} ` },
+    });
+
+    expect(result.process.status).toBe(1);
+    expect(result.trace).toBe("");
+    expectSigningIdentitySource(result, undefined);
+    expect(result.process.stderr).toContain(
+      `Desktop signing identity environment aliases conflict: canonical_key=${canonicalSigningIdentityAlias} legacy_key=${legacySigningIdentityAlias} state=conflict`,
+    );
+    expectNoSensitiveValueDisclosure(result);
   });
 });


### PR DESCRIPTION
## Summary

- add one shared, synchronous Desktop signing-identity resolver for `OKOU_DESKTOP_SIGNING_IDENTITY` and `VM0_DESKTOP_SIGNING_IDENTITY`, using exact presence and byte equality without trimming or normalization
- use the resolver at the Forge and packaged-app JavaScript signing entry points while preserving Forge CI/local fallbacks and the packaged helper's exact legacy required-variable failure
- fail closed on conflicts before any signing or notarization call and emit only fixed, value-free source evidence for canonical-only, legacy-only, and byte-equal dual inputs
- cover the complete input matrix at both real Node entry points, including explicit-empty aliases, call prevention, unchanged signing options, and value non-disclosure

## Base and overlap audit

- refreshed `origin/main` immediately before implementation and based this change on exact SHA `c31a72a0c68e5435179097d73e498b60b6de0bd4`
- audited every `OKOU_DESKTOP_SIGNING_IDENTITY` and `VM0_DESKTOP_SIGNING_IDENTITY` occurrence before editing
- fully checked all 30 open PRs; only #25722 overlaps the out-of-scope `.github/workflows/release-please.yml`, and its fully paginated 185-file list does not touch either JavaScript reader, the focused entry-point test, or the new resolver
- verified `.github/workflows/release-please.yml` is byte-for-byte identical to the base blob `9cca52e89178607ee46e1522f24f01b615e9cc46`; every production writer and shell consumer remains legacy-only

## Verification

- `pnpm format` with lockfile-pinned Prettier 3.8.1
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks passed
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — 12/12 tasks passed
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `node --check` for the Forge config, shared resolver, and packaged-app helper
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` — 37/37 tests passed
- `git diff --check`

PR CI remains authoritative for the repository. No full local Vitest suite or development server was run.

## Fallbacks

- `turbo/apps/desktop/scripts/desktop-signing-identity-environment.js:resolveDesktopSigningIdentityEnvironment` — dual-reads the legacy release-workflow key while new JavaScript signing readers also accept the canonical key. Surface: legacy production Desktop release workflow → new Desktop JavaScript readers, on the Desktop release path outside the frontend/backend/runner deployment model. Window and removal gate: retain through an ordinary signed release proving legacy-only evidence at both readers and the supported Desktop rollback floor; after the later atomic writer cutover, remove only when canonical-only production evidence exists, the supported rollback window has expired, and legacy-use evidence is zero. Follow-up: #28914.

This reader-only stage leaves signing, notarization credentials and options, product/platform identity, certificate and Keychain handling, artifacts, bundle identifiers, and release control flow unchanged. The production release workflow continues to supply only the existing legacy key, so reverting this PR does not require a writer rollback.

Refs #28914
Closes #29164
