### PR TITLE
fix(auth): enable fedcm for google one tap

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -321,14 +321,16 @@ export function mockUser(
 }
 
 interface MockedGoogleOneTapInitializeOptions {
+  readonly auto_select: boolean;
   readonly callback: (response: { readonly credential?: string }) => void;
+  readonly cancel_on_tap_outside: boolean;
   readonly client_id: string;
+  readonly itp_support: boolean;
+  readonly use_fedcm_for_prompt: boolean;
 }
 
 type MockedGoogleOneTapMomentCallback = (notification: {
-  isDismissedMoment(): boolean;
-  isNotDisplayed(): boolean;
-  isSkippedMoment(): boolean;
+  getMomentType(): "dismissed" | "display" | "skipped";
 }) => void;
 
 let internalMockedGoogleOneTapCredential: string | null = null;
@@ -349,13 +351,10 @@ function defaultGoogleOneTapPromptImpl(
     internalMockedGoogleOneTapCallback?.({
       credential: internalMockedGoogleOneTapCredential,
     });
+    callback({ getMomentType: () => "dismissed" });
     return;
   }
-  callback({
-    isDismissedMoment: () => false,
-    isNotDisplayed: () => true,
-    isSkippedMoment: () => false,
-  });
+  callback({ getMomentType: () => "skipped" });
 }
 
 export const mockedGoogleOneTap = {

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
@@ -26,9 +26,7 @@ interface GoogleCredentialResponse {
 }
 
 interface GooglePromptMomentNotification {
-  isDismissedMoment(): boolean;
-  isNotDisplayed(): boolean;
-  isSkippedMoment(): boolean;
+  getMomentType(): "dismissed" | "display" | "skipped";
 }
 
 interface GoogleIdentityApi {
@@ -39,6 +37,7 @@ interface GoogleIdentityApi {
     readonly cancel_on_tap_outside: boolean;
     readonly client_id: string;
     readonly itp_support: boolean;
+    readonly use_fedcm_for_prompt: boolean;
   }): void;
   prompt(
     callback: (notification: GooglePromptMomentNotification) => void,
@@ -120,13 +119,11 @@ async function startGoogleOneTapPrompt(
     cancel_on_tap_outside: true,
     client_id: clientId,
     itp_support: true,
+    use_fedcm_for_prompt: true,
   });
   api.prompt((notification) => {
-    if (
-      notification.isDismissedMoment() ||
-      notification.isNotDisplayed() ||
-      notification.isSkippedMoment()
-    ) {
+    const momentType = notification.getMomentType();
+    if (momentType === "dismissed" || momentType === "skipped") {
       finish(null);
     }
   });

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -347,6 +347,7 @@ describe("auth v2 sign-in flow", () => {
 
     await waitFor(() => {
       expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledTimes(1);
       expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
         signUpIfMissing: false,
         strategy: "google_one_tap",
@@ -354,12 +355,108 @@ describe("auth v2 sign-in flow", () => {
       });
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
-    expect(mockedGoogleOneTap.initialize).toHaveBeenCalledWith(
-      expect.objectContaining({
-        auto_select: false,
-        client_id: "google-client-id",
-      }),
-    );
+    expect(mockedGoogleOneTap.initialize).toHaveBeenCalledTimes(1);
+    expect(mockedGoogleOneTap.initialize).toHaveBeenCalledWith({
+      auto_select: false,
+      callback: expect.any(Function),
+      cancel_on_tap_outside: true,
+      client_id: "google-client-id",
+      itp_support: true,
+      use_fedcm_for_prompt: true,
+    });
+  });
+
+  it.each(["dismissed", "skipped"] as const)(
+    "settles a FedCM %s moment without legacy notification methods",
+    async (momentType) => {
+      mockAuthV2Capabilities({
+        googleOAuth: true,
+        googleOneTapClientId: "google-client-id",
+      });
+      mockGoogleOneTapCredential(null);
+      mockedGoogleOneTap.prompt.mockImplementation((callback) => {
+        callback({
+          getMomentType: () => {
+            return momentType;
+          },
+        });
+      });
+
+      setupSignInPage({ status: "needs_identifier" });
+
+      await waitFor(() => {
+        expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+      });
+      expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    },
+  );
+
+  it("ignores a legacy display moment until a terminal moment arrives", async () => {
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential(null);
+    mockedGoogleOneTap.prompt.mockImplementation((callback) => {
+      callback({
+        getMomentType: () => {
+          return "display";
+        },
+      });
+      callback({
+        getMomentType: () => {
+          return "skipped";
+        },
+      });
+    });
+
+    setupSignInPage({ status: "needs_identifier" });
+
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("cancels an aborted FedCM prompt and ignores late credential events", async () => {
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential(null);
+    mockedGoogleOneTap.prompt.mockImplementation(() => {});
+
+    setupSignInPage({ status: "needs_identifier" });
+
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+    });
+    const initializeOptions =
+      mockedGoogleOneTap.initialize.mock.calls.at(-1)?.[0];
+    const promptCallback = mockedGoogleOneTap.prompt.mock.calls.at(-1)?.[0];
+    if (!initializeOptions || !promptCallback) {
+      throw new Error("Expected Google One Tap callbacks to be registered");
+    }
+
+    fireEvent.click(await waitForRoleElement("link", "Use current sign-in"));
+    await expect(
+      screen.findByTestId("clerk-sign-in"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    initializeOptions.callback({ credential: "late-google-one-tap-token" });
+    promptCallback({
+      getMomentType: () => {
+        return "skipped";
+      },
+    });
+
+    expect(mockedGoogleOneTap.cancel).toHaveBeenCalledTimes(1);
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
   });
 
   it("does not start Google One Tap on a nested sign-in route", async () => {


### PR DESCRIPTION
## Summary

- enable FedCM mediation for the Auth v2 Google One Tap prompt
- replace FedCM-incompatible display-moment predicates with the common typed `getMomentType()` contract
- preserve GIS's documented legacy-browser compatibility while making credential, terminal-moment, and abort settlement idempotent
- extend the existing Auth v2 sign-in integration harness with initialize-option, FedCM notification, success, skip, dismiss, display, cancel, abort, late-callback, and exactly-once coverage

## Context

Part of #28927.

This PR is intentionally limited to the Auth v2 Google One Tap sign-in strategy and its existing test harness. It does not change production routing, v1 auth, sign-up initialization, the sign-in/sign-up switch UI, locales, generic form accessibility, or the Auth v2 E2E files.

## Contract evidence

- The current [Google Identity Services JavaScript reference](https://developers.google.com/identity/gsi/web/reference/js-reference) defines `use_fedcm_for_prompt`, the shared `getMomentType()` values, and marks display-moment helpers as unsupported under FedCM.
- Google's [FedCM migration guide](https://developers.google.com/identity/gsi/web/guides/fedcm-migration) directs integrations to remove display-moment method usage while retaining skipped/dismissed terminal handling, and documents GIS's backward-compatible migration behavior.
- The installed `@clerk/ui` 1.27.0 reference passes `use_fedcm_for_prompt` and handles the typed moment value in [`one-tap-start.tsx`](https://github.com/clerk/javascript/blob/%40clerk/ui%401.27.0/packages/ui/src/components/GoogleOneTap/one-tap-start.tsx); its GIS types use the same surface in [`one-tap.ts`](https://github.com/clerk/javascript/blob/%40clerk/ui%401.27.0/packages/ui/src/utils/one-tap.ts).

The implementation therefore uses the public GIS contract directly and does not depend on private Clerk APIs. A legacy `display` moment remains nonterminal and is ignored until GIS reports `skipped` or `dismissed`.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged repository type checks for non-app/non-API packages, `@okouai/app`, and `api`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` — 29/29 passed
- after rebasing onto latest `origin/main`: focused Prettier check, full app lint, app production/test type-check, and the same 29-test file all passed

## Preview boundary

The exact-head Auth v2 sign-in smoke check will be recorded after the app preview deploys. The real Google credential ceremony remains a manual boundary because it requires a valid Google session and browser-mediated FedCM UI.
