### PR TITLE
docs: correct retired token and environment claims in cli cutover record

### DIFF
--- a/docs/okou-cli-cutover.md
+++ b/docs/okou-cli-cutover.md
@@ -55,12 +55,15 @@ contexts retain their immutable commit-addressed artifact and are not rewritten.
 ## Preserved protocol identities
 
 The executable cleanup does not rename internal protocol or product identities.
-Keep the `OKOU_TOKEN` preference with `ZERO_TOKEN` fallback, `OKOU_AGENT_ID` and
-`ZERO_AGENT_ID`, paired deployment environment injection, canonical `OKOU_*`
-names and `/api/okou/**`, `commands/zero`, other `ZERO_*` names and
-`/api/zero/**`, database and backend identifiers, the Slack `/zero model`
-interaction, and the separate Desktop identity. These are not executable CLI
-producers.
+Keep `OKOU_TOKEN`, `OKOU_AGENT_ID`, the canonical `OKOU_*` names,
+`commands/zero`, other `ZERO_*` names and `/api/zero/**`, database and backend
+identifiers, the Slack `/zero model` interaction, and the separate Desktop
+identity. These are not executable CLI producers.
+
+`/api/okou/**` is not a preserved identity. It is a compatibility surface being
+drained under #26701: it is down to 62 rows in `MIGRATED_BRANDED_PATHS`, and
+after #28984 no contract declares a branded path, so those rows are the only
+thing still registering one.
 
 The run-token scope pair was the one exception, retired separately once the
 issuing side had drained; see `docs/okou-protocol-migration.md`.

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -198,7 +198,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",
     description:
-      "Enable the managed banking gateway and banking:read ZERO_TOKEN capability for Finicity-backed accounts, balances, and transactions.",
+      "Enable the managed banking gateway and banking:read OKOU_TOKEN capability for Finicity-backed accounts, balances, and transactions.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
Closes #29277. Part of #26701.

Corrects two statements that describe a token and environment contract that no longer exists on `main`.

## 1. `docs/okou-cli-cutover.md` — "Preserved protocol identities"

Three items removed from the keep-list, one reworded:

- **Removed `ZERO_TOKEN` fallback.** The CLI reads only `OKOU_TOKEN`. `turbo/apps/cli/src/lib/api/__tests__/config.test.ts:26,34` assert the opposite of a fallback ("ignores ZERO_TOKEN when OKOU_TOKEN is present", "does not fall back to ZERO_TOKEN when OKOU_TOKEN is empty"), and `docs/testing/cli-testing.md:34` already states the correct behaviour — the two documents contradicted each other.
- **Removed `ZERO_AGENT_ID`.** The only non-test occurrence across `turbo` and `crates` is `turbo/apps/cli/src/test/setup.ts:17`, a fixture stubbing it empty; `turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts:4208` asserts a claim must not carry it.
- **Removed paired deployment environment injection.** `.github/actions/web-api-env/action.yml` has nine `add_var` / `add_secret` calls and none reads a `ZERO_` name; `.github/scripts/tests/web-api-env-action-test.sh:357` forbids reintroducing one. The injection is single-name now.
- **Reworded `/api/okou/**`.** Listed beside the canonical `OKOU_*` names it read as a preserved identity that should not be touched. It is the opposite: a compatibility surface being drained under #26701, down to 62 rows in `MIGRATED_BRANDED_PATHS` (verified by counting the table at `turbo/apps/api/src/signals/route-entry.ts:305-936`), and after #28984 no contract declares a branded path, so those rows are the only thing still registering one.

The five items that are still accurate — `commands/zero`, other `ZERO_*` names and `/api/zero/**`, database and backend identifiers, the Slack `/zero model` interaction, and the separate Desktop identity — are unchanged.

## 2. `turbo/packages/core/src/feature-switch.ts:201`

The user-visible Banking feature-switch description named the retired token. `banking:read` is a real capability (`packages/api-contracts/src/contracts/capabilities.ts:30`, enforced at `apps/api/src/signals/routes/banking.ts:143`), but it is carried on `OKOU_TOKEN`. Only that token name changed; the rest of the sentence is untouched. It states the same fact as part 1, and a `docs/`-only grep does not reach it, which is how it survived.

## Out of scope

`turbo/apps/cli/src/test/setup.ts` is untouched — stubbing the retired names to empty is what makes the "no fallback" tests meaningful. No other `ZERO_`/`zero` occurrence was swept: the remaining ones are deliberate (the numeral "zero", auditor fixtures, real artifact names, security-boundary assertions, and the live `docs/zero-desktop-migration-rollout.md` runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)