### PR TITLE
fix(connectors): polish account manager hierarchy

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2234,6 +2234,7 @@
       "deleteDescriptionWithCount_one": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "{{account}} löschen?",
+      "fallbackName": "Konto #{{id}}",
       "find": "Konten suchen",
       "loading": "Konten werden geladen…",
       "loadingMore": "Wird geladen…",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2232,6 +2232,7 @@
       "deleteDescription": "Threads using this account will return to default inheritance.",
       "deleteDescriptionWithCount": "{{value}} threads will return to default inheritance.",
       "deleteTitle": "Delete {{account}}?",
+      "fallbackName": "Account #{{id}}",
       "find": "Find accounts",
       "loading": "Loading accounts…",
       "loadingMore": "Loading…",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2280,6 +2280,7 @@
       "deleteDescriptionWithCount_many": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "¿Eliminar {{account}}?",
+      "fallbackName": "Cuenta #{{id}}",
       "find": "Buscar cuentas",
       "loading": "Cargando cuentas…",
       "loadingMore": "Cargando…",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2280,6 +2280,7 @@
       "deleteDescriptionWithCount_many": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "Supprimer {{account}} ?",
+      "fallbackName": "Compte #{{id}}",
       "find": "Rechercher des comptes",
       "loading": "Chargement des comptes…",
       "loadingMore": "Chargement…",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2234,6 +2234,7 @@
       "deleteDescriptionWithCount_one": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "{{account}} को हटाएँ?",
+      "fallbackName": "खाता #{{id}}",
       "find": "खाते खोजें",
       "loading": "खाते लोड हो रहे हैं…",
       "loadingMore": "लोड हो रहा है…",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2228,6 +2228,7 @@
       "deleteDescriptionWithCount": "{{value}} thread akan kembali ke pewarisan default.",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "Hapus {{account}}?",
+      "fallbackName": "Akun #{{id}}",
       "find": "Cari akun",
       "loading": "Memuat akun…",
       "loadingMore": "Memuat…",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2280,6 +2280,7 @@
       "deleteDescriptionWithCount_many": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "Eliminare {{account}}?",
+      "fallbackName": "Account #{{id}}",
       "find": "Cerca account",
       "loading": "Caricamento account…",
       "loadingMore": "Caricamento…",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2228,6 +2228,7 @@
       "deleteDescriptionWithCount": "{{value}} 件のスレッドがデフォルトの継承に戻ります。",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "{{account}} を削除しますか？",
+      "fallbackName": "アカウント #{{id}}",
       "find": "アカウントを検索",
       "loading": "アカウントを読み込み中…",
       "loadingMore": "読み込み中…",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2228,6 +2228,7 @@
       "deleteDescriptionWithCount": "{{value}}개 스레드가 기본 상속으로 돌아갑니다.",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "{{account}}을(를) 삭제할까요?",
+      "fallbackName": "계정 #{{id}}",
       "find": "계정 찾기",
       "loading": "계정 불러오는 중…",
       "loadingMore": "불러오는 중…",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2280,6 +2280,7 @@
       "deleteDescriptionWithCount_many": "",
       "deleteDescriptionWithCount_other": "",
       "deleteTitle": "Excluir {{account}}?",
+      "fallbackName": "Conta #{{id}}",
       "find": "Buscar contas",
       "loading": "Carregando contas…",
       "loadingMore": "Carregando…",

