### PR TITLE
refactor(python): share deferred callback scheduling helpers

### DIFF
--- a/crates/runner/mitm-addon/tests/deferred_callback_helpers.py
+++ b/crates/runner/mitm-addon/tests/deferred_callback_helpers.py
@@ -1,0 +1,31 @@
+"""Shared deferred callback scheduling helpers for mitm addon tests."""
+
+from collections.abc import Callable
+
+import pytest
+
+import deferred_callbacks
+
+type ScheduledCallback = Callable[[], None]
+
+
+def capture_deferred_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[ScheduledCallback]:
+    scheduled: list[ScheduledCallback] = []
+
+    def call_soon[CallbackArg](callback: Callable[[CallbackArg], None], arg: CallbackArg) -> None:
+        def run_callback() -> None:
+            callback(arg)
+
+        scheduled.append(run_callback)
+
+    monkeypatch.setattr(deferred_callbacks, "call_soon", call_soon)
+    return scheduled
+
+
+def run_deferred_callbacks(scheduled: list[ScheduledCallback]) -> None:
+    pending = list(scheduled)
+    scheduled.clear()
+    for callback in pending:
+        callback()

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -1,31 +1,27 @@
 """Shared WebSocket helpers for model-provider usage tests."""
 
 import json
-from collections.abc import Callable
 
 import pytest
 from mitmproxy import http, websocket
 from wsproto.frame_protocol import Opcode
 
-import deferred_callbacks
 import mitm_addon
 import model_websocket_usage
+from tests.deferred_callback_helpers import (
+    ScheduledCallback,
+    capture_deferred_callbacks,
+    run_deferred_callbacks,
+)
 from usage.json_selective import JsonSelectiveExtractor
 
-_WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
-ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
+type ScheduledWebSocketTrim = ScheduledCallback
 
 
 def capture_deferred_websocket_trims(
     monkeypatch: pytest.MonkeyPatch,
 ) -> list[ScheduledWebSocketTrim]:
-    scheduled: list[ScheduledWebSocketTrim] = []
-
-    def call_soon(callback: _WebSocketTrimCallback, flow: http.HTTPFlow) -> None:
-        scheduled.append((callback, flow))
-
-    monkeypatch.setattr(deferred_callbacks, "call_soon", call_soon)
-    return scheduled
+    return capture_deferred_callbacks(monkeypatch)
 
 
 def capture_openai_responses_extractor_feeds(
@@ -44,10 +40,7 @@ def capture_openai_responses_extractor_feeds(
 
 
 def run_deferred_websocket_trims(scheduled: list[ScheduledWebSocketTrim]) -> None:
-    pending = list(scheduled)
-    scheduled.clear()
-    for callback, flow in pending:
-        callback(flow)
+    run_deferred_callbacks(scheduled)
 
 
 def _make_websocket_message(

--- a/crates/runner/mitm-addon/tests/test_tcp_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_hooks.py
@@ -2,7 +2,6 @@
 
 import json
 import time
-from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -10,32 +9,16 @@ import pytest
 from mitmproxy import tcp
 from mitmproxy.flow import Error
 
-import deferred_callbacks
 import flow_metadata_keys as metadata_keys
 import logging_utils
 import mitm_addon
 import registry
+from tests.deferred_callback_helpers import (
+    capture_deferred_callbacks,
+    run_deferred_callbacks,
+)
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
-
-_ScheduledTcpDrain = tuple[Callable[[tcp.TCPFlow], None], tcp.TCPFlow]
-
-
-def _capture_tcp_drains(monkeypatch: pytest.MonkeyPatch) -> list[_ScheduledTcpDrain]:
-    scheduled: list[_ScheduledTcpDrain] = []
-
-    def call_soon(callback: Callable[[tcp.TCPFlow], None], flow: tcp.TCPFlow) -> None:
-        scheduled.append((callback, flow))
-
-    monkeypatch.setattr(deferred_callbacks, "call_soon", call_soon)
-    return scheduled
-
-
-def _run_scheduled_tcp_drains(scheduled: list[_ScheduledTcpDrain]) -> None:
-    pending = list(scheduled)
-    scheduled.clear()
-    for callback, flow in pending:
-        callback(flow)
 
 
 class TestTcpStart:
@@ -205,7 +188,7 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = log_path
-        scheduled = _capture_tcp_drains(monkeypatch)
+        scheduled = capture_deferred_callbacks(monkeypatch)
 
         with mitm_ctx():
             mitm_addon.tcp_message(flow)
@@ -214,7 +197,7 @@ class TestTcpLog:
         assert flow.messages == messages
         assert len(scheduled) == 1
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
 
         assert flow.messages == []
 
@@ -236,7 +219,7 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = log_path
-        scheduled = _capture_tcp_drains(monkeypatch)
+        scheduled = capture_deferred_callbacks(monkeypatch)
 
         with mitm_ctx():
             mitm_addon.tcp_message(flow)
@@ -247,7 +230,7 @@ class TestTcpLog:
         assert entry["response_size"] == len(b"server-response")
         assert flow.messages == []
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
         assert flow.messages == []
 
     def test_tcp_message_reschedules_after_previous_drain(
@@ -259,12 +242,12 @@ class TestTcpLog:
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = log_path
-        scheduled = _capture_tcp_drains(monkeypatch)
+        scheduled = capture_deferred_callbacks(monkeypatch)
 
         with mitm_ctx():
             mitm_addon.tcp_message(flow)
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
         assert flow.messages == []
 
         second_client = tcp.TCPMessage(True, b"second-client")
@@ -276,7 +259,7 @@ class TestTcpLog:
 
         assert len(scheduled) == 1
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
 
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
@@ -291,7 +274,7 @@ class TestTcpLog:
     ):
         messages = [tcp.TCPMessage(True, b"client")]
         flow = real_tcp_flow(messages=messages)
-        scheduled = _capture_tcp_drains(monkeypatch)
+        scheduled = capture_deferred_callbacks(monkeypatch)
 
         with mitm_ctx():
             mitm_addon.tcp_message(flow)
@@ -310,14 +293,14 @@ class TestTcpLog:
         flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.SANDBOX_NETWORK_LOG_PATH] = log_path
         monkeypatch.setattr(logging_utils, "NETWORK_LOG_MAX_SAFE_SIZE", max_log_size)
-        scheduled = _capture_tcp_drains(monkeypatch)
+        scheduled = capture_deferred_callbacks(monkeypatch)
 
         with mitm_ctx():
             mitm_addon.tcp_message(flow)
 
         assert len(scheduled) == 1
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
         assert flow.messages == []
 
         flow.messages.append(second_client)
@@ -333,5 +316,5 @@ class TestTcpLog:
         assert entry["response_size"] == 0
         assert flow.messages == []
 
-        _run_scheduled_tcp_drains(scheduled)
+        run_deferred_callbacks(scheduled)
         assert flow.messages == []


### PR DESCRIPTION
## Summary

- centralize deferred callback capture and one-snapshot draining in a protocol-neutral test helper
- preserve WebSocket-specific helper names as thin wrappers while removing their scheduler implementation
- migrate TCP hook tests off their private duplicate scheduler

## Scope

This is a test-harness refactor only. It does not change production scheduling behavior, dependencies, persisted data, or deployable interfaces.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_tcp_hooks.py tests/test_websocket_retention.py tests/test_model_provider_websocket_usage_aggregation.py` (52 passed)
- `uv run --no-sync python -m pytest tests/` (6606 passed)

Closes #29210
