### PR TITLE
test(guest-agent): rename the zero web search policy test to match the agent run naming

### DIFF
--- a/crates/guest-agent/tests/agent_web_search_policy.rs
+++ b/crates/guest-agent/tests/agent_web_search_policy.rs
@@ -1,4 +1,4 @@
-//! Zero runs must use managed web search instead of framework-native search.
+//! Agent runs must use managed web search instead of framework-native search.
 
 mod common;
 
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 #[tokio::test]
-async fn zero_marker_disables_builtin_web_search_for_claude_and_codex() -> TestResult {
+async fn okou_agent_id_disables_builtin_web_search_for_claude_and_codex() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
     let root = tempfile::tempdir()?;
     let claude_mock = common::build_and_locate_mock()?;
@@ -60,7 +60,7 @@ fn build_runtime(
     real_mock: &Path,
     args_path: &Path,
 ) -> TestResult<GuestRuntime> {
-    let run_id = format!("zero-web-search-{framework}");
+    let run_id = format!("agent-web-search-{framework}");
     let home = root.join("home");
     let runtime_dir = root.join("runtime");
     std::fs::create_dir_all(&home)?;


### PR DESCRIPTION
Closes #29264. Part of #26873.

The guest-agent web-search policy test still described the retired "Zero run" concept in prose, while everything it exercises is already neutral: the trigger is `OKOU_AGENT_ID` (`OKOU_AGENT_ID_ENV_KEY` in `crates/guest-agent/src/cli/mod.rs:397`) and the test's own fixture already writes that key. This renames the narrative text to match.

## Changes

| Current | New |
|---|---|
| `crates/guest-agent/tests/zero_web_search_policy.rs` | `crates/guest-agent/tests/agent_web_search_policy.rs` |
| `//! Zero runs must use managed web search…` | `//! Agent runs must use managed web search instead of framework-native search.` |
| `zero_marker_disables_builtin_web_search_for_claude_and_codex` | `okou_agent_id_disables_builtin_web_search_for_claude_and_codex` |
| `format!("zero-web-search-{framework}")` | `format!("agent-web-search-{framework}")` |

The test function is named after the env key rather than an abstract "marker", so it is greppable from the constant. The `run_id` is fixture text only; no assertion reads it.

No `Cargo.toml`, workflow, or script referenced the old file name, so the rename needs no other edit. No behavior change — assertions, fixtures, and the implementation are untouched.

## Out of scope

`crates/guest-agent/src/cli/mod.rs` and other implementation files are already neutral and were not touched. `WEB_SEARCH_TOOL_NAME`, `CronCreate`, and `WebSearch` are the frameworks' own tool identifiers and keep their names.

## Verification

`cargo test -p guest-agent --test agent_web_search_policy` passes locally (1 passed). `cargo fmt --check -p guest-agent` is clean.