### PR TITLE
refactor(guest-agent): dual-read execution timeout aliases

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -411,7 +411,7 @@ impl<'a> CliRuntimeConfig<'a> {
                     .ok_or_else(|| {
                         AgentError::Execution(format!(
                             "{} is too large",
-                            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV
+                            env::AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC
                         ))
                     })
             })

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -20,6 +20,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
 const RUN_PAYLOAD_FILE_ENV_KEY: &str = guest_contracts::env::RUN_PAYLOAD_FILE_ENV;
 const POST_RESULT_CLEANUP_MAX_SECS: u64 = 60 * 60;
+pub(crate) const AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC: &str = "agent execution timeout";
 #[cfg(debug_assertions)]
 const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "VM0_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
@@ -117,6 +118,36 @@ fn api_token_env_or_empty() -> Result<String, String> {
     log_info!(
         LOG_TAG,
         "api_token_env_source key={canonical_key} source={source}"
+    );
+    Ok(value)
+}
+
+/// Resolve the runner-owned agent execution timeout at the single process-env
+/// capture boundary. Both aliases are reader-only during #28914 migration
+/// Stage 1; the runner writer remains
+/// [`guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV`].
+fn agent_execution_timeout_env_or_empty() -> Result<String, String> {
+    let canonical_key = guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV;
+    let legacy_key = guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV;
+    let canonical = std::env::var(canonical_key).ok();
+    let legacy = std::env::var(legacy_key).ok();
+
+    let (value, source) = match (canonical, legacy) {
+        (None, None) => return Ok(String::new()),
+        (Some(value), None) => (value, "canonical-only"),
+        (None, Some(value)) => (value, "legacy-only"),
+        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(_), Some(_)) => {
+            return Err(format!(
+                "conflicting agent execution timeout environment aliases: \
+                 canonical_key={canonical_key} legacy_key={legacy_key} state=conflict"
+            ));
+        }
+    };
+
+    log_info!(
+        LOG_TAG,
+        "agent_execution_timeout_env_source key={canonical_key} source={source}"
     );
     Ok(value)
 }
@@ -411,9 +442,7 @@ impl GuestConfigRaw {
                 guest_contracts::env::CANONICAL_API_START_TIME_ENV,
                 guest_contracts::env::API_START_TIME_ENV,
             )?,
