### PR TITLE
fix(guest-agent): bound api response bodies

### DIFF
--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -28,6 +28,16 @@ pub const HTTP_UPLOAD_TIMEOUT_SECS: u64 = 60;
 /// HTTP request timeout for one active-input receipt attempt.
 pub const ACTIVE_INPUT_RECEIPT_TIMEOUT_SECS: u64 = 5;
 
+/// Maximum collected successful VM0 API response body size.
+///
+/// This provides headroom above Vercel's 4.5 MB non-streaming function
+/// response limit. Model output and presigned object transfers do not use this
+/// control-plane response path.
+pub const API_SUCCESS_RESPONSE_BODY_MAX_BYTES: usize = 5 * 1024 * 1024;
+
+/// Maximum collected non-retryable VM0 API error response body size.
+pub const API_ERROR_RESPONSE_BODY_MAX_BYTES: usize = 64 * 1024;
+
 /// Global active-input receipt finalization budget.
 pub const ACTIVE_INPUT_RECEIPT_FINALIZE_TIMEOUT_SECS: u64 = 5;
 

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -33,6 +33,15 @@ const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[cfg(debug_assertions)]
 const TEST_DISABLE_HTTP_RETRY_DELAY_ENV: &str = "VM0_TEST_DISABLE_HTTP_RETRY_DELAY";
 const GUEST_AGENT_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const API_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC: &str =
+    "VM0 API response body exceeds the configured limit";
+const API_ERROR_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC: &str =
+    "VM0 API error response body exceeds the configured limit";
+
+enum ResponseBodyCollectionError {
+    TooLarge,
+    Transport(reqwest::Error),
+}
 
 /// Content-safe facts published before one event request is awaited.
 #[derive(Debug, Clone)]
@@ -508,6 +517,52 @@ fn observe_attempt_finished(
     })
 }
 
