### PR TITLE
fix(dev-runner): wait for deployed runner readiness

### DIFF
--- a/.github/scripts/tests/dev-runner-test.sh
+++ b/.github/scripts/tests/dev-runner-test.sh
@@ -68,6 +68,25 @@ case "$command" in
     ;;
   *" service start "*)
     ;;
+  *" service wait-running "*)
+    case "${READINESS_RESULT:-success}" in
+      success)
+        printf '%s\n' "4"
+        ;;
+      inactive)
+        echo "vm0-runner-local-test.service is not active while waiting for running" >&2
+        exit 1
+        ;;
+      timeout)
+        echo "timed out waiting 120s for vm0-runner-local-test.service to reach running" >&2
+        exit 1
+        ;;
+      *)
+        echo "unexpected readiness result: $READINESS_RESULT" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   *)
     echo "unexpected cf-ssh command: $command" >&2
     exit 2
@@ -139,6 +158,31 @@ gc_command=$(grep " gc --keep-latest 3$" "${TMPDIR}/x86-success/cf-ssh.log")
 [[ "$gc_command" != *"R2_"* ]] || fail "gc should not receive R2 credentials"
 build_command=$(grep " build --profile vm0/default$" "${TMPDIR}/x86-success/cf-ssh.log")
 [[ "$build_command" == *"R2_ACCOUNT_ID="* ]] || fail "build should retain R2 credentials"
+grep -q " service wait-running --name local-test --timeout-secs 120$" "${TMPDIR}/x86-success/cf-ssh.log" || fail "expected readiness command"
+start_line=$(grep -n " service start " "${TMPDIR}/x86-success/cf-ssh.log" | cut -d: -f1)
+readiness_line=$(grep -n " service wait-running " "${TMPDIR}/x86-success/cf-ssh.log" | cut -d: -f1)
+[ "$start_line" -lt "$readiness_line" ] || fail "readiness should follow service start"
+grep -q "\[runner\] Waiting for Runner readiness..." "${TMPDIR}/x86-success.err" || fail "expected readiness progress"
+grep -q "\[runner\] Done! Runner local-test deployed to dev-host" "${TMPDIR}/x86-success.err" || fail "expected completion after readiness"
+if grep -q '^4$' "${TMPDIR}/x86-success.out"; then
+  fail "readiness capacity should not be printed"
+fi
+
+if run_deploy readiness-inactive x86_64 env READINESS_RESULT=inactive >"${TMPDIR}/readiness-inactive.out" 2>"${TMPDIR}/readiness-inactive.err"; then
+  fail "expected inactive Runner readiness to fail"
+fi
+grep -q "is not active while waiting for running" "${TMPDIR}/readiness-inactive.err" || fail "expected inactive Runner diagnostic"
+if grep -q "\[runner\] Done!" "${TMPDIR}/readiness-inactive.err"; then
+  fail "inactive Runner should not report completion"
+fi
+
+if run_deploy readiness-timeout x86_64 env READINESS_RESULT=timeout >"${TMPDIR}/readiness-timeout.out" 2>"${TMPDIR}/readiness-timeout.err"; then
+  fail "expected Runner readiness timeout to fail"
+fi
+grep -q "timed out waiting 120s" "${TMPDIR}/readiness-timeout.err" || fail "expected Runner readiness timeout diagnostic"
+if grep -q "\[runner\] Done!" "${TMPDIR}/readiness-timeout.err"; then
+  fail "timed out Runner should not report completion"
+fi
 
 run_deploy x86-explicit-success x86_64 env RUNNER_TARGET_TRIPLE=x86_64-unknown-linux-musl >"${TMPDIR}/x86-explicit-success.out" 2>"${TMPDIR}/x86-explicit-success.err"
 grep -q -- "--target x86_64-unknown-linux-musl" "${TMPDIR}/x86-explicit-success/cargo.log" || fail "expected explicit x86_64 cargo target"

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -202,6 +202,9 @@ cmd_deploy() {
   ssh_cmd "$RUNNER_BIN service start --name $RUNNER_NAME \
     --config $RUNNER_DIR/runner.yaml $LOCAL_FLAG $MOCK_FLAG"
 
+  log "Waiting for Runner readiness..."
+  ssh_cmd "$RUNNER_BIN service wait-running --name $RUNNER_NAME --timeout-secs 120" >/dev/null
+
   log "Done! Runner $RUNNER_NAME deployed to $HOST"
 }
 


### PR DESCRIPTION
## Summary

- wait for the newly started dev Runner to reach its authoritative `mode=running` readiness state
- propagate inactive-service and timeout failures without printing a false deployment completion
- cover successful readiness, command order, initialization failure, timeout, and diagnostic preservation at the shell entry point

## Behavior

`pnpm runner` now invokes the existing remote `runner service wait-running --timeout-secs 120` command after `service start`. The documented machine-readable success value is discarded because the interactive deployment does not consume it; readiness diagnostics remain on stderr and any non-zero status exits the deployment before `Done`.

## Scope

- no Runner CLI or readiness-state change
- no production install or rollout change
- no automatic cleanup of a failed transient unit; its existing restart behavior and journal remain available for diagnosis
- no CPU-topology compatibility change, which remains tracked by #29258

## Validation

- `bash -n scripts/dev-runner.sh .github/scripts/tests/dev-runner-test.sh`
- `shellcheck -x scripts/dev-runner.sh .github/scripts/tests/dev-runner-test.sh .github/scripts/runner-image-target.sh .github/scripts/runner-guest-binaries.sh`
- `bash .github/scripts/tests/dev-runner-test.sh`
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #29259
