### PR TITLE
fix(vsock-host): bound chunked write temp names

### DIFF
--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -556,13 +556,15 @@ impl VsockHost {
                 .await;
         }
 
+        validate_write_file_chunk_request(WriteFileChunkRequest::standard(path, &[], sudo, false))?;
         let _path_guard = self.file_write_path_locks.acquire_shared(path).await;
         let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
 
-        // Write chunks to a per-call temp file, then atomic rename. The
-        // suffix prevents concurrent large writes to the same destination
-        // from appending to or cleaning up each other's staging file.
-        let tmp = format!("{path}.vm0tmp-{}", self.shared.next_temp_seq());
+        // Write chunks to a bounded per-call sibling, then atomic rename. The UUID
+        // prevents concurrent writes from sharing or cleaning up a staging file.
+        let tmp_path = std::path::Path::new(path)
+            .with_file_name(format!(".vm0tmp-{}", uuid::Uuid::new_v4().simple()));
+        let tmp = tmp_path.to_string_lossy();
         let quoted_tmp = quote_shell_arg(&tmp);
         let rm_tmp = format!("rm -f -- {quoted_tmp}");
         let cleanup_armed = Arc::new(AtomicBool::new(false));

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::io;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -76,11 +77,7 @@ impl ChunkedWriteFixture {
             assert_eq!(frame.path.as_str(), temp_path);
             assert!(frame.append);
         } else {
-            assert!(
-                frame
-                    .path
-                    .starts_with(&format!("{}.vm0tmp-", self.target_path))
-            );
+            assert_chunked_temp_path(self.target_path, &frame.path);
             assert!(!frame.append);
             self.temp_path = Some(frame.path.clone());
         }
