### PR TITLE
test(guest-agent): exercise post-rejection event delivery

### DIFF
--- a/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
@@ -11,7 +11,8 @@ use serde_json::json;
 use std::io;
 use std::time::Duration;
 
-const TOTAL_EVENTS: usize = 34;
+const EVENT_BATCH_SIZE: usize = 32;
+const TOTAL_EVENTS: usize = EVENT_BATCH_SIZE * 3;
 
 #[tokio::test]
 async fn nonretryable_client_rejection_records_one_attempt()
@@ -70,6 +71,7 @@ async fn nonretryable_client_rejection_records_one_attempt()
 
     let rejected_request = server.next_request(Duration::from_secs(5)).await?;
     let rejected_sequences = common::event_request_sequences(&rejected_request.request)?;
+    assert_eq!(rejected_sequences.len(), EVENT_BATCH_SIZE);
     let rejected_request_id = rejected_request
         .request
         .client_request_id
@@ -77,8 +79,18 @@ async fn nonretryable_client_rejection_records_one_attempt()
         .ok_or_else(|| io::Error::other("rejected request omitted x-client-request-id"))?;
     rejected_request.respond(400)?;
 
+    let later_request = server.next_request(Duration::from_secs(5)).await?;
+    let later_sequences = common::event_request_sequences(&later_request.request)?;
+    assert_eq!(later_sequences.len(), EVENT_BATCH_SIZE);
+    assert_ne!(
+        later_sequences, rejected_sequences,
+        "a non-retryable 4xx response must not retry the rejected batch"
+    );
+    later_request.respond(200)?;
+
     let mut logical_sequences = first_sequences;
     logical_sequences.extend(rejected_sequences.iter().copied());
+    logical_sequences.extend(later_sequences);
     while logical_sequences.len() < TOTAL_EVENTS {
         let request = server.next_request(Duration::from_secs(5)).await?;
         let sequences = common::event_request_sequences(&request.request)?;


### PR DESCRIPTION
## Summary

- expand the non-retryable event rejection fixture to guarantee a complete queued batch remains after the HTTP 400 batch
- unconditionally observe and validate that complete later batch so a stopped sender or rejected-batch retry fails the integration test
- preserve exact FIFO sequence coverage, the frozen watermark, and the existing structured single-attempt failure diagnostics

## Scope

This is a test-only change. It does not modify production event batching, retry behavior, diagnostics, APIs, protocols, persisted state, or deployment compatibility.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test event_delivery_nonretryable_failure -- --nocapture`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- repository pre-commit and commit-message hooks

Closes #29160
