### PR TITLE
fix(auth): derive pristine sign-up fields from clerk config

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,4 +1,9 @@
-import type { ClerkAPIError, PasswordValidation } from "@clerk/react/types";
+import type {
+  Attribute,
+  AttributeData,
+  ClerkAPIError,
+  PasswordValidation,
+} from "@clerk/react/types";
 import { vi } from "vitest";
 import { replaceState } from "../signals/location.ts";
 
@@ -102,9 +107,17 @@ export interface MockedSignUpResourceState {
 }
 
 interface MockedSignUpConfiguration {
+  readonly attributes?: Partial<
+    Record<
+      Attribute,
+      Pick<AttributeData, "enabled" | "required" | "used_for_first_factor">
+    >
+  >;
   readonly captchaEnabled?: boolean;
   readonly captchaWidgetType?: "invisible" | "smart" | null;
+  readonly legalConsentEnabled?: boolean;
   readonly privacyPolicyUrl?: string;
+  readonly progressive?: boolean;
   readonly termsUrl?: string;
 }
 
@@ -168,16 +181,50 @@ let internalMockedSignUpResourceState: Required<MockedSignUpResourceState> = {
   isTransferable: false,
   lastName: null,
   legalAcceptedAt: null,
-  missingFields: ["email_address", "password"],
-  optionalFields: ["first_name", "last_name"],
-  requiredFields: ["email_address", "password"],
+  missingFields: [],
+  optionalFields: [],
+  requiredFields: [],
   status: null,
   unverifiedFields: [],
 };
 let internalMockedSignUpConfiguration: Required<MockedSignUpConfiguration> = {
+  attributes: {
+    email_address: {
+      enabled: true,
+      required: true,
+      used_for_first_factor: true,
+    },
+    first_name: {
+      enabled: true,
+      required: false,
+      used_for_first_factor: false,
+    },
+    last_name: {
+      enabled: true,
+      required: false,
+      used_for_first_factor: false,
+    },
+    password: {
+      enabled: true,
+      required: true,
+      used_for_first_factor: true,
+    },
+    phone_number: {
+      enabled: false,
+      required: false,
+      used_for_first_factor: false,
+    },
+    username: {
+      enabled: false,
+      required: false,
+      used_for_first_factor: false,
+    },
+  },
   captchaEnabled: false,
   captchaWidgetType: null,
+  legalConsentEnabled: false,
   privacyPolicyUrl: "https://vm0.ai/privacy",
+  progressive: true,
   termsUrl: "https://vm0.ai/terms",
 };
 let internalMockedPasswordValidation: PasswordValidation = {
@@ -209,11 +256,13 @@ export function mockSignUpResource(state: MockedSignUpResourceState): void {
     isTransferable: state.isTransferable ?? false,
     lastName: state.lastName ?? null,
     legalAcceptedAt: state.legalAcceptedAt ?? null,
-    missingFields:
-      state.missingFields ??
-      (state.status === null ? ["email_address", "password"] : []),
-    optionalFields: state.optionalFields ?? ["first_name", "last_name"],
-    requiredFields: state.requiredFields ?? ["email_address", "password"],
+    missingFields: state.missingFields ?? [],
+    optionalFields:
+      state.optionalFields ??
+      (state.status === null ? [] : ["first_name", "last_name"]),
+    requiredFields:
+      state.requiredFields ??
+      (state.status === null ? [] : ["email_address", "password"]),
     status: state.status,
     unverifiedFields: state.unverifiedFields ?? [],
   };
@@ -222,13 +271,55 @@ export function mockSignUpResource(state: MockedSignUpResourceState): void {
 export function mockSignUpConfiguration(
   configuration: MockedSignUpConfiguration,
 ): void {
+  const attributes = configuration.attributes;
   internalMockedSignUpConfiguration = {
+    attributes: {
+      ...attributes,
+      email_address: {
+        enabled: true,
+        required: true,
+        used_for_first_factor: true,
+        ...attributes?.email_address,
+      },
+      first_name: {
+        enabled: true,
+        required: false,
+        used_for_first_factor: false,
+        ...attributes?.first_name,
+      },
+      last_name: {
+        enabled: true,
+        required: false,
+        used_for_first_factor: false,
+        ...attributes?.last_name,
+      },
+      password: {
+        enabled: true,
+        required: true,
+        used_for_first_factor: true,
+        ...attributes?.password,
+      },
+      phone_number: {
+        enabled: false,
+        required: false,
+        used_for_first_factor: false,
+        ...attributes?.phone_number,
+      },
+      username: {
+        enabled: false,
+        required: false,
+        used_for_first_factor: false,
+        ...attributes?.username,
+      },
+    },
     captchaEnabled: configuration.captchaEnabled ?? false,
     captchaWidgetType:
       configuration.captchaWidgetType ??
       (configuration.captchaEnabled ? "smart" : null),
+    legalConsentEnabled: configuration.legalConsentEnabled ?? false,
     privacyPolicyUrl:
       configuration.privacyPolicyUrl ?? "https://vm0.ai/privacy",
+    progressive: configuration.progressive ?? true,
     termsUrl: configuration.termsUrl ?? "https://vm0.ai/terms",
   };
 }
@@ -1018,8 +1109,10 @@ export const mockedClerk = {
       },
       userSettings: {
         attributes: {
+          ...internalMockedSignUpConfiguration.attributes,
           passkey: {
             enabled: internalMockedAuthV2Capabilities.passkey,
+            required: false,
             used_for_first_factor: internalMockedAuthV2Capabilities.passkey,
           },
         },
@@ -1027,6 +1120,11 @@ export const mockedClerk = {
           internalMockedAuthV2Capabilities.googleOAuth ? ["oauth_google"] : [],
         passkeySettings: {
           show_sign_in_button: internalMockedAuthV2Capabilities.passkey,
+        },
+        signUp: {
+          legal_consent_enabled:
+            internalMockedSignUpConfiguration.legalConsentEnabled,
+          progressive: internalMockedSignUpConfiguration.progressive,
         },
       },
     };

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -1,4 +1,7 @@
 import type {
+  Attribute,
+  AttributeData,
+  Attributes,
   PasswordValidation,
   SignUpCreateParams,
   SignUpField,
@@ -32,12 +35,16 @@ export const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS = 30;
 const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS =
   AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS * 1000;
 
-const SUPPORTED_SIGN_UP_FIELDS = [
+const SUPPORTED_SIGN_UP_ATTRIBUTES = [
   "email_address",
   "first_name",
   "last_name",
-  "legal_accepted",
   "password",
+] as const satisfies readonly Attribute[];
+
+const SUPPORTED_SIGN_UP_FIELDS = [
+  ...SUPPORTED_SIGN_UP_ATTRIBUTES,
+  "legal_accepted",
 ] as const satisfies readonly SignUpField[];
 
 type SupportedSignUpField = (typeof SUPPORTED_SIGN_UP_FIELDS)[number];
@@ -152,8 +159,11 @@ export interface AuthV2SignUpSignals {
 }
 
 interface SignUpConfiguration {
+  readonly attributes: Attributes;
   readonly captchaEnabled: boolean;
+  readonly legalConsentEnabled: boolean;
   readonly privacyPolicyUrl: string | null;
+  readonly progressive: boolean;
   readonly termsUrl: string | null;
 }
 
@@ -172,7 +182,7 @@ interface SignUpResourceSnapshot {
   readonly legal: AuthV2SignUpLegalConfig;
   readonly missingFields: readonly SignUpField[];
   readonly transferable: boolean;
-  readonly unsupportedFields: readonly SignUpField[];
+  readonly unsupportedFields: readonly string[];
   readonly unverifiedEmailAddress: boolean;
   readonly verification: SignUpVerificationSnapshot;
 }
@@ -235,7 +245,169 @@ function fieldRequirement(
   return optionalFields.has(field) ? "optional" : "hidden";
 }
 
-function signUpFields(resource: SignUpResource): AuthV2SignUpFields {
+interface ConfiguredIdentifierRequirements {
+  readonly emailAddress: boolean;
+  readonly phoneNumber: boolean;
+  readonly username: boolean;
+}
+
+interface ConfiguredIdentifierAttribute {
+  readonly enabled: boolean;
+  readonly firstFactor: boolean;
+  readonly required: boolean;
+}
+
+function configuredEmailIdentifierRequired(
+  email: ConfiguredIdentifierAttribute,
+  phone: ConfiguredIdentifierAttribute,
+  username: ConfiguredIdentifierAttribute,
+): boolean {
+  return (
+    (email.enabled && !phone.enabled && !username.enabled) ||
+    (email.enabled && !email.required && phone.enabled && !phone.required) ||
+    (username.firstFactor &&
+      !username.required &&
+      email.enabled &&
+      !email.required) ||
+    (username.required &&
+      !username.firstFactor &&
+      email.enabled &&
+      phone.enabled)
+  );
+}
+
+function configuredPhoneIdentifierRequired(
+  email: ConfiguredIdentifierAttribute,
+  phone: ConfiguredIdentifierAttribute,
+  username: ConfiguredIdentifierAttribute,
+): boolean {
+  return (
+    (phone.enabled && !email.required && !phone.required) ||
+    (username.firstFactor &&
+      !username.required &&
+      phone.enabled &&
+      !phone.required) ||
+    (phone.firstFactor && !email.firstFactor && !username.firstFactor) ||
+    (username.required &&
+      !username.firstFactor &&
+      phone.enabled &&
+      email.enabled) ||
+    (!email.enabled && phone.enabled && username.enabled)
+  );
+}
+
+function configuredUsernameIdentifierRequired(
+  email: ConfiguredIdentifierAttribute,
+  phone: ConfiguredIdentifierAttribute,
+  username: ConfiguredIdentifierAttribute,
+): boolean {
+  return (
+    (username.enabled &&
+      username.firstFactor &&
+      !email.enabled &&
+      !phone.enabled) ||
+    (username.required &&
+      !username.firstFactor &&
+      email.enabled &&
+      phone.enabled)
+  );
+}
+
+function configuredIdentifierRequirements(
+  attributes: Attributes,
+): ConfiguredIdentifierRequirements {
+  const email = {
+    enabled: attributes.email_address.enabled,
+    firstFactor: attributes.email_address.used_for_first_factor,
+    required: attributes.email_address.required,
+  };
+  const phone = {
+    enabled: attributes.phone_number.enabled,
+    firstFactor: attributes.phone_number.used_for_first_factor,
+    required: attributes.phone_number.required,
+  };
+  const username = {
+    enabled: attributes.username.enabled,
+    firstFactor: attributes.username.used_for_first_factor,
+    required: attributes.username.required,
+  };
+  const passwordRequired =
+    attributes.password.enabled && attributes.password.required;
+
+  if (
+    !passwordRequired ||
+    email.required ||
+    phone.required ||
+    (username.required && username.firstFactor)
+  ) {
+    return {
+      emailAddress: email.required,
+      phoneNumber: phone.required,
+      username: username.required,
+    };
+  }
+  if (!email.enabled && !phone.enabled && !username.enabled) {
+    return { emailAddress: false, phoneNumber: false, username: false };
+  }
+
+  const emailAddress = configuredEmailIdentifierRequired(
+    email,
+    phone,
+    username,
+  );
+  const phoneNumber = configuredPhoneIdentifierRequired(email, phone, username);
+  const usernameRequired = configuredUsernameIdentifierRequired(
+    email,
+    phone,
+    username,
+  );
+
+  if (!emailAddress && !phoneNumber && !usernameRequired) {
+    return { emailAddress: true, phoneNumber: false, username: false };
+  }
+  return {
+    emailAddress,
+    phoneNumber,
+    username: usernameRequired,
+  };
+}
+
+function configuredAttributeRequirement(
+  attribute: AttributeData,
+): FieldRequirement {
+  if (!attribute.enabled) {
+    return "hidden";
+  }
+  return attribute.required ? "required" : "optional";
+}
+
+function configuredSignUpFields(
+  configuration: SignUpConfiguration,
+): AuthV2SignUpFields {
+  const { attributes } = configuration;
+  const identifierRequirements = configuredIdentifierRequirements(attributes);
+  const emailEnabled =
+    attributes.email_address.enabled &&
+    (configuration.progressive ||
+      attributes.email_address.used_for_first_factor);
+  return {
+    emailAddress: emailEnabled
+      ? configuration.progressive
+        ? identifierRequirements.emailAddress
+          ? "required"
+          : "optional"
+        : "required"
+      : "hidden",
+    firstName: configuredAttributeRequirement(attributes.first_name),
+    lastName: configuredAttributeRequirement(attributes.last_name),
+    password:
+      attributes.password.enabled && attributes.password.required
+        ? "required"
+        : "hidden",
+  };
+}
+
+function resourceSignUpFields(resource: SignUpResource): AuthV2SignUpFields {
   const requiredFields = new Set(resource.requiredFields);
   const optionalFields = new Set(resource.optionalFields);
   return {
@@ -252,9 +424,48 @@ function signUpFields(resource: SignUpResource): AuthV2SignUpFields {
   };
 }
 
+function usesConfiguredInitialRequirements(resource: SignUpResource): boolean {
+  return (
+    resource.status === null &&
+    resource.requiredFields.length === 0 &&
+    resource.optionalFields.length === 0 &&
+    resource.missingFields.length === 0
+  );
+}
+
+function signUpFields(
+  resource: SignUpResource,
+  configuration: SignUpConfiguration,
+): AuthV2SignUpFields {
+  return usesConfiguredInitialRequirements(resource)
+    ? configuredSignUpFields(configuration)
+    : resourceSignUpFields(resource);
+}
+
+function unsupportedConfiguredSignUpFields(
+  configuration: SignUpConfiguration,
+): readonly string[] {
+  const supportedAttributes = new Set<string>(SUPPORTED_SIGN_UP_ATTRIBUTES);
+  return Object.entries(configuration.attributes)
+    .filter(([attributeName, attribute]) => {
+      return (
+        attribute.enabled &&
+        attribute.required &&
+        !supportedAttributes.has(attributeName)
+      );
+    })
+    .map(([attributeName]) => {
+      return attributeName;
+    });
+}
+
 function unsupportedSignUpFields(
   resource: SignUpResource,
-): readonly SignUpField[] {
+  configuration: SignUpConfiguration,
+): readonly string[] {
+  if (usesConfiguredInitialRequirements(resource)) {
+    return unsupportedConfiguredSignUpFields(configuration);
+  }
   const supportedFields = new Set<SignUpField>(SUPPORTED_SIGN_UP_FIELDS);
   return [...resource.requiredFields, ...resource.missingFields].filter(
     (field, index, fields) => {
@@ -268,15 +479,18 @@ function snapshotSignUpResource(
   configuration: SignUpConfiguration,
 ): SignUpResourceSnapshot {
   const verification = resource.verifications.emailAddress;
-  const legalRequired =
-    resource.requiredFields.includes("legal_accepted") &&
-    resource.missingFields.includes("legal_accepted");
+  const configuredInitialRequirements =
+    usesConfiguredInitialRequirements(resource);
+  const legalRequired = configuredInitialRequirements
+    ? configuration.legalConsentEnabled
+    : resource.requiredFields.includes("legal_accepted") &&
+      resource.missingFields.includes("legal_accepted");
   return {
     captchaEnabled: configuration.captchaEnabled,
     clerkStatus: resource.status,
     createdSessionId: resource.createdSessionId,
     emailAddress: resource.emailAddress,
-    fields: signUpFields(resource),
+    fields: signUpFields(resource, configuration),
     legal: {
       privacyPolicyUrl: configuration.privacyPolicyUrl,
       required: legalRequired,
@@ -284,7 +498,7 @@ function snapshotSignUpResource(
     },
     missingFields: [...resource.missingFields],
     transferable: resource.__internal_future.isTransferable,
-    unsupportedFields: unsupportedSignUpFields(resource),
+    unsupportedFields: unsupportedSignUpFields(resource, configuration),
     unverifiedEmailAddress: resource.unverifiedFields.includes("email_address"),
     verification: {
       expireAtMs: verification.expireAt?.getTime() ?? null,
@@ -579,18 +793,22 @@ export const clerkSignUpResource$ = computed(async (get) => {
 
 const clerkSignUpConfiguration$ = computed(async (get) => {
   const clerk = await get(clerk$);
-  const displayConfig = clerk.__internal_environment?.displayConfig;
-  if (!displayConfig) {
+  const environment = clerk.__internal_environment;
+  if (!environment) {
     throw new Error(
-      "Loaded Clerk instance did not provide display configuration",
+      "Loaded Clerk instance did not provide environment configuration",
     );
   }
+  const { displayConfig, userSettings } = environment;
   return {
+    attributes: userSettings.attributes,
     captchaEnabled:
       displayConfig.captchaWidgetType !== null &&
       (displayConfig.captchaPublicKey !== null ||
         displayConfig.captchaPublicKeyInvisible !== null),
+    legalConsentEnabled: userSettings.signUp.legal_consent_enabled,
     privacyPolicyUrl: displayConfig.privacyPolicyUrl || null,
+    progressive: userSettings.signUp.progressive,
     termsUrl: displayConfig.termsUrl || null,
   } satisfies SignUpConfiguration;
 });

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -140,6 +140,144 @@ describe("auth v2 sign-up flow", () => {
     ).resolves.toBeVisible();
   });
 
+  it("renders pristine Clerk environment requirements without mutating the sign-up resource", async () => {
+    mockSignUpConfiguration({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+        first_name: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: false,
+        },
+        last_name: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: false,
+        },
+        password: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+      },
+      captchaEnabled: true,
+      legalConsentEnabled: true,
+      privacyPolicyUrl: "https://vm0.ai/legal/privacy",
+      progressive: true,
+      termsUrl: "https://vm0.ai/legal/terms",
+    });
+    setupSignUpPage({
+      missingFields: [],
+      optionalFields: [],
+      requiredFields: [],
+      status: null,
+    });
+
+    const emailInput = await screen.findByLabelText("Email address");
+    const passwordInput = screen.getByLabelText("Password");
+    const firstNameInput = screen.getByLabelText(/First name/);
+    const lastNameInput = screen.getByLabelText(/Last name/);
+    expect(emailInput).toBeRequired();
+    expect(passwordInput).toBeRequired();
+    expect(firstNameInput).not.toBeRequired();
+    expect(lastNameInput).not.toBeRequired();
+    expect(screen.getByRole("checkbox")).toBeVisible();
+    expect(roleElement("link", "Terms of Service")).toHaveAttribute(
+      "href",
+      "https://vm0.ai/legal/terms",
+    );
+    expect(roleElement("link", "Privacy Policy")).toHaveAttribute(
+      "href",
+      "https://vm0.ai/legal/privacy",
+    );
+    expect(document.querySelector("#clerk-captcha")).toBeInTheDocument();
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
+    expect(mockedClerk.signUpUpdate).not.toHaveBeenCalled();
+    expect(
+      mockedClerk.signUpPrepareEmailAddressVerification,
+    ).not.toHaveBeenCalled();
+    expect(
+      mockedClerk.signUpAttemptEmailAddressVerification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("keeps restored resource requirements ahead of current environment settings", async () => {
+    mockSignUpConfiguration({
+      attributes: {
+        first_name: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        last_name: {
+          enabled: false,
+          required: false,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+      },
+      legalConsentEnabled: true,
+    });
+    setupSignUpPage(
+      readyEmailVerificationState({
+        optionalFields: ["first_name", "last_name"],
+        requiredFields: ["email_address", "password"],
+      }),
+    );
+
+    await expect(
+      screen.findByLabelText("Verification code"),
+    ).resolves.toBeVisible();
+    expect(screen.queryByText("Access restricted")).not.toBeInTheDocument();
+    expect(
+      mockedClerk.signUpPrepareEmailAddressVerification,
+    ).not.toHaveBeenCalled();
+
+    fireEvent.click(await waitForRoleElement("button", "Edit email address"));
+    await expect(
+      screen.findByLabelText("Email address"),
+    ).resolves.toBeRequired();
+    expect(screen.getByLabelText(/First name/)).not.toBeRequired();
+    expect(screen.getByLabelText(/Last name/)).not.toBeRequired();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("fails closed for a required unsupported pristine attribute", async () => {
+    mockSignUpConfiguration({
+      attributes: {
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+      },
+    });
+    setupSignUpPage({
+      missingFields: [],
+      optionalFields: [],
+      requiredFields: [],
+      status: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Access restricted" }),
+    ).resolves.toBeVisible();
+    expect(screen.queryByLabelText("Email address")).not.toBeInTheDocument();
+    expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
+    expect(mockedClerk.signUpUpdate).not.toHaveBeenCalled();
+    expect(
+      mockedClerk.signUpPrepareEmailAddressVerification,
+    ).not.toHaveBeenCalled();
+  });
+
   it("hides Google when the current Clerk environment does not support it", async () => {
     setupSignUpPage({ status: null });
 


### PR DESCRIPTION
## Summary

- derive pristine Auth v2 sign-up fields from Clerk environment attributes when the SignUpResource arrays are empty
- derive initial legal consent from Clerk sign-up settings while preserving configured Terms, Privacy, and CAPTCHA behavior
- keep resource-owned requirements authoritative after sign-up begins and fail closed for newly required unsupported attributes
- make the auth mock reflect Clerk's real pristine resource state and add focused regression coverage

Part of #28927.

## Testing

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx` (25/25)
