### PR TITLE
fix(release): bound release target resolution inputs

### DIFF
--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -216,25 +216,42 @@ target_commit=$target_commit_before
 
 release_target_script="${tmp_dir}/resolve-release-target.sh"
 ruby -e '
+  require "json"
   require "yaml"
   workflow = YAML.safe_load(File.read(ARGV[0]), aliases: true)
   release_job = workflow.fetch("jobs").fetch("release-please")
   release_target_step = release_job.fetch("steps").find { |step| step["id"] == "release-target" }
   raise "missing release target resolver step" unless release_target_step
+
+  resolver_env = release_target_step.fetch("env")
+  unless resolver_env.keys == ["RELEASE_SHAS"]
+    raise "release target resolver environment must contain only RELEASE_SHAS"
+  end
+
+  projection = resolver_env.fetch("RELEASE_SHAS")
+  projected_paths = projection.scan(/steps\.release\.outputs\[\x27([^\x27]+)--sha\x27\]/).flatten
+  output_reference_count = projection.scan(/steps\.release\.outputs/).length
+  unless output_reference_count == projected_paths.length
+    raise "release bodies, changelogs, and complete outputs must not enter the release target resolver environment"
+  end
+
+  configured_paths = JSON.parse(File.read(ARGV[1])).fetch("packages").keys
+  missing_paths = configured_paths - projected_paths
+  unknown_paths = projected_paths - configured_paths
+  duplicate_paths = projected_paths.group_by(&:itself).select { |_, paths| paths.length > 1 }.keys
+  unless missing_paths.empty? && unknown_paths.empty? && duplicate_paths.empty?
+    raise "release SHA projection mismatch: missing=#{missing_paths.sort}, unknown=#{unknown_paths.sort}, duplicates=#{duplicate_paths.sort}"
+  end
+
   puts release_target_step.fetch("run")
-' "${repo_root}/.github/workflows/release-please.yml" >"$release_target_script"
+' \
+  "${repo_root}/.github/workflows/release-please.yml" \
+  "${repo_root}/release-please-config.json" \
+  >"$release_target_script"
 
 release_target=cccccccccccccccccccccccccccccccccccccccc
-release_outputs=$(jq -nc \
-  --arg target "$release_target" \
-  '{
-    "turbo/apps/api--sha": $target,
-    "turbo/apps/platform--sha": $target,
-    "turbo/apps/api--body": "release notes",
-    releases_created: "true"
-  }')
 release_target_output="${tmp_dir}/release-target.output"
-RELEASE_OUTPUTS="$release_outputs" \
+RELEASE_SHAS="$(jq -nc --arg target "$release_target" '["", $target, "", $target]')" \
   GITHUB_OUTPUT="$release_target_output" \
   bash "$release_target_script"
 grep -qx "sha=${release_target}" "$release_target_output" || fail "release target resolver did not publish the unique release SHA"
@@ -243,20 +260,29 @@ missing_release_target_output="${tmp_dir}/missing-release-target.output"
 assert_failure \
   "release-please returned no release SHA" \
   env \
-  RELEASE_OUTPUTS='{"releases_created":"true"}' \
+  RELEASE_SHAS='["", ""]' \
   GITHUB_OUTPUT="$missing_release_target_output" \
   bash "$release_target_script"
 [ ! -s "$missing_release_target_output" ] || fail "missing release SHA must not publish an output"
 
-multiple_release_targets=$(jq -nc '{
-  "turbo/apps/api--sha": "cccccccccccccccccccccccccccccccccccccccc",
-  "turbo/apps/platform--sha": "dddddddddddddddddddddddddddddddddddddddd"
-}')
+invalid_release_target_output="${tmp_dir}/invalid-release-target.output"
+assert_failure \
+  "release-please returned invalid release SHA" \
+  env \
+  RELEASE_SHAS='["cccccccccccccccccccccccccccccccccccccccc", "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]' \
+  GITHUB_OUTPUT="$invalid_release_target_output" \
+  bash "$release_target_script"
+[ ! -s "$invalid_release_target_output" ] || fail "invalid release SHA must not publish an output"
+
+multiple_release_targets=$(jq -nc '[
+  "cccccccccccccccccccccccccccccccccccccccc",
+  "dddddddddddddddddddddddddddddddddddddddd"
+]')
 multiple_release_target_output="${tmp_dir}/multiple-release-target.output"
 assert_failure \
   "release-please returned multiple release SHAs" \
   env \
