### PR TITLE
feat(ads): add adsmarch website conversions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,3 +102,24 @@ _Avoid_: Bank consent, Mastercard connection
 **Banking access request**:
 An agent's user-visible request for a banking agent grant, including the purpose for access. The request may first require the user to create or repair a banking connection.
 _Avoid_: Banking connection, automatic grant
+
+# Acquisition Attribution Context
+
+This context separates browser conversion delivery from its server-confirmed
+source and server-side fallback.
+
+## Language
+
+**Browser conversion**:
+A Google Ads website conversion emitted by gtag from an authenticated browser.
+_Avoid_: Data Manager upload, server conversion
+
+**Conversion milestone baseline**:
+The first server-confirmed milestone snapshot recorded in a browser without
+emitting historical conversions.
+_Avoid_: Backfill, initial conversion batch
+
+**Data Manager fallback**:
+A server-side upload to the same conversion action using the same transaction
+ID when browser delivery may be missed.
+_Avoid_: Separate conversion, duplicate conversion

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -329,6 +329,7 @@ export interface StripeInvoice {
     } | null;
   } | null;
   readonly amount_due: number;
+  readonly amount_paid?: number;
   readonly currency: string;
   readonly status: "draft" | "open" | "paid" | "uncollectible" | "void" | null;
   readonly paid?: boolean;

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -163,3 +163,25 @@ describe("POST /api/attribution/signup", () => {
     expect(context.mocks.clerk.users.updateUserMetadata).not.toHaveBeenCalled();
   });
 });
