### PR TITLE
fix(platform): split growth entry click areas

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
@@ -109,6 +109,18 @@ describe("home growth entry", () => {
     expect(entry).toHaveTextContent("Add Zero in Slack");
 
     await user.click(entry);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(pathname()).toBe("/works");
+    });
+  });
+
+  it("opens channel choices from the separate menu button", async () => {
+    const user = userEvent.setup();
+    setupGrowthEntry({ isConnected: false, isInstalled: false });
+
+    await screen.findByTestId("growth-entry");
+    await user.click(screen.getByTestId("growth-entry-menu"));
     const menu = await screen.findByRole("menu");
     const slackAction = within(menu).getByTestId("growth-slack");
     expect(slackAction).toHaveTextContent("Add Zero in Slack");
@@ -134,6 +146,19 @@ describe("home growth entry", () => {
     expect(entry).toHaveTextContent("Invite humans 🤝");
 
     await user.click(entry);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await expect(screen.findByRole("dialog")).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(search()).toContain("settings=people");
+    });
+  });
+
+  it("opens growth options from the separate menu button", async () => {
+    const user = userEvent.setup();
+    setupGrowthEntry({ isConnected: false, isInstalled: true });
+
+    await screen.findByTestId("growth-entry");
+    await user.click(screen.getByTestId("growth-entry-menu"));
     const menu = await screen.findByRole("menu");
     const slackStatus = within(menu).getByTestId("growth-slack");
     expect(slackStatus).toHaveTextContent("Zero is in Slack");
@@ -150,7 +175,8 @@ describe("home growth entry", () => {
     const user = userEvent.setup();
     setupGrowthEntry({ isConnected: true, isInstalled: true });
 
-    await user.click(await screen.findByTestId("growth-entry"));
+    await screen.findByTestId("growth-entry");
+    await user.click(screen.getByTestId("growth-entry-menu"));
     const menu = await screen.findByRole("menu");
     const credits = await within(menu).findByTestId("growth-credits");
 
@@ -178,10 +204,10 @@ describe("home growth entry", () => {
       { usagePackPlansEnabled: true },
     );
 
-    const entry = await screen.findByTestId("growth-entry");
+    await screen.findByTestId("growth-entry");
     expect(usagePackCreditRequests).toBe(0);
 
-    await user.click(entry);
+    await user.click(screen.getByTestId("growth-entry-menu"));
     const menu = await screen.findByRole("menu");
     await within(menu).findByTestId("growth-credits");
     expect(usagePackCreditRequests).toBe(1);

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -180,42 +180,53 @@ function GrowthEntry({ slackInstalled }: { slackInstalled: boolean }) {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+      <div
+        // 12px, not the Button default 8px: the split control and the menu it
+        // opens read as one object when their outer radii agree.
+        className="inline-flex h-8 items-stretch rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card shadow-[var(--zero-card-shadow)]"
+      >
         <Button
           type="button"
-          variant="outline"
+          variant="quiet"
           size="sm"
-          // 12px, not the Button default 8px: this trigger is one half of a
-          // pair with the 12px menu it opens, so they read as one object.
-          className="h-8 gap-0 rounded-[12px] bg-card px-[11px] shadow-[var(--zero-card-shadow)]"
+          className="h-full gap-[9px] rounded-l-[11px] rounded-r-none px-[11px] pr-[9px] text-foreground"
+          onClick={leadIsSlack ? openWorks : openInvite}
           data-testid="growth-entry"
         >
-          <span className="flex items-center gap-[9px]">
-            {leadIsSlack ? (
-              <SlackMark size={16} />
-            ) : (
-              <PlusCircle className="text-primary" />
-            )}
-            <span className="text-[13px] font-medium">
-              {leadIsSlack
-                ? t(
-                    ($) => {
-                      return $.chat.agentPage.growth.addInSlack;
-                    },
-                    { assistantName },
-                  )
-                : t(($) => {
-                    return $.chat.agentPage.growth.inviteMember;
-                  })}
-            </span>
+          {leadIsSlack ? (
+            <SlackMark size={16} />
+          ) : (
+            <PlusCircle className="text-primary" />
+          )}
+          <span className="text-[13px] font-medium">
+            {leadIsSlack
+              ? t(
+                  ($) => {
+                    return $.chat.agentPage.growth.addInSlack;
+                  },
+                  { assistantName },
+                )
+              : t(($) => {
+                  return $.chat.agentPage.growth.inviteMember;
+                })}
           </span>
-          <span
-            aria-hidden="true"
-            className="mx-[9px] h-4 w-[0.7px] shrink-0 bg-[hsl(var(--gray-300))]"
-          />
-          <ChevronDown className="text-muted-foreground" />
         </Button>
-      </DropdownMenuTrigger>
+
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="quiet"
+            size="icon-sm"
+            aria-label={t(($) => {
+              return $.chat.actions.more;
+            })}
+            className="h-full w-9 rounded-l-none rounded-r-[11px] border-l-[0.7px] border-[hsl(var(--gray-300))] data-popup-open:bg-state-hover data-popup-open:text-foreground"
+            data-testid="growth-entry-menu"
+          >
+            <ChevronDown />
+          </Button>
+        </DropdownMenuTrigger>
+      </div>
 
       <DropdownMenuContent align="end" className="w-[268px]">
         <DropdownMenuItem


### PR DESCRIPTION
## Summary

- split the top-right growth entry into separate primary and menu click targets
- open Works or People directly from the label region based on the current lead action
- keep the arrow as the only menu trigger with its own hover and open state
- cover both click regions across installed and uninstalled Slack states

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/home-growth-entry.test.tsx`

Browser verification was not run locally because repository instructions prohibit starting the dev server unless explicitly requested.
