### PR TITLE
perf(guest-agent): retain compact pi terminal state

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -12,12 +12,35 @@ use crate::error::AgentError;
 
 const PI_RPC_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+#[derive(Default)]
+struct PiAssistantTerminal {
+    failed: bool,
+    result: String,
+}
+
+impl PiAssistantTerminal {
+    fn from_message(message: &Value) -> Self {
+        let stop_reason = message.get("stopReason").and_then(Value::as_str);
+        let failed = matches!(stop_reason, Some("error" | "aborted"));
+        let result = message
+            .get("errorMessage")
+            .and_then(Value::as_str)
+            .map_or_else(|| assistant_text(message), ToString::to_string);
+        let result = if result.is_empty() {
+            stop_reason.map_or_else(String::new, |reason| format!("Pi model turn {reason}"))
+        } else {
+            result
+        };
+        Self { failed, result }
+    }
+}
+
 pub(super) struct PiRpcProjection {
     run_id: String,
     session_id: String,
     started_at: Instant,
     emitted_session_init: bool,
-    final_assistant: Option<Value>,
+    assistant_terminal: Option<PiAssistantTerminal>,
     terminal_error: bool,
 }
 
@@ -28,7 +51,7 @@ impl PiRpcProjection {
             session_id: session_id.to_string(),
             started_at: Instant::now(),
             emitted_session_init: false,
-            final_assistant: None,
+            assistant_terminal: None,
             terminal_error: false,
         }
     }
@@ -119,7 +142,7 @@ impl PiRpcProjection {
     }
 
     fn project_assistant_message(&mut self, message: &Value) -> Result<Option<Value>, AgentError> {
-        self.final_assistant = Some(message.clone());
+        self.assistant_terminal = Some(PiAssistantTerminal::from_message(message));
         let content = assistant_content(message)?;
         if content.is_empty() {
             return Ok(None);
@@ -200,27 +223,12 @@ impl PiRpcProjection {
     }
 
     fn project_agent_settled(&mut self) -> Value {
-        let assistant = self.final_assistant.take();
-        let stop_reason = assistant
-            .as_ref()
-            .and_then(|message| message.get("stopReason"))
-            .and_then(Value::as_str);
-        let failed = matches!(stop_reason, Some("error" | "aborted"));
-        let result = assistant
-            .as_ref()
-            .and_then(|message| message.get("errorMessage"))
-            .and_then(Value::as_str)
-            .map(ToString::to_string)
-            .or_else(|| assistant.as_ref().map(assistant_text))
-            .filter(|text| !text.is_empty())
-            .unwrap_or_else(|| {
-                stop_reason.map_or_else(String::new, |reason| format!("Pi model turn {reason}"))
-            });
+        let assistant = self.assistant_terminal.take().unwrap_or_default();
         json!({
             "type": "result",
-            "subtype": if failed { "error_during_execution" } else { "success" },
-            "is_error": failed,
-            "result": result,
+            "subtype": if assistant.failed { "error_during_execution" } else { "success" },
+            "is_error": assistant.failed,
+            "result": assistant.result,
             "session_id": self.session_id,
             "duration_ms": self.started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
         })

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -18,6 +18,39 @@ async fn guest_projects_pi_rpc_events_and_exposes_canonical_run_id()
     std::fs::create_dir_all(&bin_dir)?;
     let capture_path = tmp.path().join("canonical-run-id.txt");
     let payload_capture_path = tmp.path().join("pi-launch-payload-path.txt");
+    let final_assistant_event_path = tmp.path().join("pi-final-assistant-event.jsonl");
+    let large_tool_payload = "x".repeat(1024 * 1024);
+    std::fs::write(
+        &final_assistant_event_path,
+        format!(
+            "{}\n",
+            serde_json::json!({
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "text", "text": "official rpc projection" },
+                        {
+                            "type": "toolCall",
+                            "id": "tool-4",
+                            "name": "large_payload",
+                            "arguments": { "payload": large_tool_payload },
+                        },
+                    ],
+                    "model": "deepseek-v4-flash",
+                    "responseId": "response-3",
+                    "usage": {
+                        "input": 13,
+                        "output": 7,
+                        "cacheRead": 2,
+                        "cacheWrite": 1,
+                    },
+                    "stopReason": "stop",
+                    "timestamp": 6,
+                },
+            })
+        ),
+    )?;
     let npx = bin_dir.join("npx");
     std::fs::write(
         &npx,
@@ -26,6 +59,7 @@ set -eu
 test -n "${OKOU_RUN_ID:-}"
 test -z "${OKOU_PI_LAUNCH_CONFIG:-}"
 test -n "${OKOU_PI_LAUNCH_PAYLOAD_FILE:-}"
+test -n "${PI_FINAL_ASSISTANT_EVENT_PATH:-}"
 printf '%s' "$OKOU_RUN_ID" > "$RUN_ID_CAPTURE_PATH"
 printf '%s' "$OKOU_PI_LAUNCH_PAYLOAD_FILE" > "$PI_PAYLOAD_CAPTURE_PATH"
 IFS= read -r state_command
@@ -49,7 +83,7 @@ printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId"
 printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"checking both"},{"type":"toolCall","id":"tool-2","name":"read_file","arguments":{"path":"README.md"}},{"type":"text","text":"and"},{"type":"toolCall","id":"tool-3","name":"render_image","arguments":{"format":"png"}}],"model":"deepseek-v4-flash","responseId":"response-2","usage":{"input":8,"output":5,"cacheRead":2,"cacheWrite":1},"stopReason":"toolUse","timestamp":3}}'
 printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-2","toolName":"read_file","content":[{"type":"text","text":"file contents"}],"isError":false,"timestamp":4}}'
 printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-3","toolName":"render_image","content":[{"type":"text","text":"render failed"},{"type":"image","data":"aW1hZ2U=","mimeType":"image/png"}],"isError":true,"timestamp":5}}'
-printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"official rpc projection"}],"model":"deepseek-v4-flash","responseId":"response-3","usage":{"input":13,"output":7,"cacheRead":2,"cacheWrite":1},"stopReason":"stop","timestamp":6}}'
+cat "$PI_FINAL_ASSISTANT_EVENT_PATH"
 printf '%s\n' '{"type":"agent_settled"}'
 if IFS= read -r unexpected; then
   exit 23
@@ -106,6 +140,10 @@ fi
                 (
                     "PI_PAYLOAD_CAPTURE_PATH".to_string(),
                     payload_capture_path.to_string_lossy().into_owned(),
+                ),
+                (
+                    "PI_FINAL_ASSISTANT_EVENT_PATH".to_string(),
+                    final_assistant_event_path.to_string_lossy().into_owned(),
                 ),
             ]),
         )?;
@@ -255,6 +293,30 @@ fi
     assert_eq!(
         delivered_events[6].pointer("/message/content/0/text"),
         Some(&Value::String("official rpc projection".to_string()))
+    );
+    assert_eq!(
+        delivered_events[6].pointer("/message/content/1/type"),
+        Some(&Value::String("tool_use".to_string()))
+    );
+    assert_eq!(delivered_events[6]["message"]["content"][1]["id"], "tool-4");
+    assert_eq!(
+        delivered_events[6]["message"]["content"][1]["name"],
+        "large_payload"
+    );
+    assert_eq!(
+        delivered_events[6]["message"]["content"][1]["input"]["payload"]
+            .as_str()
+            .map(str::len),
+        Some(1024 * 1024)
+    );
+    assert_eq!(
+        delivered_events[6]["message"]["usage"],
+        serde_json::json!({
+            "input_tokens": 13,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 2,
+            "cache_creation_input_tokens": 1,
+        })
     );
     assert_eq!(delivered_events[7]["type"], "result");
     assert_eq!(delivered_events[7]["subtype"], "success");

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -1,0 +1,198 @@
+//! Pi CLI terminal results preserve error-message and aborted fallback
+//! semantics through the guest's public event projection.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+
+async fn run_settlement_case(
+    run_id: &str,
+    assistant_message: &Value,
+    expected_result: &str,
+    base_path: &OsStr,
+    original_directory: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let assistant_event_path = tmp.path().join("pi-assistant-event.jsonl");
+    std::fs::write(
+        &assistant_event_path,
+        format!(
+            "{}\n",
+            serde_json::json!({
+                "type": "message_end",
+                "message": assistant_message,
+            })
+        ),
+    )?;
+
+    let npx = bin_dir.join("npx");
+    std::fs::write(
+        &npx,
+        r#"#!/bin/sh
+set -eu
+IFS= read -r state_command
+case "$state_command" in
+  *'"type":"get_state"'*) ;;
+  *) exit 21 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:get-state\",\"type\":\"response\",\"command\":\"get_state\",\"success\":true,\"data\":{\"sessionId\":\"11111111-1111-4111-8111-111111111111\",\"sessionFile\":\"/home/user/.pi/agent/sessions/--home-user-workspace--/session.jsonl\"}}"
+IFS= read -r prompt_command
+case "$prompt_command" in
+  *'"type":"prompt"'*) ;;
+  *) exit 22 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:initial-prompt\",\"type\":\"response\",\"command\":\"prompt\",\"success\":true}"
+cat "$PI_ASSISTANT_EVENT_PATH"
+printf '%s\n' '{"type":"agent_settled"}'
+if IFS= read -r unexpected; then
+  exit 23
+fi
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&npx)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&npx, permissions)?;
+
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)?;
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
+        std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
+        std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(
+            guest_contracts::env::SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var("HOME", tmp.path());
+        let mut paths = vec![bin_dir];
+        paths.extend(std::env::split_paths(base_path));
+        std::env::set_var("PATH", std::env::join_paths(paths)?);
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "verify Pi terminal result".to_string(),
+                pi_launch_config:
+                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#
+                        .to_string(),
+                pi_model_config: "{}".to_string(),
+                pi_session_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
+        common::set_user_env_file_env_for_test(
+            &runtime_dir,
+            &HashMap::from([
+                (
+                    "CLI_PKG_URL".to_string(),
+                    "https://example.invalid/current-okou-cli.tgz".to_string(),
+                ),
+                (
+                    "PI_ASSISTANT_EVENT_PATH".to_string(),
+                    assistant_event_path.to_string_lossy().into_owned(),
+                ),
+            ]),
+        )?;
+    }
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(tmp.path())?;
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        ),
+    )
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "Pi CLI process timed out"))??;
+
+    std::env::set_current_dir(original_directory)?;
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(
+        result.claude_result.map(|summary| summary.status),
+        Some(guest_agent::cli::ClaudeResultStatus::Error)
+    );
+
+    let mut delivered_events = Vec::new();
+    for request in server.requests()? {
+        let body: Value = serde_json::from_str(&request.body)?;
+        delivered_events.extend(
+            body.get("events")
+                .and_then(Value::as_array)
+                .ok_or_else(|| std::io::Error::other("Pi event request omitted its events"))?
+                .iter()
+                .cloned(),
+        );
+    }
+    let assistant = delivered_events
+        .iter()
+        .find(|event| event["type"] == "assistant")
+        .ok_or_else(|| std::io::Error::other("assistant event was not delivered"))?;
+    assert_eq!(
+        assistant.pointer("/message/content/0/text"),
+        Some(&Value::String("ignored assistant text".to_string()))
+    );
+    let terminal = delivered_events
+        .iter()
+        .find(|event| event["type"] == "result")
+        .ok_or_else(|| std::io::Error::other("terminal result was not delivered"))?;
+    assert_eq!(terminal["subtype"], "error_during_execution");
+    assert_eq!(terminal["is_error"], true);
+    assert_eq!(terminal["result"], expected_result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_preserves_pi_error_and_aborted_settlement_results()
+-> Result<(), Box<dyn std::error::Error>> {
+    let base_path = std::env::var_os("PATH").unwrap_or_default();
+    let original_directory = std::env::current_dir()?;
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000124",
+        &serde_json::json!({
+            "role": "assistant",
+            "content": [{ "type": "text", "text": "ignored assistant text" }],
+            "model": "deepseek-v4-flash",
+            "responseId": "response-error",
+            "usage": {},
+            "stopReason": "error",
+            "errorMessage": "provider failed",
+            "timestamp": 1,
+        }),
+        "provider failed",
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000125",
+        &serde_json::json!({
+            "role": "assistant",
+            "content": [{ "type": "text", "text": "ignored assistant text" }],
+            "model": "deepseek-v4-flash",
+            "responseId": "response-aborted",
+            "usage": {},
+            "stopReason": "aborted",
+            "errorMessage": "",
+            "timestamp": 1,
+        }),
+        "Pi model turn aborted",
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- replace Pi's retained full assistant JSON with a compact terminal result snapshot
- preserve public assistant events, including large tool-call arguments and usage fields
- cover success, error-message, aborted fallback, successive-message, and large-payload behavior through the guest-agent CLI boundary

## Scope

This changes only the internal state retained between Pi `message_end` and `agent_settled`. It does not change public event schemas, API contracts, persistence, deployment compatibility, or event-delivery payload limits.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test pi_cli_run_id_env`
- `cargo test -p guest-agent --test pi_cli_settlement_errors`
- `cargo test -p guest-agent --all-targets --all-features`
- pre-commit workspace Cargo formatting, documentation, Clippy, and file-size hooks

Closes #29148