-  RELEASE_OUTPUTS="$multiple_release_targets" \
+  RELEASE_SHAS="$multiple_release_targets" \
   GITHUB_OUTPUT="$multiple_release_target_output" \
   bash "$release_target_script"
 [ ! -s "$multiple_release_target_output" ] || fail "ambiguous release SHAs must not publish an output"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,21 +104,57 @@ jobs:
         id: release-target
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         env:
-          RELEASE_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+          RELEASE_SHAS: >-
+            [
+              ${{ toJSON(steps.release.outputs['crates/ably-subscriber--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/api-contracts--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-agent--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-common--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-contracts--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-download--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-init--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-mock-claude--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-mock-codex--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-reseed--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-session-prune--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-tool-exec--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/guest-write-file--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/nbd-cow--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/process-control-ipc--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/runner--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox-fc--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/sandbox-mock--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/shell-quote--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/tracing-test-support--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-guest--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-host--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-proto--sha']) }},
+              ${{ toJSON(steps.release.outputs['crates/vsock-test--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/api--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/cli--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/desktop--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/host-worker--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/apps/platform--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/api-contracts--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/connectors--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/core--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/db--sha']) }},
+              ${{ toJSON(steps.release.outputs['turbo/packages/pi-agent-runtime--sha']) }}
+            ]
         run: |
           set -euo pipefail
 
           release_target=$(
             jq -er '
-              [
-                to_entries[]
-                | select(.key == "sha" or (.key | endswith("--sha")))
-                | .value
-                | select(
-                    type == "string" and
-                    test("^[0-9a-f]{40}$")
-                  )
-              ]
+              map(select(. != ""))
+              | map(
+                  if test("^[0-9a-f]{40}$") then
+                    .
+                  else
+                    error("release-please returned invalid release SHA: " + .)
+                  end
+                )
               | unique
               | if length == 1 then
                   .[0]
@@ -130,7 +166,7 @@ jobs:
                     join(", ")
                   )
                 end
-            ' <<<"$RELEASE_OUTPUTS"
+            ' <<<"$RELEASE_SHAS"
           )
 
           echo "sha=$release_target" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- replace the complete `steps.release.outputs` resolver environment projection with exactly the 35 configured component `--sha` outputs
- ignore empty component outputs, validate every remaining value as a full lowercase 40-character SHA, and require one unique release target
- enforce release-please config/workflow parity and prevent release bodies, changelogs, or complete action outputs from entering the resolver environment

## Incident

- workflow run: https://github.com/vm0-ai/vm0/actions/runs/32820603967
- failed job: https://github.com/vm0-ai/vm0/actions/runs/32820603967/job/97717753237

This repairs release-target resolution for a future release workflow run. It does not replay the failed release, approve production, trigger a release, or claim a production deployment.

## Verification

- `bash -n .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `npx --yes prettier@3.8.1 --check .github/workflows/release-please.yml`
- actionlint v1.7.12 on `.github/workflows/release-please.yml`, with ShellCheck v0.11.0 available
- `shellcheck .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `git diff --check`

## Safety

- preserves the `releases_created` guard, `release_target` output, production queue, downstream conditions, checkout refs, deployment DAG, and rollback-dashboard contract
- inspected open PR #25722 at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`; its overlapping file hunks remain confined to later API Worker deployment/rollback behavior and test harness coverage
- based on `main@c26835df8e932fb7616d82a97fe05f404e4f7c8b`

Closes #29268