@@ -124,6 +121,18 @@ impl ChunkedWriteFixture {
     fn temp_path(&self) -> &str {
         self.temp_path.as_deref().expect("temp path")
     }
+}
+
+fn assert_chunked_temp_path(target_path: &str, temp_path: &str) {
+    let target = Path::new(target_path);
+    let temp = Path::new(temp_path);
+    assert_eq!(temp.parent(), target.parent());
+    let temp_name = temp
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("UTF-8 temp file name");
+    assert!(temp_name.starts_with(".vm0tmp-"));
+    assert!(temp_name.len() <= 255);
 }
 
 async fn write_file_with_small_chunks(
@@ -454,41 +463,6 @@ async fn write_file_chunked_rejects_invalid_guest_path_before_cleanup_or_write()
     let err = file_impl::test_support::write_file_with_small_chunks(
         &host,
         "/tmp/has\0nul",
-        &content,
-        false,
-        FrameWriteObserver::new({
-            let write_start_count = Arc::clone(&write_start_count);
-            move || {
-                write_start_count.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }),
-    )
-    .await
-    .unwrap_err();
-
-    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
-    );
-    assert_eq!(operation_count(&host), 0);
-
-    assert_connection_accepts_exec_operation(&host, &mut guest).await;
-}
-
-#[tokio::test]
-async fn write_file_chunked_rejects_temp_path_overflow_before_cleanup_or_write() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let write_start_count = Arc::new(AtomicUsize::new(0));
-    let path = format!("/{}", "a".repeat(u16::MAX as usize - 1));
-    let content = ChunkedWriteFixture::two_chunk_content();
-
-    let err = file_impl::test_support::write_file_with_small_chunks(
-        &host,
-        &path,
         &content,
         false,
         FrameWriteObserver::new({
@@ -1013,7 +987,7 @@ async fn write_file_chunked_quotes_target_path_with_single_quote() {
     send_write_file_success(&mut fixture.guest, second.seq()).await;
 
     let rename = fixture.expect_rename().await;
-    assert!(rename.command.contains("'/tmp/big'\\''quote.bin.vm0tmp-"));
+    assert!(rename.command.starts_with("mv -fT -- '/tmp/.vm0tmp-"));
     assert!(rename.command.ends_with(" '/tmp/big'\\''quote.bin'"));
     send_exec_result(
         &mut fixture.guest,
@@ -1025,11 +999,7 @@ async fn write_file_chunked_quotes_target_path_with_single_quote() {
     .await;
 
     let cleanup = fixture.expect_cleanup().await;
-    assert!(
-        cleanup
-            .command
-            .starts_with("rm -f -- '/tmp/big'\\''quote.bin.vm0tmp-")
-    );
+    assert!(cleanup.command.starts_with("rm -f -- '/tmp/.vm0tmp-"));
     send_exec_result(
         &mut fixture.guest,
         cleanup.seq(),
@@ -1074,7 +1044,7 @@ async fn write_file_chunked_concurrent_writes_to_same_target_use_distinct_temp_p
                     vsock_proto::decode_write_file(&msg.payload).unwrap();
                 assert!(!sudo);
                 assert!(!private);
-                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+                assert_chunked_temp_path(target_path, path);
                 let marker = *content.first().expect("chunk content");
                 assert!(matches!(marker, 0xAA | 0xBB));
                 assert!(content.iter().all(|byte| *byte == marker));
@@ -1170,7 +1140,7 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
                     vsock_proto::decode_write_file(&msg.payload).unwrap();
                 assert!(!sudo);
                 assert!(!private);
-                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+                assert_chunked_temp_path(target_path, path);
                 let marker = *content.first().expect("chunk content");
                 assert!(matches!(marker, 0xAA | 0xBB));
                 assert!(content.iter().all(|byte| *byte == marker));
@@ -1886,7 +1856,7 @@ async fn write_file_production_chunk_boundaries() {
         );
 
         let first = expect_write_file(&mut guest).await;
-        assert!(first.path.starts_with(&format!("{target_path}.vm0tmp-")));
+        assert_chunked_temp_path(target_path, &first.path);
         let temp_path = first.path.clone();
         assert_eq!(first.content.len(), chunk_limit);
         assert!(first.content.iter().all(|byte| *byte == marker));
@@ -2052,7 +2022,7 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
                         continue;
                     }
 
-                    assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
+                    assert_chunked_temp_path("/tmp/big.bin", path);
                     assert!(!append);
                     temp_path = Some(path.to_string());
                     send_write_file_success(guest.stream_mut(), msg.seq).await;

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -461,10 +461,13 @@ async fn test_write_file_large() {
 async fn test_write_file_chunked() {
     let h = Harness::new().await;
 
-    let file_path = h.dir.join("chunked'quote.bin");
+    let file_name = format!("{}'x", "a".repeat(253));
+    assert_eq!(file_name.len(), 255);
+    let file_path = h.dir.join(file_name);
     let file_path_str = file_path.to_string_lossy().to_string();
     // 16 MB content exceeds the 15 MB chunk limit, triggering the staging +
-    // shell rename path. The quote in the file name covers shell escaping.
+    // shell rename path. The maximum-length file name covers NAME_MAX, and
+    // its quote covers shell escaping of the unchanged rename target.
     let content = vec![0xABu8; 16 * 1024 * 1024];
 
     h.host()
@@ -477,12 +480,17 @@ async fn test_write_file_chunked() {
     assert_eq!(written, content);
 
     // Temp file should not remain
-    let temp_prefix = format!("{file_path_str}.vm0tmp-");
     let temp_remains = std::fs::read_dir(file_path.parent().unwrap())
         .expect("failed to read temp dir")
         .flatten()
-        .any(|entry| entry.path().to_string_lossy().starts_with(&temp_prefix));
+        .any(|entry| entry.file_name().to_string_lossy().starts_with(".vm0tmp-"));
     assert!(!temp_remains, "temp file was not cleaned up");
+
+    let result = run_exec(h.host(), "printf reusable", 5000, &[], false)
+        .await
+        .expect("connection should accept exec after chunked write");
+    assert_eq!(exec_exit_code(&result), Some(0));
+    assert_eq!(captured_output_bytes(&result.stdout), b"reusable");
     h.finish();
 }
 
@@ -509,11 +517,10 @@ async fn test_write_file_chunked_directory_target_fails() {
         "temp file must not be moved into target directory"
     );
 
-    let temp_prefix = format!("{target_dir_str}.vm0tmp-");
     let sibling_temp_remains = fs::read_dir(target_dir.parent().unwrap())
         .expect("read parent directory")
         .flatten()
-        .any(|entry| entry.path().to_string_lossy().starts_with(&temp_prefix));
+        .any(|entry| entry.file_name().to_string_lossy().starts_with(".vm0tmp-"));
     assert!(!sibling_temp_remains, "temp file was not cleaned up");
 
     h.finish();


### PR DESCRIPTION
## Summary

- stage large ordinary guest writes in bounded, same-directory UUID temp files instead of extending the destination basename
- preserve destination protocol validation, per-call cleanup, and atomic `mv -fT` replacement semantics
- cover an exact 255-byte destination basename with real host/guest filesystem integration, including cleanup and connection reuse

## Scope

- no wire-format, guest-helper, public API, database, configuration, or migration changes
- private and single-frame file writes remain unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-host -p vsock-test --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-host -p vsock-test --all-features --no-deps`
- `cargo test -p vsock-host`
- `cargo test -p vsock-test --test integration`
- pre-commit workspace Rust format, Clippy, rustdoc, file-size, and commitlint hooks

Closes #29290
