### PR TITLE
docs(rust): document drain override cleanup transaction invariants

### DIFF
--- a/crates/runner/src/cmd/service/drain_override_cleanup.rs
+++ b/crates/runner/src/cmd/service/drain_override_cleanup.rs
@@ -1,3 +1,32 @@
+//! Reconciles VM0's drain restart override with systemd's effective state.
+//!
+//! Removing `50-vm0-drain.conf` changes the on-disk state, but systemd can keep
+//! the drop-in loaded in `DropInPaths` until a coordinated reload. The cleanup
+//! transaction therefore retains the removal outcome and always asks the
+//! reload coordinator to make the expected absence effective, including when
+//! the override is already absent or removal itself fails. This also repairs a
+//! retry interrupted after disk removal but before the reload, while the
+//! coordinator avoids an unnecessary daemon reload when effective state already
+//! matches.
+//!
+//! Restoration is compensation for a failed absence reload, and is allowed
+//! only after this attempt removed the override file (`OverrideRemoved`). A
+//! `DirectoryRemoved` outcome means that only the empty drop-in directory was
+//! removed, and `AlreadyAbsent` means that neither path was removed; neither
+//! outcome owns restoration. Recreating `Restart=no` for either case could
+//! reintroduce the drain policy that this cleanup is removing.
+//!
+//! The same unbounded or bounded reload policy is used for the forward absence
+//! transition and for compensation back to expected presence. Cleanup-mode
+//! stop supplies the bounded policy with its existing lock and systemd-command
+//! timeouts. Removal, reload, restoration, and combined failures retain their
+//! error context so that a partial transition is diagnosable.
+//!
+//! Transient `service start` and default `service stop` use the unbounded
+//! policy; cleanup-mode `service stop` uses the bounded policy. Install and
+//! uninstall retain their separate service-lifecycle ordering and rollback
+//! contracts and are outside this transaction.
+
 use std::time::Duration;
 
 use crate::error::{RunnerError, RunnerResult};


### PR DESCRIPTION
## Summary

- Document the drain override cleanup transaction's on-disk versus systemd effective-state invariant.
- Explain expected-absence reconciliation, `OverrideRemoved`-only compensation, reload policy propagation, combined errors, and the `service start`/stop callers.

## Scope

- Documentation-only change in `crates/runner/src/cmd/service/drain_override_cleanup.rs`.
- No runtime statements, tests, public interfaces, configuration, migrations, or install/uninstall behavior changed.

## Validation

- ✅ `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- ✅ `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- ✅ `git diff --check`
- ⚠️ `cargo test --manifest-path crates/Cargo.toml -p runner drain_override_cleanup` is blocked by the pre-existing `crates/runner/src/network_logs.rs:716` `unused import: AsyncReadExt` error under `-D warnings`.
- ⚠️ `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings` is blocked by the pre-existing `crates/vsock-proto/src/payloads/memory_snapshot.rs:77,92` `chunks_exact_to_as_chunks` lints.

Closes #29200
