### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,7 +112,7 @@ ROOTFS_DIR=""
 CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
-GO_VERSION="1.26.7"
+GO_VERSION="1.27.0"
 CLAUDE_CODE_VERSION="2.1.241"
 CODEX_CLI_VERSION="0.149.1"
 GWS_CLI_VERSION="0.22.5"
@@ -121,8 +121,8 @@ AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
 PNPM_VERSION="11.23.0"
-CHROMIUM_VERSION="151.0.7922.137-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260813T095557Z"
+CHROMIUM_VERSION="151.0.7922.173-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260824T110509Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Go from `1.26.7` to `1.27.0`.
- Update Chromium from `151.0.7922.137-1~deb12u1` to `151.0.7922.173-1~deb12u1`.
- Update the Debian Security snapshot from `20260813T095557Z` to `20260824T110509Z` for the Chromium package update.

The pinned Claude Code, Codex CLI, Google Workspace CLI, xurl, agent-browser, and pnpm versions are already current.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Confirmed Go 1.27.0 tarballs are available for amd64 and arm64.
- Confirmed Chromium, chromium-common, and chromium-sandbox 151.0.7922.173-1~deb12u1 are available for amd64 and arm64 in the selected Debian Security snapshot.
