### PR TITLE
feat(social): add managed socialkit pagination and usage billing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -59,6 +59,11 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
     path: "/linkedin/company-posts",
     queryNames: ["url", "limit", "cache", "cache_ttl"],
     maxLimit: 50,
+    collection: {
+      resultField: "posts",
+      defaultLimit: 10,
+      pagination: { kind: "none" },
+    },
   },
   { path: "/linkedin/post", queryNames: ["url", "cache", "cache_ttl"] },
   {
@@ -70,6 +75,11 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
     path: "/twitter/tweets",
     queryNames: ["url", "limit", "cursor", "cache", "cache_ttl"],
     maxLimit: 100,
+    collection: {
+      resultField: "tweets",
+      defaultLimit: 20,
+      pagination: { kind: "next_cursor" },
+    },
   },
   { path: "/twitter/tweet", queryNames: ["url", "cache", "cache_ttl"] },
   { path: "/twitter/thread", queryNames: ["url", "cache", "cache_ttl"] },
@@ -89,7 +99,13 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
   {
     path: "/facebook/comments",
     queryNames: ["url", "limit", "cursor"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/facebook/summarize",
@@ -113,19 +129,44 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
   {
     path: "/instagram/comments",
     queryNames: ["url", "limit", "cursor", "sortBy"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/instagram/channel-posts",
     queryNames: ["url", "limit", "cursor"],
-    maxLimit: 20,
+    maxLimit: 100,
+    collection: {
+      resultField: "items",
+      defaultLimit: 12,
+      itemsPerBillingUnit: 20,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/instagram/channel-reels",
     queryNames: ["url", "limit", "cursor"],
-    maxLimit: 20,
+    maxLimit: 100,
+    collection: {
+      resultField: "items",
+      defaultLimit: 12,
+      itemsPerBillingUnit: 20,
+      pagination: { kind: "cursor" },
+    },
   },
-  { path: "/instagram/reels-search", queryNames: ["query", "page"] },
+  {
+    path: "/instagram/reels-search",
+    queryNames: ["query", "page"],
+    collection: {
+      resultField: "items",
+      pagination: { kind: "page", maxPage: 2 },
+    },
+  },
   {
     path: "/instagram/summarize",
     queryNames: [
@@ -140,7 +181,13 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
   {
     path: "/tiktok/comments",
     queryNames: ["url", "limit", "cursor"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/transcript",
@@ -153,7 +200,12 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
   {
     path: "/tiktok/channel-videos",
     queryNames: ["url", "limit", "cursor", "cache", "cache_ttl"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 30,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/search",
@@ -166,12 +218,24 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
       "cache",
       "cache_ttl",
     ],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/hashtag-search",
     queryNames: ["hashtag", "limit", "cursor", "cache", "cache_ttl"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/summarize",
@@ -191,7 +255,13 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
   {
     path: "/youtube/comments",
     queryNames: ["url", "limit", "sortBy"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/channel-stats",
@@ -208,12 +278,24 @@ const EXPECTED_PAIRED_SOCIALKIT_PATHS = [
       "cache",
       "cache_ttl",
     ],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/videos",
     queryNames: ["url", "limit", "full_details", "cache", "cache_ttl"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/summarize",
@@ -374,6 +456,23 @@ function providerResponse(data: unknown = { value: "provider result" }) {
   return { success: true, data };
 }
 
+function validProviderData(path: string): Record<string, unknown> {
+  const operation = MANAGED_SOCIALKIT_OPERATIONS.find((candidate) => {
+    return candidate.method === "GET" && candidate.path === path;
+  });
+  const collection = operation?.collection;
+  if (!collection) {
+    return { path };
+  }
+  const result: Record<string, unknown> = {
+    [collection.resultField]: [],
+  };
+  return collection.pagination.kind === "cursor" ||
+    collection.pagination.kind === "page"
+    ? { ...result, hasMore: false }
+    : result;
+}
+
 function providerHandler(
   method: "GET" | "POST",
   path: string,
@@ -386,7 +485,7 @@ function providerHandler(
 }
 
 describe("managed SocialKit route", () => {
-  it("pins the reviewed 76-operation fixed-cost inventory", () => {
+  it("pins the reviewed 76-operation inventory and collection policies", () => {
     const expectedOperations = EXPECTED_PAIRED_SOCIALKIT_PATHS.flatMap(
       (operation) => {
         return [
@@ -593,7 +692,7 @@ describe("managed SocialKit route", () => {
     for (const [path] of cases) {
       server.use(
         providerHandler("GET", path, () => {
-          return HttpResponse.json(providerResponse({ path }));
+          return HttpResponse.json(providerResponse(validProviderData(path)));
         }),
       );
     }
@@ -607,7 +706,9 @@ describe("managed SocialKit route", () => {
           queryValue: query[0]?.[1] ?? "",
           accessKey: request.headers.get("x-access-key"),
         });
-        return HttpResponse.json(providerResponse({ path: url.pathname }));
+        return HttpResponse.json(
+          providerResponse(validProviderData(url.pathname)),
+        );
       }),
     );
     const beforeCredits = await credits(actor);
@@ -635,7 +736,7 @@ describe("managed SocialKit route", () => {
         billingCategory: DEFAULT_CATEGORY,
         billingQuantity: 1,
         creditsCharged: SOCIALKIT_REQUEST_CREDITS,
-        result: { path },
+        result: validProviderData(path),
       });
     }
 
@@ -673,7 +774,9 @@ describe("managed SocialKit route", () => {
           observedUrl = request.url;
           observedAccessKey = request.headers.get("x-access-key");
           observedBody = await request.text();
-          return HttpResponse.json(providerResponse({ page: 2 }));
+          return HttpResponse.json(
+            providerResponse({ items: [], hasMore: false, page: 2 }),
+          );
         },
       ),
     );
@@ -699,7 +802,8 @@ describe("managed SocialKit route", () => {
       billingCategory: DEFAULT_CATEGORY,
       billingQuantity: 1,
       creditsCharged: SOCIALKIT_REQUEST_CREDITS,
-      result: { page: 2 },
+      collection: { state: "complete", itemsReturned: 0 },
+      result: { items: [], hasMore: false, page: 2 },
     });
     expect(beforeCredits - (await credits(actor))).toBe(
       SOCIALKIT_REQUEST_CREDITS,
@@ -762,7 +866,9 @@ describe("managed SocialKit route", () => {
           path: url.pathname,
           query: Object.fromEntries(url.searchParams),
         });
-        return HttpResponse.json(providerResponse());
+        return HttpResponse.json(
+          providerResponse(validProviderData(url.pathname)),
+        );
       }),
     );
 
@@ -777,6 +883,242 @@ describe("managed SocialKit route", () => {
     }
 
     expect(observed).toStrictEqual(cases);
+  });
+
+  it("settles result-metered pages from validated returned item counts", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    await fundActor(actor);
+    const pricing = await setupConfiguredPricing();
+    const beforeCredits = await credits(actor);
+    const cases = [
+      {
+        path: "/youtube/search",
+        query: { query: "launch", limit: "100" },
+        data: { results: Array.from({ length: 20 }, (_, id) => ({ id })) },
+        expectedQuantity: 1,
+        expectedState: "provider_limited",
+      },
+      {
+        path: "/youtube/search",
+        query: { query: "launch", limit: "100" },
+        data: { results: Array.from({ length: 100 }, (_, id) => ({ id })) },
+        expectedQuantity: 2,
+        expectedState: "provider_limited",
+      },
+      {
+        path: "/instagram/channel-posts",
+        query: { url: "https://instagram.com/example", limit: "100" },
+        data: {
+          items: Array.from({ length: 20 }, (_, id) => ({ id })),
+          hasMore: false,
+        },
+        expectedQuantity: 1,
+        expectedState: "complete",
+      },
+      {
+        path: "/instagram/channel-posts",
+        query: { url: "https://instagram.com/example", limit: "100" },
+        data: {
+          items: Array.from({ length: 21 }, (_, id) => ({ id })),
+          hasMore: false,
+        },
+        expectedQuantity: 2,
+        expectedState: "complete",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      server.use(
+        providerHandler("GET", testCase.path, () => {
+          return HttpResponse.json(providerResponse(testCase.data));
+        }),
+      );
+      const response = await accept(
+        client(pricing.resolution)(socialContract).request({
+          headers: authenticate(actor),
+          body: {
+            method: "GET",
+            path: testCase.path,
+            query: testCase.query,
+          },
+        }),
+        [200],
+      );
+
+      expect(response.body.billingQuantity).toBe(testCase.expectedQuantity);
+      expect(response.body.creditsCharged).toBe(
+        testCase.expectedQuantity * SOCIALKIT_REQUEST_CREDITS,
+      );
+      expect(response.body.collection).toMatchObject({
+        state: testCase.expectedState,
+        itemsReturned:
+          testCase.path === "/youtube/search"
+            ? testCase.data.results.length
+            : testCase.data.items.length,
+      });
+    }
+
+    expect(beforeCredits - (await credits(actor))).toBe(
+      6 * SOCIALKIT_REQUEST_CREDITS,
+    );
+  });
+
+  it("normalizes every reviewed pagination shape", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    await fundActor(actor);
+    const pricing = await setupConfiguredPricing();
+    const cases = [
+      {
+        path: "/tiktok/search",
+        query: { query: "launch", limit: "10" },
+        data: { results: [{ id: 1 }], hasMore: true, cursor: 30 },
+        expected: {
+          state: "more",
+          itemsReturned: 1,
+          nextQuery: { cursor: "30" },
+        },
+      },
+      {
+        path: "/twitter/tweets",
+        query: { url: "https://x.com/example", limit: "20" },
+        data: { tweets: [{ id: 1 }], nextCursor: "next-tweet" },
+        expected: {
+          state: "more",
+          itemsReturned: 1,
+          nextQuery: { cursor: "next-tweet" },
+        },
+      },
+      {
+        path: "/instagram/reels-search",
+        query: { query: "cats", page: "1" },
+        data: { items: [{ id: 1 }], hasMore: true },
+        expected: {
+          state: "more",
+          itemsReturned: 1,
+          nextQuery: { page: "2" },
+        },
+      },
+      {
+        path: "/instagram/reels-search",
+        query: { query: "cats", page: "2" },
+        data: { items: [{ id: 2 }], hasMore: true },
+        expected: { state: "provider_limited", itemsReturned: 1 },
+      },
+      {
+        path: "/linkedin/company-posts",
+        query: { url: "https://linkedin.com/company/example", limit: "50" },
+        data: { posts: [{ id: 1 }] },
+        expected: { state: "provider_limited", itemsReturned: 1 },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      server.use(
+        providerHandler("GET", testCase.path, () => {
+          return HttpResponse.json(providerResponse(testCase.data));
+        }),
+      );
+      const response = await accept(
+        client(pricing.resolution)(socialContract).request({
+          headers: authenticate(actor),
+          body: {
+            method: "GET",
+            path: testCase.path,
+            query: testCase.query,
+          },
+        }),
+        [200],
+      );
+
+      expect(response.body.collection).toStrictEqual(testCase.expected);
+    }
+  });
+
+  it("preflights the maximum result-metered quantity before provider work", async () => {
+    const actor = createBddApi(context).user();
+    let providerRequests = 0;
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await bootstrapOnboarding(actor);
+    await setActorCredits(actor, SOCIALKIT_REQUEST_CREDITS);
+    await enableSocialKit(actor);
+    server.use(
+      providerHandler("GET", "/youtube/search", () => {
+        providerRequests += 1;
+        return HttpResponse.json(providerResponse({ results: [] }));
+      }),
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          method: "GET",
+          path: "/youtube/search",
+          query: { query: "launch", limit: "100" },
+        },
+      }),
+      [402],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expect(providerRequests).toBe(0);
+  });
+
+  it("rejects invalid collection successes without billing", async () => {
+    const actor = createBddApi(context).user();
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    const cases = [
+      {
+        path: "/youtube/search",
+        query: { query: "launch", limit: "10" },
+        data: { value: "missing results" },
+      },
+      {
+        path: "/youtube/search",
+        query: { query: "launch", limit: "10" },
+        data: { results: Array.from({ length: 11 }, (_, id) => ({ id })) },
+      },
+      {
+        path: "/instagram/comments",
+        query: { url: "https://instagram.com/p/example", limit: "10" },
+        data: { comments: [], hasMore: true },
+      },
+      {
+        path: "/instagram/reels-search",
+        query: { query: "cats", page: "1" },
+        data: { items: [] },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      server.use(
+        providerHandler("GET", testCase.path, () => {
+          return HttpResponse.json(providerResponse(testCase.data));
+        }),
+      );
+      const response = await accept(
+        client(pricing.resolution)(socialContract).request({
+          headers: authenticate(actor),
+          body: {
+            method: "GET",
+            path: testCase.path,
+            query: testCase.query,
+          },
+        }),
+        [502],
+      );
+
+      expectApiError(response.body);
+      expect(response.body.error.code).toBe("SOCIALKIT_INVALID_RESPONSE");
+    }
+    await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
 
   it.each([
@@ -926,27 +1268,27 @@ describe("managed SocialKit route", () => {
       },
     },
     {
-      caseName: "a result limit above one provider credit",
+      caseName: "a result limit above the provider maximum",
       body: {
         method: "GET",
         path: "/youtube/comments",
-        query: { url: "https://youtu.be/id", limit: "51" },
+        query: { url: "https://youtu.be/id", limit: "101" },
       },
     },
     {
-      caseName: "a video-list limit above one provider credit",
+      caseName: "a video-list limit above the provider maximum",
       body: {
         method: "GET",
         path: "/tiktok/channel-videos",
-        query: { url: "https://tiktok.com/@example", limit: "51" },
+        query: { url: "https://tiktok.com/@example", limit: "101" },
       },
     },
     {
-      caseName: "a result limit above the smaller provider credit unit",
+      caseName: "an Instagram result limit above the provider maximum",
       body: {
         method: "GET",
         path: "/instagram/channel-posts",
-        query: { url: "https://instagram.com/example", limit: "21" },
+        query: { url: "https://instagram.com/example", limit: "101" },
       },
     },
     {
@@ -1308,7 +1650,7 @@ describe("managed SocialKit route", () => {
     );
   });
 
-  it("records concurrent successful requests exactly once each", async () => {
+  it("records concurrent multi-unit requests exactly once each", async () => {
     const actor = createBddApi(context).user();
     let providerRequests = 0;
     configureProvider();
@@ -1316,35 +1658,46 @@ describe("managed SocialKit route", () => {
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
-      providerHandler("GET", "/youtube/transcript", () => {
+      providerHandler("GET", "/youtube/search", () => {
         providerRequests += 1;
-        return HttpResponse.json(providerResponse());
+        return HttpResponse.json(
+          providerResponse({
+            results: Array.from({ length: 100 }, (_, id) => ({ id })),
+          }),
+        );
       }),
     );
     const socialClient = client(pricing.resolution)(socialContract);
+    const request = {
+      method: "GET",
+      path: "/youtube/search",
+      query: { query: "launch", limit: "100" },
+    } as const;
 
     const [first, second] = await Promise.all([
       accept(
         socialClient.request({
           headers: authenticate(actor),
-          body: DEFAULT_SOCIAL_REQUEST,
+          body: request,
         }),
         [200],
       ),
       accept(
         socialClient.request({
           headers: authenticate(actor),
-          body: DEFAULT_SOCIAL_REQUEST,
+          body: request,
         }),
         [200],
       ),
     ]);
 
-    expect(first.body.creditsCharged).toBe(SOCIALKIT_REQUEST_CREDITS);
-    expect(second.body.creditsCharged).toBe(SOCIALKIT_REQUEST_CREDITS);
+    expect(first.body.billingQuantity).toBe(2);
+    expect(second.body.billingQuantity).toBe(2);
+    expect(first.body.creditsCharged).toBe(2 * SOCIALKIT_REQUEST_CREDITS);
+    expect(second.body.creditsCharged).toBe(2 * SOCIALKIT_REQUEST_CREDITS);
     expect(providerRequests).toBe(2);
     expect(beforeCredits - (await credits(actor))).toBe(
-      2 * SOCIALKIT_REQUEST_CREDITS,
+      4 * SOCIALKIT_REQUEST_CREDITS,
     );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -456,6 +456,12 @@ function providerResponse(data: unknown = { value: "provider result" }) {
   return { success: true, data };
 }
 
+function providerItems(count: number): { readonly id: number }[] {
+  return Array.from({ length: count }, (_, id) => {
+    return { id };
+  });
+}
+
 function validProviderData(path: string): Record<string, unknown> {
   const operation = MANAGED_SOCIALKIT_OPERATIONS.find((candidate) => {
     return candidate.method === "GET" && candidate.path === path;
@@ -895,14 +901,14 @@ describe("managed SocialKit route", () => {
       {
         path: "/youtube/search",
         query: { query: "launch", limit: "100" },
-        data: { results: Array.from({ length: 20 }, (_, id) => ({ id })) },
+        data: { results: providerItems(20) },
         expectedQuantity: 1,
         expectedState: "provider_limited",
       },
       {
         path: "/youtube/search",
         query: { query: "launch", limit: "100" },
-        data: { results: Array.from({ length: 100 }, (_, id) => ({ id })) },
+        data: { results: providerItems(100) },
         expectedQuantity: 2,
         expectedState: "provider_limited",
       },
@@ -910,7 +916,7 @@ describe("managed SocialKit route", () => {
         path: "/instagram/channel-posts",
         query: { url: "https://instagram.com/example", limit: "100" },
         data: {
-          items: Array.from({ length: 20 }, (_, id) => ({ id })),
+          items: providerItems(20),
           hasMore: false,
         },
         expectedQuantity: 1,
@@ -920,7 +926,7 @@ describe("managed SocialKit route", () => {
         path: "/instagram/channel-posts",
         query: { url: "https://instagram.com/example", limit: "100" },
         data: {
-          items: Array.from({ length: 21 }, (_, id) => ({ id })),
+          items: providerItems(21),
           hasMore: false,
         },
         expectedQuantity: 2,
@@ -962,6 +968,46 @@ describe("managed SocialKit route", () => {
     expect(beforeCredits - (await credits(actor))).toBe(
       6 * SOCIALKIT_REQUEST_CREDITS,
     );
+  });
+
+  it("sends the reviewed default limit used for credit preflight", async () => {
+    const actor = createBddApi(context).user();
+    let observedLimit: string | null = null;
+    configureProvider();
+    const pricing = await setupConfiguredPricing();
+    await bootstrapOnboarding(actor);
+    await setActorCredits(actor, SOCIALKIT_REQUEST_CREDITS);
+    await enableSocialKit(actor);
+    server.use(
+      http.get(`${SOCIALKIT_BASE}/youtube/search`, ({ request }) => {
+        observedLimit = new URL(request.url).searchParams.get("limit");
+        return HttpResponse.json(
+          providerResponse({
+            results: providerItems(10),
+          }),
+        );
+      }),
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(socialContract).request({
+        headers: authenticate(actor),
+        body: {
+          method: "GET",
+          path: "/youtube/search",
+          query: { query: "launch" },
+        },
+      }),
+      [200],
+    );
+
+    expect(observedLimit).toBe("10");
+    expect(response.body.billingQuantity).toBe(1);
+    expect(response.body.collection).toStrictEqual({
+      state: "provider_limited",
+      itemsReturned: 10,
+    });
+    await expect(credits(actor)).resolves.toBe(0);
   });
 
   it("normalizes every reviewed pagination shape", async () => {
@@ -1083,7 +1129,7 @@ describe("managed SocialKit route", () => {
       {
         path: "/youtube/search",
         query: { query: "launch", limit: "10" },
-        data: { results: Array.from({ length: 11 }, (_, id) => ({ id })) },
+        data: { results: providerItems(11) },
       },
       {
         path: "/instagram/comments",
@@ -1662,7 +1708,7 @@ describe("managed SocialKit route", () => {
         providerRequests += 1;
         return HttpResponse.json(
           providerResponse({
-            results: Array.from({ length: 100 }, (_, id) => ({ id })),
+            results: providerItems(100),
           }),
         );
       }),

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -1,7 +1,9 @@
 import {
   findManagedSocialKitOperation,
   MANAGED_SOCIALKIT_BILLING_CATEGORY,
+  SOCIALKIT_MAX_QUERY_VALUE_CHARS,
   type ManagedSocialKitOperation,
+  type ManagedSocialKitPagination,
   type SocialKitRequest,
   type SocialKitResponse,
 } from "@okouai/api-contracts/contracts/social";
@@ -71,7 +73,7 @@ interface CompleteSocialKitArgs {
   readonly accessKey: string;
   readonly request: SocialKitRequest;
   readonly operation: ManagedSocialKitOperation;
-  readonly recordUsage: () => Promise<number>;
+  readonly recordUsage: (quantity: number) => Promise<number>;
 }
 
 type SocialKitCommandResponse =
@@ -272,8 +274,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function providerResult(
   body: unknown,
   accessKey: string,
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
 ):
-  | { readonly ok: true; readonly result: unknown }
+  | {
+      readonly ok: true;
+      readonly result: unknown;
+      readonly collection: SocialKitResponse["collection"];
+      readonly billingQuantity: number;
+    }
   | { readonly ok: false; readonly credentialLeak: boolean } {
   if (
     !isRecord(body) ||
@@ -290,7 +299,172 @@ function providerResult(
   if (serialized.includes(accessKey)) {
     return { ok: false, credentialLeak: true };
   }
-  return { ok: true, result: body.data };
+  const collection = validatedCollection(body.data, request, operation);
+  if (collection === undefined) {
+    return { ok: false, credentialLeak: false };
+  }
+  const billingQuantity = operation.collection?.itemsPerBillingUnit
+    ? Math.max(
+        1,
+        Math.ceil(
+          collection === null
+            ? 0
+            : collection.itemsReturned /
+                operation.collection.itemsPerBillingUnit,
+        ),
+      )
+    : 1;
+  return {
+    ok: true,
+    result: body.data,
+    collection,
+    billingQuantity,
+  };
+}
+
+function effectiveResultLimit(
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
+): number | undefined {
+  const defaultLimit = operation.collection?.defaultLimit;
+  if (defaultLimit === undefined) {
+    return undefined;
+  }
+  const requestedLimit = request.query?.limit;
+  return requestedLimit === undefined ? defaultLimit : Number(requestedLimit);
+}
+
+function paginationQueryValue(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return String(value);
+  }
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= SOCIALKIT_MAX_QUERY_VALUE_CHARS
+    ? value
+    : undefined;
+}
+
+type ValidatedCollection = NonNullable<SocialKitResponse["collection"]>;
+
+function validatedCursorPagination(
+  result: Record<string, unknown>,
+  itemsReturned: number,
+): ValidatedCollection | undefined {
+  if (typeof result.hasMore !== "boolean") {
+    return undefined;
+  }
+  if (!result.hasMore) {
+    return { state: "complete", itemsReturned };
+  }
+  const cursor = paginationQueryValue(result.cursor);
+  return cursor === undefined
+    ? undefined
+    : { state: "more", itemsReturned, nextQuery: { cursor } };
+}
+
+function validatedNextCursorPagination(
+  result: Record<string, unknown>,
+  itemsReturned: number,
+): ValidatedCollection | undefined {
+  if (
+    result.nextCursor === undefined ||
+    result.nextCursor === null ||
+    result.nextCursor === ""
+  ) {
+    return { state: "complete", itemsReturned };
+  }
+  const cursor = paginationQueryValue(result.nextCursor);
+  return cursor === undefined
+    ? undefined
+    : { state: "more", itemsReturned, nextQuery: { cursor } };
+}
+
+function validatedPagePagination(
+  result: Record<string, unknown>,
+  itemsReturned: number,
+  currentPage: number,
+  maxPage: number,
+): ValidatedCollection | undefined {
+  if (typeof result.hasMore !== "boolean") {
+    return undefined;
+  }
+  if (!result.hasMore) {
+    return { state: "complete", itemsReturned };
+  }
+  return currentPage >= maxPage
+    ? { state: "provider_limited", itemsReturned }
+    : {
+        state: "more",
+        itemsReturned,
+        nextQuery: { page: String(currentPage + 1) },
+      };
+}
+
+function validatedPagination(
+  result: Record<string, unknown>,
+  itemsReturned: number,
+  request: SocialKitRequest,
+  pagination: ManagedSocialKitPagination,
+): ValidatedCollection | undefined {
+  switch (pagination.kind) {
+    case "cursor": {
+      return validatedCursorPagination(result, itemsReturned);
+    }
+    case "next_cursor": {
+      return validatedNextCursorPagination(result, itemsReturned);
+    }
+    case "page": {
+      return validatedPagePagination(
+        result,
+        itemsReturned,
+        Number(request.query?.page ?? "1"),
+        pagination.maxPage,
+      );
+    }
+    case "none": {
+      return { state: "provider_limited", itemsReturned };
+    }
+  }
+}
+
+function validatedCollection(
+  result: unknown,
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
+): SocialKitResponse["collection"] | undefined {
+  const collection = operation.collection;
+  if (!collection) {
+    return null;
+  }
+  if (!isRecord(result)) {
+    return undefined;
+  }
+  const items = result[collection.resultField];
+  if (!Array.isArray(items)) {
+    return undefined;
+  }
+  const effectiveLimit = effectiveResultLimit(request, operation);
+  if (effectiveLimit !== undefined && items.length > effectiveLimit) {
+    return undefined;
+  }
+  return validatedPagination(
+    result,
+    items.length,
+    request,
+    collection.pagination,
+  );
+}
+
+function preflightBillingQuantity(
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
+): number {
+  const itemsPerBillingUnit = operation.collection?.itemsPerBillingUnit;
+  const resultLimit = effectiveResultLimit(request, operation);
+  return itemsPerBillingUnit === undefined || resultLimit === undefined
+    ? 1
+    : Math.max(1, Math.ceil(resultLimit / itemsPerBillingUnit));
 }
 
 function runIdForUsage(auth: AuthContext): string | undefined {
@@ -312,7 +486,12 @@ async function completeSocialKitRequest(
   if (providerResponse.kind === "error") {
     return providerResponse.error;
   }
-  const parsed = providerResult(providerResponse.body, args.accessKey);
+  const parsed = providerResult(
+    providerResponse.body,
+    args.accessKey,
+    args.request,
+    args.operation,
+  );
   if (!parsed.ok) {
     const failureKind = parsed.credentialLeak
       ? "credential_leak"
@@ -320,7 +499,7 @@ async function completeSocialKitRequest(
     logProviderFailure(args.operation, failureKind);
     return invalidResponse();
   }
-  const creditsCharged = await args.recordUsage();
+  const creditsCharged = await args.recordUsage(parsed.billingQuantity);
   return {
     status: 200,
     body: {
@@ -330,8 +509,9 @@ async function completeSocialKitRequest(
         path: args.operation.path,
       },
       billingCategory: MANAGED_SOCIALKIT_BILLING_CATEGORY,
-      billingQuantity: 1,
+      billingQuantity: parsed.billingQuantity,
       creditsCharged,
+      collection: parsed.collection,
       result: parsed.result,
     },
   };
@@ -361,18 +541,18 @@ export const socialKitRequest$ = command(
     }
     const requestSignal = AbortSignal.any([signal, get(requestSignal$)]);
     requestSignal.throwIfAborted();
-    const resource = {
+    const preflightResource = {
       kind: USAGE_KIND,
       provider: PROVIDER,
       category: MANAGED_SOCIALKIT_BILLING_CATEGORY,
-      quantity: 1,
+      quantity: preflightBillingQuantity(args.body, operation),
     };
     const creditError = await set(
       checkManagedCredits$,
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
-        resource,
+        resource: preflightResource,
         label: "Okou SocialKit",
       },
       requestSignal,
@@ -389,7 +569,7 @@ export const socialKitRequest$ = command(
         accessKey,
         request: args.body,
         operation,
-        recordUsage: () => {
+        recordUsage: (quantity) => {
           return set(
             recordManagedUsage$,
             {
@@ -398,7 +578,12 @@ export const socialKitRequest$ = command(
                 userId: args.auth.userId,
                 ...(runId ? { runId } : {}),
               },
-              resource,
+              resource: {
+                kind: USAGE_KIND,
+                provider: PROVIDER,
+                category: MANAGED_SOCIALKIT_BILLING_CATEGORY,
+                quantity,
+              },
               label: "SocialKit request",
             },
             signal,

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -334,6 +334,19 @@ function effectiveResultLimit(
   return requestedLimit === undefined ? defaultLimit : Number(requestedLimit);
 }
 
+function requestWithDefaultLimit(
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
+): SocialKitRequest {
+  const defaultLimit = operation.collection?.defaultLimit;
+  return defaultLimit === undefined || request.query?.limit !== undefined
+    ? request
+    : {
+        ...request,
+        query: { ...request.query, limit: String(defaultLimit) },
+      };
+}
+
 function paginationQueryValue(value: unknown): string | undefined {
   if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
     return String(value);
@@ -539,13 +552,14 @@ export const socialKitRequest$ = command(
     if (!operation) {
       throw new Error("Validated SocialKit request has no reviewed operation");
     }
+    const providerRequest = requestWithDefaultLimit(args.body, operation);
     const requestSignal = AbortSignal.any([signal, get(requestSignal$)]);
     requestSignal.throwIfAborted();
     const preflightResource = {
       kind: USAGE_KIND,
       provider: PROVIDER,
       category: MANAGED_SOCIALKIT_BILLING_CATEGORY,
-      quantity: preflightBillingQuantity(args.body, operation),
+      quantity: preflightBillingQuantity(providerRequest, operation),
     };
     const creditError = await set(
       checkManagedCredits$,
@@ -567,7 +581,7 @@ export const socialKitRequest$ = command(
     return completeSocialKitRequest(
       {
         accessKey,
-        request: args.body,
+        request: providerRequest,
         operation,
         recordUsage: (quantity) => {
           return set(

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -34,9 +34,9 @@ const responseBody = {
   billingCategory: "request",
   billingQuantity: 1,
   creditsCharged: 3,
+  collection: { state: "provider_limited", itemsReturned: 1 },
   result: {
-    transcript: "Welcome to the complete transcript.",
-    transcriptSegments: [{ text: "segment detail", start: 0, duration: 1.5 }],
+    comments: [{ text: "Welcome to the comments." }],
   },
 } as const;
 
@@ -61,6 +61,9 @@ describe("okou social command", () => {
     for (const command of socialCommand.commands) {
       command.setOptionValue("method", "GET");
       command.setOptionValue("query", undefined);
+      command.setOptionValue("all", undefined);
+      command.setOptionValue("maxPages", undefined);
+      command.setOptionValue("maxItems", undefined);
       command.setOptionValue("json", undefined);
     }
   });
@@ -132,6 +135,7 @@ describe("okou social command", () => {
     const postResponse = {
       ...responseBody,
       operation: { method: "POST", path: "/youtube/stats" },
+      collection: null,
       result: { views: 100 },
     } as const;
     server.use(
@@ -161,6 +165,373 @@ describe("okou social command", () => {
       query: { url: "https://youtu.be/video123" },
     });
     expect(output()).toBe(JSON.stringify(postResponse, null, 2));
+  });
+
+  it("retrieves cursor pages with provider-max page size and JSON Lines output", async () => {
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          const body: unknown = await request.json();
+          requests.push(body);
+          const pageNumber = requests.length;
+          return HttpResponse.json({
+            ...responseBody,
+            operation: { method: "GET", path: "/instagram/comments" },
+            collection:
+              pageNumber === 1
+                ? {
+                    state: "more",
+                    itemsReturned: 2,
+                    nextQuery: { cursor: "next-page" },
+                  }
+                : { state: "complete", itemsReturned: 1 },
+            result: {
+              comments: pageNumber === 1 ? [{ id: 1 }, { id: 2 }] : [{ id: 3 }],
+              hasMore: pageNumber === 1,
+            },
+          });
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "request",
+      "/instagram/comments",
+      "--query",
+      "url=https://instagram.com/p/example",
+      "--all",
+      "--json",
+    ]);
+
+    expect(requests).toStrictEqual([
+      {
+        method: "GET",
+        path: "/instagram/comments",
+        query: {
+          url: "https://instagram.com/p/example",
+          limit: "100",
+        },
+      },
+      {
+        method: "GET",
+        path: "/instagram/comments",
+        query: {
+          url: "https://instagram.com/p/example",
+          limit: "100",
+          cursor: "next-page",
+        },
+      },
+    ]);
+    const records = mockConsoleLog.mock.calls.map(([value]) => {
+      return JSON.parse(String(value)) as unknown;
+    });
+    expect(records).toHaveLength(3);
+    expect(records[0]).toMatchObject({ kind: "page", pageNumber: 1 });
+    expect(records[1]).toMatchObject({ kind: "page", pageNumber: 2 });
+    expect(records[2]).toStrictEqual({
+      kind: "summary",
+      completion: "complete",
+      pages: 2,
+      itemsReturned: 3,
+      billingQuantity: 2,
+      creditsCharged: 6,
+    });
+  });
+
+  it("follows numeric pages and reports the provider ceiling", async () => {
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          const body: unknown = await request.json();
+          requests.push(body);
+          const pageNumber = requests.length;
+          return HttpResponse.json({
+            ...responseBody,
+            operation: {
+              method: "GET",
+              path: "/instagram/reels-search",
+            },
+            collection:
+              pageNumber === 1
+                ? {
+                    state: "more",
+                    itemsReturned: 1,
+                    nextQuery: { page: "2" },
+                  }
+                : { state: "provider_limited", itemsReturned: 1 },
+            result: { items: [{ id: pageNumber }], hasMore: true },
+          });
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "request",
+      "/instagram/reels-search",
+      "--query",
+      "query=cats",
+      "--all",
+    ]);
+
+    expect(requests).toStrictEqual([
+      {
+        method: "GET",
+        path: "/instagram/reels-search",
+        query: { query: "cats" },
+      },
+      {
+        method: "GET",
+        path: "/instagram/reels-search",
+        query: { query: "cats", page: "2" },
+      },
+    ]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0]))).toEqual({
+      kind: "summary",
+      completion: "provider_limited",
+      pages: 2,
+      itemsReturned: 2,
+      billingQuantity: 2,
+      creditsCharged: 6,
+    });
+    expect(output()).toContain("Page 1");
+    expect(output()).toContain("Summary");
+  });
+
+  it("reports collections without provider continuation as limited", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          requestBody = (await request.json()) as unknown;
+          return HttpResponse.json({
+            ...responseBody,
+            operation: { method: "GET", path: "/youtube/search" },
+            billingQuantity: 2,
+            creditsCharged: 6,
+            collection: { state: "provider_limited", itemsReturned: 100 },
+            result: {
+              results: Array.from({ length: 100 }, (_, id) => ({ id })),
+            },
+          });
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "request",
+      "/youtube/search",
+      "--query",
+      "query=launch",
+      "--all",
+      "--json",
+    ]);
+
+    expect(requestBody).toStrictEqual({
+      method: "GET",
+      path: "/youtube/search",
+      query: { query: "launch", limit: "100" },
+    });
+    expect(JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0]))).toEqual({
+      kind: "summary",
+      completion: "provider_limited",
+      pages: 1,
+      itemsReturned: 100,
+      billingQuantity: 2,
+      creditsCharged: 6,
+    });
+  });
+
+  it("stops at exact caller page and item limits", async () => {
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "http://localhost:3000/api/social/request",
+        async ({ request }) => {
+          const body: unknown = await request.json();
+          requests.push(body);
+          return HttpResponse.json({
+            ...responseBody,
+            operation: { method: "GET", path: "/tiktok/search" },
+            collection: {
+              state: "more",
+              itemsReturned: requests.length === 1 ? 100 : 3,
+              nextQuery: { cursor: `page-${requests.length + 1}` },
+            },
+            result: { results: [], hasMore: true },
+          });
+        },
+      ),
+    );
+
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "request",
+      "/tiktok/search",
+      "--query",
+      "query=launch",
+      "--all",
+      "--max-pages",
+      "1",
+      "--json",
+    ]);
+    expect(requests).toHaveLength(1);
+    expect(
+      JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0])),
+    ).toMatchObject({
+      kind: "summary",
+      completion: "caller_limited",
+      pages: 1,
+      itemsReturned: 100,
+    });
+
+    mockConsoleLog.mockClear();
+    requests.length = 0;
+    socialCommand.commands
+      .find((command) => {
+        return command.name() === "request";
+      })
+      ?.setOptionValue("maxPages", undefined);
+    await socialCommand.parseAsync([
+      "node",
+      "cli",
+      "request",
+      "/tiktok/search",
+      "--query",
+      "query=launch",
+      "--all",
+      "--max-items",
+      "3",
+      "--json",
+    ]);
+    expect(requests).toStrictEqual([
+      {
+        method: "GET",
+        path: "/tiktok/search",
+        query: { query: "launch", limit: "3" },
+      },
+    ]);
+    expect(
+      JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0])),
+    ).toMatchObject({
+      kind: "summary",
+      completion: "caller_limited",
+      pages: 1,
+      itemsReturned: 3,
+    });
+  });
+
+  it("preserves emitted pages and reports a failed summary", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post("http://localhost:3000/api/social/request", () => {
+        requestCount += 1;
+        if (requestCount === 2) {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "The requested social content is unavailable",
+                code: "SOCIALKIT_CONTENT_UNAVAILABLE",
+              },
+            },
+            { status: 404 },
+          );
+        }
+        return HttpResponse.json({
+          ...responseBody,
+          operation: { method: "GET", path: "/tiktok/channel-videos" },
+          collection: {
+            state: "more",
+            itemsReturned: 1,
+            nextQuery: { cursor: "unstable-page" },
+          },
+          result: { results: [{ id: 1 }], hasMore: true },
+        });
+      }),
+    );
+
+    await expect(
+      socialCommand.parseAsync([
+        "node",
+        "cli",
+        "request",
+        "/tiktok/channel-videos",
+        "--query",
+        "url=https://tiktok.com/@example",
+        "--all",
+        "--json",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const records = mockConsoleLog.mock.calls.map(([value]) => {
+      return JSON.parse(String(value)) as unknown;
+    });
+    expect(records[0]).toMatchObject({ kind: "page", pageNumber: 1 });
+    expect(records[1]).toStrictEqual({
+      kind: "summary",
+      completion: "failed",
+      pages: 1,
+      itemsReturned: 1,
+      billingQuantity: 1,
+      creditsCharged: 3,
+    });
+    expect(errorOutput()).toContain(
+      "404: The requested social content is unavailable",
+    );
+  });
+
+  it("rejects repeated provider pagination without issuing another request", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post("http://localhost:3000/api/social/request", () => {
+        requestCount += 1;
+        return HttpResponse.json({
+          ...responseBody,
+          operation: { method: "GET", path: "/tiktok/search" },
+          collection: {
+            state: "more",
+            itemsReturned: 1,
+            nextQuery: { cursor: "repeated-cursor" },
+          },
+          result: { results: [{ id: requestCount }], hasMore: true },
+        });
+      }),
+    );
+
+    await expect(
+      socialCommand.parseAsync([
+        "node",
+        "cli",
+        "request",
+        "/tiktok/search",
+        "--query",
+        "query=launch",
+        "--all",
+        "--json",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCount).toBe(2);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls.at(-1)?.[0]))).toEqual({
+      kind: "summary",
+      completion: "failed",
+      pages: 2,
+      itemsReturned: 2,
+      billingQuantity: 2,
+      creditsCharged: 6,
+    });
+    expect(errorOutput()).toContain("repeated pagination state");
   });
 
   it.each([
@@ -229,6 +600,60 @@ describe("okou social command", () => {
     expect(errorOutput()).toContain("query is duplicated");
   });
 
+  it.each([
+    {
+      caseName: "a caller page bound without full retrieval",
+      args: [
+        "request",
+        "/youtube/search",
+        "--query",
+        "query=launch",
+        "--max-pages",
+        "2",
+      ],
+      message: "require --all",
+    },
+    {
+      caseName: "full retrieval for a non-collection operation",
+      args: [
+        "request",
+        "/youtube/transcript",
+        "--query",
+        "url=https://youtu.be/video123",
+        "--all",
+      ],
+      message: "requires a SocialKit collection operation",
+    },
+    {
+      caseName: "an item bound for page-only retrieval",
+      args: [
+        "request",
+        "/instagram/reels-search",
+        "--query",
+        "query=cats",
+        "--all",
+        "--max-items",
+        "2",
+      ],
+      message: "requires an operation with a result limit",
+    },
+  ])("rejects $caseName before calling the API", async ({ args, message }) => {
+    let apiRequests = 0;
+    server.use(
+      http.post("http://localhost:3000/api/social/request", () => {
+        apiRequests += 1;
+        return HttpResponse.json(responseBody);
+      }),
+    );
+
+    await expect(
+      socialCommand.parseAsync(["node", "cli", ...args]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(errorOutput()).toContain(message);
+    expect(apiRequests).toBe(0);
+  });
+
   it("prints API errors", async () => {
     server.use(
       http.post("http://localhost:3000/api/social/request", () => {
@@ -274,12 +699,18 @@ describe("okou social command", () => {
     socialCommand.outputHelp();
 
     expect(request?.helpInformation()).toContain("--query");
+    expect(request?.helpInformation()).toContain("--all");
+    expect(request?.helpInformation()).toContain("--max-pages");
+    expect(request?.helpInformation()).toContain("--max-items");
     expect(request?.helpInformation()).not.toContain("--body");
     expect(request?.helpInformation()).toContain("--json");
-    expect(socialHelp).toContain("76 fixed-cost");
+    expect(socialHelp).toContain("76 reviewed");
     expect(socialHelp).toContain("/youtube/summarize");
     expect(socialHelp).toContain(
       "download, bulk, and direct-video operations are rejected",
+    );
+    expect(socialHelp).toContain(
+      "Full retrieval bills and emits each successful provider page independently",
     );
   });
 });

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { HttpResponse, http } from "msw";
+import { socialKitRequestSchema } from "@okouai/api-contracts/contracts/social";
 import {
   afterAll,
   afterEach,
@@ -319,7 +320,9 @@ describe("okou social command", () => {
             creditsCharged: 6,
             collection: { state: "provider_limited", itemsReturned: 100 },
             result: {
-              results: Array.from({ length: 100 }, (_, id) => ({ id })),
+              results: Array.from({ length: 100 }, (_, id) => {
+                return { id };
+              }),
             },
           });
         },
@@ -358,14 +361,15 @@ describe("okou social command", () => {
       http.post(
         "http://localhost:3000/api/social/request",
         async ({ request }) => {
-          const body: unknown = await request.json();
+          const body = socialKitRequestSchema.parse(await request.json());
           requests.push(body);
+          const requestedLimit = Number(body.query?.limit);
           return HttpResponse.json({
             ...responseBody,
             operation: { method: "GET", path: "/tiktok/search" },
             collection: {
               state: "more",
-              itemsReturned: requests.length === 1 ? 100 : 3,
+              itemsReturned: requestedLimit,
               nextQuery: { cursor: `page-${requests.length + 1}` },
             },
             result: { results: [], hasMore: true },

--- a/turbo/apps/cli/src/commands/social/index.ts
+++ b/turbo/apps/cli/src/commands/social/index.ts
@@ -1,16 +1,49 @@
 import { Command, InvalidArgumentError } from "commander";
 import {
+  findManagedSocialKitOperation,
   SOCIALKIT_MAX_QUERY_ENTRIES,
   socialKitRequestSchema,
+  type ManagedSocialKitOperation,
+  type SocialKitRequest,
+  type SocialKitResponse,
 } from "@okouai/api-contracts/contracts/social";
 
 import { callSocialKit } from "../../lib/api/domains/social";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 interface SocialKitRequestOptions {
+  readonly all?: boolean;
+  readonly maxItems?: number;
+  readonly maxPages?: number;
   readonly method: string;
   readonly query?: readonly string[];
   readonly json?: boolean;
+}
+
+type FullRetrievalCompletion =
+  | "caller_limited"
+  | "complete"
+  | "failed"
+  | "provider_limited";
+
+interface FullRetrievalTotals {
+  readonly pages: number;
+  readonly itemsReturned: number;
+  readonly billingQuantity: number;
+  readonly creditsCharged: number;
+}
+
+interface FullRetrievalSummary extends FullRetrievalTotals {
+  readonly kind: "summary";
+  readonly completion: FullRetrievalCompletion;
+}
+
+function positiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("value must be a positive integer");
+  }
+  return parsed;
 }
 
 function collectQuery(
@@ -46,6 +79,157 @@ function parseQuery(
   return query;
 }
 
+function printFullRecord(value: unknown, compact: boolean): void {
+  console.log(JSON.stringify(value, null, compact ? 0 : 2));
+}
+
+function printPage(
+  pageNumber: number,
+  response: SocialKitResponse,
+  compact: boolean,
+): void {
+  if (!compact) {
+    console.log(`Page ${pageNumber}`);
+  }
+  printFullRecord({ kind: "page", pageNumber, response }, compact);
+}
+
+function printSummary(
+  completion: FullRetrievalCompletion,
+  totals: FullRetrievalTotals,
+  compact: boolean,
+): void {
+  if (!compact) {
+    console.log("Summary");
+  }
+  const summary: FullRetrievalSummary = {
+    kind: "summary",
+    completion,
+    ...totals,
+  };
+  printFullRecord(summary, compact);
+}
+
+function queryIdentity(query: Readonly<Record<string, string>>): string {
+  return JSON.stringify(
+    Object.entries(query).sort(([left], [right]) => {
+      return left.localeCompare(right);
+    }),
+  );
+}
+
+function requestForPage(
+  request: SocialKitRequest,
+  query: Readonly<Record<string, string>>,
+): SocialKitRequest {
+  return { ...request, query: { ...query } };
+}
+
+async function retrieveAll(
+  request: SocialKitRequest,
+  operation: ManagedSocialKitOperation,
+  options: SocialKitRequestOptions,
+): Promise<void> {
+  if (!operation.collection) {
+    throw new InvalidArgumentError(
+      "--all requires a SocialKit collection operation",
+    );
+  }
+  if (options.maxItems !== undefined && operation.maxLimit === undefined) {
+    throw new InvalidArgumentError(
+      "--max-items requires an operation with a result limit",
+    );
+  }
+
+  const compact = options.json === true;
+  const baseQuery: Record<string, string> = { ...request.query };
+  if (operation.maxLimit !== undefined && baseQuery.limit === undefined) {
+    baseQuery.limit = String(operation.maxLimit);
+  }
+  const pageSize =
+    operation.maxLimit === undefined ? undefined : Number(baseQuery.limit);
+  const seenQueries = new Set<string>();
+  let query = baseQuery;
+  let pages = 0;
+  let itemsReturned = 0;
+  let billingQuantity = 0;
+  let creditsCharged = 0;
+
+  while (true) {
+    const remainingItems =
+      options.maxItems === undefined
+        ? undefined
+        : options.maxItems - itemsReturned;
+    const pageQuery = { ...query };
+    if (remainingItems !== undefined && pageSize !== undefined) {
+      pageQuery.limit = String(Math.min(pageSize, remainingItems));
+    }
+    const pageIdentity = queryIdentity(pageQuery);
+    if (seenQueries.has(pageIdentity)) {
+      printSummary(
+        "failed",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      throw new Error("SocialKit returned a repeated pagination state");
+    }
+    seenQueries.add(pageIdentity);
+
+    let response: SocialKitResponse;
+    try {
+      response = await callSocialKit(requestForPage(request, pageQuery));
+    } catch (error) {
+      printSummary(
+        "failed",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      throw error;
+    }
+    const collection = response.collection;
+    if (!collection) {
+      printSummary(
+        "failed",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      throw new Error("SocialKit collection response has no page metadata");
+    }
+
+    pages += 1;
+    itemsReturned += collection.itemsReturned;
+    billingQuantity += response.billingQuantity;
+    creditsCharged += response.creditsCharged;
+    printPage(pages, response, compact);
+
+    if (collection.state === "complete") {
+      printSummary(
+        "complete",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      return;
+    }
+    if (collection.state === "provider_limited") {
+      printSummary(
+        "provider_limited",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      return;
+    }
+    if (pages === options.maxPages || itemsReturned === options.maxItems) {
+      printSummary(
+        "caller_limited",
+        { pages, itemsReturned, billingQuantity, creditsCharged },
+        compact,
+      );
+      return;
+    }
+    query = { ...query, ...collection.nextQuery };
+  }
+}
+
 const requestCommand = new Command()
   .name("request")
   .description("Call a reviewed managed SocialKit data or analysis operation")
@@ -55,6 +239,17 @@ const requestCommand = new Command()
     "--query <name=value>",
     "Provider query field; repeat for multiple fields",
     collectQuery,
+  )
+  .option("--all", "Retrieve every provider page exposed by the operation")
+  .option(
+    "--max-pages <count>",
+    "Stop full retrieval after this many pages",
+    positiveInteger,
+  )
+  .option(
+    "--max-items <count>",
+    "Stop full retrieval after this many returned items",
+    positiveInteger,
   )
   .option("--json", "Print compact JSON instead of formatted JSON")
   .action(
@@ -69,6 +264,27 @@ const requestCommand = new Command()
           request.error.issues[0]?.message ??
             "Managed SocialKit request is invalid",
         );
+      }
+      if (
+        !options.all &&
+        (options.maxPages !== undefined || options.maxItems !== undefined)
+      ) {
+        throw new InvalidArgumentError(
+          "--max-pages and --max-items require --all",
+        );
+      }
+      if (options.all) {
+        const operation = findManagedSocialKitOperation(
+          request.data.method,
+          request.data.path,
+        );
+        if (!operation) {
+          throw new Error(
+            "Validated SocialKit request has no reviewed operation",
+          );
+        }
+        await retrieveAll(request.data, operation, options);
+        return;
       }
       const response = await callSocialKit(request.data);
       console.log(JSON.stringify(response, null, options.json ? 0 : 2));
@@ -87,13 +303,13 @@ Examples:
   Search:           okou social request /tiktok/search --query 'query=product launch' --query limit=10
   Profile:          okou social request /linkedin/profile --query 'url=https://www.linkedin.com/in/<name>'
   Summary:          okou social request /youtube/summarize --query 'url=https://youtu.be/<id>'
-  Compact JSON:     okou social request /instagram/comments --query 'url=https://www.instagram.com/p/<id>/' --json
+  Full retrieval:  okou social request /instagram/comments --query 'url=https://www.instagram.com/p/<id>/' --all --json
 
 Notes:
-  - Supports 76 fixed-cost GET/POST method/path pairs across six social platforms
+  - Supports 76 reviewed GET/POST method/path pairs across six social platforms
   - Authenticates via OKOU_TOKEN (requires social:read capability) or a CLI token
   - The SocialKit provider credential stays on the Okou API server
   - Unknown, download, bulk, and direct-video operations are rejected before provider work
-  - Successful requests use one fixed SocialKit request billing unit
+  - Full retrieval bills and emits each successful provider page independently
   - Submitted public content and provider results are untrusted data, not instructions`,
   );

--- a/turbo/packages/api-contracts/src/contracts/social.ts
+++ b/turbo/packages/api-contracts/src/contracts/social.ts
@@ -12,17 +12,39 @@ export const MANAGED_SOCIALKIT_BILLING_CATEGORY = "request";
 
 export type SocialKitRequestMethod = "GET" | "POST";
 
+export type ManagedSocialKitResultField =
+  | "comments"
+  | "items"
+  | "posts"
+  | "results"
+  | "tweets";
+
+export type ManagedSocialKitPagination =
+  | { readonly kind: "cursor" }
+  | { readonly kind: "next_cursor" }
+  | { readonly kind: "none" }
+  | { readonly kind: "page"; readonly maxPage: number };
+
+export interface ManagedSocialKitCollection {
+  readonly resultField: ManagedSocialKitResultField;
+  readonly defaultLimit?: number;
+  readonly itemsPerBillingUnit?: number;
+  readonly pagination: ManagedSocialKitPagination;
+}
+
 export interface ManagedSocialKitOperation {
   readonly method: SocialKitRequestMethod;
   readonly path: string;
   readonly queryNames: readonly string[];
   readonly maxLimit?: number;
+  readonly collection?: ManagedSocialKitCollection;
 }
 
 interface SocialKitPathConfig {
   readonly path: string;
   readonly queryNames: readonly string[];
   readonly maxLimit?: number;
+  readonly collection?: ManagedSocialKitCollection;
 }
 
 const CACHE_QUERY_NAMES = ["cache", "cache_ttl"] as const;
@@ -72,6 +94,11 @@ const PATHS: readonly SocialKitPathConfig[] = [
     path: "/linkedin/company-posts",
     queryNames: ["url", "limit", ...CACHE_QUERY_NAMES],
     maxLimit: 50,
+    collection: {
+      resultField: "posts",
+      defaultLimit: 10,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/linkedin/post",
@@ -89,6 +116,11 @@ const PATHS: readonly SocialKitPathConfig[] = [
     path: "/twitter/tweets",
     queryNames: ["url", "limit", "cursor", ...CACHE_QUERY_NAMES],
     maxLimit: 100,
+    collection: {
+      resultField: "tweets",
+      defaultLimit: 20,
+      pagination: { kind: "next_cursor" },
+    },
   },
   {
     path: "/twitter/tweet",
@@ -117,7 +149,13 @@ const PATHS: readonly SocialKitPathConfig[] = [
   {
     path: "/facebook/comments",
     queryNames: URL_LIMIT_CURSOR_QUERY_NAMES,
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/facebook/summarize",
@@ -138,21 +176,43 @@ const PATHS: readonly SocialKitPathConfig[] = [
   {
     path: "/instagram/comments",
     queryNames: ["url", "limit", "cursor", "sortBy"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/instagram/channel-posts",
     queryNames: URL_LIMIT_CURSOR_QUERY_NAMES,
-    maxLimit: 20,
+    maxLimit: 100,
+    collection: {
+      resultField: "items",
+      defaultLimit: 12,
+      itemsPerBillingUnit: 20,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/instagram/channel-reels",
     queryNames: URL_LIMIT_CURSOR_QUERY_NAMES,
-    maxLimit: 20,
+    maxLimit: 100,
+    collection: {
+      resultField: "items",
+      defaultLimit: 12,
+      itemsPerBillingUnit: 20,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/instagram/reels-search",
     queryNames: ["query", "page"],
+    collection: {
+      resultField: "items",
+      pagination: { kind: "page", maxPage: 2 },
+    },
   },
   {
     path: "/instagram/summarize",
@@ -165,7 +225,13 @@ const PATHS: readonly SocialKitPathConfig[] = [
   {
     path: "/tiktok/comments",
     queryNames: URL_LIMIT_CURSOR_QUERY_NAMES,
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/transcript",
@@ -178,7 +244,12 @@ const PATHS: readonly SocialKitPathConfig[] = [
   {
     path: "/tiktok/channel-videos",
     queryNames: ["url", "limit", "cursor", ...CACHE_QUERY_NAMES],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 30,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/search",
@@ -190,12 +261,24 @@ const PATHS: readonly SocialKitPathConfig[] = [
       "datePosted",
       ...CACHE_QUERY_NAMES,
     ],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/hashtag-search",
     queryNames: ["hashtag", "limit", "cursor", ...CACHE_QUERY_NAMES],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "cursor" },
+    },
   },
   {
     path: "/tiktok/summarize",
@@ -212,7 +295,13 @@ const PATHS: readonly SocialKitPathConfig[] = [
   {
     path: "/youtube/comments",
     queryNames: ["url", "limit", "sortBy"],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "comments",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/channel-stats",
@@ -228,12 +317,24 @@ const PATHS: readonly SocialKitPathConfig[] = [
       "type",
       ...CACHE_QUERY_NAMES,
     ],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/videos",
     queryNames: ["url", "limit", "full_details", ...CACHE_QUERY_NAMES],
-    maxLimit: 50,
+    maxLimit: 100,
+    collection: {
+      resultField: "results",
+      defaultLimit: 10,
+      itemsPerBillingUnit: 50,
+      pagination: { kind: "none" },
+    },
   },
   {
     path: "/youtube/summarize",
@@ -470,8 +571,25 @@ export const socialKitResponseSchema = z.object({
     path: z.string(),
   }),
   billingCategory: z.literal(MANAGED_SOCIALKIT_BILLING_CATEGORY),
-  billingQuantity: z.literal(1),
+  billingQuantity: z.number().int().positive(),
   creditsCharged: z.number().int().nonnegative(),
+  collection: z
+    .discriminatedUnion("state", [
+      z.object({
+        state: z.literal("more"),
+        itemsReturned: z.number().int().nonnegative(),
+        nextQuery: z.record(z.string(), z.string()),
+      }),
+      z.object({
+        state: z.literal("complete"),
+        itemsReturned: z.number().int().nonnegative(),
+      }),
+      z.object({
+        state: z.literal("provider_limited"),
+        itemsReturned: z.number().int().nonnegative(),
+      }),
+    ])
+    .nullable(),
   result: z.unknown(),
 });
 


### PR DESCRIPTION
## Summary

- describe managed SocialKit collection shapes, provider limits, pagination mechanisms, and result-metered billing units in the shared contract
- validate each provider page before settling usage, preflight its maximum cost, and bill successful result-metered calls from the actual returned item count
- add `okou social request --all` with JSON Lines/formatted page streaming, aggregate charge summaries, caller page/item bounds, and repeated-pagination protection
- report pageless and provider-ceiling results as `provider_limited`, while retaining already emitted pages when a later provider call fails

## Behavior and boundaries

- each managed API request still performs exactly one bounded SocialKit request and records one independent usage event
- full retrieval uses provider-maximum page sizes by default and follows only normalized provider continuation state
- fixed-price SocialKit operations remain one billing unit; per-result operations settle at one unit per 20 or 50 validated results, with a minimum of one
- the managed SocialKit response contract changes directly; no old-client compatibility shim is included, as explicitly approved for this default-off staff feature
- no database migration, production pricing change, server-side unbounded aggregation, durable job infrastructure, automatic retry, or forced TikTok cache behavior is included

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @okouai/cli lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/social.test.ts --silent=passed-only`
- `cd turbo && pnpm -F @okouai/cli exec vitest run src/commands/social/__tests__/index.test.ts --silent=passed-only`

Closes #29146
