### PR TITLE
fix(connectors): keep default accounts visible in manager

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -17,7 +17,9 @@ const CONNECTOR_ACCOUNT_PAGE_SIZE = 50;
 
 export type ConnectorAccountMutationVersion = number | string | null;
 
-function connectorAccountTargetKey(target: ConnectorAccountTarget): string {
+export function connectorAccountTargetKey(
+  target: ConnectorAccountTarget,
+): string {
   return target.kind === "builtin"
     ? `builtin:${target.connectorSlug}`
     : `custom:${target.customConnectorId}`;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1501,28 +1501,34 @@ describe("connectors page", () => {
       throw new Error("Expected GitHub fixture connector");
     }
     const accounts = Array.from({ length: 101 }, (_, index) => {
+      const isDefault = index === 0;
       return {
-        id:
-          index === 0
-            ? "00000000-0000-4000-a000-000000000001"
-            : crypto.randomUUID(),
+        id: isDefault
+          ? "00000000-0000-4000-a000-000000000001"
+          : crypto.randomUUID(),
         target: { kind: "builtin" as const, connectorSlug: "github" },
         authMethod: "oauth",
-        displayName: index === 0 ? null : `Work ${index}`,
-        isDefault: index === 0,
+        displayName: isDefault ? null : `Work ${index}`,
+        isDefault,
         externalId: null,
-        externalUsername: index === 0 ? null : `octocat-${index}`,
+        externalUsername: isDefault ? null : `octocat-${index}`,
         externalEmail: null,
         oauthScopes: [],
-        connectionStatus: "connected" as const,
-        reconnectReason: null,
+        connectionStatus: isDefault
+          ? ("reconnect-required" as const)
+          : ("connected" as const),
+        reconnectReason: isDefault
+          ? ("authorization_expired_or_revoked" as const)
+          : null,
         tokenExpiresAt: null,
         createdAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
       } satisfies ConnectorAccountConnection;
-    });
+    }).reverse();
     context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
-      const [defaultAccount] = accounts;
+      const defaultAccount = accounts.find((account) => {
+        return account.isDefault;
+      });
       if (!defaultAccount) {
         throw new Error("Expected a default account fixture");
       }
@@ -1531,7 +1537,7 @@ describe("connectors page", () => {
           {
             target: { kind: "builtin", connectorSlug: "github" },
             accountCount: accounts.length,
-            attentionCount: 0,
+            attentionCount: 1,
             defaultConnection: defaultAccount,
           },
         ],
@@ -1592,11 +1598,29 @@ describe("connectors page", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "GitHub",
     });
-    expect(within(dialog).getByText("Account #00000000")).toBeInTheDocument();
+    const defaultGroup = within(dialog).getByRole("group", {
+      name: "Default",
+    });
+    expect(
+      within(defaultGroup).getByText("Account #00000000"),
+    ).toBeInTheDocument();
+    expect(
+      within(defaultGroup).getByText("Reconnect required"),
+    ).toBeInTheDocument();
+    expect(
+      within(defaultGroup).getByLabelText("Account actions"),
+    ).toBeInTheDocument();
+    expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     expect(within(dialog).queryByText("Work 50")).toBeNull();
     click(buttonByText("Load more", dialog));
     await waitFor(() => {
       expect(within(dialog).getByText("Work 50")).toBeInTheDocument();
+    });
+    click(buttonByText("Load more", dialog));
+    await waitFor(() => {
+      expect(queryButtonByText("Load more", dialog)).toBeNull();
+      expect(within(dialog).getByText("Work 1")).toBeInTheDocument();
+      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
     await fill(
       within(dialog).getByPlaceholderText("Find accounts"),
@@ -1604,7 +1628,15 @@ describe("connectors page", () => {
     );
     await waitFor(() => {
       expect(within(dialog).getByText("Work 100")).toBeInTheDocument();
-      expect(within(dialog).queryByText("Account #00000000")).toBeNull();
+      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+    });
+    await fill(
+      within(dialog).getByPlaceholderText("Find accounts"),
+      "No matching account",
+    );
+    await waitFor(() => {
+      expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
+      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
   });
 
@@ -1690,6 +1722,11 @@ describe("connectors page", () => {
     const manager = await screen.findByRole("dialog", {
       name: "GitHub",
     });
+    expect(
+      within(within(manager).getByRole("group", { name: "Default" })).getByText(
+        "Work",
+      ),
+    ).toBeInTheDocument();
     expect(within(manager).queryByPlaceholderText("Find accounts")).toBeNull();
     const actions = within(manager).getAllByLabelText("Account actions");
     const personalActions = actions.at(1);
@@ -1702,6 +1739,12 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(defaultConnectionId).toBe(personalAccount.id);
       expect(connectorCardByLabel("GitHub")).toHaveTextContent("2 accounts");
+      const defaultGroup = within(manager).getByRole("group", {
+        name: "Default",
+      });
+      expect(within(defaultGroup).getByText("Personal")).toBeInTheDocument();
+      expect(within(manager).getAllByText("Personal")).toHaveLength(1);
+      expect(within(manager).getAllByText("Work")).toHaveLength(1);
     });
   });
 
@@ -6451,7 +6494,11 @@ describe("connectors page", () => {
     const manager = await screen.findByRole("dialog", {
       name: connector.displayName,
     });
-    click(await within(manager).findByLabelText("Account actions"));
+    const defaultGroup = within(manager).getByRole("group", {
+      name: "Default",
+    });
+    expect(within(defaultGroup).getByText("Existing")).toBeInTheDocument();
+    click(within(defaultGroup).getByLabelText("Account actions"));
     click(menuItemByText("Reconnect"));
     const dialog = await screen.findByRole("dialog", {
       name: `Connect ${connector.displayName}`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1804,6 +1804,9 @@ describe("connectors page", () => {
       ),
     ).resolves.toBeInTheDocument();
     expect(buttonByText("Add account", manager)).toBeDisabled();
+    expect(
+      within(manager).queryByRole("group", { name: "Default" }),
+    ).toBeNull();
   });
 
   it("does not restore a pending deletion draft after the manager closes", async () => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -25,6 +25,8 @@ import {
 import { connectorAccountEffectiveLabel } from "../../../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
+  connectorAccountSummaryByTarget$,
+  connectorAccountTargetKey,
   deleteConnectorAccount$,
   renameConnectorAccount$,
   setDefaultConnectorAccount$,
@@ -220,11 +222,13 @@ function AccountRow({
 
 function AccountList({
   loadable,
+  defaultConnectionId,
   target,
   connectionActionsEnabled,
   onReconnect,
 }: {
   readonly loadable: Loadable<ConnectorAccountList>;
+  readonly defaultConnectionId: string | null;
   readonly target: ConnectorAccountTarget;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
@@ -267,20 +271,58 @@ function AccountList({
       </p>
     );
   }
-  return loadable.data.connections.flatMap((account) => {
-    return [
+  return loadable.data.connections
+    .filter((account) => {
+      return account.id !== defaultConnectionId;
+    })
+    .flatMap((account) => {
+      return [
+        <AccountRow
+          key={`${account.id}-row`}
+          target={target}
+          account={account}
+          connectionActionsEnabled={connectionActionsEnabled}
+          onReconnect={onReconnect}
+        />,
+        renameDraft?.account.id === account.id ? (
+          <RenameAccountForm key={`${account.id}-rename`} target={target} />
+        ) : null,
+      ];
+    });
+}
+
+function DefaultAccount({
+  target,
+  account,
+  connectionActionsEnabled,
+  onReconnect,
+}: {
+  readonly target: ConnectorAccountTarget;
+  readonly account: ConnectorAccountConnection;
+  readonly connectionActionsEnabled: boolean;
+  readonly onReconnect: (account: ConnectorAccountConnection) => void;
+}) {
+  const { t } = useTranslation();
+  const renameDraft = useGet(connectorAccountRenameDraft$);
+  return (
+    <div
+      role="group"
+      aria-label={t(($) => {
+        return $.connectors.accounts.default;
+      })}
+      className="border-b border-border bg-muted/20 text-sm text-muted-foreground"
+    >
       <AccountRow
-        key={`${account.id}-row`}
         target={target}
         account={account}
         connectionActionsEnabled={connectionActionsEnabled}
         onReconnect={onReconnect}
-      />,
-      renameDraft?.account.id === account.id ? (
-        <RenameAccountForm key={`${account.id}-rename`} target={target} />
-      ) : null,
-    ];
-  });
+      />
+      {renameDraft?.account.id === account.id ? (
+        <RenameAccountForm target={target} />
+      ) : null}
+    </div>
+  );
 }
 
 function RenameAccountForm({ target }: { target: ConnectorAccountTarget }) {
@@ -427,6 +469,29 @@ function DeleteAccountConfirmation({
   );
 }
 
+function ConnectorAccountSearch({
+  value,
+  onChange,
+}: {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="border-b border-border px-6 py-3">
+      <Input
+        value={value}
+        onChange={(event) => {
+          return onChange(event.target.value);
+        }}
+        placeholder={t(($) => {
+          return $.connectors.accounts.find;
+        })}
+      />
+    </div>
+  );
+}
+
 export function ConnectorAccountManagerDialog({
   target,
   connectorLabel,
@@ -438,6 +503,7 @@ export function ConnectorAccountManagerDialog({
 }: ConnectorAccountManagerDialogProps) {
   const { t } = useTranslation();
   const accountsLoadable = useLoadable(settingsConnectorAccounts.accounts$);
+  const summariesLoadable = useLoadable(connectorAccountSummaryByTarget$);
   const search = useGet(settingsConnectorAccounts.search$);
   const setSearch = useSet(settingsConnectorAccounts.setSearch$);
   const [loadMoreLoadable, loadMore] = useLoadableSet(
@@ -449,6 +515,11 @@ export function ConnectorAccountManagerDialog({
     accountsLoadable.state === "hasData"
       ? accountsLoadable.data.nextCursor
       : null;
+  const defaultConnection =
+    summariesLoadable.state === "hasData"
+      ? (summariesLoadable.data.get(connectorAccountTargetKey(target))
+          ?.defaultConnection ?? null)
+      : null;
   const showSearch =
     search.length > 0 ||
     (accountsLoadable.state === "hasData" &&
@@ -457,6 +528,11 @@ export function ConnectorAccountManagerDialog({
   const leave = (next: () => void) => {
     resetDrafts();
     next();
+  };
+  const reconnect = (account: ConnectorAccountConnection) => {
+    leave(() => {
+      return onReconnect(account);
+    });
   };
   return (
     <Dialog
@@ -497,28 +573,23 @@ export function ConnectorAccountManagerDialog({
           </div>
         </DialogHeader>
         {showSearch ? (
-          <div className="border-b border-border px-6 py-3">
-            <Input
-              value={search}
-              onChange={(event) => {
-                return setSearch(event.target.value);
-              }}
-              placeholder={t(($) => {
-                return $.connectors.accounts.find;
-              })}
-            />
-          </div>
+          <ConnectorAccountSearch value={search} onChange={setSearch} />
+        ) : null}
+        {defaultConnection ? (
+          <DefaultAccount
+            target={target}
+            account={defaultConnection}
+            connectionActionsEnabled={connectionActionsEnabled}
+            onReconnect={reconnect}
+          />
         ) : null}
         <div className="max-h-[min(60vh,420px)] overflow-y-auto text-sm text-muted-foreground">
           <AccountList
             loadable={accountsLoadable}
+            defaultConnectionId={defaultConnection?.id ?? null}
             target={target}
             connectionActionsEnabled={connectionActionsEnabled}
-            onReconnect={(account) => {
-              leave(() => {
-                return onReconnect(account);
-              });
-            }}
+            onReconnect={reconnect}
           />
         </div>
         {nextCursor ? (

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -516,7 +516,9 @@ export function ConnectorAccountManagerDialog({
       ? accountsLoadable.data.nextCursor
       : null;
   const defaultConnection =
-    summariesLoadable.state === "hasData"
+    summariesLoadable.state === "hasData" &&
+    accountsLoadable.state === "hasData" &&
+    accountsLoadable.data.available
       ? (summariesLoadable.data.get(connectorAccountTargetKey(target))
           ?.defaultConnection ?? null)
       : null;


### PR DESCRIPTION
## Summary

- keep the exact default connector account in a fixed manager section outside the paginated scroll area
- reuse the existing bounded account summary for built-in and user-managed custom targets
- remove the pinned connection ID from loaded/search result rows without changing cursor state
- preserve rename, reconnect, delete, fallback-label, and reconnect-required behavior on the pinned row

## Behavior

- an oldest default remains visible and actionable even when more than 50 newer accounts precede it
- loading the page that also contains the default does not render a duplicate or omit non-default accounts
- search keeps the default as structurally separate target context while the result list remains filtered
- setting a new default updates the fixed row in the still-open manager and returns the previous default to the ordinary list

## Scope and compatibility

- Platform-only presentation and state selection
- no API contract, route, service, database, cursor, Runner protocol, permission, persisted-state, runtime credential, or thread-inheritance change
- consumes the already-deployed `defaultConnection` summary field, so independently deployed frontend/API revisions remain compatible
- search matching and request debouncing remain in #29222 and #29223

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (109 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit: affected-file Prettier, full-repository Knip, sequential workspace type checks (14/14), file-size check, and commitlint
- `git diff --check`

Closes #29225

Parent context: #22832