-            agent_execution_timeout_secs: env_or_empty(
-                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-            ),
+            agent_execution_timeout_secs: agent_execution_timeout_env_or_empty()?,
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
@@ -551,7 +580,7 @@ impl GuestConfig {
             resume_session_id: raw.resume_session_id,
             api_start_time: raw.api_start_time,
             agent_execution_timeout: optional_positive_duration_secs(
-                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC,
                 non_empty(&raw.agent_execution_timeout_secs),
             )?,
             secret_values: payload.secret_values,
@@ -1006,30 +1035,29 @@ mod tests {
     #[test]
     fn agent_execution_timeout_is_optional_and_strict() {
         assert_eq!(
-            optional_positive_duration_secs(
-                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-                None,
-            )
-            .unwrap(),
+            optional_positive_duration_secs(AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC, None,).unwrap(),
             None
         );
         assert_eq!(
-            optional_positive_duration_secs(
-                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-                Some("7200"),
-            )
-            .unwrap(),
+            optional_positive_duration_secs(AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC, Some("7200"),)
+                .unwrap(),
             Some(Duration::from_secs(7200))
         );
 
         for invalid in ["0", "-1", "not-a-number", "18446744073709551615"] {
-            let error = optional_positive_duration_secs(
-                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
-                Some(invalid),
-            )
-            .unwrap_err();
+            let error =
+                optional_positive_duration_secs(AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC, Some(invalid))
+                    .unwrap_err();
             assert!(
-                error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+                error.contains(AGENT_EXECUTION_TIMEOUT_DIAGNOSTIC),
+                "{error}"
+            );
+            assert!(
+                !error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+                "{error}"
+            );
+            assert!(
+                !error.contains(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV),
                 "{error}"
             );
         }

--- a/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
+++ b/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
@@ -1,0 +1,516 @@
+//! Agent execution timeout aliases are resolved once at the process-env boundary.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
+use std::path::Path;
+use std::time::Duration;
+
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::run_context::GuestRuntime;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const VALID_TIMEOUT: &str = "37";
+const CANONICAL_CONFLICT_TIMEOUT: &str = "41";
+const LEGACY_CONFLICT_TIMEOUT: &str = "43";
+const CANONICAL_INVALID_TIMEOUT: &str = "canonical-invalid-timeout-must-not-leak";
+const LEGACY_INVALID_TIMEOUT: &str = "legacy-invalid-timeout-must-not-leak";
+const TOO_LARGE_TIMEOUT: &str = "18446744073709551615";
+const SOURCE_EVENT: &str = "agent_execution_timeout_env_source";
+const PARSE_ERROR: &str = "agent execution timeout must be a positive integer number of seconds";
+const ZERO_ERROR: &str = "agent execution timeout must be greater than zero";
+const TOO_LARGE_ERROR: &str = "agent execution timeout is too large";
+
+#[derive(Clone, Copy)]
+enum AliasInput {
+    Absent,
+    Readable(&'static str),
+    NonUnicode,
+}
+
+#[derive(Clone, Copy)]
+struct SuccessCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_raw: &'static str,
+    expected_timeout_secs: Option<u64>,
+    expected_source: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct ConflictCase {
+    name: &'static str,
+    canonical: &'static str,
+    legacy: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct ValidationCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_raw: &'static str,
+    expected_source: &'static str,
+    expected_error: &'static str,
+}
+
+const SUCCESS_CASES: [SuccessCase; 14] = [
+    SuccessCase {
+        name: "both-absent",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Absent,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-only",
+        canonical: AliasInput::Readable(VALID_TIMEOUT),
+        legacy: AliasInput::Absent,
+        expected_raw: VALID_TIMEOUT,
+        expected_timeout_secs: Some(37),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(VALID_TIMEOUT),
+        expected_raw: VALID_TIMEOUT,
+        expected_timeout_secs: Some(37),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual",
+        canonical: AliasInput::Readable(VALID_TIMEOUT),
+        legacy: AliasInput::Readable(VALID_TIMEOUT),
+        expected_raw: VALID_TIMEOUT,
+        expected_timeout_secs: Some(37),
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-empty-only",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Absent,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(""),
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(""),
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-non-unicode-only",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Absent,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "legacy-non-unicode-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::NonUnicode,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "both-non-unicode",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::NonUnicode,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-with-unreadable-legacy",
+        canonical: AliasInput::Readable(VALID_TIMEOUT),
+        legacy: AliasInput::NonUnicode,
+        expected_raw: VALID_TIMEOUT,
+        expected_timeout_secs: Some(37),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(VALID_TIMEOUT),
+        expected_raw: VALID_TIMEOUT,
+        expected_timeout_secs: Some(37),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "canonical-empty-with-unreadable-legacy",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::NonUnicode,
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(""),
+        expected_raw: "",
+        expected_timeout_secs: None,
+        expected_source: Some("legacy-only"),
+    },
+];
+
+const CONFLICT_CASES: [ConflictCase; 3] = [
+    ConflictCase {
+        name: "different-non-empty-values",
+        canonical: CANONICAL_CONFLICT_TIMEOUT,
+        legacy: LEGACY_CONFLICT_TIMEOUT,
+    },
+    ConflictCase {
+        name: "canonical-empty-legacy-non-empty",
+        canonical: "",
+        legacy: LEGACY_CONFLICT_TIMEOUT,
+    },
+    ConflictCase {
+        name: "canonical-non-empty-legacy-empty",
+        canonical: CANONICAL_CONFLICT_TIMEOUT,
+        legacy: "",
+    },
+];
+
+const VALIDATION_CASES: [ValidationCase; 8] = [
+    ValidationCase {
+        name: "canonical-invalid",
+        canonical: AliasInput::Readable(CANONICAL_INVALID_TIMEOUT),
+        legacy: AliasInput::Absent,
+        expected_raw: CANONICAL_INVALID_TIMEOUT,
+        expected_source: "canonical-only",
+        expected_error: PARSE_ERROR,
+    },
+    ValidationCase {
+        name: "legacy-invalid",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(LEGACY_INVALID_TIMEOUT),
+        expected_raw: LEGACY_INVALID_TIMEOUT,
+        expected_source: "legacy-only",
+        expected_error: PARSE_ERROR,
+    },
+    ValidationCase {
+        name: "canonical-whitespace",
+        canonical: AliasInput::Readable(" 37 "),
+        legacy: AliasInput::Absent,
+        expected_raw: " 37 ",
+        expected_source: "canonical-only",
+        expected_error: PARSE_ERROR,
+    },
+    ValidationCase {
+        name: "legacy-whitespace",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable("37 "),
+        expected_raw: "37 ",
+        expected_source: "legacy-only",
+        expected_error: PARSE_ERROR,
+    },
+    ValidationCase {
+        name: "canonical-zero",
+        canonical: AliasInput::Readable("0"),
+        legacy: AliasInput::Absent,
+        expected_raw: "0",
+        expected_source: "canonical-only",
+        expected_error: ZERO_ERROR,
+    },
+    ValidationCase {
+        name: "legacy-zero",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable("0"),
+        expected_raw: "0",
+        expected_source: "legacy-only",
+        expected_error: ZERO_ERROR,
+    },
+    ValidationCase {
+        name: "canonical-too-large",
+        canonical: AliasInput::Readable(TOO_LARGE_TIMEOUT),
+        legacy: AliasInput::Absent,
+        expected_raw: TOO_LARGE_TIMEOUT,
+        expected_source: "canonical-only",
+        expected_error: TOO_LARGE_ERROR,
+    },
+    ValidationCase {
+        name: "legacy-too-large",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(TOO_LARGE_TIMEOUT),
+        expected_raw: TOO_LARGE_TIMEOUT,
+        expected_source: "legacy-only",
+        expected_error: TOO_LARGE_ERROR,
+    },
+];
+
+fn set_test_env(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env(key: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+fn apply_alias(key: &str, input: AliasInput) {
+    remove_test_env(key);
+    match input {
+        AliasInput::Absent => {}
+        AliasInput::Readable(value) => set_test_env(key, value),
+        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+    }
+}
+
+fn clear_timeout_env() {
+    remove_test_env(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV);
+    remove_test_env(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV);
+}
+
+fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
+    guest_common::log::set_system_log_file(log_path);
+    let raw = GuestConfigRaw::from_process_env();
+    guest_common::log::clear_system_log_file();
+    let log = match std::fs::read_to_string(log_path) {
+        Ok(log) => log,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    Ok((raw, log))
+}
+
+fn assert_source_evidence(log: &str, case_name: &str, expected_source: Option<&str>) {
+    let source_messages = log
+        .lines()
+        .filter(|line| line.contains(SOURCE_EVENT))
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .collect::<Vec<_>>();
+
+    match expected_source {
+        Some(source) => {
+            let expected = format!(
+                "{SOURCE_EVENT} key={} source={source}",
+                guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV
+            );
+            assert_eq!(
+                source_messages,
+                [expected.as_str()],
+                "{case_name} emitted incorrect fixed source evidence"
+            );
+        }
+        None => assert!(
+            source_messages.is_empty(),
+            "{case_name} emitted source evidence for unreadable aliases"
+        ),
+    }
+}
+
+fn materialize_config(
+    tmp: &Path,
+    case_name: &str,
+    raw: GuestConfigRaw,
+) -> Result<GuestConfig, String> {
+    let runtime_dir = tmp.join(format!("{case_name}-runtime"));
+    let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&payload_dir)
+        .map_err(|error| format!("create payload directory: {error}"))?;
+    let payload = serde_json::to_vec(&guest_contracts::env::RunPayload::default())
+        .map_err(|error| format!("serialize run payload: {error}"))?;
+    std::fs::write(&payload_path, payload)
+        .map_err(|error| format!("write run payload: {error}"))?;
+
+    GuestConfig::from_raw(GuestConfigRaw {
+        run_id: format!("agent-execution-timeout-alias-{case_name}"),
+        home: Some(tmp.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir),
+        run_payload_file: payload_path.to_string_lossy().into_owned(),
+        ..raw
+    })
+}
+
+fn expected_conflict_error() -> String {
+    format!(
+        "conflicting agent execution timeout environment aliases: canonical_key={} \
+         legacy_key={} state=conflict",
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV
+    )
+}
+
+fn assert_source_neutral_validation_error(error: &str, case: ValidationCase) {
+    assert_eq!(
+        error, case.expected_error,
+        "{} returned the wrong validation category",
+        case.name
+    );
+    assert!(
+        !error.contains(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+        "{} named the canonical alias",
+        case.name
+    );
+    assert!(
+        !error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+        "{} named the legacy alias",
+        case.name
+    );
+    if !case.expected_raw.is_empty() {
+        assert!(
+            !error.contains(case.expected_raw),
+            "{} exposed the raw timeout input",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn process_env_dual_reads_agent_execution_timeout_aliases_without_value_leaks() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+
+    for case in SUCCESS_CASES {
+        apply_alias(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.canonical,
+        );
+        apply_alias(
+            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.legacy,
+        );
+        let (raw, log) = capture_raw(&tmp.path().join(format!("success-{}.log", case.name)))?;
+        let raw = raw.map_err(std::io::Error::other)?;
+        assert_eq!(
+            raw.agent_execution_timeout_secs, case.expected_raw,
+            "{} resolved the wrong raw timeout",
+            case.name
+        );
+        assert_source_evidence(&log, case.name, case.expected_source);
+
+        let config = materialize_config(tmp.path(), &format!("success-{}", case.name), raw)
+            .map_err(std::io::Error::other)?;
+        assert_eq!(
+            config.agent_execution_timeout,
+            case.expected_timeout_secs.map(Duration::from_secs),
+            "{} produced the wrong configured duration",
+            case.name
+        );
+    }
+
+    let expected_conflict = expected_conflict_error();
+    for case in CONFLICT_CASES {
+        set_test_env(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.canonical,
+        );
+        set_test_env(
+            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.legacy,
+        );
+        let (raw, log) = capture_raw(&tmp.path().join(format!("conflict-{}.log", case.name)))?;
+        let error = match raw {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} accepted conflicting readable aliases",
+                    case.name
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+        assert_eq!(
+            error, expected_conflict,
+            "{} returned the wrong fixed conflict diagnostic",
+            case.name
+        );
+        assert!(
+            !log.contains(SOURCE_EVENT),
+            "{} emitted success evidence for a conflict",
+            case.name
+        );
+    }
+
+    for case in VALIDATION_CASES {
+        apply_alias(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.canonical,
+        );
+        apply_alias(
+            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            case.legacy,
+        );
+        let (raw, log) = capture_raw(&tmp.path().join(format!("validation-{}.log", case.name)))?;
+        let raw = raw.map_err(std::io::Error::other)?;
+        assert_eq!(
+            raw.agent_execution_timeout_secs, case.expected_raw,
+            "{} changed the selected raw timeout before validation",
+            case.name
+        );
+        assert_source_evidence(&log, case.name, Some(case.expected_source));
+
+        let error = match materialize_config(tmp.path(), &format!("validation-{}", case.name), raw)
+        {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} accepted an invalid timeout",
+                    case.name
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+        assert_source_neutral_validation_error(&error, case);
+    }
+
+    set_test_env(
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        CANONICAL_CONFLICT_TIMEOUT,
+    );
+    set_test_env(
+        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        LEGACY_CONFLICT_TIMEOUT,
+    );
+    for key in [
+        process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+        guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+        guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
+        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+    ] {
+        remove_test_env(key);
+    }
+    let runtime_error = match GuestRuntime::from_process_env() {
+        Ok(_) => {
+            return Err(
+                "production runtime accepted conflicting agent execution timeout aliases".into(),
+            );
+        }
+        Err(error) => error,
+    };
+    assert_eq!(
+        runtime_error, expected_conflict,
+        "production runtime did not fail at timeout capture"
+    );
+
+    clear_timeout_env();
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -44,6 +44,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("VM0_APPEND_SYSTEM_PROMPT", "runner append prompt");
         std::env::set_var("VM0_FEATURE_FLAGS", r#"{"flag":true}"#);
         std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "60");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "60",
+        );
     }
 
     let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV)?;
@@ -82,6 +86,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     let runtime = GuestRuntime::from_process_env()?;
     assert!(!user_env_path.exists());
     assert!(!user_env_dir.exists());
+    assert_eq!(
+        runtime.config.agent_execution_timeout,
+        Some(std::time::Duration::from_secs(60))
+    );
     assert_eq!(runtime.config.home_dir, user_home_str);
     assert_eq!(
         runtime.config.claude_config_dir,
@@ -207,7 +215,15 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key("VM0_SANDBOX_ID"));
     assert!(!cli_env.contains_key("VM0_SANDBOX_REUSE_RESULT"));
     assert!(!cli_env.contains_key("VM0_FEATURE_FLAGS"));
-    assert!(!cli_env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
+    for key in [
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+    ] {
+        assert!(
+            !cli_env.contains_key(key),
+            "Claude child env contains {key}"
+        );
+    }
     assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
     for key in [
         process_control_ipc::BOOTSTRAP_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1018,6 +1018,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::API_START_TIME_ENV,
         guest_contracts::env::CANONICAL_API_START_TIME_ENV,
         guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
         guest_contracts::env::SECRET_VALUES_ENV,
         guest_contracts::env::DISALLOWED_TOOLS_ENV,
         guest_contracts::env::TOOLS_ENV,

--- a/crates/guest-agent/tests/execution_timeout.rs
+++ b/crates/guest-agent/tests/execution_timeout.rs
@@ -13,7 +13,10 @@ async fn execution_timeout_reaps_a_sigterm_deaf_cli() -> Result<(), Box<dyn std:
     let tmp = tempfile::tempdir()?;
     unsafe {
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let masker = SecretMasker::from_raw("");

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -107,6 +107,13 @@ pub const CANONICAL_API_START_TIME_ENV: &str = "OKOU_API_START_TIME";
 /// local user-tuning key.
 pub const AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
 
+/// Canonical agent execution timeout alias accepted by guest readers.
+///
+/// Runner writers keep using [`AGENT_EXECUTION_TIMEOUT_SECS_ENV`] until the
+/// deployed reader floor, sandbox drain, rollback window, and legacy-read-zero
+/// gates are complete.
+pub const CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "OKOU_AGENT_EXECUTION_TIMEOUT_SECS";
+
 /// Logical run-payload field name for sensitive values used by the guest-agent
 /// masker.
 ///
@@ -553,6 +560,10 @@ mod tests {
         assert_eq!(
             AGENT_EXECUTION_TIMEOUT_SECS_ENV,
             "VM0_AGENT_EXECUTION_TIMEOUT_SECS"
+        );
+        assert_eq!(
+            CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "OKOU_AGENT_EXECUTION_TIMEOUT_SECS"
         );
         assert_eq!(USER_ENV_FILE_ENV, "VM0_USER_ENV_FILE");
         assert_eq!(CANONICAL_USER_ENV_FILE_ENV, "OKOU_USER_ENV_FILE");


### PR DESCRIPTION
## Summary

- define `OKOU_AGENT_EXECUTION_TIMEOUT_SECS` as a reader-only canonical alias while retaining the legacy runner-writer constant byte-for-byte
- resolve canonical and legacy process values once at `GuestConfigRaw` capture with presence-before-content conflict handling and fixed, value-free evidence
- keep both aliases out of the curated CLI child environment and add process-isolated full-matrix, validation, and execution/isolation coverage

Parent EPIC: #28914

Closes #29197

## Revision anchors

- implementation base after the required `origin/main` refresh: `f07d4c6afa2f160a78f235aa00405ceb41cd12b8`
- PR base reviewed before pr-auto: `9c61cecb5a6f5a4dfcaa045910a4646d1576f5fe`
- PR head: `5a4f43b5bfceda9a55d3736c904fd02f1121dca4`
- the three post-authoring main commits have no diff in the Wave 34 contract, reader, CLI, test-precedent, runner-writer, or runner-writer-test surface

## Scope

- reader Stage 1 only; the runner remains a legacy-only writer of `VM0_AGENT_EXECUTION_TIMEOUT_SECS=7200`
- empty readable values participate in equality/conflict checks before the existing empty-to-no-deadline conversion
- absent and non-Unicode aliases remain unreadable; unequal readable aliases fail closed without value-derived diagnostics
- parse and deadline-overflow diagnostics are source-neutral and never echo raw input
- no writer, timeout budget, supervisor/finalization, tuning-key, ownership-predicate, platform-environment, release, deployment, or drain changes
- stale PR #25722 remains the only open overlap and its Cloudflare Access hunks are not imported

## Fallbacks

- `crates/guest-agent/src/env.rs:agent_execution_timeout_env_or_empty` — accepts either the retained legacy writer spelling or the canonical reader spelling during the reader-first migration. Surface: existing runner and reusable sandbox, with a two-hour execution budget plus bounded finalization and the supported rollback window. Remove the legacy branch only after #28914 records the exact deployed reader artifact/embedded Guest Agent/rootfs identity, completes and verifies the prescribed runner and sandbox drain, closes the rollback window, and observes zero legacy-only reads; the parent EPIC tracks the later writer-cutover and legacy-reader-removal follow-ups.

## Verification

All Rust commands below passed with Rust 1.96.0:

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p guest-agent --all-targets -- -D warnings`
- `cargo check -p guest-contracts -p guest-agent --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p guest-contracts -p guest-agent`
- `cargo test -p guest-contracts env::tests::contract_names_match_wire_values`
- `cargo test -p guest-agent --test agent_execution_timeout_env_aliases`
- `cargo test -p guest-agent --lib env::tests::agent_execution_timeout_is_optional_and_strict`
- `cargo test -p guest-agent --test cli_child_env`
- `cargo test -p guest-agent --test execution_timeout`
- `cargo test -p guest-agent --test execution_timeout_recovery`
- `cargo test -p guest-agent --test post_result_reap_execution_deadline`

Focused evidence checks also passed:

- runner source and focused test have no diff from the implementation base
- runner source SHA-256 remains `456a6ae8a8a2ae711ca26ccb82b384637620ec5438833f60d4d993ffbdd3c6eb`
- runner test SHA-256 remains `bfc335052a797439cdb87c00598d9a7a906f69a6bbea3a0ff9e63e60903de9d0`
- caller search confirms the new canonical spelling has no production writer
- `git diff --check` passes

The repository's full local Vitest suite was not run and no local development server was started; protected PR CI remains authoritative for repository-wide checks.

## Rollout and rollback

Rollout is the EPIC's reader-first Stage 1: merge and release this dual reader while the runner writer remains on the retained legacy spelling. Any writer cutover remains separately gated on an exact deployed reader artifact, embedded Guest Agent/rootfs identity, sandbox drain evidence, and rollback-window requirements from #28914.

Rollback is a revert of this reader-only PR. It remains safe because both the current and rollback runner continue writing the unchanged legacy alias. This PR does not perform or claim a release, production acceptance, drain, writer cutover, or legacy-reader removal.
