### PR TITLE
perf(api): reuse expanded connector firewall defaults

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13565,7 +13565,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });
 
-  it("uses connector-specific unknown endpoint defaults with user grant overrides", async () => {
+  it("preserves defaults and overrides across a broad Zero connector scope", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
@@ -13580,7 +13580,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       authMethod: "oauth",
       accessToken: "cloudflare-bdd-token",
     });
-    await api.enableAgentConnectors(actor, agentId, ["cloudflare"]);
+    // Nintendo Store owns a catalog skill, so enabling it without its account
+    // intentionally fails run preparation before firewall policy assembly.
+    const broadConnectorScope = API_TEST_CONNECTOR_FIREWALL_CONFIGS.filter(
+      (firewall) => {
+        return firewall.name !== "nintendo-store";
+      },
+    ).map((firewall) => {
+      return firewall.name;
+    });
+    expect(broadConnectorScope.length).toBeGreaterThanOrEqual(17);
+    await api.enableAgentConnectors(actor, agentId, broadConnectorScope);
 
     async function claimCloudflarePolicy(prompt: string): Promise<{
       readonly allow: readonly string[];
@@ -13610,13 +13620,20 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.applyUserPermissionGrant(actor, {
       agentId,
       connectorSlug: "cloudflare",
+      permission: "dns-firewall.write",
+      action: "allow",
+    });
+    await api.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorSlug: "cloudflare",
       permission: UNKNOWN_PERMISSION_GRANT,
       action: "allow",
     });
 
     const overridden = await claimCloudflarePolicy("allow unknown endpoints");
     expect(overridden.allow).toContain("dns-firewall.read");
-    expect(overridden.deny).toContain("dns-firewall.write");
+    expect(overridden.allow).toContain("dns-firewall.write");
+    expect(overridden.deny).not.toContain("dns-firewall.write");
     expect(overridden.unknownPolicy).toBe("allow");
   });
 

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -6,11 +6,7 @@ import {
   type ConnectorRuntimeBindingEntry,
 } from "@okouai/connectors/connector-auth-method";
 import type { ConnectorAuthMethodRuntimeConfig } from "@okouai/connectors/connector-config";
