### PR TITLE
docs(python): define invalid registry sandbox diagnostic contract

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -128,6 +128,14 @@ def block_invalid_registry_sandbox(
     flow: http.HTTPFlow,
     invalid_sandbox: registry.InvalidSandboxEntry,
 ) -> None:
+    """Block a flow for an invalid registry sandbox with a fail-closed 503.
+
+    The JSON response contains the fixed ``invalid_registry_sandbox`` error,
+    ``message`` copied verbatim from ``InvalidSandboxEntry.message``, and
+    ``reason`` copied verbatim from ``InvalidSandboxEntry.reason``. The reason
+    is the stable category; the message is detailed validation text for the
+    individual sandbox entry.
+    """
     flow_metadata.set_firewall_decision(
         flow.metadata,
         "BLOCK",

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -35,7 +35,33 @@ class _RegistryFormatError(ValueError):
 
 @dataclass(frozen=True)
 class InvalidSandboxEntry:
-    """Registry entry present for an IP but invalid for runtime sandbox context use."""
+    """Registry entry present for an IP but invalid for runtime sandbox context use.
+
+    ``reason`` is the stable, client-visible diagnostic category. The supported
+    values and their validation conditions are:
+
+    - ``invalid_sandbox_entry``: the entry is not an object.
+    - ``missing_run_id``: the ``runId`` field is absent.
+    - ``invalid_run_id``: ``runId`` is not a string or has leading or trailing
+      whitespace.
+    - ``empty_run_id``: ``runId`` is a string whose stripped value is empty.
+    - ``invalid_billable_firewalls``: ``billableFirewalls`` is not a list of
+      strings.
+    - ``missing_cli_agent_type``: the ``cliAgentType`` field is absent.
+    - ``invalid_cli_agent_type``: ``cliAgentType`` is not a string.
+    - ``empty_cli_agent_type``: ``cliAgentType`` is an empty string.
+    - ``invalid_firewalls``: ``firewalls`` is a non-null non-list, or firewall
+      entry resolution fails.
+    - ``invalid_omitted_intents``: omitted firewall or connector ID metadata is
+      not a list of non-empty strings or contains duplicates.
+    - ``invalid_connector_routing_variables``: connector routing metadata is
+      not an object with connector identities and string-map values.
+
+    ``message`` is the detailed validation text for the individual entry. Both
+    fields are copied verbatim into the local ``invalid_registry_sandbox`` 503
+    response. Consumers should use ``reason`` for category-level handling and
+    treat ``message`` as diagnostic text.
+    """
 
     reason: str
     message: str
@@ -472,6 +498,11 @@ def load_registry_state(registry_path: str) -> RegistryState:
     failed key so repeated reads of the same bad bytes do not reparse or
     re-warn. File read errors keep retrying that key, and internal
     compile/eviction errors are allowed to propagate.
+
+    Per-entry validation failures remain in ``invalid_sandboxes`` within the
+    successful snapshot while valid entries remain in ``sandboxes`` and stay
+    available for enforcement. They do not make the whole registry unavailable;
+    requests for an invalid entry are blocked as ``invalid_registry_sandbox``.
 
     ``stat_failed`` covers failures before a file identity is available, and
     later calls retry opening the path while the stat warning guard suppresses


### PR DESCRIPTION
## Summary

- Document the complete `InvalidSandboxEntry.reason` vocabulary and validation conditions at the registry state boundary.
- Document successful-snapshot isolation of invalid entries and continued availability of valid entries for enforcement.
- Document the `invalid_registry_sandbox` 503 response fields and verbatim propagation of `reason` and `message`.

## Scope

This is a documentation-only change. Runtime reason values, response fields, validation order, snapshot publication, and enforcement behavior are unchanged. No tests were modified because the existing registry-loading and request-admission tests already provide executable coverage of the preserved contract.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_registry_loading.py tests/test_request_handler_registry_admission.py` (76 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`

Closes #29204