+async fn collect_response_body(
+    mut response: Response,
+    max_bytes: usize,
+) -> Result<Bytes, ResponseBodyCollectionError> {
+    let capacity = match response.content_length() {
+        Some(length) if length > max_bytes as u64 => {
+            return Err(ResponseBodyCollectionError::TooLarge);
+        }
+        Some(length) => {
+            usize::try_from(length).map_err(|_| ResponseBodyCollectionError::TooLarge)?
+        }
+        None => 0,
+    };
+    let mut body = BytesMut::with_capacity(capacity);
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(ResponseBodyCollectionError::Transport)?
+    {
+        let length = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or(ResponseBodyCollectionError::TooLarge)?;
+        if length > max_bytes {
+            return Err(ResponseBodyCollectionError::TooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body.freeze())
+}
+
+async fn collect_api_success_body(response: Response) -> Result<Bytes, AgentError> {
+    collect_response_body(response, constants::API_SUCCESS_RESPONSE_BODY_MAX_BYTES)
+        .await
+        .map_err(|error| match error {
+            ResponseBodyCollectionError::TooLarge => {
+                AgentError::Http(API_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC.to_string())
+            }
+            ResponseBodyCollectionError::Transport(error) => {
+                AgentError::Http(format_reqwest_error(error))
+            }
+        })
+}
+
 impl HttpClient {
     /// POST JSON to a webhook endpoint with Bearer auth, Vercel bypass, and retry.
     ///
@@ -535,15 +590,12 @@ impl HttpClient {
             .post_json_response(url, body, max_attempts, None, None)
             .await?;
 
-        let text = resp
-            .text()
-            .await
-            .map_err(|error| AgentError::Http(format_reqwest_error(error)))?;
-        if text.is_empty() {
+        let body = collect_api_success_body(resp).await?;
+        if body.is_empty() {
             return Ok(None);
         }
         let val: Value =
-            serde_json::from_str(&text).map_err(|e| AgentError::Http(e.to_string()))?;
+            serde_json::from_slice(&body).map_err(|error| AgentError::Http(error.to_string()))?;
         Ok(Some(val))
     }
 
@@ -581,10 +633,9 @@ impl HttpClient {
                 )),
             )
             .await?;
-        response
-            .json::<ActiveInputReceiptResponse>()
-            .await
-            .map_err(|error| AgentError::Http(format_reqwest_error(error)))
+        let body = collect_api_success_body(response).await?;
+        serde_json::from_slice::<ActiveInputReceiptResponse>(&body)
+            .map_err(|error| AgentError::Http(error.to_string()))
     }
 
     async fn post_json_response(
@@ -630,12 +681,33 @@ impl HttpClient {
                 let url = url.to_owned();
                 async move {
                     let status = resp.status();
-                    let error_msg = resp
-                        .text()
-                        .await
-                        .ok()
-                        .and_then(|body| serde_json::from_str::<Value>(&body).ok())
-                        .and_then(|v| v.get("error")?.get("message")?.as_str().map(String::from));
+                    let error_msg = match collect_response_body(
+                        resp,
+                        constants::API_ERROR_RESPONSE_BODY_MAX_BYTES,
+                    )
+                    .await
+                    {
+                        Ok(body) => serde_json::from_slice::<Value>(&body).ok().and_then(|value| {
+                            value
+                                .get("error")?
+                                .get("message")?
+                                .as_str()
+                                .map(String::from)
+                        }),
+                        Err(ResponseBodyCollectionError::TooLarge) => {
+                            log_warn!(
+                                LOG_TAG,
+                                "HTTP POST failed: HTTP {status} — {API_ERROR_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC}",
+                            );
+                            return AgentError::HttpStatus {
+                                status: status.as_u16(),
+                                message: format!(
+                                    "HTTP {status}: {API_ERROR_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC}"
+                                ),
+                            };
+                        }
+                        Err(ResponseBodyCollectionError::Transport(_)) => None,
+                    };
 
                     match error_msg {
                         Some(msg) => {

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -3,6 +3,7 @@ use api_contracts::generated::constants::client::headers::{
     CLIENT_REQUEST_ID_HEADER, CLIENT_SESSION_ID_HEADER, CLIENT_TYPE_HEADER, CLIENT_VERSION_HEADER,
 };
 use api_contracts::generated::constants::client::types::CLIENT_TYPE_GUEST_AGENT;
+use api_contracts::generated::types::runners::runs::active_inputs::receipt::Response as ActiveInputReceiptResponse;
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
@@ -13,7 +14,104 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
 use uuid::Uuid;
+
+const RESPONSE_LIMIT_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES: usize = 5 * 1024 * 1024;
+const EXPECTED_ERROR_RESPONSE_BODY_LIMIT_BYTES: usize = 64 * 1024;
+const EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_DIAGNOSTIC: &str =
+    "VM0 API response body exceeds the configured limit";
+const EXPECTED_ERROR_RESPONSE_BODY_LIMIT_DIAGNOSTIC: &str =
+    "HTTP 400 Bad Request: VM0 API error response body exceeds the configured limit";
+
+struct HeldOpenResponseServer {
+    base_url: String,
+    release: oneshot::Sender<()>,
+    handle: tokio::task::JoinHandle<std::io::Result<()>>,
+}
+
+impl HeldOpenResponseServer {
+    async fn start(response_parts: Vec<Vec<u8>>) -> std::io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let (release, release_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+            read_raw_request(&mut socket).await?;
+            for part in response_parts {
+                socket.write_all(&part).await?;
+            }
+            let _ = release_rx.await;
+            Ok(())
+        });
+        Ok(Self {
+            base_url: format!("http://{address}"),
+            release,
+            handle,
+        })
+    }
+
+    async fn finish(self) {
+        let _ = self.release.send(());
+        assert!(matches!(self.handle.await, Ok(Ok(()))));
+    }
+}
+
+async fn read_raw_request(socket: &mut TcpStream) -> std::io::Result<()> {
+    let mut request = Vec::new();
+    let header_end = loop {
+        if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index;
+        }
+        let mut chunk = [0_u8; 1024];
+        let read = socket.read(&mut chunk).await?;
+        assert!(read > 0, "connection closed before request headers");
+        let bytes = chunk
+            .get(..read)
+            .ok_or_else(|| std::io::Error::other("invalid request read length"))?;
+        request.extend_from_slice(bytes);
+    };
+    let header_bytes = request
+        .get(..header_end)
+        .ok_or_else(|| std::io::Error::other("invalid request header length"))?;
+    let headers = std::str::from_utf8(header_bytes)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let content_length = headers
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .map(|(_, value)| value.trim().parse::<usize>())
+        .transpose()
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?
+        .unwrap_or_default();
+    let body_end = header_end + 4 + content_length;
+    while request.len() < body_end {
+        let mut chunk = [0_u8; 1024];
+        let read = socket.read(&mut chunk).await?;
+        assert!(read > 0, "connection closed before request body");
+        let bytes = chunk
+            .get(..read)
+            .ok_or_else(|| std::io::Error::other("invalid request read length"))?;
+        request.extend_from_slice(bytes);
+    }
+    Ok(())
+}
+
+fn padded_json_body(total_bytes: usize, prefix: &str, suffix: &str) -> String {
+    assert!(prefix.len() + suffix.len() <= total_bytes);
+    let mut body = String::with_capacity(total_bytes);
+    body.push_str(prefix);
+    body.extend(std::iter::repeat_n(
+        'x',
+        total_bytes - prefix.len() - suffix.len(),
+    ));
+    body.push_str(suffix);
+    assert_eq!(body.len(), total_bytes);
+    body
+}
 
 struct CountingJsonBody<'a> {
     serializations: &'a AtomicUsize,
@@ -178,6 +276,140 @@ async fn post_json_retry_exhausted() {
     assert!(result.is_err());
 }
 
+#[tokio::test]
+async fn post_json_accepts_response_at_success_body_limit() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let body = padded_json_body(
+        EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES,
+        "{\"value\":\"",
+        "\"}",
+    );
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/exact-response-limit");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .body(body);
+    });
+
+    let url = api.url("/test/exact-response-limit");
+    let response = http_client!()
+        .post_json(&url, &json!({}), 1)
+        .await
+        .unwrap()
+        .unwrap();
+
+    mock.assert_calls_async(1).await;
+    assert_eq!(
+        response["value"].as_str().unwrap().len(),
+        EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES - "{\"value\":\"".len() - "\"}".len(),
+    );
+}
+
+#[tokio::test]
+async fn post_json_rejects_declared_response_over_success_body_limit() {
+    let response_head = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES + 1,
+    );
+    let server = HeldOpenResponseServer::start(vec![response_head.into_bytes()])
+        .await
+        .unwrap();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "authorization-secret",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let url = format!("{}/test?query-secret", server.base_url);
+
+    let result = tokio::time::timeout(
+        RESPONSE_LIMIT_TEST_TIMEOUT,
+        client.post_json(&url, &json!({}), 1),
+    )
+    .await
+    .expect("client waited for an oversized declared response");
+
+    let Err(AgentError::Http(message)) = result else {
+        panic!("expected response body limit error");
+    };
+    assert_eq!(message, EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_DIAGNOSTIC);
+    server.finish().await;
+}
+
+#[tokio::test]
+async fn post_json_rejects_chunked_response_over_success_body_limit() {
+    let first_chunk = vec![b'x'; EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES];
+    let first_chunk_head = format!("{:X}\r\n", first_chunk.len());
+    let server = HeldOpenResponseServer::start(vec![
+        b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n"
+            .to_vec(),
+        first_chunk_head.into_bytes(),
+        first_chunk,
+        b"\r\n1\r\nx\r\n".to_vec(),
+    ])
+    .await
+    .unwrap();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let url = format!("{}/test", server.base_url);
+
+    let result = tokio::time::timeout(
+        RESPONSE_LIMIT_TEST_TIMEOUT,
+        client.post_json(&url, &json!({}), 1),
+    )
+    .await
+    .expect("client waited after a chunked response exceeded the limit");
+
+    let Err(AgentError::Http(message)) = result else {
+        panic!("expected response body limit error");
+    };
+    assert_eq!(message, EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_DIAGNOSTIC);
+    server.finish().await;
+}
+
+#[tokio::test]
+async fn post_json_rejects_no_length_response_over_success_body_limit() {
+    let server = HeldOpenResponseServer::start(vec![
+        b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n".to_vec(),
+        vec![b'x'; EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES],
+        vec![b'x'],
+    ])
+    .await
+    .unwrap();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let url = format!("{}/test", server.base_url);
+
+    let result = tokio::time::timeout(
+        RESPONSE_LIMIT_TEST_TIMEOUT,
+        client.post_json(&url, &json!({}), 1),
+    )
+    .await
+    .expect("client waited after a response without content-length exceeded the limit");
+
+    let Err(AgentError::Http(message)) = result else {
+        panic!("expected response body limit error");
+    };
+    assert_eq!(message, EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_DIAGNOSTIC);
+    server.finish().await;
+}
+
 // =========================================================================
 // post_json 4xx handling
 // =========================================================================
