### PR TITLE
perf(ci): dynamically link libstd for Rust coverage

### DIFF
--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/crates.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null || fail "yq is required"
+workflow_json=$(yq -o=json '.' "$WORKFLOW")
+
+jq -e '
+  .jobs.coverage as $coverage |
+  ($coverage["timeout-minutes"] == 20) and
+  ($coverage.env.CARGO_PROFILE_TEST_DEBUG == "line-tables-only") and
+  ($coverage.env.RUSTFLAGS == "-C link-arg=-fuse-ld=mold") and
+  (any($coverage.steps[];
+    .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
+    .with.workspaces == "crates -> target" and
+    .with["shared-key"] == "coverage-line-tables-only-mold" and
+    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' }}"
+  )) and
+  (any($coverage.steps[];
+    .name == "Run tests with coverage" and
+    (.run | split("\n") | map(select(length > 0))) == [
+      "cd crates",
+      "cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info"
+    ]
+  )) and
+  (any($coverage.steps[];
+    .name == "Upload coverage to Codecov" and
+    .if == "success() || failure()" and
+    .["continue-on-error"] == true and
+    .["timeout-minutes"] == 1 and
+    .uses == "codecov/codecov-action@v7" and
+    .with.files == "crates/lcov.info" and
+    .with.flags == "rust"
+  )) and
+  ([.jobs | to_entries[] | select(.key != "coverage") | .value.env.RUSTFLAGS?] |
+    all(. == null))
+' <<<"$workflow_json" >/dev/null || fail "Rust coverage workflow contract changed"
+
+echo "rust-coverage-workflow-test: ok"

--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -22,7 +22,7 @@ jq -e '
     .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
     .with.workspaces == "crates -> target" and
     .with["shared-key"] == "coverage-line-tables-only-mold" and
-    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' || github.head_ref == '\''perf/issue-29242-rust-coverage-mold'\'' }}"
+    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' }}"
   )) and
   (any($coverage.steps[];
     .name == "Run tests with coverage" and

--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -17,12 +17,12 @@ jq -e '
   .jobs.coverage as $coverage |
   ($coverage["timeout-minutes"] == 20) and
   ($coverage.env.CARGO_PROFILE_TEST_DEBUG == "line-tables-only") and
-  ($coverage.env.RUSTFLAGS == "-C link-arg=-fuse-ld=mold") and
+  ($coverage.env.RUSTFLAGS == "-C prefer-dynamic") and
   (any($coverage.steps[];
     .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
     .with.workspaces == "crates -> target" and
-    .with["shared-key"] == "coverage-line-tables-only-mold" and
-    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' }}"
+    .with["shared-key"] == "coverage-line-tables-only-prefer-dynamic" and
+    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' || github.head_ref == '\''perf/issue-29242-rust-coverage-mold'\'' }}"
   )) and
   (any($coverage.steps[];
     .name == "Run tests with coverage" and

--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -22,7 +22,7 @@ jq -e '
     .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
     .with.workspaces == "crates -> target" and
     .with["shared-key"] == "coverage-line-tables-only-mold" and
-    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' }}"
+    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' || github.head_ref == '\''perf/issue-29242-rust-coverage-mold'\'' }}"
   )) and
   (any($coverage.steps[];
     .name == "Run tests with coverage" and

--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -17,11 +17,11 @@ jq -e '
   .jobs.coverage as $coverage |
   ($coverage["timeout-minutes"] == 20) and
   ($coverage.env.CARGO_PROFILE_TEST_DEBUG == "line-tables-only") and
-  ($coverage.env.RUSTFLAGS == "-C prefer-dynamic") and
+  ($coverage.env.RUSTFLAGS == "-C prefer-dynamic -C rpath") and
   (any($coverage.steps[];
     .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
     .with.workspaces == "crates -> target" and
-    .with["shared-key"] == "coverage-line-tables-only-prefer-dynamic" and
+    .with["shared-key"] == "coverage-line-tables-only-prefer-dynamic-rpath" and
     .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' || github.head_ref == '\''perf/issue-29242-rust-coverage-mold'\'' }}"
   )) and
   (any($coverage.steps[];

--- a/.github/scripts/tests/rust-coverage-workflow-test.sh
+++ b/.github/scripts/tests/rust-coverage-workflow-test.sh
@@ -22,7 +22,7 @@ jq -e '
     .uses == "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae" and
     .with.workspaces == "crates -> target" and
     .with["shared-key"] == "coverage-line-tables-only-prefer-dynamic-rpath" and
-    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' || github.head_ref == '\''perf/issue-29242-rust-coverage-mold'\'' }}"
+    .with["save-if"] == "${{ github.ref == '\''refs/heads/main'\'' }}"
   )) and
   (any($coverage.steps[];
     .name == "Run tests with coverage" and

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -414,7 +414,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: coverage-line-tables-only-mold
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -414,7 +414,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: coverage-line-tables-only-mold
-          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -414,7 +414,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: coverage-line-tables-only-prefer-dynamic-rpath
-          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -402,7 +402,7 @@ jobs:
     timeout-minutes: 20
     env:
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+      RUSTFLAGS: -C prefer-dynamic
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
@@ -413,8 +413,8 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
-          shared-key: coverage-line-tables-only-mold
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: coverage-line-tables-only-prefer-dynamic
+          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -414,8 +414,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: coverage-line-tables-only-mold
-          # Seed this PR's isolated mold cache once for a warm A/B measurement.
-          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -402,6 +402,7 @@ jobs:
     timeout-minutes: 20
     env:
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
@@ -412,8 +413,9 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
-          shared-key: coverage-line-tables-only
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: coverage-line-tables-only-mold
+          # Seed this PR's isolated mold cache once for a warm A/B measurement.
+          save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
 
       - name: Report coverage disk usage after cache restore
         run: |

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -402,7 +402,7 @@ jobs:
     timeout-minutes: 20
     env:
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
-      RUSTFLAGS: -C prefer-dynamic
+      RUSTFLAGS: -C prefer-dynamic -C rpath
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
@@ -413,7 +413,7 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
-          shared-key: coverage-line-tables-only-prefer-dynamic
+          shared-key: coverage-line-tables-only-prefer-dynamic-rpath
           save-if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'perf/issue-29242-rust-coverage-mold' }}
 
       - name: Report coverage disk usage after cache restore

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -295,6 +295,7 @@ jobs:
             .github/scripts/tests/reconcile-runner-binary-groups-test.sh \
             .github/scripts/tests/report-cgroup-memory-peak-test.sh \
             .github/scripts/tests/runner-lifecycle-lock-test.sh \
