### PR TITLE
test(guest-agent): observe claude tracker overflow behavior

### DIFF
--- a/crates/guest-agent/tests/claude_tool_tracking_overflow.rs
+++ b/crates/guest-agent/tests/claude_tool_tracking_overflow.rs
@@ -1,29 +1,34 @@
-//! Claude tool tracking must keep the run alive when the bounded watchdog
-//! state cannot admit another unmatched call.
+//! Claude tool tracking must reject an over-capacity call while preserving
+//! watchdog coverage for a later call admitted into a freed slot.
 
 mod common;
 
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
 use serde_json::json;
 use std::time::Duration;
 
-// Keep this one above MAX_TRACKED_STUCK_TOOLS in cli::claude.rs. The stream is
-// intentionally made of supported network tools so the test exercises tracker
-// admission without involving event delivery or the stuck-tool timeout.
-const TRACKED_TOOL_CAPACITY_PLUS_ONE: usize = 257;
+// Match MAX_TRACKED_STUCK_TOOLS in cli::claude.rs. If production capacity grows
+// above this fixture, the overflow WebFetch is retained and the WebSearch
+// assertion below fails instead of silently weakening the boundary coverage.
+const TRACKED_TOOL_CAPACITY: usize = 256;
+
+// Keep the fence larger than the 8 KiB agent-log buffer. Observing the marker
+// on disk then proves all preceding events completed the sequential read loop.
+const AGENT_LOG_FENCE_PADDING_BYTES: usize = 16 * 1024;
 
 #[tokio::test]
-async fn claude_tool_tracking_overflow_does_not_terminate_run()
+async fn claude_tool_tracking_overflow_preserves_later_watchdog_coverage()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let mut prompt_lines = vec!["@ECHO@".to_string()];
-    prompt_lines.extend((0..TRACKED_TOOL_CAPACITY_PLUS_ONE).map(|index| {
+    let mut prompt_lines = vec!["@ECHO-HANG@".to_string()];
+    prompt_lines.extend((0..TRACKED_TOOL_CAPACITY).map(|index| {
         json!({
             "type": "assistant",
             "message": {
                 "content": [{
                     "type": "tool_use",
-                    "id": format!("tracking-overflow-{index}"),
+                    "id": format!("tracking-admitted-{index}"),
                     "name": "WebFetch",
                     "input": {}
                 }]
@@ -33,31 +38,97 @@ async fn claude_tool_tracking_overflow_does_not_terminate_run()
     }));
     prompt_lines.push(
         json!({
-            "type": "result",
-            "subtype": "success",
-            "is_error": false,
-            "result": "done"
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tracking-overflow",
+                    "name": "WebFetch",
+                    "input": {}
+                }]
+            }
+        })
+        .to_string(),
+    );
+    prompt_lines.extend((0..TRACKED_TOOL_CAPACITY).map(|index| {
+        json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": format!("tracking-admitted-{index}"),
+                    "content": "done"
+                }]
+            }
+        })
+        .to_string()
+    }));
+    prompt_lines.push(
+        json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tracking-later-probe",
+                    "name": "WebSearch",
+                    "input": {}
+                }]
+            }
+        })
+        .to_string(),
+    );
+    prompt_lines.push(
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": common::MOCK_TERMINATION_READY_EVENT,
+                "padding": "x".repeat(AGENT_LOG_FENCE_PADDING_BYTES)
+            }
         })
         .to_string(),
     );
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt_lines.join("\n"), 1, 1)?;
+        std::env::set_var(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV, "1");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
     let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        runtime.paths.agent_log_file(),
+        common::MOCK_TERMINATION_READY_EVENT,
+        Duration::from_secs(5),
+    )];
     let execution = tokio::time::timeout(
-        Duration::from_secs(10),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        Duration::from_secs(15),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("tool tracking overflow should not stall the run")?;
+    .expect("tool tracking overflow should reach the watchdog within 15s")??;
 
-    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
-    assert!(execution.control_error.is_none());
-    assert!(execution.cli_termination.is_none());
+    assert_eq!(execution.exit_code, common::SIGTERM_EXIT);
+    let error = execution
+        .control_error
+        .as_ref()
+        .expect("the later WebSearch should trigger the stuck-tool watchdog");
+    assert!(
+        error
+            .to_string()
+            .contains("Tool timeout: WebSearch exceeded 1s"),
+        "expected the later WebSearch to remain tracked, got {error}"
+    );
+    let termination = execution
+        .cli_termination
+        .expect("stuck-tool timeout should attach CLI termination diagnostics");
+    assert_eq!(termination.reason, CliTerminationReason::StuckToolWatchdog);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- replace the Claude tracker overflow test's clean-exit assertion with an observable watchdog
  state transition through the real CLI execution path
- fill the tracker, reject an extra `WebFetch`, release every admitted call, then prove a later
  `WebSearch` occupies the freed slot and triggers structured watchdog termination
- synchronize on a padded agent-log ingestion fence and advance Tokio time instead of waiting for
  the production timeout

## Scope

This is a test-only `guest-agent` change. It does not change production behavior, public APIs, the
mock protocol, event schemas, persisted data, runner protocols, dependencies, or CI configuration.

The fixture still repeats the private 256-entry capacity, but the assertion now fails if production
capacity grows above it: the extra older `WebFetch` becomes retained and wins watchdog selection
instead of the expected later `WebSearch`.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test claude_tool_tracking_overflow`
- `cargo test -p guest-agent --all-targets --all-features`
- pre-commit workspace Cargo fmt, docs, Clippy, file-size check, and commitlint
- manual mutation checks verified the focused test fails when the capacity guard is bypassed, the
  stdout-to-tracker call is disabled, or production capacity is raised above the fixture

Closes #29192
