### PR TITLE
refactor(desktop): dual-read notarization keychain aliases

### DIFF
--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -7,6 +7,9 @@ const {
   resolveDesktopNotarizeApiEnvironment,
 } = require("./scripts/desktop-notarize-api-environment");
 const {
+  resolveDesktopNotarizeKeychainEnvironment,
+} = require("./scripts/desktop-notarize-keychain-environment");
+const {
   resolveDesktopSigningIdentityEnvironment,
 } = require("./scripts/desktop-signing-identity-environment");
 
@@ -29,12 +32,11 @@ function desktopNotarizeOptions() {
     return undefined;
   }
 
-  if (process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE?.trim()) {
+  const keychainEnvironment = resolveDesktopNotarizeKeychainEnvironment();
+  if (keychainEnvironment) {
     return {
-      keychainProfile: process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE,
-      keychain:
-        process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN?.trim() ||
-        DEFAULT_NOTARIZE_KEYCHAIN,
+      keychainProfile: keychainEnvironment.keychainProfile,
+      keychain: keychainEnvironment.keychain ?? DEFAULT_NOTARIZE_KEYCHAIN,
     };
   }
 

--- a/turbo/apps/desktop/scripts/desktop-notarize-keychain-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-notarize-keychain-environment.js
@@ -1,0 +1,58 @@
+const CANONICAL_KEYCHAIN_PROFILE = "OKOU_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE";
+const LEGACY_KEYCHAIN_PROFILE = "VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE";
+const CANONICAL_KEYCHAIN = "OKOU_DESKTOP_NOTARIZE_KEYCHAIN";
+const LEGACY_KEYCHAIN = "VM0_DESKTOP_NOTARIZE_KEYCHAIN";
+
+function nonblankEnvironmentValue(name) {
+  const value = process.env[name];
+  return value?.trim() ? value : undefined;
+}
+
+function resolveEnvironmentAlias(canonicalKey, legacyKey) {
+  const canonicalValue = nonblankEnvironmentValue(canonicalKey);
+  const legacyValue = nonblankEnvironmentValue(legacyKey);
+  const canonicalPresent = canonicalValue !== undefined;
+  const legacyPresent = legacyValue !== undefined;
+
+  if (!canonicalPresent && !legacyPresent) {
+    return undefined;
+  }
+  if (canonicalPresent && legacyPresent && canonicalValue !== legacyValue) {
+    throw new Error(
+      `Desktop notarization Keychain environment aliases conflict: canonical_key=${canonicalKey} legacy_key=${legacyKey} state=conflict`,
+    );
+  }
+
+  const source =
+    canonicalPresent && legacyPresent
+      ? "dual"
+      : canonicalPresent
+        ? "canonical-only"
+        : "legacy-only";
+  console.info(
+    `desktop_notarize_keychain_env_source key=${canonicalKey} source=${source}`,
+  );
+  return canonicalPresent ? canonicalValue : legacyValue;
+}
+
+// The README remains legacy-only for this external local-build reader stage.
+// Production silence cannot prove that independent local configuration drained.
+// Remove these aliases only after the later documentation cutover and explicit
+// external-support rollback window complete under #28914.
+function resolveDesktopNotarizeKeychainEnvironment() {
+  const keychainProfile = resolveEnvironmentAlias(
+    CANONICAL_KEYCHAIN_PROFILE,
+    LEGACY_KEYCHAIN_PROFILE,
+  );
+  if (!keychainProfile) {
+    return undefined;
+  }
+
+  const keychain = resolveEnvironmentAlias(CANONICAL_KEYCHAIN, LEGACY_KEYCHAIN);
+  return {
+    keychainProfile,
+    keychain: keychain?.trim(),
+  };
+}
+
+module.exports = { resolveDesktopNotarizeKeychainEnvironment };

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -37,6 +37,14 @@ const allAliases = [
   ...Object.values(canonicalAliases),
   ...Object.values(legacyAliases),
 ];
+const canonicalKeychainAliases = {
+  profile: "OKOU_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE",
+  path: "OKOU_DESKTOP_NOTARIZE_KEYCHAIN",
+} as const;
+const legacyKeychainAliases = {
+  profile: "VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE",
+  path: "VM0_DESKTOP_NOTARIZE_KEYCHAIN",
+} as const;
 const canonicalSigningIdentityAlias = "OKOU_DESKTOP_SIGNING_IDENTITY";
 const legacySigningIdentityAlias = "VM0_DESKTOP_SIGNING_IDENTITY";
 const developerIdApplicationIdentity =
@@ -116,8 +124,8 @@ export async function notarize(options) {
   } else if (mode === "custom-keychain") {
     credentialsAreUnchanged =
       options.keychainProfile ===
-        process.env.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE &&
-      options.keychain === process.env.TEST_EXPECTED_DEFAULT_KEYCHAIN &&
+        process.env.TEST_EXPECTED_KEYCHAIN_PROFILE &&
+      options.keychain === process.env.TEST_EXPECTED_KEYCHAIN &&
       options.appleApiKey === undefined &&
       options.appleApiKeyId === undefined &&
       options.appleApiIssuer === undefined;
@@ -153,6 +161,13 @@ type SuccessfulSource = "canonical-only" | "legacy-only" | "dual";
 interface SigningIdentityInput {
   readonly canonical?: string;
   readonly legacy?: string;
+}
+
+interface KeychainEnvironmentInput {
+  readonly canonicalProfile?: string;
+  readonly legacyProfile?: string;
+  readonly canonicalPath?: string;
+  readonly legacyPath?: string;
 }
 
 interface CredentialValues {
@@ -273,6 +288,26 @@ function applySigningIdentityInput(
   );
 }
 
+function applyKeychainEnvironmentInput(
+  environment: NodeJS.ProcessEnv,
+  input: KeychainEnvironmentInput,
+): readonly string[] {
+  const valuesByAlias = [
+    [canonicalKeychainAliases.profile, input.canonicalProfile],
+    [legacyKeychainAliases.profile, input.legacyProfile],
+    [canonicalKeychainAliases.path, input.canonicalPath],
+    [legacyKeychainAliases.path, input.legacyPath],
+  ] as const;
+  for (const [alias, value] of valuesByAlias) {
+    if (value !== undefined) {
+      environment[alias] = value;
+    }
+  }
+  return valuesByAlias.flatMap(([, value]) =>
+    value?.trim() ? [value.trim()] : [],
+  );
+}
+
 function baseEnvironment(harness: TestHarness): NodeJS.ProcessEnv {
   return {
     CI: "true",
@@ -303,6 +338,9 @@ function runForge(
     readonly notarize?: boolean;
     readonly source?: SuccessfulSource;
     readonly keychainMode?: "default-keychain" | "custom-keychain";
+    readonly keychainInput?: KeychainEnvironmentInput;
+    readonly expectedKeychainProfile?: string;
+    readonly expectedKeychain?: string;
     readonly signingIdentity?: SigningIdentityInput;
     readonly ci?: boolean;
   } = {},
@@ -324,6 +362,16 @@ function runForge(
     environment,
     harness.directory,
     credentialCase,
+  );
+  const defaultCustomKeychainProfile = randomUUID();
+  const keychainInput: KeychainEnvironmentInput =
+    options.keychainInput ??
+    (options.keychainMode === "custom-keychain"
+      ? { legacyProfile: defaultCustomKeychainProfile }
+      : {});
+  const keychainValues = applyKeychainEnvironmentInput(
+    environment,
+    keychainInput,
   );
   const signingIdentity = options.signingIdentity ?? {};
   const signingIdentityValues = applySigningIdentityInput(
@@ -348,7 +396,13 @@ function runForge(
     environment.TEST_NOTARIZE_MODE = options.keychainMode;
   }
   if (options.keychainMode === "custom-keychain") {
-    environment.VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE = randomUUID();
+    environment.TEST_EXPECTED_KEYCHAIN_PROFILE =
+      options.expectedKeychainProfile ??
+      keychainInput.canonicalProfile ??
+      keychainInput.legacyProfile ??
+      defaultCustomKeychainProfile;
+    environment.TEST_EXPECTED_KEYCHAIN =
+      options.expectedKeychain ?? environment.TEST_EXPECTED_DEFAULT_KEYCHAIN;
   }
 
   const processResult = spawnSync(
@@ -369,7 +423,11 @@ function runForge(
   return {
     process: processResult,
     trace: trace(harness),
-    sensitiveValues: [...credentialValues, ...signingIdentityValues],
+    sensitiveValues: [
+      ...credentialValues,
+      ...keychainValues,
+      ...signingIdentityValues,
+    ],
   };
 }
 
@@ -447,6 +505,12 @@ function sourceEvents(result: EntryPointResult): readonly string[] {
     .filter((line) => line.startsWith("desktop_notarize_api_env_source "));
 }
 
+function keychainSourceEvents(result: EntryPointResult): readonly string[] {
+  return result.process.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("desktop_notarize_keychain_env_source "));
+}
+
 function signingIdentitySourceEvents(
   result: EntryPointResult,
 ): readonly string[] {
@@ -506,6 +570,8 @@ afterEach(() => {
 });
 
 describe("Desktop Forge notarization entry point", () => {
+  const precedenceProfile = ` precedence-profile-${randomUUID()} `;
+
   it.each([
     ["canonical-only", "canonical-only"],
     ["legacy-only", "legacy-only"],
@@ -543,22 +609,243 @@ describe("Desktop Forge notarization entry point", () => {
     },
   );
 
-  it("keeps a custom Keychain profile ahead of conflicting API aliases", () => {
-    const result = runForge("conflict", {
-      keychainMode: "custom-keychain",
-    });
-    expect(result.process.status === 0).toBe(true);
-    expect(result.trace).toBe("sign\nnotarize\n");
-    expect(sourceEvents(result)).toStrictEqual([]);
-    expectNoSensitiveValueDisclosure(result);
-  });
+  it.each([
+    ["conflict", { canonicalProfile: precedenceProfile }, "canonical-only"],
+    ["mixed", { legacyProfile: precedenceProfile }, "legacy-only"],
+    [
+      "incomplete",
+      {
+        canonicalProfile: precedenceProfile,
+        legacyProfile: precedenceProfile,
+      },
+      "dual",
+    ],
+  ] as const)(
+    "keeps a custom Keychain profile ahead of %s API aliases",
+    (credentialCase, keychainInput, source) => {
+      const result = runForge(credentialCase, {
+        keychainMode: "custom-keychain",
+        keychainInput,
+        expectedKeychainProfile: precedenceProfile,
+      });
+      expect(result.process.status === 0).toBe(true);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(sourceEvents(result)).toStrictEqual([]);
+      expect(keychainSourceEvents(result)).toStrictEqual([
+        `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=${source}`,
+      ]);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
 
   it("keeps notarization disabled unless the existing toggle is true", () => {
-    const result = runForge("canonical-only", { notarize: false });
+    const result = runForge("canonical-only", {
+      notarize: false,
+      keychainInput: {
+        canonicalProfile: randomUUID(),
+        legacyProfile: randomUUID(),
+      },
+    });
     expect(result.process.status === 0).toBe(true);
     expect(result.trace).toBe("sign\n");
     expect(sourceEvents(result)).toStrictEqual([]);
+    expect(keychainSourceEvents(result)).toStrictEqual([]);
     expectNoSensitiveValueDisclosure(result);
+  });
+});
+
+describe("Desktop Forge Keychain notarization environment entry point", () => {
+  const sharedProfile = ` profile-${randomUUID()} `;
+  const sharedPath = ` /tmp/keychain-${randomUUID()} `;
+  const canonicalPath = `/tmp/canonical-keychain-${randomUUID()}`;
+  const legacyPath = `/tmp/legacy-keychain-${randomUUID()}`;
+
+  it.each([
+    [
+      "canonical-only",
+      { canonicalProfile: sharedProfile, legacyProfile: " \t " },
+      "canonical-only",
+    ],
+    [
+      "legacy-only",
+      { canonicalProfile: "", legacyProfile: sharedProfile },
+      "legacy-only",
+    ],
+    [
+      "byte-equal dual",
+      { canonicalProfile: sharedProfile, legacyProfile: sharedProfile },
+      "dual",
+    ],
+  ] as const)(
+    "passes the %s profile through byte-for-byte",
+    (_, keychainInput, source) => {
+      const result = runForge("absent", {
+        keychainMode: "custom-keychain",
+        keychainInput,
+        expectedKeychainProfile: sharedProfile,
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(sourceEvents(result)).toStrictEqual([]);
+      expect(keychainSourceEvents(result)).toStrictEqual([
+        `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=${source}`,
+      ]);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it.each([
+    ["absent", { canonicalPath, legacyPath }],
+    [
+      "empty",
+      {
+        canonicalProfile: "",
+        legacyProfile: "",
+        canonicalPath,
+        legacyPath,
+      },
+    ],
+    [
+      "whitespace-only",
+      {
+        canonicalProfile: " \t ",
+        legacyProfile: "\n ",
+        canonicalPath,
+        legacyPath,
+      },
+    ],
+  ] as const)(
+    "ignores unequal path-only aliases when profiles are %s",
+    (_, keychainInput) => {
+      const result = runForge("absent", {
+        keychainMode: "default-keychain",
+        keychainInput,
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(sourceEvents(result)).toStrictEqual([]);
+      expect(keychainSourceEvents(result)).toStrictEqual([]);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it.each([
+    ["absent", {}],
+    ["empty", { canonicalPath: "", legacyPath: "" }],
+    ["whitespace-only", { canonicalPath: " \t ", legacyPath: "\n " }],
+  ] as const)(
+    "uses the default path when selected-profile paths are %s",
+    (_, pathInput) => {
+      const result = runForge("absent", {
+        keychainMode: "custom-keychain",
+        keychainInput: {
+          canonicalProfile: sharedProfile,
+          ...pathInput,
+        },
+        expectedKeychainProfile: sharedProfile,
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(keychainSourceEvents(result)).toStrictEqual([
+        `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=canonical-only`,
+      ]);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it.each([
+    [
+      "canonical-only",
+      { canonicalPath: sharedPath, legacyPath: " \t " },
+      "canonical-only",
+    ],
+    [
+      "legacy-only",
+      { canonicalPath: "", legacyPath: sharedPath },
+      "legacy-only",
+    ],
+    [
+      "byte-equal dual",
+      { canonicalPath: sharedPath, legacyPath: sharedPath },
+      "dual",
+    ],
+  ] as const)(
+    "trims the selected %s path before use",
+    (_, pathInput, source) => {
+      const result = runForge("absent", {
+        keychainMode: "custom-keychain",
+        keychainInput: {
+          canonicalProfile: sharedProfile,
+          ...pathInput,
+        },
+        expectedKeychainProfile: sharedProfile,
+        expectedKeychain: sharedPath.trim(),
+      });
+
+      expect(result.process.status, result.process.stderr).toBe(0);
+      expect(result.trace).toBe("sign\nnotarize\n");
+      expect(keychainSourceEvents(result)).toStrictEqual([
+        `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=canonical-only`,
+        `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.path} source=${source}`,
+      ]);
+      expectNoSensitiveValueDisclosure(result);
+    },
+  );
+
+  it("rejects conflicting profile aliases before external effects", () => {
+    const profile = `profile-${randomUUID()}`;
+    const result = runForge("conflict", {
+      keychainMode: "custom-keychain",
+      keychainInput: {
+        canonicalProfile: profile,
+        legacyProfile: ` ${profile} `,
+      },
+    });
+
+    expect(result.process.status).toBe(1);
+    expect(result.trace).toBe("");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expect(keychainSourceEvents(result)).toStrictEqual([]);
+    expect(result.process.stderr).toContain(
+      `Desktop notarization Keychain environment aliases conflict: canonical_key=${canonicalKeychainAliases.profile} legacy_key=${legacyKeychainAliases.profile} state=conflict`,
+    );
+    expectNoSensitiveValueDisclosure(result);
+  });
+
+  it("rejects conflicting path aliases only under a selected profile", () => {
+    const result = runForge("conflict", {
+      keychainMode: "custom-keychain",
+      keychainInput: {
+        canonicalProfile: sharedProfile,
+        canonicalPath,
+        legacyPath: ` ${canonicalPath} `,
+      },
+      expectedKeychainProfile: sharedProfile,
+    });
+
+    expect(result.process.status).toBe(1);
+    expect(result.trace).toBe("");
+    expect(sourceEvents(result)).toStrictEqual([]);
+    expect(keychainSourceEvents(result)).toStrictEqual([
+      `desktop_notarize_keychain_env_source key=${canonicalKeychainAliases.profile} source=canonical-only`,
+    ]);
+    expect(result.process.stderr).toContain(
+      `Desktop notarization Keychain environment aliases conflict: canonical_key=${canonicalKeychainAliases.path} legacy_key=${legacyKeychainAliases.path} state=conflict`,
+    );
+    expectNoSensitiveValueDisclosure(result);
+  });
+
+  it("ignores unequal path-only aliases when API mode is selected", () => {
+    const result = runForge("canonical-only", {
+      source: "canonical-only",
+      keychainInput: { canonicalPath, legacyPath },
+    });
+
+    expectSuccessfulApiEntryPoint(result, "canonical-only");
+    expect(keychainSourceEvents(result)).toStrictEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add one focused synchronous resolver for the Desktop notarization Keychain profile/path aliases, selecting nonblank canonical-only, legacy-only, and byte-equal dual values with fixed value-free source evidence
- resolve the path pair only after a custom profile is selected, passing the selected profile byte-for-byte while trimming only the selected nonblank path
- fail closed on relevant profile/path conflicts before signing or notarization while preserving custom-profile precedence over conflicting, mixed, or incomplete API credentials and preserving the API/default-Keychain branch when no profile is selected
- cover the complete behavior matrix through the real Forge entry point while replacing only the external Apple signing and notarization modules

## Base and overlap audit

- refreshed `origin/main` before implementation at `4069e2a30f8dc2b9beaccaeda44edc1116b5de70`; after two unrelated Platform changes merged, refreshed again and rebased the unpushed commit onto final base `10fbb8ea6b69d90f09d0b0a71042a088a87c3d7c`
- audited the exact Keychain profile/path literals and callers separately from the notarization API credential aliases; Forge was the sole code reader, the README was the sole documentation surface, and the focused test contained the only repository fixture writes
- fully checked the latest 26 open PRs for scoped-file, literal, resolver-name, metadata, and semantic overlap; #25722 was fully paginated through all 185 files, and no overlap was found
- verified the two intervening `main` commits touched only Platform/Core files and contained no Keychain alias or resolver semantic overlap
- `turbo/apps/desktop/README.md`, `turbo/apps/desktop/package.json`, and `.github/**` remain byte-for-byte unchanged; documented inputs remain legacy-only and no repository writer or workflow was added or modified

## Verification

- `pnpm exec prettier --check apps/desktop/forge.config.js apps/desktop/scripts/desktop-notarize-keychain-environment.js apps/desktop/src/desktop-notarize-entry-points.test.ts` — Prettier 3.8.1
- `pnpm -F @okouai/desktop lint`
- `pnpm -F @okouai/desktop check-types`
- `pnpm knip --workspace @okouai/desktop`
- `node --check apps/desktop/forge.config.js`
- `node --check apps/desktop/scripts/desktop-notarize-keychain-environment.js`
- `pnpm -F @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` — 54/54 tests passed
- `git diff --check origin/main...HEAD`
- focused README/package/workflow byte-identity and exact-literal checks

No full local Vitest suite or development server was run. PR CI remains authoritative for the broader repository matrix.

## Fallbacks

- External local-build surface: `VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE` and `VM0_DESKTOP_NOTARIZE_KEYCHAIN` remain the only documented inputs in `turbo/apps/desktop/README.md`, and developers may configure them independently of any repository checkout. Centralized production silence therefore cannot prove that external legacy use has drained.
- Reader-only stage: `resolveDesktopNotarizeKeychainEnvironment` adds canonical reads while retaining the existing legacy reads. No writer, workflow, package script, credential, signing/notarization option, artifact, or release behavior changes, so reverting this PR returns to the prior legacy-only reader without a writer rollback.
- Path-without-profile invariant: the resolver returns before reading or conflict-checking either path alias unless a nonblank custom profile was selected. Path-only input, including unequal canonical/legacy paths, remains ignored so the existing API/default-Keychain branch continues unchanged.
- Later README cutover: a separate focused issue may change the documented local inputs to canonical spelling only after defining the explicit external deprecation, support, observation, and rollback policy.
- Legacy-reader removal: removal is a separate final gate under #28914 after the external-support window and supported rollback policy complete; it must not rely solely on absence of centralized production events. The temporary `VM0_*` ownership guard remains untouched.

Closes #29189
Refs #28914
