### PR TITLE
perf: resize uploaded template previews

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3873,6 +3873,129 @@ describe("chat composer templates", () => {
     expect(secondaryDetailRequestCount).toBe(0);
   });
 
+  it("loads resized uploaded deck previews with bounded thumbnail priority", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    const templateId = "6fbcce0d-cb09-42de-8d8a-d525f813f312";
+    const pageUrls = Array.from({ length: 18 }, (_, index) => {
+      const slideNumber = (index + 1).toString().padStart(3, "0");
+      return `https://cdn.vm0.io/artifacts/user/template/page-${slideNumber}.png?X-Amz-Signature=slide-${slideNumber}`;
+    });
+    const coverUrl = pageUrls[0];
+    if (coverUrl === undefined) {
+      throw new Error("Uploaded template cover URL not found");
+    }
+    const cardCoverUrl = r2ImageTransformUrl(coverUrl, {
+      width: 480,
+      height: 270,
+    });
+    const highResolutionUrl = r2ImageTransformUrl(coverUrl, {
+      width: 708,
+      height: 398,
+    });
+    const imageDecodes = controlImportedTemplateImageDecodes([
+      highResolutionUrl,
+    ]);
+    const template = {
+      id: templateId,
+      title: "Edge resized deck",
+      sourceFilename: "edge-resized-deck.pptx",
+      coverUrl,
+      pageCount: pageUrls.length,
+      visibility: "private" as const,
+      canManage: true,
+      pageUrls,
+      createdAt: "2026-08-25T03:00:00.000Z",
+      updatedAt: "2026-08-25T03:00:00.000Z",
+    };
+    context.mocks.api(presentationTemplatesContract.list, ({ respond }) => {
+      return respond(200, [presentationTemplateSummary(template)]);
+    });
+    context.mocks.api(
+      presentationTemplatesContract.get,
+      ({ params, respond }) => {
+        expect(params.templateId).toBe(templateId);
+        return respond(200, template);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const preloadedCover = await waitFor(() => {
+      const found = document.querySelector(`img[src="${cardCoverUrl}"]`);
+      if (!(found instanceof HTMLImageElement)) {
+        throw new Error("Resized uploaded template cover was not prefetched");
+      }
+      return found;
+    });
+    expect(preloadedCover).toHaveAttribute("loading", "eager");
+    expect(preloadedCover).toHaveAttribute("fetchpriority", "high");
+    expect(document.querySelector(`img[src="${coverUrl}"]`)).toBeNull();
+
+    await user.click(screen.getByLabelText("Template"));
+    const dialog = screen.getByRole("dialog");
+    const card = await waitFor(() => {
+      const found = dialog.querySelector(
+        `[data-imported-presentation-template="${templateId}"]`,
+      );
+      if (!(found instanceof HTMLElement)) {
+        throw new Error("Resized uploaded template card not found");
+      }
+      return found;
+    });
+    const previewButton = within(card).getByLabelText(
+      "Preview Edge resized deck at current slide",
+    );
+    const cardMedia = previewButton.parentElement;
+    if (cardMedia === null) {
+      throw new Error("Resized uploaded template card media not found");
+    }
+    await loadImportedTemplateImage(cardMedia, cardCoverUrl);
+    click(previewButton);
+
+    const detailPreview = await screen.findByTestId(
+      "Edge resized deck imported detail image preview",
+    );
+    const detailImage = activeImportedTemplateImage(detailPreview);
+    expect(detailImage).toHaveAttribute("src", cardCoverUrl);
+    expect(detailImage).not.toHaveAttribute("src", highResolutionUrl);
+    await loadImportedTemplateImage(detailPreview, cardCoverUrl);
+    expect(activeImportedTemplateImage(detailPreview)).toBe(detailImage);
+    expect(detailImage).toHaveAttribute("src", cardCoverUrl);
+    await imageDecodes.complete(highResolutionUrl);
+    await waitFor(() => {
+      expect(detailImage).toHaveAttribute("src", highResolutionUrl);
+    });
+    expect(activeImportedTemplateImage(detailPreview)).toBe(detailImage);
+
+    const thumbnailCases = [
+      { slideNumber: 1, loading: "eager", priority: "high" },
+      { slideNumber: 16, loading: "eager", priority: "auto" },
+      { slideNumber: 17, loading: "lazy", priority: "low" },
+    ] as const;
+    for (const { slideNumber, loading, priority } of thumbnailCases) {
+      const thumbnailButton = await screen.findByLabelText(
+        `Preview slide ${slideNumber.toString()}`,
+      );
+      const pageUrl = pageUrls[slideNumber - 1];
+      if (pageUrl === undefined) {
+        throw new Error("Uploaded template thumbnail URL not found");
+      }
+      const thumbnailUrl = r2ImageTransformUrl(pageUrl, {
+        width: 224,
+        height: 126,
+      });
+      const thumbnailImage = activeImportedTemplateImage(thumbnailButton);
+      expect(thumbnailImage).toHaveAttribute("src", thumbnailUrl);
+      expect(thumbnailImage).toHaveAttribute("loading", loading);
+      expect(thumbnailImage).toHaveAttribute("fetchpriority", priority);
+    }
+  });
+
   it("makes a workspace template published after navigating away usable in the other thread", async () => {
     const user = userEvent.setup({ delay: null });
     const analysisCatalogLoaded = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -352,6 +352,7 @@ const PRESENTATION_GALLERY_PREVIEW_BASE_URL = platformPublicStaticUrl(
 );
 const PRESENTATION_GALLERY_SLIDE_COUNT = 15;
 const TEMPLATE_PREWARM_IMAGE_COUNT = 15;
+const IMPORTED_PRESENTATION_TEMPLATE_EAGER_THUMBNAIL_COUNT = 16;
 const ILLUSTRATION_PREWARM_IMAGE_COUNT = 24;
 const ILLUSTRATION_EAGER_IMAGE_COUNT = 24;
 const ILLUSTRATION_SCROLL_PREWARM_LOOKAHEAD_COUNT = 12;
@@ -5009,6 +5010,25 @@ function ImportedPptCardMediaControls({
 // Keep one rendered image stable while its replacement loads and decodes
 // off-DOM, then swap the src atomically. Stale requests are ignored by URL.
 
+function importedPptImageVariant(
+  imageUrl: string,
+  size: TemplatePreviewImageSize,
+): string;
+function importedPptImageVariant(
+  imageUrl: null,
+  size: TemplatePreviewImageSize,
+): null;
+function importedPptImageVariant(
+  imageUrl: string | null,
+  size: TemplatePreviewImageSize,
+): string | null;
+function importedPptImageVariant(
+  imageUrl: string | null,
+  size: TemplatePreviewImageSize,
+): string | null {
+  return imageUrl === null ? null : r2ImageTransformUrl(imageUrl, size);
+}
+
 function importedPptImage(media: HTMLElement): HTMLImageElement | null {
   return media.querySelector<HTMLImageElement>(
     "[data-imported-presentation-template-image]",
@@ -5383,8 +5403,12 @@ function ImportedPptCard({
       slideCount - 1,
     ),
   );
-  const activeImageUrl =
+  const activeImageSource =
     detail?.pageUrls[activeSlideIndex] ?? template.coverUrl;
+  const activeImageUrl = importedPptImageVariant(
+    activeImageSource,
+    TEMPLATE_CARD_PREVIEW_SIZE,
+  );
   const loading =
     requestedTemplateId === template.id && detailLoadable.state === "loading";
   const label = t(
@@ -5719,12 +5743,25 @@ function ImportedPresentationTemplateMainPreview({
     },
     { title },
   );
+  const highResolutionImageUrl = importedPptImageVariant(
+    activeImageUrl,
+    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
+  );
+  const lowResolutionImageUrl = importedPptImageVariant(
+    activeImageUrl,
+    TEMPLATE_CARD_PREVIEW_SIZE,
+  );
   return (
     <div
       role="group"
       aria-label={previewLabel}
       ref={(media) => {
-        syncImportedPptImage(media, activeImageUrl, previewLabel);
+        syncImportedPptImage(
+          media,
+          highResolutionImageUrl,
+          previewLabel,
+          lowResolutionImageUrl,
+        );
       }}
       data-imported-presentation-template-image-container=""
       data-testid={`${title} imported detail image preview`}
@@ -5790,6 +5827,12 @@ function ImportedPresentationTemplateThumbnails({
       {pageUrls.map((pageUrl, index) => {
         const slideNumber = index + 1;
         const active = index === activeSlideIndex;
+        const eagerlyLoad =
+          index < IMPORTED_PRESENTATION_TEMPLATE_EAGER_THUMBNAIL_COUNT;
+        const thumbnailUrl = importedPptImageVariant(
+          pageUrl,
+          TEMPLATE_DETAIL_THUMBNAIL_PREVIEW_SIZE,
+        );
         const previewLabel = t(
           ($) => {
             return $.artifacts.templates.previewSlide;
@@ -5803,7 +5846,7 @@ function ImportedPresentationTemplateThumbnails({
             aria-label={previewLabel}
             aria-pressed={active}
             ref={(media) => {
-              syncImportedPptImage(media, pageUrl, previewLabel);
+              syncImportedPptImage(media, thumbnailUrl, previewLabel);
             }}
             data-imported-presentation-template-image-container=""
             onClick={() => {
@@ -5817,8 +5860,8 @@ function ImportedPresentationTemplateThumbnails({
             )}
           >
             <ImportedPptImage
-              loading="lazy"
-              fetchPriority="auto"
+              loading={eagerlyLoad ? "eager" : "lazy"}
+              fetchPriority={active ? "high" : eagerlyLoad ? "auto" : "low"}
               className="pointer-events-none absolute inset-0 h-full w-full object-cover"
             />
             <span className="absolute bottom-1 right-1 rounded border border-border bg-background/90 px-1.5 py-0.5 text-[10px] font-semibold text-foreground shadow-sm backdrop-blur">
@@ -6889,11 +6932,15 @@ function ImportedPresentationTemplateResourcePreload({
   return detail?.pageUrls
     .slice(startPageIndex, startPageIndex + pageCount)
     .map((pageUrl) => {
+      const previewUrl = importedPptImageVariant(
+        pageUrl,
+        TEMPLATE_CARD_PREVIEW_SIZE,
+      );
       return (
         <img
-          key={pageUrl}
+          key={previewUrl}
           alt=""
-          src={pageUrl}
+          src={previewUrl}
           loading="eager"
           decoding="async"
           fetchPriority="low"
@@ -6939,7 +6986,11 @@ function ComposerTemplateAttachmentSync({
   );
   const importedTemplateCoverUrls = uniqueTemplatePreviewImageUrls(
     importedTemplates.flatMap((template) => {
-      return template.coverUrl === null ? [] : [template.coverUrl];
+      const coverUrl = importedPptImageVariant(
+        template.coverUrl,
+        TEMPLATE_CARD_PREVIEW_SIZE,
+      );
+      return coverUrl === null ? [] : [coverUrl];
     }),
   );
   const importedTemplatePagePreloads =


### PR DESCRIPTION
## Summary

- serve uploaded-template covers, cards, page preloads, and thumbnails through Cloudflare edge-resized variants while preserving signed query parameters
- show the 480x270 preview first, then atomically replace it with the decoded 708x398 detail image using the single-image flow from #29308
- keep every uploaded-template cover eager/high priority, load the first 16 detail thumbnails eagerly, and defer the remainder with low priority

## Stack

- depends on #29308
- no API, database, storage, or backfill migration is required

## Verification

- pnpm exec prettier --check on all changed files
- pnpm --filter @okouai/app lint
- pnpm --filter @okouai/app check-types
- pnpm knip
- pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx (45 passed)