### PR TITLE
fix(ably-subscriber): bound token exchange responses

### DIFF
--- a/crates/ably-subscriber/Cargo.toml
+++ b/crates/ably-subscriber/Cargo.toml
@@ -23,7 +23,7 @@ hmac = { workspace = true }
 httpmock = { workspace = true }
 proptest.workspace = true
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "net"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "net", "io-util"] }
 tracing-subscriber = { workspace = true }
 tracing-test-support = { workspace = true }
 

--- a/crates/ably-subscriber/src/connection/auth.rs
+++ b/crates/ably-subscriber/src/connection/auth.rs
@@ -1,7 +1,14 @@
 use crate::TokenRequest;
+use crate::protocol::error_code;
 use crate::types::{Error, TokenDetails};
 
 use super::endpoint::{PROTOCOL_VERSION, build_token_request_url};
+
+/// Maximum encoded JSON payload accepted from the Ably token endpoint.
+///
+/// Token details are normally small; 64 KiB leaves ample room for capability
+/// metadata while keeping response buffering bounded in the long-lived runner.
+const TOKEN_EXCHANGE_RESPONSE_MAX_BYTES: usize = 64 * 1024;
 
 /// Exchange a TokenRequest for a TokenDetails via Ably's REST API.
 pub(crate) async fn exchange_token(
@@ -10,14 +17,47 @@ pub(crate) async fn exchange_token(
     host: &str,
 ) -> Result<TokenDetails, Error> {
     let url = build_token_request_url(host, &token_request.key_name)?;
-    let resp = client
+    let response = client
         .post(url)
         .header("X-Ably-Version", PROTOCOL_VERSION)
         .json(token_request)
         .send()
         .await?
-        .error_for_status()?
-        .json::<TokenDetails>()
-        .await?;
-    Ok(resp)
+        .error_for_status()?;
+    let body = collect_token_response(response).await?;
+    serde_json::from_slice(&body).map_err(|error| Error::Protocol {
+        code: error_code::FAILED,
+        message: format!("Token exchange response JSON decode failed: {error}"),
+    })
+}
+
+async fn collect_token_response(mut response: reqwest::Response) -> Result<Vec<u8>, Error> {
+    let capacity = match response.content_length() {
+        Some(length) if length > TOKEN_EXCHANGE_RESPONSE_MAX_BYTES as u64 => {
+            return Err(token_response_too_large());
+        }
+        Some(length) => usize::try_from(length).map_err(|_| token_response_too_large())?,
+        None => 0,
+    };
+    let mut body = Vec::with_capacity(capacity);
+
+    while let Some(chunk) = response.chunk().await? {
+        let length = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(token_response_too_large)?;
+        if length > TOKEN_EXCHANGE_RESPONSE_MAX_BYTES {
+            return Err(token_response_too_large());
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
+}
+
+fn token_response_too_large() -> Error {
+    Error::Protocol {
+        code: error_code::FAILED,
+        message: "Token exchange response body exceeds 64 KiB limit".to_string(),
+    }
 }

--- a/crates/ably-subscriber/tests/integration/auth_token.rs
+++ b/crates/ably-subscriber/tests/integration/auth_token.rs
@@ -1,10 +1,27 @@
 use crate::support::*;
-use ably_subscriber::protocol::{ProtocolMessage, action, encode_msg};
-use ably_subscriber::{Event, SubscribeConfig, TimingConfig, subscribe};
+use ably_subscriber::protocol::{ProtocolMessage, action, encode_msg, error_code};
+use ably_subscriber::{Error, Event, SubscribeConfig, Subscription, TimingConfig, subscribe};
 use futures_util::SinkExt;
 use httpmock::prelude::*;
 use std::time::Duration;
+use tokio::io::AsyncWriteExt;
 use tokio_tungstenite::tungstenite;
+
+const TOKEN_EXCHANGE_RESPONSE_MAX_BYTES: usize = 64 * 1024;
+
+fn token_response_limit_error(result: Result<Subscription, Error>) -> Result<String, String> {
+    match result {
+        Err(Error::Protocol { code, message }) => {
+            assert_eq!(code, error_code::FAILED);
+            assert_eq!(message, "Token exchange response body exceeds 64 KiB limit");
+            Ok(message)
+        }
+        Err(other) => Err(format!(
+            "expected token response limit error, got {other:?}"
+        )),
+        Ok(_) => Err("expected token response limit error, got subscription".to_string()),
+    }
+}
 
 #[tokio::test]
 async fn http_token_exchange_error() {
@@ -63,7 +80,7 @@ async fn token_exchange_encodes_key_name_as_path_segment() {
 }
 
 #[tokio::test]
-async fn token_exchange_invalid_json_response_is_http_error() {
+async fn token_exchange_invalid_json_response_is_protocol_error() {
     let http = MockServer::start();
     http.mock(|when, then| {
         when.method(POST).path("/keys/testKey.testId/requestToken");
@@ -74,10 +91,143 @@ async fn token_exchange_invalid_json_response_is_http_error() {
 
     let result = subscribe(test_config(19999, http.port(), "ch")).await;
     match result {
-        Err(ably_subscriber::Error::Http(_)) => {}
-        Err(other) => panic!("expected Http error, got {other:?}"),
+        Err(Error::Protocol { code, message }) => {
+            assert_eq!(code, error_code::FAILED);
+            assert!(
+                message.starts_with("Token exchange response JSON decode failed:"),
+                "got: {message}"
+            );
+        }
+        Err(other) => panic!("expected Protocol error, got {other:?}"),
         Ok(_) => panic!("expected error, got Ok"),
     }
+}
+
+#[tokio::test]
+async fn token_exchange_rejects_declared_response_over_limit_without_body() {
+    let http = RawTokenServer::start().await.unwrap();
+    let http_port = http.port();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        let mut stream = http.accept_request().await.unwrap();
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    TOKEN_EXCHANGE_RESPONSE_MAX_BYTES + 1
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let _ = release_rx.await;
+    });
+
+    let result = tokio::time::timeout(
+        TEST_IO_TIMEOUT,
+        subscribe(test_config(19999, http_port, "ch")),
+    )
+    .await
+    .expect("token exchange waited for an oversized declared body");
+    token_response_limit_error(result).unwrap();
+
+    release_tx.send(()).unwrap();
+    join_server_task(server_task, "declared oversized token response")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn token_exchange_rejects_chunked_response_over_limit() {
+    const RESPONSE_MARKER: &[u8] = b"token-response-secret-marker";
+
+    let http = RawTokenServer::start().await.unwrap();
+    let http_port = http.port();
+    let server_task = tokio::spawn(async move {
+        let mut stream = http.accept_request().await.unwrap();
+        stream
+            .write_all(
+                b"HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+
+        let mut first = vec![b'a'; TOKEN_EXCHANGE_RESPONSE_MAX_BYTES / 2];
+        first[..RESPONSE_MARKER.len()].copy_from_slice(RESPONSE_MARKER);
+        let second = vec![b'b'; TOKEN_EXCHANGE_RESPONSE_MAX_BYTES + 1 - first.len()];
+        for chunk in [&first, &second] {
+            stream
+                .write_all(format!("{:X}\r\n", chunk.len()).as_bytes())
+                .await
+                .unwrap();
+            stream.write_all(chunk).await.unwrap();
+            stream.write_all(b"\r\n").await.unwrap();
+        }
+        let _ = stream.write_all(b"0\r\n\r\n").await;
+    });
+
+    let result = subscribe(test_config(19999, http_port, "ch")).await;
+    let message = token_response_limit_error(result).unwrap();
+    assert!(!message.contains("token-response-secret-marker"));
+
+    join_server_task(server_task, "chunked oversized token response")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn token_exchange_accepts_valid_response_at_limit() {
+    let http = RawTokenServer::start().await.unwrap();
+    let ws = MockAblyServer::start().await.unwrap();
+    let now = now_ms();
+    let token_body = |capability: &str| {
+        serde_json::to_vec(&serde_json::json!({
+            "token": "mock-token-abc",
+            "expires": now + 3_600_000,
+            "issued": now,
+            "capability": capability,
+        }))
+        .unwrap()
+    };
+    let base_body = token_body("");
+    let body = token_body(&"x".repeat(TOKEN_EXCHANGE_RESPONSE_MAX_BYTES - base_body.len()));
+    assert_eq!(body.len(), TOKEN_EXCHANGE_RESPONSE_MAX_BYTES);
+
+    let http_port = http.port();
+    let token_server_task = tokio::spawn(async move {
+        let mut stream = http.accept_request().await.unwrap();
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        stream.write_all(&body).await.unwrap();
+    });
+
+    let ws_port = ws.port;
+    let websocket_server_task = tokio::spawn(async move {
+        let _conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http_port, "ch"))
+        .await
+        .unwrap();
+    expect_connected(&mut sub, "exact-limit token response")
+        .await
+        .unwrap();
+    sub.close();
+
+    join_server_task(token_server_task, "exact-limit token response")
+        .await
+        .unwrap();
+    join_server_task(websocket_server_task, "exact-limit token websocket")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/ably-subscriber/tests/integration/support/mod.rs
+++ b/crates/ably-subscriber/tests/integration/support/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use protocol::{
     send_message_with_channel_serial,
 };
 pub(crate) use server::{HandshakeOptions, MockAblyServer, WsStream};
-pub(crate) use token::mock_token_endpoint;
+pub(crate) use token::{RawTokenServer, mock_token_endpoint};
 pub(crate) use websocket::{
     expect_websocket_close_frame, expect_websocket_close_frame_while_ignoring_attach,
     expect_websocket_closed,

--- a/crates/ably-subscriber/tests/integration/support/token.rs
+++ b/crates/ably-subscriber/tests/integration/support/token.rs
@@ -1,6 +1,99 @@
+use std::io;
+
 use httpmock::prelude::*;
+use tokio::io::AsyncReadExt;
+use tokio::net::{TcpListener, TcpStream};
 
 use super::now_ms;
+
+const TOKEN_REQUEST_MAX_BYTES: usize = 16 * 1024;
+
+pub(crate) struct RawTokenServer {
+    listener: TcpListener,
+    port: u16,
+}
+
+impl RawTokenServer {
+    pub(crate) async fn start() -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        Ok(Self { listener, port })
+    }
+
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub(crate) async fn accept_request(&self) -> io::Result<TcpStream> {
+        let (mut stream, _) = self.listener.accept().await?;
+        read_request(&mut stream).await?;
+        Ok(stream)
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> io::Result<()> {
+    let mut request = Vec::with_capacity(1024);
+    let mut buffer = [0_u8; 1024];
+
+    loop {
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "token request closed before its body completed",
+            ));
+        }
+        let next_length = request
+            .len()
+            .checked_add(read)
+            .ok_or_else(request_too_large)?;
+        if next_length > TOKEN_REQUEST_MAX_BYTES {
+            return Err(request_too_large());
+        }
+        request.extend(buffer.iter().take(read).copied());
+
+        let Some(header_end) = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+        else {
+            continue;
+        };
+        let headers = request.get(..header_end).ok_or_else(request_too_large)?;
+        let content_length = request_content_length(headers)?;
+        let request_end = header_end
+            .checked_add(content_length)
+            .ok_or_else(request_too_large)?;
+        if request_end > TOKEN_REQUEST_MAX_BYTES {
+            return Err(request_too_large());
+        }
+        if request.len() >= request_end {
+            return Ok(());
+        }
+    }
+}
+
+fn request_content_length(headers: &[u8]) -> io::Result<usize> {
+    let headers = std::str::from_utf8(headers)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let value = headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length")
+            .then_some(value.trim())
+    });
+    value.map_or(Ok(0), |value| {
+        value
+            .parse()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    })
+}
+
+fn request_too_large() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "token request exceeds test fixture limit",
+    )
+}
 
 pub(crate) fn mock_token_endpoint(server: &MockServer, key_name: &str) {
     let path = format!("/keys/{key_name}/requestToken");


### PR DESCRIPTION
## Summary

- cap successful Ably token exchange responses at 64 KiB before buffering them
- reject oversized `Content-Length` and chunked responses with a fixed redacted protocol error
- cover the declared-length, streamed overflow, exact-limit, and malformed JSON boundaries through `subscribe`

## Scope

- preserves existing request timeouts, HTTP status handling, renewal, and reconnect paths
- does not change the public error enum, wire protocols, or persisted state

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features --quiet`
- repository pre-commit Rust checks

Closes #29190
