### PR TITLE
perf(vsock-guest): eliminate idle drain wakeups

### DIFF
--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -1,12 +1,57 @@
 use std::io;
-use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Default buffer size for reading process output from stdout/stderr pipes.
 const DEFAULT_DRAIN_READ_BYTES: usize = 64 * 1024;
 /// Initial allocation for captured output, independent of the drain read size.
 const INITIAL_CAPTURE_CAPACITY_BYTES: usize = 8 * 1024;
-const DRAIN_POLL_TIMEOUT_MS: libc::c_int = 100;
+
+pub(crate) struct DrainCancellation {
+    cancelled: AtomicBool,
+    wake_reader: OwnedFd,
+    wake_writer: Mutex<Option<OwnedFd>>,
+}
+
+impl DrainCancellation {
+    pub(crate) fn new() -> io::Result<Self> {
+        let mut fds = [0; 2];
+        // SAFETY: `pipe2` initializes both descriptor slots on success.
+        if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `pipe2` returned two distinct owned descriptors.
+        let wake_reader = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        // SAFETY: ownership of the second descriptor is transferred separately.
+        let wake_writer = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        Ok(Self {
+            cancelled: AtomicBool::new(false),
+            wake_reader,
+            wake_writer: Mutex::new(Some(wake_writer)),
+        })
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        // Closing the sole writer leaves POLLHUP level-visible to every drain
+        // polling the shared reader.
+        drop(
+            self.wake_writer
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .take(),
+        );
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    fn wake_fd(&self) -> RawFd {
+        self.wake_reader.as_raw_fd()
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct BoundedStreamConfig {
@@ -23,48 +68,61 @@ pub(crate) struct BoundedDrainResult {
 /// Drain `pipe` until EOF or `cancel` is set, calling `on_chunk` for each
 /// non-empty read.
 ///
-/// Cancel mechanism: each iteration polls for input with a 100 ms timeout
-/// before reading from the same fd, so the cancel flag is observed at most
-/// ~100 ms after it's set even if a leaked grandchild still holds the pipe
-/// write end open. When the loop returns, dropping the owned read end closes
-/// it, at which point any still-writing producer gets EPIPE / SIGPIPE on its
+/// Each iteration polls the output and cancellation descriptors indefinitely.
+/// Cancelling closes the sole cancellation-pipe writer, so every worker sharing
+/// its reader wakes through level-triggered POLLHUP even if a leaked grandchild
+/// still holds the output writer open. Returning drops the owned output read
+/// end, at which point any still-writing producer gets EPIPE / SIGPIPE on its
 /// next write. That's the property a tempfile-based capture cannot offer: a
 /// regular file is always writable, so a leaked daemon would grow tmpfs memory
 /// indefinitely.
 pub(crate) fn drain_until_eof_or_cancelled(
     pipe: impl Into<OwnedFd>,
-    cancel: &AtomicBool,
+    cancel: &DrainCancellation,
     mut on_chunk: impl FnMut(&[u8]),
 ) {
     let pipe = pipe.into();
     let raw_fd = pipe.as_raw_fd();
     let mut chunk = [0u8; DEFAULT_DRAIN_READ_BYTES];
     loop {
-        if cancel.load(Ordering::Acquire) {
+        if cancel.is_cancelled() {
             break;
         }
 
-        let mut pfd = libc::pollfd {
-            fd: raw_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        // SAFETY: pfd is a valid pollfd; nfds=1 matches the single descriptor.
-        let r = unsafe { libc::poll(&mut pfd, 1, DRAIN_POLL_TIMEOUT_MS) };
+        let mut pollfds = [
+            libc::pollfd {
+                fd: raw_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: cancel.wake_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        // SAFETY: `pollfds` contains two initialized descriptors that remain
+        // owned by `pipe` and `cancel` for the duration of this call.
+        let r = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1) };
         if r < 0 {
             if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
                 continue;
             }
             break;
         }
-        if r == 0 {
-            continue; // timeout — re-check cancel
-        }
-        if pfd.revents & libc::POLLNVAL != 0 {
+        if cancel.is_cancelled() {
             break;
         }
-        if pfd.revents & (libc::POLLIN | libc::POLLHUP) == 0 {
-            if pfd.revents & libc::POLLERR != 0 {
+        let cancel_revents = pollfds[1].revents;
+        if cancel_revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0 {
+            break;
+        }
+        let pipe_revents = pollfds[0].revents;
+        if pipe_revents & libc::POLLNVAL != 0 {
+            break;
+        }
+        if pipe_revents & (libc::POLLIN | libc::POLLHUP) == 0 {
+            if pipe_revents & libc::POLLERR != 0 {
                 break;
             }
             continue;
@@ -92,7 +150,10 @@ pub(crate) fn drain_until_eof_or_cancelled(
 
 /// Buffered variant of [`drain_until_eof_or_cancelled`]: accumulates
 /// everything read into a `Vec<u8>` and returns it.
-pub(crate) fn drain_into_vec_cancellable(pipe: impl Into<OwnedFd>, cancel: &AtomicBool) -> Vec<u8> {
+pub(crate) fn drain_into_vec_cancellable(
+    pipe: impl Into<OwnedFd>,
+    cancel: &DrainCancellation,
+) -> Vec<u8> {
     let mut buf = Vec::new();
     drain_until_eof_or_cancelled(pipe, cancel, |chunk| buf.extend_from_slice(chunk));
     buf
@@ -106,7 +167,7 @@ pub(crate) fn drain_into_vec_cancellable(pipe: impl Into<OwnedFd>, cancel: &Atom
 /// further stream forwarding; draining still continues unless `cancel` is set.
 pub(crate) fn drain_bounded_cancellable<R>(
     pipe: R,
-    cancel: &AtomicBool,
+    cancel: &DrainCancellation,
     capture_limit_bytes: Option<usize>,
     stream: Option<BoundedStreamConfig>,
     mut on_stream_chunk: impl FnMut(&[u8], bool) -> bool,
@@ -249,51 +310,81 @@ mod tests {
     }
 
     #[test]
-    fn drain_cancel_closes_reader_while_writer_fd_remains_open() {
-        let (reader, mut writer) = pipe_pair();
+    fn drain_cancel_wakes_all_idle_workers_and_closes_owned_readers() {
+        let (first_reader, first_writer) = pipe_pair();
+        let (second_reader, second_writer) = pipe_pair();
+        let pipe_targets = [
+            fd_target(first_reader.as_raw_fd()),
+            fd_target(second_reader.as_raw_fd()),
+        ];
+        let writer_fds = [first_writer.as_raw_fd(), second_writer.as_raw_fd()];
+        let cancel = Arc::new(DrainCancellation::new().unwrap());
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let handles = [first_reader, second_reader]
+            .into_iter()
+            .map(|reader| {
+                let drain_cancel = Arc::clone(&cancel);
+                let ready_tx = ready_tx.clone();
+                let done_tx = done_tx.clone();
+                thread::spawn(move || {
+                    let _ = ready_tx.send(());
+                    drain_until_eof_or_cancelled(reader, &drain_cancel, |_| {});
+                    let _ = done_tx.send(());
+                })
+            })
+            .collect::<Vec<_>>();
+        drop(ready_tx);
+        drop(done_tx);
+
+        for _ in 0..2 {
+            ready_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+        assert!(
+            matches!(
+                done_rx.recv_timeout(Duration::from_millis(250)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "idle drains must remain blocked beyond the removed poll timeout"
+        );
+
+        cancel.cancel();
+        cancel.cancel();
+        for _ in 0..2 {
+            done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+
+        for (index, writer_fd) in writer_fds.into_iter().enumerate() {
+            assert_fd_open(
+                writer_fd,
+                "writer fd should remain open after drain cancellation",
+            );
+            assert_no_current_process_read_end(&pipe_targets[index], writer_fd);
+        }
+        drop(first_writer);
+        drop(second_writer);
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn drain_cancelled_before_entry_closes_owned_reader() {
+        let (reader, writer) = pipe_pair();
         let pipe_target = fd_target(reader.as_raw_fd());
         let writer_fd = writer.as_raw_fd();
-        let cancel = Arc::new(AtomicBool::new(false));
-        let (chunk_tx, chunk_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
+        let cancel = DrainCancellation::new().unwrap();
+        cancel.cancel();
 
-        let drain_cancel = Arc::clone(&cancel);
-        let handle = thread::spawn(move || {
-            let mut output = Vec::new();
-            let mut sent_first_chunk = false;
-            drain_until_eof_or_cancelled(reader, &drain_cancel, |chunk| {
-                output.extend_from_slice(chunk);
-                if !sent_first_chunk {
-                    sent_first_chunk = true;
-                    let _ = chunk_tx.send(chunk.to_vec());
-                }
-            });
-            let _ = done_tx.send(output);
+        drain_until_eof_or_cancelled(reader, &cancel, |_| {
+            panic!("pre-cancelled drain must not read output");
         });
 
-        writer.write_all(b"hello").unwrap();
-        let first_chunk = chunk_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        assert_eq!(first_chunk, b"hello".to_vec());
-
-        cancel.store(true, Ordering::Release);
-        let output = match done_rx.recv_timeout(Duration::from_secs(1)) {
-            Ok(output) => output,
-            Err(e) => {
-                drop(writer);
-                panic!("drain did not observe cancel while writer stayed open: {e}");
-            }
-        };
-
-        assert_eq!(output, b"hello".to_vec());
-        // A concurrent fork can briefly inherit this pipe, so assert local fd
-        // ownership directly instead of requiring the writer to see EPIPE.
         assert_fd_open(
             writer_fd,
-            "writer fd should remain open after drain cancellation",
+            "writer fd should remain open after pre-cancelled drain",
         );
         assert_no_current_process_read_end(&pipe_target, writer_fd);
-        drop(writer);
-        handle.join().unwrap();
     }
 
     #[test]
@@ -301,7 +392,7 @@ mod tests {
         let (reader, writer) = pipe_pair();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut output = Vec::new();
         drain_until_eof_or_cancelled(reader, &cancel, |chunk| {
             output.extend_from_slice(chunk);
@@ -316,7 +407,7 @@ mod tests {
         writer.write_all(b"abcdef").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let result = drain_bounded_cancellable(reader, &cancel, Some(3), None, |_, _| true);
 
         assert_eq!(result.captured, Some(b"abc".to_vec()));
@@ -329,7 +420,7 @@ mod tests {
         writer.write_all(b"abc").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let result = drain_bounded_cancellable(reader, &cancel, Some(3), None, |_, _| true);
 
         assert_eq!(result.captured, Some(b"abc".to_vec()));
@@ -342,7 +433,7 @@ mod tests {
         writer.write_all(b"abc").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let result = drain_bounded_cancellable(reader, &cancel, Some(0), None, |_, _| true);
 
         assert_eq!(result.captured, Some(Vec::new()));
@@ -355,7 +446,7 @@ mod tests {
         writer.write_all(b"abc").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let result = drain_bounded_cancellable(reader, &cancel, None, None, |_, _| true);
 
         assert_eq!(result.captured, None);
@@ -367,7 +458,7 @@ mod tests {
         assert_eq!(DEFAULT_DRAIN_READ_BYTES, EXPECTED_DEFAULT_DRAIN_READ_BYTES);
         let input = vec![b'x'; EXPECTED_DEFAULT_DRAIN_READ_BYTES * 3 + 123];
         let reader = file_with_contents(&input);
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut streamed = Vec::new();
         let mut chunk_lengths = Vec::new();
 
@@ -406,7 +497,7 @@ mod tests {
         let input = vec![b'y'; EXPECTED_DEFAULT_DRAIN_READ_BYTES + 123];
         let stream_limit = EXPECTED_DEFAULT_DRAIN_READ_BYTES / 2;
         let reader = file_with_contents(&input);
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
 
         let result = drain_bounded_cancellable(
@@ -434,7 +525,7 @@ mod tests {
         writer.write_all(b"abcdef").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
         let result = drain_bounded_cancellable(
             reader,
@@ -469,7 +560,7 @@ mod tests {
         writer.write_all(b"abcd").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
         let result = drain_bounded_cancellable(
             reader,
@@ -498,7 +589,7 @@ mod tests {
         writer.write_all(b"abc").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
         let result = drain_bounded_cancellable(
             reader,
@@ -524,7 +615,7 @@ mod tests {
         writer.write_all(b"abc").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
         let result = drain_bounded_cancellable(
             reader,
@@ -550,7 +641,7 @@ mod tests {
         writer.write_all(b"abcdef").unwrap();
         drop(writer);
 
-        let cancel = AtomicBool::new(false);
+        let cancel = DrainCancellation::new().unwrap();
         let mut chunks = Vec::new();
         let result = drain_bounded_cancellable(
             reader,

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -64,7 +64,9 @@ use vsock_proto::{
 #[cfg(test)]
 use vsock_proto::MSG_EXEC_RESULT;
 
-use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
+use crate::drain::{
+    BoundedDrainResult, BoundedStreamConfig, DrainCancellation, drain_bounded_cancellable,
+};
 use crate::error::to_io_error;
 use crate::exec_control::ExecControlGuard;
 use crate::log::log;
@@ -318,7 +320,7 @@ struct DrainWorker {
     stream: ExecOutputStream,
     policy: OutputSettings,
     stream_writer: Option<SharedExecStreamWriter>,
-    drain_cancel: Arc<AtomicBool>,
+    drain_cancel: Arc<DrainCancellation>,
     exec_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
 }
@@ -466,7 +468,7 @@ struct ExecSetup {
     process_containment: ExecProcessContainment,
     placement_bootstrap: Option<WorkloadPlacementBootstrap>,
     stdin_writer: Option<StdinWriter>,
-    drain_cancel: Arc<AtomicBool>,
+    drain_cancel: Arc<DrainCancellation>,
     drain_done_tx: mpsc::Sender<()>,
     drain_done_rx: mpsc::Receiver<()>,
 }
@@ -476,8 +478,8 @@ impl ExecSetup {
         child: Child,
         process_containment: ExecProcessContainment,
         placement_bootstrap: Option<WorkloadPlacementBootstrap>,
+        drain_cancel: Arc<DrainCancellation>,
     ) -> Self {
-        let drain_cancel = Arc::new(AtomicBool::new(false));
         let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
         Self {
             child,
@@ -506,7 +508,7 @@ impl ExecSetup {
         self.stdin_writer = Some(writer);
     }
 
-    fn drain_cancel(&self) -> Arc<AtomicBool> {
+    fn drain_cancel(&self) -> Arc<DrainCancellation> {
         self.drain_cancel.clone()
     }
 
@@ -542,7 +544,7 @@ impl ExecSetup {
             drain_done_rx: _,
         } = self;
         exec_cancel.store(true, Ordering::Release);
-        drain_cancel.store(true, Ordering::Release);
+        drain_cancel.cancel();
         kill_and_reap_child(child);
         drop(placement_bootstrap);
         let containment_result =
@@ -586,7 +588,7 @@ struct ExecSetupWithStdout {
 }
 
 impl ExecSetupWithStdout {
-    fn drain_cancel(&self) -> Arc<AtomicBool> {
+    fn drain_cancel(&self) -> Arc<DrainCancellation> {
         self.setup.drain_cancel()
     }
 
@@ -615,7 +617,7 @@ impl ExecSetupWithStdout {
             drain_done_rx: _,
         } = setup;
         exec_cancel.store(true, Ordering::Release);
-        drain_cancel.store(true, Ordering::Release);
+        drain_cancel.cancel();
         kill_and_reap_child(child);
         drop(placement_bootstrap);
         let containment_result =
@@ -680,7 +682,7 @@ struct RunningExec {
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
     stderr_handle: JoinHandle<()>,
     stderr_result_rx: mpsc::Receiver<BoundedDrainResult>,
-    drain_cancel: Arc<AtomicBool>,
+    drain_cancel: Arc<DrainCancellation>,
     drain_done_rx: mpsc::Receiver<()>,
 }
 
@@ -740,7 +742,7 @@ impl RunningExec {
             || containment_result.is_err()
         {
             exec_cancel.store(true, Ordering::Release);
-            drain_cancel.store(true, Ordering::Release);
+            drain_cancel.cancel();
         }
 
         let completed =
@@ -966,6 +968,15 @@ fn run_exec_operation_worker<S>(
         completion.start_failed(&diagnostic);
         return;
     }
+    let drain_cancel = match DrainCancellation::new() {
+        Ok(cancel) => Arc::new(cancel),
+        Err(error) => {
+            completion.start_failed(&format!(
+                "Failed to initialize output drain cancellation: {error}"
+            ));
+            return;
+        }
+    };
     let stdin_bytes = request.stdin_bytes.take();
     let pipe_stdin = stdin_bytes.is_some();
 
@@ -1046,7 +1057,7 @@ fn run_exec_operation_worker<S>(
         process_containment,
     } = spawned;
     let _env_script = env_script;
-    let mut setup = ExecSetup::new(child, process_containment, workload_bootstrap);
+    let mut setup = ExecSetup::new(child, process_containment, workload_bootstrap, drain_cancel);
 
     if request.lifecycle == ExecOperationLifecycle::Supervised
         && let Err(e) = send_exec_started(request.seq, setup.child.id(), &writer)
@@ -1284,7 +1295,7 @@ where
                     let Some(stream_writer) = &stream_writer else {
                         return true;
                     };
-                    if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
+                    if exec_cancel.load(Ordering::Acquire) || drain_cancel.is_cancelled() {
                         return false;
                     }
                     let mut writer = match stream_writer.lock() {
@@ -1292,11 +1303,11 @@ where
                         Err(_) => {
                             log("ERROR", "exec operation: stream writer mutex poisoned");
                             exec_cancel.store(true, Ordering::Release);
-                            drain_cancel.store(true, Ordering::Release);
+                            drain_cancel.cancel();
                             return false;
                         }
                     };
-                    if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
+                    if exec_cancel.load(Ordering::Acquire) || drain_cancel.is_cancelled() {
                         return false;
                     }
                     match writer.write_output(stream, chunk, truncated) {
@@ -1310,7 +1321,7 @@ where
                                 ),
                             );
                             exec_cancel.store(true, Ordering::Release);
-                            drain_cancel.store(true, Ordering::Release);
+                            drain_cancel.cancel();
                             false
                         }
                         Err(ExecStreamWriteError::Write(e)) => {
@@ -1322,7 +1333,7 @@ where
                                 ),
                             );
                             exec_cancel.store(true, Ordering::Release);
-                            drain_cancel.store(true, Ordering::Release);
+                            drain_cancel.cancel();
                             false
                         }
                     }

--- a/crates/vsock-guest/src/guest_dns_readiness.rs
+++ b/crates/vsock-guest/src/guest_dns_readiness.rs
@@ -13,7 +13,7 @@ use vsock_proto::{
     GuestDnsReadinessTermination, MSG_GUEST_DNS_READINESS_RESULT,
 };
 
-use crate::drain::{BoundedDrainResult, drain_bounded_cancellable};
+use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
@@ -225,6 +225,16 @@ fn run_probe(
     connection_cancel: &AtomicBool,
 ) -> GuestDnsReadinessOutput {
     let started = Instant::now();
+    let drain_cancel = match DrainCancellation::new() {
+        Ok(cancel) => Arc::new(cancel),
+        Err(error) => {
+            return failed_output(
+                GuestDnsReadinessTermination::StartFailed,
+                started,
+                format!("failed to initialize guest DNS output drain cancellation: {error}"),
+            );
+        }
+    };
     let mut command = Command::new(program);
     command
         .arg(RESOLVER_DATABASE)
@@ -268,7 +278,6 @@ fn run_probe(
         );
     };
 
-    let drain_cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = mpsc::channel();
     let stdout_drain = match spawn_drain(
         stdout.into(),
@@ -297,7 +306,7 @@ fn run_probe(
     ) {
         Ok(drain) => drain,
         Err(error) => {
-            drain_cancel.store(true, Ordering::Release);
+            drain_cancel.cancel();
             kill_and_reap_child(child);
             drop(drain_done_tx);
             let _ = stdout_drain.join();
@@ -319,7 +328,7 @@ fn run_probe(
         || true,
     );
     if !matches!(outcome, WaitOutcome::Exited(_)) {
-        drain_cancel.store(true, Ordering::Release);
+        drain_cancel.cancel();
     }
     let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel, OUTPUT_DRAIN_DEADLINE);
     let stdout_result = stdout_drain.join();
@@ -376,7 +385,7 @@ impl DrainHandle {
 fn spawn_drain(
     pipe: OwnedFd,
     limit: usize,
-    cancel: Arc<AtomicBool>,
+    cancel: Arc<DrainCancellation>,
     done_tx: mpsc::Sender<()>,
     thread_name: &'static str,
 ) -> io::Result<DrainHandle> {

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use vsock_proto::{ExecCapturedOutput, ExecTermination, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES};
 
-use crate::drain::{BoundedDrainResult, drain_bounded_cancellable};
+use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
@@ -287,6 +287,16 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         drain_deadline,
     } = input;
     let started = Instant::now();
+    let drain_cancel = match DrainCancellation::new() {
+        Ok(cancel) => Arc::new(cancel),
+        Err(error) => {
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("Failed to initialize storage output drain cancellation: {error}"),
+            );
+        }
+    };
     let process_containment =
         match ExecProcessContainment::create(seq, process_containment_mode, false) {
             Ok(process_containment) => process_containment,
@@ -370,7 +380,6 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         );
     };
 
-    let drain_cancel = Arc::new(AtomicBool::new(false));
     let (drain_done_tx, drain_done_rx) = mpsc::channel();
     let stdout_drain = match spawn_drain(
         stdout,
@@ -402,7 +411,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
     ) {
         Ok(drain) => drain,
         Err(error) => {
-            drain_cancel.store(true, Ordering::Release);
+            drain_cancel.cancel();
             drop(stdin);
             kill_and_reap_child(child);
             let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
@@ -421,7 +430,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
     let stdin_writer = match spawn_stdin(stdin, manifest_json) {
         Ok(writer) => writer,
         Err(error) => {
-            drain_cancel.store(true, Ordering::Release);
+            drain_cancel.cancel();
             kill_and_reap_child(child);
             let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
             drop(drain_done_tx);
@@ -455,7 +464,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         || cancellation_observed
         || containment_result.is_err()
     {
-        drain_cancel.store(true, Ordering::Release);
+        drain_cancel.cancel();
     }
     let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel, drain_deadline);
     let stdout_result = stdout_drain.join();
@@ -567,7 +576,7 @@ impl DrainHandle {
 
 fn spawn_drain(
     pipe: impl Into<std::os::fd::OwnedFd> + Send + 'static,
-    cancel: Arc<AtomicBool>,
+    cancel: Arc<DrainCancellation>,
     done_tx: mpsc::Sender<()>,
     thread_name: &'static str,
 ) -> io::Result<DrainHandle> {

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
     MSG_WRITE_FILES_RESULT,
 };
 
-use crate::drain::drain_into_vec_cancellable;
+use crate::drain::{DrainCancellation, drain_into_vec_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
@@ -119,6 +119,16 @@ fn wait_write_file_child_with_timeout<S>(
 where
     S: ThreadSpawner,
 {
+    let cancel = match DrainCancellation::new() {
+        Ok(cancel) => Arc::new(cancel),
+        Err(error) => {
+            kill_and_reap_child(child);
+            return (
+                false,
+                format!("Failed to initialize stderr drain cancellation: {error}"),
+            );
+        }
+    };
     let stdin_pipe = match child.stdin.take() {
         Some(p) => p,
         None => {
@@ -142,7 +152,6 @@ where
             return (false, "missing stderr pipe".to_string());
         }
     };
-    let cancel = Arc::new(AtomicBool::new(false));
     let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
     let stderr_handle = {
         let drain_cancel = cancel.clone();
@@ -156,7 +165,7 @@ where
         ) {
             Ok(handle) => handle,
             Err(e) => {
-                cancel.store(true, std::sync::atomic::Ordering::Release);
+                cancel.cancel();
                 drop(stdin_pipe);
                 kill_and_reap_child(child);
                 return (false, format!("Failed to spawn stderr drain thread: {e}"));
@@ -174,7 +183,7 @@ where
         }) {
             Ok(handle) => handle,
             Err(e) => {
-                cancel.store(true, std::sync::atomic::Ordering::Release);
+                cancel.cancel();
                 kill_and_reap_child(child);
                 let _ = await_drain_deadline(&done_rx, 1, &cancel, EXEC_OUTPUT_DRAIN_DEADLINE);
                 let _ = stderr_handle.join();

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::drain::DrainCancellation;
 use crate::process::{kill_and_reap_child, kill_owned_child_process_group, process_signal_pid};
 use crate::threading::spawn_scoped_named;
 
@@ -38,7 +39,7 @@ enum WaitDecision {
 pub(crate) fn await_drain_deadline(
     done_rx: &mpsc::Receiver<()>,
     expected: usize,
-    cancel: &AtomicBool,
+    cancel: &DrainCancellation,
     drain_deadline: Duration,
 ) -> usize {
     let deadline = Instant::now() + drain_deadline;
@@ -53,7 +54,7 @@ pub(crate) fn await_drain_deadline(
             Err(_) => break,
         }
     }
-    cancel.store(true, Ordering::Release);
+    cancel.cancel();
     completed
 }
 


### PR DESCRIPTION
## Summary

- replace the shared vsock output drain's 100 ms timer polling with indefinite polling on output and cancellation descriptors
- wake every stdout/stderr drain in a cancellation group by closing one shared cancellation-pipe writer
- propagate the active cancellation primitive through exec, write-file, DNS readiness, storage manifest, and drain-deadline paths
- add deterministic coverage for two idle workers, pre-cancellation, repeated cancellation, and owned-reader closure while output writers remain open

## Compatibility

- no wire protocol, public API, persisted state, configuration, or host/runner contract changes
- each active drain cancellation group now owns one two-fd wake pipe shared by all of its workers

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- pre-commit workspace Rust fmt, Clippy, rustdoc, and file-size hooks

Closes #29201
