### PR TITLE
perf(runner): skip codex cleanup in fresh sandboxes

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1791,7 +1791,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             WorkspaceSessionHistoryMaterialization::Materialized { session, timings } => {
                 record_workspace_session_history_timings(telemetry, timings);
                 let guest_restore_started = Instant::now();
-                let restore_result = restore_session(sandbox, context, &session).await;
+                let restore_result =
+                    restore_session(sandbox, context, &session, start.reuse_result).await;
                 let guest_restore_elapsed = guest_restore_started.elapsed();
                 telemetry.record(
                     "session_history_workspace_cache_guest_restore",
@@ -1975,7 +1976,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
         if let Some(session) = resume_session {
             let t = Instant::now();
-            let result = restore_session(sandbox, context, &session).await;
+            let result = restore_session(sandbox, context, &session, start.reuse_result).await;
             let err = result.as_ref().err().map(|e| e.to_string());
             telemetry.record(
                 "session_restore",

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -15,7 +15,7 @@ use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::RestoredSessionIdentity;
-use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind};
+use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind, SandboxReuseResult};
 use api_contracts::generated::constants::runners::paths::{
     CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_WORKING_DIR,
 };
@@ -145,6 +145,7 @@ pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &MaterializedResumeSession,
+    sandbox_reuse_result: SandboxReuseResult,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
     // Only allow alnum, dash, and underscore.
@@ -166,7 +167,7 @@ pub(super) async fn restore_session(
             restore_claude_session(sandbox, context, session).await
         }
         EffectiveCliFramework::Codex => {
-            codex::restore_codex_session(sandbox, context, session).await
+            codex::restore_codex_session(sandbox, context, session, sandbox_reuse_result).await
         }
         EffectiveCliFramework::Pi => restore_pi_session(sandbox, context, session).await,
     }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -58,8 +58,8 @@ pub(super) async fn restore_codex_session(
     // Only an idle-reused sandbox can retain a prior framework home. Fresh
     // sandboxes may attach a cached workspace drive, but that drive contains
     // only the working directory and cannot contain Codex session rollouts.
-    let logical_path = if sandbox_reuse_result == SandboxReuseResult::Reused {
-        cleanup_existing_codex_session_files(
+    let logical_path = match sandbox_reuse_result {
+        SandboxReuseResult::Reused => cleanup_existing_codex_session_files(
             sandbox,
             context,
             session_id,
@@ -67,9 +67,12 @@ pub(super) async fn restore_codex_session(
             &fallback_logical_path,
         )
         .await?
-        .unwrap_or(fallback_logical_path)
-    } else {
-        fallback_logical_path
+        .unwrap_or(fallback_logical_path),
+        SandboxReuseResult::NoReuseKey
+        | SandboxReuseResult::PoolMiss
+        | SandboxReuseResult::ProfileMismatch
+        | SandboxReuseResult::DeviceLimitMismatch
+        | SandboxReuseResult::UnparkFailed => fallback_logical_path,
     };
     let session_path = format!("{logical_path}{physical_suffix}");
 

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -8,7 +8,7 @@ use api_contracts::generated::constants::runners::paths::{
 
 use super::{MaterializedResumeSession, SessionRestoreDiagnostics, write_session_history_file};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
-use crate::types::ExecutionContext;
+use crate::types::{ExecutionContext, SandboxReuseResult};
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use guest_contracts::{
@@ -36,6 +36,7 @@ pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &MaterializedResumeSession,
+    sandbox_reuse_result: SandboxReuseResult,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let original_session_id = session.cli_agent_session_id();
     let thread_id = CodexThreadId::parse(original_session_id)
@@ -54,15 +55,22 @@ pub(super) async fn restore_codex_session(
         codex_rollout_relative_path(&thread_id, timestamp)
     );
 
-    let logical_path = cleanup_existing_codex_session_files(
-        sandbox,
-        context,
-        session_id,
-        &session_filename_key,
-        &fallback_logical_path,
-    )
-    .await?
-    .unwrap_or(fallback_logical_path);
+    // Only an idle-reused sandbox can retain a prior framework home. Fresh
+    // sandboxes may attach a cached workspace drive, but that drive contains
+    // only the working directory and cannot contain Codex session rollouts.
+    let logical_path = if sandbox_reuse_result == SandboxReuseResult::Reused {
+        cleanup_existing_codex_session_files(
+            sandbox,
+            context,
+            session_id,
+            &session_filename_key,
+            &fallback_logical_path,
+        )
+        .await?
+        .unwrap_or(fallback_logical_path)
+    } else {
+        fallback_logical_path
+    };
     let session_path = format!("{logical_path}{physical_suffix}");
 
     write_session_history_file(sandbox, &session_path, session_history).await?;

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
@@ -1013,17 +1013,25 @@ async fn run_in_sandbox_materializes_prune_eligible_codex_zstd_sidecar_as_raw() 
 async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = sandbox_mock::MockSandbox::with_overrides("test", Arc::clone(&overrides));
+    let write_gate = MockLifecycleGate::new();
+    sandbox.set_write_file_lifecycle_gate(write_gate.clone());
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let history =
-        b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let mut history =
+        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n"
+            .to_string();
+    history.push_str(&"{}\n".repeat(22 * 1024));
+    assert!(history.len() > 64 * 1024);
     let sidecar_path = dir.path().join("session-history.jsonl");
-    tokio::fs::write(&sidecar_path, history).await.unwrap();
+    tokio::fs::write(&sidecar_path, history.as_bytes())
+        .await
+        .unwrap();
     let server = MockServer::start_async().await;
     let history_mock = server
         .mock_async(|when, then| {
             when.method(GET).path("/history.blob");
-            then.status(200).body(history);
+            then.status(200).body(history.clone());
         })
         .await;
     let mut ctx = minimal_context();
@@ -1033,7 +1041,7 @@ async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
         history: ResumeSessionHistory::Ref {
             history_ref: ResumeSessionHistoryRef {
                 kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
+                hash: hex::encode(Sha256::digest(history.as_bytes())),
                 url: server.url("/history.blob?token=secret"),
                 encoding: ResumeSessionHistoryEncoding::Identity,
                 raw_size: history.len() as u64,
@@ -1056,59 +1064,6 @@ async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
     )
     .await;
     let mut telemetry = test_telemetry(&config, &ctx);
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::PoolMiss,
-            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(cancel, None).with_session_history_restore_plan(restore_plan),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    let writes = sandbox.write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(
-        writes[0].path,
-        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
-    );
-    assert_eq!(writes[0].content, history);
-    assert!(
-        sandbox
-            .exec_calls()
-            .iter()
-            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
-        "fresh workspace restore must not scan retained Codex sessions"
-    );
-    history_mock.assert_calls_async(0).await;
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_large_inline_codex_history_before_spawn_without_cleanup() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let sandbox = sandbox_mock::MockSandbox::with_overrides("test", Arc::clone(&overrides));
-    let write_gate = MockLifecycleGate::new();
-    sandbox.set_write_file_lifecycle_gate(write_gate.clone());
-    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let mut history =
-        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n"
-            .to_string();
-    history.push_str(&"{}\n".repeat(22 * 1024));
-    assert!(history.len() > 64 * 1024);
-    let mut ctx = minimal_context();
-    ctx.cli_agent_type = "codex".into();
-    ctx.resume_session = Some(ResumeSession::inline(session_id.into(), history.clone()));
-
-    let mut telemetry = test_telemetry(&config, &ctx);
     let run = run_in_sandbox(
         &sandbox,
         &ctx,
@@ -1116,35 +1071,35 @@ async fn run_in_sandbox_restores_large_inline_codex_history_before_spawn_without
         RunStart {
             restore_guest_state: false,
             reuse_result: SandboxReuseResult::PoolMiss,
-            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+            workspace_reuse_result: crate::types::WorkspaceReuseResult::Reused,
             prev_storage: None,
         },
         &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+        RunControls::new(cancel, None).with_session_history_restore_plan(restore_plan),
     );
     tokio::pin!(run);
     tokio::select! {
-        _ = &mut run => panic!("run reached spawn before session restore gate"),
+        _ = &mut run => panic!("workspace run reached spawn before session restore gate"),
         entered = write_gate.wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT) => {
-            entered.expect("session restore should reach the guest write gate");
+            entered.expect("workspace session restore should reach the guest write gate");
         }
     }
 
     assert!(
         overrides.start_process_calls().is_empty(),
-        "agent process must not start before session restore completes"
+        "agent process must not start before workspace session restore completes"
     );
     assert!(
         sandbox
             .exec_calls()
             .iter()
             .all(|call| !call.cmd.contains("collect_matching_session_entries")),
-        "fresh cold restore must not scan retained Codex sessions"
+        "fresh workspace restore must not scan retained Codex sessions"
     );
     write_gate.release_one();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
         .await
-        .expect("run should finish after session restore is released")
+        .expect("workspace run should finish after session restore is released")
         .unwrap();
 
     assert!(result.failure.is_none());
@@ -1156,6 +1111,56 @@ async fn run_in_sandbox_restores_large_inline_codex_history_before_spawn_without
     );
     assert_eq!(writes[0].content, history.as_bytes());
     assert_eq!(overrides.start_process_calls().len(), 1);
+    assert!(
+        sandbox
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
+        "fresh workspace restore must not scan retained Codex sessions"
+    );
+    history_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_large_inline_codex_history_without_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let mut history =
+        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n"
+            .to_string();
+    history.push_str(&"{}\n".repeat(22 * 1024));
+    assert!(history.len() > 64 * 1024);
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession::inline(session_id.into(), history.clone()));
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+    );
+    assert_eq!(writes[0].content, history.as_bytes());
     assert!(
         sandbox
             .exec_calls()

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use flate2::{Compression, write::GzEncoder};
 use httpmock::prelude::*;
 use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
+use sandbox_mock::MockLifecycleGate;
 use sha2::{Digest, Sha256};
 use tokio::sync::{Notify, oneshot};
 
@@ -919,6 +920,13 @@ async fn run_in_sandbox_restores_codex_zstd_sidecar_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl.zst"
     );
     assert_eq!(writes[0].content, compressed_history);
+    assert!(
+        sandbox
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
+        "fresh workspace restore must not scan retained Codex sessions"
+    );
     history_mock.assert_calls_async(0).await;
 }
 
@@ -1072,23 +1080,36 @@ async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
     );
     assert_eq!(writes[0].content, history);
+    assert!(
+        sandbox
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
+        "fresh workspace restore must not scan retained Codex sessions"
+    );
     history_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]
-async fn run_in_sandbox_restores_inline_codex_history_with_session_timestamp() {
+async fn run_in_sandbox_restores_large_inline_codex_history_before_spawn_without_cleanup() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = sandbox_mock::MockSandbox::with_overrides("test", Arc::clone(&overrides));
+    let write_gate = MockLifecycleGate::new();
+    sandbox.set_write_file_lifecycle_gate(write_gate.clone());
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let history =
-        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let mut history =
+        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n"
+            .to_string();
+    history.push_str(&"{}\n".repeat(22 * 1024));
+    assert!(history.len() > 64 * 1024);
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    ctx.resume_session = Some(ResumeSession::inline(session_id.into(), history.into()));
+    ctx.resume_session = Some(ResumeSession::inline(session_id.into(), history.clone()));
 
     let mut telemetry = test_telemetry(&config, &ctx);
-    let result = run_in_sandbox(
+    let run = run_in_sandbox(
         &sandbox,
         &ctx,
         &config,
@@ -1100,9 +1121,31 @@ async fn run_in_sandbox_restores_inline_codex_history_with_session_timestamp() {
         },
         &mut telemetry,
         RunControls::new(tokio_util::sync::CancellationToken::new(), None),
-    )
-    .await
-    .unwrap();
+    );
+    tokio::pin!(run);
+    tokio::select! {
+        _ = &mut run => panic!("run reached spawn before session restore gate"),
+        entered = write_gate.wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT) => {
+            entered.expect("session restore should reach the guest write gate");
+        }
+    }
+
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "agent process must not start before session restore completes"
+    );
+    assert!(
+        sandbox
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
+        "fresh cold restore must not scan retained Codex sessions"
+    );
+    write_gate.release_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
+        .await
+        .expect("run should finish after session restore is released")
+        .unwrap();
 
     assert!(result.failure.is_none());
     let writes = sandbox.write_file_calls();
