### PR TITLE
fix(ci): make release recovery idempotent

### DIFF
--- a/.github/scripts/tests/release-recovery-test.sh
+++ b/.github/scripts/tests/release-recovery-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+workflow="${repo_root}/.github/workflows/release-please.yml"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+fake_bin="${tmp_dir}/bin"
+mkdir -p "$fake_bin"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+target_sha=2db202a9412368457b40f8bb5374d7302982ef52
+main_sha=fbb7a4a7a8907254b9b98592cd4f5c8f18051edf
+wrong_sha=cccccccccccccccccccccccccccccccccccccccc
+release_fixture="${tmp_dir}/releases.json"
+missing_app_fixture="${tmp_dir}/missing-app-releases.json"
+recovery_script="${tmp_dir}/recovery.sh"
+
+ruby -e '
+  require "yaml"
+  workflow = YAML.safe_load(File.read(ARGV[0]), aliases: true)
+  step = workflow.fetch("jobs").fetch("release-please").fetch("steps").find { |candidate| candidate["id"] == "recovery_release" }
+  raise "missing recovery mapping step" unless step
+  puts step.fetch("run")
+' "$workflow" >"$recovery_script"
+chmod +x "$recovery_script"
+
+jq -n --arg sha "$target_sha" '[
+  {target_commitish: $sha, draft: false, tag_name: "api-v1.488.1"},
+  {target_commitish: $sha, draft: false, tag_name: "db-v1.223.2"},
+  {target_commitish: $sha, draft: false, tag_name: "app-v0.794.1"},
+  {target_commitish: $sha, draft: false, tag_name: "runner-rs-v0.173.2"},
+  {target_commitish: $sha, draft: false, tag_name: "core-v8.590.2"}
+]' >"$release_fixture"
+jq 'map(select(.tag_name != "app-v0.794.1"))' "$release_fixture" >"$missing_app_fixture"
+
+cat >"${fake_bin}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "${1:-}" = "api" ] || {
+  echo "unexpected gh command: $*" >&2
+  exit 2
+}
+route=${2:-}
+repo="${MOCK_REPO:?}"
+target_sha="${MOCK_TARGET_SHA:?}"
+main_sha="${MOCK_MAIN_SHA:?}"
+
+if [ "$route" = "repos/${repo}/commits/main" ]; then
+  printf '%s\n' "$main_sha"
+elif [ "$route" = "repos/${repo}/commits/${target_sha}" ]; then
+  printf '%s\n' "$target_sha"
+elif [ "$route" = "repos/${repo}/compare/${target_sha}...${main_sha}" ]; then
+  printf '%s\n' "${MOCK_LINEAGE:-ahead}"
+elif [ "$route" = "repos/${repo}/releases?per_page=100" ]; then
+  cat "${MOCK_RELEASES_FILE:?}"
+elif [[ "$route" == "repos/${repo}/commits/"* ]]; then
+  tag=${route##*/commits/}
+  if [ "${MOCK_WRONG_TAG:-}" = "$tag" ]; then
+    printf '%s\n' "${MOCK_WRONG_TAG_SHA:?}"
+  else
+    printf '%s\n' "$target_sha"
+  fi
+else
+  echo "unexpected gh api route: $route" >&2
+  exit 2
+fi
+SH
+chmod +x "${fake_bin}/gh"
+
+run_recovery() {
+  local output_file=$1
+  shift
+  : >"$output_file"
+  env -i \
+    PATH="${fake_bin}:$PATH" \
+    HOME="${HOME:-/tmp}" \
+    GH_TOKEN=test-github-token \
+    GITHUB_OUTPUT="$output_file" \
+    MOCK_MAIN_SHA="$main_sha" \
+    MOCK_RELEASES_FILE="$release_fixture" \
+    MOCK_REPO=vm0-ai/vm0 \
+    MOCK_TARGET_SHA="$target_sha" \
+    REPO=vm0-ai/vm0 \
+    RECOVERY_RELEASE_SHA="$target_sha" \
+    "$@" \
+    bash "$recovery_script"
+}
+
+assert_failure() {
+  local expected_message=$1
+  shift
+  if "$@" >"${tmp_dir}/failure.log" 2>&1; then
+    fail "expected command to fail: ${expected_message}"
+  fi
+  grep -q "$expected_message" "${tmp_dir}/failure.log" || fail "missing failure message: ${expected_message}"
+}
+
+success_output="${tmp_dir}/success.output"
+run_recovery "$success_output"
+grep -qx "releases_created=true" "$success_output" || fail "recovery did not report releases_created"
+grep -qx "release_target=${target_sha}" "$success_output" || fail "recovery did not preserve the exact target"
+grep -qx "api_version=1.488.1" "$success_output" || fail "recovery did not map API version"
+grep -qx "app_version=0.794.1" "$success_output" || fail "recovery did not map App version"
+grep -qx "runner_rs_version=0.173.2" "$success_output" || fail "recovery did not map Runner version"
+
+wrong_target_output="${tmp_dir}/wrong-target.output"
+assert_failure \
+  "only supports incident release SHA" \
+  run_recovery "$wrong_target_output" RECOVERY_RELEASE_SHA="$wrong_sha"
+[ ! -s "$wrong_target_output" ] || fail "wrong incident target must not publish outputs"
+
+wrong_lineage_output="${tmp_dir}/wrong-lineage.output"
+assert_failure \
+  "not an ancestor" \
+  run_recovery "$wrong_lineage_output" MOCK_LINEAGE=behind
+[ ! -s "$wrong_lineage_output" ] || fail "wrong ancestry must not publish outputs"
+
+wrong_tag_output="${tmp_dir}/wrong-tag.output"
+assert_failure \
+  "targets ${wrong_sha}" \
+  run_recovery \
+  "$wrong_tag_output" \
+  MOCK_WRONG_TAG=app-v0.794.1 \
+  MOCK_WRONG_TAG_SHA="$wrong_sha"
+[ ! -s "$wrong_tag_output" ] || fail "wrong tag target must not publish outputs"
+
+missing_release_output="${tmp_dir}/missing-release.output"
+assert_failure \
+  "missing a required API/DB/App/Runner release" \
+  run_recovery "$missing_release_output" MOCK_RELEASES_FILE="$missing_app_fixture"
+[ ! -s "$missing_release_output" ] || fail "missing required release must not publish outputs"
+
+echo "release recovery tests passed"

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -251,7 +251,7 @@ ruby -e '
 
 release_target=cccccccccccccccccccccccccccccccccccccccc
 release_target_output="${tmp_dir}/release-target.output"
-RELEASE_SHAS="$(jq -nc --arg target "$release_target" '["", $target, "", $target]')" \
+RELEASE_SHAS="$(jq -nc --arg target "$release_target" '[null, "", $target, null]')" \
   GITHUB_OUTPUT="$release_target_output" \
   bash "$release_target_script"
 grep -qx "sha=${release_target}" "$release_target_output" || fail "release target resolver did not publish the unique release SHA"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,12 @@ name: release-please
 on:
   push:
     branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      recovery_release_sha:
+        description: "Existing release commit to deploy without creating releases"
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -34,6 +40,7 @@ jobs:
         env:
           COMMIT_MESSAGES: ${{ toJSON(github.event.commits.*.message) }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          RECOVERY_RELEASE_SHA: ${{ inputs.recovery_release_sha || '' }}
         run: |
           set -euo pipefail
 
@@ -43,11 +50,19 @@ jobs:
           fi
 
           release=false
-          while IFS= read -r subject; do
-            case "$subject" in
-            'chore: release'*) release=true ;;
-            esac
-          done <<<"$subjects"
+          if [ -n "$RECOVERY_RELEASE_SHA" ]; then
+            if [[ ! "$RECOVERY_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::Recovery release SHA must be a full lowercase SHA-1: $RECOVERY_RELEASE_SHA"
+              exit 1
+            fi
+            release=true
+          else
+            while IFS= read -r subject; do
+              case "$subject" in
+              'chore: release'*) release=true ;;
+              esac
+            done <<<"$subjects"
+          fi
 
           echo "release=$release" >> "$GITHUB_OUTPUT"
           echo "release commit in this push: $release"
@@ -74,31 +89,132 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      release_target: ${{ steps.release-target.outputs.sha }}
-      api_release_created: ${{ steps.release.outputs['turbo/apps/api--release_created'] }}
-      core_release_created: ${{ steps.release.outputs['turbo/packages/core--release_created'] }}
-      api_contracts_release_created: ${{ steps.release.outputs['turbo/packages/api-contracts--release_created'] }}
-      connectors_release_created: ${{ steps.release.outputs['turbo/packages/connectors--release_created'] }}
-      db_release_created: ${{ steps.release.outputs['turbo/packages/db--release_created'] }}
-      app_release_created: ${{ steps.release.outputs['turbo/apps/platform--release_created'] }}
-      desktop_release_created: ${{ steps.release.outputs['turbo/apps/desktop--release_created'] }}
-      host_worker_release_created: ${{ steps.release.outputs['turbo/apps/host-worker--release_created'] }}
-      runner_rs_release_created: ${{ steps.release.outputs['crates/runner--release_created'] }}
-      api_runtime_dependency_release_created: ${{ steps.release.outputs['turbo/packages/core--release_created'] == 'true' || steps.release.outputs['turbo/packages/api-contracts--release_created'] == 'true' || steps.release.outputs['turbo/packages/connectors--release_created'] == 'true' }}
-      api_deploy_required: ${{ steps.release.outputs['turbo/apps/api--release_created'] == 'true' || steps.release.outputs['turbo/packages/core--release_created'] == 'true' || steps.release.outputs['turbo/packages/api-contracts--release_created'] == 'true' || steps.release.outputs['turbo/packages/connectors--release_created'] == 'true' }}
-      runner_rs_version: ${{ steps.release.outputs['crates/runner--version'] }}
-      api_version: ${{ steps.release.outputs['turbo/apps/api--version'] }}
-      app_version: ${{ steps.release.outputs['turbo/apps/platform--version'] }}
-      desktop_version: ${{ steps.release.outputs['turbo/apps/desktop--version'] }}
+      releases_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.releases_created || steps.release.outputs.releases_created }}
+      release_target: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.release_target || steps.release-target.outputs.sha }}
+      api_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_release_created || steps.release.outputs['turbo/apps/api--release_created'] }}
+      core_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.core_release_created || steps.release.outputs['turbo/packages/core--release_created'] }}
+      api_contracts_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_contracts_release_created || steps.release.outputs['turbo/packages/api-contracts--release_created'] }}
+      connectors_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.connectors_release_created || steps.release.outputs['turbo/packages/connectors--release_created'] }}
+      db_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.db_release_created || steps.release.outputs['turbo/packages/db--release_created'] }}
+      app_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.app_release_created || steps.release.outputs['turbo/apps/platform--release_created'] }}
+      desktop_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.desktop_release_created || steps.release.outputs['turbo/apps/desktop--release_created'] }}
+      host_worker_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.host_worker_release_created || steps.release.outputs['turbo/apps/host-worker--release_created'] }}
+      runner_rs_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.runner_rs_release_created || steps.release.outputs['crates/runner--release_created'] }}
+      api_runtime_dependency_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_runtime_dependency_release_created || steps.release.outputs['turbo/packages/core--release_created'] == 'true' || steps.release.outputs['turbo/packages/api-contracts--release_created'] == 'true' || steps.release.outputs['turbo/packages/connectors--release_created'] == 'true' }}
+      api_deploy_required: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_deploy_required || steps.release.outputs['turbo/apps/api--release_created'] == 'true' || steps.release.outputs['turbo/packages/core--release_created'] == 'true' || steps.release.outputs['turbo/packages/api-contracts--release_created'] == 'true' || steps.release.outputs['turbo/packages/connectors--release_created'] == 'true' }}
+      runner_rs_version: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.runner_rs_version || steps.release.outputs['crates/runner--version'] }}
+      api_version: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_version || steps.release.outputs['turbo/apps/api--version'] }}
+      app_version: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.app_version || steps.release.outputs['turbo/apps/platform--version'] }}
+      desktop_version: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.desktop_version || steps.release.outputs['turbo/apps/desktop--version'] }}
     steps:
       - uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
         id: release
