### PR TITLE
perf(ci): remove container from crates detection

### DIFF
--- a/.github/scripts/tests/crates-detect-workflow-test.sh
+++ b/.github/scripts/tests/crates-detect-workflow-test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CRATES_WORKFLOW="${REPO_ROOT}/.github/workflows/crates.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null || fail "yq is required"
+crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
+
+jq -e '
+  .jobs.detect as $detect |
+  {
+    "any-changed": "${{ steps.detect.outputs.any-changed }}",
+    "ci-changed": "${{ steps.detect.outputs.ci-changed }}",
+    "mitm-addon-test-inputs-changed": "${{ steps.detect.outputs.mitm-addon-test-inputs-changed }}",
+    "mitm-addon-pricing-seed-changed": "${{ steps.detect.outputs.mitm-addon-pricing-seed-changed }}",
+    "runner-firewall-contract-inputs-changed": "${{ steps.detect.outputs.runner-firewall-contract-inputs-changed }}",
+    "api-contracts-rust-bindings-changed": "${{ steps.detect.outputs.api-contracts-rust-bindings-changed }}",
+    "ably-subscriber-changed": "${{ steps.detect.outputs.ably-subscriber-changed }}",
+    "api-contracts-changed": "${{ steps.detect.outputs.api-contracts-changed }}",
+    "runner-changed": "${{ steps.detect.outputs.runner-changed }}",
+    "nbd-cow-changed": "${{ steps.detect.outputs.nbd-cow-changed }}",
+    "vsock-test-changed": "${{ steps.detect.outputs.vsock-test-changed }}",
+    "crates-runner-consumer-needed": "${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}",
+    "metal-job-ref": "${{ steps.runner-job-ref.outputs.job-ref }}",
+    "runner-image-job-ref": "${{ steps.runner-job-ref.outputs.image-job-ref }}"
+  } as $required_outputs |
+  $detect["runs-on"] == "ubuntu-latest" and
+  ($detect | has("container") | not) and
+  any($detect.steps[]?;
+    ((.uses // "") | startswith("actions/checkout@")) and
+    .with["fetch-depth"] == 2
+  ) and
+  all($required_outputs | to_entries[]; $detect.outputs[.key] == .value) and
+  any($detect.steps[]?;
+    .id == "detect" and
+    (.run | contains(".github/scripts/changed-base-ref.sh")) and
+    (.run | contains("./scripts/crate-changed.sh")) and
+    (.run | contains("safe.directory") | not)
+  ) and
+  any($detect.steps[]?;
+    .id == "runner-tests" and
+    .run == ".github/scripts/runner-image-context.sh crates-consumer"
+  ) and
+  any($detect.steps[]?;
+    .id == "runner-job-ref" and
+    (.run | contains("job-ref=${JOB_REF}")) and
+    (.run | contains("image-job-ref=${IMAGE_JOB_REF}"))
+  )
+' <<<"$crates_json" >/dev/null || fail "Crates detect workflow contract changed"
+
+echo "crates-detect-workflow-test: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -59,8 +59,6 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -89,10 +87,6 @@ jobs:
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          # In CI containers, the repo may be owned by a different user (host vs container).
-          # Git 2.35.2+ rejects such repos unless marked as safe.
-          git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
-
           BASE_REF=$(.github/scripts/changed-base-ref.sh)
           echo "${{ github.event_name }} mode: comparing against base $BASE_REF"
           # Check if the workflow file or ansible playbooks changed


### PR DESCRIPTION
## Summary

- run the Crates `detect` job directly on the GitHub-hosted `ubuntu-latest` runner
- remove the Git ownership workaround that was only required across the container boundary
- add a workflow contract covering the host environment, output mappings, checkout depth, and detection step contracts

## Scope

Rust compilation, coverage, runner, firewall-contract, and NBD jobs keep their existing toolchain containers. The crate dependency resolver, event-specific base selection, detect outputs, and downstream conditions are unchanged.

## Validation

- `bash .github/scripts/tests/crates-detect-workflow-test.sh`
- `bash .github/scripts/tests/crate-changed-test.sh`
- `bash .github/scripts/tests/changed-base-ref-test.sh`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash .github/scripts/tests/checkout-depth-test.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `bash -n .github/scripts/tests/crates-detect-workflow-test.sh`
- `shellcheck .github/scripts/tests/crates-detect-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml`
- `git diff --check`
- `lefthook run pre-commit`

The PR's live Crates run will verify hosted-runner tool availability and confirm that `detect` no longer has an `Initialize containers` phase.

Closes #29241
