### PR TITLE
perf(connectors): debounce account search requests

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -69,19 +69,27 @@ export const customAccountConnectDialog$ = computed((get) => {
 });
 
 export const openBuiltinAccountManager$ = command(
-  ({ set }, connector: PlatformConnectorCatalogStatusItem) => {
+  (
+    { set },
+    connector: PlatformConnectorCatalogStatusItem,
+    signal: AbortSignal,
+  ) => {
     set(internalBuiltinAccountManager$, connector);
     set(internalBuiltinAccountConnectDialog$, null);
-    set(settingsConnectorAccounts.setTarget$, {
-      kind: "builtin",
-      connectorSlug: connector.slug,
-    });
+    set(
+      settingsConnectorAccounts.setTarget$,
+      {
+        kind: "builtin",
+        connectorSlug: connector.slug,
+      },
+      signal,
+    );
   },
 );
 
 export const closeBuiltinAccountManager$ = command(({ set }) => {
   set(internalBuiltinAccountManager$, null);
-  set(settingsConnectorAccounts.setTarget$, null);
+  set(settingsConnectorAccounts.clearTarget$);
 });
 
 export const openBuiltinAccountConnectDialog$ = command(
@@ -91,7 +99,7 @@ export const openBuiltinAccountConnectDialog$ = command(
     mode: ConnectorAccountConnectMode,
   ) => {
     set(internalBuiltinAccountManager$, null);
-    set(settingsConnectorAccounts.setTarget$, null);
+    set(settingsConnectorAccounts.clearTarget$);
     set(internalBuiltinAccountConnectDialog$, { connector, mode });
   },
 );
@@ -101,19 +109,23 @@ export const closeBuiltinAccountConnectDialog$ = command(({ set }) => {
 });
 
 export const openCustomAccountManager$ = command(
-  ({ set }, connector: CustomConnectorResponse) => {
+  ({ set }, connector: CustomConnectorResponse, signal: AbortSignal) => {
     set(internalCustomAccountManager$, connector);
     set(internalCustomAccountConnectDialog$, null);
-    set(settingsConnectorAccounts.setTarget$, {
-      kind: "custom",
-      customConnectorId: connector.id,
-    });
+    set(
+      settingsConnectorAccounts.setTarget$,
+      {
+        kind: "custom",
+        customConnectorId: connector.id,
+      },
+      signal,
+    );
   },
 );
 
 export const closeCustomAccountManager$ = command(({ set }) => {
   set(internalCustomAccountManager$, null);
-  set(settingsConnectorAccounts.setTarget$, null);
+  set(settingsConnectorAccounts.clearTarget$);
 });
 
 export const openCustomAccountConnectDialog$ = command(
@@ -123,7 +135,7 @@ export const openCustomAccountConnectDialog$ = command(
     mode: ConnectorAccountConnectMode,
   ) => {
     set(internalCustomAccountManager$, null);
-    set(settingsConnectorAccounts.setTarget$, null);
+    set(settingsConnectorAccounts.clearTarget$);
     set(internalCustomAccountConnectDialog$, { connector, mode });
   },
 );
@@ -177,7 +189,6 @@ export const finishConnectorAccountConnection$ = command(
     },
   ) => {
     set(reloadConnectorAccountSummaries$);
-    set(settingsConnectorAccounts.reload$);
     if (args.mode.kind !== "add" || !args.connectionId) {
       return;
     }
@@ -289,5 +300,5 @@ export const resetConnectorAccountDialogs$ = command(({ set }) => {
   set(internalConnectorAccountNamePrompt$, null);
   set(internalConnectorAccountNamePromptValue$, "");
   set(resetConnectorAccountManagerDrafts$);
-  set(settingsConnectorAccounts.setTarget$, null);
+  set(settingsConnectorAccounts.clearTarget$);
 });

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -1,4 +1,5 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Command, type State } from "ccstate";
+import { delay } from "signal-timers";
 import {
   connectorAccountsContract,
   type ConnectorAccountConnection,
@@ -11,9 +12,11 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../../lib/accept.ts";
 import { apiClient$, type ApiClientFactory } from "../../api-client.ts";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
-import { onRejection } from "../../utils.ts";
+import { onRejection, resetSignal } from "../../utils.ts";
 
 const CONNECTOR_ACCOUNT_PAGE_SIZE = 50;
+/** Keep account search responsive while coalescing normal typing bursts. */
+const CONNECTOR_ACCOUNT_SEARCH_DEBOUNCE_MS = 250;
 
 export type ConnectorAccountMutationVersion = number | string | null;
 
@@ -136,6 +139,10 @@ interface ConnectorAccountPage {
   readonly available: boolean;
 }
 
+function emptyConnectorAccountPage(): ConnectorAccountPage {
+  return { connections: [], nextCursor: null, available: false };
+}
+
 export interface ConnectorAccountList {
   readonly connections: readonly ConnectorAccountConnection[];
   readonly nextCursor: string | null;
@@ -177,13 +184,65 @@ function targetListQuery(
       };
 }
 
-function createConnectorAccountListSignals() {
+async function fetchConnectorAccountFirstPage(
+  createClient: ApiClientFactory,
+  target: ConnectorAccountTarget,
+  search: string,
+  signal: AbortSignal,
+): Promise<ConnectorAccountPage> {
+  const result = await accept(
+    createClient(connectorAccountsContract).connections({
+      query: targetListQuery(target, search),
+      fetchOptions: { signal },
+    }),
+    [200, 404],
+    signal,
+  );
+  signal.throwIfAborted();
+  return result.status === 404
+    ? emptyConnectorAccountPage()
+    : { ...result.body, available: true };
+}
+
+function createConnectorAccountFirstPageQuery(
+  effectiveSearch$: State<string>,
+  resetPages$: Command<void, []>,
+) {
+  return command(
+    async (
+      { get, set },
+      target: ConnectorAccountTarget,
+      search: string,
+      debounce: boolean,
+      signal: AbortSignal,
+    ): Promise<ConnectorAccountPage> => {
+      if (debounce) {
+        await delay(CONNECTOR_ACCOUNT_SEARCH_DEBOUNCE_MS, { signal });
+      }
+      signal.throwIfAborted();
+      set(effectiveSearch$, search);
+      set(resetPages$);
+      return fetchConnectorAccountFirstPage(
+        get(apiClient$),
+        target,
+        search,
+        signal,
+      );
+    },
+  );
+}
+
+function createConnectorAccountFirstPageSignals() {
   const target$ = state<ConnectorAccountTarget | null>(null);
   const search$ = state("");
-  const reloadVersion$ = state(0);
+  const effectiveSearch$ = state("");
   const generation$ = state(0);
   const pages$ = state<readonly ConnectorAccountPage[]>([]);
   const loadingCursor$ = state<string | null>(null);
+  const firstPage$ = state<Promise<ConnectorAccountPage>>(
+    Promise.resolve(emptyConnectorAccountPage()),
+  );
+  const resetQuerySignal$ = resetSignal();
 
   const resetPages$ = command(({ set }) => {
     set(pages$, []);
@@ -193,22 +252,23 @@ function createConnectorAccountListSignals() {
     });
   });
 
-  const firstPage$ = computed(async (get): Promise<ConnectorAccountPage> => {
-    get(reloadVersion$);
-    const target = get(target$);
-    if (!target) {
-      return { connections: [], nextCursor: null, available: false };
-    }
-    const result = await accept(
-      get(apiClient$)(connectorAccountsContract).connections({
-        query: targetListQuery(target, get(search$)),
-      }),
-      [200, 404],
-    );
-    return result.status === 404
-      ? { connections: [], nextCursor: null, available: false }
-      : { ...result.body, available: true };
-  });
+  const queryFirstPage$ = createConnectorAccountFirstPageQuery(
+    effectiveSearch$,
+    resetPages$,
+  );
+
+  const startFirstPageQuery$ = command(
+    (
+      { set },
+      target: ConnectorAccountTarget,
+      search: string,
+      debounce: boolean,
+      signal: AbortSignal,
+    ): void => {
+      const request = set(queryFirstPage$, target, search, debounce, signal);
+      set(firstPage$, request);
+    },
+  );
 
   const accounts$ = computed(async (get): Promise<ConnectorAccountList> => {
     const firstPage = await get(firstPage$);
@@ -216,102 +276,150 @@ function createConnectorAccountListSignals() {
   });
 
   const setTarget$ = command(
-    ({ get, set }, target: ConnectorAccountTarget | null) => {
+    ({ get, set }, target: ConnectorAccountTarget, signal: AbortSignal) => {
       const current = get(target$);
       if (
         current &&
-        target &&
         connectorAccountTargetKey(current) === connectorAccountTargetKey(target)
       ) {
         return;
       }
       set(target$, target);
       set(search$, "");
-      set(resetPages$);
+      const querySignal = set(resetQuerySignal$, signal);
+      set(startFirstPageQuery$, target, "", false, querySignal);
     },
   );
 
-  const setSearch$ = command(({ get, set }, search: string) => {
-    const normalized = search.trimStart();
-    if (get(search$) === normalized) {
-      return;
-    }
-    set(search$, normalized);
+  const clearTarget$ = command(({ set }) => {
+    set(resetQuerySignal$);
+    set(target$, null);
+    set(search$, "");
+    set(effectiveSearch$, "");
     set(resetPages$);
+    set(firstPage$, Promise.resolve(emptyConnectorAccountPage()));
   });
 
-  const reload$ = command(({ set }) => {
-    set(resetPages$);
-    set(reloadVersion$, (version) => {
-      return version + 1;
-    });
-  });
-
-  const loadMore$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      const generation = get(generation$);
+  const setSearch$ = command(
+    ({ get, set }, search: string, signal: AbortSignal) => {
+      const normalized = search.trimStart();
+      if (get(search$) === normalized) {
+        return;
+      }
+      set(search$, normalized);
       const target = get(target$);
       if (!target) {
         return;
       }
-      const loaded = await get(accounts$);
+
+      const querySignal = set(resetQuerySignal$, signal);
+      set(
+        startFirstPageQuery$,
+        target,
+        normalized,
+        normalized.length > 0,
+        querySignal,
+      );
+    },
+  );
+
+  const reload$ = command(({ get, set }, signal: AbortSignal) => {
+    const target = get(target$);
+    if (!target) {
+      return;
+    }
+
+    const querySignal = set(resetQuerySignal$, signal);
+    set(startFirstPageQuery$, target, get(search$), false, querySignal);
+  });
+
+  return {
+    target$,
+    effectiveSearch$,
+    generation$,
+    pages$,
+    loadingCursor$,
+    search$: computed((get) => {
+      return get(search$);
+    }),
+    accounts$,
+    setTarget$,
+    clearTarget$,
+    setSearch$,
+    reload$,
+  };
+}
+
+function createConnectorAccountListSignals() {
+  const firstPageSignals = createConnectorAccountFirstPageSignals();
+  const loadMore$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      const generation = get(firstPageSignals.generation$);
+      const target = get(firstPageSignals.target$);
+      if (!target) {
+        return;
+      }
+      const loaded = await get(firstPageSignals.accounts$);
       signal.throwIfAborted();
-      if (get(generation$) !== generation) {
+      if (get(firstPageSignals.generation$) !== generation) {
         return;
       }
       const cursor = loaded.nextCursor;
-      if (!cursor || get(loadingCursor$) !== null) {
+      if (!cursor || get(firstPageSignals.loadingCursor$) !== null) {
         return;
       }
-      set(loadingCursor$, cursor);
+      set(firstPageSignals.loadingCursor$, cursor);
       const result = await onRejection(
         accept(
           get(apiClient$)(connectorAccountsContract).connections({
-            query: targetListQuery(target, get(search$), cursor),
+            query: targetListQuery(
+              target,
+              get(firstPageSignals.effectiveSearch$),
+              cursor,
+            ),
             fetchOptions: { signal },
           }),
           [200, 404],
           signal,
         ),
         () => {
-          if (get(generation$) !== generation) {
+          if (get(firstPageSignals.generation$) !== generation) {
             return;
           }
-          set(loadingCursor$, null);
+          set(firstPageSignals.loadingCursor$, null);
         },
       );
       signal.throwIfAborted();
-      if (get(generation$) !== generation) {
+      if (get(firstPageSignals.generation$) !== generation) {
         return;
       }
       if (result.status === 404) {
-        set(reload$);
+        set(firstPageSignals.reload$, signal);
         return;
       }
-      set(pages$, (pages) => {
+      set(firstPageSignals.pages$, (pages) => {
         return [...pages, { ...result.body, available: true }];
       });
-      set(loadingCursor$, null);
+      set(firstPageSignals.loadingCursor$, null);
     },
   );
 
   return {
-    search$: computed((get) => {
-      return get(search$);
-    }),
-    accounts$,
-    setTarget$,
-    setSearch$,
-    reload$,
+    search$: firstPageSignals.search$,
+    accounts$: firstPageSignals.accounts$,
+    setTarget$: firstPageSignals.setTarget$,
+    clearTarget$: firstPageSignals.clearTarget$,
+    setSearch$: firstPageSignals.setSearch$,
+    reload$: firstPageSignals.reload$,
     loadMore$,
   };
 }
 
 export const settingsConnectorAccounts = createConnectorAccountListSignals();
 
-const invalidateConnectorAccounts$ = command(({ set }) => {
+const invalidateConnectorAccounts$ = command(({ set }, signal: AbortSignal) => {
   set(reloadConnectorAccountSummaries$);
-  set(settingsConnectorAccounts.reload$);
+  set(settingsConnectorAccounts.reload$, signal);
 });
 
 export const renameConnectorAccount$ = command(
@@ -333,7 +441,7 @@ export const renameConnectorAccount$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(invalidateConnectorAccounts$);
+    set(invalidateConnectorAccounts$, signal);
   },
 );
 
@@ -355,7 +463,7 @@ export const setDefaultConnectorAccount$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(invalidateConnectorAccounts$);
+    set(invalidateConnectorAccounts$, signal);
   },
 );
 
@@ -399,7 +507,7 @@ export const deleteConnectorAccount$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(invalidateConnectorAccounts$);
+    set(invalidateConnectorAccounts$, signal);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -61,7 +61,7 @@ import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
-import { resetSignal } from "../../../signals/utils.ts";
+import { createDeferredPromise, resetSignal } from "../../../signals/utils.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { submitManualGrant$ } from "../../../signals/okou-page/settings/connectors.ts";
 import { customConnectorCreateForm$ } from "../../../signals/okou-page/settings/custom-connectors.ts";
@@ -1543,9 +1543,31 @@ describe("connectors page", () => {
         ],
       });
     });
+    const accountQueries: {
+      readonly search: string | null;
+      readonly cursor: string | null;
+    }[] = [];
+    const heldSearchRequest: {
+      signal: AbortSignal | null;
+      release: (() => void) | null;
+      completed: boolean;
+    } = { signal: null, release: null, completed: false };
     context.mocks.api(
       connectorAccountsContract.connections,
-      ({ query, respond }) => {
+      async ({ query, request, respond }) => {
+        accountQueries.push({
+          search: query.search ?? null,
+          cursor: query.cursor ?? null,
+        });
+        if (query.search === "Work 1") {
+          const heldSearch = createDeferredPromise<void>(context.signal);
+          heldSearchRequest.signal = request.signal;
+          heldSearchRequest.release = () => {
+            heldSearch.resolve();
+          };
+          await heldSearch.promise;
+          heldSearchRequest.completed = true;
+        }
         const search = query.search;
         const filtered = search
           ? accounts.filter((account) => {
@@ -1622,21 +1644,51 @@ describe("connectors page", () => {
       expect(within(dialog).getByText("Work 1")).toBeInTheDocument();
       expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
-    await fill(
-      within(dialog).getByPlaceholderText("Find accounts"),
-      "Work 100",
-    );
+    const searchInput = within(dialog).getByPlaceholderText("Find accounts");
+    const queryCountBeforeSearch = accountQueries.length;
+    fireEvent.input(searchInput, { target: { value: "W" } });
+    fireEvent.input(searchInput, { target: { value: "Work" } });
+    fireEvent.input(searchInput, { target: { value: "Work 10" } });
+    expect(searchInput).toHaveValue("Work 10");
+    expect(accountQueries).toHaveLength(queryCountBeforeSearch);
     await waitFor(() => {
-      expect(within(dialog).getByText("Work 100")).toBeInTheDocument();
+      expect(accountQueries.slice(queryCountBeforeSearch)).toStrictEqual([
+        { search: "Work 10", cursor: null },
+      ]);
+      expect(within(dialog).getByText("Work 10")).toBeInTheDocument();
       expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
-    await fill(
-      within(dialog).getByPlaceholderText("Find accounts"),
-      "No matching account",
-    );
+
+    fireEvent.input(searchInput, {
+      target: { value: "No matching account" },
+    });
     await waitFor(() => {
       expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
       expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+    });
+
+    fireEvent.input(searchInput, { target: { value: "Work 1" } });
+    await waitFor(() => {
+      expect(heldSearchRequest.signal).not.toBeNull();
+    });
+    fireEvent.input(searchInput, { target: { value: "" } });
+    expect(searchInput).toHaveValue("");
+    expect(heldSearchRequest.signal?.aborted).toBeTruthy();
+    await waitFor(() => {
+      expect(accountQueries.at(-1)).toStrictEqual({
+        search: null,
+        cursor: null,
+      });
+    });
+    const releaseHeldSearch = heldSearchRequest.release;
+    if (!releaseHeldSearch) {
+      throw new Error("Expected held account search request");
+    }
+    releaseHeldSearch();
+    await waitFor(() => {
+      expect(heldSearchRequest.completed).toBeTruthy();
+      expect(within(dialog).getByText("Account #00000000")).toBeInTheDocument();
+      expect(within(dialog).queryByText("Work 1")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1674,6 +1674,7 @@ describe("connectors page", () => {
         { search: "Work 2", cursor: null },
       ]);
       expect(within(dialog).getByText("Work 2")).toBeInTheDocument();
+      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
 
     fireEvent.input(searchInput, {
@@ -1685,6 +1686,7 @@ describe("connectors page", () => {
         cursor: null,
       });
       expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
+      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -253,6 +253,56 @@ function mockConnectors(
   return responses;
 }
 
+function mockGitHubConnectorAccounts(
+  accountCount: number,
+): ConnectorAccountConnection[] {
+  mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);
+  const accounts = Array.from({ length: accountCount }, (_, index) => {
+    const isDefault = index === 0;
+    return {
+      id: isDefault
+        ? "00000000-0000-4000-a000-000000000001"
+        : crypto.randomUUID(),
+      target: { kind: "builtin" as const, connectorSlug: "github" },
+      authMethod: "oauth",
+      displayName: isDefault ? null : `Work ${index}`,
+      isDefault,
+      externalId: null,
+      externalUsername: isDefault ? null : `octocat-${index}`,
+      externalEmail: null,
+      oauthScopes: [],
+      connectionStatus: isDefault
+        ? ("reconnect-required" as const)
+        : ("connected" as const),
+      reconnectReason: isDefault
+        ? ("authorization_expired_or_revoked" as const)
+        : null,
+      tokenExpiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    } satisfies ConnectorAccountConnection;
+  }).reverse();
+  const defaultAccount = accounts.find((account) => {
+    return account.isDefault;
+  });
+  if (!defaultAccount) {
+    throw new Error("Expected a default account fixture");
+  }
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return respond(200, {
+      summaries: [
+        {
+          target: { kind: "builtin", connectorSlug: "github" },
+          accountCount: accounts.length,
+          attentionCount: 1,
+          defaultConnection: defaultAccount,
+        },
+      ],
+    });
+  });
+  return accounts;
+}
+
 async function setupAwsExternalCodeConnection(): Promise<{
   dialog: HTMLElement;
   complete: HTMLElement;
@@ -1493,98 +1543,11 @@ describe("connectors page", () => {
     expect(submittedAuthorizeAgent).toBeUndefined();
   });
 
-  it("paginates and searches a feature-on account manager", async () => {
-    const [connector] = mockConnectors([
-      { connectorSlug: "github", externalUsername: "octocat" },
-    ]);
-    if (!connector) {
-      throw new Error("Expected GitHub fixture connector");
-    }
-    const accounts = Array.from({ length: 101 }, (_, index) => {
-      const isDefault = index === 0;
-      return {
-        id: isDefault
-          ? "00000000-0000-4000-a000-000000000001"
-          : crypto.randomUUID(),
-        target: { kind: "builtin" as const, connectorSlug: "github" },
-        authMethod: "oauth",
-        displayName: isDefault ? null : `Work ${index}`,
-        isDefault,
-        externalId: null,
-        externalUsername: isDefault ? null : `octocat-${index}`,
-        externalEmail: null,
-        oauthScopes: [],
-        connectionStatus: isDefault
-          ? ("reconnect-required" as const)
-          : ("connected" as const),
-        reconnectReason: isDefault
-          ? ("authorization_expired_or_revoked" as const)
-          : null,
-        tokenExpiresAt: null,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-      } satisfies ConnectorAccountConnection;
-    }).reverse();
-    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
-      const defaultAccount = accounts.find((account) => {
-        return account.isDefault;
-      });
-      if (!defaultAccount) {
-        throw new Error("Expected a default account fixture");
-      }
-      return respond(200, {
-        summaries: [
-          {
-            target: { kind: "builtin", connectorSlug: "github" },
-            accountCount: accounts.length,
-            attentionCount: 1,
-            defaultConnection: defaultAccount,
-          },
-        ],
-      });
+  it("opens feature-on account and access managers independently", async () => {
+    const accounts = mockGitHubConnectorAccounts(7);
+    context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+      return respond(200, { connections: accounts, nextCursor: null });
     });
-    const accountQueries: {
-      readonly search: string | null;
-      readonly cursor: string | null;
-    }[] = [];
-    const heldSearchRequest: {
-      signal: AbortSignal | null;
-      release: (() => void) | null;
-      completed: boolean;
-    } = { signal: null, release: null, completed: false };
-    context.mocks.api(
-      connectorAccountsContract.connections,
-      async ({ query, request, respond }) => {
-        accountQueries.push({
-          search: query.search ?? null,
-          cursor: query.cursor ?? null,
-        });
-        if (query.search === "Work 1") {
-          const heldSearch = createDeferredPromise<void>(context.signal);
-          heldSearchRequest.signal = request.signal;
-          heldSearchRequest.release = () => {
-            heldSearch.resolve();
-          };
-          await heldSearch.promise;
-          heldSearchRequest.completed = true;
-        }
-        const search = query.search;
-        const filtered = search
-          ? accounts.filter((account) => {
-              return account.displayName
-                ?.toLowerCase()
-                .includes(search.toLowerCase());
-            })
-          : accounts;
-        const start = query.cursor ? Number(query.cursor) : 0;
-        const page = filtered.slice(start, start + query.limit);
-        const next = start + page.length;
-        return respond(200, {
-          connections: page,
-          nextCursor: next < filtered.length ? String(next) : null,
-        });
-      },
-    );
     detachedSetupPage({
       context,
       path: "/connectors",
@@ -1592,8 +1555,7 @@ describe("connectors page", () => {
     });
 
     await waitFor(() => {
-      const candidate = connectorCardByLabel("GitHub");
-      expect(candidate).toHaveTextContent("101 accounts");
+      expect(connectorCardByLabel("GitHub")).toHaveTextContent("7 accounts");
     });
     const manageAccounts = await waitForButtonByAriaLabel(
       "Manage GitHub accounts",
@@ -1617,9 +1579,7 @@ describe("connectors page", () => {
     });
     click(manageAccounts);
 
-    const dialog = await screen.findByRole("dialog", {
-      name: "GitHub",
-    });
+    const dialog = await screen.findByRole("dialog", { name: "GitHub" });
     const defaultGroup = within(dialog).getByRole("group", {
       name: "Default",
     });
@@ -1633,6 +1593,30 @@ describe("connectors page", () => {
       within(defaultGroup).getByLabelText("Account actions"),
     ).toBeInTheDocument();
     expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+  });
+
+  it("paginates a feature-on account manager", async () => {
+    const accounts = mockGitHubConnectorAccounts(101);
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        const start = query.cursor ? Number(query.cursor) : 0;
+        const page = accounts.slice(start, start + query.limit);
+        const next = start + page.length;
+        return respond(200, {
+          connections: page,
+          nextCursor: next < accounts.length ? String(next) : null,
+        });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const dialog = await screen.findByRole("dialog", { name: "GitHub" });
     expect(within(dialog).queryByText("Work 50")).toBeNull();
     click(buttonByText("Load more", dialog));
     await waitFor(() => {
@@ -1644,30 +1628,122 @@ describe("connectors page", () => {
       expect(within(dialog).getByText("Work 1")).toBeInTheDocument();
       expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
     });
+  });
+
+  it("debounces feature-on account manager searches", async () => {
+    const accounts = mockGitHubConnectorAccounts(7);
+    const accountQueries: {
+      readonly search: string | null;
+      readonly cursor: string | null;
+    }[] = [];
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        accountQueries.push({
+          search: query.search ?? null,
+          cursor: query.cursor ?? null,
+        });
+        const search = query.search;
+        const filtered = search
+          ? accounts.filter((account) => {
+              return account.displayName
+                ?.toLowerCase()
+                .includes(search.toLowerCase());
+            })
+          : accounts;
+        return respond(200, { connections: filtered, nextCursor: null });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const dialog = await screen.findByRole("dialog", { name: "GitHub" });
     const searchInput = within(dialog).getByPlaceholderText("Find accounts");
     const queryCountBeforeSearch = accountQueries.length;
     fireEvent.input(searchInput, { target: { value: "W" } });
     fireEvent.input(searchInput, { target: { value: "Work" } });
-    fireEvent.input(searchInput, { target: { value: "Work 10" } });
-    expect(searchInput).toHaveValue("Work 10");
+    fireEvent.input(searchInput, { target: { value: "Work 2" } });
+    expect(searchInput).toHaveValue("Work 2");
     expect(accountQueries).toHaveLength(queryCountBeforeSearch);
     await waitFor(() => {
       expect(accountQueries.slice(queryCountBeforeSearch)).toStrictEqual([
-        { search: "Work 10", cursor: null },
+        { search: "Work 2", cursor: null },
       ]);
-      expect(within(dialog).getByText("Work 10")).toBeInTheDocument();
-      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+      expect(within(dialog).getByText("Work 2")).toBeInTheDocument();
     });
 
     fireEvent.input(searchInput, {
       target: { value: "No matching account" },
     });
     await waitFor(() => {
+      expect(accountQueries.at(-1)).toStrictEqual({
+        search: "No matching account",
+        cursor: null,
+      });
       expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
-      expect(within(dialog).getAllByText("Account #00000000")).toHaveLength(1);
+    });
+  });
+
+  it("cancels stale feature-on account manager searches", async () => {
+    const accounts = mockGitHubConnectorAccounts(7);
+    const defaultAccount = accounts.find((account) => {
+      return account.isDefault;
+    });
+    if (!defaultAccount) {
+      throw new Error("Expected a default account fixture");
+    }
+    const staleAccount: ConnectorAccountConnection = {
+      ...defaultAccount,
+      id: crypto.randomUUID(),
+      displayName: "Stale result",
+      isDefault: false,
+    };
+    const accountQueries: {
+      readonly search: string | null;
+      readonly cursor: string | null;
+    }[] = [];
+    const heldSearchRequest: {
+      signal: AbortSignal | null;
+      release: (() => void) | null;
+      completed: boolean;
+    } = { signal: null, release: null, completed: false };
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      async ({ query, request, respond }) => {
+        accountQueries.push({
+          search: query.search ?? null,
+          cursor: query.cursor ?? null,
+        });
+        if (query.search === "Stale") {
+          const heldSearch = createDeferredPromise<void>(context.signal);
+          heldSearchRequest.signal = request.signal;
+          heldSearchRequest.release = () => {
+            heldSearch.resolve();
+          };
+          await heldSearch.promise;
+          heldSearchRequest.completed = true;
+          return respond(200, {
+            connections: [staleAccount],
+            nextCursor: null,
+          });
+        }
+        return respond(200, { connections: accounts, nextCursor: null });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
     });
 
-    fireEvent.input(searchInput, { target: { value: "Work 1" } });
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const dialog = await screen.findByRole("dialog", { name: "GitHub" });
+    const searchInput = within(dialog).getByPlaceholderText("Find accounts");
+    fireEvent.input(searchInput, { target: { value: "Stale" } });
     await waitFor(() => {
       expect(heldSearchRequest.signal).not.toBeNull();
     });
@@ -1687,8 +1763,8 @@ describe("connectors page", () => {
     releaseHeldSearch();
     await waitFor(() => {
       expect(heldSearchRequest.completed).toBeTruthy();
-      expect(within(dialog).getByText("Account #00000000")).toBeInTheDocument();
-      expect(within(dialog).queryByText("Work 1")).toBeNull();
+      expect(within(dialog).getByText("Work 1")).toBeInTheDocument();
+      expect(within(dialog).queryByText("Stale result")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -469,20 +469,16 @@ function DeleteAccountConfirmation({
   );
 }
 
-function ConnectorAccountSearch({
-  value,
-  onChange,
-}: {
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-}) {
+function ConnectorAccountSearch({ value }: { readonly value: string }) {
   const { t } = useTranslation();
+  const setSearch = useSet(settingsConnectorAccounts.setSearch$);
+  const signal = useGet(pageSignal$);
   return (
     <div className="border-b border-border px-6 py-3">
       <Input
         value={value}
         onChange={(event) => {
-          return onChange(event.target.value);
+          return setSearch(event.target.value, signal);
         }}
         placeholder={t(($) => {
           return $.connectors.accounts.find;
@@ -505,7 +501,6 @@ export function ConnectorAccountManagerDialog({
   const accountsLoadable = useLoadable(settingsConnectorAccounts.accounts$);
   const summariesLoadable = useLoadable(connectorAccountSummaryByTarget$);
   const search = useGet(settingsConnectorAccounts.search$);
-  const setSearch = useSet(settingsConnectorAccounts.setSearch$);
   const [loadMoreLoadable, loadMore] = useLoadableSet(
     settingsConnectorAccounts.loadMore$,
   );
@@ -574,9 +569,7 @@ export function ConnectorAccountManagerDialog({
             </Button>
           </div>
         </DialogHeader>
-        {showSearch ? (
-          <ConnectorAccountSearch value={search} onChange={setSearch} />
-        ) : null}
+        {showSearch ? <ConnectorAccountSearch value={search} /> : null}
         {defaultConnection ? (
           <DefaultAccount
             target={target}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -639,7 +639,7 @@ function CustomConnectorGrid({
             accountSummaryStatus={accountSummaryStatus}
             accountManagement={connectorAccountsEnabled}
             onManageAccounts={() => {
-              return openAccountManager(connector);
+              return openAccountManager(connector, signal);
             }}
           />
         );

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -1200,7 +1200,7 @@ export function ConnectorsPage() {
           detach(disconnectHandler(c.slug, c.label), Reason.DomCallback);
         }}
         onManageAccounts={() => {
-          return openAccountManager(c);
+          return openAccountManager(c, signal);
         }}
         onManageAccess={() => {
           return setManagedConnectorSlug(c.slug);


### PR DESCRIPTION
## Summary

- debounce connector account searches for 250 ms while updating the input immediately
- cancel superseded debounce and fetch work through the page-owned signal hierarchy
- keep the active first-page promise in list state so stale responses cannot replace a newer search or a cleared query
- preserve pagination against the effective server query and refresh account mutations without blocking their UI completion

## Scope

- connector account manager search only
- no API, database, protocol, localization, or other connector UX changes

## Validation

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (112 tests)
- `pnpm -F @okouai/app exec vitest run --maxWorkers=4 --silent=passed-only` (2036 tests)
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: full-repository Knip and Turbo type checks

Closes #29223

Delivery parent: #22832