### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1658,7 +1658,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",


### PR DESCRIPTION
## Summary

- update `h2` from 0.4.18 to 0.4.19
- keep Cargo manifests unchanged; no manual dependency constraints were adjusted

## Blocked dependencies

- `generic-array` remains at 0.14.7 (0.14.9 available) because `crypto-common` 0.1.7 requires exactly 0.14.7 through the active `runner` dependency graph (`digest` -> `crc-fast` -> `aws-smithy-checksums` -> `aws-sdk-s3`)

## Validation

- `cargo test --workspace --exclude runner --no-fail-fast` passed, including doctests
- `cargo check -p runner` passed after rebasing the latest Cargo changes from `main`
- `cargo test -p runner --no-fail-fast` is blocked on current `main` by an unrelated test-only `-D warnings` failure: unused import `AsyncReadExt` in `runner/src/network_logs.rs:716`
- final `cargo update --verbose` reported zero additional updates on the latest `main`
