### PR TITLE
fix(platform): show marks in the viewer and edit notes on the image

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -492,12 +492,14 @@
     "annotation": {
       "attach": "Markierungen anhängen",
       "draftOnly": "Markierungen bleiben im Entwurf — bis zum Senden änderbar",
+      "inkLabel": "Farbe {{color}}",
       "notePlaceholder": "Beschreiben Sie, was sich hier ändern soll",
       "open": "Markieren",
       "redo": "Wiederholen",
       "removeMark": "Markierung entfernen",
       "subtitle_one": "{{count}} Markierung",
       "subtitle_other": "{{count}} Markierungen",
+      "textPlaceholder": "Beschriftung eingeben",
       "tools": {
         "arrow": "Pfeil",
         "box": "Rechteck",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -492,12 +492,14 @@
     "annotation": {
       "attach": "Attach marks",
       "draftOnly": "Marks stay in the draft — you can change them until you send",
+      "inkLabel": "Ink {{color}}",
       "notePlaceholder": "Say what should change here",
       "open": "Annotate",
       "redo": "Redo",
       "removeMark": "Remove mark",
       "subtitle_one": "{{count}} mark",
       "subtitle_other": "{{count}} marks",
+      "textPlaceholder": "Type the label",
       "tools": {
         "arrow": "Arrow",
         "box": "Box",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -506,6 +506,7 @@
     "annotation": {
       "attach": "Adjuntar marcas",
       "draftOnly": "Las marcas se quedan en el borrador — puedes cambiarlas hasta enviar",
+      "inkLabel": "Color {{color}}",
       "notePlaceholder": "Di qué debería cambiar aquí",
       "open": "Anotar",
       "redo": "Rehacer",
@@ -513,6 +514,7 @@
       "subtitle_one": "{{count}} marca",
       "subtitle_many": "{{count}} marcas",
       "subtitle_other": "{{count}} marcas",
+      "textPlaceholder": "Escribe la etiqueta",
       "tools": {
         "arrow": "Flecha",
         "box": "Rectángulo",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -506,6 +506,7 @@
     "annotation": {
       "attach": "Joindre les annotations",
       "draftOnly": "Les annotations restent dans le brouillon — modifiables jusqu'à l'envoi",
+      "inkLabel": "Couleur {{color}}",
       "notePlaceholder": "Dites ce qui doit changer ici",
       "open": "Annoter",
       "redo": "Rétablir",
@@ -513,6 +514,7 @@
       "subtitle_one": "{{count}} annotation",
       "subtitle_many": "{{count}} annotations",
       "subtitle_other": "{{count}} annotations",
+      "textPlaceholder": "Saisissez le libellé",
       "tools": {
         "arrow": "Flèche",
         "box": "Rectangle",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -492,12 +492,14 @@
     "annotation": {
       "attach": "चिह्न संलग्न करें",
       "draftOnly": "चिह्न ड्राफ़्ट में रहते हैं — भेजने तक बदल सकते हैं",
+      "inkLabel": "रंग {{color}}",
       "notePlaceholder": "यहाँ क्या बदलना चाहिए, लिखें",
       "open": "टिप्पणी करें",
       "redo": "फिर से करें",
       "removeMark": "चिह्न हटाएँ",
       "subtitle_one": "{{count}} चिह्न",
       "subtitle_other": "{{count}} चिह्न",
+      "textPlaceholder": "लेबल लिखें",
       "tools": {
         "arrow": "तीर",
         "box": "बॉक्स",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -492,11 +492,13 @@
     "annotation": {
       "attach": "Lampirkan tanda",
       "draftOnly": "Tanda tersimpan di draf — Anda bisa mengubahnya sampai dikirim",
+      "inkLabel": "Warna {{color}}",
       "notePlaceholder": "Tulis apa yang harus diubah di sini",
       "open": "Anotasi",
       "redo": "Ulangi",
       "removeMark": "Hapus tanda",
       "subtitle_other": "{{count}} tanda",
+      "textPlaceholder": "Ketik labelnya",
       "tools": {
         "arrow": "Panah",
         "box": "Kotak",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -506,6 +506,7 @@
     "annotation": {
       "attach": "Allega segni",
       "draftOnly": "I segni restano nella bozza — puoi modificarli fino all'invio",
+      "inkLabel": "Colore {{color}}",
       "notePlaceholder": "Scrivi cosa dovrebbe cambiare qui",
       "open": "Annota",
       "redo": "Ripeti",
@@ -513,6 +514,7 @@
       "subtitle_one": "{{count}} segno",
       "subtitle_many": "{{count}} segni",
       "subtitle_other": "{{count}} segni",
+      "textPlaceholder": "Scrivi l'etichetta",
       "tools": {
         "arrow": "Freccia",
         "box": "Rettangolo",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -492,11 +492,13 @@
     "annotation": {
       "attach": "マークを添付",
       "draftOnly": "マークは下書きに残ります。送信するまで変更できます",
+      "inkLabel": "色 {{color}}",
       "notePlaceholder": "ここをどう変えたいか書いてください",
       "open": "注釈",
       "redo": "やり直す",
       "removeMark": "マークを削除",
       "subtitle_other": "{{count}} 件のマーク",
+      "textPlaceholder": "ラベルを入力",
       "tools": {
         "arrow": "矢印",
         "box": "矩形",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -492,11 +492,13 @@
     "annotation": {
       "attach": "표시 첨부",
       "draftOnly": "표시는 임시 보관함에 남아 있으며 보내기 전까지 수정할 수 있습니다",
+      "inkLabel": "색상 {{color}}",
       "notePlaceholder": "여기를 어떻게 바꿀지 적어 주세요",
       "open": "주석",
       "redo": "다시 실행",
       "removeMark": "표시 삭제",
       "subtitle_other": "표시 {{count}}개",
+      "textPlaceholder": "라벨 입력",
       "tools": {
         "arrow": "화살표",
         "box": "사각형",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -506,6 +506,7 @@
     "annotation": {
       "attach": "Anexar marcações",
       "draftOnly": "As marcações ficam no rascunho — você pode alterá-las até enviar",
+      "inkLabel": "Cor {{color}}",
       "notePlaceholder": "Diga o que deve mudar aqui",
       "open": "Anotar",
       "redo": "Refazer",
@@ -513,6 +514,7 @@
       "subtitle_one": "{{count}} marcação",
       "subtitle_many": "{{count}} marcações",
       "subtitle_other": "{{count}} marcações",
+      "textPlaceholder": "Digite o rótulo",
       "tools": {
         "arrow": "Seta",
         "box": "Retângulo",

--- a/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
@@ -146,6 +146,15 @@ const disposeLightboxSession$ = command(({ set }) => {
   set(releaseLightboxObjectUrlResources$);
 });
 
+/**
+ * Closes without the exit animation. Handing the screen to the annotation
+ * editor used to animate the viewer out while the editor animated in, and the
+ * two transitions read as the modal jumping.
+ */
+export const closeLightboxImmediately$ = command(({ set }) => {
+  set(disposeLightboxSession$);
+});
+
 const disposeLightboxForDialogUnmountToken$ = command(
   ({ get, set }, token: number) => {
     if (get(internalLightboxDialogMountToken$) !== token) {

--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -352,6 +352,15 @@ export const removeAnnotationMark$ = command(({ get, set }, id: string) => {
   }
 });
 
+/** Deletes whatever is selected. Bound to Delete/Backspace in the editor. */
+export const removeSelectedAnnotationMark$ = command(({ get, set }) => {
+  const id = get(internalSelectedMarkId$);
+  if (id === null) {
+    return;
+  }
+  set(removeAnnotationMark$, id);
+});
+
 export const setAnnotationMarkNote$ = command(
   ({ set }, id: string, note: string) => {
     set(pushAnnotation$, (current) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -219,6 +219,55 @@ describe("composer image annotation", () => {
     ).toHaveLength(1);
   });
 
+  it("draws stored marks in the read-only viewer, not just in the editor", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage([boxMark()]);
+
+    setup(true);
+
+    const chip = await screen.findByLabelText(
+      "Open image preview for billing-page.png",
+    );
+    await user.click(chip);
+
+    // The viewer shows the image as stored, so the marks have to be drawn over
+    // it — otherwise reopening an annotated image looks like the marks vanished.
+    await screen.findByTestId("attachment-lightbox");
+    await waitFor(() => {
+      expect(screen.getByTestId("annotation-mark-layer")).toBeInTheDocument();
+    });
+  });
+
+  it("deletes the selected mark", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage([boxMark()]);
+
+    setup(true);
+
+    const chip = await screen.findByLabelText(
+      "Open image preview for billing-page.png",
+    );
+    await user.click(chip);
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+
+    await waitFor(() => {
+      expect(screen.getByText("1 mark")).toBeInTheDocument();
+    });
+
+    // Selecting a mark opens its note beside it; the note owns the delete.
+    await user.click(screen.getByTestId("annotation-mark-1"));
+    await user.click(await screen.findByLabelText("Remove mark"));
+
+    await waitFor(() => {
+      expect(screen.getByText("0 marks")).toBeInTheDocument();
+    });
+  });
+
   it("keeps an opened-but-untouched image unannotated", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -43,6 +43,7 @@ import { MarkdownEventBody } from "../components/markdown.tsx";
 import {
   attachmentSidebarRef,
   lightboxUrl$,
+  closeLightboxImmediately$,
   closeLightboxWithDialogExit$,
   lightboxDialogFullscreen$,
   lightboxDialogVisible$,
@@ -61,6 +62,7 @@ import {
   artifactPreviewUrlsMatch,
   attachmentFilenameFromUrl,
 } from "./attachment-url.ts";
+import { AnnotationMarkLayer } from "./image-annotation-marks.tsx";
 import {
   annotationMarkCount,
   DEFAULT_ANNOTATION_INK,
@@ -752,6 +754,9 @@ function ArtifactDialogImageStage({
   resourceUrl: string | null;
 }) {
   const fullscreen = useGet(lightboxDialogFullscreen$);
+  // Marks live on the draft rather than in the file, so the viewer has to draw
+  // them too — otherwise reopening an annotated image shows a clean picture.
+  const annotation = preview.annotationTarget?.annotation ?? null;
 
   return (
     <ArtifactDialogStage flush scrollable={false}>
@@ -770,6 +775,11 @@ function ArtifactDialogImageStage({
               contentClassName="p-6"
               imageClassName="rounded-lg shadow-sm"
               canvasTestId="artifact-dialog-image-stage"
+              overlay={
+                annotation ? (
+                  <AnnotationMarkLayer annotation={annotation} />
+                ) : undefined
+              }
             >
               {(controls) => {
                 return <ArtifactDialogImageZoomControls controls={controls} />;
@@ -1249,6 +1259,7 @@ function ArtifactPreviewDialogActions({
   const showShare = preview.shareAvailable !== false;
   const showSplitView = preview.splitViewAvailable !== false;
   const openAnnotationEditor = useSet(openAnnotationEditor$);
+  const closeLightboxImmediately = useSet(closeLightboxImmediately$);
   const annotationTarget =
     preview.kind === "image" ? preview.annotationTarget : undefined;
   const resetDialogImageZoom = (targetFullscreen: boolean) => {
@@ -1285,9 +1296,10 @@ function ArtifactPreviewDialogActions({
           })}
           onClick={() => {
             // The editor owns the whole surface while it is open, so the
-            // read-only viewer steps aside rather than stacking behind it.
+            // read-only viewer steps aside — instantly, or the two dialogs
+            // cross-fade and the modal appears to jump.
             openAnnotationEditor(annotationTarget);
-            closeLightboxWithDialogExit(rootSignal);
+            closeLightboxImmediately();
           }}
         >
           <Pencil size={18} />

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -15,6 +15,13 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@okouai/ui/components/ui/button";
+import { Input } from "@okouai/ui/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@okouai/ui/components/ui/tooltip";
 import { cn } from "@okouai/ui";
 import type { ImageAnnotationMark } from "@okouai/api-contracts/contracts/chat-threads";
 import {
@@ -32,18 +39,15 @@ import {
   bindAnnotationSurface$,
   closeAnnotationEditor$,
   commitAnnotation$,
-  HIGHLIGHT_FILL,
   redoAnnotation$,
-  REDACT_FILL,
   removeAnnotationMark$,
+  removeSelectedAnnotationMark$,
   selectAnnotationMark$,
   setAnnotationCrop$,
   setAnnotationInk$,
   setAnnotationMarkNote$,
   setAnnotationStroke$,
   setAnnotationTool$,
-  STROKE_HALO_INNER,
-  STROKE_HALO_OUTER,
   undoAnnotation$,
   type AnnotationInk,
   type AnnotationPoint,
@@ -52,6 +56,7 @@ import {
   type AnnotationTool,
 } from "../../signals/okou-page/image-annotation.ts";
 import { useResolvedAttachmentUrl } from "./attachment-resource.ts";
+import { markInk, MarkShape } from "./image-annotation-marks.tsx";
 
 const TOOLS: readonly { tool: AnnotationTool; icon: typeof Square }[] = [
   { tool: "select", icon: MousePointer2 },
@@ -82,6 +87,10 @@ function rectFrom(a: AnnotationPoint, b: AnnotationPoint) {
     width: Math.abs(b.x - a.x),
     height: Math.abs(b.y - a.y),
   };
+}
+
+function percent(value: number): string {
+  return `${value * 100}%`;
 }
 
 function buildMark(
@@ -121,13 +130,6 @@ function buildMark(
   }
 }
 
-function markInk(mark: ImageAnnotationMark): string {
-  if (mark.shape === "highlight" || mark.shape === "redact") {
-    return REDACT_FILL;
-  }
-  return mark.ink;
-}
-
 function noteOf(mark: ImageAnnotationMark): string {
   if (mark.shape === "text") {
     return mark.text;
@@ -138,177 +140,17 @@ function noteOf(mark: ImageAnnotationMark): string {
   return mark.note ?? "";
 }
 
-function percent(value: number): string {
-  return `${value * 100}%`;
-}
-
-function StrokeMark({ mark }: { mark: ImageAnnotationMark }) {
-  if (mark.shape === "pen") {
-    const points = mark.points
-      .map((point) => {
-        return `${point.x * 100},${point.y * 100}`;
-      })
-      .join(" ");
-    return (
-      <svg
-        viewBox="0 0 100 100"
-        preserveAspectRatio="none"
-        className="pointer-events-none absolute inset-0 h-full w-full"
-      >
-        <polyline
-          points={points}
-          fill="none"
-          stroke={STROKE_HALO_OUTER}
-          vectorEffect="non-scaling-stroke"
-          style={{ strokeWidth: 5 }}
-        />
-        <polyline
-          points={points}
-          fill="none"
-          stroke={mark.ink}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-          style={{ strokeWidth: 3 }}
-        />
-      </svg>
-    );
-  }
-
-  if (mark.shape !== "arrow") {
-    return null;
-  }
-
-  return (
-    <svg
-      viewBox="0 0 100 100"
-      preserveAspectRatio="none"
-      className="pointer-events-none absolute inset-0 h-full w-full"
-    >
-      <line
-        x1={mark.from.x * 100}
-        y1={mark.from.y * 100}
-        x2={mark.to.x * 100}
-        y2={mark.to.y * 100}
-        stroke={STROKE_HALO_OUTER}
-        vectorEffect="non-scaling-stroke"
-        style={{ strokeWidth: 5 }}
-      />
-      <line
-        x1={mark.from.x * 100}
-        y1={mark.from.y * 100}
-        x2={mark.to.x * 100}
-        y2={mark.to.y * 100}
-        stroke={mark.ink}
-        strokeLinecap="round"
-        vectorEffect="non-scaling-stroke"
-        style={{ strokeWidth: 3 }}
-      />
-      <circle
-        cx={mark.to.x * 100}
-        cy={mark.to.y * 100}
-        r={1.4}
-        fill={mark.ink}
-      />
-    </svg>
-  );
-}
-
-function BoxedMark({
-  mark,
-  ordinal,
-  selected,
-  onSelect,
-}: {
-  mark: Extract<ImageAnnotationMark, { shape: "box" | "highlight" | "redact" }>;
-  ordinal: number;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  const fill =
-    mark.shape === "redact"
-      ? { background: REDACT_FILL }
-      : mark.shape === "highlight"
-        ? { background: HIGHLIGHT_FILL }
-        : {
-            border: `2.5px solid ${mark.ink}`,
-            background: `${mark.ink}1A`,
-            boxShadow: `0 0 0 1px ${STROKE_HALO_OUTER}, inset 0 0 0 1px ${STROKE_HALO_INNER}`,
-          };
-
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      style={{
-        left: percent(mark.rect.x),
-        top: percent(mark.rect.y),
-        width: percent(mark.rect.width),
-        height: percent(mark.rect.height),
-        borderRadius: mark.shape === "box" ? 4 : 3,
-        ...fill,
-        ...(selected
-          ? { outline: `2px solid ${markInk(mark)}`, outlineOffset: "3px" }
-          : {}),
-      }}
-      className="absolute"
-    >
-      {mark.shape === "box" && (
-        <span
-          style={{ background: mark.ink }}
-          className="absolute -left-[11px] -top-[11px] flex h-[22px] w-[22px] items-center justify-center rounded-full border-[1.5px] border-white text-[11px] font-bold text-white shadow"
-        >
-          {ordinal}
-        </span>
-      )}
-    </button>
-  );
-}
-
-function MarkLayer({
-  mark,
-  ordinal,
-  selected,
-  onSelect,
-}: {
-  mark: ImageAnnotationMark;
-  ordinal: number;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  if (mark.shape === "pen" || mark.shape === "arrow") {
-    return <StrokeMark mark={mark} />;
-  }
-
+function markAnchor(mark: ImageAnnotationMark): AnnotationPoint {
   if (mark.shape === "text") {
-    return (
-      <button
-        type="button"
-        onClick={onSelect}
-        style={{
-          left: percent(mark.at.x),
-          top: percent(mark.at.y),
-          color: mark.ink,
-          textShadow: `0 0 3px ${STROKE_HALO_INNER}, 0 0 3px ${STROKE_HALO_INNER}`,
-          ...(selected
-            ? { outline: `2px solid ${mark.ink}`, outlineOffset: "3px" }
-            : {}),
-        }}
-        className="absolute whitespace-pre text-sm font-bold"
-      >
-        {mark.text || "…"}
-      </button>
-    );
+    return mark.at;
   }
-
-  return (
-    <BoxedMark
-      mark={mark}
-      ordinal={ordinal}
-      selected={selected}
-      onSelect={onSelect}
-    />
-  );
+  if (mark.shape === "arrow") {
+    return mark.to;
+  }
+  if (mark.shape === "pen") {
+    return mark.points[0] ?? { x: 0.5, y: 0.5 };
+  }
+  return { x: mark.rect.x, y: mark.rect.y + mark.rect.height };
 }
 
 /**
@@ -365,34 +207,47 @@ function useToolLabel(): (tool: AnnotationTool) => string {
 }
 
 function InkSwatches() {
+  const { t } = useTranslation();
   const ink = useGet(annotationInk$);
   const setInk = useSet(setAnnotationInk$);
 
   return (
-    <div className="flex items-center gap-1.5 px-1">
+    <div className="flex items-center gap-0.5 px-1">
       {ANNOTATION_INKS.map((candidate) => {
         const active = candidate === ink;
         return (
-          <button
-            key={candidate}
-            type="button"
-            onClick={() => {
-              setInk(candidate);
-            }}
-            aria-pressed={active}
-            aria-label={candidate}
-            title={candidate}
-            style={{
-              background: candidate,
-              boxShadow: active
-                ? `0 0 0 2px hsl(var(--card)), 0 0 0 3.5px ${candidate}`
-                : "0 0 0 1px hsl(var(--gray-300))",
-            }}
-            className={cn(
-              "rounded-full transition-all",
-              active ? "h-[18px] w-[18px]" : "h-4 w-4",
-            )}
-          />
+          <Tooltip key={candidate}>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="quiet"
+                  size="icon-xs"
+                  aria-pressed={active}
+                  aria-label={t(
+                    ($) => {
+                      return $.artifacts.annotation.inkLabel;
+                    },
+                    { color: candidate },
+                  )}
+                  onClick={() => {
+                    setInk(candidate);
+                  }}
+                >
+                  <span
+                    style={{ background: candidate }}
+                    className={cn(
+                      "rounded-full transition-all",
+                      active
+                        ? "h-[18px] w-[18px] ring-2 ring-card ring-offset-2"
+                        : "h-4 w-4",
+                    )}
+                  />
+                </Button>
+              }
+            />
+            <TooltipContent>{candidate}</TooltipContent>
+          </Tooltip>
         );
       })}
     </div>
@@ -408,23 +263,28 @@ function ToolPill() {
     <div className="absolute bottom-4 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1 rounded-xl border border-border bg-background p-1.5 shadow-lg">
       {TOOLS.map(({ tool: candidate, icon: Icon }) => {
         return (
-          <Button
-            key={candidate}
-            type="button"
-            variant="quiet"
-            size="icon-sm"
-            aria-pressed={tool === candidate}
-            aria-label={toolLabel(candidate)}
-            title={toolLabel(candidate)}
-            onClick={() => {
-              setTool(candidate);
-            }}
-            className={cn(
-              tool === candidate && "bg-foreground text-background",
-            )}
-          >
-            <Icon size={16} />
-          </Button>
+          <Tooltip key={candidate}>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="quiet"
+                  size="icon-sm"
+                  aria-pressed={tool === candidate}
+                  aria-label={toolLabel(candidate)}
+                  onClick={() => {
+                    setTool(candidate);
+                  }}
+                  className={cn(
+                    tool === candidate && "bg-foreground text-background",
+                  )}
+                >
+                  <Icon size={16} />
+                </Button>
+              }
+            />
+            <TooltipContent>{toolLabel(candidate)}</TooltipContent>
+          </Tooltip>
         );
       })}
       <span className="mx-1 h-[18px] w-px bg-border" />
@@ -433,40 +293,69 @@ function ToolPill() {
   );
 }
 
-function NoteField({ mark }: { mark: ImageAnnotationMark }) {
+/**
+ * The note lives next to the mark it belongs to rather than in a bar at the
+ * bottom of the dialog: a field detached from the thing it describes gives no
+ * clue which mark is being edited, and text marks were being typed twice —
+ * once on the image and once underneath it.
+ */
+function MarkNotePopover({ mark }: { mark: ImageAnnotationMark }) {
   const { t } = useTranslation();
   const setNote = useSet(setAnnotationMarkNote$);
   const removeMark = useSet(removeAnnotationMark$);
+  const anchor = markAnchor(mark);
 
   return (
-    <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-2.5">
-      <span
-        style={{ background: markInk(mark) }}
-        className="h-2.5 w-2.5 shrink-0 rounded-full"
-      />
-      <input
-        value={noteOf(mark)}
-        onChange={(event) => {
-          setNote(mark.id, event.target.value);
-        }}
-        placeholder={t(($) => {
-          return $.artifacts.annotation.notePlaceholder;
-        })}
-        className="h-8 flex-1 rounded-lg border border-border bg-input px-3 text-sm"
-      />
-      <Button
-        type="button"
-        variant="quiet"
-        size="icon-sm"
-        onClick={() => {
-          removeMark(mark.id);
-        }}
-        aria-label={t(($) => {
-          return $.artifacts.annotation.removeMark;
-        })}
-      >
-        <Trash2 size={16} />
-      </Button>
+    <div
+      style={{ left: percent(anchor.x), top: percent(anchor.y) }}
+      // The popover lives inside the drawing surface so it can be positioned
+      // against the mark, which means its own clicks would otherwise start a
+      // stroke on the canvas underneath it.
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
+      onPointerUp={(event) => {
+        event.stopPropagation();
+      }}
+      className="absolute z-30 w-[248px] translate-y-2 rounded-xl border border-border bg-popover p-2 shadow-lg"
+      data-testid="annotation-note-popover"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          style={{ background: markInk(mark) }}
+          className="h-2.5 w-2.5 shrink-0 rounded-full"
+        />
+        <Input
+          autoFocus
+          value={noteOf(mark)}
+          onChange={(event) => {
+            setNote(mark.id, event.target.value);
+          }}
+          placeholder={
+            mark.shape === "text"
+              ? t(($) => {
+                  return $.artifacts.annotation.textPlaceholder;
+                })
+              : t(($) => {
+                  return $.artifacts.annotation.notePlaceholder;
+                })
+          }
+          className="h-8 flex-1 text-sm"
+        />
+        <Button
+          type="button"
+          variant="quiet"
+          size="icon-sm"
+          onClick={() => {
+            removeMark(mark.id);
+          }}
+          aria-label={t(($) => {
+            return $.artifacts.annotation.removeMark;
+          })}
+        >
+          <Trash2 size={16} />
+        </Button>
+      </div>
     </div>
   );
 }
@@ -493,30 +382,52 @@ function EditorHeader({ filename }: { filename: string }) {
           )}
         </div>
       </div>
-      <Button
-        type="button"
-        variant="quiet"
-        size="icon-sm"
-        disabled={!canUndo}
-        onClick={undo}
-        aria-label={t(($) => {
-          return $.artifacts.annotation.undo;
-        })}
-      >
-        <Undo2 size={18} />
-      </Button>
-      <Button
-        type="button"
-        variant="quiet"
-        size="icon-sm"
-        disabled={!canRedo}
-        onClick={redo}
-        aria-label={t(($) => {
-          return $.artifacts.annotation.redo;
-        })}
-      >
-        <Redo2 size={18} />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant="quiet"
+              size="icon-sm"
+              disabled={!canUndo}
+              onClick={undo}
+              aria-label={t(($) => {
+                return $.artifacts.annotation.undo;
+              })}
+            >
+              <Undo2 size={18} />
+            </Button>
+          }
+        />
+        <TooltipContent>
+          {t(($) => {
+            return $.artifacts.annotation.undo;
+          })}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant="quiet"
+              size="icon-sm"
+              disabled={!canRedo}
+              onClick={redo}
+              aria-label={t(($) => {
+                return $.artifacts.annotation.redo;
+              })}
+            >
+              <Redo2 size={18} />
+            </Button>
+          }
+        />
+        <TooltipContent>
+          {t(($) => {
+            return $.artifacts.annotation.redo;
+          })}
+        </TooltipContent>
+      </Tooltip>
       <Button
         type="button"
         variant="quiet"
@@ -556,6 +467,44 @@ function EditorFooter() {
         })}
       </Button>
     </div>
+  );
+}
+
+/** Delete and Backspace remove the selected mark, unless a field has focus. */
+function DeleteKeyBinding() {
+  const removeSelected = useSet(removeSelectedAnnotationMark$);
+  let cleanup: (() => void) | null = null;
+
+  return (
+    <span
+      ref={(node) => {
+        cleanup?.();
+        cleanup = null;
+        if (!node) {
+          return;
+        }
+        const onKeyDown = (event: KeyboardEvent) => {
+          if (event.key !== "Delete" && event.key !== "Backspace") {
+            return;
+          }
+          const active = document.activeElement;
+          if (
+            active instanceof HTMLInputElement ||
+            active instanceof HTMLTextAreaElement ||
+            (active instanceof HTMLElement && active.isContentEditable)
+          ) {
+            return;
+          }
+          event.preventDefault();
+          removeSelected();
+        };
+        document.addEventListener("keydown", onKeyDown, true);
+        cleanup = () => {
+          document.removeEventListener("keydown", onKeyDown, true);
+        };
+      }}
+      hidden
+    />
   );
 }
 
@@ -629,9 +578,11 @@ function useStrokeHandlers(): StrokeHandlers {
       }
       const mark = buildMark(stroke, ink);
       if (mark) {
+        // Adding selects the mark, so its note opens straight away — a shape
+        // and the sentence explaining it are one gesture. The tool stays put so
+        // several boxes in a row do not need the tool re-picked each time; only
+        // text hands over to select, because it has nothing until it is typed.
         addMark(mark);
-        // A text mark is useless until it has words, so the note field is where
-        // the user lands the moment the mark exists.
         if (mark.shape === "text") {
           setTool("select");
         }
@@ -654,6 +605,9 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
 
   const preview =
     stroke && stroke.tool !== "pen" ? rectFrom(stroke.from, stroke.to) : null;
+  const selectedMark = annotation.marks.find((mark) => {
+    return mark.id === selectedId;
+  });
 
   return (
     <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/30 p-5">
@@ -682,15 +636,14 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
               top: percent(annotation.crop.y),
               width: percent(annotation.crop.width),
               height: percent(annotation.crop.height),
-              boxShadow: "0 0 0 9999px rgba(20,23,29,.55)",
               outline: `2px solid ${ink}`,
             }}
-            className="pointer-events-none absolute rounded-sm"
+            className="pointer-events-none absolute rounded-sm shadow-[0_0_0_9999px_hsl(var(--overlay)/0.55)]"
           />
         )}
         {annotation.marks.map((mark, index) => {
           return (
-            <MarkLayer
+            <MarkShape
               key={mark.id}
               mark={mark}
               ordinal={index + 1}
@@ -702,6 +655,9 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
             />
           );
         })}
+        {selectedMark && selectedMark.shape !== "redact" && (
+          <MarkNotePopover mark={selectedMark} />
+        )}
         {preview && (
           <div
             style={{
@@ -736,31 +692,25 @@ export function ImageAnnotationEditor() {
 }
 
 function AnnotationSurface({ target }: { target: AnnotationTarget }) {
-  const annotation = useGet(annotationDraft$);
-  const selectedId = useGet(annotationSelectedMarkId$);
   const resolvedUrl = useResolvedAttachmentUrl(target.url);
 
   if (resolvedUrl === null) {
     return null;
   }
 
-  const selectedMark = annotation.marks.find((mark) => {
-    return mark.id === selectedId;
-  });
-
   return (
-    <div
-      className="zero-app fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
-      data-testid="image-annotation-editor"
-    >
-      <div className="flex h-[min(700px,90vh)] w-[min(980px,94vw)] min-h-0 flex-col overflow-hidden rounded-2xl bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]">
-        <EditorHeader filename={target.filename} />
-        <EditorStage filename={target.filename} url={resolvedUrl} />
-        {selectedMark && selectedMark.shape !== "redact" && (
-          <NoteField mark={selectedMark} />
-        )}
-        <EditorFooter />
+    <TooltipProvider delayDuration={300}>
+      <div
+        className="zero-app fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
+        data-testid="image-annotation-editor"
+      >
+        <DeleteKeyBinding />
+        <div className="flex h-[min(700px,90vh)] w-[min(980px,94vw)] min-h-0 flex-col overflow-hidden rounded-2xl bg-background text-foreground shadow-[0_24px_70px_hsl(var(--overlay)/0.30)]">
+          <EditorHeader filename={target.filename} />
+          <EditorStage filename={target.filename} url={resolvedUrl} />
+          <EditorFooter />
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -1,0 +1,206 @@
+import type {
+  ImageAnnotation,
+  ImageAnnotationMark,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  HIGHLIGHT_FILL,
+  REDACT_FILL,
+  STROKE_HALO_INNER,
+  STROKE_HALO_OUTER,
+} from "../../signals/okou-page/image-annotation.ts";
+
+/**
+ * One renderer for both surfaces. The read-only viewer and the editor drew the
+ * same marks from two implementations before, which is how the viewer ended up
+ * showing a clean image while the editor showed the annotations.
+ */
+
+export function markInk(mark: ImageAnnotationMark): string {
+  if (mark.shape === "highlight" || mark.shape === "redact") {
+    return REDACT_FILL;
+  }
+  return mark.ink;
+}
+
+function percent(value: number): string {
+  return `${value * 100}%`;
+}
+
+function StrokeMark({ mark }: { mark: ImageAnnotationMark }) {
+  if (mark.shape === "pen") {
+    const points = mark.points
+      .map((point) => {
+        return `${point.x * 100},${point.y * 100}`;
+      })
+      .join(" ");
+    return (
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="pointer-events-none absolute inset-0 h-full w-full"
+      >
+        <polyline
+          points={points}
+          fill="none"
+          stroke={STROKE_HALO_OUTER}
+          vectorEffect="non-scaling-stroke"
+          style={{ strokeWidth: 5 }}
+        />
+        <polyline
+          points={points}
+          fill="none"
+          stroke={mark.ink}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          style={{ strokeWidth: 3 }}
+        />
+      </svg>
+    );
+  }
+
+  if (mark.shape !== "arrow") {
+    return null;
+  }
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      className="pointer-events-none absolute inset-0 h-full w-full"
+    >
+      <line
+        x1={mark.from.x * 100}
+        y1={mark.from.y * 100}
+        x2={mark.to.x * 100}
+        y2={mark.to.y * 100}
+        stroke={STROKE_HALO_OUTER}
+        vectorEffect="non-scaling-stroke"
+        style={{ strokeWidth: 5 }}
+      />
+      <line
+        x1={mark.from.x * 100}
+        y1={mark.from.y * 100}
+        x2={mark.to.x * 100}
+        y2={mark.to.y * 100}
+        stroke={mark.ink}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        style={{ strokeWidth: 3 }}
+      />
+      <circle
+        cx={mark.to.x * 100}
+        cy={mark.to.y * 100}
+        r={1.4}
+        fill={mark.ink}
+      />
+    </svg>
+  );
+}
+
+function boxedFill(
+  mark: Extract<ImageAnnotationMark, { shape: "box" | "highlight" | "redact" }>,
+) {
+  if (mark.shape === "redact") {
+    return { background: REDACT_FILL };
+  }
+  if (mark.shape === "highlight") {
+    return { background: HIGHLIGHT_FILL };
+  }
+  return {
+    border: `2.5px solid ${mark.ink}`,
+    background: `${mark.ink}1A`,
+    boxShadow: `0 0 0 1px ${STROKE_HALO_OUTER}, inset 0 0 0 1px ${STROKE_HALO_INNER}`,
+  };
+}
+
+export function MarkShape({
+  mark,
+  ordinal,
+  selected = false,
+  onSelect,
+}: {
+  mark: ImageAnnotationMark;
+  ordinal: number;
+  selected?: boolean;
+  onSelect?: () => void;
+}) {
+  const ring = selected
+    ? { outline: `2px solid ${markInk(mark)}`, outlineOffset: "3px" }
+    : {};
+  // Without a handler the mark is decoration, so it must not eat pointer events
+  // from the surface underneath — that surface is where new marks get drawn.
+  const interaction = onSelect
+    ? {
+        onClick: onSelect,
+        className: "absolute cursor-pointer",
+        "data-testid": `annotation-mark-${ordinal}`,
+      }
+    : { className: "pointer-events-none absolute" };
+
+  if (mark.shape === "pen" || mark.shape === "arrow") {
+    return <StrokeMark mark={mark} />;
+  }
+
+  if (mark.shape === "text") {
+    return (
+      <span
+        {...interaction}
+        style={{
+          left: percent(mark.at.x),
+          top: percent(mark.at.y),
+          color: mark.ink,
+          textShadow: `0 0 3px ${STROKE_HALO_INNER}, 0 0 3px ${STROKE_HALO_INNER}`,
+          ...ring,
+        }}
+      >
+        <span className="whitespace-pre text-sm font-bold">{mark.text}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      {...interaction}
+      style={{
+        left: percent(mark.rect.x),
+        top: percent(mark.rect.y),
+        width: percent(mark.rect.width),
+        height: percent(mark.rect.height),
+        borderRadius: mark.shape === "box" ? 4 : 3,
+        ...boxedFill(mark),
+        ...ring,
+      }}
+    >
+      {mark.shape === "box" && (
+        <span
+          style={{ background: mark.ink }}
+          className="absolute -left-[11px] -top-[11px] flex h-[22px] w-[22px] items-center justify-center rounded-full border-[1.5px] border-on-filled text-[11px] font-bold text-on-filled"
+        >
+          {ordinal}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The read-only layer. Sits inside whatever element carries the image so the
+ * normalized geometry lands on the same box the marks were drawn against.
+ */
+export function AnnotationMarkLayer({
+  annotation,
+}: {
+  annotation: ImageAnnotation;
+}) {
+  return (
+    <span
+      className="pointer-events-none absolute inset-0"
+      data-testid="annotation-mark-layer"
+    >
+      {annotation.marks.map((mark, index) => {
+        return <MarkShape key={mark.id} mark={mark} ordinal={index + 1} />;
+      })}
+    </span>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/okou-page/zoomable-image-canvas.tsx
@@ -102,6 +102,11 @@ export type ZoomableImageControls = {
 
 type ZoomableArtifactImageCanvasProps = {
   alt: string;
+  /**
+   * Drawn over the image *inside* the zoom transform, so an overlay stays
+   * registered with the pixels it describes at every zoom level.
+   */
+  overlay?: ReactNode;
   canvasTestId?: string;
   children?: (controls: ZoomableImageControls) => ReactNode;
   className?: string;
@@ -277,10 +282,72 @@ function ZoomableArtifactImageElement({
   );
 }
 
+function ZoomableArtifactImageFrame({
+  element,
+  overlay,
+}: {
+  element: ZoomableArtifactImageElementProps;
+  overlay?: ReactNode;
+}) {
+  return (
+    <div className="relative shrink-0">
+      <ZoomableArtifactImageElement {...element} />
+      {overlay}
+    </div>
+  );
+}
+
+function ZoomableArtifactImageViewport({
+  canvasTestId,
+  contentClassName,
+  element,
+  instance,
+  overlay,
+}: {
+  canvasTestId: string;
+  contentClassName?: string;
+  element: ZoomableArtifactImageElementProps;
+  instance: ReactZoomPanPinchContext;
+  overlay?: ReactNode;
+}) {
+  return (
+    <div
+      className="h-full min-h-0 w-full cursor-grab overscroll-contain active:cursor-grabbing"
+      data-testid={canvasTestId}
+      data-zoomable-image-canvas="true"
+      style={{ touchAction: "none" }}
+    >
+      <TransformComponent
+        contentStyle={{ height: "100%", width: "100%" }}
+        wrapperClass="h-full min-h-0 w-full"
+        wrapperProps={{
+          onWheelCapture: proportionalImageWheelHandler(instance),
+        }}
+        wrapperStyle={{
+          height: "100%",
+          touchAction: "none",
+          width: "100%",
+        }}
+      >
+        <div
+          className={cn(
+            "flex h-full w-full items-center justify-center",
+            contentClassName,
+          )}
+          data-testid={`${canvasTestId}-content`}
+        >
+          <ZoomableArtifactImageFrame element={element} overlay={overlay} />
+        </div>
+      </TransformComponent>
+    </div>
+  );
+}
+
 export function ZoomableArtifactImageCanvas({
   alt,
   canvasTestId = "zoomable-image-canvas",
   children,
+  overlay,
   className,
   contentClassName,
   imageClassName,
@@ -362,44 +429,22 @@ export function ZoomableArtifactImageCanvas({
             )}
           >
             {children?.(controls)}
-            <div
-              className="h-full min-h-0 w-full cursor-grab overscroll-contain active:cursor-grabbing"
-              data-testid={canvasTestId}
-              data-zoomable-image-canvas="true"
-              style={{ touchAction: "none" }}
-            >
-              <TransformComponent
-                contentStyle={{ height: "100%", width: "100%" }}
-                wrapperClass="h-full min-h-0 w-full"
-                wrapperProps={{
-                  onWheelCapture: proportionalImageWheelHandler(instance),
-                }}
-                wrapperStyle={{
-                  height: "100%",
-                  touchAction: "none",
-                  width: "100%",
-                }}
-              >
-                <div
-                  className={cn(
-                    "flex h-full w-full items-center justify-center",
-                    contentClassName,
-                  )}
-                  data-testid={`${canvasTestId}-content`}
-                >
-                  <ZoomableArtifactImageElement
-                    alt={alt}
-                    imageClassName={imageClassName}
-                    imageRef={imageRef}
-                    imageTestId={imageTestId}
-                    imageWidth={imageWidth}
-                    onError={onError}
-                    onLoad={handleImageLoad}
-                    src={src}
-                  />
-                </div>
-              </TransformComponent>
-            </div>
+            <ZoomableArtifactImageViewport
+              canvasTestId={canvasTestId}
+              contentClassName={contentClassName}
+              element={{
+                alt,
+                imageClassName,
+                imageRef,
+                imageTestId,
+                imageWidth,
+                onError,
+                onLoad: handleImageLoad,
+                src,
+              }}
+              instance={instance}
+              overlay={overlay}
+            />
           </div>
         );
       }}


### PR DESCRIPTION
Five items from dogfooding #28976 / #29173.

## 1. Marks were invisible in the read-only viewer

Reopening an annotated image showed a clean picture — the viewer drew the stored file, and only the editor drew the marks, from a second implementation. Both surfaces now share `image-annotation-marks.tsx`, and `ZoomableArtifactImageCanvas` takes an `overlay` slot rendered **inside** the zoom transform so marks stay registered with the pixels at every zoom level.

## 2. Nothing could be deleted

Selecting a mark opens its note anchored beside it; the note owns a delete button, and Delete/Backspace removes the selection unless a field has focus.

While testing this I found the popover sits inside the drawing surface (it has to, to be positioned against the mark) — so its own buttons were starting a stroke on the canvas underneath instead of clicking. It now stops its pointer events.

## 3. The modal flashed on open

The viewer animated out while the editor animated in. The viewer now closes instantly via `closeLightboxImmediately$`.

## 4. Design-system pass

- native `title` tooltips → the `Tooltip` component
- ink swatches were bare `<button>`s with no hover → `Button variant="quiet"`, so they carry the standard hover
- the note field → the `Input` component
- raw `rgba(20,23,29,.55)` / `rgba(0,0,0,0.30)` → `hsl(var(--overlay)/…)`
- hardcoded `border-white` / `text-white` on the numbered pin → `border-on-filled` / `text-on-filled`

## 5. The bottom note bar is gone

Text marks are typed where they sit. A field detached from the mark it describes never said which mark it meant, and text was being entered twice.

## Behaviour change worth flagging

The drawing tool now **stays selected** after a mark is drawn, so several boxes in a row do not need the tool re-picked. Only `text` hands over to select. A first pass switched to select after every mark and the existing test caught it.

## Verification

- `pnpm -F @okouai/app lint`, both `tsc` configs, `knip` — clean
- `i18next-cli extract --ci` — clean, new keys translated across all 10 locales
- `vitest`: `image-annotation` now 6 tests — two new ones cover exactly the reported bugs (marks drawn in the viewer; delete removes the mark), plus `attachment-chips` (48) as regression cover

Still not exercised outside tests: the flatten and the two-file send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)