@@ -228,6 +460,68 @@ async fn post_json_4xx_error_body_preserves_status_and_message() {
     };
     assert_eq!(status, 401);
     assert!(message.contains("token expired"));
+}
+
+#[tokio::test]
+async fn post_json_accepts_error_response_at_body_limit() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let body = padded_json_body(
+        EXPECTED_ERROR_RESPONSE_BODY_LIMIT_BYTES,
+        "{\"error\":{\"message\":\"at limit\"},\"padding\":\"",
+        "\"}",
+    );
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/exact-error-limit");
+        then.status(400)
+            .header("Content-Type", "application/json")
+            .body(body);
+    });
+
+    let url = api.url("/test/exact-error-limit");
+    let result = http_client!().post_json(&url, &json!({}), 1).await;
+
+    mock.assert_calls_async(1).await;
+    let Err(AgentError::HttpStatus { status, message }) = result else {
+        panic!("expected structured HTTP status error");
+    };
+    assert_eq!(status, 400);
+    assert!(message.contains("at limit"));
+}
+
+#[tokio::test]
+async fn post_json_rejects_declared_error_body_over_limit_with_safe_diagnostic() {
+    let response_head = format!(
+        "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        EXPECTED_ERROR_RESPONSE_BODY_LIMIT_BYTES + 1,
+    );
+    let server = HeldOpenResponseServer::start(vec![response_head.into_bytes()])
+        .await
+        .unwrap();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "authorization-secret",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let url = format!("{}/test?query-secret", server.base_url);
+
+    let result = tokio::time::timeout(
+        RESPONSE_LIMIT_TEST_TIMEOUT,
+        client.post_json(&url, &json!({}), 1),
+    )
+    .await
+    .expect("client waited for an oversized declared error response");
+
+    let Err(AgentError::HttpStatus { status, message }) = result else {
+        panic!("expected structured HTTP status error");
+    };
+    assert_eq!(status, 400);
+    assert_eq!(message, EXPECTED_ERROR_RESPONSE_BODY_LIMIT_DIAGNOSTIC);
+    server.finish().await;
 }
 
 #[tokio::test]
