### PR TITLE
fix: handle revoked claude code oauth tokens

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -273,6 +273,11 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::TermsAcceptanceRequired);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_oauth_token_revoked_error(&normalized)
+    {
+        return Some(FailureReason::ReconnectRequired);
+    }
+    if matches!(framework, AgentFramework::ClaudeCode)
         && is_claude_invalid_credentials_error(&normalized)
     {
         return Some(FailureReason::InvalidCredentials);
@@ -378,6 +383,13 @@ fn has_insufficient_credits_response_envelope(normalized: &str) -> bool {
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
     normalized.contains("failed to authenticate")
         && normalized.contains("api error: 401 invalid authentication credentials")
+}
+
+fn is_claude_oauth_token_revoked_error(normalized: &str) -> bool {
+    normalized.contains("failed to authenticate")
+        && has_claude_api_status(normalized, "401")
+        && normalized.contains("oauth access token")
+        && normalized.contains("revoked")
 }
 
 fn is_claude_terms_acceptance_required_error(normalized: &str) -> bool {

--- a/crates/guest-agent/tests/claude_result_failure_logging.rs
+++ b/crates/guest-agent/tests/claude_result_failure_logging.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::SystemLogOverrideGuard;
 use guest_agent::masker::SecretMasker;
-use guest_contracts::diagnostics::FailureDetailSource;
+use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
 use std::time::Duration;
 
 #[tokio::test]
@@ -15,13 +15,14 @@ async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn st
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let system_log_path = tmp.path().join("system.log");
-    let failure_reason = "permission denied while running command";
+    let failure_message =
+        "Failed to authenticate. API Error: 401 OAuth access token has been revoked.";
 
     unsafe {
         common::setup_env(
             &mock,
             tmp.path(),
-            &format!("printf '{failure_reason}'; exit 2"),
+            &format!("printf '{failure_message}'; exit 2"),
             3,
             1,
         )?;
@@ -45,7 +46,7 @@ async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn st
             .failure_diagnostic
             .as_ref()
             .map(|diagnostic| diagnostic.message.as_str()),
-        Some(failure_reason)
+        Some(failure_message)
     );
     assert_eq!(
         cli_result
@@ -54,12 +55,22 @@ async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn st
             .map(|diagnostic| diagnostic.source),
         Some(FailureDetailSource::ClaudeResult)
     );
+    let terminal_failure = guest_agent::failure_diagnostics::cli_nonzero_failure_for_config(
+        &runtime.config,
+        None,
+        &cli_result,
+    );
+    assert_eq!(terminal_failure.message, failure_message);
+    assert_eq!(
+        terminal_failure.diagnostic.failure_reason,
+        Some(FailureReason::ReconnectRequired)
+    );
 
     let system_log = std::fs::read_to_string(&system_log_path)?;
     assert!(
-        system_log.contains(
-            "Claude JSONL failure result seq=4 subtype=error: permission denied while running command"
-        ),
+        system_log.contains(&format!(
+            "Claude JSONL failure result seq=4 subtype=error: {failure_message}"
+        )),
         "system log should include Claude JSONL failure reason: {system_log}"
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -225,6 +225,32 @@ async function entitledChatMemberActor(): Promise<EntitledChatActor> {
   return { ...adminFixture, actor, agentId: agent.agentId };
 }
 
+async function configureClaudeCodeSubscriptionProvider(
+  fixture: EntitledChatActor,
+): Promise<void> {
+  await misc.upsertPersonalModelProvider(
+    fixture.actor,
+    { type: "claude-code-oauth-token", secret: "sk-ant-oat-bdd" },
+    [200, 201],
+  );
+  await api.updateOrgModelPolicies(fixture.actor, [
+    {
+      model: "claude-sonnet-5",
+      isDefault: true,
+      defaultProviderType: "anthropic-api-key",
+      credentialScope: "org",
+      modelProviderId: fixture.providerId,
+    },
+    {
+      model: "claude-opus-4-8",
+      isDefault: false,
+      defaultProviderType: "claude-code-oauth-token",
+      credentialScope: "member",
+      modelProviderId: null,
+    },
+  ]);
+}
+
 async function startChatRun(
   actor: ApiTestUser,
   body: {
@@ -4372,9 +4398,12 @@ describe("CHAT-02: failed chat callbacks", () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const upstreamAuthError =
       "Failed to authenticate. API Error: 401 Invalid authentication credentials";
+    const revokedOAuthError =
+      "Failed to authenticate. API Error: 401 OAuth access token has been revoked.";
 
     async function failAndReadError(params: {
       readonly prompt: string;
+      readonly errorMessage?: string;
       readonly selectedModel?: SupportedRunModel;
       readonly orgRole?: TestOrgRole;
       readonly publicBrand?: PublicBrand;
@@ -4410,7 +4439,11 @@ describe("CHAT-02: failed chat callbacks", () => {
           params.orgRole === "admin" ? "org:admin" : "org:member",
         );
       }
-      await failChatRun(run.runId, sandboxHeaders, upstreamAuthError);
+      await failChatRun(
+        run.runId,
+        sandboxHeaders,
+        params.errorMessage ?? upstreamAuthError,
+      );
 
       const page = await waitForThreadMessages(
         fixture.actor,
@@ -4437,33 +4470,28 @@ describe("CHAT-02: failed chat callbacks", () => {
         prompt: "subscription credential failed",
         selectedModel: "claude-opus-4-8",
         publicBrand: "okou",
-        async configureProvider(fixture) {
-          await misc.upsertPersonalModelProvider(
-            fixture.actor,
-            { type: "claude-code-oauth-token", secret: "sk-ant-oat-bdd" },
-            [200, 201],
-          );
-          await api.updateOrgModelPolicies(fixture.actor, [
-            {
-              model: "claude-sonnet-5",
-              isDefault: true,
-              defaultProviderType: "anthropic-api-key",
-              credentialScope: "org",
-              modelProviderId: fixture.providerId,
-            },
-            {
-              model: "claude-opus-4-8",
-              isDefault: false,
-              defaultProviderType: "claude-code-oauth-token",
-              credentialScope: "member",
-              modelProviderId: null,
-            },
-          ]);
-        },
+        configureProvider: configureClaudeCodeSubscriptionProvider,
       }),
     ).resolves.toBe(
       "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.okou.ai/?settings=model",
     );
+    await expect(
+      failAndReadError({
+        prompt: "revoked subscription credential failed",
+        errorMessage: revokedOAuthError,
+        selectedModel: "claude-opus-4-8",
+        configureProvider: configureClaudeCodeSubscriptionProvider,
+      }),
+    ).resolves.toBe(
+      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.vm0.ai/?settings=model",
+    );
+    await expect(
+      failAndReadError({
+        prompt: "revoked OAuth text with an Anthropic API key",
+        errorMessage: revokedOAuthError,
+        selectedModel: "claude-sonnet-5",
+      }),
+    ).resolves.toBe("Oops, something went wrong. Please try again later.");
     await expect(
       failAndReadError({
         prompt: "legacy callback without public brand failed for admin",

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -461,6 +461,16 @@ export function isClaudeCodeAuthenticationCredentialsError(
   );
 }
 
+function isClaudeCodeOAuthTokenRevokedError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("failed to authenticate") &&
+    /api error:[\s:.-]*401(?![a-z0-9_-])/u.test(normalized) &&
+    normalized.includes("oauth access token") &&
+    normalized.includes("revoked")
+  );
+}
+
 function isClaudeCodeTermsAcceptanceRequiredError(
   errorMessage: string,
 ): boolean {
@@ -571,7 +581,10 @@ export function formatRunErrorForExternalSurface(params: {
 
   if (
     params.claudeCodeCredentialRecovery !== undefined &&
-    isClaudeCodeAuthenticationCredentialsError(errorMessage)
+    (isClaudeCodeAuthenticationCredentialsError(errorMessage) ||
+      (params.claudeCodeCredentialRecovery.modelProviderType ===
+        "claude-code-oauth-token" &&
+        isClaudeCodeOAuthTokenRevokedError(errorMessage)))
   ) {
     const recoveryMessage = formatClaudeCodeCredentialRecoveryMessage(
       params.claudeCodeCredentialRecovery,


### PR DESCRIPTION
## Summary

- classify Claude Code's revoked OAuth access-token response as `ReconnectRequired` in guest diagnostics
- show provider-aware reconnect guidance on chat and external surfaces when the failed provider is a Claude Code OAuth subscription
- keep the same upstream text generic for Anthropic API-key credentials

## Explicit exclusions

- do not persist `needsReconnect` from a late run completion because it does not carry the credential revision and could invalidate a newer token
- do not add a new protocol enum, schema, migration, or UI state

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `pnpm knip`

Closes #29128
