### PR TITLE
perf(runner): skip codex cleanup on fresh sandboxes

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1791,7 +1791,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             WorkspaceSessionHistoryMaterialization::Materialized { session, timings } => {
                 record_workspace_session_history_timings(telemetry, timings);
                 let guest_restore_started = Instant::now();
-                let restore_result = restore_session(sandbox, context, &session).await;
+                let restore_result =
+                    restore_session(sandbox, context, start.reuse_result, &session).await;
                 let guest_restore_elapsed = guest_restore_started.elapsed();
                 telemetry.record(
                     "session_history_workspace_cache_guest_restore",
@@ -1975,7 +1976,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
         if let Some(session) = resume_session {
             let t = Instant::now();
-            let result = restore_session(sandbox, context, &session).await;
+            let result = restore_session(sandbox, context, start.reuse_result, &session).await;
             let err = result.as_ref().err().map(|e| e.to_string());
             telemetry.record(
                 "session_restore",

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -15,7 +15,7 @@ use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::RestoredSessionIdentity;
-use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind};
+use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind, SandboxReuseResult};
 use api_contracts::generated::constants::runners::paths::{
     CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_WORKING_DIR,
 };
@@ -144,6 +144,7 @@ pub(super) struct SessionRestoreDiagnostics {
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
+    sandbox_reuse_result: SandboxReuseResult,
     session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
@@ -166,7 +167,7 @@ pub(super) async fn restore_session(
             restore_claude_session(sandbox, context, session).await
         }
         EffectiveCliFramework::Codex => {
-            codex::restore_codex_session(sandbox, context, session).await
+            codex::restore_codex_session(sandbox, context, sandbox_reuse_result, session).await
         }
         EffectiveCliFramework::Pi => restore_pi_session(sandbox, context, session).await,
     }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -8,7 +8,7 @@ use api_contracts::generated::constants::runners::paths::{
 
 use super::{MaterializedResumeSession, SessionRestoreDiagnostics, write_session_history_file};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
-use crate::types::ExecutionContext;
+use crate::types::{ExecutionContext, SandboxReuseResult};
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use guest_contracts::{
@@ -35,6 +35,7 @@ fn codex_restore_rollout_timestamp(
 pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
+    sandbox_reuse_result: SandboxReuseResult,
     session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let original_session_id = session.cli_agent_session_id();
@@ -54,15 +55,22 @@ pub(super) async fn restore_codex_session(
         codex_rollout_relative_path(&thread_id, timestamp)
     );
 
-    let logical_path = cleanup_existing_codex_session_files(
-        sandbox,
-        context,
-        session_id,
-        &session_filename_key,
-        &fallback_logical_path,
-    )
-    .await?
-    .unwrap_or(fallback_logical_path);
+    let logical_path = if sandbox_reuse_result == SandboxReuseResult::Reused {
+        cleanup_existing_codex_session_files(
+            sandbox,
+            context,
+            session_id,
+            &session_filename_key,
+            &fallback_logical_path,
+        )
+        .await?
+        .unwrap_or(fallback_logical_path)
+    } else {
+        // Only actual sandbox reuse retains the framework home. Fresh
+        // sandboxes may mount a reused workspace drive, but it contains only
+        // the working directory and cannot contain a prior Codex rollout.
+        fallback_logical_path
+    };
     let session_path = format!("{logical_path}{physical_suffix}");
 
     write_session_history_file(sandbox, &session_path, session_history).await?;

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
@@ -919,6 +919,12 @@ async fn run_in_sandbox_restores_codex_zstd_sidecar_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl.zst"
     );
     assert_eq!(writes[0].content, compressed_history);
+    assert!(sandbox.exec_calls().iter().all(|call| {
+        !call
+            .env_keys
+            .iter()
+            .any(|key| key == "OKOU_CODEX_RESTORE_SESSION_ID")
+    }));
     history_mock.assert_calls_async(0).await;
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests/claude.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/claude.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::super::support::sandbox_write_file_error;
 use super::*;
 use sandbox::{SandboxError, SandboxInvalidStateContext, SandboxOperation};

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::super::support::sandbox_write_file_error;
 use super::*;
 use sandbox::{ExecResult, ExecTermination};
@@ -22,6 +21,29 @@ fn restore_session_writes_codex_session() {
         writes[0].path
     );
     assert_eq!(writes[0].content, session.history_bytes());
+    assert_eq!(diagnostics.bytes_in, history.len());
+}
+
+#[test]
+fn fresh_sandbox_restore_writes_codex_session_without_cleanup() {
+    let sandbox = MockSandbox::new("test");
+    let ctx = codex_context();
+    let history = codex_session_meta_history(CODEX_SESSION_ID);
+    let session = materialized_text_session(CODEX_SESSION_ID, history.clone());
+
+    let diagnostics = run_restore_session(restore_session_for_sandbox(
+        &sandbox,
+        &ctx,
+        SandboxReuseResult::PoolMiss,
+        &session,
+    ))
+    .unwrap();
+
+    assert!(sandbox.exec_calls().is_empty());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert!(writes[0].path.ends_with(CODEX_CANONICAL_ROLLOUT_SUFFIX));
+    assert_eq!(writes[0].content, history.as_bytes());
     assert_eq!(diagnostics.bytes_in, history.len());
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -12,11 +12,14 @@ use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_history_cpu::codex_timestamp_for_test;
-use super::super::session_restore::MaterializedResumeSession;
+use super::super::session_restore::{
+    MaterializedResumeSession, SessionRestoreDiagnostics,
+    restore_session as restore_session_for_sandbox,
+};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context};
 use crate::types::{
     ExecutionContext, ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding,
-    ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
+    ResumeSessionHistoryRef, ResumeSessionHistoryRefKind, SandboxReuseResult,
 };
 
 static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
@@ -199,6 +202,14 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(!exec_calls[0].cmd.contains("tr -d"));
     assert!(!exec_calls[0].cmd.contains("-delete"));
     assert!(!exec_calls[0].cmd.contains("for path in \"$dir\"/*"));
+}
+
+async fn restore_session(
+    sandbox: &dyn sandbox::Sandbox,
+    context: &ExecutionContext,
+    session: &MaterializedResumeSession,
+) -> crate::error::RunnerResult<SessionRestoreDiagnostics> {
+    restore_session_for_sandbox(sandbox, context, SandboxReuseResult::Reused, session).await
 }
 
 fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)

--- a/crates/runner/src/executor/tests/session_restore_tests/pi.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/pi.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::*;
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests/validation.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/validation.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::*;
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- pass the sandbox reuse outcome into session restoration
- skip Codex rollout cleanup and path discovery for newly created sandboxes
- preserve cleanup for actually reused sandboxes and add coverage for both paths

## Scope

- Claude and Pi restoration behavior is unchanged
- runner protocols, API contracts, persistence, and telemetry schemas are unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo build -p runner`
- `cargo test -p runner executor::tests::session_restore_tests`
- `cargo test -p runner executor::tests::agent_run_tests::session_history::materialization::run_in_sandbox_restores_codex_zstd_sidecar_with_session_timestamp`
- `cargo test -p runner` (3,285 passed; the unrelated `proxy::process::tests::initial_start_retries_an_occupied_selected_port` test failed locally and reproduced in isolation)

Closes #29150

Parent: #24203