+
+describe("GET /api/attribution/google-ads-milestones", () => {
+  it("requires a Clerk session", async () => {
+    const response = await client().googleAdsMilestones();
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns no milestones for a user without acquisition activity", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+
+    const response = await accept(
+      client().googleAdsMilestones({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ milestones: [] });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -1,13 +1,33 @@
 import { randomUUID } from "node:crypto";
 
-import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
-import { describe, expect, it } from "vitest";
+import {
+  acquisitionAttributionContract,
+  type GoogleAdsConversionMilestone,
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
+import {
+  testUsageStateContract,
+  type TestUsageStateActionBody,
+  type TestUsageStateFixture,
+} from "@okouai/api-contracts/contracts/test-usage-state";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockNow } from "../../../lib/time";
+import {
+  deleteUsagePricingRows,
+  seedUsagePricingRows,
+} from "../../../test-fixtures/system-config-seeds";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRouteMocks } from "./helpers/route-test";
 import { acquisitionAttributionRoutes } from "../acquisition-attribution";
+import { testUsageStateRoutes } from "../test-usage-state";
+import {
+  testUsagePackSubscriptionStateContract,
+  testUsagePackSubscriptionStateRoutes,
+} from "../test-usage-pack-subscription-state";
 
 const context = testContext();
 const mocks = createRouteMocks(context);
@@ -27,6 +47,61 @@ function client() {
   return setupApp({ context, routes: acquisitionAttributionRoutes })(
     acquisitionAttributionContract,
   );
+}
+
+async function usageStateAction(body: TestUsageStateActionBody) {
+  return await accept(
+    setupApp({ context, routes: testUsageStateRoutes })(
+      testUsageStateContract,
+    ).action({ body }),
+    [200],
+  );
+}
+
+async function cleanupAcquisitionFixture(
+  fixture: TestUsageStateFixture,
+): Promise<void> {
+  await accept(
+    setupApp({ context, routes: testUsagePackSubscriptionStateRoutes })(
+      testUsagePackSubscriptionStateContract,
+    ).action({ body: { action: "cleanup-migration", orgId: fixture.org_id } }),
+    [200],
+  );
+  await usageStateAction({ action: "delete-fixture", fixture });
+}
+
+async function seedAcquisitionFixture(): Promise<TestUsageStateFixture> {
+  const response = await usageStateAction({ action: "seed-fixture" });
+  if (!response.body.fixture) {
+    throw new Error("Expected an acquisition fixture");
+  }
+  const fixture = response.body.fixture;
+  onTestFinished(async () => {
+    await cleanupAcquisitionFixture(fixture);
+  });
+  return fixture;
+}
+
+function actorForFixture(fixture: TestUsageStateFixture): ApiTestUser {
+  return {
+    userId: fixture.user_id,
+    orgId: fixture.org_id,
+    orgRole: "org:admin",
+    email: `${fixture.user_id}@example.test`,
+  };
+}
+
+async function readGoogleAdsMilestones(
+  actor: ApiTestUser,
+): Promise<readonly GoogleAdsConversionMilestone[]> {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  const response = await accept(
+    client().googleAdsMilestones({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  return response.body.milestones;
 }
 
 describe("POST /api/attribution/signup", () => {
@@ -183,5 +258,179 @@ describe("GET /api/attribution/google-ads-milestones", () => {
     );
 
     expect(response.body).toStrictEqual({ milestones: [] });
+  });
+
+  it("returns stable run and connector milestones through the public route", async () => {
+    const fixture = await seedAcquisitionFixture();
+    const actor = actorForFixture(fixture);
+    const compose = await usageStateAction({
+      action: "seed-compose",
+      org_id: fixture.org_id,
+      user_id: fixture.user_id,
+    });
+    if (!compose.body.compose_id) {
+      throw new Error("Expected a seeded acquisition Agent");
+    }
+
+    // Production has no endpoint for constructing exact historical run
+    // timestamps, so the scoped test API supplies the cross-day fixture while
+    // the assertion remains at the production attribution route boundary.
+    await usageStateAction({
+      action: "seed-run",
+      org_id: fixture.org_id,
+      user_id: fixture.user_id,
+      compose_id: compose.body.compose_id,
+      status: "completed",
+      created_at: "2026-08-23T07:55:00.000Z",
+      started_at: "2026-08-23T07:56:00.000Z",
+      completed_at: "2026-08-23T08:00:00.000Z",
+    });
+    await usageStateAction({
+      action: "seed-run",
+      org_id: fixture.org_id,
+      user_id: fixture.user_id,
+      compose_id: compose.body.compose_id,
+      status: "completed",
+      created_at: "2026-08-24T07:55:00.000Z",
+      started_at: "2026-08-24T07:56:00.000Z",
+      completed_at: "2026-08-24T08:00:00.000Z",
+    });
+    const connectors = createConnectorBddApi(context);
+    await connectors.connectManualGrant(
+      actor,
+      "gitlab",
+      "api-token",
+      { accessToken: "gitlab-acquisition-token" },
+      compose.body.compose_id,
+    );
+    await connectors.connectManualGrant(
+      actor,
+      "figma",
+      "api-token",
+      { accessToken: "figma-acquisition-token" },
+      compose.body.compose_id,
+    );
+
+    const milestones = await readGoogleAdsMilestones(actor);
+    expect(milestones).toStrictEqual([
+      {
+        kind: "first_run_completed",
+        transactionId: `gdm-first_run_completed-${fixture.user_id}`,
+      },
+      {
+        kind: "second_run_completed",
+        transactionId: `gdm-second_run_completed-${fixture.user_id}`,
+      },
+      {
+        kind: "multi_day_run_completed",
+        transactionId: `gdm-multi_day_run_completed-${fixture.user_id}`,
+      },
+      {
+        kind: "one_connector_connected",
+        transactionId: `gdm-one_connector_connected-${fixture.user_id}`,
+      },
+      {
+        kind: "two_connectors_connected",
+        transactionId: `gdm-two_connectors_connected-${fixture.user_id}`,
+      },
+    ]);
+    await expect(readGoogleAdsMilestones(actor)).resolves.toStrictEqual(
+      milestones,
+    );
+  });
+
+  it("returns the stable milestone for the user who exhausts a free trial", async () => {
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped acquisition actor");
+    }
+    const fixture = { org_id: actor.orgId, user_id: actor.userId };
+    onTestFinished(async () => {
+      await cleanupAcquisitionFixture(fixture);
+    });
+    bdd.acceptAgentStorageWrites();
+    await bdd.bootstrapLimitedFreeOnboarding(actor, {
+      displayName: "Acquisition Milestone Agent",
+    });
+
+    const usageProvider = `acquisition-${randomUUID()}`;
+    await seedUsagePricingRows([
+      {
+        kind: "model",
+        provider: usageProvider,
+        category: "tokens.input",
+        unitPrice: 3000,
+        unitSize: 1_000_000,
+      },
+    ]);
+    onTestFinished(async () => {
+      await deleteUsagePricingRows({
+        kind: "model",
+        provider: usageProvider,
+        categories: ["tokens.input"],
+      });
+    });
+
+    // Usage settlement is the production mechanism that exhausts the grant;
+    // the scoped API only inserts the otherwise runner-owned usage event.
+    await usageStateAction({
+      action: "insert-usage-event",
+      org_id: actor.orgId,
+      user_id: actor.userId,
+      kind: "model",
+      provider: usageProvider,
+      category: "tokens.input",
+      quantity: 1_000_000,
+      status: "pending",
+    });
+    const billing = createBillingMediaApi(context);
+    await billing.processOrgUsageEvents(actor);
+    await expect(billing.readBillingStatus(actor)).resolves.toMatchObject({
+      credits: 0,
+    });
+
+    const milestones = await readGoogleAdsMilestones(actor);
+    expect(milestones).toStrictEqual([
+      {
+        kind: "free_trial_completed",
+        transactionId: expect.stringMatching(
+          /^gdm-free-trial-completed-[0-9a-f-]{36}$/,
+        ),
+      },
+    ]);
+    await expect(readGoogleAdsMilestones(actor)).resolves.toStrictEqual(
+      milestones,
+    );
+  });
+
+  it("excludes activity from internal organizations", async () => {
+    const fixture = {
+      org_id: "org_3AW2PMh2ZLwsNXJAH6rufx2HUQu",
+      user_id: `user_${randomUUID()}`,
+    };
+    onTestFinished(async () => {
+      await cleanupAcquisitionFixture(fixture);
+    });
+    const compose = await usageStateAction({
+      action: "seed-compose",
+      org_id: fixture.org_id,
+      user_id: fixture.user_id,
+    });
+    if (!compose.body.compose_id) {
+      throw new Error("Expected a seeded internal acquisition Agent");
+    }
+    await usageStateAction({
+      action: "seed-run",
+      org_id: fixture.org_id,
+      user_id: fixture.user_id,
+      compose_id: compose.body.compose_id,
+      status: "completed",
+      completed_at: "2026-08-25T08:00:00.000Z",
+    });
+
+    await expect(
+      readGoogleAdsMilestones(actorForFixture(fixture)),
+    ).resolves.toStrictEqual([]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -14943,7 +14943,7 @@ describe("POST /api/billing/checkout/complete", () => {
     expect(status.currentPeriodEnd).toBeNull();
   });
 
-  it("allows completion when the same subscription is already stored", async () => {
+  it("returns the paid invoice conversion when the subscription is already stored", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
     const fixture = await trackedSeed({
@@ -14965,6 +14965,12 @@ describe("POST /api/billing/checkout/complete", () => {
       id: subscriptionId,
       status: "active",
       cancel_at_period_end: false,
+      latest_invoice: {
+        id: "in_checkout_paid",
+        status: "paid",
+        currency: "usd",
+        amount_paid: 20_000,
+      },
       items: {
         data: [
           {
@@ -14987,7 +14993,13 @@ describe("POST /api/billing/checkout/complete", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ completed: true });
+    expect(response.body).toStrictEqual({
+      completed: true,
+      googleAdsConversion: {
+        transactionId: "in_checkout_paid",
+        valueUsd: 200,
+      },
+    });
   });
 
   it("returns 400 when completed checkout would downgrade the current tier", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -450,21 +450,6 @@ async function prepareUsagePackCheckoutOrg(
   );
 }
 
-function cleanupUsagePackSnapshotOnTestFinished(
-  fixture: BillingOrgFixture,
-  usagePackSubscriptionId: string,
-): void {
-  onTestFinished(async () => {
-    await usagePackStateAction({
-      action: "cleanup",
-      orgId: fixture.orgId,
-      usagePackSubscriptionId,
-      deleteGrants: false,
-      deleteOrgMetadata: false,
-    });
-  });
-}
-
 async function createSubscriptionOrg(args: {
   readonly tier: "pro" | "team" | "custom";
   readonly customerId?: string;
@@ -2665,6 +2650,126 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledWith(
       expect.objectContaining({ preview_mode: "recurring" }),
     );
+    if (!("previewToken" in response.body)) {
+      throw new Error("Expected a usage pack purchase preview");
+    }
+
+    const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
+    const billingPeriod = {
+      start: currentSecond(),
+      end: currentSecond() + 30 * 86_400,
+    };
+    let usagePackSubscriptionId: string | undefined;
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.subscriptions.create.mockImplementation((input) => {
+      const metadata = stripeInputMetadata(input);
+      usagePackSubscriptionId = metadata.usagePackSubscriptionId;
+      const paidInvoice = {
+        id: invoiceId,
+        customer: customerId,
+        metadata,
+        status: "paid" as const,
+        paid: true,
+        amount_due: 2000,
+        amount_paid: 2000,
+        currency: "usd",
+        hosted_invoice_url: null,
+        parent: {
+          subscription_details: { subscription: subscriptionId, metadata },
+        },
+        lines: {
+          has_more: false,
+          data: [
+            {
+              id: `il_${randomUUID()}`,
+              amount: 2000,
+              subtotal: 2000,
+              quantity: 1,
+              price: { id: TEST_PRICE_USAGE_PACK_20 },
+              period: billingPeriod,
+              parent: {
+                type: "subscription_item_details" as const,
+                subscription_item_details: { proration: false },
+              },
+            },
+          ],
+        },
+      };
+      const subscription = {
+        id: subscriptionId,
+        customer: customerId,
+        status: "active",
+        cancel_at: null,
+        cancel_at_period_end: false,
+        schedule: null,
+        metadata,
+        items: {
+          data: [
+            {
+              id: `si_${randomUUID()}`,
+              price: {
+                id: TEST_PRICE_USAGE_PACK_PLAN_PRO,
+                recurring: { interval: "month", interval_count: 1 },
+              },
+              quantity: 1,
+              current_period_start: billingPeriod.start,
+              current_period_end: billingPeriod.end,
+            },
+            {
+              id: `si_${randomUUID()}`,
+              price: {
+                id: TEST_PRICE_USAGE_PACK_20,
+                recurring: { interval: "month", interval_count: 1 },
+              },
+              quantity: 1,
+              current_period_start: billingPeriod.start,
+              current_period_end: billingPeriod.end,
+            },
+          ],
+        },
+        latest_invoice: paidInvoice,
+      };
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+        subscription,
+      );
+      return Promise.resolve(subscription);
+    });
+
+    const confirmation = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        billingUsagePackCheckoutContract,
+      ).confirm({
+        body: { previewToken: response.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "completed",
+      hostedInvoiceUrl: null,
+      googleAdsConversion: {
+        transactionId: invoiceId,
+        valueUsd: 20,
+      },
+    });
+    if (!usagePackSubscriptionId) {
+      throw new Error("Expected the confirmed usage pack subscription ID");
+    }
+    const confirmedUsagePackSubscriptionId = usagePackSubscriptionId;
+    onTestFinished(async () => {
+      await usagePackStateAction({
+        action: "cleanup",
+        orgId: fixture.orgId,
+        usagePackSubscriptionId: confirmedUsagePackSubscriptionId,
+        deleteGrants: true,
+        deleteOrgMetadata: true,
+      });
+    });
   });
 
   it("recovers usage pack checkout from a transient Clerk rate limit", async () => {

--- a/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
+++ b/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
@@ -13,6 +13,7 @@ import {
   parseStoredSignupAttribution,
   persistOrgAcquisitionAttribution$,
 } from "../services/acquisition-attribution.service";
+import { googleAdsConversionMilestonesForUser$ } from "../services/google-ads-conversion-milestones.service";
 import type { RouteEntry } from "../route-entry";
 
 const SIGNUP_ATTRIBUTION_KEY = "signup_attribution";
@@ -23,6 +24,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 const recordSignupBody$ = bodyResultOf(
   acquisitionAttributionContract.recordSignup,
+);
+
+const googleAdsMilestonesInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const milestones = await set(
+      googleAdsConversionMilestonesForUser$,
+      auth.userId,
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body: { milestones } };
+  },
 );
 
 const recordSignupInner$ = command(
@@ -98,6 +112,10 @@ const recordSignupInner$ = command(
 );
 
 export const acquisitionAttributionRoutes: readonly RouteEntry[] = [
+  {
+    route: acquisitionAttributionContract.googleAdsMilestones,
+    handler: authRoute({ accept: ["session"] }, googleAdsMilestonesInner$),
+  },
   {
     route: acquisitionAttributionContract.recordSignup,
     handler: authRoute({ accept: ["session"] }, recordSignupInner$),

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -36,7 +36,7 @@ import {
   type ClerkClient,
 } from "../external/clerk";
 import { db$, writeDb$, type Db } from "../external/db";
-import { getStripeClient } from "../external/stripe-client";
+import { getStripeClient, type StripeInvoice } from "../external/stripe-client";
 import {
   activePriceId,
   activeUsagePackPlanPriceId,
@@ -477,6 +477,26 @@ function usagePackCheckoutTierConflicts(
   );
 }
 
+function googleAdsPaidConversion(invoice: StripeInvoice | null):
+  | {
+      readonly transactionId: string;
+      readonly valueUsd: number;
+    }
+  | undefined {
+  const amountPaidCents = invoice?.amount_paid ?? 0;
+  if (
+    invoice?.status !== "paid" ||
+    invoice.currency.toLowerCase() !== "usd" ||
+    amountPaidCents <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    transactionId: invoice.id,
+    valueUsd: amountPaidCents / 100,
+  };
+}
+
 const confirmPlanPurchaseForOrg$ = command(
   async ({ set }, orgId: string, previewToken: string, signal: AbortSignal) => {
     const result = await set(confirmPlanPurchase$, orgId, previewToken, signal);
@@ -497,7 +517,14 @@ const confirmPlanPurchaseForOrg$ = command(
         );
       }
     }
-    return { status: 200 as const, body: result.response };
+    const conversion = googleAdsPaidConversion(result.paidInvoice);
+    return {
+      status: 200 as const,
+      body:
+        result.response.status === "completed" && conversion
+          ? { ...result.response, googleAdsConversion: conversion }
+          : result.response,
+    };
   },
 );
 
@@ -1826,9 +1853,16 @@ const checkoutCompleteAuthed$ = command(
       );
     }
 
+    const conversion =
+      result.status === "completed"
+        ? googleAdsPaidConversion(result.paidInvoice)
+        : undefined;
     return {
       status: 200 as const,
-      body: { completed: result.status === "completed" },
+      body: {
+        completed: result.status === "completed",
+        ...(conversion ? { googleAdsConversion: conversion } : {}),
+      },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -721,7 +721,14 @@ const confirmUsagePackPurchaseForOrg$ = command(
         );
       }
     }
-    return { status: 200 as const, body: result.response };
+    const conversion = googleAdsPaidConversion(result.paidInvoice);
+    return {
+      status: 200 as const,
+      body:
+        result.response.status === "completed" && conversion
+          ? { ...result.response, googleAdsConversion: conversion }
+          : result.response,
+    };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-checkout.service.ts
@@ -87,7 +87,10 @@ interface CompleteCheckoutSessionArgs {
 }
 
 type CheckoutCompletionResult =
-  | { readonly status: "completed" }
+  | {
+      readonly status: "completed";
+      readonly paidInvoice: StripeInvoice | null;
+    }
   | { readonly status: "pending" }
   | { readonly status: "customer_mismatch" }
   | {
@@ -1360,7 +1363,9 @@ export const completeCheckoutSession$ = command(
       return { status: "pending" };
     }
 
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
+      expand: ["latest_invoice"],
+    });
     signal.throwIfAborted();
 
     const priceId = knownPlanPriceItem(subscription.items.data)?.price.id;
@@ -1401,7 +1406,12 @@ export const completeCheckoutSession$ = command(
       );
     signal.throwIfAborted();
 
-    return { status: alreadyPaidSubscription ? "completed" : "pending" };
+    return alreadyPaidSubscription
+      ? {
+          status: "completed",
+          paidInvoice: expandedLatestInvoice(subscription),
+        }
+      : { status: "pending" };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/google-ads-conversion-milestones.service.ts
+++ b/turbo/apps/api/src/signals/services/google-ads-conversion-milestones.service.ts
@@ -1,0 +1,295 @@
+import { command } from "ccstate";
+import type {
+  GoogleAdsConversionMilestone,
+  GoogleAdsConversionMilestoneKind,
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { connectors } from "@okouai/db/schema/connector";
+import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  notInArray,
+} from "drizzle-orm";
+
+import { db$ } from "../external/db";
+
+const GOOGLE_ADS_ACCOUNT_TIME_ZONE = "America/Los_Angeles";
+const FREE_TRIAL_CREDIT_SOURCES = Object.freeze([
+  "onboarding",
+  "starter_grant",
+]);
+const INTERNAL_ORG_IDS = Object.freeze([
+  "org_3AW2PMh2ZLwsNXJAH6rufx2HUQu",
+  "org_3EIyMn16PGrzscXQQQxvZTaiIUW",
+  "org_3C3uya6QPgVprQsAaDqCPgoBry6",
+  "org_3AVxy08nV0RDyXtFj19Ohv0i6YD",
+  "org_3AW2PmtD1KxaZivngfL2Ud0sHBf",
+  "org_3AW2MBAPXq6wUJZOd4hz97Az7I0",
+  "org_3BTOoX3y81Ngrjtu1LI1dqBzXcB",
+  "org_3ApJjGcaXGOqK9X7DaFcVemqBnw",
+  "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+  "org_3AW2QiNyfbz196bcHexc1E35nOq",
+]);
+
+function googleAdsAccountDay(date: Date): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: GOOGLE_ADS_ACCOUNT_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const year = parts.find((part) => {
+    return part.type === "year";
+  })?.value;
+  const month = parts.find((part) => {
+    return part.type === "month";
+  })?.value;
+  const day = parts.find((part) => {
+    return part.type === "day";
+  })?.value;
+  return `${year}-${month}-${day}`;
+}
+
+function milestone(
+  kind: GoogleAdsConversionMilestoneKind,
+  transactionId: string,
+): GoogleAdsConversionMilestone {
+  return { kind, transactionId };
+}
+
+function runMilestones(
+  userId: string,
+  rows: readonly { readonly completedAt: Date | null }[],
+): GoogleAdsConversionMilestone[] {
+  const completedAt = rows.flatMap((row) => {
+    return row.completedAt ? [row.completedAt] : [];
+  });
+  const milestones: GoogleAdsConversionMilestone[] = [];
+  if (completedAt[0]) {
+    milestones.push(
+      milestone("first_run_completed", `gdm-first_run_completed-${userId}`),
+    );
+  }
+  if (completedAt[1]) {
+    milestones.push(
+      milestone("second_run_completed", `gdm-second_run_completed-${userId}`),
+    );
+  }
+
+  const firstDay = completedAt[0]
+    ? googleAdsAccountDay(completedAt[0])
+    : undefined;
+  if (
+    firstDay &&
+    completedAt.some((date) => {
+      return googleAdsAccountDay(date) !== firstDay;
+    })
+  ) {
+    milestones.push(
+      milestone(
+        "multi_day_run_completed",
+        `gdm-multi_day_run_completed-${userId}`,
+      ),
+    );
+  }
+  return milestones;
+}
+
+function connectorMilestones(
+  userId: string,
+  rows: readonly { readonly connectorSlug: string | null }[],
+): GoogleAdsConversionMilestone[] {
+  const distinctConnectorSlugs = new Set(
+    rows.flatMap((row) => {
+      return row.connectorSlug ? [row.connectorSlug] : [];
+    }),
+  );
+  const milestones: GoogleAdsConversionMilestone[] = [];
+  if (distinctConnectorSlugs.size >= 1) {
+    milestones.push(
+      milestone(
+        "one_connector_connected",
+        `gdm-one_connector_connected-${userId}`,
+      ),
+    );
+  }
+  if (distinctConnectorSlugs.size >= 2) {
+    milestones.push(
+      milestone(
+        "two_connectors_connected",
+        `gdm-two_connectors_connected-${userId}`,
+      ),
+    );
+  }
+  return milestones;
+}
+
+interface TrialGrant {
+  readonly id: string;
+  readonly orgId: string;
+  readonly amount: number;
+  readonly createdAt: Date;
+}
+
+interface ProcessedUsage {
+  readonly id: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly creditsCharged: number | null;
+  readonly processedAt: Date | null;
+}
+
+function freeTrialMilestones(
+  userId: string,
+  grants: readonly TrialGrant[],
+  usageRows: readonly ProcessedUsage[],
+): GoogleAdsConversionMilestone[] {
+  const milestones: GoogleAdsConversionMilestone[] = [];
+  for (const grant of grants) {
+    if (grant.amount <= 0) {
+      continue;
+    }
+    let cumulativeCredits = 0;
+    for (const usageRow of usageRows) {
+      if (
+        usageRow.orgId !== grant.orgId ||
+        !usageRow.processedAt ||
+        usageRow.processedAt < grant.createdAt
+      ) {
+        continue;
+      }
+      cumulativeCredits += usageRow.creditsCharged ?? 0;
+      if (cumulativeCredits < grant.amount) {
+        continue;
+      }
+      if (usageRow.userId === userId) {
+        milestones.push(
+          milestone(
+            "free_trial_completed",
+            `gdm-free-trial-completed-${grant.id}`,
+          ),
+        );
+      }
+      break;
+    }
+  }
+  return milestones;
+}
+
+export const googleAdsConversionMilestonesForUser$ = command(
+  async ({ get }, userId: string, signal: AbortSignal) => {
+    const db = get(db$);
+    const [completedRuns, connectedConnectors, userUsageRows] =
+      await Promise.all([
+        db
+          .select({ completedAt: agentRuns.completedAt })
+          .from(agentRuns)
+          .where(
+            and(
+              eq(agentRuns.userId, userId),
+              eq(agentRuns.status, "completed"),
+              isNotNull(agentRuns.completedAt),
+              notInArray(agentRuns.orgId, [...INTERNAL_ORG_IDS]),
+            ),
+          )
+          .orderBy(asc(agentRuns.completedAt), asc(agentRuns.id)),
+        db
+          .select({ connectorSlug: connectors.connectorSlug })
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.userId, userId),
+              isNotNull(connectors.connectorSlug),
+              notInArray(connectors.orgId, [...INTERNAL_ORG_IDS]),
+            ),
+          )
+          .orderBy(asc(connectors.createdAt), asc(connectors.id)),
+        db
+          .select({
+            orgId: usageEvent.orgId,
+            processedAt: usageEvent.processedAt,
+          })
+          .from(usageEvent)
+          .where(
+            and(
+              eq(usageEvent.userId, userId),
+              eq(usageEvent.status, "processed"),
+              gt(usageEvent.creditsCharged, 0),
+              isNotNull(usageEvent.processedAt),
+              notInArray(usageEvent.orgId, [...INTERNAL_ORG_IDS]),
+            ),
+          )
+          .orderBy(asc(usageEvent.processedAt), asc(usageEvent.id)),
+      ]);
+    signal.throwIfAborted();
+
+    const orgIds = [
+      ...new Set(
+        userUsageRows.map((row) => {
+          return row.orgId;
+        }),
+      ),
+    ];
+    let trialMilestones: GoogleAdsConversionMilestone[] = [];
+    if (orgIds.length > 0) {
+      const grants = await db
+        .select({
+          id: creditExpiresRecord.id,
+          orgId: creditExpiresRecord.orgId,
+          amount: creditExpiresRecord.amount,
+          createdAt: creditExpiresRecord.createdAt,
+        })
+        .from(creditExpiresRecord)
+        .where(
+          and(
+            inArray(creditExpiresRecord.orgId, orgIds),
+            inArray(creditExpiresRecord.source, [...FREE_TRIAL_CREDIT_SOURCES]),
+            eq(creditExpiresRecord.remaining, 0),
+          ),
+        )
+        .orderBy(
+          asc(creditExpiresRecord.createdAt),
+          asc(creditExpiresRecord.id),
+        );
+      signal.throwIfAborted();
+
+      const earliestGrantCreatedAt = grants[0]?.createdAt;
+      if (earliestGrantCreatedAt) {
+        const usageRows = await db
+          .select({
+            id: usageEvent.id,
+            orgId: usageEvent.orgId,
+            userId: usageEvent.userId,
+            creditsCharged: usageEvent.creditsCharged,
+            processedAt: usageEvent.processedAt,
+          })
+          .from(usageEvent)
+          .where(
+            and(
+              inArray(usageEvent.orgId, orgIds),
+              eq(usageEvent.status, "processed"),
+              gt(usageEvent.creditsCharged, 0),
+              isNotNull(usageEvent.processedAt),
+              gte(usageEvent.processedAt, earliestGrantCreatedAt),
+            ),
+          )
+          .orderBy(asc(usageEvent.processedAt), asc(usageEvent.id));
+        signal.throwIfAborted();
+        trialMilestones = freeTrialMilestones(userId, grants, usageRows);
+      }
+    }
+
+    return [
+      ...runMilestones(userId, completedRuns),
+      ...connectorMilestones(userId, connectedConnectors),
+      ...trialMilestones,
+    ];
+  },
+);

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -848,17 +848,17 @@
           hostname.endsWith(".okou.ai");
         if (!isProductionHost) return;
 
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () {
+          window.dataLayer.push(arguments);
+        };
+        window.gtag("js", new Date());
+        window.gtag("config", "AW-18144854014");
+        window.gtag("config", "AW-18407336975");
+
         var initialized = false;
 
         function loadMarketingScripts() {
-          window.dataLayer = window.dataLayer || [];
-          window.gtag = function () {
-            window.dataLayer.push(arguments);
-          };
-          window.gtag("js", new Date());
-          window.gtag("config", "AW-18144854014");
-          window.gtag("config", "AW-18407336975");
-
           var gtagScript = document.createElement("script");
           gtagScript.async = true;
           gtagScript.src =

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -857,6 +857,7 @@
           };
           window.gtag("js", new Date());
           window.gtag("config", "AW-18144854014");
+          window.gtag("config", "AW-18407336975");
 
           var gtagScript = document.createElement("script");
           gtagScript.async = true;

--- a/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
@@ -2,6 +2,9 @@ import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/
 import { mockApi } from "../msw-contract.ts";
 
 export const apiAttributionHandlers = [
+  mockApi(acquisitionAttributionContract.googleAdsMilestones, ({ respond }) => {
+    return respond(200, { milestones: [] });
+  }),
   mockApi(acquisitionAttributionContract.recordSignup, ({ respond }) => {
     return respond(200, { recorded: true });
   }),

--- a/turbo/apps/platform/src/signals/__tests__/google-ads-conversion-milestones.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/google-ads-conversion-milestones.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquisitionAttributionContract,
+  type GoogleAdsConversionMilestone,
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
+
+import {
+  clearMockedAuthOnAbort,
+  mockOrganization,
+  mockUser,
+} from "../../__tests__/mock-auth.ts";
+import { syncGoogleAdsConversionMilestones$ } from "../bootstrap/google-ads-conversion-milestones.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+type GtagFn = (...args: unknown[]) => void;
+type WindowWithGtag = Window & { gtag?: GtagFn };
+
+function mockSignedInUser(userId = "test-user-123"): void {
+  mockUser(
+    {
+      id: userId,
+      fullName: "Test User",
+      email: "test@example.com",
+      createdAt: new Date("2026-08-25T00:00:00.000Z"),
+    },
+    { token: "test-token" },
+  );
+  mockOrganization({
+    activeOrg: { id: "org_default", name: "Default Org" },
+    memberships: [{ id: "org_default" }],
+  });
+  clearMockedAuthOnAbort(context.signal);
+}
+
+const MILESTONE_CASES: readonly {
+  readonly kind: GoogleAdsConversionMilestone["kind"];
+  readonly sendTo: string;
+  readonly value: number;
+}[] = [
+  {
+    kind: "free_trial_completed",
+    sendTo: "AW-18407336975/kS5jCP6RrOccEI_YpslE",
+    value: 15,
+  },
+  {
+    kind: "first_run_completed",
+    sendTo: "AW-18407336975/uEoeCIGSrOccEI_YpslE",
+    value: 5,
+  },
+  {
+    kind: "second_run_completed",
+    sendTo: "AW-18407336975/0S04CISSrOccEI_YpslE",
+    value: 10,
+  },
+  {
+    kind: "multi_day_run_completed",
+    sendTo: "AW-18407336975/ZGzhCI2SrOccEI_YpslE",
+    value: 15,
+  },
+  {
+    kind: "one_connector_connected",
+    sendTo: "AW-18407336975/QpfCCIeSrOccEI_YpslE",
+    value: 8,
+  },
+  {
+    kind: "two_connectors_connected",
+    sendTo: "AW-18407336975/DFtNCIqSrOccEI_YpslE",
+    value: 15,
+  },
+];
+
+function installGtagMock(): ReturnType<typeof vi.fn<GtagFn>> {
+  const windowWithGtag = window as WindowWithGtag;
+  const originalGtag = windowWithGtag.gtag;
+  const gtag = vi.fn<GtagFn>();
+  Object.defineProperty(windowWithGtag, "gtag", {
+    configurable: true,
+    value: gtag,
+    writable: true,
+  });
+  context.signal.addEventListener("abort", () => {
+    if (originalGtag) {
+      Object.defineProperty(windowWithGtag, "gtag", {
+        configurable: true,
+        value: originalGtag,
+        writable: true,
+      });
+    } else {
+      Reflect.deleteProperty(windowWithGtag, "gtag");
+    }
+  });
+  return gtag;
+}
+
+describe("google ads conversion milestone sync", () => {
+  it("baselines existing milestones and emits only newly achieved ones", async () => {
+    mockSignedInUser();
+    const gtag = installGtagMock();
+    let milestones: readonly GoogleAdsConversionMilestone[] = [
+      {
+        kind: "first_run_completed",
+        transactionId: "gdm-first_run_completed-test-user-123",
+      },
+    ];
+    context.mocks.api(
+      acquisitionAttributionContract.googleAdsMilestones,
+      ({ respond }) => {
+        return respond(200, { milestones: [...milestones] });
+      },
+    );
+
+    await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+    expect(gtag).not.toHaveBeenCalled();
+
+    milestones = [
+      ...milestones,
+      {
+        kind: "second_run_completed",
+        transactionId: "gdm-second_run_completed-test-user-123",
+      },
+    ];
+    await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+    await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+
+    expect(gtag).toHaveBeenCalledTimes(1);
+    expect(gtag).toHaveBeenCalledWith("event", "conversion", {
+      send_to: "AW-18407336975/0S04CISSrOccEI_YpslE",
+      value: 10,
+      currency: "USD",
+      transaction_id: "gdm-second_run_completed-test-user-123",
+    });
+  });
+
+  it.each(MILESTONE_CASES)(
+    "emits $kind with the configured action and value",
+    async ({ kind, sendTo, value }) => {
+      const userId = `test-user-${kind}`;
+      mockSignedInUser(userId);
+      const gtag = installGtagMock();
+      let milestones: readonly GoogleAdsConversionMilestone[] = [];
+      context.mocks.api(
+        acquisitionAttributionContract.googleAdsMilestones,
+        ({ respond }) => {
+          return respond(200, { milestones: [...milestones] });
+        },
+      );
+
+      await context.store.set(
+        syncGoogleAdsConversionMilestones$,
+        context.signal,
+      );
+      expect(gtag).not.toHaveBeenCalled();
+
+      const transactionId = `transaction-${kind}-${userId}`;
+      milestones = [{ kind, transactionId }];
+      await context.store.set(
+        syncGoogleAdsConversionMilestones$,
+        context.signal,
+      );
+      await context.store.set(
+        syncGoogleAdsConversionMilestones$,
+        context.signal,
+      );
+
+      expect(gtag).toHaveBeenCalledTimes(1);
+      expect(gtag).toHaveBeenCalledWith("event", "conversion", {
+        send_to: sendTo,
+        value,
+        currency: "USD",
+        transaction_id: transactionId,
+      });
+    },
+  );
+});

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -22,6 +22,7 @@ import { testContext } from "./test-helpers.ts";
 const context = testContext();
 const STORED_AD_ATTRIBUTION_KEY = "vm0.adAttribution";
 const SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
+const ADSMARCH_SIGNUP_SEND_TO = "AW-18407336975/8mCZCLORrOccEI_YpslE";
 const storedAdAttributionStorage = sessionStorageSignals(
   STORED_AD_ATTRIBUTION_KEY,
 );
@@ -53,7 +54,7 @@ function mockSignedInUser(options: { readonly createdAt?: Date } = {}): void {
 function installGtagMock() {
   const windowWithGtag = window as WindowWithGtag;
   const originalGtag = windowWithGtag.gtag;
-  const gtag = vi.fn();
+  const gtag = vi.fn<(...args: unknown[]) => void>();
 
   Object.defineProperty(windowWithGtag, "gtag", {
     configurable: true,
@@ -129,10 +130,20 @@ describe("signup attribution Google Ads conversion", () => {
         currency: "USD",
       }),
     );
+    expect(gtag).toHaveBeenCalledWith(
+      "event",
+      "conversion",
+      expect.objectContaining({
+        send_to: ADSMARCH_SIGNUP_SEND_TO,
+        value: 1,
+        currency: "USD",
+        transaction_id: "test-user-123",
+      }),
+    );
 
     await context.store.set(recordSignupAttribution$, context.signal);
 
-    expect(gtag).toHaveBeenCalledTimes(1);
+    expect(gtag).toHaveBeenCalledTimes(2);
   });
 
   it("records the GA4 client ID for a recent signup without stored ad attribution", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -4,6 +4,7 @@ import {
   type AdAttributionMetadata,
 } from "@okouai/api-contracts/contracts/acquisition-attribution";
 
+import indexHtml from "../../../index.html?raw";
 import {
   clearMockedAuthOnAbort,
   mockOrganization,
@@ -30,6 +31,66 @@ const storedAdAttributionStorage = sessionStorageSignals(
 type WindowWithGtag = Window & {
   gtag?: (...args: unknown[]) => void;
 };
+
+type WindowWithMarketingQueue = WindowWithGtag & {
+  dataLayer?: IArguments[];
+};
+
+type MarketingEntrypointScript = (
+  windowObject: Window,
+  documentObject: Document,
+) => void;
+
+function marketingEntrypointSource(): string {
+  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)]
+    .map((match) => {
+      return match[1];
+    })
+    .find((script) => {
+      return script?.includes('window.gtag("config", "AW-18407336975")');
+    });
+  if (source === undefined) {
+    throw new Error("Unable to locate the marketing loader in index.html");
+  }
+  return source;
+}
+
+function executeMarketingEntrypoint(): WindowWithMarketingQueue {
+  const marketingWindow = window as WindowWithMarketingQueue;
+  const originalDataLayer = marketingWindow.dataLayer;
+  const originalGtag = marketingWindow.gtag;
+  context.mocks.browser.url("https://app.vm0.ai/");
+  const timeout = vi.spyOn(window, "setTimeout").mockImplementation(() => {
+    return 1;
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      timeout.mockRestore();
+      if (originalDataLayer === undefined) {
+        Reflect.deleteProperty(marketingWindow, "dataLayer");
+      } else {
+        marketingWindow.dataLayer = originalDataLayer;
+      }
+      if (originalGtag === undefined) {
+        Reflect.deleteProperty(marketingWindow, "gtag");
+      } else {
+        marketingWindow.gtag = originalGtag;
+      }
+    },
+    { once: true },
+  );
+  Reflect.deleteProperty(marketingWindow, "dataLayer");
+  Reflect.deleteProperty(marketingWindow, "gtag");
+
+  const executeEntrypointScript = new Function(
+    "window",
+    "document",
+    `${marketingEntrypointSource()}\n//# sourceURL=platform-marketing-entrypoint-test.js`,
+  ) as MarketingEntrypointScript;
+  executeEntrypointScript(window, document);
+  return marketingWindow;
+}
 
 function mockSignedInUser(options: { readonly createdAt?: Date } = {}): void {
   mockNow(context.signal);
@@ -95,6 +156,43 @@ function setGoogleAnalyticsCookie(value: string): void {
 }
 
 describe("signup attribution Google Ads conversion", () => {
+  it("queues Signup conversions before external marketing scripts load", async () => {
+    const marketingWindow = executeMarketingEntrypoint();
+    const queuedBeforeSignup = marketingWindow.dataLayer?.map((entry) => {
+      return [...entry];
+    });
+    expect(queuedBeforeSignup).toStrictEqual([
+      ["js", expect.any(Date)],
+      ["config", "AW-18144854014"],
+      ["config", "AW-18407336975"],
+    ]);
+
+    mockSignedInUser();
+    storePaidSignupAttribution();
+    context.mocks.api(
+      acquisitionAttributionContract.recordSignup,
+      ({ respond }) => {
+        return respond(200, { recorded: true });
+      },
+    );
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    const queuedAfterSignup = marketingWindow.dataLayer?.map((entry) => {
+      return [...entry];
+    });
+    expect(queuedAfterSignup).toContainEqual([
+      "event",
+      "conversion",
+      expect.objectContaining({ send_to: SIGNUP_SEND_TO }),
+    ]);
+    expect(queuedAfterSignup).toContainEqual([
+      "event",
+      "conversion",
+      expect.objectContaining({ send_to: ADSMARCH_SIGNUP_SEND_TO }),
+    ]);
+  });
+
   it("fires the Signup conversion after first-time signup attribution is recorded", async () => {
     const gtag = installGtagMock();
     let recordedAttribution: AdAttributionMetadata | undefined;

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
@@ -1,0 +1,177 @@
+import { command, state } from "ccstate";
+import {
+  acquisitionAttributionContract,
+  type GoogleAdsConversionMilestoneKind,
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
+
+import { accept } from "../../lib/accept.ts";
+import { apiClient$ } from "../api-client.ts";
+import { user$ } from "../auth.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
+import { jsonParseOr } from "../utils.ts";
+import {
+  fireGoogleAdsConversion,
+  GOOGLE_ADS_ADSMARCH_FIRST_RUN_COMPLETED_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_FREE_TRIAL_COMPLETED_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_MULTI_DAY_RUN_COMPLETED_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_ONE_CONNECTOR_CONNECTED_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_SECOND_RUN_COMPLETED_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_TWO_CONNECTORS_CONNECTED_SEND_TO,
+} from "./google-ads-conversion.ts";
+
+const GOOGLE_ADS_MILESTONE_STORAGE_KEY =
+  "vm0.googleAds.18407336975.conversionMilestones";
+
+const milestoneStorage = localStorageSignals(GOOGLE_ADS_MILESTONE_STORAGE_KEY);
+const bootstrappedUserIds$ = state<ReadonlySet<string>>(new Set());
+
+interface StoredMilestoneState {
+  readonly transactionIds: readonly string[];
+}
+
+type StoredMilestonesByUser = Readonly<Record<string, StoredMilestoneState>>;
+
+const MILESTONE_CONFIG = {
+  free_trial_completed: {
+    sendTo: GOOGLE_ADS_ADSMARCH_FREE_TRIAL_COMPLETED_SEND_TO,
+    value: 15,
+  },
+  first_run_completed: {
+    sendTo: GOOGLE_ADS_ADSMARCH_FIRST_RUN_COMPLETED_SEND_TO,
+    value: 5,
+  },
+  second_run_completed: {
+    sendTo: GOOGLE_ADS_ADSMARCH_SECOND_RUN_COMPLETED_SEND_TO,
+    value: 10,
+  },
+  multi_day_run_completed: {
+    sendTo: GOOGLE_ADS_ADSMARCH_MULTI_DAY_RUN_COMPLETED_SEND_TO,
+    value: 15,
+  },
+  one_connector_connected: {
+    sendTo: GOOGLE_ADS_ADSMARCH_ONE_CONNECTOR_CONNECTED_SEND_TO,
+    value: 8,
+  },
+  two_connectors_connected: {
+    sendTo: GOOGLE_ADS_ADSMARCH_TWO_CONNECTORS_CONNECTED_SEND_TO,
+    value: 15,
+  },
+} satisfies Readonly<
+  Record<
+    GoogleAdsConversionMilestoneKind,
+    { readonly sendTo: string; readonly value: number }
+  >
+>;
+
+function storedMilestonesByUser(raw: string | null): StoredMilestonesByUser {
+  if (!raw) {
+    return {};
+  }
+  const parsed = jsonParseOr<unknown>(raw, null);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+
+  const result: Record<string, StoredMilestoneState> = {};
+  for (const [userId, value] of Object.entries(parsed)) {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      !("transactionIds" in value) ||
+      !Array.isArray(value.transactionIds) ||
+      !value.transactionIds.every((transactionId: unknown) => {
+        return typeof transactionId === "string";
+      })
+    ) {
+      continue;
+    }
+    result[userId] = { transactionIds: value.transactionIds };
+  }
+  return result;
+}
+
+function writeUserMilestoneState(
+  stored: StoredMilestonesByUser,
+  userId: string,
+  transactionIds: Iterable<string>,
+): string {
+  return JSON.stringify({
+    ...stored,
+    [userId]: { transactionIds: [...transactionIds] },
+  });
+}
+
+export const syncGoogleAdsConversionMilestones$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const user = await get(user$);
+    signal.throwIfAborted();
+    if (!user) {
+      return;
+    }
+
+    const client = get(apiClient$)(acquisitionAttributionContract);
+    const response = await accept(
+      client.googleAdsMilestones({ fetchOptions: { signal } }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    const stored = storedMilestonesByUser(get(milestoneStorage.get$));
+    const previous = stored[user.id];
+    if (!previous) {
+      set(
+        milestoneStorage.set$,
+        writeUserMilestoneState(
+          stored,
+          user.id,
+          response.body.milestones.map((item) => {
+            return item.transactionId;
+          }),
+        ),
+      );
+      return;
+    }
+
+    const deliveredTransactionIds = new Set(previous.transactionIds);
+    let changed = false;
+    for (const item of response.body.milestones) {
+      if (deliveredTransactionIds.has(item.transactionId)) {
+        continue;
+      }
+      const config = MILESTONE_CONFIG[item.kind];
+      const fired = fireGoogleAdsConversion({
+        sendTo: config.sendTo,
+        dedupeValue: item.transactionId,
+        value: config.value,
+        storedDedupeValue: null,
+        transactionId: item.transactionId,
+      });
+      if (fired) {
+        deliveredTransactionIds.add(item.transactionId);
+        changed = true;
+      }
+    }
+    if (changed) {
+      set(
+        milestoneStorage.set$,
+        writeUserMilestoneState(stored, user.id, deliveredTransactionIds),
+      );
+    }
+  },
+);
+
+export const bootstrapGoogleAdsConversionMilestones$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const user = await get(user$);
+    signal.throwIfAborted();
+    if (!user || get(bootstrappedUserIds$).has(user.id)) {
+      return;
+    }
+    await set(syncGoogleAdsConversionMilestones$, signal);
+    signal.throwIfAborted();
+    set(bootstrappedUserIds$, (previous) => {
+      return new Set([...previous, user.id]);
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
@@ -1,14 +1,36 @@
 // Google Ads website-tag conversions. The gtag base snippet lives in
 // `apps/platform/index.html`; these are the event snippets for the conversion
-// actions that Google Ads uses as bidding signals. `UPLOAD_CLICKS` conversion
-// actions (the Data Manager imports) are uploaded server-side and are not
-// fired from here.
+// actions that Google Ads uses as bidding signals. Legacy `UPLOAD_CLICKS`
+// actions remain server-only; the adsmarch website actions can also receive a
+// server-side Data Manager fallback with the same transaction ID.
 
 export const GOOGLE_ADS_SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
 export const GOOGLE_ADS_ONBOARDING_START_SEND_TO =
   "AW-18144854014/GVKdCLbQ9LscEP7_kcxD";
 export const GOOGLE_ADS_CHECKOUT_START_SEND_TO =
   "AW-18144854014/EEovCKmuvbscEP7_kcxD";
+export const GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO =
+  "AW-18407336975/8mCZCLORrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO =
+  "AW-18407336975/xkGcCLaRrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO =
+  "AW-18407336975/hWi8CPWRrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_PAID_IN_ONBOARDING_SEND_TO =
+  "AW-18407336975/M7QYCPiRrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_PAID_AFTER_ONBOARDING_SEND_TO =
+  "AW-18407336975/ePWuCPuRrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_FREE_TRIAL_COMPLETED_SEND_TO =
+  "AW-18407336975/kS5jCP6RrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_FIRST_RUN_COMPLETED_SEND_TO =
+  "AW-18407336975/uEoeCIGSrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_SECOND_RUN_COMPLETED_SEND_TO =
+  "AW-18407336975/0S04CISSrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_ONE_CONNECTOR_CONNECTED_SEND_TO =
+  "AW-18407336975/QpfCCIeSrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_TWO_CONNECTORS_CONNECTED_SEND_TO =
+  "AW-18407336975/DFtNCIqSrOccEI_YpslE";
+export const GOOGLE_ADS_ADSMARCH_MULTI_DAY_RUN_COMPLETED_SEND_TO =
+  "AW-18407336975/ZGzhCI2SrOccEI_YpslE";
 
 type GoogleTag = (
   command: "event",
@@ -17,6 +39,7 @@ type GoogleTag = (
     readonly send_to: string;
     readonly value: number;
     readonly currency: "USD";
+    readonly transaction_id?: string;
   },
 ) => void;
 
@@ -33,6 +56,7 @@ export function fireGoogleAdsConversion(args: {
   readonly dedupeValue: string;
   readonly value: number;
   readonly storedDedupeValue: string | null;
+  readonly transactionId?: string;
 }): boolean {
   if (args.storedDedupeValue === args.dedupeValue) {
     return false;
@@ -50,6 +74,9 @@ export function fireGoogleAdsConversion(args: {
     send_to: args.sendTo,
     value: args.value,
     currency: "USD",
+    ...(args.transactionId === undefined
+      ? {}
+      : { transaction_id: args.transactionId }),
   });
   return true;
 }

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-paid-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-paid-conversion.ts
@@ -1,0 +1,105 @@
+import { command } from "ccstate";
+import {
+  billingCheckoutContract,
+  type GoogleAdsPaidConversion,
+} from "@okouai/api-contracts/contracts/billing";
+
+import { IN_VITEST } from "../../env.ts";
+import { accept } from "../../lib/accept.ts";
+import { apiClient$ } from "../api-client.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
+import { setLoop } from "../utils.ts";
+import {
+  fireGoogleAdsConversion,
+  GOOGLE_ADS_ADSMARCH_PAID_AFTER_ONBOARDING_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_PAID_IN_ONBOARDING_SEND_TO,
+} from "./google-ads-conversion.ts";
+
+const PAID_IN_ONBOARDING_CONVERSION_KEY =
+  "vm0.googleAds.18407336975.paidInOnboardingConversion";
+const PAID_AFTER_ONBOARDING_CONVERSION_KEY =
+  "vm0.googleAds.18407336975.paidAfterOnboardingConversion";
+const CHECKOUT_POLL_LIMIT = IN_VITEST ? 2 : 90;
+const CHECKOUT_POLL_INTERVAL_MS = 1000;
+
+const paidInOnboardingStorage = localStorageSignals(
+  PAID_IN_ONBOARDING_CONVERSION_KEY,
+);
+const paidAfterOnboardingStorage = localStorageSignals(
+  PAID_AFTER_ONBOARDING_CONVERSION_KEY,
+);
+
+export type GoogleAdsPaidConversionKind =
+  | "paid_in_onboarding"
+  | "paid_after_onboarding";
+
+export const fireGoogleAdsPaidConversion$ = command(
+  (
+    { get, set },
+    kind: GoogleAdsPaidConversionKind,
+    conversion: GoogleAdsPaidConversion,
+  ): void => {
+    const storage =
+      kind === "paid_in_onboarding"
+        ? paidInOnboardingStorage
+        : paidAfterOnboardingStorage;
+    const sendTo =
+      kind === "paid_in_onboarding"
+        ? GOOGLE_ADS_ADSMARCH_PAID_IN_ONBOARDING_SEND_TO
+        : GOOGLE_ADS_ADSMARCH_PAID_AFTER_ONBOARDING_SEND_TO;
+    const fired = fireGoogleAdsConversion({
+      sendTo,
+      dedupeValue: conversion.transactionId,
+      value: kind === "paid_in_onboarding" ? conversion.valueUsd : 40,
+      storedDedupeValue: get(storage.get$),
+      transactionId: conversion.transactionId,
+    });
+    if (fired) {
+      set(storage.set$, conversion.transactionId);
+    }
+  },
+);
+
+export const completeGoogleAdsPaidCheckout$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly sessionId: string;
+      readonly kind: GoogleAdsPaidConversionKind;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(apiClient$)(billingCheckoutContract);
+    let attempts = 0;
+    await setLoop(
+      async (loopSignal) => {
+        attempts += 1;
+        const result = await accept(
+          client.complete({
+            body: { sessionId: args.sessionId },
+            fetchOptions: { signal: loopSignal },
+          }),
+          [200],
+        );
+        loopSignal.throwIfAborted();
+        if (result.body.completed) {
+          if (result.body.googleAdsConversion) {
+            set(
+              fireGoogleAdsPaidConversion$,
+              args.kind,
+              result.body.googleAdsConversion,
+            );
+          }
+          return true;
+        }
+        if (attempts >= CHECKOUT_POLL_LIMIT) {
+          throw new Error("Checkout completion timed out");
+        }
+        return false;
+      },
+      CHECKOUT_POLL_INTERVAL_MS,
+      signal,
+      { retryTransientErrors: false },
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
@@ -9,6 +9,8 @@ import { command } from "ccstate";
 import { capturePaidOnboardingEvent } from "../../lib/posthog.ts";
 import {
   fireGoogleAdsConversion,
+  GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
+  GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
   GOOGLE_ADS_CHECKOUT_START_SEND_TO,
   GOOGLE_ADS_ONBOARDING_START_SEND_TO,
 } from "./google-ads-conversion.ts";
@@ -20,13 +22,24 @@ const ONBOARDING_START_CONVERSION_KEY =
   "vm0.googleAdsOnboardingStartConversionRecorded";
 const CHECKOUT_START_CONVERSION_KEY =
   "vm0.googleAdsCheckoutStartConversionRecorded";
+const ADSMARCH_ONBOARDING_START_CONVERSION_KEY =
+  "vm0.googleAdsAdsmarchOnboardingStartConversionRecorded";
+const ADSMARCH_CHECKOUT_START_CONVERSION_KEY =
+  "vm0.googleAdsAdsmarchCheckoutStartConversionRecorded";
 const ONBOARDING_START_CONVERSION_VALUE_USD = 1;
 const CHECKOUT_START_CONVERSION_VALUE_USD = 1;
+const ADSMARCH_CHECKOUT_START_CONVERSION_VALUE_USD = 5;
 const onboardingStartConversionStorage = sessionStorageSignals(
   ONBOARDING_START_CONVERSION_KEY,
 );
 const checkoutStartConversionStorage = sessionStorageSignals(
   CHECKOUT_START_CONVERSION_KEY,
+);
+const adsmarchOnboardingStartConversionStorage = sessionStorageSignals(
+  ADSMARCH_ONBOARDING_START_CONVERSION_KEY,
+);
+const adsmarchCheckoutStartConversionStorage = sessionStorageSignals(
+  ADSMARCH_CHECKOUT_START_CONVERSION_KEY,
 );
 
 // Ordered so `step_index` / `step_count` stay comparable across the three
@@ -88,6 +101,19 @@ export const capturePaidOnboardingStepViewed$ = command(
         GOOGLE_ADS_ONBOARDING_START_SEND_TO,
       );
     }
+
+    const adsmarchConversionFired = fireGoogleAdsConversion({
+      sendTo: GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
+      dedupeValue: GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
+      value: ONBOARDING_START_CONVERSION_VALUE_USD,
+      storedDedupeValue: get(adsmarchOnboardingStartConversionStorage.get$),
+    });
+    if (adsmarchConversionFired) {
+      set(
+        adsmarchOnboardingStartConversionStorage.set$,
+        GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
+      );
+    }
   },
 );
 
@@ -126,6 +152,19 @@ export const capturePaidOnboardingRedirectToStripe$ = command(
       set(
         checkoutStartConversionStorage.set$,
         GOOGLE_ADS_CHECKOUT_START_SEND_TO,
+      );
+    }
+
+    const adsmarchConversionFired = fireGoogleAdsConversion({
+      sendTo: GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
+      dedupeValue: GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
+      value: ADSMARCH_CHECKOUT_START_CONVERSION_VALUE_USD,
+      storedDedupeValue: get(adsmarchCheckoutStartConversionStorage.get$),
+    });
+    if (adsmarchConversionFired) {
+      set(
+        adsmarchCheckoutStartConversionStorage.set$,
+        GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
       );
     }
   },

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -13,11 +13,14 @@ import { sessionStorageSignals } from "../external/session-storage.ts";
 import { readStoredAdAttributionMetadata$ } from "./ad-attribution.ts";
 import {
   fireGoogleAdsConversion,
+  GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO,
   GOOGLE_ADS_SIGNUP_SEND_TO,
 } from "./google-ads-conversion.ts";
 
 const SIGNUP_ATTRIBUTION_RECORDED_KEY = "vm0.signupAttributionRecorded";
 const SIGNUP_CONVERSION_RECORDED_KEY = "vm0.googleAdsSignupConversionRecorded";
+const ADSMARCH_SIGNUP_CONVERSION_RECORDED_KEY =
+  "vm0.googleAdsAdsmarchSignupConversionRecorded";
 const SIGNUP_CONVERSION_VALUE_USD = 1;
 const SIGNUP_CONVERSION_MAX_USER_AGE_MS = 30 * 60 * 1000;
 const signupAttributionRecordedStorage = sessionStorageSignals(
@@ -25,6 +28,9 @@ const signupAttributionRecordedStorage = sessionStorageSignals(
 );
 const signupConversionRecordedStorage = sessionStorageSignals(
   SIGNUP_CONVERSION_RECORDED_KEY,
+);
+const adsmarchSignupConversionRecordedStorage = sessionStorageSignals(
+  ADSMARCH_SIGNUP_CONVERSION_RECORDED_KEY,
 );
 
 function timestampMs(value: unknown): number | null {
@@ -111,6 +117,17 @@ export const recordSignupAttribution$ = command(
       });
       if (conversionFired) {
         set(signupConversionRecordedStorage.set$, user.id);
+      }
+
+      const adsmarchConversionFired = fireGoogleAdsConversion({
+        sendTo: GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO,
+        dedupeValue: user.id,
+        value: SIGNUP_CONVERSION_VALUE_USD,
+        storedDedupeValue: get(adsmarchSignupConversionRecordedStorage.get$),
+        transactionId: user.id,
+      });
+      if (adsmarchConversionFired) {
+        set(adsmarchSignupConversionRecordedStorage.set$, user.id);
       }
     }
   },

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
@@ -12,6 +12,7 @@ import type { ChatEventCursor } from "@okouai/api-contracts/contracts/chat-event
 import type { ChatEvent as PersistedChatEvent } from "@okouai/api-contracts/contracts/chat-threads";
 import { captureTaskCompletedSuccessfully } from "../../lib/posthog.ts";
 import { settle } from "../utils.ts";
+import { syncGoogleAdsConversionMilestones$ } from "../bootstrap/google-ads-conversion-milestones.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
 import type { ChatEventDataKey } from "../../shared-database/data-key.ts";
 import {
@@ -69,7 +70,7 @@ function reportNewCompletedRuns({
 }: {
   persistentEvents: readonly PersistedChatEvent[];
   events: readonly PersistedChatEvent[];
-}): void {
+}): boolean {
   const reportedCompletedRunIds = new Set(
     completedRunIdsFromEvents(persistentEvents),
   );
@@ -81,6 +82,7 @@ function reportNewCompletedRuns({
   for (const _ of newlyCompletedRunIds) {
     captureTaskCompletedSuccessfully();
   }
+  return newlyCompletedRunIds.length > 0;
 }
 
 function mergePersistentEvents(
@@ -408,7 +410,7 @@ export function createChatEventStorageSignals({
       if (events.length === 0) {
         return;
       }
-      reportNewCompletedRuns({
+      const hasNewCompletedRun = reportNewCompletedRuns({
         persistentEvents: get(persistentChatEvents$),
         events,
       });
@@ -418,6 +420,9 @@ export function createChatEventStorageSignals({
       set(reconcileOptimisticChatEvents$, { threadId, events });
       await set(notifyChatEventsChanged$, chatEvents$, signal);
       signal.throwIfAborted();
+      if (hasNewCompletedRun) {
+        await settle(set(syncGoogleAdsConversionMilestones$, signal), signal);
+      }
     },
   );
   const syncLegacyRemoteEvents$ = createSyncRemoteRowsCommand({

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -23,8 +23,9 @@ import { localStorageSignals } from "../external/local-storage.ts";
 import { updatePage$ } from "../react-router.ts";
 import { pathParams$, replacePathSilently$, searchParams$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
-import { jsonParseOr } from "../utils.ts";
+import { jsonParseOr, settle } from "../utils.ts";
 import { i18n } from "../../i18n/index.ts";
+import { syncGoogleAdsConversionMilestones$ } from "../bootstrap/google-ads-conversion-milestones.ts";
 
 type ConnectorCallbackPageResult =
   | { readonly status: "loading" }
@@ -278,6 +279,9 @@ export const setupConnectorCallbackPage$ = command(
             query,
             signal,
           );
+    if (result.status === "success") {
+      await settle(set(syncGoogleAdsConversionMilestones$, signal), signal);
+    }
     set(updatePage$, callbackPageElement(connectorIcon, label, result));
 
     const resultSearchParams = new URLSearchParams();

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -921,13 +921,9 @@ export const startUsagePackCheckout$ = command(
   },
 );
 
-const fireConfirmedPlanGoogleAdsConversion$ = command(
-  (
-    { set },
-    purchaseType: "plan" | "usage_pack",
-    conversion: GoogleAdsPaidConversion | undefined,
-  ): void => {
-    if (purchaseType !== "plan" || !conversion) {
+const fireConfirmedGoogleAdsConversion$ = command(
+  ({ set }, conversion: GoogleAdsPaidConversion | undefined): void => {
+    if (!conversion) {
       return;
     }
     set(fireGoogleAdsPaidConversion$, "paid_after_onboarding", conversion);
@@ -1041,11 +1037,7 @@ export const confirmSubscriptionPurchase$ = command(
       }
       return;
     }
-    set(
-      fireConfirmedPlanGoogleAdsConversion$,
-      state.purchaseType,
-      response.body.googleAdsConversion,
-    );
+    set(fireConfirmedGoogleAdsConversion$, response.body.googleAdsConversion);
     set(internalSubscriptionPurchasePreview$, null);
     set(reloadBillingStatus$);
     toast.success(

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -25,6 +25,7 @@ import {
   type UsagePackCheckoutRequest,
   type UsagePackPurchasePreviewResponse,
   type UsagePackMigrationStateResponse,
+  type GoogleAdsPaidConversion,
 } from "@okouai/api-contracts/contracts/billing";
 import { FeatureSwitchKey } from "@okouai/core";
 import { toast } from "@okouai/ui/components/ui/sonner";
@@ -45,6 +46,10 @@ import {
   capturePaidOnboardingCheckoutCreated$,
   capturePaidOnboardingRedirectToStripe$,
 } from "../bootstrap/paid-funnel-telemetry.ts";
+import {
+  completeGoogleAdsPaidCheckout$,
+  fireGoogleAdsPaidConversion$,
+} from "../bootstrap/google-ads-paid-conversion.ts";
 import { currentLocale, i18n } from "../../i18n/index.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { refreshOrgMembers$ } from "../external/org-members.ts";
@@ -656,10 +661,23 @@ export const handleBillingRedirect$ = command(
 
     const searchParams = new URLSearchParams(get(searchParams$));
     const billing = searchParams.get("billing");
+    const billingSessionId = searchParams.get("billing_session_id");
     const credits = searchParams.get("credits");
     const concurrency = searchParams.get("concurrency");
     if (!billing && !credits && !concurrency) {
       return;
+    }
+
+    if ((billing === "pro" || billing === "team") && billingSessionId) {
+      await set(
+        completeGoogleAdsPaidCheckout$,
+        {
+          sessionId: billingSessionId,
+          kind: "paid_after_onboarding",
+        },
+        signal,
+      );
+      signal.throwIfAborted();
     }
 
     searchParams.delete("billing");
@@ -903,6 +921,19 @@ export const startUsagePackCheckout$ = command(
   },
 );
 
+const fireConfirmedPlanGoogleAdsConversion$ = command(
+  (
+    { set },
+    purchaseType: "plan" | "usage_pack",
+    conversion: GoogleAdsPaidConversion | undefined,
+  ): void => {
+    if (purchaseType !== "plan" || !conversion) {
+      return;
+    }
+    set(fireGoogleAdsPaidConversion$, "paid_after_onboarding", conversion);
+  },
+);
+
 export const confirmSubscriptionPurchase$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const state = get(internalSubscriptionPurchasePreview$);
@@ -1010,6 +1041,11 @@ export const confirmSubscriptionPurchase$ = command(
       }
       return;
     }
+    set(
+      fireConfirmedPlanGoogleAdsConversion$,
+      state.purchaseType,
+      response.body.googleAdsConversion,
+    );
     set(internalSubscriptionPurchasePreview$, null);
     set(reloadBillingStatus$);
     toast.success(

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -49,7 +49,13 @@ import {
   apiClient$,
   type ApiClientFactory,
 } from "../../api-client.ts";
-import { resetSignal, setLoop, tapError, withCleanup } from "../../utils.ts";
+import {
+  resetSignal,
+  setLoop,
+  settle,
+  tapError,
+  withCleanup,
+} from "../../utils.ts";
 import { setAblyPayloadLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { subagents$ } from "../../agent.ts";
@@ -70,6 +76,7 @@ import {
   readConnectorAccountMutationVersion,
   type ConnectorAccountMutationVersion,
 } from "./connector-accounts.ts";
+import { syncGoogleAdsConversionMilestones$ } from "../../bootstrap/google-ads-conversion-milestones.ts";
 
 const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
   CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
@@ -877,6 +884,7 @@ const finishConnectorConnection$ = command(
     if (options.clearSelectedConnector) {
       set(internalSelectedConnectorSlug$, null);
     }
+    await settle(set(syncGoogleAdsConversionMilestones$, signal), signal);
     return true;
   },
 );

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -7,11 +7,9 @@ import {
 } from "@okouai/api-contracts/contracts/billing";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
-import { IN_VITEST } from "../../env.ts";
 import { apiClient$ } from "../api-client.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
 import { ROUTES } from "../route-paths.ts";
-import { setLoop } from "../utils.ts";
 import { billingStatusAsync$ } from "../okou-page/billing.ts";
 import { readStoredAdAttributionMetadata$ } from "../bootstrap/ad-attribution.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
@@ -27,6 +25,7 @@ import {
   capturePaidOnboardingRedirectToStripe$,
   capturePaidOnboardingRoleConfirmed$,
 } from "../bootstrap/paid-funnel-telemetry.ts";
+import { completeGoogleAdsPaidCheckout$ } from "../bootstrap/google-ads-paid-conversion.ts";
 
 export const completeOnboarding$ = command(
   async (
@@ -170,35 +169,12 @@ export const prepareOnboardingVideoRun$ = command(
   },
 );
 
-const CHECKOUT_POLL_LIMIT = IN_VITEST ? 2 : 90;
-const CHECKOUT_POLL_INTERVAL_MS = 1000;
-
 export const completeOnboardingCheckoutReturn$ = command(
-  async ({ get }, sessionId: string, signal: AbortSignal): Promise<void> => {
-    const client = get(apiClient$)(billingCheckoutContract);
-    let attempts = 0;
-    await setLoop(
-      async (loopSignal) => {
-        attempts += 1;
-        const result = await accept(
-          client.complete({
-            body: { sessionId },
-            fetchOptions: { signal: loopSignal },
-          }),
-          [200],
-        );
-        loopSignal.throwIfAborted();
-        if (result.body.completed) {
-          return true;
-        }
-        if (attempts >= CHECKOUT_POLL_LIMIT) {
-          throw new Error("Checkout completion timed out");
-        }
-        return false;
-      },
-      CHECKOUT_POLL_INTERVAL_MS,
+  async ({ set }, sessionId: string, signal: AbortSignal): Promise<void> => {
+    await set(
+      completeGoogleAdsPaidCheckout$,
+      { sessionId, kind: "paid_in_onboarding" },
       signal,
-      { retryTransientErrors: false },
     );
   },
 );

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -5,11 +5,12 @@ import { clerk$, needsOrgSelection$, resolveAppAuthUrl } from "./auth.ts";
 import { pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
-import { detach, onDomEventFn, Reason, resetSignal } from "./utils.ts";
+import { detach, onDomEventFn, Reason, resetSignal, settle } from "./utils.ts";
 import { logger } from "./log.ts";
 import { capturePageView, markNavigationPushState$ } from "../lib/posthog.ts";
 import { recordAdAttribution$ } from "./bootstrap/ad-attribution.ts";
 import { recordSignupAttribution$ } from "./bootstrap/signup-attribution.ts";
+import { bootstrapGoogleAdsConversionMilestones$ } from "./bootstrap/google-ads-conversion-milestones.ts";
 
 const L = logger("Route");
 
@@ -130,6 +131,7 @@ const loadRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
   // record, so this only performs network work on the first qualifying load.
   if (currentRoute.analytics !== false) {
     await set(recordSignupAttribution$, signal);
+    await settle(set(bootstrapGoogleAdsConversionMilestones$, signal), signal);
   }
 });
 

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -73,6 +73,10 @@ function firstItem<Item>(items: readonly Item[]): Item {
 
 const ONBOARDING_START_SEND_TO = "AW-18144854014/GVKdCLbQ9LscEP7_kcxD";
 const CHECKOUT_START_SEND_TO = "AW-18144854014/EEovCKmuvbscEP7_kcxD";
+const ADSMARCH_ONBOARDING_START_SEND_TO = "AW-18407336975/xkGcCLaRrOccEI_YpslE";
+const ADSMARCH_CHECKOUT_START_SEND_TO = "AW-18407336975/hWi8CPWRrOccEI_YpslE";
+const ADSMARCH_PAID_IN_ONBOARDING_SEND_TO =
+  "AW-18407336975/M7QYCPiRrOccEI_YpslE";
 
 type GtagFn = (...args: unknown[]) => void;
 
@@ -1311,6 +1315,7 @@ describe("onboarding flow", () => {
   });
 
   it("resumes a video run after checkout and completes onboarding", async () => {
+    const gtag = installGtagMock();
     const template = firstItem(VIDEO_TEMPLATE_ITEMS);
     let runPrompt: string | undefined;
     let generationType: string | undefined;
@@ -1323,7 +1328,18 @@ describe("onboarding flow", () => {
     });
     context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
       checkoutCompletionAttempts += 1;
-      return respond(200, { completed: checkoutCompletionAttempts >= 2 });
+      return respond(
+        200,
+        checkoutCompletionAttempts >= 2
+          ? {
+              completed: true,
+              googleAdsConversion: {
+                transactionId: "in_onboarding_paid",
+                valueUsd: 49,
+              },
+            }
+          : { completed: false },
+      );
     });
     mockOnboardingNeeded();
     const params = new URLSearchParams({
@@ -1344,6 +1360,12 @@ describe("onboarding flow", () => {
       expect(generationType).toBe("video");
       expect(checkoutCompletionAttempts).toBe(2);
       expect(pathname()).toMatch(/^\/chats\//u);
+    });
+    expect(gtag).toHaveBeenCalledWith("event", "conversion", {
+      send_to: ADSMARCH_PAID_IN_ONBOARDING_SEND_TO,
+      value: 49,
+      currency: "USD",
+      transaction_id: "in_onboarding_paid",
     });
   });
 
@@ -1420,7 +1442,10 @@ describe("onboarding flow", () => {
 
     await openMakePage();
 
-    expect(sentConversions(gtag)).toStrictEqual([ONBOARDING_START_SEND_TO]);
+    expect(sentConversions(gtag)).toStrictEqual([
+      ONBOARDING_START_SEND_TO,
+      ADSMARCH_ONBOARDING_START_SEND_TO,
+    ]);
 
     chooseMakeOption("Video production");
     await expect(
@@ -1446,7 +1471,9 @@ describe("onboarding flow", () => {
     await waitFor(() => {
       expect(sentConversions(gtag)).toStrictEqual([
         ONBOARDING_START_SEND_TO,
+        ADSMARCH_ONBOARDING_START_SEND_TO,
         CHECKOUT_START_SEND_TO,
+        ADSMARCH_CHECKOUT_START_SEND_TO,
       ]);
     });
   });

--- a/turbo/apps/platform/src/views/router/__tests__/billing-redirect-toast.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/billing-redirect-toast.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { billingCheckoutContract } from "@okouai/api-contracts/contracts/billing";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { search } from "../../../signals/location.ts";
@@ -12,7 +13,7 @@ type WindowWithGtag = Window & {
 };
 
 describe("billing redirect toast", () => {
-  it("does not fire Google Ads conversion on Pro checkout success redirects", async () => {
+  it("fires Paid After Onboarding after the checkout invoice is confirmed", async () => {
     const windowWithGtag = window as WindowWithGtag;
     const originalGtag = windowWithGtag.gtag;
     const gtag = vi.fn<(...args: unknown[]) => void>();
@@ -33,6 +34,15 @@ describe("billing redirect toast", () => {
       }
       Reflect.deleteProperty(windowWithGtag, "gtag");
     });
+    context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
+      return respond(200, {
+        completed: true,
+        googleAdsConversion: {
+          transactionId: "in_after_onboarding",
+          valueUsd: 99,
+        },
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -45,7 +55,12 @@ describe("billing redirect toast", () => {
         new URLSearchParams(search()).has("billing_session_id"),
       ).toBeFalsy();
     });
-    expect(gtag).not.toHaveBeenCalled();
+    expect(gtag).toHaveBeenCalledWith("event", "conversion", {
+      send_to: "AW-18407336975/ePWuCPuRrOccEI_YpslE",
+      value: 40,
+      currency: "USD",
+      transaction_id: "in_after_onboarding",
+    });
   });
 
   it("shows concurrency purchase success after returning from Stripe", async () => {

--- a/turbo/apps/platform/src/views/router/__tests__/billing-redirect-toast.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/billing-redirect-toast.test.tsx
@@ -1,10 +1,22 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { billingCheckoutContract } from "@okouai/api-contracts/contracts/billing";
+import {
+  billingCheckoutContract,
+  billingUsagePackCheckoutContract,
+} from "@okouai/api-contracts/contracts/billing";
 
+import {
+  clearMockedAuthOnAbort,
+  mockOrganization,
+  mockUser,
+} from "../../../__tests__/mock-auth.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { search } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  confirmSubscriptionPurchase$,
+  startUsagePackCheckout$,
+} from "../../../signals/okou-page/billing.ts";
 
 const context = testContext();
 
@@ -12,18 +24,19 @@ type WindowWithGtag = Window & {
   gtag?: (...args: unknown[]) => void;
 };
 
-describe("billing redirect toast", () => {
-  it("fires Paid After Onboarding after the checkout invoice is confirmed", async () => {
-    const windowWithGtag = window as WindowWithGtag;
-    const originalGtag = windowWithGtag.gtag;
-    const gtag = vi.fn<(...args: unknown[]) => void>();
+function installGtagMock(): ReturnType<typeof vi.fn> {
+  const windowWithGtag = window as WindowWithGtag;
+  const originalGtag = windowWithGtag.gtag;
+  const gtag = vi.fn<(...args: unknown[]) => void>();
 
-    Object.defineProperty(windowWithGtag, "gtag", {
-      configurable: true,
-      value: gtag,
-      writable: true,
-    });
-    context.signal.addEventListener("abort", () => {
+  Object.defineProperty(windowWithGtag, "gtag", {
+    configurable: true,
+    value: gtag,
+    writable: true,
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
       if (originalGtag !== undefined) {
         Object.defineProperty(windowWithGtag, "gtag", {
           configurable: true,
@@ -33,7 +46,15 @@ describe("billing redirect toast", () => {
         return;
       }
       Reflect.deleteProperty(windowWithGtag, "gtag");
-    });
+    },
+    { once: true },
+  );
+  return gtag;
+}
+
+describe("billing redirect toast", () => {
+  it("fires Paid After Onboarding after the checkout invoice is confirmed", async () => {
+    const gtag = installGtagMock();
     context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
       return respond(200, {
         completed: true,
@@ -60,6 +81,62 @@ describe("billing redirect toast", () => {
       value: 40,
       currency: "USD",
       transaction_id: "in_after_onboarding",
+    });
+  });
+
+  it("fires Paid After Onboarding after a usage pack purchase is confirmed", async () => {
+    const gtag = installGtagMock();
+    context.mocks.browser.url("http://localhost/");
+    mockUser(
+      { id: "test-user-123", fullName: "Test User" },
+      { token: "test-token" },
+    );
+    mockOrganization({
+      activeOrg: { id: "org_default", name: "Default Org" },
+      memberships: [{ id: "org_default" }],
+    });
+    clearMockedAuthOnAbort(context.signal);
+    context.mocks.api(
+      billingUsagePackCheckoutContract.create,
+      ({ body, respond }) => {
+        if (body.previewToken) {
+          return respond(200, {
+            status: "completed",
+            hostedInvoiceUrl: null,
+            googleAdsConversion: {
+              transactionId: "in_usage_pack_after_onboarding",
+              valueUsd: 20,
+            },
+          });
+        }
+        return respond(200, {
+          status: "preview",
+          purchaseType: "usage_pack",
+          tier: "pro",
+          immediateAmountCents: 2000,
+          nextRecurringAmountCents: 2000,
+          currency: "usd",
+          expiresAt: "2026-08-25T13:00:00.000Z",
+          previewToken: "usage-pack-preview-token",
+        });
+      },
+    );
+    await context.store.set(
+      startUsagePackCheckout$,
+      {
+        tier: "pro",
+        memberUsagePacks: [{ memberId: "test-user-123", usagePackUsd: 20 }],
+      },
+      false,
+      context.signal,
+    );
+    await context.store.set(confirmSubscriptionPurchase$, context.signal);
+
+    expect(gtag).toHaveBeenCalledWith("event", "conversion", {
+      send_to: "AW-18407336975/ePWuCPuRrOccEI_YpslE",
+      value: 40,
+      currency: "USD",
+      transaction_id: "in_usage_pack_after_onboarding",
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
+++ b/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
@@ -64,7 +64,37 @@ const recordSignupAttributionResponseSchema = z.object({
   recorded: z.boolean(),
 });
 
+export const GOOGLE_ADS_CONVERSION_MILESTONE_KINDS = [
+  "free_trial_completed",
+  "first_run_completed",
+  "second_run_completed",
+  "multi_day_run_completed",
+  "one_connector_connected",
+  "two_connectors_connected",
+] as const;
+
+const googleAdsConversionMilestoneSchema = z.object({
+  kind: z.enum(GOOGLE_ADS_CONVERSION_MILESTONE_KINDS),
+  transactionId: z.string().min(1),
+});
+
+const googleAdsConversionMilestonesResponseSchema = z.object({
+  milestones: z.array(googleAdsConversionMilestoneSchema),
+});
+
 export const acquisitionAttributionContract = c.router({
+  googleAdsMilestones: {
+    method: "GET",
+    path: "/api/attribution/google-ads-milestones",
+    headers: authHeadersSchema,
+    responses: {
+      200: googleAdsConversionMilestonesResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Get server-confirmed Google Ads conversion milestones for the current user",
+  },
   recordSignup: {
     method: "POST",
     path: "/api/attribution/signup",
@@ -86,6 +116,14 @@ export type RecordSignupAttributionRequest = z.infer<
 >;
 export type RecordSignupAttributionResponse = z.infer<
   typeof recordSignupAttributionResponseSchema
+>;
+export type GoogleAdsConversionMilestoneKind =
+  (typeof GOOGLE_ADS_CONVERSION_MILESTONE_KINDS)[number];
+export type GoogleAdsConversionMilestone = z.infer<
+  typeof googleAdsConversionMilestoneSchema
+>;
+export type GoogleAdsConversionMilestonesResponse = z.infer<
+  typeof googleAdsConversionMilestonesResponseSchema
 >;
 export type AcquisitionAttributionContract =
   typeof acquisitionAttributionContract;

--- a/turbo/packages/api-contracts/src/contracts/billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/billing.ts
@@ -134,10 +134,16 @@ const usagePackPurchasePreviewResponseSchema =
     purchaseType: z.literal("usage_pack"),
   });
 
+const googleAdsPaidConversionSchema = z.object({
+  transactionId: z.string().min(1),
+  valueUsd: z.number().positive(),
+});
+
 const billingPurchaseConfirmResponseSchema = z.discriminatedUnion("status", [
   z.object({
     status: z.literal("completed"),
     hostedInvoiceUrl: z.null(),
+    googleAdsConversion: googleAdsPaidConversionSchema.optional(),
   }),
   z.object({
     status: z.literal("pending_payment"),
@@ -151,6 +157,7 @@ const billingPurchaseConfirmResponseSchema = z.discriminatedUnion("status", [
 
 const checkoutCompleteResponseSchema = z.object({
   completed: z.boolean(),
+  googleAdsConversion: googleAdsPaidConversionSchema.optional(),
 });
 
 const redeemCodeResponseSchema = z.object({
@@ -1403,6 +1410,9 @@ export type UsagePackPurchasePreviewResponse = z.infer<
 >;
 export type BillingPurchaseConfirmResponse = z.infer<
   typeof billingPurchaseConfirmResponseSchema
+>;
+export type GoogleAdsPaidConversion = z.infer<
+  typeof googleAdsPaidConversionSchema
 >;
 export type RedeemCodeResponse = z.infer<typeof redeemCodeResponseSchema>;
 export type ConcurrencyCheckoutRequest = z.infer<


### PR DESCRIPTION
## Summary

- keep the three legacy Google Ads website conversions unchanged while dual-sending Signup, Onboarding Start, and Checkout Start to the adsmarch account
- add gtag delivery for Paid In Onboarding, Paid After Onboarding, and six server-confirmed acquisition milestones
- use Stripe invoice IDs and the existing Data Manager milestone transaction IDs so browser and server delivery deduplicate against the same conversion action
- baseline the first authenticated milestone snapshot without historical backfill, then sync after run completion and connector connection

## Compatibility

- the billing response fields are optional, so older clients remain compatible
- legacy Google tag IDs, labels, values, and dedupe storage remain unchanged
- recommended merge order: this PR first, then the vm0-marketing Data Manager fallback companion

## Testing

- `pnpm format`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- API and platform workspace type checks
- targeted ESLint for all changed API and platform sources
- targeted platform Vitest: 4 files, 49 tests passed

The new API route integration test requires PostgreSQL; the local attempt was blocked by no database listening on port 5432, so that database-backed case is left to the PR pipeline.

Companion PR: https://github.com/vm0-ai/vm0-marketing/pull/501
