### PR TITLE
fix(auth): associate sign-in field errors with alerts

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-error-alert.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-error-alert.tsx
@@ -2,15 +2,18 @@ import { Alert, AlertDescription } from "@okouai/ui/components/ui/alert";
 
 export function AuthV2ErrorAlert({
   focusKey,
+  id,
   message,
 }: {
   readonly focusKey: string;
+  readonly id?: string;
   readonly message: string;
 }) {
   return (
     <Alert
       aria-atomic="true"
       className="outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      id={id}
       ref={(element) => {
         if (!element || element.dataset.authV2ErrorFocusKey === focusKey) {
           return;

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-password-input.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-password-input.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../signals/auth-v2-presentation.ts";
 
 interface AuthV2PasswordInputProps {
+  readonly ariaDescribedBy?: string;
   readonly ariaInvalid?: boolean;
   readonly autoComplete: string;
   readonly hidePasswordLabel: string;
@@ -21,6 +22,7 @@ interface AuthV2PasswordInputProps {
 }
 
 export function AuthV2PasswordInput({
+  ariaDescribedBy,
   ariaInvalid,
   autoComplete,
   hidePasswordLabel,
@@ -39,6 +41,7 @@ export function AuthV2PasswordInput({
   return (
     <div className="relative">
       <Input
+        aria-describedby={ariaDescribedBy}
         aria-invalid={ariaInvalid}
         autoComplete={autoComplete}
         className="pr-10"

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -129,6 +129,25 @@ async function waitForRoleElement(
   return element;
 }
 
+function expectFieldErrorAssociation(
+  input: HTMLElement,
+  alert: HTMLElement,
+): void {
+  const description = alert.textContent;
+  if (!description) {
+    throw new Error("Expected the field error alert to have text");
+  }
+  expect(alert.id).not.toBe("");
+  expect(input).toHaveAttribute("aria-invalid", "true");
+  expect(input).toHaveAttribute("aria-describedby", alert.id);
+  expect(input).toHaveAccessibleDescription(description);
+}
+
+function expectNoFieldErrorAssociation(input: HTMLElement): void {
+  expect(input).not.toHaveAttribute("aria-invalid");
+  expect(input).not.toHaveAttribute("aria-describedby");
+}
+
 function createStalledGoogleOneTapScript(): HTMLScriptElement {
   const script = document.createElement("script");
   script.dataset.authV2GoogleOneTap = "true";
@@ -247,6 +266,65 @@ describe("auth v2 sign-in flow", () => {
       navigate: expect.any(Function),
       session: "session_password",
     });
+  });
+
+  it("associates only typed password errors and clears them on change", async () => {
+    setupSignInPage({ status: "needs_identifier" });
+    await submitIdentifier("person@example.com", [passwordFactor()]);
+    fireEvent.click(
+      await waitForRoleElement("button", "Sign in with your password"),
+    );
+
+    const passwordInput = await screen.findByLabelText("Password");
+    mockedClerk.signInAttemptFirstFactor
+      .mockRejectedValueOnce({
+        errors: [
+          {
+            code: "form_identifier_invalid",
+            longMessage: "Private identifier provider detail.",
+            meta: { paramName: "identifier" },
+          },
+        ],
+      })
+      .mockRejectedValueOnce({
+        errors: [
+          {
+            code: "form_password_incorrect",
+            longMessage: "Private password provider detail.",
+            meta: { paramName: "password" },
+          },
+        ],
+      });
+
+    fireEvent.change(passwordInput, { target: { value: "first-attempt" } });
+    fireEvent.submit(containingForm(passwordInput));
+
+    const unrelatedAlert = await screen.findByRole("alert");
+    expect(document.activeElement).toBe(unrelatedAlert);
+    expectNoFieldErrorAssociation(passwordInput);
+    expect(
+      screen.queryByText("Private identifier provider detail."),
+    ).toBeNull();
+
+    fireEvent.change(passwordInput, { target: { value: "second-attempt" } });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(passwordInput).toHaveValue("second-attempt");
+    expectNoFieldErrorAssociation(passwordInput);
+
+    fireEvent.submit(containingForm(passwordInput));
+    const passwordAlert = await screen.findByRole("alert");
+    expect(document.activeElement).toBe(passwordAlert);
+    expectFieldErrorAssociation(passwordInput, passwordAlert);
+    expect(screen.queryByText("Private password provider detail.")).toBeNull();
+
+    fireEvent.change(passwordInput, { target: { value: "retry-password" } });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(passwordInput).toHaveValue("retry-password");
+    expectNoFieldErrorAssociation(passwordInput);
   });
 
   it("hands Google OAuth to Clerk once with typed callback and completion URLs", async () => {
@@ -751,9 +829,22 @@ describe("auth v2 sign-in flow", () => {
       "This verification code has expired. Request a new code.",
     );
     expect(document.activeElement).toBe(alert);
+    expectFieldErrorAssociation(codeInput, alert);
     expect(
       screen.queryByText("Sensitive provider detail must not be rendered."),
     ).toBeNull();
+
+    fireEvent.change(codeInput, { target: { value: "654321" } });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(codeInput).toHaveValue("654321");
+    expectNoFieldErrorAssociation(codeInput);
+
+    fireEvent.submit(containingForm(codeInput));
+    const retryAlert = await screen.findByRole("alert");
+    expect(document.activeElement).toBe(retryAlert);
+    expectFieldErrorAssociation(codeInput, retryAlert);
 
     const resend = await waitForRoleElement(
       "button",
@@ -766,6 +857,11 @@ describe("auth v2 sign-in flow", () => {
     await waitFor(() => {
       expect(mockedClerk.signInPrepareFirstFactor).toHaveBeenCalledTimes(2);
     });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expectNoFieldErrorAssociation(codeInput);
+    });
+    expect(codeInput).toHaveValue("");
   });
 
   it("recovers a prepared email-code step without another initial dispatch", async () => {
@@ -919,14 +1015,23 @@ describe("auth v2 sign-in flow", () => {
     });
     fireEvent.submit(containingForm(newPasswordInput));
 
-    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
-      "Passwords don't match.",
-    );
+    const mismatchAlert = await screen.findByRole("alert");
+    expect(mismatchAlert).toHaveTextContent("Passwords don't match.");
+    expect(document.activeElement).toBe(mismatchAlert);
+    expectFieldErrorAssociation(newPasswordInput, mismatchAlert);
+    expectFieldErrorAssociation(confirmPasswordInput, mismatchAlert);
     expect(mockedClerk.signInResetPassword).not.toHaveBeenCalled();
 
     fireEvent.change(confirmPasswordInput, {
       target: { value: "new-password" },
     });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(newPasswordInput).toHaveValue("new-password");
+    expect(confirmPasswordInput).toHaveValue("new-password");
+    expectNoFieldErrorAssociation(newPasswordInput);
+    expectNoFieldErrorAssociation(confirmPasswordInput);
     mockedClerk.signInResetPassword.mockResolvedValue(
       moveSignInTo({
         createdSessionId: "session_reset",
@@ -944,7 +1049,7 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it("keeps an incomplete step usable after a Clerk API error", async () => {
-    mockedClerk.clientSignInCreate.mockRejectedValue({
+    mockedClerk.clientSignInCreate.mockRejectedValueOnce({
       errors: [
         {
           longMessage: "We couldn't find an account with that identifier.",
@@ -963,13 +1068,41 @@ describe("auth v2 sign-in flow", () => {
     });
     fireEvent.submit(containingForm(identifierInput));
 
-    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
       "This action couldn't be completed. Please try again later or contact support if this persists.",
     );
+    expect(document.activeElement).toBe(alert);
+    expectFieldErrorAssociation(identifierInput, alert);
+    expect(
+      Array.from(document.querySelectorAll("[id]")).filter((element) => {
+        return element.id === alert.id;
+      }),
+    ).toHaveLength(1);
     expect(
       screen.queryByText("We couldn't find an account with that identifier."),
     ).toBeNull();
     expect(identifierInput).toBeVisible();
+    expect(identifierInput).toHaveValue("missing@example.com");
+
+    fireEvent.change(identifierInput, {
+      target: { value: "retry@example.com" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(identifierInput).toHaveValue("retry@example.com");
+    expectNoFieldErrorAssociation(identifierInput);
+
+    const nextResource = moveSignInTo({
+      status: "needs_first_factor",
+      supportedFirstFactors: [passwordFactor()],
+    });
+    mockedClerk.clientSignInCreate.mockResolvedValueOnce(nextResource);
+    fireEvent.submit(containingForm(identifierInput));
+    await expect(
+      waitForRoleElement("button", "Sign in with your password"),
+    ).resolves.toBeVisible();
   });
 
   it("substitutes the Okou brand and support address in safe errors", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -30,9 +30,12 @@ interface SignInStepProps {
   readonly signals: AuthV2SignInSignals;
 }
 
+const AUTH_V2_SIGN_IN_ERROR_ID = "auth-v2-sign-in-error";
+
 function TextField({
   autoComplete,
   inputMode,
+  invalid,
   label,
   name,
   onChange,
@@ -41,6 +44,7 @@ function TextField({
 }: {
   readonly autoComplete: string;
   readonly inputMode?: "email" | "numeric";
+  readonly invalid: boolean;
   readonly label: string;
   readonly name: string;
   readonly onChange: (value: string) => void;
@@ -54,6 +58,8 @@ function TextField({
         {label}
       </label>
       <Input
+        aria-describedby={invalid ? AUTH_V2_SIGN_IN_ERROR_ID : undefined}
+        aria-invalid={invalid ? true : undefined}
         id={id}
         name={name}
         autoComplete={autoComplete}
@@ -77,6 +83,7 @@ function FlowErrorAlert({ copy, signals }: SignInStepProps) {
   return (
     <AuthV2ErrorAlert
       focusKey={`${error.code}:${error.field}:${error.clerkCode ?? ""}`}
+      id={AUTH_V2_SIGN_IN_ERROR_ID}
       message={signInErrorMessage(error, copy)}
     />
   );
@@ -106,7 +113,8 @@ function PasswordField({
         {label}
       </label>
       <AuthV2PasswordInput
-        ariaInvalid={invalid}
+        ariaDescribedBy={invalid ? AUTH_V2_SIGN_IN_ERROR_ID : undefined}
+        ariaInvalid={invalid ? true : undefined}
         autoComplete={autoComplete}
         hidePasswordLabel={copy.hidePassword}
         id={id}
@@ -143,6 +151,7 @@ function IdentifierStep({
   state,
 }: SignInStepProps & { readonly state: IncompleteSignInState }) {
   const identifier = useGet(signals.identifier$);
+  const error = useGet(signals.error$);
   const pageSignal = useGet(pageSignal$);
   const setIdentifier = useSet(signals.setIdentifier$);
   const [submitLoadable, submit] = useLoadableSet(signals.submit$);
@@ -189,6 +198,7 @@ function IdentifierStep({
       <TextField
         autoComplete="username"
         inputMode="email"
+        invalid={error?.field === "identifier"}
         label={copy.identifierLabel}
         name="identifier"
         onChange={setIdentifier}
@@ -439,6 +449,7 @@ function CodeStep({
       <TextField
         autoComplete="one-time-code"
         inputMode="numeric"
+        invalid={error?.field === "code"}
         label={copy.codeLabel}
         name="code"
         onChange={setCode}


### PR DESCRIPTION
## Summary

- give the visible Auth v2 sign-in error alert one stable association target
- expose `aria-invalid="true"` and `aria-describedby` only on the field selected by the typed sign-in error mapping, including identifier, both verification-code flows, password, and the new-password pair
- remove both ARIA attributes after a genuine field value change through the existing error-clearing commands while preserving the edited values
- preserve the existing alert-focus contract and privacy-safe mapped copy

## Issue context

Part of #28927. This closes the focused sign-in field-error semantics gap without changing production routing, v1 auth, sign-up initialization, auth switching/navigation, locales, Google/FedCM, or the #29194 E2E files.

No focus, blur, or same-value clearing behavior was added. A same-value browser fill can remain a no-op; the focused regression coverage changes the value before asserting recovery.

## Verification

- branch rebased onto `origin/main` at `c27e3fa6ca856a65ef8d4b195f7da91dbf86942a`
- `pnpm format` — passed
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks passed
- `pnpm knip` — passed (configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — 12/12 tasks passed
- `pnpm --filter @okouai/app run check-types` — passed production and test projects
- `pnpm --filter api run check-types` — passed all bounded API projects
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` — 1 file passed, 26/26 tests passed on head `d932e9929bff7fc9f3fff55e64e128fa83b56467`

### Exact-head preview accessibility smoke

- target: `https://pr-29247-app.omby.ai/v2/sign-in`
- deployed revision: pull-request merge revision `7de20d7694b6d3446cb2c2e9de83403e6b8d6f81`, whose second parent is exact PR head `d932e9929bff7fc9f3fff55e64e128fa83b56467`
- environment: Chromium 151, Linux headless, 1440×1000; no feature switches or onboarding bypass; fresh development-Clerk `+clerk_test` identity
- keyboard path: identifier and factor choices submitted with keyboard focus/Enter; errors inspected through the rendered DOM
- identifier, normal email code, reset-password code, password, and new-password/confirmation errors each rendered one privacy-safe `role="alert"` with ID `auth-v2-sign-in-error`; that alert received focus and only the typed applicable field(s) exposed `aria-invalid="true"` plus `aria-describedby="auth-v2-sign-in-error"`
- duplicate-ID count was exactly 1 in every error state
- genuine different values removed the visible alert and both ARIA attributes for identifier, both code paths, password, and the new-password pair while retaining the edited values
- password classification: after a live server error, changing from the rejected password to a genuinely different valid value cleared the alert/ARIA state immediately; restoring the correct password and submitting signed in successfully. Product clearing is working, so the same-value #29194 checkpoint remains an E2E fixture/assertion issue.

Evidence: [identifier error](https://cdn.vm0.io/artifacts/t7xsclil3r.png), [identifier recovered](https://cdn.vm0.io/artifacts/46jrhu2hxm.png), [password error](https://cdn.vm0.io/artifacts/tqskenh591.png), [password recovered](https://cdn.vm0.io/artifacts/txb0n87yz6.png), [normal code error](https://cdn.vm0.io/artifacts/4txusgshsq.png), [reset code error](https://cdn.vm0.io/artifacts/boxmksnjj4.png), [new-password mismatch](https://cdn.vm0.io/artifacts/vfmndut4wv.png), [new-password recovered](https://cdn.vm0.io/artifacts/u1zrkjt5b8.png).

The preview gateway produced unrelated authenticated-shell API/Ably fetch warnings after successful sign-in; they did not affect the Auth v2 flows or DOM assertions above.
