### PR TITLE
fix(python): reject null sigv4 session token config

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -429,11 +429,12 @@ def _auth_config_is_valid(api_entry: dict) -> bool:
             return False
         if not raw_aws_sigv4["secretAccessKey"]:
             return False
-        optional_value = raw_aws_sigv4.get("sessionToken")
-        if optional_value is not None and not isinstance(optional_value, str):
-            return False
-        if optional_value == "":
-            return False
+        if "sessionToken" in raw_aws_sigv4:
+            optional_value = raw_aws_sigv4["sessionToken"]
+            if not isinstance(optional_value, str):
+                return False
+            if not optional_value:
+                return False
         if raw_auth.get("headers"):
             return False
         if raw_auth.get("query"):

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_auth.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_auth.py
@@ -119,6 +119,130 @@ def test_malformed_auth_config_fails_closed_after_base_match(auth_config):
 
 
 @pytest.mark.parametrize(
+    "aws_sigv4",
+    [
+        pytest.param([], id="non-object"),
+        pytest.param(
+            {
+                "accessKeyId": "key",
+                "secretAccessKey": "secret",
+                "unknown": "value",
+            },
+            id="unknown-field",
+        ),
+        pytest.param({"secretAccessKey": "secret"}, id="access-key-missing"),
+        pytest.param(
+            {"accessKeyId": 123, "secretAccessKey": "secret"},
+            id="access-key-non-string",
+        ),
+        pytest.param(
+            {"accessKeyId": "", "secretAccessKey": "secret"},
+            id="access-key-empty",
+        ),
+        pytest.param({"accessKeyId": "key"}, id="secret-key-missing"),
+        pytest.param(
+            {"accessKeyId": "key", "secretAccessKey": 123},
+            id="secret-key-non-string",
+        ),
+        pytest.param(
+            {"accessKeyId": "key", "secretAccessKey": ""},
+            id="secret-key-empty",
+        ),
+        pytest.param(
+            {
+                "accessKeyId": "key",
+                "secretAccessKey": "secret",
+                "sessionToken": None,
+            },
+            id="session-token-null",
+        ),
+        pytest.param(
+            {
+                "accessKeyId": "key",
+                "secretAccessKey": "secret",
+                "sessionToken": 123,
+            },
+            id="session-token-non-string",
+        ),
+        pytest.param(
+            {
+                "accessKeyId": "key",
+                "secretAccessKey": "secret",
+                "sessionToken": "",
+            },
+            id="session-token-empty",
+        ),
+    ],
+)
+def test_malformed_aws_sigv4_config_fails_closed_and_skips_credential_authority(
+    aws_sigv4,
+):
+    compiled_firewalls = compile_firewalls_or_fail(
+        _github_firewalls_with_auth({"awsSigv4": aws_sigv4})
+    )
+    policies = _github_policies()
+
+    unrelated = matching.match_compiled_firewall_request(
+        "https://api.gitlab.com/repos/org/repo",
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+    result = matching.match_compiled_firewall_request(
+        REPO_URL,
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+
+    assert unrelated is None
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.permissions == ()
+    assert result.reason == "malformed_firewall_config"
+    assert not compiled_firewalls.matches_ordinary_credential_authority(
+        "api.github.com",
+        443,
+    )
+
+
+@pytest.mark.parametrize(
+    "aws_sigv4",
+    [
+        pytest.param(
+            {"accessKeyId": "key", "secretAccessKey": "secret"},
+            id="session-token-omitted",
+        ),
+        pytest.param(
+            {
+                "accessKeyId": "key",
+                "secretAccessKey": "secret",
+                "sessionToken": "token",
+            },
+            id="session-token-present",
+        ),
+    ],
+)
+def test_valid_aws_sigv4_config_can_match_and_admit_credential_authority(aws_sigv4):
+    compiled_firewalls = compile_firewalls_or_fail(
+        _github_firewalls_with_auth({"awsSigv4": aws_sigv4})
+    )
+
+    result = matching.match_compiled_firewall_request(
+        REPO_URL,
+        "GET",
+        compiled_firewalls,
+        _github_policies(unknown_policy="deny"),
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.permission == "repo-read"
+    assert compiled_firewalls.matches_ordinary_credential_authority(
+        "api.github.com",
+        443,
+    )
+
+
+@pytest.mark.parametrize(
     "auth_config",
     [
         {"base": "https://example.com/hook?token=static"},


### PR DESCRIPTION
## Summary

- reject an explicitly present null AWS SigV4 `sessionToken` during compiled firewall validation
- preserve valid omitted and non-empty string session tokens
- cover every SigV4 config shape guard through compiled request matching and ordinary-credential authority admission

## Problem

The Python matcher used `dict.get()` for the optional SigV4 session token, so an omitted field and a present JSON null were treated alike. A malformed registry entry with `sessionToken: null` could therefore authorize a matching request and enter the ordinary-credential authority index even though the canonical TypeScript firewall schema rejects null.

## Implementation

- validate the session token only when its key is present, then require a non-empty string
- add a focused malformed matrix for non-object input, unknown fields, required credential shapes, and optional token shapes
- assert unrelated-base isolation, `malformed_firewall_config`, empty denied permissions, and authority-index exclusion for every malformed case
- assert valid SigV4 configurations with omitted and present tokens still match and receive authority admission

This PR does not change the API, runner protocol, registry format, persistence, database schema, cache format, or deployment ordering.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_malformed_auth.py -q` (78 passed)
- `uv run --no-sync python -m pytest tests/` (6619 passed)

Closes #29228
