### PR TITLE
refactor(runner): reuse raw http fixture in storage tests

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/storage.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/storage.rs
@@ -1,12 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use sandbox::{ProcessOutputChunk, ProcessOutputMode};
 use sandbox_mock::MockLifecycleGate;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
-use tokio::sync::oneshot;
 
 use super::support::{
     assert_failed_action_error_once, assert_no_action, assert_successful_action_once,
@@ -19,44 +15,24 @@ use crate::executor::tests::support::{
 };
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::storage_manifest::StorageManifest;
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, http_response};
 use crate::types::SandboxReuseResult;
 
-async fn serve_storage_archive_for_cache(
-    body: &'static [u8],
-) -> (String, tokio::task::JoinHandle<()>, oneshot::Receiver<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let address = listener.local_addr().unwrap();
-    let (request_tx, request_rx) = oneshot::channel();
-    let handle = tokio::spawn(async move {
-        let probe_response = format!(
-            "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
-            body.len()
-        )
-        .into_bytes();
-        let mut full_response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        )
-        .into_bytes();
-        full_response.extend_from_slice(body);
-
-        let mut request_tx = Some(request_tx);
-        for response in [probe_response, full_response] {
-            let (mut stream, _) = listener.accept().await.unwrap();
-            let mut request = [0u8; 1024];
-            let _ = stream.read(&mut request).await;
-            if let Some(request_tx) = request_tx.take() {
-                let _ = request_tx.send(());
-            }
-            stream.write_all(&response).await.unwrap();
-        }
-    });
-    (
-        format!("http://{address}/archive.tar.gz"),
-        handle,
-        request_rx,
+async fn spawn_storage_archive_server(body: &[u8]) -> RawHttpTestServer {
+    let probe_response = format!(
+        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+        body.len()
     )
+    .into_bytes();
+    let full_response = http_response("200 OK", body);
+
+    RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(probe_response),
+        RawHttpAction::Respond(full_response),
+    ])
+    .await
 }
+
 #[tokio::test]
 async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization() {
     let dir = tempfile::tempdir().unwrap();
@@ -122,8 +98,8 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
     overrides.set_start_process_lifecycle_gate(start_process_gate.clone());
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let mut ctx = minimal_context();
-    let (archive_url, archive_server, mut archive_request) =
-        serve_storage_archive_for_cache(b"cache-archive").await;
+    let mut archive_server = spawn_storage_archive_server(b"cache-archive").await;
+    let archive_url = format!("{}/archive.tar.gz", archive_server.url());
     let storage = api_storage("instructions", "/home/user/.codex", "v1", &archive_url);
     ctx.storage_manifest = Some(StorageManifest {
         storages: vec![storage],
@@ -163,8 +139,8 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
         .expect("run should reach the start-process barrier");
 
         assert!(matches!(
-            archive_request.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
+            archive_server.try_next_request(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         ));
         assert_eq!(overrides.storage_manifest_calls().len(), 1);
 
@@ -175,14 +151,10 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
             .unwrap();
     }
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut archive_request)
-        .await
-        .expect("deferred cache fill should contact the archive after spawn")
-        .expect("archive server should report its first request");
-    tokio::time::timeout(Duration::from_secs(5), archive_server)
-        .await
-        .expect("background cache fill should fetch archive")
-        .expect("background cache fill server task should not panic");
+    archive_server
+        .next_request("deferred cache fill archive request after spawn")
+        .await;
+    archive_server.assert_finished().await;
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
     assert_successful_action_once(&ops, "runner_storage_manifest_cache_populate");
@@ -228,8 +200,8 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_agent_spawn_fails() {
     );
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let mut ctx = minimal_context();
-    let (archive_url, archive_server, mut archive_request) =
-        serve_storage_archive_for_cache(b"cache-archive").await;
+    let mut archive_server = spawn_storage_archive_server(b"cache-archive").await;
+    let archive_url = format!("{}/archive.tar.gz", archive_server.url());
     ctx.storage_manifest = Some(StorageManifest {
         storages: vec![api_storage(
             "instructions",
@@ -260,8 +232,8 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_agent_spawn_fails() {
     tokio::task::yield_now().await;
 
     assert!(matches!(
-        archive_request.try_recv(),
-        Err(oneshot::error::TryRecvError::Empty)
+        archive_server.try_next_request(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
     ));
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_count_1");
@@ -274,8 +246,7 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_agent_spawn_fails() {
     assert_no_action(&ops, "storage_cache_background_fill_scheduled_count_1");
     assert_no_action(&ops, "runner_executor_start_to_spawn");
 
-    archive_server.abort();
-    let _ = archive_server.await;
+    archive_server.cancel_and_reap().await;
 }
 
 #[tokio::test]
@@ -285,8 +256,8 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_guest_download_fails() {
     let sandbox = sandbox_mock::MockSandbox::new("test");
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
     let mut ctx = minimal_context();
-    let (archive_url, archive_server, mut archive_request) =
-        serve_storage_archive_for_cache(b"cache-archive").await;
+    let mut archive_server = spawn_storage_archive_server(b"cache-archive").await;
+    let archive_url = format!("{}/archive.tar.gz", archive_server.url());
     ctx.storage_manifest = Some(StorageManifest {
         storages: vec![api_storage(
             "instructions",
@@ -316,8 +287,8 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_guest_download_fails() {
     tokio::task::yield_now().await;
 
     assert!(matches!(
-        archive_request.try_recv(),
-        Err(oneshot::error::TryRecvError::Empty)
+        archive_server.try_next_request(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
     ));
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_count_1");
@@ -330,8 +301,7 @@ async fn run_in_sandbox_drops_deferred_cache_fill_when_guest_download_fails() {
         "storage-download-failed",
     );
 
-    archive_server.abort();
-    let _ = archive_server.await;
+    archive_server.cancel_and_reap().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- replace the deferred storage tests' private loopback listener with `RawHttpTestServer`
- preserve the ordered range probe and full archive responses while using complete request capture
- use bounded fixture completion for successful fill and bounded cancellation/reaping for no-request paths

## Scope

This changes runner test infrastructure only. Production storage-cache behavior, protocols, dependencies, and deployment compatibility are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --bin runner executor::tests::agent_run_tests::storage::run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn -- --exact`
- `cargo test -p runner --bin runner executor::tests::agent_run_tests::storage::run_in_sandbox_drops_deferred_cache_fill_when_agent_spawn_fails -- --exact`
- `cargo test -p runner --bin runner executor::tests::agent_run_tests::storage::run_in_sandbox_drops_deferred_cache_fill_when_guest_download_fails -- --exact`
- pre-commit Rust formatting, workspace rustdoc, workspace Clippy, file-size, and commit-message hooks

The complete runner suite was also attempted locally: 3,288 tests passed and one unchanged proxy test failed under the non-root development user. Focused reproduction showed its retry helper creates a read-only `fake-mitmdump.environ` file and then cannot overwrite it on the second launch; `proxy/process.rs` is identical to `origin/main` and the independent fixture bug is tracked by #29248.

Closes #29212
