### PR TITLE
test(runner): make mitmdump retry fixture work for non-root users

### DIFF
--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -887,7 +887,7 @@ set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
 printf '%s\n%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
   "$VM0_MITMDUMP_RUNTIME_DIR" "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
-cp "/proc/$$/environ" "$0.environ"
+cp -f "/proc/$$/environ" "$0.environ"
 port=""
 ready_path=""
 usage_state_id=""


### PR DESCRIPTION
## Summary

- force the fake mitmdump fixture to replace its environment capture when startup retries reuse the same path
- preserve the raw NUL-delimited environment artifact and its existing compatibility assertion
- preserve the real child-process and TCP-listener coverage of occupied-port recovery

## Scope

This changes runner test infrastructure only. Production proxy startup behavior, protocols, persisted data, dependencies, and deployment compatibility are unchanged.

## Validation

- `cargo test -p runner --bin runner proxy::process::tests::initial_start_retries_an_occupied_selected_port -- --exact` (three consecutive non-root runs)
- `cargo test -p runner --bin runner proxy::process::tests::spawn_mitmdump_passes_runner_options_and_preserves_ca -- --exact`
- `cargo test -p runner --bin runner proxy::process::tests::` (32 passed)
- `cargo test -p runner --bin runner` (3,289 passed, 21 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- pre-commit workspace Rust formatting, Clippy, rustdoc, file-size, and commit-message hooks

Closes #29248