+            .github/scripts/tests/rust-coverage-workflow-test.sh \
             .github/scripts/tests/rust-ci-memory-workflow-test.sh \
             .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \


### PR DESCRIPTION
## Status: blocked on performance trade-off

This PR is a measured experiment and is **not merge-ready**. Both diagnostics-preserving candidates passed the complete coverage path but missed the issue's required 10% steady-state latency improvement.

## Results

| Candidate | Compile | Tests | Report | Coverage command | Outcome |
| --- | ---: | ---: | ---: | ---: | --- |
| Historical baseline | ~109s | ~70s | ~2s | 217s p50 | baseline |
| mold | 135s | ~81.6s | ~2.5s | 224s | rejected |
| dynamic libstd + rpath | 132s | ~80.4s | ~2.5s | 220s | rejected |

Final dynamic candidate: https://github.com/vm0-ai/vm0/actions/runs/32830836835/job/97749006564

- exact full cache match: 451,116,574-byte archive; 1.3 GB restored target
- all targets, features, and tests passed
- LCOV generation and Codecov upload succeeded
- final target: 8.3 GB, versus 9.9 GB for the static candidate
- peak memory: 15,396,077,568 bytes, versus 16,919,515,136 bytes for mold

Dynamic linkage improves cold compilation and resource usage, but the warm command is only about 1% different from the 217-second baseline and remains well above the 195-second acceptance gate. It should not be merged as a latency fix.

## Preserved behavior

- `CARGO_PROFILE_TEST_DEBUG=line-tables-only` and source-located failure backtraces
- the full `cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info` path
- Cargo/libtest execution and process isolation
- the 20-minute timeout, disk and memory diagnostics, and non-blocking one-minute Codecov upload
- main-only cache writes in the current configuration

## Validation completed

- YAML parsing and actionlint
- ShellCheck and both Rust workflow contract tests
- focused cargo-llvm-cov smoke (15 tests and LCOV)
- empty-environment execution of a dynamic+rpath test ELF
- deliberate failure retained exact file, line, and column diagnostics
- full hosted all-target/all-feature coverage run

Issue #29242 records the required decision: pay for a larger runner, accept reduced debug information, change test scheduling semantics, or revert the experiment.
