### PR TITLE
perf(runner): wake local provider from queue changes

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1739,8 +1739,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     // Pin the discover future so it survives cancellation by other select!
     // branches (heartbeat, lifecycle changes, etc.). Without pinning, heartbeat
-    // (10s) cancels discover() on every tick, restarting its internal poll
-    // sleep (30s) from scratch — so poll never fires. See #8747.
+    // (10s) cancels discover() on every tick, restarting its provider-owned
+    // wait from scratch before reconciliation can run. See #8747.
     let mut discover_fut = Box::pin(provider_state.provider.discover());
 
     let mut current_mode = startup_mode;
@@ -1843,9 +1843,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             .and_then(JobCandidate::runner_preference)
             .map(crate::provider::ActiveRunnerPreference::deadline);
         tokio::select! {
-            // Job discovery via provider (Ably wakeups + HTTP poll).
+            // Job discovery via provider (Ably/filesystem wakeups + reconciliation).
             // The future is pinned outside the loop so other reactor branches
-            // do not cancel and restart its internal poll timer. See #8747.
+            // do not cancel and restart its internal wait timer. See #8747.
             discovered = &mut discover_fut, if can_discover => {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.

--- a/crates/runner/src/provider/local/cancel.rs
+++ b/crates/runner/src/provider/local/cancel.rs
@@ -1,27 +1,28 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::ids::RunId;
-#[cfg(test)]
 use crate::local_queue;
 use crate::local_queue::{CancelTargetState, LocalQueue};
 #[cfg(test)]
 use crate::run_cancellation::RunCancellationRegistration;
 use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistry};
 
-/// Poll interval for scanning local cancel markers.
-const POLL_INTERVAL: Duration = Duration::from_millis(100);
+#[cfg(test)]
+use super::ScanObserver;
+use super::watch::{QueueFileKind, RECONCILE_INTERVAL, ensure_watcher, next_change_or_pending};
 
 #[derive(Clone)]
 pub(super) struct LocalCancelScanner {
     queue: LocalQueue,
     cancel_tokens: RunCancellationRegistry,
     owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
+    #[cfg(test)]
+    scan_observer: ScanObserver,
 }
 
 pub(super) struct LocalCancelWatcher {
@@ -39,6 +40,8 @@ impl LocalCancelScanner {
             queue,
             cancel_tokens,
             owned_claims,
+            #[cfg(test)]
+            scan_observer: ScanObserver::default(),
         }
     }
 
@@ -50,6 +53,8 @@ impl LocalCancelScanner {
     /// token are kept while a claim/job may still exist, and are deleted only
     /// after they no longer have a pending target.
     pub(super) async fn scan_cancel_files(&self) {
+        #[cfg(test)]
+        let _scan_observation = self.scan_observer.observe();
         let queue = self.queue.clone();
         let cancel_markers =
             match tokio::task::spawn_blocking(move || queue.collect_cancel_markers_sync()).await {
@@ -142,6 +147,16 @@ impl LocalCancelScanner {
             owned.remove(&run_id);
         }
     }
+
+    #[cfg(test)]
+    pub(super) async fn wait_for_scan_count(&self, expected: usize) {
+        self.scan_observer.wait_for_count(expected).await;
+    }
+
+    #[cfg(test)]
+    pub(super) fn scan_count(&self) -> usize {
+        self.scan_observer.count()
+    }
 }
 
 impl LocalCancelWatcher {
@@ -149,16 +164,43 @@ impl LocalCancelWatcher {
         let shutdown = CancellationToken::new();
         let task_shutdown = shutdown.clone();
         let handle = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => Some(handle.spawn(async move {
-                loop {
-                    scanner.prune_owned_claims_without_tokens().await;
-                    scanner.scan_cancel_files().await;
-                    tokio::select! {
-                        () = task_shutdown.cancelled() => break,
-                        () = tokio::time::sleep(POLL_INTERVAL) => {}
+            Ok(handle) => {
+                let cancel_dir = match local_queue::ensure_cancels_dir(scanner.queue.group_dir()) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        warn!(error = %error, "local: cancel directory unavailable, using reconciliation");
+                        local_queue::cancels_dir(scanner.queue.group_dir())
                     }
+                };
+                let watch_paths = vec![cancel_dir];
+                let mut watcher = None;
+                if let Err(error) =
+                    ensure_watcher(&mut watcher, &watch_paths, QueueFileKind::Cancel)
+                {
+                    warn!(error = %error, "local: cancel watcher unavailable, using reconciliation");
                 }
-            })),
+                Some(handle.spawn(async move {
+                    loop {
+                        if let Err(error) =
+                            ensure_watcher(&mut watcher, &watch_paths, QueueFileKind::Cancel)
+                        {
+                            warn!(error = %error, "local: cancel watcher unavailable, using reconciliation");
+                        }
+                        scanner.prune_owned_claims_without_tokens().await;
+                        scanner.scan_cancel_files().await;
+                        tokio::select! {
+                            () = task_shutdown.cancelled() => break,
+                            () = tokio::time::sleep(RECONCILE_INTERVAL) => {}
+                            result = next_change_or_pending(&mut watcher) => {
+                                if let Err(error) = result {
+                                    warn!(error = %error, "local: cancel watcher failed, using reconciliation");
+                                    watcher = None;
+                                }
+                            }
+                        }
+                    }
+                }))
+            }
             Err(e) => {
                 warn!(error = %e, "local: cancel watcher not started because no tokio runtime is active");
                 None
@@ -212,6 +254,8 @@ impl Drop for LocalCancelWatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     fn empty_cancel_tokens() -> RunCancellationRegistry {

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -1,18 +1,18 @@
 //! [`JobProvider`] backed by a file queue in a shared group directory.
 //!
 //! `submit` writes a `{job_id}.job` file under the requested profile
-//! partition. Runners poll only the profile partitions they support and race
+//! partition. Runners watch only the profile partitions they support and race
 //! to claim discovered jobs via group-wide `{job_id}.claim` files (O_EXCL).
 //! The winning runner executes the job and writes a group-wide
 //! `{job_id}.result` file that `submit` polls for.
 
 mod cancel;
+mod watch;
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -22,19 +22,66 @@ use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{CompleteRequest, ExecutionContext, HeartbeatState};
 use cancel::{LocalCancelScanner, LocalCancelWatcher};
+use watch::{QueueFileKind, RECONCILE_INTERVAL, ensure_watcher, next_change_or_pending};
 
-/// Poll interval for discovering new job files and local cancel markers.
-const POLL_INTERVAL: Duration = Duration::from_millis(100);
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct ScanObserver {
+    inner: Arc<ScanObserverInner>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct ScanObserverInner {
+    count: AtomicUsize,
+    changed: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl ScanObserver {
+    fn record(&self) {
+        self.inner.count.fetch_add(1, Ordering::Relaxed);
+        self.inner.changed.notify_one();
+    }
+
+    fn count(&self) -> usize {
+        self.inner.count.load(Ordering::Relaxed)
+    }
+
+    async fn wait_for_count(&self, expected: usize) {
+        loop {
+            if self.count() >= expected {
+                return;
+            }
+            self.inner.changed.notified().await;
+        }
+    }
+
+    fn observe(&self) -> ScanObservation {
+        ScanObservation(self.clone())
+    }
+}
+
+#[cfg(test)]
+struct ScanObservation(ScanObserver);
+
+#[cfg(test)]
+impl Drop for ScanObservation {
+    fn drop(&mut self) {
+        self.0.record();
+    }
+}
+
 /// [`JobProvider`] backed by a file queue in a shared group directory.
 ///
-/// - `discover()` polls supported profile partitions under `jobs/`.
+/// - `discover()` watches and reconciles supported profile partitions under `jobs/`.
 /// - `claim()` atomically creates `claims/{job_id}.claim` via `O_EXCL`.
 /// - `complete()` writes `results/{job_id}.result`.
 ///
-/// A provider-owned watcher scans `cancels/{run_id}.cancel` independently from
-/// discovery so active-job cancellation remains live while discovery is gated
-/// by capacity or drain mode. `discover()` also performs the same scan as a
-/// fast path, but correctness does not depend on discovery being polled.
+/// A provider-owned watcher reconciles `cancels/{run_id}.cancel` independently
+/// from discovery so active-job cancellation remains live while discovery is
+/// gated by capacity or drain mode. Claim performs one additional reconciliation
+/// after ownership changes so a preexisting marker cannot be stranded.
 pub struct LocalProvider {
     queue: LocalQueue,
     supported_profiles: Vec<String>,
@@ -42,6 +89,8 @@ pub struct LocalProvider {
     cancel: CancellationToken,
     cancel_scanner: LocalCancelScanner,
     cancel_watcher: LocalCancelWatcher,
+    #[cfg(test)]
+    job_scan_observer: ScanObserver,
 }
 
 impl LocalProvider {
@@ -84,10 +133,14 @@ impl LocalProvider {
             cancel,
             cancel_scanner,
             cancel_watcher,
+            #[cfg(test)]
+            job_scan_observer: ScanObserver::default(),
         })
     }
 
     async fn find_unclaimed_job_blocking(&self) -> Option<JobCandidate> {
+        #[cfg(test)]
+        let _scan_observation = self.job_scan_observer.observe();
         let start = self.profile_cursor.fetch_add(1, Ordering::Relaxed);
         let queue = self.queue.clone();
         let supported_profiles = self.supported_profiles.clone();
@@ -103,6 +156,42 @@ impl LocalProvider {
             }
         }
     }
+
+    fn job_watch_paths(&self) -> Vec<PathBuf> {
+        self.supported_profiles
+            .iter()
+            .filter_map(|profile| match crate::local_queue::profile_jobs_dir(
+                self.queue.group_dir(),
+                profile,
+            ) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    warn!(profile, error = %error, "local: invalid supported profile watch path");
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    async fn wait_for_job_scan_count(&self, expected: usize) {
+        self.job_scan_observer.wait_for_count(expected).await;
+    }
+
+    #[cfg(test)]
+    fn job_scan_count(&self) -> usize {
+        self.job_scan_observer.count()
+    }
+
+    #[cfg(test)]
+    async fn wait_for_cancel_scan_count(&self, expected: usize) {
+        self.cancel_scanner.wait_for_scan_count(expected).await;
+    }
+
+    #[cfg(test)]
+    fn cancel_scan_count(&self) -> usize {
+        self.cancel_scanner.scan_count()
+    }
 }
 
 fn job_candidate_from_discovered(discovered: LocalDiscoveredJob) -> JobCandidate {
@@ -117,12 +206,15 @@ fn job_candidate_from_discovered(discovered: LocalDiscoveredJob) -> JobCandidate
 #[async_trait::async_trait]
 impl JobProvider for LocalProvider {
     async fn discover(&self) -> Option<JobCandidate> {
+        let watch_paths = self.job_watch_paths();
+        let mut watcher = None;
         loop {
             if self.cancel.is_cancelled() {
                 return None;
             }
-            // Check for cancel requests before looking for new jobs.
-            self.cancel_scanner.scan_cancel_files().await;
+            if let Err(error) = ensure_watcher(&mut watcher, &watch_paths, QueueFileKind::Job) {
+                warn!(error = %error, "local: job watcher unavailable, using reconciliation");
+            }
             if let Some(candidate) = self.find_unclaimed_job_blocking().await {
                 info!(
                     run_id = %candidate.run_id(),
@@ -133,7 +225,13 @@ impl JobProvider for LocalProvider {
             }
             tokio::select! {
                 () = self.cancel.cancelled() => return None,
-                () = tokio::time::sleep(POLL_INTERVAL) => {}
+                () = tokio::time::sleep(RECONCILE_INTERVAL) => {}
+                result = next_change_or_pending(&mut watcher) => {
+                    if let Err(error) = result {
+                        warn!(error = %error, "local: job watcher failed, using reconciliation");
+                        watcher = None;
+                    }
+                }
             }
         }
     }
@@ -207,6 +305,7 @@ impl JobProvider for LocalProvider {
         match ClaimedJob::local_with_active_input_source(run_id, context, active_input_source) {
             Ok(claimed) => {
                 self.cancel_scanner.mark_owned_claim(run_id).await;
+                self.cancel_scanner.scan_cancel_files().await;
                 info!(run_id = %run_id, "local: job claimed");
                 Some(claimed)
             }

--- a/crates/runner/src/provider/local/tests/cancellation.rs
+++ b/crates/runner/src/provider/local/tests/cancellation.rs
@@ -10,7 +10,8 @@ async fn cancel_file_triggers_token() {
     let registration = insert_cancel_registration(&tokens, run_id).await;
     let job_token = registration.token();
 
-    let provider = default_provider(dir.path(), cancel, tokens);
+    let provider = LocalProvider::new(dir.path().to_path_buf(), default_profiles(), cancel, tokens);
+    provider.wait_for_cancel_scan_count(1).await;
 
     // Write a .cancel file and a dummy .job so discover returns.
     std::fs::create_dir_all(local_queue::cancels_dir(dir.path())).unwrap();
@@ -18,10 +19,12 @@ async fn cancel_file_triggers_token() {
     let other_job = RunId::new_v4();
     write_job(dir.path(), other_job, "keep going");
 
-    // discover() should scan cancel files then find the unclaimed job.
     let candidate = provider.discover().await.unwrap();
     assert_eq!(candidate.run_id(), other_job);
-    assert!(job_token.is_cancelled(), "cancel token should be triggered");
+    tokio::time::timeout(Duration::from_secs(2), job_token.cancelled())
+        .await
+        .expect("cancel watcher should trigger token");
+    provider.shutdown().await;
 }
 
 #[tokio::test]
@@ -31,10 +34,17 @@ async fn owned_cancel_file_is_deleted_after_provider_claim() {
     let run_id = RunId::new_v4();
     let registration = insert_cancel_registration(&tokens, run_id).await;
     let job_token = registration.token();
-    let provider = default_provider(dir.path(), CancellationToken::new(), tokens);
+    let provider = LocalProvider::new(
+        dir.path().to_path_buf(),
+        default_profiles(),
+        CancellationToken::new(),
+        tokens,
+    );
+    provider.wait_for_cancel_scan_count(1).await;
     write_job(dir.path(), run_id, "owned");
     let candidate = provider.discover().await.unwrap();
     provider.claim(candidate).await.unwrap();
+    let cancel_scans_before_marker = provider.cancel_scan_count();
 
     let cancel_path = local_queue::cancel_path(dir.path(), run_id);
     std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
@@ -43,19 +53,31 @@ async fn owned_cancel_file_is_deleted_after_provider_claim() {
     write_job(dir.path(), other_job, "next");
 
     let candidate = provider.discover().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), job_token.cancelled())
+        .await
+        .expect("cancel watcher should trigger token");
+    provider
+        .wait_for_cancel_scan_count(cancel_scans_before_marker + 1)
+        .await;
 
     assert_eq!(candidate.run_id(), other_job);
-    assert!(job_token.is_cancelled(), "cancel token should be triggered");
     assert!(
         !cancel_path.exists(),
         "owned cancel file should be deleted after triggering the token"
     );
+    provider.shutdown().await;
 }
 
 #[tokio::test]
 async fn stale_cancel_file_is_deleted_before_provider_discovers_next_job() {
     let dir = tempfile::tempdir().unwrap();
-    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let provider = LocalProvider::new(
+        dir.path().to_path_buf(),
+        default_profiles(),
+        CancellationToken::new(),
+        empty_cancel_tokens(),
+    );
+    provider.wait_for_cancel_scan_count(1).await;
     let stale_id = RunId::new_v4();
     let cancel_path = local_queue::cancel_path(dir.path(), stale_id);
     std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
@@ -64,12 +86,14 @@ async fn stale_cancel_file_is_deleted_before_provider_discovers_next_job() {
     write_job(dir.path(), job_id, "still works");
 
     let candidate = provider.discover().await.unwrap();
+    provider.wait_for_cancel_scan_count(2).await;
 
     assert_eq!(candidate.run_id(), job_id);
     assert!(
         !cancel_path.exists(),
         "stale cancel file should be deleted when no token, claim, or job remains"
     );
+    provider.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -143,7 +143,7 @@ async fn claim_marks_unreadable_job_path_failed() {
 /// Malformed .job is a permanent error (submit writes atomically, so it
 /// can't be "half-written"). claim() must delete the .job + .claim and
 /// write a .result so the submitter unblocks and discover stops returning
-/// the poisoned job on every poll.
+/// the poisoned job on every scan.
 #[tokio::test]
 async fn claim_handles_poison_job_json() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -107,6 +107,67 @@ async fn shutdown_returns_none() {
 }
 
 #[tokio::test]
+async fn atomic_job_publication_wakes_idle_discovery() {
+    let dir = tempfile::tempdir().unwrap();
+    local_queue::ensure_profile_jobs_dir(dir.path(), crate::profile::DEFAULT_PROFILE).unwrap();
+    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let discover = {
+        let provider = Arc::clone(&provider);
+        tokio::spawn(async move { provider.discover().await })
+    };
+    provider.wait_for_job_scan_count(1).await;
+
+    let job_id = RunId::new_v4();
+    write_job_atomically(dir.path(), job_id, "published after idle");
+
+    let candidate = tokio::time::timeout(Duration::from_secs(2), discover)
+        .await
+        .expect("job publication should wake discovery")
+        .unwrap()
+        .unwrap();
+    assert_eq!(candidate.run_id(), job_id);
+    assert_eq!(provider.job_scan_count(), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_provider_scans_only_at_reconciliation_bound() {
+    let dir = tempfile::tempdir().unwrap();
+    local_queue::ensure_profile_jobs_dir(dir.path(), crate::profile::DEFAULT_PROFILE).unwrap();
+    let cancel = CancellationToken::new();
+    let provider = LocalProvider::new(
+        dir.path().to_path_buf(),
+        default_profiles(),
+        cancel.clone(),
+        empty_cancel_tokens(),
+    );
+    let discover = {
+        let provider = Arc::clone(&provider);
+        tokio::spawn(async move { provider.discover().await })
+    };
+    provider.wait_for_job_scan_count(1).await;
+    provider.wait_for_cancel_scan_count(1).await;
+    tokio::task::yield_now().await;
+    let initial_job_scans = provider.job_scan_count();
+    let initial_cancel_scans = provider.cancel_scan_count();
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert_eq!(provider.job_scan_count(), initial_job_scans);
+    assert_eq!(provider.cancel_scan_count(), initial_cancel_scans);
+
+    tokio::time::advance(RECONCILE_INTERVAL - Duration::from_secs(1)).await;
+    provider
+        .wait_for_job_scan_count(initial_job_scans + 1)
+        .await;
+    provider
+        .wait_for_cancel_scan_count(initial_cancel_scans + 1)
+        .await;
+
+    cancel.cancel();
+    assert!(discover.await.unwrap().is_none());
+    provider.shutdown().await;
+}
+
+#[tokio::test]
 async fn skips_already_claimed_jobs() {
     let dir = tempfile::tempdir().unwrap();
     let cancel = CancellationToken::new();

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -6,6 +6,7 @@ pub(super) use std::time::Duration;
 
 pub(super) use super::super::LocalProvider;
 use super::super::job_candidate_from_discovered;
+pub(super) use super::super::watch::RECONCILE_INTERVAL;
 pub(super) use crate::ids::RunId;
 pub(super) use crate::local_queue;
 use crate::local_queue::JobRequest;
@@ -99,6 +100,24 @@ pub(super) fn write_job(dir: &std::path::Path, job_id: RunId, prompt: &str) {
         prompt,
         Some(crate::profile::DEFAULT_PROFILE),
     );
+}
+
+pub(super) fn write_job_atomically(dir: &std::path::Path, job_id: RunId, prompt: &str) {
+    let partition_profile = crate::profile::DEFAULT_PROFILE;
+    let json = job_request_json(
+        job_id,
+        prompt,
+        JobOptions {
+            profile: Some(partition_profile),
+            ..JobOptions::default()
+        },
+    );
+    let job_dir = local_queue::profile_jobs_dir(dir, partition_profile).unwrap();
+    std::fs::create_dir_all(&job_dir).unwrap();
+    let job_path = local_queue::job_path(dir, partition_profile, job_id).unwrap();
+    let temporary_path = job_dir.join(format!("{job_id}.job.tmp"));
+    std::fs::write(&temporary_path, json).unwrap();
+    std::fs::rename(temporary_path, job_path).unwrap();
 }
 
 pub(super) fn write_job_with_profile(
@@ -199,6 +218,17 @@ fn write_job_in_partition_with_options(
     prompt: &str,
     options: JobOptions<'_>,
 ) {
+    let json = job_request_json(job_id, prompt, options);
+    let job_dir = local_queue::profile_jobs_dir(dir, partition_profile).unwrap();
+    std::fs::create_dir_all(&job_dir).unwrap();
+    std::fs::write(
+        local_queue::job_path(dir, partition_profile, job_id).unwrap(),
+        &json,
+    )
+    .unwrap();
+}
+
+fn job_request_json(job_id: RunId, prompt: &str, options: JobOptions<'_>) -> Vec<u8> {
     let req = JobRequest {
         job_id,
         prompt: prompt.into(),
@@ -213,14 +243,7 @@ fn write_job_in_partition_with_options(
         feature_flags: None,
         active_input: options.active_input,
     };
-    let json = serde_json::to_vec(&req).unwrap();
-    let job_dir = local_queue::profile_jobs_dir(dir, partition_profile).unwrap();
-    std::fs::create_dir_all(&job_dir).unwrap();
-    std::fs::write(
-        local_queue::job_path(dir, partition_profile, job_id).unwrap(),
-        &json,
-    )
-    .unwrap();
+    serde_json::to_vec(&req).unwrap()
 }
 
 pub(super) fn write_job_with_environments(

--- a/crates/runner/src/provider/local/watch.rs
+++ b/crates/runner/src/provider/local/watch.rs
@@ -1,0 +1,275 @@
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::os::fd::{AsFd, AsRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use nix::errno::Errno;
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, WatchDescriptor};
+use tokio::io::unix::AsyncFd;
+
+use crate::error::{RunnerError, RunnerResult};
+
+pub(super) const RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
+
+const PUBLICATION_FLAGS: AddWatchFlags =
+    AddWatchFlags::IN_MOVED_TO.union(AddWatchFlags::IN_CLOSE_WRITE);
+const INVALIDATION_FLAGS: AddWatchFlags = AddWatchFlags::IN_DELETE_SELF
+    .union(AddWatchFlags::IN_MOVE_SELF)
+    .union(AddWatchFlags::IN_UNMOUNT)
+    .union(AddWatchFlags::IN_IGNORED);
+const WATCH_FLAGS: AddWatchFlags = PUBLICATION_FLAGS
+    .union(AddWatchFlags::IN_DELETE_SELF)
+    .union(AddWatchFlags::IN_MOVE_SELF)
+    .union(AddWatchFlags::IN_UNMOUNT)
+    .union(AddWatchFlags::IN_ONLYDIR)
+    .union(AddWatchFlags::IN_DONT_FOLLOW);
+const MAX_EVENT_READ_BATCHES_PER_CHANGE: usize = 16;
+
+#[derive(Clone, Copy)]
+pub(super) enum QueueFileKind {
+    Job,
+    Cancel,
+}
+
+impl QueueFileKind {
+    fn extension(self) -> &'static OsStr {
+        match self {
+            Self::Job => OsStr::new("job"),
+            Self::Cancel => OsStr::new("cancel"),
+        }
+    }
+}
+
+/// Advisory inotify waiter for local queue leaf directories.
+pub(super) struct LocalQueueWatcher {
+    inotify: AsyncFd<AsyncInotify>,
+    desired_paths: Vec<PathBuf>,
+    path_by_watch: BTreeMap<WatchDescriptor, PathBuf>,
+    watch_by_path: BTreeMap<PathBuf, WatchDescriptor>,
+    kind: QueueFileKind,
+}
+
+struct AsyncInotify(Inotify);
+
+impl AsRawFd for AsyncInotify {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_fd().as_raw_fd()
+    }
+}
+
+impl LocalQueueWatcher {
+    pub(super) fn new(mut desired_paths: Vec<PathBuf>, kind: QueueFileKind) -> RunnerResult<Self> {
+        desired_paths.sort();
+        desired_paths.dedup();
+        let inotify = Inotify::init(InitFlags::IN_CLOEXEC | InitFlags::IN_NONBLOCK)
+            .map_err(|error| watcher_error("initialize", error))?;
+        let inotify = AsyncFd::new(AsyncInotify(inotify))
+            .map_err(|error| watcher_io_error("register descriptor", error.kind()))?;
+        Ok(Self {
+            inotify,
+            desired_paths,
+            path_by_watch: BTreeMap::new(),
+            watch_by_path: BTreeMap::new(),
+            kind,
+        })
+    }
+
+    /// Install watches that are currently missing.
+    pub(super) fn reconcile(&mut self) -> RunnerResult<()> {
+        let missing_paths: Vec<PathBuf> = self
+            .desired_paths
+            .iter()
+            .filter(|path| !self.watch_by_path.contains_key(*path))
+            .cloned()
+            .collect();
+        let mut first_error = None;
+        for path in missing_paths {
+            match self.inotify.get_ref().0.add_watch(&path, WATCH_FLAGS) {
+                Ok(watch) => {
+                    self.path_by_watch.insert(watch, path.clone());
+                    self.watch_by_path.insert(path, watch);
+                }
+                Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => {}
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(watcher_error("watch queue directory", error));
+                    }
+                }
+            }
+        }
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Wait for a matching publication or a condition requiring reconciliation.
+    pub(super) async fn next_change(&mut self) -> RunnerResult<()> {
+        loop {
+            let mut ready = self
+                .inotify
+                .readable()
+                .await
+                .map_err(|error| watcher_io_error("wait for events", error.kind()))?;
+
+            let mut changed = false;
+            let mut drained_all_events = false;
+            let mut invalidated_watches = Vec::new();
+            for _ in 0..MAX_EVENT_READ_BATCHES_PER_CHANGE {
+                match self.inotify.get_ref().0.read_events() {
+                    Ok(events) => {
+                        for event in events {
+                            if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
+                                changed = true;
+                                continue;
+                            }
+                            if event.mask.intersects(INVALIDATION_FLAGS) {
+                                invalidated_watches.push(event.wd);
+                                changed = true;
+                                continue;
+                            }
+                            if !event.mask.intersects(PUBLICATION_FLAGS)
+                                || !self.path_by_watch.contains_key(&event.wd)
+                            {
+                                continue;
+                            }
+                            if event.name.as_deref().is_some_and(|name| {
+                                Path::new(name).extension() == Some(self.kind.extension())
+                            }) {
+                                changed = true;
+                            }
+                        }
+                    }
+                    Err(Errno::EAGAIN) => {
+                        drained_all_events = true;
+                        break;
+                    }
+                    Err(error) => return Err(watcher_error("read events", error)),
+                }
+            }
+            if drained_all_events {
+                ready.clear_ready();
+            }
+            drop(ready);
+            for watch in invalidated_watches {
+                self.forget_watch(watch);
+            }
+
+            if changed || !drained_all_events {
+                return Ok(());
+            }
+        }
+    }
+
+    fn forget_watch(&mut self, watch: WatchDescriptor) {
+        if let Some(path) = self.path_by_watch.remove(&watch) {
+            self.watch_by_path.remove(&path);
+        }
+    }
+}
+
+pub(super) fn ensure_watcher(
+    watcher: &mut Option<LocalQueueWatcher>,
+    desired_paths: &[PathBuf],
+    kind: QueueFileKind,
+) -> RunnerResult<()> {
+    match watcher {
+        Some(watcher) => watcher.reconcile(),
+        None => {
+            let mut created = LocalQueueWatcher::new(desired_paths.to_vec(), kind)?;
+            let result = created.reconcile();
+            *watcher = Some(created);
+            result
+        }
+    }
+}
+
+pub(super) async fn next_change_or_pending(
+    watcher: &mut Option<LocalQueueWatcher>,
+) -> RunnerResult<()> {
+    match watcher {
+        Some(watcher) => watcher.next_change().await,
+        None => std::future::pending().await,
+    }
+}
+
+fn watcher_error(action: &str, error: Errno) -> RunnerError {
+    RunnerError::Internal(format!("local queue watcher {action}: {error}"))
+}
+
+fn watcher_io_error(action: &str, kind: std::io::ErrorKind) -> RunnerError {
+    RunnerError::Internal(format!("local queue watcher {action}: {kind:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn watcher(path: &Path, kind: QueueFileKind) -> LocalQueueWatcher {
+        let mut watcher = LocalQueueWatcher::new(vec![path.to_path_buf()], kind).unwrap();
+        watcher.reconcile().unwrap();
+        watcher
+    }
+
+    #[tokio::test]
+    async fn job_watcher_ignores_temporary_file_until_final_rename() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut watcher = watcher(dir.path(), QueueFileKind::Job);
+        let temporary_path = dir.path().join("run.job.tmp");
+        let job_path = dir.path().join("run.job");
+        std::fs::write(&temporary_path, b"job").unwrap();
+        std::fs::write(dir.path().join("noise.txt"), b"noise").unwrap();
+
+        let mut next_change = Box::pin(watcher.next_change());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut next_change)
+                .await
+                .is_err(),
+            "temporary and unrelated files must not wake job discovery"
+        );
+
+        std::fs::rename(temporary_path, job_path).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), &mut next_change)
+            .await
+            .expect("final job rename should wake watcher")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_watcher_reports_close_written_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut watcher = watcher(dir.path(), QueueFileKind::Cancel);
+
+        std::fs::write(dir.path().join("run.cancel"), b"").unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), watcher.next_change())
+            .await
+            .expect("closed cancel marker should wake watcher")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalidated_directory_can_be_reconciled_after_recreation() {
+        let root = tempfile::tempdir().unwrap();
+        let watched_dir = root.path().join("jobs");
+        std::fs::create_dir(&watched_dir).unwrap();
+        let mut watcher = watcher(&watched_dir, QueueFileKind::Job);
+
+        std::fs::remove_dir(&watched_dir).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), watcher.next_change())
+            .await
+            .expect("directory invalidation should request reconciliation")
+            .unwrap();
+        watcher.reconcile().unwrap();
+
+        std::fs::create_dir(&watched_dir).unwrap();
+        watcher.reconcile().unwrap();
+        std::fs::write(watched_dir.join("run.job"), b"job").unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), watcher.next_change())
+            .await
+            .expect("recreated directory should be watched again")
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- replace the local provider's 100 ms job and cancellation polling loops with inotify wakeups
- keep a 5-second filesystem reconciliation interval for missed events, watcher failures, and directory recreation
- reconcile cancellation markers after a successful claim so markers created before ownership registration are not stranded
- add integration coverage for atomic job publication, independent cancellation wakeups, watcher recovery, and idle scan frequency

## Scope

- local runner provider only
- no queue file format, API, database, CLI, frontend, or feature-switch changes
- the filesystem remains authoritative; inotify is only an advisory wakeup

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`

Closes #29289