@@ -1112,6 +1155,14 @@ async fn run_in_sandbox_restores_inline_codex_history_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
     );
     assert_eq!(writes[0].content, history.as_bytes());
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert!(
+        sandbox
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("collect_matching_session_entries")),
+        "completed fresh cold restore must not scan retained Codex sessions"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests/claude.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/claude.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::super::support::sandbox_write_file_error;
 use super::*;
 use sandbox::{SandboxError, SandboxInvalidStateContext, SandboxOperation};

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::super::support::sandbox_write_file_error;
 use super::*;
 use sandbox::{ExecResult, ExecTermination};
@@ -22,6 +21,24 @@ fn restore_session_writes_codex_session() {
         writes[0].path
     );
     assert_eq!(writes[0].content, session.history_bytes());
+    assert_eq!(diagnostics.bytes_in, history.len());
+}
+
+#[test]
+fn restore_session_skips_codex_cleanup_in_fresh_sandbox() {
+    let sandbox = MockSandbox::new("test");
+    let ctx = codex_context();
+    let history = codex_session_meta_history(CODEX_SESSION_ID);
+    let session = materialized_text_session(CODEX_SESSION_ID, history.clone());
+
+    let diagnostics =
+        run_restore_session(restore_session_in_fresh_sandbox(&sandbox, &ctx, &session)).unwrap();
+
+    assert!(sandbox.exec_calls().is_empty());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, CODEX_CANONICAL_ROLLOUT_PATH);
+    assert_eq!(writes[0].content, history.as_bytes());
     assert_eq!(diagnostics.bytes_in, history.len());
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -12,11 +12,14 @@ use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_history_cpu::codex_timestamp_for_test;
-use super::super::session_restore::MaterializedResumeSession;
+use super::super::session_restore::{
+    MaterializedResumeSession, SessionRestoreDiagnostics,
+    restore_session as restore_session_with_reuse_result,
+};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context};
 use crate::types::{
     ExecutionContext, ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding,
-    ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
+    ResumeSessionHistoryRef, ResumeSessionHistoryRefKind, SandboxReuseResult,
 };
 
 static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
