### PR TITLE
docs(rust): document encode_exec_result error conditions

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -113,6 +113,12 @@ fn append_exec_result_payload(
 }
 
 /// Encode exec_result payload.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `diagnostic` or captured stdout/stderr cannot
+/// fit its wire length field, or the encoded payload exceeds the maximum
+/// message size.
 pub fn encode_exec_result(
     termination: ExecTermination,
     duration_ms: u32,


### PR DESCRIPTION
## Summary

- Document the `ProtocolError` conditions for the public `encode_exec_result` payload encoder.
- Align the payload encoder's rustdoc with the existing `encode_exec_result_frame_into` contract.

## Scope

This is a documentation-only change in `crates/vsock-proto/src/payloads/exec_operation/result.rs`. It does not change encoding logic, wire bytes, error values, public signatures, tests, or compatibility behavior.

Closes #29286

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo test -p vsock-proto` — passed; 152 unit tests and all crate integration/property/doc-test targets passed.
- `cargo doc --workspace --all-features --no-deps` — passed; workspace documentation, including `vsock-proto`, generated successfully.
- `cargo clippy --all-targets --all-features` — blocked by two pre-existing `clippy::chunks-exact-to-as-chunks` errors in unchanged `crates/vsock-proto/src/payloads/memory_snapshot.rs:77,92` under local Rust/Clippy 1.98.0. The changed file produced no Clippy finding.
