### PR TITLE
fix(auth): preserve v2 sign-up switch context

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-page.tsx
@@ -37,7 +37,10 @@ export function AuthV2Page(props: AuthV2PageProps) {
           state={continuationState}
         />
       ) : props.mode === "sign-in" ? (
-        <AuthV2SignInCard signals={props.signInSignals} />
+        <AuthV2SignInCard
+          navigation={props.platformContext.navigation}
+          signals={props.signInSignals}
+        />
       ) : (
         <AuthV2SignUpCard
           authBrand={props.platformContext.authBrand}

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -165,6 +165,25 @@ function expectNoFieldErrorAssociation(input: HTMLElement): void {
   expect(input).not.toHaveAttribute("aria-describedby");
 }
 
+function signUpSwitchContext(): {
+  readonly expectedHref: string;
+  readonly url: string;
+} {
+  const redirectUrl = "https://app.okou.ai/onboarding?source=auth-switch";
+  const searchParams = new URLSearchParams([
+    ["redirect_url", redirectUrl],
+    ["gclid", "click-123"],
+    ["utm_campaign", "summer"],
+    ["utm_content", "hero"],
+    ["utm_content", "footer"],
+  ]);
+  const hash = `#/factor-one?step=code&redirect_url=${encodeURIComponent(redirectUrl)}`;
+  return {
+    expectedHref: `/v2/sign-up?${searchParams.toString()}${hash}`,
+    url: `https://app.vm0.ai/v2/sign-in?${searchParams.toString()}${hash}`,
+  };
+}
+
 function createStalledGoogleOneTapScript(): HTMLScriptElement {
   const script = document.createElement("script");
   script.dataset.authV2GoogleOneTap = "true";
@@ -206,6 +225,7 @@ describe("auth v2 sign-in flow", () => {
     expect(loadingState).toHaveTextContent(
       "Checking what your account needs next.",
     );
+    expect(roleElement("link", "Sign up")).toBeUndefined();
 
     await act(async () => {
       clerkLoad.resolve(undefined);
@@ -226,6 +246,17 @@ describe("auth v2 sign-in flow", () => {
     await expect(
       screen.findByLabelText("Email address or username"),
     ).resolves.toHaveValue("");
+  });
+
+  it("preserves exact navigation context in the ordinary sign-up switch", async () => {
+    const { expectedHref, url } = signUpSwitchContext();
+    setupSignInPage({ status: "needs_identifier" }, { url });
+
+    const signUp = await waitForRoleElement("link", "Sign up");
+    expect(signUp).toHaveAttribute("href", expectedHref);
+    expect(signUp.parentElement).toHaveTextContent(
+      "Don’t have an account? Sign up",
+    );
   });
 
   it("discovers password factors, coalesces duplicate submits, and activates once", async () => {
@@ -1363,13 +1394,52 @@ describe("auth v2 sign-in flow", () => {
     });
 
     const signUp = await waitForRoleElement("link", "Sign up");
-    expect(signUp).toHaveAttribute("href", "/v2/sign-up");
+    expect(signUp).toHaveAttribute(
+      "href",
+      "/v2/sign-up?redirect_url=https%3A%2F%2Fapp.vm0.ai",
+    );
     expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
 
     fireEvent.click(await waitForRoleElement("button", "Use another method"));
     await expect(
       screen.findByLabelText("Email address or username"),
     ).resolves.toHaveValue("");
+  });
+
+  it("preserves exact navigation context in the transfer sign-up action", async () => {
+    const { expectedHref, url } = signUpSwitchContext();
+    setupSignInPage(
+      {
+        isTransferable: true,
+        status: "needs_identifier",
+      },
+      { url },
+    );
+
+    const signUp = await waitForRoleElement("link", "Sign up");
+    expect(signUp).toHaveAttribute("href", expectedHref);
+    expect(
+      queryAllByRoleFast("link").filter((candidate) => {
+        return candidate.textContent?.trim() === "Sign up";
+      }),
+    ).toHaveLength(1);
+    expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
+  });
+
+  it("does not render the ordinary sign-up switch while completing", async () => {
+    const activation = createDeferredPromise<void>(context.signal);
+    mockedClerk.setActive.mockImplementation(() => {
+      return activation.promise;
+    });
+    setupSignInPage({
+      createdSessionId: "session_complete",
+      status: "complete",
+    });
+
+    await waitFor(() => {
+      expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(roleElement("link", "Sign up")).toBeUndefined();
   });
 
   it.each([
@@ -1393,5 +1463,6 @@ describe("auth v2 sign-in flow", () => {
     await expect(
       waitForRoleElement("button", "Use another method"),
     ).resolves.toBeVisible();
+    expect(roleElement("link", "Sign up")).toBeUndefined();
   });
 });

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -1,21 +1,25 @@
 import { Button } from "@okouai/ui";
 import { useGet } from "ccstate-react";
 
+import type { AuthV2Navigation } from "../../../signals/auth-v2/navigation.ts";
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { Link } from "../../router/link.tsx";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
-import { SignInCardContent } from "./sign-in-content.tsx";
+import { SignInCardContent, SignInSwitch } from "./sign-in-content.tsx";
 import { signInCardDescription, useAuthV2SignInCopy } from "./sign-in-copy.ts";
 
 export function AuthV2SignInCard({
+  navigation,
   signals,
 }: {
+  readonly navigation: AuthV2Navigation;
   readonly signals: AuthV2SignInSignals;
 }) {
   const copy = useAuthV2SignInCopy();
   const flowState = useGet(signals.state$);
   const description = signInCardDescription(flowState, copy);
+  const signUpHref = navigation.href("sign-up");
   const focusKey =
     flowState.status === "incomplete"
       ? `sign-in:${flowState.status}:${flowState.step}`
@@ -28,7 +32,15 @@ export function AuthV2SignInCard({
       title={copy.signInTitle}
     >
       <div className="space-y-4">
-        <SignInCardContent copy={copy} signals={signals} state={flowState} />
+        <SignInCardContent
+          copy={copy}
+          signUpHref={signUpHref}
+          signals={signals}
+          state={flowState}
+        />
+        {flowState.status === "incomplete" ? (
+          <SignInSwitch copy={copy} signUpHref={signUpHref} />
+        ) : null}
         <div className="flex justify-center">
           <Button asChild size="sm" variant="link">
             <Link

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -2,7 +2,7 @@ import { Button, Input } from "@okouai/ui";
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Loader2 } from "lucide-react";
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 
 import type {
   AuthV2SignInSignals,
@@ -86,6 +86,34 @@ function FlowErrorAlert({ copy, signals }: SignInStepProps) {
       id={AUTH_V2_SIGN_IN_ERROR_ID}
       message={signInErrorMessage(error, copy)}
     />
+  );
+}
+
+function signUpLinkOptions(signUpHref: string) {
+  const url = new URL(signUpHref, location.origin);
+  return {
+    hash: url.hash,
+    searchParams: url.searchParams,
+  };
+}
+
+function SignUpLink({
+  children,
+  className,
+  signUpHref,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly signUpHref: string;
+}) {
+  return (
+    <Link
+      className={className}
+      options={signUpLinkOptions(signUpHref)}
+      pathname={ROUTES.signUpV2}
+    >
+      {children}
+    </Link>
   );
 }
 
@@ -559,12 +587,16 @@ function CompleteStep({ copy }: { readonly copy: AuthV2SignInCopy }) {
   );
 }
 
-function TransferStep({ copy, signals }: SignInStepProps) {
+function TransferStep({
+  copy,
+  signUpHref,
+  signals,
+}: SignInStepProps & { readonly signUpHref: string }) {
   const restart = useSet(signals.restart$);
   return (
     <div className="space-y-3">
       <Button className="w-full" asChild>
-        <Link pathname={ROUTES.signUpV2}>{copy.signUp}</Link>
+        <SignUpLink signUpHref={signUpHref}>{copy.signUp}</SignUpLink>
       </Button>
       <Button
         className="w-full"
@@ -599,9 +631,13 @@ function UnknownStep({ copy, signals }: SignInStepProps) {
 
 export function SignInCardContent({
   copy,
+  signUpHref,
   signals,
   state,
-}: SignInStepProps & { readonly state: AuthV2SignInState }) {
+}: SignInStepProps & {
+  readonly signUpHref: string;
+  readonly state: AuthV2SignInState;
+}) {
   if (state.status === "loading") {
     return <LoadingStep copy={copy} />;
   }
@@ -609,7 +645,9 @@ export function SignInCardContent({
     return <CompleteStep copy={copy} />;
   }
   if (state.status === "transfer") {
-    return <TransferStep copy={copy} signals={signals} />;
+    return (
+      <TransferStep copy={copy} signUpHref={signUpHref} signals={signals} />
+    );
   }
   if (state.status === "unknown") {
     return <UnknownStep copy={copy} signals={signals} />;
@@ -635,4 +673,24 @@ export function SignInCardContent({
     return <CodeStep copy={copy} reset signals={signals} state={state} />;
   }
   return <NewPasswordStep copy={copy} signals={signals} />;
+}
+
+export function SignInSwitch({
+  copy,
+  signUpHref,
+}: {
+  readonly copy: AuthV2SignInCopy;
+  readonly signUpHref: string;
+}) {
+  return (
+    <p className="text-center text-sm text-muted-foreground">
+      {copy.noAccount}{" "}
+      <SignUpLink
+        className="font-medium text-foreground underline underline-offset-4"
+        signUpHref={signUpHref}
+      >
+        {copy.signUp}
+      </SignUpLink>
+    </p>
+  );
 }


### PR DESCRIPTION
## Summary

- pass the Auth v2 navigation contract into the sign-in card and derive the safe sign-up destination once
- use that destination for both the ordinary incomplete-state switch and transfer-state action, preserving redirect, campaign, search, and hash context
- cover exact link context plus switch exclusion for loading, transfer duplication, complete, and unknown states

## Scope

This is limited to the Auth v2 sign-in surface. It does not change production routing, v1 auth routes, the sign-up initial-config adapter, locale files, the canonical tracker comment, or PR #29194 E2E coverage.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; only existing warnings)
- `pnpm knip` (passed; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@okouai/app"` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` (27/27 tests passed)
- `git diff --check`
- PR pipeline: all required checks passed, including Turbo CI gate, 8/8 app test shards, lint, formatting, Knip, type checks, security scans, CodeQL, and Codecov patch coverage

## Preview QA

- Exact head: `3120ce56da1895813a7f8897ebcb09331e665881`
- App origin: `https://pr-29262-app.omby.ai`
- Environment: unauthenticated Auth v2 page, no feature switches, no onboarding bypass; 1280x900; HeadlessChrome 151
- Passed: ordinary incomplete-state switch rendered with the sign-up CTA; its deployed href and click preserved the navigation-validated completion redirect, `gclid`, `utm_campaign`, both repeated `utm_content` values, and the full hash while landing on `/v2/sign-up`
- Runtime: no page errors; only the expected Clerk development-key warning
- Transfer state was not induced against live Clerk; its exact contextual href and no-duplicate-switch behavior are covered by the focused component test

Refs #28927