@@ -139,6 +142,22 @@ fn codex_minimal_session_meta_history(session_id: &str) -> String {
             },
         }),
     )
+}
+
+async fn restore_session(
+    sandbox: &MockSandbox,
+    context: &ExecutionContext,
+    session: &MaterializedResumeSession,
+) -> super::super::RunnerResult<SessionRestoreDiagnostics> {
+    restore_session_with_reuse_result(sandbox, context, session, SandboxReuseResult::Reused).await
+}
+
+async fn restore_session_in_fresh_sandbox(
+    sandbox: &MockSandbox,
+    context: &ExecutionContext,
+    session: &MaterializedResumeSession,
+) -> super::super::RunnerResult<SessionRestoreDiagnostics> {
+    restore_session_with_reuse_result(sandbox, context, session, SandboxReuseResult::PoolMiss).await
 }
 
 fn assert_codex_cleanup_call(sandbox: &MockSandbox) {

--- a/crates/runner/src/executor/tests/session_restore_tests/pi.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/pi.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::*;
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests/validation.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/validation.rs
@@ -1,4 +1,3 @@
-use super::super::super::session_restore::restore_session;
 use super::*;
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- pass the actual sandbox reuse outcome into session restoration
- skip Codex retained-session discovery and cleanup for newly created sandboxes
- keep cleanup unchanged for idle-reused sandboxes and preserve the existing canonical write path for raw, zstd, and large histories
- cover cold and workspace-sidecar restores, including restore-before-spawn ordering

## Why

A fresh sandbox cannot retain a prior framework home. Workspace reuse attaches only the working-directory drive, so running the Codex cleanup helper before every fresh restore adds a guest exec and sessions-tree scan without state to discover. Production data shows aggregate workspace guest restore is material, but current telemetry cannot attribute the full 489 ms p90 to Codex; this PR removes one code-proven Codex operation without claiming that entire aggregate gain.

## Compatibility and risk

There is no API, database, queue, sidecar, workspace-image, guest protocol, or persisted-state change. `SandboxReuseResult::Reused` continues to run the bounded cleanup helper, preserving duplicate removal and prior logical-path continuity. Non-reused outcomes retain the same timestamp-derived canonical destination and `Sandbox::write_file` behavior.

The optimization relies on the existing invariant that newly created sandbox root filesystems do not contain prior user session history. A post-deployment fixed-revision cohort should attribute Codex separately before estimating aggregate impact.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo build --manifest-path crates/Cargo.toml -p runner --all-features`
- focused session restore and Codex workspace/cold integration tests
- Runner full suite: 3285 passed; one unchanged proxy port-retry test failed and reproduced alone locally (`proxy::process::tests::initial_start_retries_an_occupied_selected_port`); clean CI remains the merge gate
- `git diff --check`

Closes #29150
