### PR TITLE
perf(python): batch resolved auth header injection

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -616,6 +616,7 @@ def _apply_header_query_injection(
             if existing_field is None:
                 resolved_fields_by_name[normalized_name] = (encoded_name, encoded_value)
             else:
+                # Match Headers.set_all(): keep the first spelling and let the last value win.
                 resolved_fields_by_name[normalized_name] = (
                     existing_field[0],
                     encoded_value,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -605,8 +605,33 @@ def _apply_header_query_injection(
     headers: dict[str, str],
     resolved_query: dict | None,
 ) -> None:
-    for header_name, header_value in resolved_auth_header_pairs(headers):
-        flow.request.headers[header_name] = header_value
+    auth_pairs = resolved_auth_header_pairs(headers)
+    if auth_pairs:
+        resolved_fields_by_name: dict[bytes, tuple[bytes, bytes]] = {}
+        for header_name, header_value in auth_pairs:
+            encoded_name = header_name.encode()
+            encoded_value = header_value.encode()
+            normalized_name = encoded_name.lower()
+            existing_field = resolved_fields_by_name.get(normalized_name)
+            if existing_field is None:
+                resolved_fields_by_name[normalized_name] = (encoded_name, encoded_value)
+            else:
+                resolved_fields_by_name[normalized_name] = (
+                    existing_field[0],
+                    encoded_value,
+                )
+
+        remaining_fields = resolved_fields_by_name.copy()
+        merged_fields: list[tuple[bytes, bytes]] = []
+        for header_name, header_value in flow.request.headers.fields:
+            normalized_name = header_name.lower()
+            if normalized_name in remaining_fields:
+                _resolved_name, resolved_value = remaining_fields.pop(normalized_name)
+                merged_fields.append((header_name, resolved_value))
+            elif normalized_name not in resolved_fields_by_name:
+                merged_fields.append((header_name, header_value))
+        merged_fields.extend(remaining_fields.values())
+        flow.request.headers.fields = tuple(merged_fields)
     if resolved_query:
         remaining_query = resolved_query.copy()
         merged_query: list[tuple[str, str]] = []

--- a/crates/runner/mitm-addon/tests/test_auth_header_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_header_injection.py
@@ -1,0 +1,127 @@
+"""Integration tests for firewall auth header injection."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mitmproxy import http
+
+import auth
+import flow_metadata_keys as metadata_keys
+from tests.firewall_auth_helpers import (
+    apply_requestheaders_auth_without_upstream_admission,
+    handle_firewall_request_without_upstream_admission,
+    make_allow,
+)
+
+
+@pytest.mark.parametrize(
+    ("hook_phase", "expected_result"),
+    [
+        pytest.param(
+            "request",
+            auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM,
+            id="request",
+        ),
+        pytest.param(
+            "requestheaders",
+            auth.FirewallHeaderPhaseAuthResult.APPLIED,
+            id="requestheaders",
+        ),
+    ],
+)
+async def test_bulk_headers_preserve_semantics_without_per_header_rebuilds(
+    real_flow,
+    mitm_ctx,
+    monkeypatch,
+    hook_phase,
+    expected_result,
+):
+    bulk_headers = {f"X-Bulk-{index:04d}": f"resolved-{index}" for index in range(512)}
+    resolved_headers = {
+        "X-Managed": "resolved-first",
+        "x-managed": "resolved-final",
+        "Connection": "X-Connection-Only",
+        "X-Connection-Only": "filtered",
+        "Host": "resolved.example.com",
+        "Content-Length": "999",
+        "Transfer-Encoding": "chunked",
+        "Proxy-Authorization": "Basic filtered",
+        **bulk_headers,
+    }
+    flow = real_flow(
+        with_response=False,
+        host="api.example.com",
+        path="/resource",
+        request_headers=http.Headers(
+            [
+                (b"Host", b"api.example.com"),
+                (b"X-Keep", b"one"),
+                (b"x-managed", b"client-first"),
+                (b"X-Raw", b"caf\xe9"),
+                (b"X-Keep", b"two"),
+                (b"X-MANAGED", b"client-second"),
+                (b"X-Bulk-0000", b"client-bulk"),
+                (b"Content-Length", b"7"),
+            ]
+        ),
+    )
+    flow.metadata[metadata_keys.SANDBOX_RUN_ID] = "test-run"
+    allow = make_allow(
+        {
+            "base": "https://api.example.com",
+            "auth": {
+                "headers": dict.fromkeys(resolved_headers, "${{ secrets.VALUE }}"),
+            },
+        },
+        name="example",
+        permission="read",
+        rule="GET /resource",
+    )
+    sandbox_info = {
+        "runId": "run-1",
+        "sandboxToken": "tok",
+        "encryptedSecrets": "iv:tag:data",
+        "billableFirewalls": [],
+    }
+    token_meta = {
+        "headers": resolved_headers,
+        "resolved_secrets": ["VALUE"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+    header_set_all_calls = 0
+    original_set_all = http.Headers.set_all
+
+    def counted_set_all(headers, name, values):
+        nonlocal header_set_all_calls
+        header_set_all_calls += 1
+        return original_set_all(headers, name, values)
+
+    monkeypatch.setattr(http.Headers, "set_all", counted_set_all)
+
+    with (
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+        mitm_ctx(),
+    ):
+        if hook_phase == "request":
+            result = await handle_firewall_request_without_upstream_admission(
+                flow, allow, sandbox_info
+            )
+        else:
+            result = await apply_requestheaders_auth_without_upstream_admission(
+                flow, allow, sandbox_info
+            )
+
+    assert result is expected_result
+    assert header_set_all_calls == 0
+    assert flow.request.headers.fields == (
+        (b"Host", b"api.example.com"),
+        (b"X-Keep", b"one"),
+        (b"x-managed", b"resolved-final"),
+        (b"X-Raw", b"caf\xe9"),
+        (b"X-Keep", b"two"),
+        (b"X-Bulk-0000", b"resolved-0"),
+        (b"Content-Length", b"7"),
+        *((name.encode(), value.encode()) for name, value in list(bulk_headers.items())[1:]),
+    )

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -199,6 +199,7 @@ suites before committing the upgrade.
 | `test_firewall_rewrite_success.py`                      | Firewall auth URL rewrite success behavior                                                                           |
 | `test_firewall_rewrite_forwarding.py`                   | Firewall auth URL rewrite forwarding behavior                                                                        |
 | `test_firewall_rewrite_safety.py`                       | Firewall auth URL rewrite fail-closed and safety behavior                                                            |
+| `test_auth_header_injection.py`                         | Firewall auth bulk header injection, filtering, ordering, and mutation bounds                                        |
 | `test_auth_query_injection.py`                          | Firewall auth query injection and query rewrite behavior                                                             |
 | `test_host_normalization.py`                            | Shared hostname identity, ASCII fast-path, IDNA, and label-boundary contracts                                        |
 | `test_url_syntax.py`                                    | Shared raw URL code-point, whitespace, backslash, and safe-input fast-path contracts                                 |


### PR DESCRIPTION
## Summary

- merge validated inline firewall-auth headers in one linear raw-field pass instead of rebuilding mitmproxy headers once per resolved field
- preserve case-insensitive replacement, duplicate unrelated client fields, original raw bytes and order, filtered transport fields, and case-equivalent resolved-key behavior
- cover both ordinary request and requestheaders auth paths with a large-map integration regression and document the new test surface

## Scope

- no auth header-count limit or API/configuration contract change
- no change to auth.base forwarding or query injection

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_header_injection.py` (2 passed)
- `uv run --no-sync python -m pytest tests/` (6,627 passed)
- `pnpm exec prettier --check ../docs/testing/mitm-addon-testing.md`

Closes #29288
