### PR TITLE
refactor(desktop): rename notarization toggle environment key

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -25,7 +25,7 @@ const codeSigningIdentity =
   (process.env.CI === "true" ? "-" : DEVELOPER_ID_APPLICATION_IDENTITY);
 
 function desktopNotarizeOptions() {
-  if (process.env.VM0_DESKTOP_NOTARIZE !== "true") {
+  if (process.env.OKOU_DESKTOP_NOTARIZE !== "true") {
     return undefined;
   }
 

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -15,7 +15,7 @@
     "dev": "pnpm build && electron-forge start",
     "dev:packaged": "pnpm package && node scripts/run-packaged-app.js",
     "lint": "oxlint src --deny-warnings",
-    "make": "pnpm build && VM0_DESKTOP_NOTARIZE=true electron-forge make --platform darwin",
+    "make": "pnpm build && OKOU_DESKTOP_NOTARIZE=true electron-forge make --platform darwin",
     "package": "pnpm build && electron-forge package --platform darwin",
     "start": "electron-forge start",
     "test": "vitest run",

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -318,7 +318,7 @@ function runForge(
   environment.TEST_EXPECTED_APP_PATH = appPath;
   environment.TEST_OUTPUT_PATH = outputPath;
   if (options.notarize !== false) {
-    environment.VM0_DESKTOP_NOTARIZE = "true";
+    environment.OKOU_DESKTOP_NOTARIZE = "true";
   }
   const credentialValues = applyCredentialCase(
     environment,


### PR DESCRIPTION
## Summary

- Rename the exact private Desktop make handshake from `VM0_DESKTOP_NOTARIZE` to `OKOU_DESKTOP_NOTARIZE`.
- Update the package-script writer, sole Forge reader, and focused real-entry-point fixture atomically.
- Preserve exact lowercase `"true"` enablement and every signing, notarization, credential, Keychain, product, and platform behavior.

Closes #29185
Refs #28914

## Contract evidence

- Refreshed `origin/main` immediately before editing at `af365ec540a17de27449b28ce704e6d2592791b8`; the three scoped files were unchanged from the issue baseline.
- A complete tracked-file exact-key search found exactly three legacy occurrences and zero canonical occurrences before editing. The PR head has zero exact legacy toggle occurrences and exactly three canonical occurrences in the intended writer, reader, and fixture.
- Scanned all 28 currently open PRs, up to the required limit of 100, including paginated file lists; none overlaps the three scoped files or the exact toggle semantics.
- The Desktop package `make` script invokes Electron Forge from the same checkout, so the sole writer and reader are revision-locked.
- The complete diff is three files and exactly three one-to-one string replacements. Longer API credential and Keychain identifiers remain unchanged.

## Verification

- `corepack pnpm exec prettier --write apps/desktop/package.json apps/desktop/forge.config.js apps/desktop/src/desktop-notarize-entry-points.test.ts` (Prettier 3.8.1; unchanged)
- `corepack pnpm -F @okouai/desktop lint`
- `corepack pnpm -F @okouai/desktop check-types`
- `corepack pnpm exec knip --workspace apps/desktop`
- `corepack pnpm -F @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` (37 passed)
- `git diff --check origin/main...HEAD`

No full local Vitest suite or local development server was run; PR CI is authoritative.

## Fallbacks

None. This is a private same-checkout handshake: the sole writer and sole reader always come from one repository revision, with no supported external caller, installed-runtime input, persisted state, or independently deployed consumer. A dual reader or fallback would create a compatibility path that the contract does not need. Reverting this commit restores the writer and reader together.