+        if: ${{ inputs.recovery_release_sha == '' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: true
+
+      - name: Reuse existing releases for recovery
+        id: recovery_release
+        if: ${{ inputs.recovery_release_sha != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RECOVERY_RELEASE_SHA: ${{ inputs.recovery_release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
+          gh api "repos/$REPO/commits/$RECOVERY_RELEASE_SHA" --jq .sha >/dev/null
+          lineage=$(gh api "repos/$REPO/compare/$RECOVERY_RELEASE_SHA...$main_sha" --jq .status)
+          case "$lineage" in
+            identical|ahead) ;;
+            *)
+              echo "::error::Recovery release $RECOVERY_RELEASE_SHA is not an ancestor of main ($main_sha): $lineage"
+              exit 1
+              ;;
+          esac
+
+          releases_json=$(gh api "repos/$REPO/releases?per_page=100")
+          release_count=$(jq --arg sha "$RECOVERY_RELEASE_SHA" '[.[] | select(.target_commitish == $sha and (.draft | not))] | length' <<<"$releases_json")
+          if [ "$release_count" -eq 0 ]; then
+            echo "::error::No published GitHub release targets recovery SHA $RECOVERY_RELEASE_SHA"
+            exit 1
+          fi
+
+          release_tag_for_prefix() {
+            local prefix=$1
+            jq -er --arg sha "$RECOVERY_RELEASE_SHA" --arg prefix "$prefix" '
+              [.[] | select(.target_commitish == $sha and (.draft | not) and (.tag_name | startswith($prefix))) | .tag_name]
+              | if length == 1 then .[0]
+                elif length == 0 then ""
+                else error("multiple releases for prefix " + $prefix)
+                end
+            ' <<<"$releases_json"
+          }
+
+          assert_tag_target() {
+            local tag=$1
+            local tag_sha
+            tag_sha=$(gh api "repos/$REPO/commits/$tag" --jq .sha)
+            if [ "$tag_sha" != "$RECOVERY_RELEASE_SHA" ]; then
+              echo "::error::Release tag $tag targets $tag_sha, expected $RECOVERY_RELEASE_SHA"
+              exit 1
+            fi
+          }
+
+          api_tag=$(release_tag_for_prefix api-v)
+          db_tag=$(release_tag_for_prefix db-v)
+          app_tag=$(release_tag_for_prefix app-v)
+          runner_tag=$(release_tag_for_prefix runner-rs-v)
+          core_tag=$(release_tag_for_prefix core-v)
+          api_contracts_tag=$(release_tag_for_prefix api-contracts-v)
+          connectors_tag=$(release_tag_for_prefix connectors-v)
+          desktop_tag=$(release_tag_for_prefix desktop-v)
+          host_worker_tag=$(release_tag_for_prefix host-worker-v)
+
+          for required_tag in "$api_tag" "$db_tag" "$app_tag" "$runner_tag"; do
+            if [ -z "$required_tag" ]; then
+              echo "::error::Recovery release $RECOVERY_RELEASE_SHA is missing a required API/DB/App/Runner release"
+              exit 1
+            fi
+            assert_tag_target "$required_tag"
+          done
+
+          api_version=${api_tag#api-v}
+          app_version=${app_tag#app-v}
+          runner_rs_version=${runner_tag#runner-rs-v}
+          desktop_version=${desktop_tag#desktop-v}
+          api_runtime_dependency=false
+          if [ -n "$core_tag$api_contracts_tag$connectors_tag" ]; then
+            api_runtime_dependency=true
+          fi
+
+          {
+            echo "releases_created=true"
+            echo "release_target=$RECOVERY_RELEASE_SHA"
+            echo "api_release_created=true"
+            echo "core_release_created=$( [ -n "$core_tag" ] && echo true || echo false )"
+            echo "api_contracts_release_created=$( [ -n "$api_contracts_tag" ] && echo true || echo false )"
+            echo "connectors_release_created=$( [ -n "$connectors_tag" ] && echo true || echo false )"
+            echo "db_release_created=true"
+            echo "app_release_created=true"
+            echo "desktop_release_created=$( [ -n "$desktop_tag" ] && echo true || echo false )"
+            echo "host_worker_release_created=$( [ -n "$host_worker_tag" ] && echo true || echo false )"
+            echo "runner_rs_release_created=true"
+            echo "api_runtime_dependency_release_created=$api_runtime_dependency"
+            echo "api_deploy_required=true"
+            echo "runner_rs_version=$runner_rs_version"
+            echo "api_version=$api_version"
+            echo "app_version=$app_version"
+            echo "desktop_version=$desktop_version"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Recovery mode will reuse $release_count published release(s) targeting $RECOVERY_RELEASE_SHA"
+          echo "API=$api_tag DB=$db_tag App=$app_tag Runner=$runner_tag"
 
       - name: Resolve release target
         id: release-target
@@ -179,6 +295,7 @@ jobs:
   # the next push to main.
   refresh-release-pull-request:
     needs: release-please
+    if: ${{ inputs.recovery_release_sha == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -147,9 +147,11 @@ jobs:
 
           release_target=$(
             jq -er '
-              map(select(. != ""))
+              map(select(. != null and . != ""))
               | map(
-                  if test("^[0-9a-f]{40}$") then
+                  if type != "string" then
+                    error("release-please returned non-string release SHA: " + tostring)
+                  elif test("^[0-9a-f]{40}$") then
                     .
                   else
                     error("release-please returned invalid release SHA: " + .)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,7 +90,7 @@ jobs:
     if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     outputs:
       releases_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.releases_created || steps.release.outputs.releases_created }}
-      release_target: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.release_target || steps.release-target.outputs.sha }}
+      release_target: ${{ steps.release-target.outputs.sha }}
       api_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_release_created || steps.release.outputs['turbo/apps/api--release_created'] }}
       core_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.core_release_created || steps.release.outputs['turbo/packages/core--release_created'] }}
       api_contracts_release_created: ${{ inputs.recovery_release_sha != '' && steps.recovery_release.outputs.api_contracts_release_created || steps.release.outputs['turbo/packages/api-contracts--release_created'] }}
@@ -218,45 +218,45 @@ jobs:
 
       - name: Resolve release target
         id: release-target
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ inputs.recovery_release_sha != '' || steps.release.outputs.releases_created == 'true' }}
         env:
           RELEASE_SHAS: >-
             [
-              ${{ toJSON(steps.release.outputs['crates/ably-subscriber--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/api-contracts--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-agent--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-common--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-contracts--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-download--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-init--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-mock-claude--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-mock-codex--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-reseed--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-session-prune--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-tool-exec--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/guest-write-file--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/nbd-cow--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/process-control-ipc--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/runner--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/sandbox--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/sandbox-fc--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/sandbox-mock--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/shell-quote--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/tracing-test-support--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/vsock-guest--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/vsock-host--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/vsock-proto--sha']) }},
-              ${{ toJSON(steps.release.outputs['crates/vsock-test--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/apps/api--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/apps/cli--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/apps/desktop--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/apps/host-worker--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/apps/platform--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/packages/api-contracts--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/packages/connectors--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/packages/core--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/packages/db--sha']) }},
-              ${{ toJSON(steps.release.outputs['turbo/packages/pi-agent-runtime--sha']) }}
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/ably-subscriber--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/api-contracts--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-agent--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-common--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-contracts--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-download--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-init--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-mock-claude--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-mock-codex--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-reseed--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-session-prune--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-tool-exec--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/guest-write-file--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/nbd-cow--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/process-control-ipc--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/runner--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/sandbox--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/sandbox-fc--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/sandbox-mock--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/shell-quote--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/tracing-test-support--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/vsock-guest--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/vsock-host--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/vsock-proto--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['crates/vsock-test--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/apps/api--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/apps/cli--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/apps/desktop--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/apps/host-worker--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/apps/platform--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/packages/api-contracts--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/packages/connectors--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/packages/core--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/packages/db--sha']) }},
+              ${{ toJSON(inputs.recovery_release_sha || steps.release.outputs['turbo/packages/pi-agent-runtime--sha']) }}
             ]
         run: |
           set -euo pipefail

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,10 +9,13 @@ name: release-please
 on:
   push:
     branches: ["main"]
