### PR TITLE
refactor(python): centralize positive-wins model usage updates

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -17,8 +17,8 @@ from .model_http import (
     combined_value_presence_paths,
     failure_evidence_from_result,
 )
-from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
-from .quantities import MAX_USAGE_QUANTITY, is_usage_quantity
+from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES, update_model_usage_quantity
+from .quantities import MAX_USAGE_QUANTITY
 from .sse import SseUsageScanner
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
@@ -77,9 +77,7 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
     initial zero values when a category has not appeared yet.
     """
     for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
-        value = values.get((*prefix, raw_field))
-        if is_usage_quantity(value) and (value > 0 or category not in target):
-            target[category] = value
+        update_model_usage_quantity(target, category, values.get((*prefix, raw_field)))
 
 
 def create_anthropic_messages_sse_usage_extractor(

--- a/crates/runner/mitm-addon/src/usage/model_tokens.py
+++ b/crates/runner/mitm-addon/src/usage/model_tokens.py
@@ -6,6 +6,8 @@ categories after selecting a tier, while model usage observations retain the
 base categories.
 """
 
+from .quantities import is_usage_quantity
+
 MODEL_USAGE_CATEGORY_INPUT = "tokens.input"
 MODEL_USAGE_CATEGORY_OUTPUT = "tokens.output"
 MODEL_USAGE_CATEGORY_CACHE_READ = "tokens.cache_read"
@@ -18,6 +20,17 @@ MODEL_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_CACHE_READ,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
 )
+
+
+def update_model_usage_quantity(target: dict, category: str, value: object) -> None:
+    """Apply a positive-wins model usage update to one normalized category.
+
+    Provider updates may report zero after an earlier positive quantity. Preserve
+    the recorded value in that case, while retaining zero for a missing category.
+    """
+    if is_usage_quantity(value) and (value > 0 or category not in target):
+        target[category] = value
+
 
 ANTHROPIC_USAGE_FIELD_CATEGORIES = {
     "input_tokens": MODEL_USAGE_CATEGORY_INPUT,

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -55,6 +55,7 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_CACHE_READ,
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
+    update_model_usage_quantity,
 )
 from .openai_tokens import is_usage_quantity as _is_usage_quantity
 from .openai_tokens import partition_input_tokens as _partition_input_tokens
@@ -497,17 +498,6 @@ def _is_known_non_usage_event(value: object) -> bool:
     return isinstance(value, str) and value in openai_responses_events.KNOWN_NON_USAGE_EVENTS
 
 
-def _store_quantity(target: dict, category: str, value: object) -> None:
-    """Store usage quantities using positive-wins, zero-does-not-clobber semantics.
-
-    Later provider update payloads may report ``0`` for a category that an
-    earlier payload reported as non-zero. Preserve the recorded quantity in
-    that case, while still recording initial zero values for missing categories.
-    """
-    if _is_usage_quantity(value) and (value > 0 or category not in target):
-        target[category] = value
-
-
 def _has_positive_usage_quantity(values: dict) -> bool:
     for category in MODEL_USAGE_CATEGORIES:
         value = values.get(category)
@@ -551,9 +541,9 @@ def _merge_input_partition(target: dict, source: dict) -> None:
         if snapshot is None:
             continue
         input_tokens, cached_tokens, cache_write_tokens = snapshot