--- a/turbo/apps/platform/src/signals/connector-domain.ts
+++ b/turbo/apps/platform/src/signals/connector-domain.ts
@@ -30,13 +30,13 @@ export const singleAccountConnectorMutation = {
 
 export function connectorAccountEffectiveLabel(
   account: ConnectorAccountConnection,
-  connectorLabel: string,
+  fallbackLabel: string,
 ): string {
   return (
     account.displayName ??
     account.externalEmail ??
     account.externalUsername ??
     account.externalId ??
-    `${connectorLabel} · ${account.id.slice(0, 8)}`
+    fallbackLabel
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1567,7 +1567,7 @@ describe("connectors page", () => {
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
 
     const dialog = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     expect(within(dialog).getByText("Work 0")).toBeInTheDocument();
     expect(within(dialog).queryByText("Work 50")).toBeNull();
@@ -1665,7 +1665,7 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     const manager = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     const actions = within(manager).getAllByLabelText("Account actions");
     const personalActions = actions.at(1);
@@ -1729,7 +1729,7 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     const manager = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     await expect(
       within(manager).findByText(
@@ -1805,7 +1805,7 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     const firstManager = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     click(within(firstManager).getByLabelText("Account actions"));
     click(menuItemByText("Delete"));
@@ -1814,14 +1814,12 @@ describe("connectors page", () => {
     });
     click(within(firstManager).getByLabelText("Close"));
     await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Manage GitHub accounts" }),
-      ).toBeNull();
+      expect(screen.queryByRole("dialog", { name: "GitHub" })).toBeNull();
     });
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     resolveImpact();
     await waitFor(() => {
@@ -1916,7 +1914,7 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
     const dialog = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
+      name: "GitHub",
     });
     click(within(dialog).getByLabelText("Account actions"));
     click(menuItemByText("Rename"));
@@ -2048,7 +2046,7 @@ describe("connectors page", () => {
 
     click(await waitForButtonByAriaLabel("Manage Stripe accounts"));
     const manager = await screen.findByRole("dialog", {
-      name: "Manage Stripe accounts",
+      name: "Stripe",
     });
     const actions = await waitFor(() => {
       expect(accountListRequestCount).toBeGreaterThan(0);
@@ -6334,7 +6332,7 @@ describe("connectors page", () => {
       ),
     );
     const manager = await screen.findByRole("dialog", {
-      name: `Manage ${connector.displayName} accounts`,
+      name: connector.displayName,
     });
     click(buttonByText("Add account", manager));
     const dialog = await screen.findByRole("dialog", {
@@ -6427,7 +6425,7 @@ describe("connectors page", () => {
       ),
     );
     const manager = await screen.findByRole("dialog", {
-      name: `Manage ${connector.displayName} accounts`,
+      name: connector.displayName,
     });
     click(await within(manager).findByLabelText("Account actions"));
     click(menuItemByText("Reconnect"));
@@ -6505,7 +6503,7 @@ describe("connectors page", () => {
     click(await waitForButtonByAriaLabel("Manage Acme MCP accounts"));
 
     const manager = await screen.findByRole("dialog", {
-      name: "Manage Acme MCP accounts",
+      name: "Acme MCP",
     });
     expect(buttonByText("Add account", manager)).toBeDisabled();
     click(within(manager).getByLabelText("Account actions"));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1502,13 +1502,16 @@ describe("connectors page", () => {
     }
     const accounts = Array.from({ length: 101 }, (_, index) => {
       return {
-        id: crypto.randomUUID(),
+        id:
+          index === 0
+            ? "00000000-0000-4000-a000-000000000001"
+            : crypto.randomUUID(),
         target: { kind: "builtin" as const, connectorSlug: "github" },
         authMethod: "oauth",
-        displayName: `Work ${index}`,
+        displayName: index === 0 ? null : `Work ${index}`,
         isDefault: index === 0,
         externalId: null,
-        externalUsername: `octocat-${index}`,
+        externalUsername: index === 0 ? null : `octocat-${index}`,
         externalEmail: null,
         oauthScopes: [],
         connectionStatus: "connected" as const,
@@ -1569,7 +1572,7 @@ describe("connectors page", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "GitHub",
     });
-    expect(within(dialog).getByText("Work 0")).toBeInTheDocument();
+    expect(within(dialog).getByText("Account #00000000")).toBeInTheDocument();
     expect(within(dialog).queryByText("Work 50")).toBeNull();
     click(buttonByText("Load more", dialog));
     await waitFor(() => {
@@ -1581,7 +1584,7 @@ describe("connectors page", () => {
     );
     await waitFor(() => {
       expect(within(dialog).getByText("Work 100")).toBeInTheDocument();
-      expect(within(dialog).queryByText("Work 0")).toBeNull();
+      expect(within(dialog).queryByText("Account #00000000")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1570,8 +1570,23 @@ describe("connectors page", () => {
     const manageAccounts = await waitForButtonByAriaLabel(
       "Manage GitHub accounts",
     );
+    const manageAccess = within(connectorCardByLabel("GitHub")).getByLabelText(
+      "Manage GitHub access",
+    );
     expect(manageAccounts.tagName).toBe("BUTTON");
     expect(manageAccounts.querySelector("button")).toBeNull();
+    expect(manageAccounts).not.toContainElement(manageAccess);
+    click(manageAccess);
+    const accessDialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(screen.queryByRole("dialog", { name: "GitHub" })).toBeNull();
+    click(within(accessDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Manage GitHub access" }),
+      ).toBeNull();
+    });
     click(manageAccounts);
 
     const dialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1567,7 +1567,12 @@ describe("connectors page", () => {
       const candidate = connectorCardByLabel("GitHub");
       expect(candidate).toHaveTextContent("101 accounts");
     });
-    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const manageAccounts = await waitForButtonByAriaLabel(
+      "Manage GitHub accounts",
+    );
+    expect(manageAccounts.tagName).toBe("BUTTON");
+    expect(manageAccounts.querySelector("button")).toBeNull();
+    click(manageAccounts);
 
     const dialog = await screen.findByRole("dialog", {
       name: "GitHub",
@@ -1934,7 +1939,7 @@ describe("connectors page", () => {
     click(buttonByText("Save", dialog));
     await waitFor(() => {
       expect(renamedDisplayNames).toStrictEqual(["Personal", null]);
-      expect(within(dialog).getAllByText("octocat")).toHaveLength(2);
+      expect(within(dialog).getAllByText("octocat")).toHaveLength(1);
     });
     click(within(dialog).getByLabelText("Account actions"));
     click(menuItemByText("Delete"));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1667,6 +1667,7 @@ describe("connectors page", () => {
     const manager = await screen.findByRole("dialog", {
       name: "GitHub",
     });
+    expect(within(manager).queryByPlaceholderText("Find accounts")).toBeNull();
     const actions = within(manager).getAllByLabelText("Account actions");
     const personalActions = actions.at(1);
     if (!personalActions) {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -177,20 +177,21 @@ function AccountRow({
 }) {
   const { t } = useTranslation();
   const identity = accountIdentity(account);
+  const label = connectorAccountEffectiveLabel(
+    account,
+    t(
+      ($) => {
+        return $.connectors.accounts.fallbackName;
+      },
+      { id: account.id.slice(0, 8) },
+    ),
+  );
   return (
     <div className="flex min-h-16 items-center gap-3 border-b border-border px-4 py-3 last:border-b-0">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium text-foreground">
-            {connectorAccountEffectiveLabel(
-              account,
-              t(
-                ($) => {
-                  return $.connectors.accounts.fallbackName;
-                },
-                { id: account.id.slice(0, 8) },
-              ),
-            )}
+            {label}
           </span>
           {account.isDefault ? (
             <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
@@ -202,7 +203,7 @@ function AccountRow({
         </div>
         <div className="flex gap-2 truncate text-xs">
           <AccountStatus account={account} />
-          {identity ? (
+          {identity && identity !== label ? (
             <span className="truncate text-muted-foreground">{identity}</span>
           ) : null}
         </div>
@@ -373,7 +374,7 @@ function DeleteAccountConfirmation({
     >
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>
+          <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">
             {t(
               ($) => {
                 return $.connectors.accounts.deleteTitle;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -459,15 +459,15 @@ export function ConnectorAccountManagerDialog({
         className="max-w-xl gap-0 overflow-hidden p-0"
         aria-describedby={undefined}
       >
-        <DialogHeader className="border-b border-border px-6 py-5">
-          <div className="flex items-center justify-between gap-4 pr-6">
+        <DialogHeader className="border-b border-border py-4 pl-6 pr-16">
+          <div className="flex items-center justify-between gap-4">
             <div className="flex min-w-0 items-center gap-3">
               {icon}
               <DialogTitle className="truncate">{connectorLabel}</DialogTitle>
             </div>
             <Button
               type="button"
-              size="sm"
+              className="shrink-0"
               disabled={
                 !connectionActionsEnabled ||
                 accountsLoadable.state === "hasError" ||

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -167,13 +167,11 @@ function AccountActions({
 function AccountRow({
   target,
   account,
-  connectorLabel,
   connectionActionsEnabled,
   onReconnect,
 }: {
   readonly target: ConnectorAccountTarget;
   readonly account: ConnectorAccountConnection;
-  readonly connectorLabel: string;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
 }) {
@@ -184,7 +182,15 @@ function AccountRow({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium text-foreground">
-            {connectorAccountEffectiveLabel(account, connectorLabel)}
+            {connectorAccountEffectiveLabel(
+              account,
+              t(
+                ($) => {
+                  return $.connectors.accounts.fallbackName;
+                },
+                { id: account.id.slice(0, 8) },
+              ),
+            )}
           </span>
           {account.isDefault ? (
             <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
@@ -214,13 +220,11 @@ function AccountRow({
 function AccountList({
   loadable,
   target,
-  connectorLabel,
   connectionActionsEnabled,
   onReconnect,
 }: {
   readonly loadable: Loadable<ConnectorAccountList>;
   readonly target: ConnectorAccountTarget;
-  readonly connectorLabel: string;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
 }) {
@@ -268,7 +272,6 @@ function AccountList({
         key={`${account.id}-row`}
         target={target}
         account={account}
-        connectorLabel={connectorLabel}
         connectionActionsEnabled={connectionActionsEnabled}
         onReconnect={onReconnect}
       />,
@@ -339,10 +342,8 @@ function RenameAccountForm({ target }: { target: ConnectorAccountTarget }) {
 
 function DeleteAccountConfirmation({
   target,
-  connectorLabel,
 }: {
   readonly target: ConnectorAccountTarget;
-  readonly connectorLabel: string;
 }) {
   const { t } = useTranslation();
   const draft = useGet(connectorAccountDeletionDraft$);
@@ -380,7 +381,12 @@ function DeleteAccountConfirmation({
               {
                 account: connectorAccountEffectiveLabel(
                   draft.account,
-                  connectorLabel,
+                  t(
+                    ($) => {
+                      return $.connectors.accounts.fallbackName;
+                    },
+                    { id: draft.account.id.slice(0, 8) },
+                  ),
                 ),
               },
             )}
@@ -506,7 +512,6 @@ export function ConnectorAccountManagerDialog({
           <AccountList
             loadable={accountsLoadable}
             target={target}
-            connectorLabel={connectorLabel}
             connectionActionsEnabled={connectionActionsEnabled}
             onReconnect={(account) => {
               leave(() => {
@@ -536,10 +541,7 @@ export function ConnectorAccountManagerDialog({
             </Button>
           </div>
         ) : null}
-        <DeleteAccountConfirmation
-          target={target}
-          connectorLabel={connectorLabel}
-        />
+        <DeleteAccountConfirmation target={target} />
       </DialogContent>
     </Dialog>
   );

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -102,7 +102,7 @@ function AccountActions({
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
-          variant="ghost"
+          variant="quiet"
           size="icon"
           aria-label={t(($) => {
             return $.connectors.accounts.actions;
@@ -462,7 +462,7 @@ export function ConnectorAccountManagerDialog({
         className="max-w-xl gap-0 overflow-hidden p-0"
         aria-describedby={undefined}
       >
-        <DialogHeader className="border-b border-border py-4 pl-6 pr-16">
+        <DialogHeader className="border-b border-border bg-muted/40 py-4 pl-6 pr-16">
           <div className="flex items-center justify-between gap-4">
             <div className="flex min-w-0 items-center gap-3">
               {icon}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -183,7 +183,7 @@ function AccountRow({
     <div className="flex min-h-16 items-center gap-3 border-b border-border px-4 py-3 last:border-b-0">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium">
+          <span className="truncate text-sm font-medium text-foreground">
             {connectorAccountEffectiveLabel(account, connectorLabel)}
           </span>
           {account.isDefault ? (

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -53,6 +53,8 @@ interface ConnectorAccountManagerDialogProps {
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
 }
 
+const MAX_ACCOUNTS_WITHOUT_SEARCH = 6;
+
 function accountIdentity(account: ConnectorAccountConnection): string | null {
   return (
     account.externalEmail ??
@@ -443,7 +445,8 @@ export function ConnectorAccountManagerDialog({
   const showSearch =
     search.length > 0 ||
     (accountsLoadable.state === "hasData" &&
-      (accountsLoadable.data.connections.length > 1 || nextCursor !== null));
+      (accountsLoadable.data.connections.length > MAX_ACCOUNTS_WITHOUT_SEARCH ||
+        nextCursor !== null));
   const leave = (next: () => void) => {
     resetDrafts();
     next();

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -466,7 +466,9 @@ export function ConnectorAccountManagerDialog({
           <div className="flex items-center justify-between gap-4">
             <div className="flex min-w-0 items-center gap-3">
               {icon}
-              <DialogTitle className="truncate">{connectorLabel}</DialogTitle>
+              <DialogTitle className="truncate leading-6">
+                {connectorLabel}
+              </DialogTitle>
             </div>
             <Button
               type="button"

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -463,14 +463,7 @@ export function ConnectorAccountManagerDialog({
           <div className="flex items-center justify-between gap-4 pr-6">
             <div className="flex min-w-0 items-center gap-3">
               {icon}
-              <DialogTitle className="truncate">
-                {t(
-                  ($) => {
-                    return $.connectors.accounts.managerTitle;
-                  },
-                  { connector: connectorLabel },
-                )}
-              </DialogTitle>
+              <DialogTitle className="truncate">{connectorLabel}</DialogTitle>
             </div>
             <Button
               type="button"

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
@@ -68,7 +68,7 @@ export function ConnectorAccountNameDialog() {
       <DialogContent className="max-w-md">
         <form className="flex flex-col gap-5" onSubmit={submit}>
           <DialogHeader>
-            <DialogTitle>
+            <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">
               {t(
                 ($) => {
                   return $.connectors.accounts.namePromptTitle;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -366,12 +366,10 @@ function ConnectionConnectorCard({
 export function ConnectorAccountSummaryText({
   summary,
   status,
-  connectorLabel,
   className,
 }: {
   readonly summary: ConnectorAccountSummary | undefined;
   readonly status: ConnectorAccountSummaryStatus;
-  readonly connectorLabel: string;
   readonly className?: string;
 }) {
   const { t } = useTranslation();
@@ -421,7 +419,12 @@ export function ConnectorAccountSummaryText({
         summary: summaryText,
         account: connectorAccountEffectiveLabel(
           summary.defaultConnection,
-          connectorLabel,
+          t(
+            ($) => {
+              return $.connectors.accounts.fallbackName;
+            },
+            { id: summary.defaultConnection.id.slice(0, 8) },
+          ),
         ),
       },
     );
@@ -526,7 +529,6 @@ function AccountsConnectorCard({
           <ConnectorAccountSummaryText
             summary={summary}
             status={summaryStatus}
-            connectorLabel={connector.label}
             className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
           />
         )}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -462,37 +462,26 @@ function AccountsConnectorCard({
     );
   }
   const canManage = summaryStatus === "ready" && accountCount > 0 && !busy;
-  const manage = () => {
-    if (canManage) {
-      onManage();
-    }
-  };
   return (
     <div
-      role={canManage ? "button" : undefined}
-      tabIndex={canManage ? 0 : undefined}
-      aria-label={
-        canManage
-          ? t(
-              ($) => {
-                return $.connectors.accounts.managerTitle;
-              },
-              { connector: connector.label },
-            )
-          : undefined
-      }
       className={cn(
-        "zero-card flex flex-col text-left",
+        "zero-card relative flex flex-col text-left",
         canManage && "cursor-pointer",
       )}
-      onClick={manage}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          manage();
-        }
-      }}
     >
+      {canManage ? (
+        <button
+          type="button"
+          aria-label={t(
+            ($) => {
+              return $.connectors.accounts.managerTitle;
+            },
+            { connector: connector.label },
+          )}
+          className="absolute inset-0 z-10 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onManage}
+        />
+      ) : null}
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
           <ConnectorIcon icon={connector.icon} size={20} />
@@ -532,16 +521,7 @@ function AccountsConnectorCard({
             className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
           />
         )}
-        <div
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          onKeyDown={(event) => {
-            event.stopPropagation();
-          }}
-        >
-          {manageAccess}
-        </div>
+        <div className="relative z-20">{manageAccess}</div>
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -245,7 +245,6 @@ function CustomConnectorCardFooter({
           <ConnectorAccountSummaryText
             summary={accountSummary}
             status={accountSummaryStatus}
-            connectorLabel={connector.displayName}
             className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
           />
         )


### PR DESCRIPTION
## Summary

- simplify the connector account manager header to the connector name and align Add account with the close control
- distinguish the header from the account list, strengthen account-name hierarchy, neutralize row action icons, and show search only above six accounts
- prevent title clipping and close-button overlap on narrow screens, including user-defined long account names
- use a localized `Account #<short-id>` fallback without repeating the connector name or an external identity
- expose Manage accounts and Manage access as sibling native buttons instead of nested interactive controls

## Scope

- Platform connector-account presentation only
- no database, API, connector lifecycle, permission, thread-selection, or feature-switch rollout changes

Relates to #29074.
Parent context: #22832.

## Follow-ups

- #29222 tracks searching by the displayed fallback account ID
- #29223 tracks debouncing account search requests
- #29225 tracks keeping the default account discoverable across long paginated lists

## Validation

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (109 tests)
- `pnpm knip --workspace @okouai/app`
- full `pnpm knip` and `pnpm check-types` through the pre-commit hook
- browser verification at 320px for account naming, long-name deletion, identity display, Manage accounts, and Manage access
