### PR TITLE
fix(auth): restore v2 sign-in identifier after refresh

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -120,6 +120,7 @@ interface SignInResourceSnapshot {
   readonly factors: readonly AuthV2SignInFactor[];
   readonly firstFactorVerificationStatus: string | null;
   readonly firstFactorVerificationStrategy: string | null;
+  readonly identifier: string | null;
   readonly transferable: boolean;
   readonly unknownFactorStrategies: readonly string[];
 }
@@ -171,6 +172,7 @@ interface SignInFlowAtoms {
   readonly error$: State<AuthV2SignInError | null>;
   readonly fatalState$: State<AuthV2SignInUnknownState | null>;
   readonly identifier$: State<string>;
+  readonly identifierLocallyModified$: State<boolean>;
   readonly newPassword$: State<string>;
   readonly password$: State<string>;
   readonly resendRemainingSeconds$: State<number>;
@@ -284,6 +286,7 @@ function snapshotSignInResource(
       resource.firstFactorVerification?.status ?? null,
     firstFactorVerificationStrategy:
       resource.firstFactorVerification?.strategy ?? null,
+    identifier: resource.identifier,
     transferable: resource.__internal_future.isTransferable,
     unknownFactorStrategies: discovered.unknownStrategies,
   };
@@ -522,6 +525,7 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
   const fatalState$ = state<AuthV2SignInUnknownState | null>(null);
   const error$ = state<AuthV2SignInError | null>(null);
   const identifier$ = state("");
+  const identifierLocallyModified$ = state(false);
   const password$ = state("");
   const resendRemainingSeconds$ = state(0);
   const code$ = state("");
@@ -546,6 +550,7 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
     error$,
     fatalState$,
     identifier$,
+    identifierLocallyModified$,
     newPassword$,
     password$,
     resendRemainingSeconds$,
@@ -641,6 +646,15 @@ function createResourceCommands(
       );
       set(atoms.snapshot$, snapshot);
       set(atoms.fatalState$, null);
+      if (
+        snapshot.clerkStatus === "needs_first_factor" &&
+        snapshot.identifier !== null &&
+        !get(atoms.identifierLocallyModified$)
+      ) {
+        // Restore only Clerk's public identifier. Factor safeIdentifier values
+        // are masked display labels and must never become an editable draft.
+        set(atoms.identifier$, snapshot.identifier);
+      }
       const preparedFactor = preparedFactorForSnapshot(snapshot);
       if (preparedFactor) {
         set(runtime.preparedFactorId$, preparedFactor.id);
@@ -1180,6 +1194,7 @@ function createFormCommands(
       factors: entryFactors(get(atoms.capabilities$)),
       firstFactorVerificationStatus: null,
       firstFactorVerificationStrategy: null,
+      identifier: null,
       transferable: false,
       unknownFactorStrategies: [],
     });
@@ -1187,6 +1202,7 @@ function createFormCommands(
     set(atoms.editIdentifier$, false);
     set(atoms.fatalState$, null);
     set(atoms.error$, null);
+    set(atoms.identifierLocallyModified$, true);
     set(atoms.identifier$, "");
     set(atoms.password$, "");
     set(atoms.code$, "");
@@ -1197,8 +1213,11 @@ function createFormCommands(
   const useAnotherAccount$ = command(({ set }) => {
     set(atoms.useAnotherAccount$, true);
     set(atoms.error$, null);
+    set(atoms.identifierLocallyModified$, true);
+    set(atoms.identifier$, "");
   });
   const setIdentifier$ = command(({ set }, value: string) => {
+    set(atoms.identifierLocallyModified$, true);
     set(atoms.identifier$, value);
     set(atoms.error$, null);
   });

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -65,6 +65,23 @@ function moveSignInTo(state: MockedSignInResourceState) {
   return currentSignInResource();
 }
 
+function mockPreparedFirstFactor(
+  strategy: "email_code" | "reset_password_email_code",
+): void {
+  const signInResource = currentSignInResource();
+  Object.defineProperty(signInResource, "firstFactorVerification", {
+    configurable: true,
+    value: { status: "unverified", strategy },
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      Reflect.deleteProperty(signInResource, "firstFactorVerification");
+    },
+    { once: true },
+  );
+}
+
 interface SetupSignInPageOptions {
   readonly url?: string;
   readonly user?: {
@@ -179,6 +196,17 @@ describe("auth v2 sign-in flow", () => {
     await expect(
       screen.findByLabelText("Email address or username"),
     ).resolves.toBeVisible();
+  });
+
+  it("starts a fresh identifier request with an empty draft", async () => {
+    setupSignInPage({
+      identifier: "previous@example.com",
+      status: "needs_identifier",
+    });
+
+    await expect(
+      screen.findByLabelText("Email address or username"),
+    ).resolves.toHaveValue("");
   });
 
   it("discovers password factors, coalesces duplicate submits, and activates once", async () => {
@@ -568,7 +596,10 @@ describe("auth v2 sign-in flow", () => {
 
   it("can fall back from existing Clerk accounts to a new sign-in", async () => {
     setupSignInPage(
-      { status: "needs_identifier" },
+      {
+        identifier: "previous@example.com",
+        status: "needs_identifier",
+      },
       {
         user: {
           clientSessions: [
@@ -592,7 +623,7 @@ describe("auth v2 sign-in flow", () => {
 
     await expect(
       screen.findByLabelText("Email address or username"),
-    ).resolves.toBeVisible();
+    ).resolves.toHaveValue("");
   });
 
   it("prepares and resends one email code per concurrent user action", async () => {
@@ -768,40 +799,91 @@ describe("auth v2 sign-in flow", () => {
     });
   });
 
-  it("recovers a prepared email-code step without another initial dispatch", async () => {
-    const signInResource = currentSignInResource();
-    Object.defineProperty(signInResource, "firstFactorVerification", {
-      configurable: true,
-      value: { status: "unverified", strategy: "email_code" },
-    });
-    context.signal.addEventListener(
-      "abort",
-      () => {
-        Reflect.deleteProperty(signInResource, "firstFactorVerification");
-      },
-      { once: true },
-    );
+  it.each([
+    {
+      factor: emailCodeFactor(),
+      method: "Email code to p***@example.com",
+      name: "email-code",
+      strategy: "email_code" as const,
+    },
+    {
+      factor: passwordResetFactor(),
+      method: "Reset your password",
+      name: "password-reset-code",
+      strategy: "reset_password_email_code" as const,
+    },
+  ])(
+    "restores a prepared $name step and its editable identifier without another initial dispatch",
+    async (testCase) => {
+      mockPreparedFirstFactor(testCase.strategy);
+      setupSignInPage({
+        identifier: "person@example.com",
+        status: "needs_first_factor",
+        supportedFirstFactors: [testCase.factor, passwordFactor()],
+      });
 
+      await expect(
+        screen.findByLabelText("Verification code"),
+      ).resolves.toBeVisible();
+      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByLabelText("Toggle theme"));
+      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+      fireEvent.click(await waitForRoleElement("button", "Back"));
+      fireEvent.click(await waitForRoleElement("button", testCase.method));
+      await expect(
+        screen.findByLabelText("Verification code"),
+      ).resolves.toBeVisible();
+      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+
+      fireEvent.click(await waitForRoleElement("button", "Back"));
+      fireEvent.click(await waitForRoleElement("button", "Edit identifier"));
+      await expect(
+        screen.findByLabelText("Email address or username"),
+      ).resolves.toHaveValue("person@example.com");
+      expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps an edited restored identifier authoritative over a stale resource snapshot", async () => {
+    const factors = [emailCodeFactor(), passwordFactor()];
+    mockPreparedFirstFactor("email_code");
     setupSignInPage({
+      identifier: "person@example.com",
       status: "needs_first_factor",
-      supportedFirstFactors: [emailCodeFactor(), passwordFactor()],
+      supportedFirstFactors: factors,
     });
 
-    await expect(
-      screen.findByLabelText("Verification code"),
-    ).resolves.toBeVisible();
-    expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByLabelText("Toggle theme"));
-    expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+    await screen.findByLabelText("Verification code");
     fireEvent.click(await waitForRoleElement("button", "Back"));
-    fireEvent.click(
-      await waitForRoleElement("button", "Email code to p***@example.com"),
+    fireEvent.click(await waitForRoleElement("button", "Edit identifier"));
+    const identifierInput = await screen.findByLabelText(
+      "Email address or username",
     );
+    expect(identifierInput).toHaveValue("person@example.com");
+    fireEvent.change(identifierInput, {
+      target: { value: "edited@example.com" },
+    });
+
+    Reflect.deleteProperty(currentSignInResource(), "firstFactorVerification");
+    mockedClerk.clientSignInCreate.mockResolvedValue(
+      moveSignInTo({
+        identifier: "person@example.com",
+        status: "needs_first_factor",
+        supportedFirstFactors: factors,
+      }),
+    );
+    fireEvent.submit(containingForm(identifierInput));
+
+    await waitFor(() => {
+      expect(mockedClerk.clientSignInCreate).toHaveBeenCalledWith({
+        identifier: "edited@example.com",
+      });
+    });
+    fireEvent.click(await waitForRoleElement("button", "Edit identifier"));
     await expect(
-      screen.findByLabelText("Verification code"),
-    ).resolves.toBeVisible();
-    expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
+      screen.findByLabelText("Email address or username"),
+    ).resolves.toHaveValue("edited@example.com");
   });
 
   it("keeps factor selection usable when email-code preparation fails", async () => {
@@ -1044,13 +1126,20 @@ describe("auth v2 sign-in flow", () => {
 
   it("renders a transfer state without implementing sign-up", async () => {
     setupSignInPage({
+      identifier: "person@example.com",
       isTransferable: true,
-      status: "needs_identifier",
+      status: "needs_first_factor",
+      supportedFirstFactors: [passwordFactor()],
     });
 
     const signUp = await waitForRoleElement("link", "Sign up");
     expect(signUp).toHaveAttribute("href", "/v2/sign-up");
     expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
+
+    fireEvent.click(await waitForRoleElement("button", "Use another method"));
+    await expect(
+      screen.findByLabelText("Email address or username"),
+    ).resolves.toHaveValue("");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- hydrate the Auth v2 sign-in identifier draft from Clerk's restored public `SignInResource.identifier` only for `needs_first_factor`
- keep page-local user edits authoritative over later stale resource snapshots
- deliberately clear the draft for restart/use-another-account paths without exposing it through URLs, storage, logs, diagnostics, or masked `safeIdentifier` values
- cover restored email-code and password-reset-code resources, edit precedence, fresh/restart semantics, edited submission, and unchanged prepare/resend behavior

Part of #28927.

## Confirmed gap

On PR #29194 at head `4ffbc9d3b2d3` (Turbo `32817470727`, `pr-29194-app.omby.ai`), the email-code scenario reached 14/18: submit email, prepare the code once, refresh the code step, return to methods, choose **Edit identifier**, and observe an empty identifier input instead of the submitted email.

## Clerk source verification

The pinned dependency resolves `@clerk/clerk-js` 6.25.8 to public source commit [`908153417e31c03e13cc1e8e82f036e668b0e255`](https://github.com/clerk/javascript/commit/908153417e31c03e13cc1e8e82f036e668b0e255):

- [`SignInResource.identifier: string | null`](https://github.com/clerk/javascript/blob/908153417e31c03e13cc1e8e82f036e668b0e255/packages/shared/src/types/signIn.ts#L57)
- [`SignIn` hydrates `identifier` directly from the public resource payload](https://github.com/clerk/javascript/blob/908153417e31c03e13cc1e8e82f036e668b0e255/packages/clerk-js/src/core/resources/SignIn.ts#L623-L629)

## Verification

- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` — 28/28 passed

### Exact-head staging-browser Mode C — PASS

- PR head: `a2bfc23e0b0f1ec9437f647b321477b7fdbc4430`
- Turbo run/job: [`32820689794 / deploy-app 97717920599`](https://github.com/vm0-ai/vm0/actions/runs/32820689794/job/97717920599)
- Preview reported by the deploy job: `https://pr-29255-app.omby.ai`
- Environment: isolated HeadlessChrome 151, 1440×1000 viewport, no feature-switch overrides
- Path: submit a disposable Clerk test email → select email code once → observe code step → refresh → Back → Edit identifier
- Result: the editable input retained the exact submitted identifier; the request log contained one initial `prepare_first_factor` and zero additional prepares across the clean refresh/back/edit replay
- Browser evidence: no page errors and only Clerk's expected development-key console warning

![Restored identifier after refresh, back, and edit](https://cdn.vm0.io/artifacts/pg1p1nl2pu.png)

