### PR TITLE
test(runner): cover concrete active jobs service gate

### DIFF
--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -6,19 +6,22 @@ use crate::paths::HomePaths;
 use crate::status_file::{self, StatusFileReadError, StatusForGate};
 use tracing::{info, warn};
 
+use super::ServiceFuture;
 use super::diagnostic::status_field_preview;
-use super::systemctl::is_unit_active;
 use super::target::RunnerServiceUnit;
 
-/// Resolve the runner's base_dir from its service name suffix using the
-/// project-wide convention: `/var/lib/vm0-runner/runners/<suffix>/`.
+pub(super) trait ActiveJobsGateOps {
+    fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+}
+
+/// Resolve the runner's base_dir from its service name suffix and the caller's
+/// runner home using the project-wide `runners/<suffix>/` convention.
 ///
 /// This matches `ansible/playbooks/build-runner.yml` and the `--runner-dirname`
-/// default in `runner config`. Non-standard `base_dir` overrides (dev-only)
-/// will fail to locate status.json and fall through to forceful stop.
-pub(super) fn runner_base_dir(unit: &RunnerServiceUnit) -> Option<PathBuf> {
-    let home = HomePaths::new().ok()?;
-    Some(home.runners_dir().join(unit.suffix()))
+/// default in `runner config`. In production the home is
+/// `/var/lib/vm0-runner`; tests can supply an isolated home root.
+fn runner_base_dir(home: &HomePaths, unit: &RunnerServiceUnit) -> PathBuf {
+    home.runners_dir().join(unit.suffix())
 }
 
 /// Parsed snapshot of the runner's status.json.
@@ -167,10 +170,7 @@ pub(super) async fn read_runner_status(
 ///    `run_with_config`) and systemd noticing the process has exited
 ///    (marking the unit inactive). Without this, the gate could spuriously
 ///    refuse a stop issued during that window.
-/// 3. **Base-dir unresolvable** — non-standard deployments that override
-///    `base_dir` away from the `/var/lib/vm0-runner/runners/<suffix>`
-///    convention fall here. Warn-log and fall through.
-/// 4. **Status file unreadable / malformed** — missing file, permission
+/// 3. **Status file unreadable / malformed** — missing file, permission
 ///    denied, JSON parse error, bad `started_at`: warn-log and fall
 ///    through. Matches the acceptance criteria.
 ///
@@ -189,8 +189,10 @@ pub(super) async fn read_runner_status(
 /// SIGUSR1 first and waiting — which is exactly what `drain` does.
 pub(super) async fn check_active_jobs_gate(
     unit: &RunnerServiceUnit,
+    home: &HomePaths,
     force: bool,
     command_name: &'static str,
+    ops: &mut impl ActiveJobsGateOps,
 ) -> RunnerResult<()> {
     if force {
         // Leave an audit trail — --force is valid but destructive, so
@@ -204,7 +206,7 @@ pub(super) async fn check_active_jobs_gate(
     }
 
     // (1) Dead-runner short-circuit.
-    let active = is_unit_active(unit).await.unwrap_or_else(|e| {
+    let active = ops.is_unit_active(unit).await.unwrap_or_else(|e| {
         warn!(unit = %unit.unit_name(), error = %e, "cannot check unit state — skipping active-jobs gate");
         false
     });
@@ -212,13 +214,7 @@ pub(super) async fn check_active_jobs_gate(
         return Ok(());
     }
 
-    let Some(base_dir) = runner_base_dir(unit) else {
-        warn!(
-            unit = %unit.unit_name(),
-            "cannot determine vm0-runner home — skipping active-jobs gate"
-        );
-        return Ok(());
-    };
+    let base_dir = runner_base_dir(home, unit);
     let status = match read_runner_status(&base_dir).await {
         Ok(status) => status,
         Err(e) => {
@@ -247,7 +243,45 @@ pub(super) async fn check_active_jobs_gate(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::*;
+
+    struct FakeGateOps {
+        active_results: VecDeque<RunnerResult<bool>>,
+        active_queries: usize,
+    }
+
+    impl FakeGateOps {
+        fn from_results(results: impl IntoIterator<Item = RunnerResult<bool>>) -> Self {
+            Self {
+                active_results: results.into_iter().collect(),
+                active_queries: 0,
+            }
+        }
+    }
+
+    impl ActiveJobsGateOps for FakeGateOps {
+        fn is_unit_active<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, bool> {
+            self.active_queries += 1;
+            let result = self
+                .active_results
+                .pop_front()
+                .expect("unexpected unit-active query");
+            Box::pin(std::future::ready(result))
+        }
+    }
+
+    fn service_unit() -> RunnerServiceUnit {
+        RunnerServiceUnit::from_suffix("test").unwrap()
+    }
+
+    fn fake_home(dir: &tempfile::TempDir) -> HomePaths {
+        HomePaths::with_root(dir.path().join("vm0-runner"))
+    }
 
     // -----------------------------------------------------------------
     // status.json reader
@@ -542,5 +576,67 @@ mod tests {
             decide_gate(&snapshot("paused", 1)),
             GateDecision::Refuse { draining: false }
         );
+    }
+
+    // -----------------------------------------------------------------
+    // concrete gate orchestration
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_force_skips_unit_and_status_queries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ops = FakeGateOps::from_results([]);
+
+        check_active_jobs_gate(&service_unit(), &fake_home(&dir), true, "stop", &mut ops)
+            .await
+            .unwrap();
+
+        assert_eq!(ops.active_queries, 0);
+    }
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_bypasses_unavailable_unit_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = fake_home(&dir);
+        let unit = service_unit();
+
+        for result in [
+            Ok(false),
+            Err(RunnerError::Internal("systemd unavailable".to_string())),
+        ] {
+            let mut ops = FakeGateOps::from_results([result]);
+
+            check_active_jobs_gate(&unit, &home, false, "stop", &mut ops)
+                .await
+                .unwrap();
+
+            assert_eq!(ops.active_queries, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_bypasses_missing_and_malformed_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = fake_home(&dir);
+        let unit = service_unit();
+
+        let mut missing_ops = FakeGateOps::from_results([Ok(true)]);
+        check_active_jobs_gate(&unit, &home, false, "stop", &mut missing_ops)
+            .await
+            .unwrap();
+
+        let base_dir = runner_base_dir(&home, &unit);
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+        tokio::fs::write(base_dir.join("status.json"), "not json")
+            .await
+            .unwrap();
+
+        let mut malformed_ops = FakeGateOps::from_results([Ok(true)]);
+        check_active_jobs_gate(&unit, &home, false, "stop", &mut malformed_ops)
+            .await
+            .unwrap();
+
+        assert_eq!(missing_ops.active_queries, 1);
+        assert_eq!(malformed_ops.active_queries, 1);
     }
 }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -1023,6 +1023,9 @@ profiles:
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         let started_at = (chrono::Utc::now() - chrono::Duration::minutes(18))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let parsed_started_at = chrono::DateTime::parse_from_rfc3339(&started_at)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
         tokio::fs::write(
             base_dir.join("status.json"),
             format!(
@@ -1042,9 +1045,11 @@ profiles:
             gate_active_results: VecDeque::from([Ok(true)]),
         };
 
+        let before_gate = chrono::Utc::now();
         let error = uninstall_with_ops(&unit, &home, false, &mut ops)
             .await
             .unwrap_err();
+        let after_gate = chrono::Utc::now();
 
         assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
         let RunnerError::ActiveJobs(error) = error else {
@@ -1060,8 +1065,8 @@ profiles:
                 .collect::<Vec<_>>(),
             ["0191c4e0-0000-7000-8000-000000000003"]
         );
-        assert!(error.runner_uptime >= std::time::Duration::from_secs(1080));
-        assert!(error.runner_uptime < std::time::Duration::from_secs(1085));
+        assert!(error.runner_uptime >= (before_gate - parsed_started_at).to_std().unwrap());
+        assert!(error.runner_uptime <= (after_gate - parsed_started_at).to_std().unwrap());
         assert_eq!(error.command_name, "uninstall");
         assert!(error.draining);
     }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use unit_config::read_unit_config_path;
 
 use drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use drain_override_cleanup::{DrainOverrideReloadPolicy, reconcile_drain_restart_override_removal};
-use gate::check_active_jobs_gate;
+use gate::{ActiveJobsGateOps, check_active_jobs_gate};
 use reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use systemctl::{
     SystemdUnitEnablement, journalctl_logs_status, read_unit_enablement, restore_unit_enablement,
@@ -512,12 +512,62 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
 /// `service uninstall` — stop + disable + remove unit file.
 ///
 /// Refuses when the runner has active jobs unless `--force` is passed.
+trait ServiceUninstallOps: ActiveJobsGateOps {
+    type LockGuard;
+
+    fn acquire_lock<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        home: &'a HomePaths,
+    ) -> ServiceFuture<'a, Self::LockGuard>
+    where
+        Self::LockGuard: 'a;
+
+    fn uninstall_unit<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+}
+
+struct RealServiceUninstallOps;
+
+impl ActiveJobsGateOps for RealServiceUninstallOps {
+    fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        Box::pin(async move { is_unit_active(unit).await })
+    }
+}
+
+impl ServiceUninstallOps for RealServiceUninstallOps {
+    type LockGuard = nix::fcntl::Flock<std::fs::File>;
+
+    fn acquire_lock<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        home: &'a HomePaths,
+    ) -> ServiceFuture<'a, Self::LockGuard>
+    where
+        Self::LockGuard: 'a,
+    {
+        Box::pin(async move { acquire_service_lock(unit, home).await })
+    }
+
+    fn uninstall_unit<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(async move { uninstall_service_unit(unit).await })
+    }
+}
+
 async fn uninstall(args: ServiceUninstallArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;
-    let _service_lock = acquire_service_lock(&unit, &home).await?;
-    check_active_jobs_gate(&unit, args.force, "uninstall").await?;
-    uninstall_service_unit(&unit).await
+    uninstall_with_ops(&unit, &home, args.force, &mut RealServiceUninstallOps).await
+}
+
+async fn uninstall_with_ops(
+    unit: &RunnerServiceUnit,
+    home: &HomePaths,
+    force: bool,
+    ops: &mut impl ServiceUninstallOps,
+) -> RunnerResult<()> {
+    let _service_lock = ops.acquire_lock(unit, home).await?;
+    check_active_jobs_gate(unit, home, force, "uninstall", ops).await?;
+    ops.uninstall_unit(unit).await
 }
 
 fn readiness_base_dir_from_live_instances(
@@ -666,6 +716,7 @@ async fn logs(args: ServiceLogsArgs) -> RunnerResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, SystemTime};
@@ -910,6 +961,46 @@ profiles:
         RunnerServiceUnit::from_suffix("test").unwrap()
     }
 
+    struct FakeUninstallOps {
+        events: Vec<&'static str>,
+        gate_active_results: VecDeque<RunnerResult<bool>>,
+    }
+
+    impl ActiveJobsGateOps for FakeUninstallOps {
+        fn is_unit_active<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, bool> {
+            self.events.push("gate_is_active");
+            Box::pin(std::future::ready(
+                self.gate_active_results
+                    .pop_front()
+                    .expect("unexpected gate unit-active query"),
+            ))
+        }
+    }
+
+    impl ServiceUninstallOps for FakeUninstallOps {
+        type LockGuard = ();
+
+        fn acquire_lock<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            _home: &'a HomePaths,
+        ) -> ServiceFuture<'a, Self::LockGuard>
+        where
+            Self::LockGuard: 'a,
+        {
+            self.events.push("acquire_lock");
+            Box::pin(std::future::ready(Ok(())))
+        }
+
+        fn uninstall_unit<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+            self.events.push("uninstall_unit");
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+
     fn live_runner_instance(runner_name: &str, base_dir: PathBuf) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid: 123,
@@ -921,6 +1012,58 @@ profiles:
             subcommand: "start".to_string(),
             started_at: "2026-01-01T00:00:00.000Z".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn uninstall_active_draining_jobs_refuses_before_service_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let unit = service_unit();
+        let base_dir = home.runners_dir().join(unit.suffix());
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+        let started_at = (chrono::Utc::now() - chrono::Duration::minutes(18))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        tokio::fs::write(
+            base_dir.join("status.json"),
+            format!(
+                r#"{{
+                    "mode":"draining",
+                    "active_runs":[
+                        {{"run_id":"0191c4e0-0000-7000-8000-000000000003"}}
+                    ],
+                    "started_at":"{started_at}"
+                }}"#
+            ),
+        )
+        .await
+        .unwrap();
+        let mut ops = FakeUninstallOps {
+            events: Vec::new(),
+            gate_active_results: VecDeque::from([Ok(true)]),
+        };
+
+        let error = uninstall_with_ops(&unit, &home, false, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
+        let RunnerError::ActiveJobs(error) = error else {
+            panic!("expected active-jobs refusal");
+        };
+        assert_eq!(error.unit, "vm0-runner-test");
+        assert_eq!(error.suffix, "test");
+        assert_eq!(
+            error
+                .run_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["0191c4e0-0000-7000-8000-000000000003"]
+        );
+        assert!(error.runner_uptime >= std::time::Duration::from_secs(1080));
+        assert!(error.runner_uptime < std::time::Duration::from_secs(1085));
+        assert_eq!(error.command_name, "uninstall");
+        assert!(error.draining);
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -8,7 +8,7 @@ use crate::paths::HomePaths;
 use super::drain_override_cleanup::{
     DrainOverrideReloadPolicy, reconcile_drain_restart_override_removal,
 };
-use super::gate::check_active_jobs_gate;
+use super::gate::{ActiveJobsGateOps, check_active_jobs_gate};
 use super::systemctl::{
     BoundedSystemctlOutcome, CleanupUnitActiveState, cleanup_unit_active_state_bounded,
     is_unit_active, is_unit_enabled_bounded, run_systemctl, run_systemctl_bounded,
@@ -49,7 +49,7 @@ impl CleanupPolicy {
     }
 }
 
-trait ServiceStopOps {
+trait ServiceStopOps: ActiveJobsGateOps {
     type LockGuard;
 
     fn acquire_lock<'a>(
@@ -60,12 +60,6 @@ trait ServiceStopOps {
     ) -> ServiceFuture<'a, Self::LockGuard>
     where
         Self::LockGuard: 'a;
-
-    fn check_active_jobs_gate<'a>(
-        &'a mut self,
-        unit: &'a RunnerServiceUnit,
-        force: bool,
-    ) -> ServiceFuture<'a, ()>;
 
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
     fn stop<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
@@ -162,14 +156,6 @@ impl ServiceStopOps for RealServiceStopOps {
                 acquire_service_lock(unit, home).await
             }
         })
-    }
-
-    fn check_active_jobs_gate<'a>(
-        &'a mut self,
-        unit: &'a RunnerServiceUnit,
-        force: bool,
-    ) -> ServiceFuture<'a, ()> {
-        Box::pin(async move { check_active_jobs_gate(unit, force, "stop").await })
     }
 
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
@@ -289,6 +275,12 @@ impl ServiceStopOps for RealServiceStopOps {
     }
 }
 
