### PR TITLE
refactor(platform): migrate auth v2 timers to signal ownership

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2/diagnostics.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/diagnostics.test.ts
@@ -79,6 +79,13 @@ function createSignInHarness(options?: {
       }),
   );
   const noOp$ = command((): void => {});
+  const noOpRef$ = onRef(
+    command(
+      (_context, _element: HTMLSpanElement, signal: AbortSignal): void => {
+        signal.throwIfAborted();
+      },
+    ),
+  );
   const asyncNoOp$ = command((_context, signal: AbortSignal): Promise<void> => {
     signal.throwIfAborted();
     return Promise.resolve();
@@ -147,6 +154,7 @@ function createSignInHarness(options?: {
         return get(password$);
       }),
       resendCode$: asyncNoOp$,
+      resendCooldownLifecycleRef$: noOpRef$,
       resendState$: READY_SIGN_IN_RESEND_STATE$,
       restart$: noOp$,
       selectFactor$: stringAsyncNoOp$,

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -14,7 +14,7 @@ import {
 
 import { now } from "../../lib/time.ts";
 import { clerk$ } from "../auth.ts";
-import { settle, withCleanup } from "../utils.ts";
+import { onRef, setLoop, settle, withCleanup } from "../utils.ts";
 import {
   discoverAuthV2ExistingAccounts,
   discoverAuthV2ExternalCapabilities,
@@ -143,6 +143,9 @@ export interface AuthV2SignInSignals {
   readonly newPassword$: Computed<string>;
   readonly password$: Computed<string>;
   readonly resendCode$: Command<Promise<void>, [AbortSignal]>;
+  readonly resendCooldownLifecycleRef$: ReturnType<
+    typeof onRef<HTMLSpanElement>
+  >;
   readonly resendState$: Computed<AuthV2SignInResendState>;
   readonly restart$: Command<void, []>;
   readonly selectFactor$: Command<Promise<void>, [string, AbortSignal]>;
@@ -184,7 +187,6 @@ interface SignInFlowAtoms {
 
 interface SignInFlowRuntime {
   readonly cooldownDeadlineMs$: State<number | null>;
-  readonly cooldownTimer$: State<number | null>;
   readonly handledSessionId$: State<string | null>;
   readonly inFlight$: State<ReadonlyMap<CoalescedOperation, Promise<void>>>;
   readonly preparedFactorId$: State<string | null>;
@@ -564,7 +566,6 @@ function createSignInFlowAtoms(): SignInFlowAtoms {
 function createSignInFlowRuntime(): SignInFlowRuntime {
   return {
     cooldownDeadlineMs$: state<number | null>(null),
-    cooldownTimer$: state<number | null>(null),
     handledSessionId$: state<string | null>(null),
     inFlight$: state<ReadonlyMap<CoalescedOperation, Promise<void>>>(new Map()),
     preparedFactorId$: state<string | null>(null),
@@ -575,55 +576,51 @@ function createStartCooldownCommand(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
 ): Command<void, [AbortSignal]> {
-  const updateCooldown$ = command(({ get, set }): void => {
-    const deadlineMs = get(runtime.cooldownDeadlineMs$);
-    if (deadlineMs === null) {
-      set(atoms.resendRemainingSeconds$, 0);
-      return;
-    }
-    const remainingSeconds = Math.max(
-      0,
-      Math.ceil((deadlineMs - now()) / 1000),
-    );
-    set(atoms.resendRemainingSeconds$, remainingSeconds);
-    if (remainingSeconds > 0) {
-      return;
-    }
-    const timer = get(runtime.cooldownTimer$);
-    if (timer !== null) {
-      window.clearInterval(timer);
-    }
-    set(runtime.cooldownDeadlineMs$, null);
-    set(runtime.cooldownTimer$, null);
-  });
-
-  return command(({ get, set }, signal: AbortSignal): void => {
-    const currentTimer = get(runtime.cooldownTimer$);
-    if (currentTimer !== null) {
-      window.clearInterval(currentTimer);
-    }
+  return command(({ set }, signal: AbortSignal): void => {
+    signal.throwIfAborted();
     set(
       runtime.cooldownDeadlineMs$,
       now() + AUTH_V2_SIGN_IN_RESEND_COOLDOWN_MS,
     );
     set(atoms.resendRemainingSeconds$, AUTH_V2_SIGN_IN_RESEND_COOLDOWN_SECONDS);
-    const timer = window.setInterval(() => {
-      set(updateCooldown$);
-    }, 1000);
-    set(runtime.cooldownTimer$, timer);
-    signal.addEventListener(
-      "abort",
-      () => {
-        if (get(runtime.cooldownTimer$) === timer) {
-          window.clearInterval(timer);
-          set(runtime.cooldownDeadlineMs$, null);
-          set(runtime.cooldownTimer$, null);
-          set(atoms.resendRemainingSeconds$, 0);
-        }
-      },
-      { once: true },
-    );
   });
+}
+
+function createResendCooldownLifecycleRef(
+  atoms: SignInFlowAtoms,
+  runtime: SignInFlowRuntime,
+) {
+  return onRef(
+    command(
+      async (
+        { get, set },
+        _element: HTMLSpanElement,
+        signal: AbortSignal,
+      ): Promise<void> => {
+        await setLoop(
+          () => {
+            const deadlineMs = get(runtime.cooldownDeadlineMs$);
+            if (deadlineMs === null) {
+              return true;
+            }
+            const remainingSeconds = Math.max(
+              0,
+              Math.ceil((deadlineMs - now()) / 1000),
+            );
+            set(atoms.resendRemainingSeconds$, remainingSeconds);
+            if (remainingSeconds > 0) {
+              return false;
+            }
+            set(runtime.cooldownDeadlineMs$, null);
+            return true;
+          },
+          1000,
+          signal,
+          { retryTransientErrors: false },
+        );
+      },
+    ),
+  );
 }
 
 function createResourceCommands(
@@ -1161,13 +1158,8 @@ function createFormCommands(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
 ) {
-  const clearCooldown$ = command(({ get, set }): void => {
-    const timer = get(runtime.cooldownTimer$);
-    if (timer !== null) {
-      window.clearInterval(timer);
-    }
+  const clearCooldown$ = command(({ set }): void => {
     set(runtime.cooldownDeadlineMs$, null);
-    set(runtime.cooldownTimer$, null);
     set(atoms.resendRemainingSeconds$, 0);
   });
   const backToMethods$ = command(({ set }) => {
@@ -1266,6 +1258,10 @@ export function createAuthV2SignInSignals(
     applyResource$,
   );
   const startCooldown$ = createStartCooldownCommand(atoms, runtime);
+  const resendCooldownLifecycleRef$ = createResendCooldownLifecycleRef(
+    atoms,
+    runtime,
+  );
   const resendCodeOperation$ = createResendCodeOperation$(
     atoms,
     runtime,
@@ -1313,6 +1309,7 @@ export function createAuthV2SignInSignals(
       "resource",
       resendCodeOperation$,
     ),
+    resendCooldownLifecycleRef$,
     resendState$: computed((get) => {
       const remainingSeconds = get(atoms.resendRemainingSeconds$);
       return remainingSeconds > 0

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -15,12 +15,19 @@ import {
   type Computed,
   type State,
 } from "ccstate";
+import { timeout } from "signal-timers";
 
 import { now } from "../../lib/time.ts";
 import { clerk$ } from "../auth.ts";
 import { locale$ } from "../locale.ts";
 import { logger } from "../log.ts";
-import { createDeferredPromise, onRef, settle, withCleanup } from "../utils.ts";
+import {
+  createChildAbortController,
+  createDeferredPromise,
+  onRef,
+  settle,
+  withCleanup,
+} from "../utils.ts";
 import type { AuthV2ContinuationFlowHandoff } from "./continuation.ts";
 import type { AuthV2Navigation } from "./navigation.ts";
 import {
@@ -214,8 +221,8 @@ interface SignUpFlowAtoms {
 
 interface SignUpFlowRuntime {
   readonly automaticPreparationAttempted$: State<boolean>;
-  readonly cooldownTimer$: State<number | null>;
-  readonly expiryTimer$: State<number | null>;
+  readonly cooldownController$: State<AbortController | null>;
+  readonly expiryController$: State<AbortController | null>;
   readonly inFlight$: State<Promise<void> | null>;
 }
 
@@ -777,8 +784,8 @@ function createSignUpFlowAtoms(): SignUpFlowAtoms {
 function createSignUpFlowRuntime(): SignUpFlowRuntime {
   return {
     automaticPreparationAttempted$: state(false),
-    cooldownTimer$: state<number | null>(null),
-    expiryTimer$: state<number | null>(null),
+    cooldownController$: state<AbortController | null>(null),
+    expiryController$: state<AbortController | null>(null),
     inFlight$: state<Promise<void> | null>(null),
   };
 }
@@ -813,51 +820,45 @@ const clerkSignUpConfiguration$ = computed(async (get) => {
   } satisfies SignUpConfiguration;
 });
 
-function clearTimer(
-  timer: number | null,
-  setTimer: (timer: number | null) => void,
-): void {
-  if (timer !== null) {
-    window.clearTimeout(timer);
-    setTimer(null);
-  }
-}
-
 function createScheduleExpiryCommand(
   atoms: SignUpFlowAtoms,
   runtime: SignUpFlowRuntime,
 ): Command<void, [number | null, AbortSignal]> {
-  const markExpired$ = command(({ set }) => {
-    set(atoms.verificationExpired$, true);
-    set(runtime.expiryTimer$, null);
-  });
   return command(
     ({ get, set }, expireAtMs: number | null, signal: AbortSignal): void => {
-      clearTimer(get(runtime.expiryTimer$), (timer) => {
-        set(runtime.expiryTimer$, timer);
-      });
+      signal.throwIfAborted();
+      get(runtime.expiryController$)?.abort();
+      set(runtime.expiryController$, null);
       set(atoms.verificationExpired$, false);
       if (expireAtMs === null) {
         return;
       }
       const delay = Math.max(0, expireAtMs - now());
       if (delay === 0) {
-        set(markExpired$);
+        set(atoms.verificationExpired$, true);
         return;
       }
-      const timer = window.setTimeout(() => {
-        set(markExpired$);
-      }, delay);
-      set(runtime.expiryTimer$, timer);
-      signal.addEventListener(
+      const controller = createChildAbortController(signal);
+      set(runtime.expiryController$, controller);
+      controller.signal.addEventListener(
         "abort",
         () => {
-          if (get(runtime.expiryTimer$) === timer) {
-            window.clearTimeout(timer);
-            set(runtime.expiryTimer$, null);
+          if (get(runtime.expiryController$) === controller) {
+            set(runtime.expiryController$, null);
           }
         },
         { once: true },
+      );
+      timeout(
+        () => {
+          if (get(runtime.expiryController$) !== controller) {
+            return;
+          }
+          set(atoms.verificationExpired$, true);
+          controller.abort();
+        },
+        delay,
+        { signal: controller.signal },
       );
     },
   );
@@ -867,28 +868,31 @@ function createStartCooldownCommand(
   atoms: SignUpFlowAtoms,
   runtime: SignUpFlowRuntime,
 ): Command<void, [AbortSignal]> {
-  const finishCooldown$ = command(({ set }) => {
-    set(atoms.resendCoolingDown$, false);
-    set(runtime.cooldownTimer$, null);
-  });
   return command(({ get, set }, signal: AbortSignal): void => {
-    clearTimer(get(runtime.cooldownTimer$), (timer) => {
-      set(runtime.cooldownTimer$, timer);
-    });
+    signal.throwIfAborted();
+    get(runtime.cooldownController$)?.abort();
+    const controller = createChildAbortController(signal);
+    set(runtime.cooldownController$, controller);
     set(atoms.resendCoolingDown$, true);
-    const timer = window.setTimeout(() => {
-      set(finishCooldown$);
-    }, AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS);
-    set(runtime.cooldownTimer$, timer);
-    signal.addEventListener(
+    controller.signal.addEventListener(
       "abort",
       () => {
-        if (get(runtime.cooldownTimer$) === timer) {
-          window.clearTimeout(timer);
-          set(runtime.cooldownTimer$, null);
+        if (get(runtime.cooldownController$) === controller) {
+          set(runtime.cooldownController$, null);
         }
       },
       { once: true },
+    );
+    timeout(
+      () => {
+        if (get(runtime.cooldownController$) !== controller) {
+          return;
+        }
+        set(atoms.resendCoolingDown$, false);
+        controller.abort();
+      },
+      AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS,
+      { signal: controller.signal },
     );
   });
 }

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -412,6 +412,9 @@ function CodeStep({
   const pageSignal = useGet(pageSignal$);
   const setCode = useSet(signals.setCode$);
   const backToMethods = useSet(signals.backToMethods$);
+  const resendCooldownLifecycleRef = useSet(
+    signals.resendCooldownLifecycleRef$,
+  );
   const [submitLoadable, submit] = useLoadableSet(signals.submit$);
   const [resendLoadable, resendCode] = useLoadableSet(signals.resendCode$);
   const submitting = submitLoadable.state === "loading";
@@ -439,6 +442,7 @@ function CodeStep({
   };
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
+      {coolingDown ? <span ref={resendCooldownLifecycleRef} hidden /> : null}
       <FlowErrorAlert copy={copy} signals={signals} />
       <h2 className="text-base font-medium text-foreground">
         {reset ? copy.resetPasswordCodeTitle : copy.emailCodeTitle}


### PR DESCRIPTION
## Summary

- Route the sign-in resend countdown through the shared setLoop primitive, owned by the verification-code DOM lifecycle signal.
- Replace sign-up verification-expiry and resend-cooldown native timeouts with signal-timers and restartable child abort controllers derived from their action parent signals.
- Keep deadline-based countdown behavior and update the diagnostics fixture for the new lifecycle ref.

## Cancellation and restart behavior

- Unmounting the sign-in cooldown lifecycle ref aborts the active setLoop.
- Starting either sign-up timer aborts its previous child controller; aborting the parent action cascades to the active timer.
- Successful one-shot completion aborts the child controller to detach its parent listener.
- Platform src now has no native setTimeout, clearTimeout, setInterval, or clearInterval matches.

## Validation

- Prettier check
- Oxlint and type-aware Oxlint on all changed files
- ESLint on all changed files
- Platform production and test TypeScript checks
- Auth V2 diagnostics tests: 10 passed
- Focused sign-in resend cooldown test: 1 passed
- Focused sign-up resend cooldown test: 1 passed
- Lefthook pre-commit: Knip and full-repository type checks passed

Full CI is delegated to the PR pipeline.
