### PR TITLE
refactor(api): drop the zero prefix from remaining service and contract identifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -30,7 +30,7 @@ import {
   type PersistedAttachment,
   type UserMessageDocument,
   type UserMessageInputDocument,
-  type ZeroIndicators,
+  type Indicators,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { ImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import type { VideoModelId } from "@okouai/api-contracts/contracts/video-models";
@@ -560,7 +560,7 @@ export function createChatFilesBddApi(context: TestContext) {
       );
     },
 
-    async listIndicators(actor: ApiTestUser): Promise<ZeroIndicators> {
+    async listIndicators(actor: ApiTestUser): Promise<Indicators> {
       const response = await accept(
         threadsClient().indicators({
           headers: authenticate(context, actor),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -484,10 +484,10 @@ function withFinalRunAppendSystemPrompt(args: {
   readonly imageRecognitionAvailable: boolean;
   readonly mcpConnectorSlugs: readonly string[];
   readonly selectedImageModel: ImageModel | null;
-  readonly zeroCliAvailable: boolean;
+  readonly cliAvailable: boolean;
 }): CreateRunBody {
   const appendedParts: string[] = [];
-  if (args.zeroCliAvailable) {
+  if (args.cliAvailable) {
     const mcpConnectorPrompt = buildMcpConnectorPrompt(args.mcpConnectorSlugs);
     if (mcpConnectorPrompt) {
       appendedParts.push(mcpConnectorPrompt);
@@ -9752,7 +9752,7 @@ function finalizePreparedRunContext(
       mcpConnectorSlugs:
         prepared.context.customConnectorContext.mcpConnectorSlugs,
       selectedImageModel: prepared.context.selectedImageModel,
-      zeroCliAvailable: prepared.args.includeOkouTokenSecret === true,
+      cliAvailable: prepared.args.includeOkouTokenSecret === true,
     }),
   };
 }

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -110,7 +110,7 @@ const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {
     "Be encouraging and empathetic. Show that you're in the user's corner and proactively offer help.",
 };
 
-interface ZeroAgentRunRecord {
+interface AgentRunRecord {
   readonly id: string;
   readonly name: string;
   readonly orgId: string;
@@ -233,7 +233,7 @@ function forbidden(message: string) {
 }
 
 function buildAgentIdentityPrompt(
-  agent: ZeroAgentRunRecord,
+  agent: AgentRunRecord,
   publicBrand: PublicBrand | undefined,
 ): string | null {
   const parts: string[] = [];
@@ -472,7 +472,7 @@ function buildCurrentUserPrompt(userInfo: UserInfo): string {
 }
 
 function buildAppendSystemPrompt(args: {
-  readonly agent: ZeroAgentRunRecord;
+  readonly agent: AgentRunRecord;
   readonly publicBrand: PublicBrand | undefined;
   readonly userInfo: UserInfo;
   readonly triggerSource: TriggerSource;
@@ -525,7 +525,7 @@ async function inferAgentIdFromSession(
 async function loadZeroAgent(
   db: Db,
   agentId: string,
-): Promise<ZeroAgentRunRecord | null> {
+): Promise<AgentRunRecord | null> {
   const [agent] = await db
     .select({
       id: agents.id,
@@ -595,9 +595,9 @@ function agentRunTimingDimensions(args: {
   };
 }
 
-type ZeroBootstrapCountBucket = "0" | "1" | "2_4" | "5_8" | "9_16" | "17_plus";
+type BootstrapCountBucket = "0" | "1" | "2_4" | "5_8" | "9_16" | "17_plus";
 
-function zeroBootstrapCountBucket(count: number): ZeroBootstrapCountBucket {
+function bootstrapCountBucket(count: number): BootstrapCountBucket {
   if (count <= 0) {
     return "0";
   }
@@ -616,31 +616,32 @@ function zeroBootstrapCountBucket(count: number): ZeroBootstrapCountBucket {
   return "17_plus";
 }
 
-function zeroBootstrapLoadTimingDimensions(
+function bootstrapLoadTimingDimensions(
   rows: RunBootstrapSnapshotRows | undefined,
 ): ApiDispatchTimingDimensions | undefined {
   if (!rows) {
     return undefined;
   }
   return {
-    agent_run_bootstrap_total_row_count_bucket: zeroBootstrapCountBucket(
+    agent_run_bootstrap_total_row_count_bucket: bootstrapCountBucket(
       rows.metadataRows.length + rows.workflowRows.length,
     ),
-    agent_run_bootstrap_workflow_candidate_count_bucket:
-      zeroBootstrapCountBucket(rows.workflowRows.length),
+    agent_run_bootstrap_workflow_candidate_count_bucket: bootstrapCountBucket(
+      rows.workflowRows.length,
+    ),
   };
 }
 
-function zeroBootstrapMaterializeTimingDimensions(
+function bootstrapMaterializeTimingDimensions(
   rows: RunBootstrapSnapshotRows,
   context: RunBootstrapContext | undefined,
 ): ApiDispatchTimingDimensions {
   return {
-    ...zeroBootstrapLoadTimingDimensions(rows),
+    ...bootstrapLoadTimingDimensions(rows),
     ...(context
       ? {
           agent_run_bootstrap_workflow_winner_count_bucket:
-            zeroBootstrapCountBucket(context.workflows.length),
+            bootstrapCountBucket(context.workflows.length),
         }
       : {}),
   };
@@ -660,7 +661,7 @@ function agentRunOrigin(args: {
 
 function createRunBody(args: {
   readonly body: AgentRunCreateBody;
-  readonly agent: ZeroAgentRunRecord;
+  readonly agent: AgentRunRecord;
   readonly userInfo: UserInfo;
   readonly permissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerSource: TriggerSource | undefined;
@@ -721,7 +722,7 @@ function measureZeroPreCreate<T>(
   );
 }
 
-function zeroServiceEntryTiming(args: {
+function serviceEntryTiming(args: {
   readonly apiStartTime: number;
   readonly timing?: ApiDispatchTimingCollector;
 }): ApiDispatchTimingCollector {
@@ -778,7 +779,7 @@ async function loadAgentRunPostAuthorizationContext(
       return loadedRows;
     },
     () => {
-      return zeroBootstrapLoadTimingDimensions(measuredSnapshotRows);
+      return bootstrapLoadTimingDimensions(measuredSnapshotRows);
     },
   );
   signal.throwIfAborted();
@@ -796,7 +797,7 @@ async function loadAgentRunPostAuthorizationContext(
       return context;
     },
     () => {
-      return zeroBootstrapMaterializeTimingDimensions(
+      return bootstrapMaterializeTimingDimensions(
         snapshotRows,
         measuredBootstrapContext,
       );
@@ -845,7 +846,7 @@ async function loadAgentRunPostAuthorizationContext(
 
 function buildZeroCreateAgentRunArgs(args: {
   readonly command: AnyCreateAgentRunCommandArgs;
-  readonly agent: ZeroAgentRunRecord;
+  readonly agent: AgentRunRecord;
   readonly userInfo: UserInfo;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly workflows: readonly RunWorkflowRef[];
@@ -951,7 +952,7 @@ function buildZeroCreateAgentRunArgs(args: {
 }
 
 interface AgentRunAfterPreCreate {
-  readonly agent: ZeroAgentRunRecord;
+  readonly agent: AgentRunRecord;
   readonly userInfo: UserInfo;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
@@ -1101,7 +1102,7 @@ const createAgentRunAfterZeroPreCreate$ = command(
 const createAgentRunInternal$ = command(
   async ({ set }, args: AnyCreateAgentRunCommandArgs, signal: AbortSignal) => {
     assertThreadBoundAgentRunHasQueueAssociation(args);
-    const timing = zeroServiceEntryTiming({
+    const timing = serviceEntryTiming({
       apiStartTime: args.apiStartTime,
       timing: args.timing,
     });

--- a/turbo/apps/api/src/signals/services/browser.service.ts
+++ b/turbo/apps/api/src/signals/services/browser.service.ts
@@ -104,7 +104,7 @@ const TERMINAL_RUN_STATUSES = [
   "timeout",
   "cancelled",
 ] as const;
-const L = logger("ZeroBrowser");
+const L = logger("Browser");
 const browserTabSnapshotSchema = z.array(z.string().max(8192)).max(50);
 
 const BROWSER_SESSION_SELECTION = {

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -6,10 +6,10 @@ import {
   type CodexServiceTier,
   type PersistedAttachment,
   type UserMessageInputDocument,
-  type ZeroIndicator,
-  type ZeroIndicators,
+  type Indicator,
+  type Indicators,
   persistedAttachmentSchema,
-  zeroIndicatorSchema,
+  indicatorSchema,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { ImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import {
@@ -237,7 +237,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
 const INDICATOR_UNREAD_LIMIT = 50;
 const INDICATOR_UNREAD_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
-const indicatorDecoder = zodEnumDriverValueDecoder(zeroIndicatorSchema);
+const indicatorDecoder = zodEnumDriverValueDecoder(indicatorSchema);
 
 function noActiveRunsForCurrentThreadCondition(db: Pick<Db, "select">): SQL {
   return notExists(
@@ -360,8 +360,8 @@ export function chatThreadUnreads(args: {
 export function chatIndicators(args: {
   readonly userId: string;
   readonly orgId: string;
-}): Computed<Promise<ZeroIndicators>> {
-  return computed(async (get): Promise<ZeroIndicators> => {
+}): Computed<Promise<Indicators>> {
+  return computed(async (get): Promise<Indicators> => {
     const db = get(db$);
     const unreadCutoff = new Date(now() - INDICATOR_UNREAD_LOOKBACK_MS);
     const activeThreads = db.$with("active_threads").as(
@@ -437,8 +437,8 @@ export function chatIndicators(args: {
       .select()
       .from(indicatorRows);
 
-    const agentIndicators: Record<string, ZeroIndicator> = {};
-    const threads: Record<string, ZeroIndicator> = {};
+    const agentIndicators: Record<string, Indicator> = {};
+    const threads: Record<string, Indicator> = {};
     for (const row of rows) {
       threads[row.threadId] = row.indicator;
       if (

--- a/turbo/apps/api/src/signals/services/feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-connect.service.ts
@@ -38,7 +38,7 @@ import {
 } from "./feishu-config";
 import { buildFeishuOAuthConnectUrl } from "./feishu-oauth-state";
 
-const L = logger("ZeroFeishuConnect");
+const L = logger("FeishuConnect");
 
 async function loadFeishuInstallations(db: ReadonlyDb, orgId: string) {
   return await db

--- a/turbo/apps/api/src/signals/services/feishu-welcome.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-welcome.service.ts
@@ -11,7 +11,7 @@ import { nowDate } from "../../lib/time";
 import { logger } from "../../lib/log";
 import { settle } from "../utils";
 
-const L = logger("ZeroFeishuWelcome");
+const L = logger("FeishuWelcome");
 const WELCOME_RETRY_LIMIT = 20;
 
 export async function notifyFeishuConnect(

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -227,11 +227,11 @@ const chatThreadUnreadsSchema = z.object({
   ),
 });
 
-export const zeroIndicatorSchema = z.enum(["active", "unread"]);
+export const indicatorSchema = z.enum(["active", "unread"]);
 
-const zeroIndicatorsSchema = z.object({
-  agents: z.record(z.string().uuid(), zeroIndicatorSchema),
-  threads: z.record(z.string().uuid(), zeroIndicatorSchema),
+const indicatorsSchema = z.object({
+  agents: z.record(z.string().uuid(), indicatorSchema),
+  threads: z.record(z.string().uuid(), indicatorSchema),
 });
 
 const chatThreadEventIdSchema = z.string().uuid();
@@ -1086,7 +1086,7 @@ export const chatThreadsContract = c.router({
     path: "/api/indicators",
     headers: authHeadersSchema,
     responses: {
-      200: zeroIndicatorsSchema,
+      200: indicatorsSchema,
       401: apiErrorSchema,
     },
     summary:
@@ -1958,8 +1958,8 @@ export type ChatThreadMetadata = z.infer<typeof chatThreadMetadataSchema>;
 export type ChatThreadDraft = z.infer<typeof chatThreadDraftSchema>;
 export type ChatEvent = z.infer<typeof chatEventSchema>;
 export type ChatEventSendBody = z.infer<typeof chatEventsContract.send.body>;
-export type ZeroIndicator = z.infer<typeof zeroIndicatorSchema>;
-export type ZeroIndicators = z.infer<typeof zeroIndicatorsSchema>;
+export type Indicator = z.infer<typeof indicatorSchema>;
+export type Indicators = z.infer<typeof indicatorsSchema>;
 
 export function chatEventResponse(event: ChatEvent): ChatEvent {
   return chatEventSchema.parse(event);

--- a/turbo/packages/api-contracts/src/contracts/run-routes.ts
+++ b/turbo/packages/api-contracts/src/contracts/run-routes.ts
@@ -45,11 +45,11 @@ export const runCreateBodySchema = unifiedRunRequestSchema
 
 const c = initContract();
 
-const zeroAgentEventPaginationQuerySchema = createLogPaginationQuerySchema({
+const agentEventPaginationQuerySchema = createLogPaginationQuerySchema({
   cursorKind: "sequence",
 });
 
-const zeroNetworkLogPaginationQuerySchema = createLogPaginationQuerySchema({
+const networkLogPaginationQuerySchema = createLogPaginationQuerySchema({
   cursorKind: "time",
   maxLimit: 500,
   defaultLimit: 500,
@@ -129,7 +129,7 @@ export const runAgentEventsContract = c.router({
     pathParams: z.object({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
-    query: zeroAgentEventPaginationQuerySchema,
+    query: agentEventPaginationQuerySchema,
     responses: {
       200: agentEventsResponseSchema,
       400: apiErrorSchema,
@@ -246,7 +246,7 @@ export const runNetworkLogsContract = c.router({
     pathParams: z.object({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
-    query: zeroNetworkLogPaginationQuerySchema,
+    query: networkLogPaginationQuerySchema,
     responses: {
       200: networkLogsResponseSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
Closes #29315. Part of #26873.

Renames the `Zero*` / `zero*` TypeScript identifiers left in `apps/api` service code and the two `api-contracts` contract modules. Every rename is a compiler-enforced symbol; no string literal, route path, database identifier, or wire value changed.

## Renamed

**`apps/api/src/signals/services/agent-runs-create.service.ts`**

- `ZeroAgentRunRecord` → `AgentRunRecord`
- `ZeroBootstrapCountBucket` → `BootstrapCountBucket`, `zeroBootstrapCountBucket` → `bootstrapCountBucket`
- `zeroBootstrapLoadTimingDimensions` → `bootstrapLoadTimingDimensions`
- `zeroBootstrapMaterializeTimingDimensions` → `bootstrapMaterializeTimingDimensions`
- `zeroServiceEntryTiming` → `serviceEntryTiming`

**`apps/api/src/signals/services/agent-run-create.service.ts`**

- `zeroCliAvailable` → `cliAvailable`

**`packages/api-contracts/src/contracts/chat-threads.ts`** (consumed by `apps/api/src/signals/services/chat-thread.service.ts`)

- `zeroIndicatorSchema` → `indicatorSchema`, `zeroIndicatorsSchema` → `indicatorsSchema`
- `ZeroIndicator` → `Indicator`, `ZeroIndicators` → `Indicators`

**`packages/api-contracts/src/contracts/run-routes.ts`**

- `zeroAgentEventPaginationQuerySchema` → `agentEventPaginationQuerySchema`
- `zeroNetworkLogPaginationQuerySchema` → `networkLogPaginationQuerySchema`

Prettier reflowed three call sites in `agent-runs-create.service.ts` because the shorter names changed line widths. That is the only non-rename hunk in the diff.

## Heads-up for whoever maintains Axiom saved queries

Three logger tags changed:

| File | Before | After |
| --- | --- | --- |
| `apps/api/src/signals/services/browser.service.ts:107` | `logger("ZeroBrowser")` | `logger("Browser")` |
| `apps/api/src/signals/services/feishu-connect.service.ts:41` | `logger("ZeroFeishuConnect")` | `logger("FeishuConnect")` |
| `apps/api/src/signals/services/feishu-welcome.service.ts:14` | `logger("ZeroFeishuWelcome")` | `logger("FeishuWelcome")` |

These strings are emitted into production logs. **Any saved Axiom query that filters on the old tag stops matching from this deploy onward.** Historical rows keep their old tag and remain searchable, so nothing already ingested is lost — but a query pinned to `ZeroBrowser` / `ZeroFeishuConnect` / `ZeroFeishuWelcome` will silently go quiet on new traffic. Update those filters to the new tags, or make them match both if they need to span the deploy boundary.

## Deliberately not renamed

**`TEAMS_CARD_ACTION_KEY = "zeroTeamsAction"`** (`apps/api/src/signals/services/teams-dispatch.service.ts:89`) — this value is embedded in Microsoft Teams adaptive cards that have already been delivered to users. Renaming it breaks the callback match when someone clicks an action on any card sent before the deploy. It retires with a Teams card-format migration, not with a rename.

**Database identifiers** — `zero_workflows`, `zero_workflow_automations`, `zero_agent_drafts` and their constraint names are tracked under a separate EPIC and need migrations. `packages/db/src/schema` is untouched.

## Scope note for the reviewer: the issue's "Verify" end state does not hold

The issue's Verify section predicts that after this change "the only `Zero`/`zero` identifiers left in non-test `apps/api` and `packages` source should be `zeroTeamsAction` and the database identifiers named above." That is not true after implementing the issue's explicit Rename list — the list is incomplete. I implemented the list as written rather than widening scope on my own.

A tokenizer-based scan of non-test `apps/api/src` and `packages/*/src` (comments and string literals stripped, so these are real identifiers) finds the following still present on this branch:

Brand-prefix leftovers of exactly the same kind as this slice — private module-local symbols, compiler-enforced, no effect outside the repo. These look like they belong in this slice but were not listed:

- `apps/api/src/signals/services/agent-runs-create.service.ts` — `loadZeroAgent` (:525), `measureZeroPreCreate` (:709), `buildZeroCreateAgentRunArgs` (:846), `createAgentRunAfterZeroPreCreate$` (:1026). All four are in a file this PR already edits.
- `apps/api/src/signals/services/browser.service.ts` — `reconcileZeroBrowsersWithScope$` (:3555), a private command wrapped by the exported `reconcileBrowsers$` / `reconcileBrowserFixtures$`. Same file as the `ZeroBrowser` logger rename above.
- `apps/api/src/signals/routes/teams-bot.ts` — `handleZeroTeamsBot$` (:337), a private route handler. Unrelated to the `zeroTeamsAction` card key, which this PR leaves alone.

Deliberate under the issue's own criterion — each names something that still exists outside the repo, so renaming would be wrong, not just out of scope:

- `apps/api/src/signals/auth/tokens.ts` — `RetiredZeroScopePayload` (:105) names the retired `"zero"` scope literal that already-issued tokens still carry.
- `apps/api/src/signals/services/agentphone.service.ts` — `stripZeroMention` (:189); `apps/api/src/signals/routes/integrations-agentphone.ts` — `isZeroMentionText` (:645), `mentionMatchesZero` (:649). These match the live `@zero` mention token in inbound messages.
- `apps/api/src/signals/services/agent-run-create.service.ts` — `withoutLegacyZeroEntries` (:445 and five call sites) strips legacy `ZERO_*` secret entries; live migration control plane.
- `apps/api/src/signals/routes/desktop-updates.ts` and `packages/api-contracts/src/contracts/desktop-updates.ts` — the `desktopZeroMigration*` / `DesktopZeroMigration*` family; live migration control plane for the Zero desktop rollout.
- `packages/connectors/src/firewall-types.ts` — `zeroCount` (:1575), the numeric zero.
- `packages/eslint-rules/src/ccstate/` — `noNonZeroApi`, `containsNonZeroApiPath`, `nonZeroApi`; namespace-boundary assertions.

So the accurate end state for the non-test source is: this slice's list is done, three route/service brand leftovers remain unlisted, and the rest are deliberate. Happy to fold the three unlisted ones into this PR or a follow-up — say which you prefer.

## Verification

- `pnpm -F api run check-types` — passes (boundaries, gateways, core, bootstrap, tests, bootstrap-wiring)
- `pnpm -F @okouai/api-contracts run check-types` — passes (contracts, python-bindings, rust-bindings, runtime-api-schema)
- `pnpm -F api run lint` and `pnpm -F @okouai/api-contracts run lint` — no errors
- `pnpm knip` — byte-identical output to `main`
- `prettier --check` — clean on all nine touched files
- Repo-wide grep for every old name (including `crates`, `e2e`, `docs`, python/rust bindings) returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
