### PR TITLE
perf(python): bound oversized unicode labels before punycode

### DIFF
--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -30,6 +30,7 @@ _IDNA_DOT_TRANSLATION = str.maketrans(
     }
 )
 _PUNYCODE_PREFIX = "xn--"
+_PUNYCODE_INPUT_MAX_CODEPOINTS = _DNS_LABEL_MAX_LENGTH - len(_PUNYCODE_PREFIX)
 _UNICODE_CONTROL_CATEGORY_PREFIX = "C"
 _UNICODE_MARK_CATEGORY_PREFIX = "M"
 _BIDI_ARABIC_NUMBER = "AN"
@@ -349,6 +350,10 @@ def _canonical_punycode_label(label: str) -> str:
         raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
     normalized_label = _normalize_label_text(label)
     _validate_normalized_label_text(normalized_label)
+
+    # Punycode emits at least one payload byte for every input code point.
+    if len(normalized_label) > _PUNYCODE_INPUT_MAX_CODEPOINTS:
+        raise UnicodeError("IDNA label too long")
 
     try:
         payload = normalized_label.encode("punycode").decode("ascii").lower()

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -54,6 +54,13 @@ def test_ascii_label_contract(label, expected):
     assert host_normalization.normalize_idna_label(label) == expected
 
 
+def test_unicode_label_at_dns_limit_is_accepted():
+    normalized = host_normalization.normalize_idna_label("é" * 57)
+
+    assert normalized == f"xn--9c{'a' * 57}"
+    assert len(normalized) == 63
+
+
 @pytest.mark.parametrize("hostname", INVALID_IDNA_HOSTNAME_CASES)
 def test_rejects_invalid_idna_hostname(hostname):
     with pytest.raises(UnicodeError):

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -54,8 +54,8 @@ def test_ascii_label_contract(label, expected):
     assert host_normalization.normalize_idna_label(label) == expected
 
 
-def test_unicode_label_at_dns_limit_is_accepted():
-    normalized = host_normalization.normalize_idna_label("é" * 57)
+def test_decomposed_unicode_label_at_dns_limit_is_accepted():
+    normalized = host_normalization.normalize_idna_label("e\u0301" * 57)
 
     assert normalized == f"xn--9c{'a' * 57}"
     assert len(normalized) == 63

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1,5 +1,6 @@
 """Authority validation request hook integration tests."""
 
+import encodings.punycode
 import json
 from unittest.mock import patch
 
@@ -241,6 +242,59 @@ async def test_valid_pseudo_authority_allows_firewall_auth(
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+@pytest.mark.parametrize("http_version", ["HTTP/1.1", "HTTP/2.0", "HTTP/3"])
+async def test_rejects_oversized_unicode_authority_before_punycode_encoding(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    http_version,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    oversized_label = "".join(chr(0x4E00 + index) for index in range(1365))
+    assert len(oversized_label.encode()) == _MAX_HOST_HEADER_BYTES - 1
+    request_headers = (
+        headers(
+            ("Host", oversized_label),
+            ("Authorization", "Bearer sandbox-token"),
+        )
+        if http_version == "HTTP/1.1"
+        else headers(("Authorization", "Bearer sandbox-token"))
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        path="/repos",
+        request_headers=request_headers,
+    )
+    flow.request.http_version = http_version
+    if flow.request.is_http2 or flow.request.is_http3:
+        flow.request.authority = oversized_label
+    original_headers = tuple(flow.request.headers.fields)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+        patch.object(
+            encodings.punycode,
+            "punycode_encode",
+            side_effect=AssertionError("oversized authority reached punycode encoder"),
+        ),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert json.loads(flow.response.content)["error"] == "invalid_authority"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.headers["Authorization"] == "Bearer sandbox-token"
+    auth_fetch.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- derive a 59-code-point upper bound for inputs entering the canonical punycode encoder from the existing 63-byte DNS label limit and `xn--` prefix
- reject impossible normalized labels before CPython's repeated-scan punycode path while preserving unsafe-mapping/text-validation precedence and the final encoded-length check
- cover 4,095-byte HTTP/1.1 Host plus HTTP/2 and HTTP/3 authority inputs through the real request hook, and preserve an accepted decomposed Unicode label that normalizes to a 63-byte A-label

## Performance evidence

Pinned CPython 3.14.0, distinct CJK labels, median rejection time:

| Code points | Before | After |
| ---: | ---: | ---: |
| 128 | 1.24 ms | 0.115 ms |
| 256 | 4.35 ms | 0.219 ms |
| 512 | 16.24 ms | 0.470 ms |
| 1,024 | 67.38 ms | 0.992 ms |
| 1,365 (4,095 UTF-8 bytes) | 125.33 ms | 1.124 ms |
| 2,048 | 263.87 ms | 1.724 ms |

The deterministic integration regression also makes `encodings.punycode.punycode_encode` fail if any oversized authority reaches it, avoiding a wall-clock CI assertion.

## Exclusions

- no new raw Host or HTTP/2/3 authority size policy
- no custom/third-party punycode implementation, caching, timeout, or async offload
- no API, protocol, persisted-state, dependency, migration, or rollout change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_host_normalization.py` (71 passed)
- `uv run --no-sync python -m pytest tests/` (6,610 passed; 59 existing dependency deprecation warnings)
- `lefthook run pre-commit`
- commit-msg `commitlint`

Closes #29217
