### PR TITLE
refactor(python): centralize missing usage context underbilling logs

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -24,7 +24,10 @@ from logging_utils import log_proxy_entry
 
 from ...buffer import UsageEvent, buffer_usage_events
 from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR, derive_usage_idempotency_key
-from ...reporting_context import usage_reporting_context
+from ...reporting_context import (
+    log_usage_reporting_context_missing,
+    usage_reporting_context,
+)
 from ...underbilling import log_usage_underbilling
 from .x_billing import (
     INCLUDES_OVERFLOW_CATEGORY,
@@ -765,16 +768,11 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
 
     reporting_context = usage_reporting_context(flow)
     if not reporting_context.is_complete:
-        log_usage_underbilling(
-            reporting_context.proxy_log_path,
-            "Cannot report usage event: missing sandbox_token or api_url",
-            "missing_reporting_context",
-            "confirmed",
-            run_id=run_id,
-            firewall_name=firewall_name,
+        log_usage_reporting_context_missing(
+            reporting_context,
+            run_id,
+            firewall_name,
             permission=permission,
-            missing_sandbox_token=reporting_context.missing_sandbox_token,
-            missing_api_url=reporting_context.missing_api_url,
         )
         return
     events: list[UsageEvent] = []

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -54,7 +54,11 @@ from ..model_tokens import (
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
 from ..quantities import is_usage_quantity
-from ..reporting_context import UsageReportingContext, usage_reporting_context
+from ..reporting_context import (
+    UsageReportingContext,
+    log_usage_reporting_context_missing,
+    usage_reporting_context,
+)
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
@@ -295,7 +299,7 @@ def report_model_provider_usage_source(
     if not context.is_complete:
         if usage_events:
             firewall_name = flow_metadata.firewall_name(flow.metadata)
-            _log_usage_reporting_context_missing(context, run_id, firewall_name)
+            log_usage_reporting_context_missing(context, run_id, firewall_name)
         if observations:
             _log_model_usage_observation_context_missing(context)
         return
@@ -437,7 +441,7 @@ def _buffer_model_provider_usage_events(
 ) -> bool:
     context = usage_reporting_context(flow)
     if not context.is_complete:
-        _log_usage_reporting_context_missing(context, run_id, firewall_name)
+        log_usage_reporting_context_missing(context, run_id, firewall_name)
         return False
     buffer_usage_events(
         context.usage_event_url(),
@@ -546,21 +550,6 @@ def _model_input_partition_source_key(
     return derive_usage_idempotency_key(
         namespace,
         (run_id, source_id, "model_input_partition", "atomic_source"),
-    )
-
-
-def _log_usage_reporting_context_missing(
-    context: UsageReportingContext, run_id: str, firewall_name: str
-) -> None:
-    log_usage_underbilling(
-        context.proxy_log_path,
-        "Cannot report usage event: missing sandbox_token or api_url",
-        "missing_reporting_context",
-        "confirmed",
-        run_id=run_id,
-        firewall_name=firewall_name,
-        missing_sandbox_token=context.missing_sandbox_token,
-        missing_api_url=context.missing_api_url,
     )
 
 

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -5,6 +5,8 @@ from mitmproxy import http
 import flow_metadata
 from platform_api import get_api_url
 
+from .underbilling import log_usage_underbilling
+
 USAGE_EVENT_WEBHOOK_PATH = "/api/webhooks/agent/usage-event"
 MODEL_USAGE_OBSERVATION_WEBHOOK_PATH = "/api/webhooks/agent/model-usage-observation"
 AGENT_TELEMETRY_WEBHOOK_PATH = "/api/webhooks/agent/telemetry"
@@ -43,6 +45,27 @@ class UsageReportingContext:
 
     def telemetry_url(self) -> str:
         return self._url_for(AGENT_TELEMETRY_WEBHOOK_PATH)
+
+
+def log_usage_reporting_context_missing(
+    context: UsageReportingContext,
+    run_id: str,
+    firewall_name: str,
+    /,
+    **extra: object,
+) -> None:
+    """Log confirmed underbilling when usage cannot reach the platform."""
+    log_usage_underbilling(
+        context.proxy_log_path,
+        "Cannot report usage event: missing sandbox_token or api_url",
+        "missing_reporting_context",
+        "confirmed",
+        run_id=run_id,
+        firewall_name=firewall_name,
+        missing_sandbox_token=context.missing_sandbox_token,
+        missing_api_url=context.missing_api_url,
+        **extra,
+    )
 
 
 def usage_reporting_context(flow: http.HTTPFlow) -> UsageReportingContext:


### PR DESCRIPTION
## Summary

- centralize the canonical confirmed `missing_reporting_context` underbilling event in the shared reporting-context layer
- route model-provider terminal/source reporting and X connector reporting through the shared helper
- preserve caller-specific X `permission`, all common diagnostic fields, and the generic JSONL/stderr fallback

## Scope

- model-usage observation warnings remain separate
- other model-provider and X underbilling reasons are unchanged
- webhook payloads, reporting gates, persisted state, and protocols are unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_usage.py tests/test_model_provider_websocket_source_reporting.py tests/x_connector_usage/test_guards.py tests/test_usage_underbilling.py` (65 passed)
- `uv run --no-sync python -m pytest tests/` (6606 passed)
- lefthook pre-commit and commit-msg hooks

Closes #29211