+  # One-time incident recovery for #29326 / run 32830788357. Remove this
+  # dispatch and the recovery branch after the exact release has terminal
+  # production evidence; cleanup tracking: https://github.com/vm0-ai/vm0/issues/29326
   workflow_dispatch:
     inputs:
       recovery_release_sha:
-        description: "Existing release commit to deploy without creating releases"
+        description: "Incident release SHA (only 2db202a... until #29326 is closed)"
         required: true
         type: string
 
@@ -51,8 +54,9 @@ jobs:
 
           release=false
           if [ -n "$RECOVERY_RELEASE_SHA" ]; then
-            if [[ ! "$RECOVERY_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "::error::Recovery release SHA must be a full lowercase SHA-1: $RECOVERY_RELEASE_SHA"
+            incident_recovery_sha=2db202a9412368457b40f8bb5374d7302982ef52
+            if [ "$RECOVERY_RELEASE_SHA" != "$incident_recovery_sha" ]; then
+              echo "::error::Recovery dispatch only supports incident release SHA $incident_recovery_sha"
               exit 1
             fi
             release=true
@@ -126,6 +130,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # One-time recovery for the null-output incident; remove with the
+          # workflow_dispatch input after #29326's exact release is verified.
+          incident_recovery_sha=2db202a9412368457b40f8bb5374d7302982ef52
+          if [ "$RECOVERY_RELEASE_SHA" != "$incident_recovery_sha" ]; then
+            echo "::error::Recovery dispatch only supports incident release SHA $incident_recovery_sha"
+            exit 1
+          fi
 
           main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
           gh api "repos/$REPO/commits/$RECOVERY_RELEASE_SHA" --jq .sha >/dev/null


### PR DESCRIPTION
## Summary

- ignore JSON `null` release-please SHA outputs before validating the release target
- add a one-time `workflow_dispatch` recovery mode restricted to incident SHA `2db202a9412368457b40f8bb5374d7302982ef52`
- validate target ancestry and required API/DB/App/Runner tag targets before entering the normal production DAG
- skip release creation and release-PR refresh in recovery mode, so reruns cannot duplicate releases
- add CI-wired regression coverage for null/empty/valid SHA resolution and recovery success/fail-closed cases

## Recovery context

Post-merge run [32830788357](https://github.com/vm0-ai/vm0/actions/runs/32830788357) created the releases for `2db202a9412368457b40f8bb5374d7302982ef52` and then failed in `Resolve release target` because `jq test()` received `null`. All production jobs were skipped.

The recovery dispatch accepts only that exact incident SHA and must be removed after the exact release has terminal production evidence. Cleanup is tracked by [#29326](https://github.com/vm0-ai/vm0/issues/29326).

## Fallbacks

- `.github/workflows/release-please.yml: recovery_release` — explicitly reuses already-published API/DB/App/Runner release outputs after the incident workflow failure, instead of creating releases again. Surface: production release recovery; window: only incident SHA `2db202a9412368457b40f8bb5374d7302982ef52` until the exact release reaches terminal production evidence; removal condition: remove the dispatch input and recovery branch under [#29326](https://github.com/vm0-ai/vm0/issues/29326) after migration, API/App/Runner promotion, and rollback/environment verification complete; declared in PR summary: Yes; verdict: Justified and bounded.

## Validation

- `git diff --check`
- Ruby YAML parse
- `resolve-production-rollback-target-test.sh`
- `release-recovery-test.sh` (success plus wrong SHA, ancestry, tag-target, and missing-release failures)