-        _store_quantity(merged_raw, MODEL_USAGE_CATEGORY_INPUT, input_tokens)
-        _store_quantity(merged_raw, MODEL_USAGE_CATEGORY_CACHE_READ, cached_tokens)
-        _store_quantity(
+        update_model_usage_quantity(merged_raw, MODEL_USAGE_CATEGORY_INPUT, input_tokens)
+        update_model_usage_quantity(merged_raw, MODEL_USAGE_CATEGORY_CACHE_READ, cached_tokens)
+        update_model_usage_quantity(
             merged_raw,
             MODEL_USAGE_CATEGORY_CACHE_CREATION,
             cache_write_tokens,
@@ -596,23 +586,23 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
         values.get((*prefix, "usage", "input_tokens_details", "cached_tokens")),
         values.get((*prefix, "usage", "input_tokens_details", "cache_write_tokens")),
     )
-    _store_quantity(
+    update_model_usage_quantity(
         target,
         MODEL_USAGE_CATEGORY_INPUT,
         uncached_input_tokens,
     )
-    _store_quantity(
+    update_model_usage_quantity(
         target,
         MODEL_USAGE_CATEGORY_OUTPUT,
         values.get((*prefix, "usage", "output_tokens")),
     )
 
-    _store_quantity(
+    update_model_usage_quantity(
         target,
         MODEL_USAGE_CATEGORY_CACHE_READ,
         cached_tokens,
     )
-    _store_quantity(
+    update_model_usage_quantity(
         target,
         MODEL_USAGE_CATEGORY_CACHE_CREATION,
         cache_creation_tokens,
@@ -641,7 +631,7 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
     target_has_positive_quantity = _has_positive_usage_quantity(target)
     source_has_positive_quantity = _has_positive_usage_quantity(source)
     _merge_input_partition(target, source)
-    _store_quantity(
+    update_model_usage_quantity(
         target,
         MODEL_USAGE_CATEGORY_OUTPUT,
         source.get(MODEL_USAGE_CATEGORY_OUTPUT),

--- a/crates/runner/mitm-addon/tests/test_model_usage_update_contract.py
+++ b/crates/runner/mitm-addon/tests/test_model_usage_update_contract.py
@@ -1,0 +1,56 @@
+"""Cross-provider contract for temporal model usage updates."""
+
+import json
+from collections.abc import Callable
+
+import pytest
+
+from usage.anthropic_messages import create_anthropic_messages_sse_usage_extractor
+from usage.model_tokens import MODEL_USAGE_CATEGORY_OUTPUT
+from usage.openai_responses import merge_openai_responses_usage_result
+from usage.quantities import MAX_USAGE_QUANTITY
+
+UsageUpdater = Callable[[object], dict[str, object]]
+UsageUpdaterFactory = Callable[[], UsageUpdater]
+
+
+def _anthropic_output_updates() -> UsageUpdater:
+    scanner, usage = create_anthropic_messages_sse_usage_extractor()
+
+    def update(value: object) -> dict[str, object]:
+        event = json.dumps(
+            {"type": "message_delta", "usage": {"output_tokens": value}},
+            separators=(",", ":"),
+        ).encode()
+        scanner.feed(b"event: message_delta\ndata: " + event + b"\n\n")
+        return usage
+
+    return update
+
+
+def _openai_responses_output_updates() -> UsageUpdater:
+    usage: dict[str, object] = {}
+
+    def update(value: object) -> dict[str, object]:
+        merge_openai_responses_usage_result(
+            usage,
+            {MODEL_USAGE_CATEGORY_OUTPUT: value},
+        )
+        return usage
+
+    return update
+
+
+@pytest.mark.parametrize(
+    "update_factory",
+    [_anthropic_output_updates, _openai_responses_output_updates],
+    ids=("anthropic-messages", "openai-responses"),
+)
+def test_positive_wins_model_usage_updates(update_factory: UsageUpdaterFactory) -> None:
+    update = update_factory()
+
+    assert MODEL_USAGE_CATEGORY_OUTPUT not in update(MAX_USAGE_QUANTITY + 1)
+    assert update(0)[MODEL_USAGE_CATEGORY_OUTPUT] == 0
+    assert update(12)[MODEL_USAGE_CATEGORY_OUTPUT] == 12
+    assert update(0)[MODEL_USAGE_CATEGORY_OUTPUT] == 12
+    assert update(4)[MODEL_USAGE_CATEGORY_OUTPUT] == 4


### PR DESCRIPTION
## Summary

- centralize canonical positive-wins, zero-does-not-clobber model usage updates in `usage.model_tokens`
- delegate Anthropic Messages field updates and all OpenAI Responses temporal category updates to the shared primitive
- add a cross-provider integration contract covering invalid values, initial zero, positive replacement, later-zero preservation, and positive correction

## Scope

- provider field mapping remains in Anthropic Messages
- OpenAI input-token partitioning and metadata ownership remain in OpenAI Responses
- OpenAI Chat Completions keeps its intentionally different snapshot replacement behavior
- no public package facade, API, schema, queue payload, persisted state, or runner protocol changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_model_usage_update_contract.py tests/test_anthropic_messages.py tests/test_openai_responses_event_json.py` (98 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/` (6608 passed)

Closes #29209
