### PR TITLE
perf(runner): expand fresh archive delivery scan

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -75,7 +75,7 @@ const BACKGROUND_FILL_ACTIVE_LIMIT: usize = CONCURRENCY;
 const BACKGROUND_FILL_QUEUE_CAPACITY: usize = 32;
 /// Maximum number of completed telemetry tasks reaped between scheduler polls.
 const BACKGROUND_FILL_REPORT_REAP_BATCH: usize = 32;
-const FRESH_DELIVERY_SCAN_LIMIT: usize = 16;
+const FRESH_DELIVERY_SCAN_LIMIT: usize = 32;
 const FRESH_DELIVERY_PER_RUN_LIMIT: usize = 4;
 const FRESH_DELIVERY_RUNNER_LIMIT: usize = 8;
 
@@ -1916,27 +1916,9 @@ pub(crate) async fn prepare_fresh_archive_delivery(
     cancel: &CancellationToken,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<FreshArchiveDelivery> {
-    prepare_fresh_archive_delivery_with_scan_limit(
-        plan,
-        home,
-        admission,
-        cancel,
-        telemetry,
-        FRESH_DELIVERY_SCAN_LIMIT,
-    )
-    .await
-}
-
-async fn prepare_fresh_archive_delivery_with_scan_limit(
-    plan: &StoragePlan,
-    home: &HomePaths,
-    admission: &FreshArchiveDeliveryAdmission,
-    cancel: &CancellationToken,
-    telemetry: &mut JobTelemetry,
-    scan_limit: usize,
-) -> RunnerResult<FreshArchiveDelivery> {
     let groups = group_targets(collect_targets(plan));
-    let mut scan_summary = FreshDeliveryScanSummary::from_groups(&groups, scan_limit);
+    let mut scan_summary =
+        FreshDeliveryScanSummary::from_groups(&groups, FRESH_DELIVERY_SCAN_LIMIT);
     let owner_cancel = cancel.child_token();
     let mut delivery = FreshArchiveDelivery {
         cancel: owner_cancel.clone(),
@@ -1959,7 +1941,7 @@ async fn prepare_fresh_archive_delivery_with_scan_limit(
             })?;
 
         let mut scanned = 0;
-        for group in groups.into_iter().take(scan_limit) {
+        for group in groups.into_iter().take(FRESH_DELIVERY_SCAN_LIMIT) {
             if delivery.apply.len() >= FRESH_DELIVERY_PER_RUN_LIMIT {
                 scan_summary.per_run = true;
                 telemetry.record(
@@ -2098,7 +2080,7 @@ async fn prepare_fresh_archive_delivery_with_scan_limit(
                 None,
             );
         }
-        if group_count > scan_limit && scanned == scan_limit {
+        if group_count > FRESH_DELIVERY_SCAN_LIMIT && scanned == FRESH_DELIVERY_SCAN_LIMIT {
             scan_summary.scan_limit = true;
             telemetry.record(
                 STORAGE_CACHE_FRESH_DELIVERY_CAPACITY,
@@ -4844,21 +4826,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fresh_delivery_finite_scan_fixture_preserves_admission_bounds() {
+    async fn fresh_delivery_reaches_later_misses_after_warm_prefix() {
+        const WARM_PREFIX_COUNT: usize = 16;
+
         fn scan_fixture_plan(base_url: &str, body_size: u64) -> StoragePlan {
-            let storages = (0..FRESH_DELIVERY_SCAN_LIMIT + 5)
+            let storages = (0..WARM_PREFIX_COUNT + 5)
                 .map(|index| {
-                    let archive_size = if index < FRESH_DELIVERY_SCAN_LIMIT {
-                        CACHE_MAX_SIZE + 1
-                    } else {
-                        body_size
-                    };
                     storage_entry_with_archive_size(
                         format!("/mnt/scan-{index}"),
                         format!("{base_url}/scan-{index}.tar.gz"),
                         &format!("scan-{index}"),
                         "v1",
-                        Some(archive_size),
+                        Some(body_size),
                     )
                 })
                 .collect();
@@ -4868,7 +4847,7 @@ mod tests {
         let server = MockServer::start_async().await;
         let body = tarball_bytes();
         let mut gets = Vec::new();
-        for index in FRESH_DELIVERY_SCAN_LIMIT..FRESH_DELIVERY_SCAN_LIMIT + 5 {
+        for index in WARM_PREFIX_COUNT..WARM_PREFIX_COUNT + 5 {
             gets.push(
                 server
                     .mock_async(|when, then| {
@@ -4881,106 +4860,35 @@ mod tests {
             );
         }
 
-        let current_temp = tempfile::tempdir().unwrap();
-        let current_home = home_at(&current_temp);
-        let current_plan = scan_fixture_plan(&server.base_url(), body.len() as u64);
-        let current_admission = FreshArchiveDeliveryAdmission::new();
-        let current_cancel = CancellationToken::new();
-        let mut current_telemetry = new_telemetry();
-        let current_started = Instant::now();
-        let current_delivery = prepare_fresh_archive_delivery_with_scan_limit(
-            &current_plan,
-            &current_home,
-            &current_admission,
-            &current_cancel,
-            &mut current_telemetry,
-            FRESH_DELIVERY_SCAN_LIMIT,
-        )
-        .await
-        .unwrap();
-        let current_elapsed = current_started.elapsed();
-
-        assert!(current_delivery.apply.is_empty());
-        for get in &gets {
-            get.assert_calls_async(0).await;
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        for index in 0..WARM_PREFIX_COUNT {
+            let cache_dir = home.storage_cache_dir(&format!("scan-{index}"), "v1");
+            fs::create_dir_all(&cache_dir).await.unwrap();
+            fs::write(cache_dir.join("archive.tar.gz"), &body)
+                .await
+                .unwrap();
         }
-        assert!(!current_home.storage_lock("scan-16", "v1").exists());
-        let current_ops = current_telemetry.pending_ops_snapshot();
-        assert_op_count(
-            &current_ops,
-            STORAGE_CACHE_FRESH_DELIVERY_OVERSIZED,
-            FRESH_DELIVERY_SCAN_LIMIT,
-        );
-        assert!(current_ops.iter().any(|(action, success, error)| {
-            action == STORAGE_CACHE_FRESH_DELIVERY_CAPACITY
-                && *success
-                && error.as_deref() == Some("scan-limit")
-        }));
-        assert_no_op(&current_ops, STORAGE_CACHE_FRESH_DELIVERY_ADMITTED);
-        let current_outcome_ops = current_telemetry.pending_ops_with_outcome_snapshot();
-        assert_bounded_outcome(
-            &current_outcome_ops,
-            STORAGE_CACHE_FRESH_DELIVERY_SCAN_GROUPS,
-            true,
-            "17_plus",
-            Some("prepared"),
-        );
-        assert_bounded_outcome(
-            &current_outcome_ops,
-            STORAGE_CACHE_FRESH_DELIVERY_SCAN_SUFFIX,
-            true,
-            "5_8",
-            Some("5_8"),
-        );
-        assert_bounded_outcome(
-            &current_outcome_ops,
-            STORAGE_CACHE_FRESH_DELIVERY_SCAN_STOP,
-            true,
-            "scan_limit",
-            None,
-        );
-        assert_eq!(
-            bounded_outcome_count(
-                &current_outcome_ops,
-                STORAGE_CACHE_FRESH_DELIVERY_SCAN_SUFFIX_UNKNOWN,
-            ),
-            0
-        );
+        let mut plan = scan_fixture_plan(&server.base_url(), body.len() as u64);
+        let admission = FreshArchiveDeliveryAdmission::new();
+        let cancel = CancellationToken::new();
+        let mut telemetry = new_telemetry();
+        let mut delivery =
+            prepare_fresh_archive_delivery(&plan, &home, &admission, &cancel, &mut telemetry)
+                .await
+                .unwrap();
 
-        let alternative_temp = tempfile::tempdir().unwrap();
-        let alternative_home = home_at(&alternative_temp);
-        let mut alternative_plan = scan_fixture_plan(&server.base_url(), body.len() as u64);
-        let alternative_admission = FreshArchiveDeliveryAdmission::new();
-        let alternative_cancel = CancellationToken::new();
-        let mut alternative_telemetry = new_telemetry();
-        let alternative_started = Instant::now();
-        let mut alternative_delivery = prepare_fresh_archive_delivery_with_scan_limit(
-            &alternative_plan,
-            &alternative_home,
-            &alternative_admission,
-            &alternative_cancel,
-            &mut alternative_telemetry,
-            FRESH_DELIVERY_SCAN_LIMIT * 2,
-        )
-        .await
-        .unwrap();
-        let alternative_prepare_elapsed = alternative_started.elapsed();
-
-        assert_eq!(
-            alternative_delivery.apply.len(),
-            FRESH_DELIVERY_PER_RUN_LIMIT
-        );
+        assert_eq!(delivery.apply.len(), FRESH_DELIVERY_PER_RUN_LIMIT);
         let sandbox = MockSandbox::new("test");
         let deferred = populate_cache_with_fresh_delivery(
-            &mut alternative_plan,
+            &mut plan,
             &sandbox,
-            &alternative_home,
-            &mut alternative_telemetry,
-            Some(&mut alternative_delivery),
+            &home,
+            &mut telemetry,
+            Some(&mut delivery),
         )
         .await
         .unwrap();
-        let alternative_total_elapsed = alternative_started.elapsed();
 
         assert!(
             deferred.is_some(),
@@ -4993,76 +4901,63 @@ mod tests {
         gets[FRESH_DELIVERY_PER_RUN_LIMIT]
             .assert_calls_async(0)
             .await;
-        for index in
-            FRESH_DELIVERY_SCAN_LIMIT..FRESH_DELIVERY_SCAN_LIMIT + FRESH_DELIVERY_PER_RUN_LIMIT
-        {
+        for index in WARM_PREFIX_COUNT..WARM_PREFIX_COUNT + FRESH_DELIVERY_PER_RUN_LIMIT {
             assert!(
-                storage_archive_url(&alternative_plan, index)
-                    .is_some_and(|url| url.starts_with("file://")),
+                storage_archive_url(&plan, index).is_some_and(|url| url.starts_with("file://")),
                 "scan fixture entry {index} should use the staged archive"
             );
         }
-        let untouched_index = FRESH_DELIVERY_SCAN_LIMIT + FRESH_DELIVERY_PER_RUN_LIMIT;
+        let untouched_index = WARM_PREFIX_COUNT + FRESH_DELIVERY_PER_RUN_LIMIT;
         let untouched_url = server.url(format!("/scan-{untouched_index}.tar.gz"));
         assert_eq!(
-            storage_archive_url(&alternative_plan, untouched_index),
+            storage_archive_url(&plan, untouched_index),
             Some(untouched_url.as_str())
         );
-        let alternative_ops = alternative_telemetry.pending_ops_snapshot();
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op_count(&ops, STORAGE_CACHE_FRESH_DELIVERY_WARM, WARM_PREFIX_COUNT);
         assert_op_count(
-            &alternative_ops,
+            &ops,
             STORAGE_CACHE_FRESH_DELIVERY_ADMITTED,
             FRESH_DELIVERY_PER_RUN_LIMIT,
         );
         assert_op_count(
-            &alternative_ops,
+            &ops,
             STORAGE_CACHE_FRESH_DELIVERY_SINGLE_REQUEST,
             FRESH_DELIVERY_PER_RUN_LIMIT,
         );
         assert_op_count(
-            &alternative_ops,
+            &ops,
             STORAGE_CACHE_FRESH_DELIVERY_COMPLETE,
             FRESH_DELIVERY_PER_RUN_LIMIT,
         );
         assert_op_count(
-            &alternative_ops,
+            &ops,
             STORAGE_CACHE_FRESH_DELIVERY_PUBLISHED,
             FRESH_DELIVERY_PER_RUN_LIMIT,
         );
         assert_op_count(
-            &alternative_ops,
+            &ops,
             STORAGE_CACHE_FRESH_DELIVERY_STAGED,
             FRESH_DELIVERY_PER_RUN_LIMIT,
         );
-        let alternative_outcome_ops = alternative_telemetry.pending_ops_with_outcome_snapshot();
+        let outcome_ops = telemetry.pending_ops_with_outcome_snapshot();
         assert_bounded_outcome(
-            &alternative_outcome_ops,
+            &outcome_ops,
             STORAGE_CACHE_FRESH_DELIVERY_SCAN_GROUPS,
             true,
             "17_plus",
             Some("prepared"),
         );
         assert_eq!(
-            bounded_outcome_count(
-                &alternative_outcome_ops,
-                STORAGE_CACHE_FRESH_DELIVERY_SCAN_SUFFIX,
-            ),
+            bounded_outcome_count(&outcome_ops, STORAGE_CACHE_FRESH_DELIVERY_SCAN_SUFFIX),
             0
         );
         assert_bounded_outcome(
-            &alternative_outcome_ops,
+            &outcome_ops,
             STORAGE_CACHE_FRESH_DELIVERY_SCAN_STOP,
             true,
             "per_run",
             None,
-        );
-        eprintln!(
-            "fresh delivery finite scan fixture: current_scan={} prepare_ms={} alternative_scan={} prepare_ms={} total_ms={}",
-            FRESH_DELIVERY_SCAN_LIMIT,
-            current_elapsed.as_millis(),
-            FRESH_DELIVERY_SCAN_LIMIT * 2,
-            alternative_prepare_elapsed.as_millis(),
-            alternative_total_elapsed.as_millis(),
         );
     }
 
@@ -5095,6 +4990,12 @@ mod tests {
                 .unwrap();
 
         assert!(delivery.apply.is_empty());
+        assert!(
+            !home
+                .storage_lock(&format!("saturated-{FRESH_DELIVERY_SCAN_LIMIT}"), "v1")
+                .exists(),
+            "the group beyond the finite scan must remain untouched"
+        );
         let ops = telemetry.pending_ops_snapshot();
         assert_eq!(
             ops.iter()


### PR DESCRIPTION
## Summary

- increase the finite fresh archive delivery scan from 16 to 32 cache-identity groups so later
  misses can overlap fresh sandbox creation
- preserve the existing four-per-run, eight-runner-wide, 8 MiB, single-request, writer ownership,
  publication, staging, cancellation, and sequential guest fallback limits
- replace the measurement-only variable-limit fixture with production-bound coverage for sixteen
  real warm cache groups followed by later HTTP misses, and prove the group beyond the finite cap is
  untouched

## Behavior and compatibility

- applies only to fresh cold/workspace sandbox preparation; reused live sandboxes remain on the
  existing guest-owned path
- adds at most sixteen local group decisions to plans that exceed the old cap, while retained bodies
  and admitted requests remain bounded by the unchanged resource limits
- removes the obsolete private variable-scan test seam and timing output
- changes no API, database schema, queue payload, storage manifest, cache format, guest protocol,
  configuration, feature switch, or telemetry contract
- old and new Runner binaries remain compatible while deployments drain because the numeric limit
  is compiled internal behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner fresh_delivery -- --nocapture` (24 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet` (3,297 passed, 21 ignored; guest inventory passed)
- `cargo build --manifest-path crates/Cargo.toml -p runner`
- `lefthook run pre-commit`
- commit hooks, including commitlint
- `git diff --check`

Closes #29304

Parent context: #24203