+impl ActiveJobsGateOps for RealServiceStopOps {
+    fn is_unit_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        Box::pin(async move { is_unit_active(unit).await })
+    }
+}
+
 async fn stop_with_ops(
     unit: &RunnerServiceUnit,
     home: &HomePaths,
@@ -303,12 +295,12 @@ async fn stop_with_ops(
                     .to_string(),
             ));
         }
-        ops.check_active_jobs_gate(unit, force).await?;
+        check_active_jobs_gate(unit, home, force, "stop", ops).await?;
         let _service_lock = ops.acquire_lock(unit, home, Some(cleanup)).await?;
         stop_cleanup_with_ops(unit, cleanup, ops).await
     } else {
         let _service_lock = ops.acquire_lock(unit, home, cleanup).await?;
-        ops.check_active_jobs_gate(unit, force).await?;
+        check_active_jobs_gate(unit, home, force, "stop", ops).await?;
         stop_default_with_ops(unit, ops).await
     }
 }
@@ -603,7 +595,7 @@ mod tests {
     struct FakeStopOps {
         events: Vec<&'static str>,
         acquire_lock_error: bool,
-        gate_error: bool,
+        gate_active_results: VecDeque<RunnerResult<bool>>,
         active_results: VecDeque<RunnerResult<bool>>,
         stop_results: VecDeque<RunnerResult<()>>,
         bounded_stop_results: VecDeque<RunnerResult<BoundedSystemctlOutcome>>,
@@ -622,7 +614,7 @@ mod tests {
             Self {
                 events: Vec::new(),
                 acquire_lock_error: false,
-                gate_error: false,
+                gate_active_results: VecDeque::from([Ok(true)]),
                 active_results: VecDeque::from([Ok(true)]),
                 stop_results: VecDeque::from([Ok(())]),
                 bounded_stop_results: VecDeque::from([Ok(BoundedSystemctlOutcome::Success)]),
@@ -637,6 +629,20 @@ mod tests {
                 cleanup_drain_error: false,
                 advance_time_on_sleep: false,
             }
+        }
+    }
+
+    impl ActiveJobsGateOps for FakeStopOps {
+        fn is_unit_active<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, bool> {
+            self.events.push("gate_is_active");
+            Box::pin(std::future::ready(
+                self.gate_active_results
+                    .pop_front()
+                    .expect("unexpected gate unit-active query"),
+            ))
         }
     }
 
@@ -659,19 +665,6 @@ mod tests {
             });
             Box::pin(std::future::ready(if self.acquire_lock_error {
                 Err(fake_error("lock busy"))
-            } else {
-                Ok(())
-            }))
-        }
-
-        fn check_active_jobs_gate<'a>(
-            &'a mut self,
-            _unit: &'a RunnerServiceUnit,
-            _force: bool,
-        ) -> ServiceFuture<'a, ()> {
-            self.events.push("check_gate");
-            Box::pin(std::future::ready(if self.gate_error {
-                Err(fake_error("active jobs"))
             } else {
                 Ok(())
             }))