@@ -382,6 +676,65 @@ async fn post_json_uses_explicit_api_config_without_env_api_url() {
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
     mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn active_input_receipt_parses_bounded_json_response() {
+    let server = MockServer::start();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/runners/runs/run-123/active-inputs/deliveries/delivery-123/receipt");
+        then.status(200)
+            .json_body(json!({ "outcome": "delivered" }));
+    });
+
+    let response = client
+        .post_active_input_receipt("run-123", "delivery-123")
+        .await
+        .unwrap();
+
+    mock.assert_calls_async(1).await;
+    assert_eq!(response, ActiveInputReceiptResponse::Delivered);
+}
+
+#[tokio::test]
+async fn active_input_receipt_rejects_declared_response_over_success_body_limit() {
+    let response_head = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_BYTES + 1,
+    );
+    let server = HeldOpenResponseServer::start(vec![response_head.into_bytes()])
+        .await
+        .unwrap();
+    let client = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        "response-limit-run",
+        Duration::ZERO,
+    )
+    .unwrap();
+
+    let result = tokio::time::timeout(
+        RESPONSE_LIMIT_TEST_TIMEOUT,
+        client.post_active_input_receipt("run-123", "delivery-123"),
+    )
+    .await
+    .expect("receipt client waited for an oversized declared response");
+
+    let Err(AgentError::Http(message)) = result else {
+        panic!("expected response body limit error");
+    };
+    assert_eq!(message, EXPECTED_SUCCESS_RESPONSE_BODY_LIMIT_DIAGNOSTIC);
+    server.finish().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- cap collected successful VM0 control-plane response bodies at 5 MiB
- cap collected non-retryable error bodies at 64 KiB while preserving the HTTP status
- enforce limits from both declared length and actual chunks, including chunked and lengthless responses
- return fixed diagnostics for oversized bodies without including request URLs, credentials, or response content
- route generic JSON and active-input receipt responses through the bounded collector

Model-provider output streams, event acknowledgements whose bodies are discarded, and presigned object transfers remain unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration http_client`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet`

Closes #29206
