### PR TITLE
perf(runner): aggregate routine gc logs

### DIFF
--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
@@ -29,11 +29,13 @@ pub(super) async fn gc_debootstrap(
     let _lock = match probe_lock(&lock_path) {
         LockProbe::Free(lock) => lock,
         LockProbe::Held => {
-            info!("debootstrap cache: in use, skipping");
+            if dry_run {
+                info!("debootstrap cache: in use, skipping");
+            }
             return Ok(GcReport::default());
         }
         LockProbe::Error(e) => {
-            info!("debootstrap cache: lock probe failed ({e}), skipping");
+            warn!("debootstrap cache: lock probe failed ({e}), skipping");
             return Ok(GcReport::default());
         }
     };
@@ -69,11 +71,13 @@ pub(super) async fn gc_debootstrap(
     files.retain(|file| {
         let age = now.duration_since(file.mtime).unwrap_or_default();
         if age < GC_MIN_AGE {
-            info!(
-                "debootstrap cache: {} too recent ({}s old), skipping",
-                file.path.display(),
-                age.as_secs()
-            );
+            if dry_run {
+                info!(
+                    "debootstrap cache: {} too recent ({}s old), skipping",
+                    file.path.display(),
+                    age.as_secs()
+                );
+            }
             false
         } else {
             true
@@ -100,14 +104,8 @@ pub(super) async fn gc_debootstrap(
                 human_bytes(file.size)
             );
         } else if let Err(e) = tokio::fs::remove_file(&file.path).await {
-            tracing::warn!("remove {}: {e}", file.path.display());
+            warn!("remove {}: {e}", file.path.display());
             continue;
-        } else {
-            info!(
-                "debootstrap cache: removed {} ({})",
-                file.path.display(),
-                human_bytes(file.size)
-            );
         }
         report += GcReport::cleanup(1, file.size);
     }

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -69,10 +69,12 @@ async fn try_delete_orphan_rootfs(
         .duration_since(rootfs_mtime)
         .unwrap_or_default();
     if age < GC_MIN_AGE {
-        info!(
-            "images/{rootfs_hash}: orphaned but too recent ({}s), keeping",
-            age.as_secs()
-        );
+        if dry_run {
+            info!(
+                "images/{rootfs_hash}: orphaned but too recent ({}s), keeping",
+                age.as_secs()
+            );
+        }
         return None;
     }
     if dry_run {
@@ -83,11 +85,6 @@ async fn try_delete_orphan_rootfs(
     } else if let Err(e) = tokio::fs::remove_dir_all(rootfs_path).await {
         warn!("failed to remove orphaned rootfs images/{rootfs_hash}: {e}");
         return None;
-    } else {
-        info!(
-            "deleted orphaned rootfs images/{rootfs_hash} ({})",
-            human_bytes(rootfs_size)
-        );
     }
     Some(rootfs_size)
 }
@@ -108,11 +105,13 @@ async fn gc_template_warm_dir(
     let _lock = match probe_lock(&lock_path) {
         LockProbe::Free(lock) => lock,
         LockProbe::Held => {
-            info!("images/{warm_name}: template warm dir in use, skipping");
+            if dry_run {
+                info!("images/{warm_name}: template warm dir in use, skipping");
+            }
             return None;
         }
         LockProbe::Error(e) => {
-            info!("images/{warm_name}: template lock probe failed ({e}), skipping");
+            warn!("images/{warm_name}: template lock probe failed ({e}), skipping");
             return None;
         }
     };
@@ -129,10 +128,12 @@ async fn gc_template_warm_dir(
     let (size, mtime) = dir_stats(warm_path).await;
     let age = SystemTime::now().duration_since(mtime).unwrap_or_default();
     if age < GC_MIN_AGE {
-        info!(
-            "images/{warm_name}: template warm dir too recent ({}s), keeping",
-            age.as_secs()
-        );
+        if dry_run {
+            info!(
+                "images/{warm_name}: template warm dir too recent ({}s), keeping",
+                age.as_secs()
+            );
+        }
         return None;
     }
     if dry_run {
@@ -143,11 +144,6 @@ async fn gc_template_warm_dir(
     } else if let Err(e) = tokio::fs::remove_dir_all(warm_path).await {
         warn!("failed to remove template warm dir images/{warm_name}: {e}");
         return None;
-    } else {
-        info!(
-            "deleted template warm dir images/{warm_name} ({})",
-            human_bytes(size)
-        );
     }
     Some(size)
 }
@@ -167,11 +163,13 @@ async fn gc_rootfs_action(
     let _rootfs_lock = match probe_lock(&rootfs_lock_path) {
         LockProbe::Free(lock) => lock,
         LockProbe::Held => {
-            info!("images/{}: rootfs in use, skipping", state.hash);
+            if dry_run {
+                info!("images/{}: rootfs in use, skipping", state.hash);
+            }
             return GcReport::default();
         }
         LockProbe::Error(e) => {
-            info!("images/{}: lock probe failed ({e}), skipping", state.hash);
+            warn!("images/{}: lock probe failed ({e}), skipping", state.hash);
             return GcReport::default();
         }
     };
@@ -180,7 +178,7 @@ async fn gc_rootfs_action(
         Ok(GcDirStatus::RealDir(_)) => {}
         Ok(GcDirStatus::Missing) => return GcReport::default(),
         Ok(GcDirStatus::NotDirectory) => {
-            info!("images/{}: not a real directory, skipping", state.hash);
+            warn!("images/{}: not a real directory, skipping", state.hash);
             return GcReport::default();
         }
         Err(e) => {
@@ -200,7 +198,7 @@ async fn gc_rootfs_action(
                 });
         }
         Ok(GcDirStatus::NotDirectory) => {
-            info!(
+            warn!(
                 "images/{}/snapshots: not a real directory, skipping",
                 state.hash
             );
@@ -264,15 +262,17 @@ async fn gc_rootfs_action(
             LockProbe::Free(lock) => lock,
             LockProbe::Held => {
                 any_snapshot_survives = true;
-                info!(
-                    "images/{}/snapshots/{}: in use, skipping",
-                    state.hash, deletion.hash
-                );
+                if dry_run {
+                    info!(
+                        "images/{}/snapshots/{}: in use, skipping",
+                        state.hash, deletion.hash
+                    );
+                }
                 continue;
             }
             LockProbe::Error(e) => {
                 any_snapshot_survives = true;
-                info!(
+                warn!(
                     "images/{}/snapshots/{}: lock probe failed ({e}), skipping",
                     state.hash, deletion.hash
                 );
@@ -285,7 +285,7 @@ async fn gc_rootfs_action(
             Ok(GcDirStatus::Missing) => continue,
             Ok(GcDirStatus::NotDirectory) => {
                 any_snapshot_survives = true;
-                info!(
+                warn!(
                     "images/{}/snapshots/{}: not a real directory, skipping",
                     state.hash, deletion.hash
                 );
@@ -305,12 +305,14 @@ async fn gc_rootfs_action(
         let age = SystemTime::now().duration_since(mtime).unwrap_or_default();
         if age < GC_MIN_AGE {
             any_snapshot_survives = true;
-            info!(
-                "images/{}/snapshots/{}: too recent ({}s), keeping",
-                state.hash,
-                deletion.hash,
-                age.as_secs()
-            );
+            if dry_run {
+                info!(
+                    "images/{}/snapshots/{}: too recent ({}s), keeping",
+                    state.hash,
+                    deletion.hash,
+                    age.as_secs()
+                );
+            }
             continue;
         }
 
@@ -324,14 +326,7 @@ async fn gc_rootfs_action(
             dry_run_snapshot_bytes = dry_run_snapshot_bytes.saturating_add(size);
         } else {
             match tokio::fs::remove_dir_all(&deletion.path).await {
-                Ok(()) => {
-                    info!(
-                        "deleted images/{}/snapshots/{} ({})",
-                        state.hash,
-                        deletion.hash,
-                        human_bytes(size)
-                    );
-                }
+                Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(e) => {
                     any_snapshot_survives = true;
@@ -472,11 +467,13 @@ async fn gc_nested_images_with_protected_refs_and_readers(
         let rootfs_lock = match probe_lock(&rootfs_lock_path) {
             LockProbe::Free(lock) => lock,
             LockProbe::Held => {
-                info!("images/{rootfs_hash}: rootfs in use, skipping");
+                if dry_run {
+                    info!("images/{rootfs_hash}: rootfs in use, skipping");
+                }
                 continue;
             }
             LockProbe::Error(e) => {
-                info!("images/{rootfs_hash}: lock probe failed ({e}), skipping");
+                warn!("images/{rootfs_hash}: lock probe failed ({e}), skipping");
                 continue;
             }
         };
@@ -494,7 +491,7 @@ async fn gc_nested_images_with_protected_refs_and_readers(
                 continue;
             }
             Ok(GcDirStatus::NotDirectory) => {
-                info!("images/{rootfs_hash}/snapshots: not a real directory, skipping");
+                warn!("images/{rootfs_hash}/snapshots: not a real directory, skipping");
                 continue;
             }
             Err(e) => {
@@ -544,9 +541,11 @@ async fn gc_nested_images_with_protected_refs_and_readers(
             }
 
             if is_protected_image_ref(protected_image_refs, &rootfs_hash, &snap_hash) {
-                info!(
-                    "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner or service config, keeping"
-                );
+                if dry_run {
+                    info!(
+                        "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner or service config, keeping"
+                    );
+                }
                 continue;
             }
 
@@ -559,10 +558,12 @@ async fn gc_nested_images_with_protected_refs_and_readers(
                     if age < GC_MIN_AGE {
                         // Too recent to be safely deleted (races with
                         // `runner build` releasing its lock).
-                        info!(
-                            "images/{rootfs_hash}/snapshots/{snap_hash}: too recent ({}s), keeping",
-                            age.as_secs()
-                        );
+                        if dry_run {
+                            info!(
+                                "images/{rootfs_hash}/snapshots/{snap_hash}: too recent ({}s), keeping",
+                                age.as_secs()
+                            );
+                        }
                     } else {
                         candidates.push(GcCandidate {
                             hash: snap_hash,
@@ -573,10 +574,12 @@ async fn gc_nested_images_with_protected_refs_and_readers(
                     }
                 }
                 LockProbe::Held => {
-                    info!("images/{rootfs_hash}/snapshots/{snap_hash}: in use, skipping");
+                    if dry_run {
+                        info!("images/{rootfs_hash}/snapshots/{snap_hash}: in use, skipping");
+                    }
                 }
                 LockProbe::Error(e) => {
-                    info!(
+                    warn!(
                         "images/{rootfs_hash}/snapshots/{snap_hash}: lock probe failed ({e}), skipping"
                     );
                 }
@@ -605,12 +608,14 @@ async fn gc_nested_images_with_protected_refs_and_readers(
             ))
         })?;
         let disposition = if rank < keep_count {
-            info!(
-                "images/{}/snapshots/{}: keeping (global top-{keep_count}, {})",
-                state.hash,
-                candidate.hash,
-                human_bytes(candidate.size)
-            );
+            if dry_run {
+                info!(
+                    "images/{}/snapshots/{}: keeping (global top-{keep_count}, {})",
+                    state.hash,
+                    candidate.hash,
+                    human_bytes(candidate.size)
+                );
+            }
             SnapshotDisposition::Keep
         } else {
             SnapshotDisposition::Delete

--- a/crates/runner/src/cmd/gc/job_logs.rs
+++ b/crates/runner/src/cmd/gc/job_logs.rs
@@ -58,9 +58,7 @@ pub(super) async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult
             );
         } else {
             match tokio::fs::remove_file(entry.path()).await {
-                Ok(()) => {
-                    info!("deleted job log {name} ({})", human_bytes(size));
-                }
+                Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
                     warn!("cannot remove {}: {e}", entry.path().display());

--- a/crates/runner/src/cmd/gc/lock_file.rs
+++ b/crates/runner/src/cmd/gc/lock_file.rs
@@ -59,12 +59,7 @@ pub(super) async fn remove_unused_lock_after_probe(
         return true;
     }
 
-    if remove_lock_file(lock_path).await {
-        info!("removed unused lock {name}");
-        true
-    } else {
-        false
-    }
+    remove_lock_file(lock_path).await
 }
 
 fn lock_guard_matches_path(lock_path: &Path, lock: &Flock<std::fs::File>) -> bool {

--- a/crates/runner/src/cmd/gc/mod.rs
+++ b/crates/runner/src/cmd/gc/mod.rs
@@ -28,7 +28,7 @@ use images::gc_nested_images_with_protected_refs;
 use job_logs::gc_job_logs;
 use nbd::gc_nbd_orphans;
 use orphaned_locks::gc_orphaned_locks;
-use report::{GcReport, log_gc_summary};
+use report::{GcReport, log_gc_phase_summary, log_gc_summary};
 use storage::gc_storage_cache;
 use version_service_locks::gc_orphaned_version_service_locks;
 use versions::{analyze_version_gc, gc_versions_with_analysis};
@@ -66,36 +66,75 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
         analyze_version_gc(&home, args.protect_version.as_deref(), args.keep_latest).await?;
     let protected_image_refs = protected_image_refs_for_gc(&home, &version_analysis).await;
 
-    let mut report = gc_nested_images_with_protected_refs(
+    let mut report = GcReport::default();
+    let images_report = gc_nested_images_with_protected_refs(
         &home,
         args.keep_latest,
         args.dry_run,
         &protected_image_refs,
     )
     .await?;
+    record_gc_phase(&mut report, "images", images_report, args.dry_run);
 
-    report += gc_nbd_orphans(args.dry_run).await?;
-    report += GcReport::from(gc_workspace_orphans(&home, args.dry_run).await?);
+    let nbd_report = gc_nbd_orphans(args.dry_run).await?;
+    record_gc_phase(&mut report, "nbd orphans", nbd_report, args.dry_run);
+
+    let workspace_report = GcReport::from(gc_workspace_orphans(&home, args.dry_run).await?);
+    record_gc_phase(
+        &mut report,
+        "workspace orphans",
+        workspace_report,
+        args.dry_run,
+    );
 
     // General lock GC preserves service locks needed by version cleanup.
-    report += gc_orphaned_locks(&home, args.dry_run).await?;
-    report += gc_job_logs(&home, args.dry_run).await?;
-    report += gc_versions_with_analysis(&home, args.dry_run, version_analysis).await?;
+    let lock_report = gc_orphaned_locks(&home, args.dry_run).await?;
+    record_gc_phase(&mut report, "orphaned locks", lock_report, args.dry_run);
+
+    let job_log_report = gc_job_logs(&home, args.dry_run).await?;
+    record_gc_phase(&mut report, "job logs", job_log_report, args.dry_run);
+
+    let version_report = gc_versions_with_analysis(&home, args.dry_run, version_analysis).await?;
+    record_gc_phase(&mut report, "versions", version_report, args.dry_run);
 
     // Version service locks become orphaned only after version cleanup.
-    report += gc_orphaned_version_service_locks(&home, args.dry_run).await?;
-    report += gc_debootstrap(&home, args.keep_latest, args.dry_run).await?;
-    report += gc_storage_cache(&home, args.dry_run).await?;
+    let version_lock_report = gc_orphaned_version_service_locks(&home, args.dry_run).await?;
+    record_gc_phase(
+        &mut report,
+        "version service locks",
+        version_lock_report,
+        args.dry_run,
+    );
+
+    let debootstrap_report = gc_debootstrap(&home, args.keep_latest, args.dry_run).await?;
+    record_gc_phase(
+        &mut report,
+        "debootstrap cache",
+        debootstrap_report,
+        args.dry_run,
+    );
+
+    let storage_report = gc_storage_cache(&home, args.dry_run).await?;
+    record_gc_phase(&mut report, "storage cache", storage_report, args.dry_run);
 
     log_gc_summary(&report, args.dry_run);
 
     Ok(())
 }
 
+fn record_gc_phase(total: &mut GcReport, domain: &str, phase: GcReport, dry_run: bool) {
+    log_gc_phase_summary(domain, &phase, dry_run);
+    *total += phase;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::{CommandFactory, Parser};
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
+
+    use crate::cmd::gc::test_support::test_home;
 
     #[derive(Parser)]
     struct GcCli {
@@ -145,5 +184,64 @@ mod tests {
                 .keep_latest,
             Some(0)
         );
+    }
+
+    async fn capture_orphaned_lock_phase(
+        home: &HomePaths,
+        dry_run: bool,
+    ) -> (GcReport, Vec<String>) {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        let phase = gc_orphaned_locks(home, dry_run).await.unwrap();
+        let mut total = GcReport::default();
+        record_gc_phase(&mut total, "orphaned locks", phase, dry_run);
+
+        drop(guard);
+        let messages = captured
+            .entries()
+            .into_iter()
+            .filter_map(|event| event.fields.get("message").cloned())
+            .collect();
+        (total, messages)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn gc_orphaned_lock_output_is_bounded_in_real_mode() {
+        const LOCK_COUNT: usize = 2_000;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+        for index in 0..LOCK_COUNT {
+            std::fs::write(locks_dir.join(format!("unused-{index}.lock")), "").unwrap();
+        }
+
+        let (dry_run_report, dry_run_messages) = capture_orphaned_lock_phase(&home, true).await;
+        assert_eq!(dry_run_report, GcReport::cleanup(LOCK_COUNT as u64, 0));
+        assert_eq!(dry_run_messages.len(), LOCK_COUNT + 1);
+        assert_eq!(
+            dry_run_messages
+                .iter()
+                .filter(|message| message.starts_with("[dry-run] would remove unused lock "))
+                .count(),
+            LOCK_COUNT
+        );
+        assert_eq!(
+            dry_run_messages.last().map(String::as_str),
+            Some("gc orphaned locks complete: would_clean=2000, would_free=0 B")
+        );
+        assert_eq!(std::fs::read_dir(&locks_dir).unwrap().count(), LOCK_COUNT);
+
+        let (real_report, real_messages) = capture_orphaned_lock_phase(&home, false).await;
+        assert_eq!(real_report, GcReport::cleanup(LOCK_COUNT as u64, 0));
+        assert_eq!(
+            real_messages,
+            ["gc orphaned locks complete: cleaned=2000, freed=0 B"]
+        );
+        assert_eq!(std::fs::read_dir(&locks_dir).unwrap().count(), 0);
     }
 }

--- a/crates/runner/src/cmd/gc/nbd.rs
+++ b/crates/runner/src/cmd/gc/nbd.rs
@@ -1,4 +1,4 @@
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::cmd::nbd::NbdOrphanDisconnect;
 use crate::error::{RunnerError, RunnerResult};
@@ -33,7 +33,6 @@ where
         return Ok(GcReport::default());
     }
 
-    let found = orphans.len() as u32;
     let mut cleaned: u32 = 0;
     for (device_index, pid) in orphans {
         if dry_run {
@@ -46,40 +45,27 @@ where
             // the allocator uses. Between the scan and now, the device could
             // have been freed and re-acquired by another runner.
             let disconnect = disconnect.clone();
-            let result = match tokio::task::spawn_blocking(move || disconnect(device_index, pid))
-                .await
-            {
-                Ok(result) => result,
-                Err(e) => {
-                    tracing::warn!("nbd disconnect task failed for /dev/nbd{device_index}: {e}");
-                    continue;
-                }
-            };
+            let result =
+                match tokio::task::spawn_blocking(move || disconnect(device_index, pid)).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        warn!("nbd disconnect task failed for /dev/nbd{device_index}: {e}");
+                        continue;
+                    }
+                };
 
             match result {
                 NbdOrphanDisconnect::Disconnected(_) => {
-                    info!(
-                        "disconnected orphan NBD device /dev/nbd{device_index} (owner PID {pid} dead)"
-                    );
                     cleaned += 1;
                 }
-                NbdOrphanDisconnect::Locked => {
-                    info!("nbd{device_index}: skipping disconnect, NBD device lock is held");
-                }
-                NbdOrphanDisconnect::Changed | NbdOrphanDisconnect::Live => {
-                    info!(
-                        "nbd{device_index}: skipping disconnect, device state changed since scan"
-                    );
-                }
+                NbdOrphanDisconnect::Locked
+                | NbdOrphanDisconnect::Changed
+                | NbdOrphanDisconnect::Live => {}
                 NbdOrphanDisconnect::Failed(e) => {
-                    info!("failed to disconnect orphan NBD device /dev/nbd{device_index}: {e}");
+                    warn!("failed to disconnect orphan NBD device /dev/nbd{device_index}: {e}");
                 }
             }
         }
-    }
-
-    if cleaned < found {
-        info!("nbd orphans: {found} found, {cleaned} cleaned");
     }
 
     Ok(GcReport::cleanup(u64::from(cleaned), 0))

--- a/crates/runner/src/cmd/gc/report.rs
+++ b/crates/runner/src/cmd/gc/report.rs
@@ -52,8 +52,19 @@ pub(super) fn log_gc_summary(report: &GcReport, dry_run: bool) {
     if report.is_empty() {
         info!("nothing to clean up");
     } else {
-        let verb = if dry_run { "would be freed" } else { "freed" };
-        info!("total: {} {verb}", human_bytes(report.freed_bytes));
+        if dry_run {
+            info!(
+                "total: would_clean={}, would_free={}",
+                report.activity_count,
+                human_bytes(report.freed_bytes)
+            );
+        } else {
+            info!(
+                "total: cleaned={}, freed={}",
+                report.activity_count,
+                human_bytes(report.freed_bytes)
+            );
+        }
         if !report.removed_versions.is_empty() {
             let list = report.removed_versions.join(", ");
             if dry_run {
@@ -78,6 +89,22 @@ pub(super) fn log_gc_summary(report: &GcReport, dry_run: bool) {
     }
 }
 
+pub(super) fn log_gc_phase_summary(domain: &str, report: &GcReport, dry_run: bool) {
+    if dry_run {
+        info!(
+            "gc {domain} complete: would_clean={}, would_free={}",
+            report.activity_count,
+            human_bytes(report.freed_bytes)
+        );
+    } else {
+        info!(
+            "gc {domain} complete: cleaned={}, freed={}",
+            report.activity_count,
+            human_bytes(report.freed_bytes)
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,6 +124,21 @@ mod tests {
             .filter_map(|event| event.fields.get("message").cloned())
             .collect()
     }
+
+    fn capture_gc_phase_summary(domain: &str, report: &GcReport, dry_run: bool) -> Vec<String> {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        log_gc_phase_summary(domain, report, dry_run);
+        drop(guard);
+        captured
+            .entries()
+            .into_iter()
+            .filter_map(|event| event.fields.get("message").cloned())
+            .collect()
+    }
+
     #[test]
     fn gc_report_composition_preserves_all_summary_fields() {
         let mut report = GcReport::cleanup(2, 512);
@@ -119,7 +161,7 @@ mod tests {
         );
         assert_eq!(
             capture_gc_summary(&GcReport::cleanup(0, 1024), false),
-            ["total: 1.0 KiB freed"]
+            ["total: cleaned=0, freed=1.0 KiB"]
         );
     }
 
@@ -127,10 +169,13 @@ mod tests {
     fn gc_summary_reports_zero_byte_activity_in_real_and_dry_run_modes() {
         let report = GcReport::cleanup(1, 0);
 
-        assert_eq!(capture_gc_summary(&report, false), ["total: 0 B freed"]);
+        assert_eq!(
+            capture_gc_summary(&report, false),
+            ["total: cleaned=1, freed=0 B"]
+        );
         assert_eq!(
             capture_gc_summary(&report, true),
-            ["total: 0 B would be freed"]
+            ["total: would_clean=1, would_free=0 B"]
         );
     }
 
@@ -142,7 +187,7 @@ mod tests {
         assert_eq!(
             capture_gc_summary(&report, false),
             [
-                "total: 0 B freed",
+                "total: cleaned=4, freed=0 B",
                 "versions removed: v1.0.0, v2.0.0",
                 "version service locks removed: 2",
             ]
@@ -150,10 +195,22 @@ mod tests {
         assert_eq!(
             capture_gc_summary(&report, true),
             [
-                "total: 0 B would be freed",
+                "total: would_clean=4, would_free=0 B",
                 "versions that would be removed: v1.0.0, v2.0.0",
                 "version service locks that would be removed: 2",
             ]
+        );
+    }
+
+    #[test]
+    fn gc_phase_summary_reports_completion_in_real_and_dry_run_modes() {
+        assert_eq!(
+            capture_gc_phase_summary("orphaned locks", &GcReport::default(), false),
+            ["gc orphaned locks complete: cleaned=0, freed=0 B"]
+        );
+        assert_eq!(
+            capture_gc_phase_summary("orphaned locks", &GcReport::cleanup(2, 1024), true),
+            ["gc orphaned locks complete: would_clean=2, would_free=1.0 KiB"]
         );
     }
 }

--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -291,10 +291,12 @@ async fn evict_storage_candidate(
     let lock = match probe_lock(&lock_path) {
         LockProbe::Free(lock) => lock,
         LockProbe::Held => {
-            info!(
-                "storages/{}/{}: in use, skipping",
-                candidate.name, candidate.version
-            );
+            if dry_run {
+                info!(
+                    "storages/{}/{}: in use, skipping",
+                    candidate.name, candidate.version
+                );
+            }
             return StorageEvictionResult {
                 freed: 0,
                 remaining_size: None,
@@ -303,7 +305,7 @@ async fn evict_storage_candidate(
             };
         }
         LockProbe::Error(e) => {
-            info!(
+            warn!(
                 "storages/{}/{}: lock probe failed ({e}), skipping",
                 candidate.name, candidate.version
             );
@@ -319,7 +321,7 @@ async fn evict_storage_candidate(
     let metadata = match gc_path_dir_status(&candidate.path).await {
         Ok(GcDirStatus::RealDir(metadata)) => metadata,
         Ok(GcDirStatus::NotDirectory) => {
-            info!(
+            warn!(
                 "storages/{}/{}: no longer a directory, skipping",
                 candidate.name, candidate.version
             );
@@ -362,12 +364,14 @@ async fn evict_storage_candidate(
         };
     let age = now.duration_since(mtime).unwrap_or_default();
     if age < GC_MIN_AGE {
-        info!(
-            "storages/{}/{}: too recent ({}s), keeping",
-            candidate.name,
-            candidate.version,
-            age.as_secs()
-        );
+        if dry_run {
+            info!(
+                "storages/{}/{}: too recent ({}s), keeping",
+                candidate.name,
+                candidate.version,
+                age.as_secs()
+            );
+        }
         return StorageEvictionResult {
             freed: 0,
             remaining_size: Some(size),
@@ -486,11 +490,13 @@ async fn gc_storage_staging_dir(
     let _lock = match probe_lock(&lock_path) {
         LockProbe::Free(l) => l,
         LockProbe::Held => {
-            info!("storages/{name_hash}/{version_hash}.tmp: in use, skipping");
+            if dry_run {
+                info!("storages/{name_hash}/{version_hash}.tmp: in use, skipping");
+            }
             return None;
         }
         LockProbe::Error(e) => {
-            info!("storages/{name_hash}/{version_hash}.tmp: lock probe failed ({e}), skipping");
+            warn!("storages/{name_hash}/{version_hash}.tmp: lock probe failed ({e}), skipping");
             return None;
         }
     };
@@ -507,10 +513,12 @@ async fn gc_storage_staging_dir(
     let (size, mtime) = dir_stats(path).await;
     let age = now.duration_since(mtime).unwrap_or_default();
     if age < GC_MIN_AGE {
-        info!(
-            "storages/{name_hash}/{version_hash}.tmp: too recent ({}s), keeping",
-            age.as_secs()
-        );
+        if dry_run {
+            info!(
+                "storages/{name_hash}/{version_hash}.tmp: too recent ({}s), keeping",
+                age.as_secs()
+            );
+        }
         return None;
     }
 
@@ -524,11 +532,6 @@ async fn gc_storage_staging_dir(
             "failed to remove stale storage staging storages/{name_hash}/{version_hash}.tmp: {e}"
         );
         return None;
-    } else {
-        info!(
-            "removed stale storage staging storages/{name_hash}/{version_hash}.tmp ({})",
-            human_bytes(size)
-        );
     }
 
     Some(size)

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -149,12 +149,12 @@ enum VersionRetentionReason {
 }
 
 impl VersionRetentionReason {
-    fn log_skip(&self, name: &str) {
+    fn log_skip(&self, name: &str, dry_run: bool) {
         match self {
-            Self::ProtectVersion => {
+            Self::ProtectVersion if dry_run => {
                 info!("version {name}: protected (--protect-version), skipping");
             }
-            Self::KeepLatest => {
+            Self::KeepLatest if dry_run => {
                 info!("version {name}: within --keep-latest, skipping");
             }
             Self::IncompleteBinaryScan => {
@@ -163,21 +163,26 @@ impl VersionRetentionReason {
             Self::UnexpectedArtifactType => {
                 warn!("version {name}: managed version path is not a directory, skipping");
             }
-            Self::Recent(age) => {
+            Self::Recent(age) if dry_run => {
                 info!("version {name}: too recent ({}s), skipping", age.as_secs());
             }
             Self::InvalidServiceSuffix(error) => {
                 warn!("version {name}: invalid service unit suffix ({error}), skipping");
             }
-            Self::ServiceLockHeld => {
+            Self::ServiceLockHeld if dry_run => {
                 info!("version {name}: service lock held, skipping");
             }
             Self::ServiceLockProbeError(error) => {
                 warn!("version {name}: cannot probe service lock ({error}), skipping");
             }
-            Self::Active => {
+            Self::Active if dry_run => {
                 info!("version {name}: active, skipping");
             }
+            Self::ProtectVersion
+            | Self::KeepLatest
+            | Self::Recent(_)
+            | Self::ServiceLockHeld
+            | Self::Active => {}
         }
     }
 }
@@ -609,7 +614,7 @@ async fn gc_versions_with_analysis_and_operations(
     for entry in &analysis.entries {
         let name = &entry.name;
         if let Some(reason) = &entry.retained {
-            reason.log_skip(name);
+            reason.log_skip(name, dry_run);
             continue;
         }
 
@@ -617,7 +622,9 @@ async fn gc_versions_with_analysis_and_operations(
         let version_config = home.runners_dir().join(name);
         let age = version_gc_age(home, name).await;
         if age < GC_MIN_AGE {
-            info!("version {name}: too recent ({}s), skipping", age.as_secs());
+            if dry_run {
+                info!("version {name}: too recent ({}s), skipping", age.as_secs());
+            }
             continue;
         }
 
@@ -658,10 +665,7 @@ async fn gc_versions_with_analysis_and_operations(
         } else {
             match lock::try_acquire_or_busy(service_lock_path.clone()).await {
                 Ok(lock::TryLock::Acquired(lock)) => Some(lock),
-                Ok(lock::TryLock::Busy) => {
-                    info!("version {name}: service lock held, skipping");
-                    continue;
-                }
+                Ok(lock::TryLock::Busy) => continue,
                 Err(e) => {
                     warn!("version {name}: cannot acquire service lock ({e}), skipping");
                     continue;
@@ -675,10 +679,12 @@ async fn gc_versions_with_analysis_and_operations(
 
         let age = version_gc_age(home, name).await;
         if age < GC_MIN_AGE {
-            info!(
-                "version {name}: became too recent before delete ({}s), skipping",
-                age.as_secs()
-            );
+            if dry_run {
+                info!(
+                    "version {name}: became too recent before delete ({}s), skipping",
+                    age.as_secs()
+                );
+            }
             continue;
         }
 
@@ -686,7 +692,9 @@ async fn gc_versions_with_analysis_and_operations(
         // race between the active probe and the remove path.
         match service::is_unit_active(&unit).await {
             Ok(true) => {
-                info!("version {name}: active, skipping");
+                if dry_run {
+                    info!("version {name}: active, skipping");
+                }
                 continue;
             }
             Ok(false) => {}
@@ -724,7 +732,6 @@ async fn gc_versions_with_analysis_and_operations(
                 continue;
             }
 
-            info!("removed version {name}");
             remove_unused_lock_after_probe(
                 &service_lock_path,
                 service_lock,

--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -384,14 +384,6 @@ async fn gc_workspace_orphans_with_candidates_and_remove(
         }
     }
 
-    if summary.workspaces_cleaned > 0 {
-        info!(
-            "workspace orphans: {} cleaned ({})",
-            summary.workspaces_cleaned,
-            human_bytes(summary.bytes_freed)
-        );
-    }
-
     Ok(summary)
 }
 
@@ -406,7 +398,7 @@ async fn gc_workspace_orphans_in_base_dir(
         Ok(GcDirStatus::RealDir(_)) => {}
         Ok(GcDirStatus::Missing) => return (0, 0, BaseDirLockDecision::RemoveIfStillFree),
         Ok(GcDirStatus::NotDirectory) => {
-            info!(
+            warn!(
                 "workspace gc: {} is not a real base directory, skipping",
                 base_dir.display()
             );
@@ -426,7 +418,7 @@ async fn gc_workspace_orphans_in_base_dir(
         Ok(GcDirStatus::RealDir(_)) => {}
         Ok(GcDirStatus::Missing) => return (0, 0, BaseDirLockDecision::RemoveIfStillFree),
         Ok(GcDirStatus::NotDirectory) => {
-            info!(
+            warn!(
                 "workspace gc: {} is not a real directory, skipping",
                 workspaces_dir.display()
             );
@@ -506,13 +498,7 @@ async fn gc_workspace_orphans_in_base_dir(
             );
         } else {
             match remove_dir_all(&path).await {
-                Ok(()) => {
-                    info!(
-                        "removed orphaned workspace {} ({})",
-                        path.display(),
-                        human_bytes(size)
-                    );
-                }
+                Ok(()) => {}
                 Err(e) => {
                     warn!("workspace gc: cannot remove {}: {e}", path.display());
                     preserve_lock = true;


### PR DESCRIPTION
## Summary

- emit an immediate count-and-bytes completion summary for every runner GC phase
- keep item-level dry-run plans and path-specific anomaly warnings while suppressing routine real-run retention and deletion records
- cover thousands of removable lock files to prove real-run output stays bounded without changing cleanup accounting

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`
- pre-commit Rust formatting, Clippy, documentation, and file-size hooks

## Scope

This PR only addresses routine runner GC log volume. Transient SSH recovery in runner image preparation is handled separately by #29311.

Closes #29306