@@ -831,13 +824,66 @@ mod tests {
             ops.events,
             [
                 "acquire_lock",
-                "check_gate",
+                "gate_is_active",
                 "is_active",
                 "stop",
                 "reset_failed",
                 "cleanup_drain_restart_override",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn stop_default_active_jobs_refuses_before_service_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let unit = service_unit();
+        let base_dir = home.runners_dir().join(unit.suffix());
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+        let started_at = (chrono::Utc::now() - chrono::Duration::minutes(10))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        tokio::fs::write(
+            base_dir.join("status.json"),
+            format!(
+                r#"{{
+                    "mode":"running",
+                    "active_runs":[
+                        {{"run_id":"0191c4e0-0000-7000-8000-000000000001"}},
+                        {{"run_id":"0191c4e0-0000-7000-8000-000000000002"}}
+                    ],
+                    "started_at":"{started_at}"
+                }}"#
+            ),
+        )
+        .await
+        .unwrap();
+        let mut ops = FakeStopOps::default();
+
+        let error = stop_with_ops(&unit, &home, false, None, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
+        let RunnerError::ActiveJobs(error) = error else {
+            panic!("expected active-jobs refusal");
+        };
+        assert_eq!(error.unit, "vm0-runner-test");
+        assert_eq!(error.suffix, "test");
+        assert_eq!(
+            error
+                .run_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            [
+                "0191c4e0-0000-7000-8000-000000000001",
+                "0191c4e0-0000-7000-8000-000000000002",
+            ]
+        );
+        assert!(error.runner_uptime >= std::time::Duration::from_secs(600));
+        assert!(error.runner_uptime < std::time::Duration::from_secs(605));
+        assert_eq!(error.command_name, "stop");
+        assert!(!error.draining);
     }
 
     #[tokio::test]
