### PR TITLE
refactor(python): reuse shared http server in x tld redirect test

### DIFF
--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -7,16 +7,15 @@ import os
 import py_compile
 import subprocess
 import sys
-import threading
 import urllib.error
 from collections.abc import Iterable
 from email.message import Message
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
 
 from scripts import update_x_tlds
+from tests.threaded_http_test_server import ThreadedHttpTestServer
 from usage.providers.connectors.x_tlds import IANA_TLD_VERSION, IANA_TLDS
 
 _ADDON_ROOT = Path(__file__).resolve().parents[1]
@@ -334,40 +333,27 @@ def test_fetch_source_preserves_http_error_status_message(monkeypatch):
 
 
 def test_fetch_source_rejects_cross_origin_redirect_without_requesting_target(monkeypatch):
-    requested_paths: list[str] = []
+    server = ThreadedHttpTestServer[str](
+        request_factory=lambda _method, path, _headers, _body: path,
+        default_status=500,
+        thread_name="x-tld-redirect-test-server",
+    )
+    server.queue_response(
+        302,
+        headers=(("Location", "https://unexpected.example/TLD/tlds-alpha-by-domain.txt"),),
+    )
 
-    class RedirectHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:
-            requested_paths.append(self.path)
-            self.send_response(302)
-            self.send_header("Location", "https://unexpected.example/TLD/tlds-alpha-by-domain.txt")
-            self.end_headers()
-
-        def log_message(self, fmt: str, *args: object) -> None:
-            return None
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
-
-    def serve_forever() -> None:
-        server.serve_forever(poll_interval=0.01)
-
-    thread = threading.Thread(target=serve_forever, daemon=True)
-    thread.start()
-    try:
+    with server.run():
         monkeypatch.setattr(
             update_x_tlds,
             "SOURCE_URL",
-            f"http://127.0.0.1:{server.server_port}{update_x_tlds.SOURCE_PATH}",
+            f"{server.api_url}{update_x_tlds.SOURCE_PATH}",
         )
 
         with pytest.raises(update_x_tlds.TldFetchError, match=r"HTTP 302"):
             update_x_tlds.fetch_source()
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join()
 
-    assert requested_paths == [update_x_tlds.SOURCE_PATH]
+    assert server.requests == (update_x_tlds.SOURCE_PATH,)
 
 
 def test_fetch_source_reports_response_read_failure_as_fetch_error(monkeypatch):


### PR DESCRIPTION
## Summary

- replace the X TLD redirect test's one-off HTTP handler, server thread, and teardown with `ThreadedHttpTestServer`
- queue the existing cross-origin 302 response through the shared helper and retain exact request-path capture
- remove the now-unused direct `threading` and `http.server` imports

## Scope

- test infrastructure only
- no production updater behavior, shared helper API, generated data, network protocol, schema, migration, or deployment compatibility changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_http_test_helpers.py tests/test_update_x_tlds.py --durations=3` (`45 passed`)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (`0 errors, 0 warnings, 0 notes`)
- `uv run --no-sync python -m pytest tests/` (`6606 passed`)
- `git diff --check`

Closes #29220