-import {
-  createFirewallMetadataPolicyResolver,
-  type FirewallMetadataPolicyResolver,
-  type FirewallPermissionPolicyDefaultMetadata,
-} from "@okouai/connectors/firewall-metadata/policy";
+import type { FirewallPermissionPolicyDefaultMetadata } from "@okouai/connectors/firewall-metadata/policy";
 import {
   extractSecretNamesFromApis,
   normalizeFirewallFixedHost,
@@ -57,9 +53,10 @@ export interface ConnectorServerFirewallPermissionIndex {
   readonly label: string;
   readonly permissionNames: ReadonlySet<string>;
   readonly permissionDescriptions: ReadonlyMap<string, string>;
+  readonly defaultPermissionPolicies: Readonly<
+    Record<string, FirewallPolicyValue>
+  >;
   readonly defaultPolicy: FirewallPermissionPolicyDefaultMetadata;
-  readonly unknownPolicy: FirewallPolicyValue;
-  readonly policyResolver: FirewallMetadataPolicyResolver;
   hasPermission(name: string): boolean;
   permissionDescription(name: string): string | null;
 }
@@ -179,22 +176,10 @@ function choosePermissionDefault(
 }
 
 function compactDefaultPolicy(args: {
-  readonly permissionNames: readonly string[];
-  readonly defaultAllowed: readonly string[] | null;
+  readonly policies: Readonly<Record<string, FirewallPolicyValue>>;
   readonly defaultUnknownPolicy: FirewallPolicyValue;
 }): FirewallPermissionPolicyDefaultMetadata {
-  const allowed = args.defaultAllowed
-    ? new Set<string>(args.defaultAllowed)
-    : null;
-  const policies = Object.fromEntries(
-    args.permissionNames.map((permission): [string, FirewallPolicyValue] => {
-      return [
-        permission,
-        allowed === null || allowed.has(permission) ? "allow" : "deny",
-      ];
-    }),
-  );
-  const permissionDefault = choosePermissionDefault(policies);
+  const permissionDefault = choosePermissionDefault(args.policies);
   const permissionOverrides: Partial<
     Record<FirewallPolicyValue, readonly string[]>
   > = {};
@@ -202,7 +187,7 @@ function compactDefaultPolicy(args: {
     if (value === permissionDefault) {
       continue;
     }
-    const permissions = Object.entries(policies)
+    const permissions = Object.entries(args.policies)
       .filter(([, policy]) => {
         return policy === value;
       })
@@ -233,31 +218,37 @@ function acceptedPermissionIndex(
       },
     ),
   );
-  const defaultPolicy = compactDefaultPolicy({
-    permissionNames: [...permissions.keys()].sort(compareStrings),
-    defaultAllowed: firewall.defaultAllowed,
-    defaultUnknownPolicy: firewall.defaultUnknownPolicy,
-  });
   permissions.delete(UNKNOWN_PERMISSION_GRANT);
   const permissionNames = [...permissions.keys()].sort(compareStrings);
+  const allowed = firewall.defaultAllowed
+    ? new Set<string>(firewall.defaultAllowed)
+    : null;
+  const defaultPermissionPolicies = Object.fromEntries(
+    permissionNames.map((permission): [string, FirewallPolicyValue] => {
+      return [
+        permission,
+        allowed === null || allowed.has(permission) ? "allow" : "deny",
+      ];
+    }),
+  );
+  const defaultPolicy = compactDefaultPolicy({
+    policies: defaultPermissionPolicies,
+    defaultUnknownPolicy: firewall.defaultUnknownPolicy,
+  });
   const permissionDescriptions = new Map<string, string>();
   for (const [name, description] of permissions) {
     if (description !== undefined) {
       permissionDescriptions.set(name, description);
     }
   }
-  const policyResolver = createFirewallMetadataPolicyResolver({
-    defaultPolicy,
-  });
   const permissionNameSet = new Set(permissionNames);
   return {
     connectorSlug: firewall.connectorSlug,
     label: firewall.label,
     permissionNames: permissionNameSet,
     permissionDescriptions,
+    defaultPermissionPolicies,
     defaultPolicy,
-    unknownPolicy: defaultPolicy.unknownPolicy,
-    policyResolver,
     hasPermission: (name) => {
       return permissionNameSet.has(name);
     },
@@ -681,26 +672,22 @@ export async function expandConnectorServerFirewallPolicies(args: {
       return args.catalog.loadPermissionIndex(connectorSlug);
     }),
   );
-  let resolved = args.stored;
+  let resolved: FirewallPolicies | null = null;
   for (const index of indexes) {
     if (!index) {
       continue;
     }
-    const policies = Object.fromEntries(
-      [...index.permissionNames].map((permission) => {
-        return [permission, index.policyResolver.permission(permission)];
-      }),
-    );
-    const existing = resolved?.[index.connectorSlug];
-    resolved = {
-      ...resolved,
-      [index.connectorSlug]: {
-        policies: { ...policies, ...existing?.policies },
-        ...(existing?.unknownPolicy !== undefined
-          ? { unknownPolicy: existing.unknownPolicy }
-          : { unknownPolicy: index.policyResolver.unknown() }),
+    resolved ??= { ...args.stored };
+    const existing = resolved[index.connectorSlug];
+    resolved[index.connectorSlug] = {
+      policies: {
+        ...index.defaultPermissionPolicies,
+        ...existing?.policies,
       },
+      ...(existing?.unknownPolicy !== undefined
+        ? { unknownPolicy: existing.unknownPolicy }
+        : { unknownPolicy: index.defaultPolicy.unknownPolicy }),
     };
   }
-  return resolved;
+  return resolved ?? args.stored;
 }

--- a/turbo/apps/api/src/signals/services/firewall-network-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/firewall-network-policy.service.ts
@@ -8,13 +8,9 @@ import type { ConnectorServerFirewallPermissionIndex } from "./connector-server-
 export function defaultFirewallPolicyForPermissionIndex(
   index: ConnectorServerFirewallPermissionIndex,
 ): FirewallPolicy {
-  const policies: FirewallPolicy["policies"] = {};
-  for (const name of index.permissionNames) {
-    policies[name] = index.policyResolver.permission(name);
-  }
   return {
-    policies,
-    unknownPolicy: index.policyResolver.unknown(),
+    policies: { ...index.defaultPermissionPolicies },
+    unknownPolicy: index.defaultPolicy.unknownPolicy,
   };
 }
 


### PR DESCRIPTION
## Summary

- retain the expanded default firewall policies that are already derived when a selected connector permission index is materialized
- assemble each run's outer firewall policy map once while preserving stored named-policy and unknown-policy precedence
- cover the production Zero pre-create path with a broad 20-connector firewall scope, including catalog defaults and stored overrides

## Behavior and compatibility

- no database schema, persisted catalog projection, HTTP API, queue payload, Runner protocol, or run-session protocol changes
- preserves missing-index, empty-scope, stored-policy, and unknown-policy semantics
- adds bounded lazy memory: one policy value per permission for each materialized selected connector index; run outputs remain independently copied
- does not add persistence, cross-process caching, warm-up traffic, or telemetry

## Validation

- `pnpm -F @okouai/db db:migrate`
- focused broad-scope lifecycle integration test (1 passed, 172 skipped)
- complete `run-lifecycle.bdd.test.ts` (173 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- `pnpm format`
- commit hooks (Prettier, repository Knip, TypeScript checks, file-size check, commitlint)

Closes #29256

Parent context: #24203
