### PR TITLE
fix: keep uploaded template images visible while refreshing

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
@@ -208,23 +208,33 @@ function createImportedPresentationTemplateUrlRefreshSignals(
   catalog$: Computed<Promise<ImportedPresentationTemplateCatalog>>,
   detailUrlsVersion$: State<number>,
 ) {
-  const internalRequestedAtMs$ = state<number | null>(null);
-  const freshAtMs = (loadedAtMs: number, requestedAtMs: number | null) => {
-    return Math.max(loadedAtMs, requestedAtMs ?? Number.NEGATIVE_INFINITY);
-  };
+  const internalDetailUrlsFreshAtMs$ = state<number | null>(null);
+  const initializeImportedPresentationTemplateDetailUrlsFreshAtMs$ = command(
+    ({ get, set }, catalogLoadedAtMs: number): number => {
+      const detailUrlsFreshAtMs = get(internalDetailUrlsFreshAtMs$);
+      if (detailUrlsFreshAtMs !== null) {
+        return detailUrlsFreshAtMs;
+      }
+      set(internalDetailUrlsFreshAtMs$, catalogLoadedAtMs);
+      return catalogLoadedAtMs;
+    },
+  );
   const refreshImportedPresentationTemplateUrlsIfStale$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const catalog = await get(catalog$);
       signal.throwIfAborted();
+      const detailUrlsFreshAtMs = set(
+        initializeImportedPresentationTemplateDetailUrlsFreshAtMs$,
+        catalog.loadedAtMs,
+      );
       const requestedAt = now();
       if (
-        requestedAt -
-          freshAtMs(catalog.loadedAtMs, get(internalRequestedAtMs$)) <
+        requestedAt - detailUrlsFreshAtMs <
         PRESENTATION_TEMPLATE_URL_REFRESH_AGE_MS
       ) {
         return;
       }
-      set(internalRequestedAtMs$, requestedAt);
+      set(internalDetailUrlsFreshAtMs$, requestedAt);
       await set(refreshAndReconcilePresentationTemplates$, signal);
       set(detailUrlsVersion$, (version) => {
         return version + 1;
@@ -239,12 +249,17 @@ function createImportedPresentationTemplateUrlRefreshSignals(
       await delay(0, { signal });
       const catalog = await get(catalog$);
       signal.throwIfAborted();
+      const detailUrlsFreshAtMs = set(
+        initializeImportedPresentationTemplateDetailUrlsFreshAtMs$,
+        catalog.loadedAtMs,
+      );
       const requestedAt = now();
       const refreshDetailUrls =
-        requestedAt -
-          freshAtMs(catalog.loadedAtMs, get(internalRequestedAtMs$)) >=
+        requestedAt - detailUrlsFreshAtMs >=
         PRESENTATION_TEMPLATE_URL_REFRESH_AGE_MS;
-      set(internalRequestedAtMs$, requestedAt);
+      if (refreshDetailUrls) {
+        set(internalDetailUrlsFreshAtMs$, requestedAt);
+      }
       await set(refreshAndReconcilePresentationTemplates$, signal);
       if (refreshDetailUrls) {
         set(detailUrlsVersion$, (version) => {
@@ -264,15 +279,15 @@ function createImportedPresentationTemplateUrlRefreshSignals(
           async (loopSignal) => {
             const catalog = await get(catalog$);
             loopSignal.throwIfAborted();
-            const loadedOrRequestedAtMs = freshAtMs(
+            const detailUrlsFreshAtMs = set(
+              initializeImportedPresentationTemplateDetailUrlsFreshAtMs$,
               catalog.loadedAtMs,
-              get(internalRequestedAtMs$),
             );
             await delay(
               Math.max(
                 0,
                 PRESENTATION_TEMPLATE_URL_REFRESH_AGE_MS -
-                  (now() - loadedOrRequestedAtMs),
+                  (now() - detailUrlsFreshAtMs),
               ),
               { signal: loopSignal },
             );

--- a/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/presentation-template-library.ts
@@ -206,6 +206,7 @@ function createImportedPresentationTemplateHoverSignals() {
 
 function createImportedPresentationTemplateUrlRefreshSignals(
   catalog$: Computed<Promise<ImportedPresentationTemplateCatalog>>,
+  detailUrlsVersion$: State<number>,
 ) {
   const internalRequestedAtMs$ = state<number | null>(null);
   const freshAtMs = (loadedAtMs: number, requestedAtMs: number | null) => {
@@ -225,16 +226,31 @@ function createImportedPresentationTemplateUrlRefreshSignals(
       }
       set(internalRequestedAtMs$, requestedAt);
       await set(refreshAndReconcilePresentationTemplates$, signal);
+      set(detailUrlsVersion$, (version) => {
+        return version + 1;
+      });
     },
   );
   const refreshImportedPresentationTemplateUrlsAfterPickerOpen$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
       // Let the picker mount the last resolved catalog before catch-up makes
       // the catalog pending, so a suspended tab still opens without a blank
       // first frame.
       await delay(0, { signal });
-      set(internalRequestedAtMs$, now());
+      const catalog = await get(catalog$);
+      signal.throwIfAborted();
+      const requestedAt = now();
+      const refreshDetailUrls =
+        requestedAt -
+          freshAtMs(catalog.loadedAtMs, get(internalRequestedAtMs$)) >=
+        PRESENTATION_TEMPLATE_URL_REFRESH_AGE_MS;
+      set(internalRequestedAtMs$, requestedAt);
       await set(refreshAndReconcilePresentationTemplates$, signal);
+      if (refreshDetailUrls) {
+        set(detailUrlsVersion$, (version) => {
+          return version + 1;
+        });
+      }
     },
   );
   const importedPresentationTemplateUrlRefreshLifecycleRef$ = onRef(
@@ -280,9 +296,7 @@ function createImportedPresentationTemplateUrlRefreshSignals(
 }
 
 function createImportedPresentationTemplateDetailSignals(
-  resources$: Computed<
-    Promise<readonly ImportedPresentationTemplateResource[]>
-  >,
+  detailUrlsVersion$: State<number>,
 ) {
   const internalRequestedTemplateId$ = state<string | null>(null);
   const importedPresentationTemplateRequestedId$ = computed((get) => {
@@ -294,11 +308,15 @@ function createImportedPresentationTemplateDetailSignals(
       if (templateId === null) {
         return null;
       }
-      const resources = await get(resources$);
-      const resource = resources.find((candidate) => {
-        return candidate.summary.id === templateId;
-      });
-      return resource === undefined ? null : await get(resource.detail$);
+      // Catalog changes carry mutable metadata. Page URLs rotate only on the
+      // TTL lifecycle so rename and visibility updates cannot reload slides.
+      get(detailUrlsVersion$);
+      const client = get(apiClient$)(presentationTemplatesContract);
+      const result = await accept(
+        client.get({ params: { templateId } }),
+        [200, 404],
+      );
+      return result.status === 404 ? null : result.body;
     },
   );
   const requestImportedPresentationTemplateDetail$ = command(
@@ -321,16 +339,17 @@ export function createImportedPresentationTemplateSignals() {
     catalog$,
     deletedPresentationTemplateIds$,
   );
-  const urlRefresh =
-    createImportedPresentationTemplateUrlRefreshSignals(catalog$);
+  const internalDetailUrlsVersion$ = state(0);
+  const urlRefresh = createImportedPresentationTemplateUrlRefreshSignals(
+    catalog$,
+    internalDetailUrlsVersion$,
+  );
   const importedPresentationTemplateResources$ =
     createImportedPresentationTemplateResources$(
       importedPresentationTemplates$,
     );
   const { internalRequestedTemplateId$, ...detailSignals } =
-    createImportedPresentationTemplateDetailSignals(
-      importedPresentationTemplateResources$,
-    );
+    createImportedPresentationTemplateDetailSignals(internalDetailUrlsVersion$);
 
   const internalPreviewTemplateId$ = state<string | null>(null);
   const importedPresentationTemplatePreviewId$ = computed((get) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -4035,9 +4035,6 @@ describe("chat composer templates", () => {
     );
     await user.click(screen.getByLabelText("Preview slide 2"));
     await imageDecodes.complete("https://example.com/imported-page-3.png");
-    await waitFor(() => {
-      expect(detailPreview).not.toHaveAttribute("data-pending-image-url");
-    });
     expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
       "src",
       "https://example.com/imported-page-2.png",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3640,7 +3640,7 @@ describe("chat composer templates", () => {
       presentationTemplatesContract.list,
       async ({ respond }) => {
         catalogRequestCount += 1;
-        if (catalogRequestCount > 2) {
+        if (catalogRequestCount > 3) {
           refreshCatalogRequested.resolve();
           await releaseRefreshCatalog.promise;
           serveRenewedUrls = true;
@@ -3778,15 +3778,24 @@ describe("chat composer templates", () => {
     expect(primaryDetailRequestCount).toBe(3);
     expect(secondaryDetailRequestCount).toBe(0);
 
-    await user.keyboard("{Escape}");
+    // A metadata-only refresh must not reset the independent signed-detail URL
+    // age, or frequent renames and visibility changes can postpone renewal
+    // until the page URLs have expired.
+    mockNow(context.signal, loadedAtMs + 5 * 60 * 1000);
+    context.mocks.ably.trigger("presentationTemplatesChanged");
     await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(catalogRequestCount).toBe(3);
+      expect(primaryDetailRequestCount).toBe(4);
     });
     // The lifecycle renews signed URLs at ten minutes, leaving five minutes of
     // overlap with the API's 15-minute expiry. Opening is also a non-blocking
     // catch-up point for a suspended tab whose timer did not run.
     mockNow(context.signal, loadedAtMs + 10 * 60 * 1000 + 1);
-    await user.click(screen.getByLabelText("Template"));
+    click(within(dialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Template"));
     await refreshCatalogRequested.promise;
 
     const refreshingDialog = screen.getByRole("dialog");
@@ -3807,6 +3816,11 @@ describe("chat composer templates", () => {
 
     releaseRefreshCatalog.resolve();
     await refreshedPrimaryDetailRequested.promise;
+    await waitFor(() => {
+      // Catalog reconciliation recreates the preload resource. The separate
+      // detail-version renewal is observed on the next card hover below.
+      expect(primaryDetailRequestCount).toBe(5);
+    });
     const refreshedPreviewButton = within(refreshingCard).getByLabelText(
       "Preview Primary draft deck at current slide",
     );
@@ -3850,7 +3864,7 @@ describe("chat composer templates", () => {
       "src",
       "https://example.com/renewed-primary-page-100.png",
     );
-    expect(catalogRequestCount).toBe(3);
+    expect(catalogRequestCount).toBe(4);
     expect(primaryDetailRequestCount).toBeGreaterThan(3);
     expect(secondaryDetailRequestCount).toBe(0);
   });
@@ -4019,6 +4033,16 @@ describe("chat composer templates", () => {
       "src",
       "https://example.com/imported-page-2.png",
     );
+    await user.click(screen.getByLabelText("Preview slide 2"));
+    await imageDecodes.complete("https://example.com/imported-page-3.png");
+    await waitFor(() => {
+      expect(detailPreview).not.toHaveAttribute("data-pending-image-url");
+    });
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+      "src",
+      "https://example.com/imported-page-2.png",
+    );
+    await user.click(screen.getByLabelText("Preview slide 3"));
     await imageDecodes.complete("https://example.com/imported-page-3.png");
     await waitFor(() => {
       expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -73,7 +73,17 @@ function sentInlineTemplate(
   return undefined;
 }
 
-async function loadImportedTemplateCardImage(
+function activeImportedTemplateImage(media: HTMLElement): HTMLImageElement {
+  const image = media.querySelector(
+    "[data-imported-presentation-template-image]",
+  );
+  if (!(image instanceof HTMLImageElement)) {
+    throw new Error("Active imported template image not found");
+  }
+  return image;
+}
+
+async function loadImportedTemplateImage(
   media: HTMLElement,
   url: string,
 ): Promise<HTMLImageElement> {
@@ -92,9 +102,63 @@ async function loadImportedTemplateCardImage(
   });
   fireEvent.load(image);
   await waitFor(() => {
-    expect(image).toHaveAttribute("data-active", "true");
+    expect(image).toHaveAttribute("data-loaded-image-url", url);
   });
   return image;
+}
+
+function controlImportedTemplateImageDecodes(
+  heldImageUrls: readonly string[],
+): {
+  complete: (imageUrl: string) => Promise<void>;
+  hold: (imageUrl: string) => void;
+} {
+  const held = new Set(heldImageUrls);
+  const pending = new Map<string, TestDeferred[]>();
+
+  class ControlledImage {
+    decoding = "auto";
+    loading = "eager";
+    fetchPriority = "auto";
+    #src = "";
+
+    get src(): string {
+      return this.#src;
+    }
+
+    set src(value: string) {
+      this.#src = value;
+    }
+
+    decode(): Promise<void> {
+      if (!held.has(this.#src)) {
+        return Promise.resolve();
+      }
+      const deferred = context.mocks.deferred<void>();
+      const requests = pending.get(this.#src) ?? [];
+      requests.push(deferred);
+      pending.set(this.#src, requests);
+      return deferred.promise;
+    }
+  }
+
+  vi.stubGlobal("Image", ControlledImage as unknown as typeof Image);
+
+  return {
+    complete: async (imageUrl) => {
+      const request = await waitFor(() => {
+        const found = pending.get(imageUrl)?.shift();
+        if (found === undefined) {
+          throw new Error(`Decoded image request not found: ${imageUrl}`);
+        }
+        return found;
+      });
+      request.resolve();
+    },
+    hold: (imageUrl) => {
+      held.add(imageUrl);
+    },
+  };
 }
 
 function presentationTemplateSummary(
@@ -3521,6 +3585,9 @@ describe("chat composer templates", () => {
     const renewedSecondaryPageUrls = Array.from({ length: 100 }, (_, index) => {
       return `https://example.com/renewed-secondary-page-${index + 1}.png`;
     });
+    const imageDecodes = controlImportedTemplateImageDecodes([
+      renewedPrimaryPageUrls[0]!,
+    ]);
     const primaryTemplate = {
       id: primaryTemplateId,
       title: "Primary draft deck",
@@ -3568,6 +3635,7 @@ describe("chat composer templates", () => {
     let catalogRequestCount = 0;
     let primaryDetailRequestCount = 0;
     let secondaryDetailRequestCount = 0;
+    let serveRenewedUrls = false;
     context.mocks.api(
       presentationTemplatesContract.list,
       async ({ respond }) => {
@@ -3575,6 +3643,7 @@ describe("chat composer templates", () => {
         if (catalogRequestCount > 2) {
           refreshCatalogRequested.resolve();
           await releaseRefreshCatalog.promise;
+          serveRenewedUrls = true;
           return respond(200, [renewedPrimarySummary, renewedSecondarySummary]);
         }
         return respond(200, [primarySummary, secondarySummary]);
@@ -3585,8 +3654,10 @@ describe("chat composer templates", () => {
       ({ params, respond }) => {
         if (params.templateId === primaryTemplateId) {
           primaryDetailRequestCount += 1;
-          if (primaryDetailRequestCount > 2) {
-            refreshedPrimaryDetailRequested.resolve();
+          if (serveRenewedUrls) {
+            if (!refreshedPrimaryDetailRequested.settled()) {
+              refreshedPrimaryDetailRequested.resolve();
+            }
             return respond(200, renewedPrimaryTemplate);
           }
           return respond(200, primaryTemplate);
@@ -3687,7 +3758,7 @@ describe("chat composer templates", () => {
     fireEvent.load(within(preview).getByRole("img"));
     fireEvent.mouseEnter(preview);
     fireEvent.mouseMove(preview, { clientX: 4, clientY: 80 });
-    await loadImportedTemplateCardImage(
+    await loadImportedTemplateImage(
       preview,
       "https://example.com/prefetch-primary-page-2.png",
     );
@@ -3704,7 +3775,7 @@ describe("chat composer templates", () => {
       );
     });
     expect(catalogRequestCount).toBe(2);
-    expect(primaryDetailRequestCount).toBe(2);
+    expect(primaryDetailRequestCount).toBe(3);
     expect(secondaryDetailRequestCount).toBe(0);
 
     await user.keyboard("{Escape}");
@@ -3743,27 +3814,13 @@ describe("chat composer templates", () => {
     if (!refreshedPreview) {
       throw new Error("Refreshed imported template preview not found");
     }
-    const renewedCover = await waitFor(() => {
-      const found = Array.from(
-        refreshedPreview.querySelectorAll<HTMLImageElement>(
-          "[data-imported-presentation-template-image]",
-        ),
-      ).find((candidate) => {
-        return (
-          candidate.getAttribute("src") ===
-          "https://example.com/renewed-primary-page-1.png"
-        );
-      });
-      if (found === undefined) {
-        throw new Error("Renewed uploaded template cover was not requested");
-      }
-      return found;
-    });
     expect(within(refreshedPreview).getByRole("img")).toHaveAttribute(
       "src",
       "https://example.com/prefetch-primary-page-1.png",
     );
-    fireEvent.load(renewedCover);
+    await imageDecodes.complete(
+      "https://example.com/renewed-primary-page-1.png",
+    );
     await waitFor(() => {
       expect(within(refreshedPreview).getByRole("img")).toHaveAttribute(
         "src",
@@ -3776,9 +3833,15 @@ describe("chat composer templates", () => {
         return new DOMRect(0, 0, 300, 160);
       },
     });
+    const detailRequestsBeforeRenewedHover = primaryDetailRequestCount;
     fireEvent.mouseEnter(refreshedPreview);
+    await waitFor(() => {
+      expect(primaryDetailRequestCount).toBeGreaterThan(
+        detailRequestsBeforeRenewedHover,
+      );
+    });
     fireEvent.mouseMove(refreshedPreview, { clientX: 299, clientY: 80 });
-    await loadImportedTemplateCardImage(
+    await loadImportedTemplateImage(
       refreshedPreview,
       "https://example.com/renewed-primary-page-100.png",
     );
@@ -3788,7 +3851,7 @@ describe("chat composer templates", () => {
       "https://example.com/renewed-primary-page-100.png",
     );
     expect(catalogRequestCount).toBe(3);
-    expect(primaryDetailRequestCount).toBe(3);
+    expect(primaryDetailRequestCount).toBeGreaterThan(3);
     expect(secondaryDetailRequestCount).toBe(0);
   });
 
@@ -3883,6 +3946,9 @@ describe("chat composer templates", () => {
 
   it("scrubs every uploaded slide and manages an owned template from its detail view", async () => {
     const user = userEvent.setup({ delay: null });
+    const imageDecodes = controlImportedTemplateImageDecodes([
+      "https://example.com/imported-page-3.png",
+    ]);
     mockChatLifecycle(context, { threadId: THREAD_ID });
     const templateId = "8f5c9a1e-6f7d-4a2b-9c3e-0d1a2b3c4d5e";
     setMockPresentationTemplates([
@@ -3927,7 +3993,7 @@ describe("chat composer templates", () => {
     fireEvent.load(within(preview).getByRole("img"));
     fireEvent.mouseEnter(preview);
     fireEvent.mouseMove(preview, { clientX: 150, clientY: 80 });
-    await loadImportedTemplateCardImage(
+    await loadImportedTemplateImage(
       preview,
       "https://example.com/imported-page-2.png",
     );
@@ -3937,17 +4003,52 @@ describe("chat composer templates", () => {
     );
 
     click(previewButton);
-    const detailImage = await screen.findByTestId(
+    const detailPreview = await screen.findByTestId(
       "Brand system imported detail image preview",
     );
-    expect(detailImage).toHaveAttribute(
+    await loadImportedTemplateImage(
+      detailPreview,
+      "https://example.com/imported-page-2.png",
+    );
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
       "src",
       "https://example.com/imported-page-2.png",
     );
     await user.click(screen.getByLabelText("Preview slide 3"));
-    expect(detailImage).toHaveAttribute(
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+      "src",
+      "https://example.com/imported-page-2.png",
+    );
+    await imageDecodes.complete("https://example.com/imported-page-3.png");
+    await waitFor(() => {
+      expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+        "src",
+        "https://example.com/imported-page-3.png",
+      );
+    });
+    imageDecodes.hold("https://example.com/imported-page-2.png");
+    imageDecodes.hold("https://example.com/imported-cover.png");
+    await user.click(screen.getByLabelText("Preview slide 2"));
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
       "src",
       "https://example.com/imported-page-3.png",
+    );
+    await user.click(screen.getByLabelText("Preview slide 1"));
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+      "src",
+      "https://example.com/imported-page-3.png",
+    );
+    await imageDecodes.complete("https://example.com/imported-cover.png");
+    await waitFor(() => {
+      expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+        "src",
+        "https://example.com/imported-cover.png",
+      );
+    });
+    await imageDecodes.complete("https://example.com/imported-page-2.png");
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
+      "src",
+      "https://example.com/imported-cover.png",
     );
     const titleInput = screen.getByRole("textbox", {
       name: "Rename template",
@@ -4011,21 +4112,14 @@ describe("chat composer templates", () => {
     };
     let detailRequestCount = 0;
     let updateRequestCount = 0;
-    let holdDetailRefresh = false;
-    const detailRefreshRequested = context.mocks.deferred<void>();
-    const releaseDetailRefresh = context.mocks.deferred<void>();
     context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
       return respond(200, [presentationTemplateSummary(template)]);
     });
     context.mocks.api(
       presentationTemplatesContract.get,
-      async ({ params, respond }) => {
+      ({ params, respond }) => {
         expect(params.templateId).toBe(template.id);
         detailRequestCount += 1;
-        if (holdDetailRefresh) {
-          detailRefreshRequested.resolve();
-          await releaseDetailRefresh.promise;
-        }
         return respond(200, template);
       },
     );
@@ -4035,7 +4129,6 @@ describe("chat composer templates", () => {
         expect(params.templateId).toBe(template.id);
         expect(body).toStrictEqual({ visibility: "public" });
         updateRequestCount += 1;
-        holdDetailRefresh = true;
         template = {
           ...template,
           coverUrl:
@@ -4062,72 +4155,59 @@ describe("chat composer templates", () => {
         "Preview Stable preview deck at current slide",
       ),
     );
-    const detailImage = await screen.findByTestId(
+    const detailPreview = await screen.findByTestId(
       "Stable preview deck imported detail image preview",
     );
     await user.click(screen.getByLabelText("Preview slide 3"));
-    expect(detailImage).toHaveAttribute(
+    await loadImportedTemplateImage(
+      detailPreview,
+      "https://example.com/stable-preview-page-3.png",
+    );
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
       "src",
       "https://example.com/stable-preview-page-3.png",
     );
     const thumbnailButtons = [1, 2, 3].map((slideNumber) => {
       return screen.getByLabelText(`Preview slide ${slideNumber.toString()}`);
     });
-    const thumbnailImages = thumbnailButtons.map((button) => {
-      const image = button.querySelector("img");
-      if (image === null) {
-        throw new Error("Uploaded template thumbnail image not found");
+    const initialPageUrls = template.pageUrls;
+    for (const [index, button] of thumbnailButtons.entries()) {
+      const pageUrl = initialPageUrls[index];
+      if (pageUrl === undefined) {
+        throw new Error("Uploaded template page URL not found");
       }
-      return image;
-    });
+      await loadImportedTemplateImage(button, pageUrl);
+    }
     const detailRequestCountBeforeUpdate = detailRequestCount;
     expect(detailRequestCountBeforeUpdate).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("combobox", { name: "Visibility" }));
     await user.click(screen.getByRole("option", { name: "Workspace" }));
-    await detailRefreshRequested.promise;
-
-    expect(updateRequestCount).toBe(1);
+    await waitFor(() => {
+      expect(updateRequestCount).toBe(1);
+      expect(
+        screen.getByRole("combobox", { name: "Visibility" }),
+      ).toHaveTextContent("Workspace");
+    });
     expect(
       screen.getByTestId("Stable preview deck imported detail image preview"),
-    ).toBe(detailImage);
-    expect(detailImage).toHaveAttribute(
+    ).toBe(detailPreview);
+    expect(activeImportedTemplateImage(detailPreview)).toHaveAttribute(
       "src",
       "https://example.com/stable-preview-page-3.png",
     );
     for (const [index, button] of thumbnailButtons.entries()) {
-      expect(
-        screen.getByLabelText(`Preview slide ${(index + 1).toString()}`),
-      ).toBe(button);
-      expect(button.querySelector("img")).toBe(thumbnailImages[index]);
-    }
-
-    releaseDetailRefresh.resolve();
-    await waitFor(() => {
-      expect(detailRequestCount).toBeGreaterThan(
-        detailRequestCountBeforeUpdate,
-      );
-      expect(
-        screen.getByRole("combobox", { name: "Visibility" }),
-      ).toHaveTextContent("Workspace");
-      expect(detailImage).toHaveAttribute(
-        "src",
-        "https://example.com/stable-preview-page-3.png?signature=renewed",
-      );
-    });
-    expect(
-      screen.getByTestId("Stable preview deck imported detail image preview"),
-    ).toBe(detailImage);
-    for (const [index, button] of thumbnailButtons.entries()) {
-      const expectedPageUrl = template.pageUrls[index];
+      const expectedPageUrl = initialPageUrls[index];
       if (expectedPageUrl === undefined) {
-        throw new Error("Renewed uploaded template page URL not found");
+        throw new Error("Uploaded template page URL not found");
       }
       expect(
         screen.getByLabelText(`Preview slide ${(index + 1).toString()}`),
       ).toBe(button);
-      expect(button.querySelector("img")).toBe(thumbnailImages[index]);
-      expect(thumbnailImages[index]).toHaveAttribute("src", expectedPageUrl);
+      expect(activeImportedTemplateImage(button)).toHaveAttribute(
+        "src",
+        expectedPageUrl,
+      );
     }
   });
 
@@ -4241,7 +4321,10 @@ describe("chat composer templates", () => {
     }
     fireEvent.load(remainingCover);
     await waitFor(() => {
-      expect(remainingCover).toHaveAttribute("data-active", "true");
+      expect(remainingCover).toHaveAttribute(
+        "data-loaded-image-url",
+        remainingTemplate.coverUrl,
+      );
     });
     const scrollContainer = presentationTemplateGridScrollContainer();
     scrollContainer.scrollTop = 187;
@@ -4274,7 +4357,10 @@ describe("chat composer templates", () => {
       ),
     ).toBe(remainingCard);
     expect(remainingCover).toBeInTheDocument();
-    expect(remainingCover).toHaveAttribute("data-active", "true");
+    expect(remainingCover).toHaveAttribute(
+      "data-loaded-image-url",
+      remainingTemplate.coverUrl,
+    );
     expect(scrollContainer.scrollTop).toBe(187);
 
     releaseDeleteRefresh.resolve();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5057,7 +5057,7 @@ async function loadDecodedImportedPptImage(
   await tapError(candidate.decode(), () => {
     decodeFailed = true;
   });
-  return !decodeFailed || (candidate.complete && candidate.naturalWidth > 0);
+  return !decodeFailed;
 }
 
 async function replaceImportedPptImageAfterDecode(

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -94,6 +94,7 @@ import { cn } from "@okouai/ui/lib/utils";
 import { processShortcut, type KeyboardEventLike } from "@okouai/ui";
 import {
   bestEffort,
+  createDeferredPromise,
   detach,
   onDomEventFn,
   Reason,
@@ -5006,19 +5007,17 @@ function ImportedPptCardMediaControls({
   );
 }
 
-type ImportedPptCardImageSlot = "a" | "b";
+// Keep one rendered image stable while its replacement loads and decodes
+// off-DOM, then swap the src atomically. Stale requests are ignored by URL.
 
-function importedPptCardImage(
-  media: HTMLDivElement,
-  slot: ImportedPptCardImageSlot,
-): HTMLImageElement | null {
+function importedPptImage(media: HTMLElement): HTMLImageElement | null {
   return media.querySelector<HTMLImageElement>(
-    `[data-imported-presentation-template-image="${slot}"]`,
+    "[data-imported-presentation-template-image]",
   );
 }
 
-function setImportedPptCardPlaceholder(
-  media: HTMLDivElement,
+function setImportedPptImagePlaceholder(
+  media: HTMLElement,
   state: "error" | "hidden" | "loading",
 ): void {
   const placeholder = media.querySelector<HTMLElement>(
@@ -5031,136 +5030,228 @@ function setImportedPptCardPlaceholder(
   placeholder.dataset.state = state;
 }
 
-function activateImportedPptCardImage(
-  media: HTMLDivElement,
-  slot: ImportedPptCardImageSlot,
-): void {
-  const active = importedPptCardImage(media, slot);
-  const inactive = importedPptCardImage(media, slot === "a" ? "b" : "a");
-  if (active === null || inactive === null) {
-    return;
-  }
-  media.dataset.activeImageSlot = slot;
-  active.dataset.active = "true";
-  active.alt = media.dataset.imageLabel ?? "";
-  active.title = media.dataset.imageLabel ?? "";
-  active.removeAttribute("aria-hidden");
-  inactive.dataset.active = "false";
-  inactive.alt = "";
-  inactive.removeAttribute("title");
-  inactive.setAttribute("aria-hidden", "true");
-  setImportedPptCardPlaceholder(media, "hidden");
-}
-
-function completeImportedPptCardImage(image: HTMLImageElement): void {
-  const media = image.closest<HTMLDivElement>(
-    "[data-imported-presentation-template-media]",
-  );
-  const slot = image.dataset.importedPresentationTemplateImage;
-  if (
-    media === null ||
-    (slot !== "a" && slot !== "b") ||
-    image.getAttribute("src") !== media.dataset.desiredImageUrl
-  ) {
-    return;
-  }
-  image.dataset.loadedImageUrl = media.dataset.desiredImageUrl;
-  activateImportedPptCardImage(media, slot);
-}
-
-async function decodeImportedPptCardImage(
+function showImportedPptImage(
+  media: HTMLElement,
   image: HTMLImageElement,
+  imageUrl: string,
+): void {
+  if (image.getAttribute("src") !== imageUrl) {
+    image.src = imageUrl;
+  }
+  image.dataset.loadedImageUrl = imageUrl;
+  image.alt = media.dataset.imageLabel ?? "";
+  image.title = media.dataset.imageLabel ?? "";
+  image.removeAttribute("aria-hidden");
+  setImportedPptImagePlaceholder(media, "hidden");
+}
+
+async function loadDecodedImportedPptImage(
+  imageUrl: string,
+  referenceImage: HTMLImageElement,
+): Promise<boolean> {
+  const candidate = new Image();
+  candidate.decoding = "async";
+  candidate.loading = "eager";
+  candidate.fetchPriority = referenceImage.fetchPriority;
+  if (candidate.decode === undefined) {
+    const deferred = createDeferredPromise<boolean>(AbortSignal.any([]));
+    candidate.addEventListener("load", () => {
+      deferred.resolve(true);
+    });
+    candidate.addEventListener("error", () => {
+      deferred.resolve(false);
+    });
+    candidate.src = imageUrl;
+    return deferred.promise;
+  }
+  candidate.src = imageUrl;
+  let decodeFailed = false;
+  await tapError(candidate.decode(), () => {
+    decodeFailed = true;
+  });
+  return !decodeFailed || (candidate.complete && candidate.naturalWidth > 0);
+}
+
+async function replaceImportedPptImageAfterDecode(
+  media: HTMLElement,
+  imageUrl: string,
+): Promise<void> {
+  const image = importedPptImage(media);
+  if (image === null) {
+    return;
+  }
+  const decoded = await loadDecodedImportedPptImage(imageUrl, image);
+  if (!decoded) {
+    if (
+      media.dataset.desiredImageUrl === imageUrl &&
+      image.dataset.loadedImageUrl === undefined
+    ) {
+      setImportedPptImagePlaceholder(media, "error");
+    }
+    if (media.dataset.pendingImageUrl === imageUrl) {
+      delete media.dataset.pendingImageUrl;
+    }
+    return;
+  }
+  if (media.dataset.desiredImageUrl !== imageUrl || !media.isConnected) {
+    return;
+  }
+  delete media.dataset.pendingImageUrl;
+  showImportedPptImage(media, image, imageUrl);
+}
+
+function requestDecodedImportedPptImage(
+  media: HTMLElement,
+  imageUrl: string,
+): void {
+  if (media.dataset.pendingImageUrl === imageUrl) {
+    return;
+  }
+  media.dataset.pendingImageUrl = imageUrl;
+  detach(
+    replaceImportedPptImageAfterDecode(media, imageUrl),
+    Reason.DomCallback,
+  );
+}
+
+function completeImportedPptImage(image: HTMLImageElement): void {
+  const media = image.closest<HTMLElement>(
+    "[data-imported-presentation-template-image-container]",
+  );
+  const imageUrl = image.getAttribute("src");
+  if (media === null || imageUrl === null) {
+    return;
+  }
+  showImportedPptImage(media, image, imageUrl);
+  if (
+    imageUrl === media.dataset.previewImageUrl &&
+    imageUrl !== media.dataset.desiredImageUrl &&
+    media.dataset.desiredImageUrl !== undefined
+  ) {
+    requestDecodedImportedPptImage(media, media.dataset.desiredImageUrl);
+  }
+}
+
+async function decodeImportedPptImage(
+  image: HTMLImageElement,
+  imageUrl: string,
 ): Promise<void> {
   await bestEffort(image.decode());
-  completeImportedPptCardImage(image);
+  if (image.getAttribute("src") === imageUrl) {
+    completeImportedPptImage(image);
+  }
 }
 
-function prepareImportedPptCardImage(image: HTMLImageElement): void {
+function prepareImportedPptImage(image: HTMLImageElement): void {
   if (image.decode === undefined) {
-    completeImportedPptCardImage(image);
+    completeImportedPptImage(image);
     return;
   }
-  detach(decodeImportedPptCardImage(image), Reason.DomCallback);
-}
-
-function failImportedPptCardImage(image: HTMLImageElement): void {
-  const media = image.closest<HTMLDivElement>(
-    "[data-imported-presentation-template-media]",
-  );
-  if (
-    media !== null &&
-    image.dataset.importedPresentationTemplateImage ===
-      media.dataset.activeImageSlot
-  ) {
-    delete image.dataset.loadedImageUrl;
-    setImportedPptCardPlaceholder(media, "error");
+  const imageUrl = image.getAttribute("src");
+  if (imageUrl !== null) {
+    detach(decodeImportedPptImage(image, imageUrl), Reason.DomCallback);
   }
 }
 
-function syncImportedPptCardImage(
-  media: HTMLDivElement | null,
+function failImportedPptImage(image: HTMLImageElement): void {
+  const media = image.closest<HTMLElement>(
+    "[data-imported-presentation-template-image-container]",
+  );
+  const imageUrl = image.getAttribute("src");
+  if (media === null || imageUrl === null) {
+    return;
+  }
+  delete image.dataset.loadedImageUrl;
+  if (
+    imageUrl === media.dataset.previewImageUrl &&
+    imageUrl !== media.dataset.desiredImageUrl &&
+    media.dataset.desiredImageUrl !== undefined
+  ) {
+    image.src = media.dataset.desiredImageUrl;
+    return;
+  }
+  setImportedPptImagePlaceholder(media, "error");
+}
+
+function syncImportedPptImage(
+  media: HTMLElement | null,
   imageUrl: string | null,
   label: string,
+  previewImageUrl: string | null = imageUrl,
 ): void {
   if (media === null) {
     return;
   }
-  const activeSlot = media.dataset.activeImageSlot === "b" ? "b" : "a";
-  const inactiveSlot = activeSlot === "a" ? "b" : "a";
-  const active = importedPptCardImage(media, activeSlot);
-  const inactive = importedPptCardImage(media, inactiveSlot);
-  if (active === null || inactive === null) {
+  const image = importedPptImage(media);
+  if (image === null) {
     return;
   }
-  media.dataset.activeImageSlot = activeSlot;
   media.dataset.imageLabel = label;
-  media.dataset.desiredImageUrl = imageUrl ?? "";
-  active.dataset.active = "true";
-  active.alt = label;
-  active.title = label;
-  active.removeAttribute("aria-hidden");
-  inactive.dataset.active = "false";
-  inactive.alt = "";
-  inactive.removeAttribute("title");
-  inactive.setAttribute("aria-hidden", "true");
+  image.alt = label;
+  image.title = label;
 
   if (imageUrl === null) {
-    active.removeAttribute("src");
-    inactive.removeAttribute("src");
-    setImportedPptCardPlaceholder(media, "error");
+    delete media.dataset.desiredImageUrl;
+    delete media.dataset.previewImageUrl;
+    delete media.dataset.pendingImageUrl;
+    image.removeAttribute("src");
+    delete image.dataset.loadedImageUrl;
+    image.setAttribute("aria-hidden", "true");
+    setImportedPptImagePlaceholder(media, "error");
     return;
   }
-  if (active.getAttribute("src") === imageUrl) {
-    if (
-      active.dataset.loadedImageUrl === imageUrl ||
-      (active.complete && active.naturalWidth > 0)
-    ) {
-      setImportedPptCardPlaceholder(media, "hidden");
-    }
-    return;
-  }
+  const resolvedPreviewImageUrl = previewImageUrl ?? imageUrl;
+  image.removeAttribute("aria-hidden");
   if (
-    inactive.getAttribute("src") === imageUrl &&
-    (inactive.dataset.loadedImageUrl === imageUrl ||
-      (inactive.complete && inactive.naturalWidth > 0))
+    media.dataset.desiredImageUrl === imageUrl &&
+    media.dataset.previewImageUrl === resolvedPreviewImageUrl
   ) {
-    activateImportedPptCardImage(media, inactiveSlot);
     return;
   }
-  if (active.getAttribute("src") === null) {
-    active.loading = "eager";
-    active.fetchPriority = "high";
-    delete active.dataset.loadedImageUrl;
-    setImportedPptCardPlaceholder(media, "loading");
-    active.src = imageUrl;
+  media.dataset.desiredImageUrl = imageUrl;
+  media.dataset.previewImageUrl = resolvedPreviewImageUrl;
+
+  if (image.dataset.loadedImageUrl === imageUrl) {
+    setImportedPptImagePlaceholder(media, "hidden");
     return;
   }
-  if (inactive.getAttribute("src") !== imageUrl) {
-    inactive.loading = "eager";
-    inactive.fetchPriority = "high";
-    delete inactive.dataset.loadedImageUrl;
-    inactive.src = imageUrl;
+  const currentImageUrl = image.getAttribute("src");
+  if (currentImageUrl === null || image.dataset.loadedImageUrl === undefined) {
+    delete image.dataset.loadedImageUrl;
+    setImportedPptImagePlaceholder(media, "loading");
+    image.src = resolvedPreviewImageUrl;
+    return;
   }
+  requestDecodedImportedPptImage(media, imageUrl);
+}
+
+function ImportedPptImage({
+  className,
+  fetchPriority,
+  loading,
+}: {
+  className: string;
+  fetchPriority: "auto" | "high" | "low";
+  loading: "eager" | "lazy";
+}) {
+  return (
+    <img
+      alt=""
+      aria-hidden="true"
+      data-imported-presentation-template-image=""
+      loading={loading}
+      decoding="async"
+      fetchPriority={fetchPriority}
+      draggable={false}
+      className={className}
+      onLoad={(event) => {
+        prepareImportedPptImage(event.currentTarget);
+      }}
+      onError={(event) => {
+        failImportedPptImage(event.currentTarget);
+      }}
+    />
+  );
 }
 
 function ImportedPptCardMedia({
@@ -5191,8 +5282,9 @@ function ImportedPptCardMedia({
   return (
     <div
       ref={(media) => {
-        syncImportedPptCardImage(media, activeImageUrl, label);
+        syncImportedPptImage(media, activeImageUrl, label);
       }}
+      data-imported-presentation-template-image-container=""
       data-imported-presentation-template-media=""
       className={cn(
         TEMPLATE_TILE_MEDIA,
@@ -5217,37 +5309,10 @@ function ImportedPptCardMedia({
         onHover(null);
       }}
     >
-      <img
-        alt=""
-        aria-hidden="true"
-        data-imported-presentation-template-image="a"
+      <ImportedPptImage
         loading="eager"
-        decoding="async"
         fetchPriority="high"
-        draggable={false}
-        className="pointer-events-none absolute inset-0 h-full w-full bg-background object-cover opacity-0 transition-opacity duration-150 data-[active=true]:opacity-100"
-        onLoad={(event) => {
-          prepareImportedPptCardImage(event.currentTarget);
-        }}
-        onError={(event) => {
-          failImportedPptCardImage(event.currentTarget);
-        }}
-      />
-      <img
-        alt=""
-        aria-hidden="true"
-        data-imported-presentation-template-image="b"
-        loading="eager"
-        decoding="async"
-        fetchPriority="high"
-        draggable={false}
-        className="pointer-events-none absolute inset-0 h-full w-full bg-background object-cover opacity-0 transition-opacity duration-150 data-[active=true]:opacity-100"
-        onLoad={(event) => {
-          prepareImportedPptCardImage(event.currentTarget);
-        }}
-        onError={(event) => {
-          failImportedPptCardImage(event.currentTarget);
-        }}
+        className="pointer-events-none absolute inset-0 h-full w-full bg-background object-cover"
       />
       <div
         data-imported-presentation-template-image-placeholder=""
@@ -5670,30 +5735,30 @@ function ImportedPresentationTemplateMainPreview({
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
 }) {
   const { t } = useTranslation();
+  const previewLabel = t(
+    ($) => {
+      return $.artifacts.templates.slidePreview;
+    },
+    { title },
+  );
   return (
     <div
       role="group"
-      aria-label={t(
-        ($) => {
-          return $.artifacts.templates.slidePreview;
-        },
-        { title },
-      )}
+      aria-label={previewLabel}
+      ref={(media) => {
+        syncImportedPptImage(media, activeImageUrl, previewLabel);
+      }}
+      data-imported-presentation-template-image-container=""
+      data-testid={`${title} imported detail image preview`}
       tabIndex={0}
       onKeyDown={onKeyDown}
       className="relative aspect-[16/9] overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      {activeImageUrl === null ? null : (
-        <img
-          alt=""
-          data-testid={`${title} imported detail image preview`}
-          src={activeImageUrl}
-          loading="eager"
-          decoding="async"
-          draggable={false}
-          className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-        />
-      )}
+      <ImportedPptImage
+        loading="eager"
+        fetchPriority="high"
+        className="pointer-events-none absolute inset-0 h-full w-full object-cover"
+      />
       <button
         type="button"
         aria-label={t(($) => {
@@ -5739,10 +5804,6 @@ function ImportedPresentationTemplateThumbnails({
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
 }) {
   const { t } = useTranslation();
-  const pageResourceKey = (pageUrl: string) => {
-    const queryStart = pageUrl.indexOf("?");
-    return queryStart === -1 ? pageUrl : pageUrl.slice(0, queryStart);
-  };
   return (
     <div
       className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(96px,1fr))] gap-1.5 lg:grid-cols-8"
@@ -5751,17 +5812,22 @@ function ImportedPresentationTemplateThumbnails({
       {pageUrls.map((pageUrl, index) => {
         const slideNumber = index + 1;
         const active = index === activeSlideIndex;
+        const previewLabel = t(
+          ($) => {
+            return $.artifacts.templates.previewSlide;
+          },
+          { slideNumber },
+        );
         return (
           <button
-            key={pageResourceKey(pageUrl)}
+            key={slideNumber}
             type="button"
-            aria-label={t(
-              ($) => {
-                return $.artifacts.templates.previewSlide;
-              },
-              { slideNumber },
-            )}
+            aria-label={previewLabel}
             aria-pressed={active}
+            ref={(media) => {
+              syncImportedPptImage(media, pageUrl, previewLabel);
+            }}
+            data-imported-presentation-template-image-container=""
             onClick={() => {
               onChange(index);
             }}
@@ -5772,13 +5838,10 @@ function ImportedPresentationTemplateThumbnails({
                 : "border-border hover:border-muted-foreground/50",
             )}
           >
-            <img
-              alt=""
-              src={pageUrl}
+            <ImportedPptImage
               loading="lazy"
-              decoding="async"
-              draggable={false}
-              className="pointer-events-none h-full w-full object-cover"
+              fetchPriority="auto"
+              className="pointer-events-none absolute inset-0 h-full w-full object-cover"
             />
             <span className="absolute bottom-1 right-1 rounded border border-border bg-background/90 px-1.5 py-0.5 text-[10px] font-semibold text-foreground shadow-sm backdrop-blur">
               {slideNumber}

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -94,7 +94,6 @@ import { cn } from "@okouai/ui/lib/utils";
 import { processShortcut, type KeyboardEventLike } from "@okouai/ui";
 import {
   bestEffort,
-  createDeferredPromise,
   detach,
   onDomEventFn,
   Reason,
@@ -5053,17 +5052,6 @@ async function loadDecodedImportedPptImage(
   candidate.decoding = "async";
   candidate.loading = "eager";
   candidate.fetchPriority = referenceImage.fetchPriority;
-  if (candidate.decode === undefined) {
-    const deferred = createDeferredPromise<boolean>(AbortSignal.any([]));
-    candidate.addEventListener("load", () => {
-      deferred.resolve(true);
-    });
-    candidate.addEventListener("error", () => {
-      deferred.resolve(false);
-    });
-    candidate.src = imageUrl;
-    return deferred.promise;
-  }
   candidate.src = imageUrl;
   let decodeFailed = false;
   await tapError(candidate.decode(), () => {
@@ -5093,10 +5081,12 @@ async function replaceImportedPptImageAfterDecode(
     }
     return;
   }
+  if (media.dataset.pendingImageUrl === imageUrl) {
+    delete media.dataset.pendingImageUrl;
+  }
   if (media.dataset.desiredImageUrl !== imageUrl || !media.isConnected) {
     return;
   }
-  delete media.dataset.pendingImageUrl;
   showImportedPptImage(media, image, imageUrl);
 }
 


### PR DESCRIPTION
## Summary

- separate uploaded-template metadata refreshes from the signed slide URL refresh lifecycle, so rename and visibility changes do not reload page images
- keep one rendered image in each preview, preload and decode replacements off-DOM, then swap the src atomically while stale requests are ignored
- keep thumbnail identity stable by slide number and add regression coverage for slide changes, URL renewal, visibility updates, and out-of-order image completion

## Verification

- pnpm exec prettier --check on all changed files
- pnpm --filter @okouai/app lint
- pnpm --filter @okouai/app check-types
- pnpm knip
- pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx (44 passed)