### PR TITLE
fix(connectors): make fallback account names searchable

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -606,9 +606,10 @@ describe("connector account lifecycle routes", () => {
     const fixture = await seedFixture();
     await setConnectorAccountsEnabled(fixture, true);
 
+    const createdAccountIds: string[] = [];
     for (let index = 0; index < 101; index += 1) {
       const label = `Bulk ${index.toString().padStart(3, "0")}`;
-      await accept(
+      const created = await accept(
         connectorClient().connect({
           headers: authHeaders(),
           params: { connectorSlug: "openai" },
@@ -620,9 +621,11 @@ describe("connector account lifecycle routes", () => {
         }),
         [200],
       );
+      createdAccountIds.push(created.body.id);
     }
 
     const ids = new Set<string>();
+    const firstPageIds = new Set<string>();
     let cursor: string | undefined;
     do {
       const page = await accept(
@@ -639,6 +642,9 @@ describe("connector account lifecycle routes", () => {
       );
       for (const account of page.body.connections) {
         ids.add(account.id);
+        if (!cursor) {
+          firstPageIds.add(account.id);
+        }
       }
       cursor = page.body.nextCursor ?? undefined;
     } while (cursor);
@@ -658,6 +664,72 @@ describe("connector account lifecycle routes", () => {
     );
     expect(searched.body.connections).toHaveLength(1);
     expect(searched.body.connections[0]!.displayName).toBe("Bulk 042");
+
+    const accountOutsideFirstPage = createdAccountIds.find((id) => {
+      return !firstPageIds.has(id);
+    });
+    if (!accountOutsideFirstPage) {
+      throw new Error("Expected an account outside the first page");
+    }
+    await accept(
+      accountClient().rename({
+        headers: authHeaders(),
+        params: { connectionId: accountOutsideFirstPage },
+        body: {
+          target: { kind: "builtin", connectorSlug: "openai" },
+          displayName: null,
+        },
+      }),
+      [200],
+    );
+    const searchedByFallback = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: {
+          kind: "builtin",
+          connectorSlug: "openai",
+          limit: 100,
+          search: accountOutsideFirstPage.slice(0, 8),
+        },
+      }),
+      [200],
+    );
+    expect(searchedByFallback.body.connections).toContainEqual(
+      expect.objectContaining({
+        id: accountOutsideFirstPage,
+        displayName: null,
+      }),
+    );
+
+    const noMatch = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: {
+          kind: "builtin",
+          connectorSlug: "openai",
+          limit: 100,
+          search: "no-matching-connector-account",
+        },
+      }),
+      [200],
+    );
+    expect(noMatch.body).toStrictEqual({
+      connections: [],
+      nextCursor: null,
+    });
+
+    await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: {
+          kind: "builtin",
+          connectorSlug: "openai",
+          limit: 100,
+          search: " ",
+        },
+      }),
+      [400],
+    );
 
     const summary = await accept(
       accountClient().summaries({ headers: authHeaders() }),
@@ -693,7 +765,12 @@ describe("connector account lifecycle routes", () => {
     const listed = await accept(
       accountClient().connections({
         headers: authHeaders(),
-        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+        query: {
+          kind: "builtin",
+          connectorSlug: "openai",
+          limit: 100,
+          search: account.body.id.slice(0, 8),
+        },
       }),
       [200],
     );
@@ -943,6 +1020,20 @@ describe("connector account lifecycle routes", () => {
       if (!work || !personal) {
         throw new Error("Expected both custom connector accounts");
       }
+
+      const searchedByFallback = await accept(
+        accountClient().connections({
+          headers: authHeaders(),
+          query: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+            limit: 100,
+            search: work.id.slice(0, 8),
+          },
+        }),
+        [200],
+      );
+      expect(searchedByFallback.body.connections).toStrictEqual([work]);
 
       const renamed = await accept(
         accountClient().rename({

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -1033,7 +1033,7 @@ describe("connector account lifecycle routes", () => {
         }),
         [200],
       );
-      expect(searchedByFallback.body.connections).toStrictEqual([work]);
+      expect(searchedByFallback.body.connections).toContainEqual(work);
 
       const renamed = await accept(
         accountClient().rename({

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -187,6 +187,7 @@ async function loadConnectorAccountRows(
     searchPattern === undefined
       ? undefined
       : or(
+          ilike(sql`${connectors.id}::text`, searchPattern),
           ilike(connectors.displayName, searchPattern),
           ilike(connectors.externalEmail, searchPattern),
           ilike(connectors.externalUsername, searchPattern),


### PR DESCRIPTION
## Summary

- include connector account IDs in the existing case-insensitive account search predicate
- cover fallback-name discovery for unnamed built-in and custom accounts
- preserve organization/member and connector-target isolation while searching by fallback ID

## Scope

This change only extends the existing connector account search predicate and route integration coverage. It does not change API schemas, response shapes, pagination contracts, frontend behavior, or database structure.

Closes #29222

Parent context: #22832

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/connector-accounts.test.ts apps/api/src/signals/services/connector-account-lifecycle.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts --maxWorkers=4`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (211 files, 3491 tests)
- pre-commit hooks: Prettier, repository Knip, repository TypeScript checks, file-size check, and commitlint
