### PR TITLE
build(toolchain): add zstd to rust image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -34,11 +34,15 @@ FROM toolchain AS toolchain-rust
 #       and proc-macro crates (needed by `cargo install` below and by any
 #       downstream `cargo build`);
 #   xz-utils        — extract the Bootlin tarball;
-#   libatomic1      — runtime dependency of the mold linker binary.
+#   libatomic1      — runtime dependency of the mold linker binary;
+#   zstd            — multi-threaded GitHub Actions cache compression.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     xz-utils \
     libatomic1 \
+    zstd \
+    && zstd --version \
+    && unzstd --version \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust toolchain with runner Linux musl targets.


### PR DESCRIPTION
## Summary

- install Ubuntu's `zstd` package in the `toolchain-rust` image stage
- verify `zstd` and `unzstd` during the image build
- keep the base non-Rust toolchain image and current immutable CI image pins unchanged

The pinned Rust cache action currently falls back to gzip because the container lacks zstd. In a recent coverage job, creating the gzip archive consumed roughly 102 seconds before a short upload. Once this image is merged, published, and adopted by #29243, cache actions can select their existing multi-threaded zstd path.

## Scope

This PR only makes zstd available in the published Rust toolchain image. It does not update workflow image pins, change cache contents, or modify coverage behavior. The dependent image-adoption work remains tracked in #29243 so CI never references an unpublished or mutable image tag.

## Validation

- `bash .devcontainer/test.sh`
- `git diff --check`
- inspected the Ubuntu 24.04 arm64 `zstd` package and confirmed it provides `/usr/bin/zstd` and the `/usr/bin/unzstd` symlink
- local image build not run because this environment has no Docker CLI; the existing pull-request workflow builds the inherited development image natively on both amd64 and arm64

Closes #29240