@@ -914,7 +960,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -966,7 +1011,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1004,7 +1048,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1039,7 +1082,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1078,7 +1120,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1197,7 +1238,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1236,7 +1276,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1275,7 +1314,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1315,7 +1353,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1353,7 +1390,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1392,7 +1428,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1431,7 +1466,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1476,7 +1510,6 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "check_gate",
                 "acquire_cleanup_lock",
                 "stop_bounded",
                 "cleanup_active_state",
@@ -1534,6 +1567,6 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("lock busy"));
-        assert_eq!(ops.events, ["check_gate", "acquire_cleanup_lock"]);
+        assert_eq!(ops.events, ["acquire_cleanup_lock"]);
     }
 }

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -614,7 +614,7 @@ mod tests {
             Self {
                 events: Vec::new(),
                 acquire_lock_error: false,
-                gate_active_results: VecDeque::from([Ok(true)]),
+                gate_active_results: VecDeque::from([Ok(false)]),
                 active_results: VecDeque::from([Ok(true)]),
                 stop_results: VecDeque::from([Ok(())]),
                 bounded_stop_results: VecDeque::from([Ok(BoundedSystemctlOutcome::Success)]),
@@ -857,7 +857,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut ops = FakeStopOps::default();
+        let mut ops = FakeStopOps {
+            gate_active_results: VecDeque::from([Ok(true)]),
+            ..FakeStopOps::default()
+        };
 
         let error = stop_with_ops(&unit, &home, false, None, &mut ops)
             .await

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -842,6 +842,9 @@ mod tests {
         tokio::fs::create_dir_all(&base_dir).await.unwrap();
         let started_at = (chrono::Utc::now() - chrono::Duration::minutes(10))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let parsed_started_at = chrono::DateTime::parse_from_rfc3339(&started_at)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
         tokio::fs::write(
             base_dir.join("status.json"),
             format!(
@@ -862,9 +865,11 @@ mod tests {
             ..FakeStopOps::default()
         };
 
+        let before_gate = chrono::Utc::now();
         let error = stop_with_ops(&unit, &home, false, None, &mut ops)
             .await
             .unwrap_err();
+        let after_gate = chrono::Utc::now();
 
         assert_eq!(ops.events, ["acquire_lock", "gate_is_active"]);
         let RunnerError::ActiveJobs(error) = error else {
@@ -883,8 +888,8 @@ mod tests {
                 "0191c4e0-0000-7000-8000-000000000002",
             ]
         );
-        assert!(error.runner_uptime >= std::time::Duration::from_secs(600));
-        assert!(error.runner_uptime < std::time::Duration::from_secs(605));
+        assert!(error.runner_uptime >= (before_gate - parsed_started_at).to_std().unwrap());
+        assert!(error.runner_uptime <= (after_gate - parsed_started_at).to_std().unwrap());
         assert_eq!(error.command_name, "stop");
         assert!(!error.draining);
     }


### PR DESCRIPTION
## Summary

- make the concrete active-jobs gate accept the caller's runner home and a narrow systemd unit-state boundary
- route both stop and uninstall orchestration through that same gate instead of replacing it with a synthetic callback in tests
- cover force, unavailable unit state, missing/malformed status, normal stop refusal, draining uninstall refusal, complete error context, and mutation suppression with real temporary status files

Closes #29208.

## Behavior and compatibility

Production stop and uninstall behavior is unchanged: `--force` still bypasses before systemd/status work, unavailable state still fails open, and active jobs still refuse before mutation. `uninstall_service_unit` remains gate-free for its existing GC caller.

This PR changes no CLI flags or output, API, database, queue payload, runner/guest protocol, persisted status schema, or deployment contract.

## Validation

- `cargo test -p runner --bin runner cmd::service::gate` — 24 passed
- `cargo test -p runner --bin runner cmd::service::stop` — 24 passed
- `cargo test -p runner --bin runner cmd::service::tests` — 13 passed
- `cargo test -p runner --bin runner cmd::service` — 250 passed, 1 ignored
- `cargo fmt --all -- --check` — passed
- `cargo clippy -p runner --all-targets --all-features -- -D warnings` — passed
- `cargo doc -p runner --all-features --no-deps` — passed
- pre-commit workspace Rust format, documentation, Clippy, file-size, and commitlint hooks — passed
- `cargo test -p runner --all-targets --all-features` — 3293 passed, 21 ignored, with one unrelated failure in `proxy::process::tests::initial_start_retries_an_occupied_selected_port`; the exact same failure was reproduced on detached `origin/main` at `e76130d842`

## Exclusions

- no active-jobs policy or TOCTOU behavior change
- no systemctl output-parser change
- no ambient-systemd or process-level E2E test
- no fix for the independently reproducible proxy port-retry test failure
