### PR TITLE
chore(core): roll out the composer flat feedback note to the staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -125,6 +125,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
+      true,
+    );
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -156,19 +159,23 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
+      false,
+    );
   });
 
-  it("should enable the Bingjie-only composer switch only for Bingjie", () => {
-    const bingjieStates = getAllFeatureStates({
-      email: "bingjie@vm0.ai",
-    });
-    expect(bingjieStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(true);
-
-    const otherStaffStates = getAllFeatureStates({
+  it("should enable the composer flat feedback note for the staff org only", () => {
+    const staffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    expect(otherStaffStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
+    expect(staffStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(true);
+
+    const otherOrgStates = getAllFeatureStates({
+      email: "bingjie@vm0.ai",
+      orgId: "org_nonexistent",
+    });
+    expect(otherOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
       false,
     );
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -385,7 +385,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Rebuild the composer quote block on ProseMirror's native machinery: the note content element is the block itself and the quote chip is a widget decoration, removing the editable wrapper elements and the custom mutation filtering that let WebKit damage go unnoticed.",
     enabled: false,
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Widens `composerFlatFeedbackNote` (#29137) from the maintainer-email allowlist to the staff org.

The rebuilt quote block dogfooded clean on the maintainer account after the release that shipped it:

- pinyin composition keeps its **first keystroke** (the defect that falsified the nested-editing-host attempt in #29037)
- composing past the point that used to collapse the block no longer truncates the send (#27787's original symptom)
- Backspace mid-composition with stacked quotes keeps the caret in the note it belongs to

## Change

```diff
   [FeatureSwitchKey.ComposerFlatFeedbackNote]: {
     enabled: false,
-    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
```

Coverage moves out of the maintainer-only test and into the staff rollout matrix, so the switch's current audience stays asserted on both the staff and non-staff sides alongside every other staff-gated switch.

## Verification

- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 25 passed
- negative control: reverting the registry line back to the email allowlist makes the two new matrix assertions fail, so they are real guards
- `@okouai/core` `check-types` and lint clean

## Rollback

Flip the registry entry back to `enabledEmailHashes`; the code path itself is unchanged and still fully gated.

Related to #27787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)