### PR TITLE
refactor(api-contracts): centralize checkpoint webhook types

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -293,21 +293,10 @@ pub mod webhooks {
     pub mod agent {
         /// DTOs for creating recoverable agent checkpoints.
         pub mod checkpoints {
-            /// Reason a checkpoint intentionally omits resumable CLI agent session history.
-            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-            pub enum RequestCliAgentSessionHistoryDisposition {
-                /// The native history was oversized and had no safe bounded generation.
-                #[serde(rename = "discarded_oversized")]
-                DiscardedOversized,
-                /// The native history was missing, unsafe, ambiguous, or otherwise unusable.
-                #[serde(rename = "unavailable")]
-                Unavailable,
-            }
-
             /// Artifact version captured by an agent checkpoint.
             #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             #[serde(rename_all = "camelCase")]
-            pub struct RequestArtifactSnapshot {
+            pub struct ArtifactSnapshot {
                 /// User-facing artifact name referenced by the run.
                 pub name: String,
                 /// Artifact version selected for the checkpoint.
@@ -319,6 +308,17 @@ pub mod webhooks {
                 pub missing_root_policy: Option<
                     crate::generated::types::runners::storage::ArtifactEntryMissingRootPolicy,
                 >,
+            }
+
+            /// Reason a checkpoint intentionally omits resumable CLI agent session history.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestCliAgentSessionHistoryDisposition {
+                /// The native history was oversized and had no safe bounded generation.
+                #[serde(rename = "discarded_oversized")]
+                DiscardedOversized,
+                /// The native history was missing, unsafe, ambiguous, or otherwise unusable.
+                #[serde(rename = "unavailable")]
+                Unavailable,
             }
 
             /// Volume versions captured by an agent checkpoint.
@@ -348,10 +348,78 @@ pub mod webhooks {
                     Option<RequestCliAgentSessionHistoryDisposition>,
                 /// Optional artifact versions captured by the checkpoint.
                 #[serde(default, skip_serializing_if = "Option::is_none")]
-                pub artifact_snapshots: Option<Vec<RequestArtifactSnapshot>>,
+                pub artifact_snapshots: Option<Vec<ArtifactSnapshot>>,
                 /// Optional volume versions captured by the checkpoint.
                 #[serde(default, skip_serializing_if = "Option::is_none")]
                 pub volume_versions_snapshot: Option<RequestVolumeVersionsSnapshot>,
+            }
+
+            /// Response body returned after creating an agent checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct Response {
+                /// Created checkpoint identifier.
+                pub checkpoint_id: String,
+                /// Agent session associated with the checkpoint.
+                pub agent_session_id: String,
+                /// Conversation captured by the checkpoint.
+                pub conversation_id: String,
+                /// Optional artifact versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub artifacts: Option<Vec<ArtifactSnapshot>>,
+                /// Optional volume versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub volumes: Option<std::collections::BTreeMap<String, String>>,
+            }
+
+            /// DTOs for preparing direct session-history uploads.
+            pub mod prepare_history {
+                /// Request body for preparing a session-history upload.
+                #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                pub struct Request {
+                    /// Agent run identifier bound to the sandbox token.
+                    pub run_id: String,
+                    /// SHA-256 hash of the uncompressed session history.
+                    pub hash: String,
+                    /// Uncompressed session-history size in bytes.
+                    pub raw_size: u64,
+                    /// Encoded session-history size in bytes.
+                    pub encoded_size: u64,
+                    /// Optional encoding used for the uploaded bytes.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    pub encoding: Option<SessionHistoryEncoding>,
+                }
+
+                /// Response body returned when preparing session history.
+                #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                pub struct Response {
+                    /// Optional presigned URL for uploading new content.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    pub presigned_url: Option<String>,
+                    /// Whether the requested session history already exists.
+                    pub existing: bool,
+                    /// Optional encoding of the persisted session history.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    pub encoding: Option<SessionHistoryEncoding>,
+                }
+
+                /// Encoding used for persisted CLI agent session history.
+                #[derive(
+                    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+                )]
+                pub enum SessionHistoryEncoding {
+                    /// Uncompressed session history bytes.
+                    #[serde(rename = "identity")]
+                    Identity,
+                    /// Gzip-compressed session history bytes.
+                    #[serde(rename = "gzip")]
+                    Gzip,
+                    /// Zstandard-compressed session history bytes.
+                    #[serde(rename = "zstd")]
+                    Zstd,
+                }
             }
         }
 

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -10,7 +10,7 @@ use api_contracts::generated::types::{
         storage as runner_storage,
     },
     webhooks::agent::{
-        checkpoints,
+        checkpoints::{self, prepare_history},
         storages::{FileEntryWithHash, commit, prepare},
     },
 };
@@ -251,7 +251,7 @@ fn generated_checkpoint_request_round_trips_preserve_parent_snapshot() {
         cli_agent_session_id: "session-1".to_string(),
         cli_agent_session_history_hash: Some("b".repeat(64)),
         cli_agent_session_history_disposition: None,
-        artifact_snapshots: Some(vec![checkpoints::RequestArtifactSnapshot {
+        artifact_snapshots: Some(vec![checkpoints::ArtifactSnapshot {
             name: "memory".to_string(),
             version: "version-1".to_string(),
             mount_path: "/memory".to_string(),
@@ -331,6 +331,160 @@ fn generated_checkpoint_request_serializes_unavailable_history() {
             "cliAgentSessionHistoryDisposition": "unavailable",
         })
     );
+}
+
+#[test]
+fn generated_checkpoint_response_deserializes_canonical_shapes() {
+    let minimal: checkpoints::Response = serde_json::from_value(json!({
+        "checkpointId": "checkpoint-1",
+        "agentSessionId": "agent-session-1",
+        "conversationId": "conversation-1",
+    }))
+    .unwrap();
+    assert_eq!(minimal.checkpoint_id, "checkpoint-1");
+    assert_eq!(minimal.agent_session_id, "agent-session-1");
+    assert_eq!(minimal.conversation_id, "conversation-1");
+    assert!(minimal.artifacts.is_none());
+    assert!(minimal.volumes.is_none());
+
+    let full: checkpoints::Response = serde_json::from_value(json!({
+        "checkpointId": "checkpoint-2",
+        "agentSessionId": "agent-session-2",
+        "conversationId": "conversation-2",
+        "artifacts": [{
+            "name": "memory",
+            "version": "version-2",
+            "mountPath": "/memory",
+            "missingRootPolicy": "preserveParentVersion",
+        }],
+        "volumes": {
+            "workspace": "volume-version-2",
+        },
+    }))
+    .unwrap();
+    assert_eq!(
+        full.artifacts.unwrap(),
+        vec![checkpoints::ArtifactSnapshot {
+            name: "memory".to_string(),
+            version: "version-2".to_string(),
+            mount_path: "/memory".to_string(),
+            missing_root_policy: Some(
+                runner_storage::ArtifactEntryMissingRootPolicy::PreserveParentVersion,
+            ),
+        }]
+    );
+    assert_eq!(
+        full.volumes.unwrap(),
+        BTreeMap::from([("workspace".to_string(), "volume-version-2".to_string())])
+    );
+}
+
+#[test]
+fn generated_checkpoint_response_rejects_invalid_required_fields() {
+    for response in [
+        json!({
+            "checkpointId": "checkpoint-1",
+            "conversationId": "conversation-1",
+        }),
+        json!({
+            "checkpointId": "checkpoint-1",
+            "agentSessionId": false,
+            "conversationId": "conversation-1",
+        }),
+    ] {
+        assert!(serde_json::from_value::<checkpoints::Response>(response).is_err());
+    }
+}
+
+#[test]
+fn generated_checkpoint_prepare_request_serializes_wire_shape() {
+    let request = prepare_history::Request {
+        run_id: "run-1".to_string(),
+        hash: "a".repeat(64),
+        raw_size: 4096,
+        encoded_size: 1024,
+        encoding: Some(prepare_history::SessionHistoryEncoding::Zstd),
+    };
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({
+            "runId": "run-1",
+            "hash": "a".repeat(64),
+            "rawSize": 4096,
+            "encodedSize": 1024,
+            "encoding": "zstd",
+        })
+    );
+
+    let request_without_encoding = prepare_history::Request {
+        run_id: "run-2".to_string(),
+        hash: "b".repeat(64),
+        raw_size: 64,
+        encoded_size: 64,
+        encoding: None,
+    };
+    let value = serde_json::to_value(request_without_encoding).unwrap();
+    assert!(value.get("encoding").is_none());
+}
+
+#[test]
+fn generated_checkpoint_prepare_encoding_serializes_wire_values() {
+    for (encoding, wire_value) in [
+        (
+            prepare_history::SessionHistoryEncoding::Identity,
+            "identity",
+        ),
+        (prepare_history::SessionHistoryEncoding::Gzip, "gzip"),
+        (prepare_history::SessionHistoryEncoding::Zstd, "zstd"),
+    ] {
+        assert_eq!(serde_json::to_value(encoding).unwrap(), json!(wire_value));
+        assert_eq!(
+            serde_json::from_value::<prepare_history::SessionHistoryEncoding>(json!(wire_value))
+                .unwrap(),
+            encoding
+        );
+    }
+}
+
+#[test]
+fn generated_checkpoint_prepare_response_deserializes_canonical_shapes() {
+    let existing: prepare_history::Response = serde_json::from_value(json!({
+        "existing": true,
+        "encoding": "gzip",
+    }))
+    .unwrap();
+    assert!(existing.existing);
+    assert!(existing.presigned_url.is_none());
+    assert_eq!(
+        existing.encoding,
+        Some(prepare_history::SessionHistoryEncoding::Gzip)
+    );
+
+    let upload: prepare_history::Response = serde_json::from_value(json!({
+        "presignedUrl": "https://storage.example.test/session-history",
+        "existing": false,
+        "encoding": "zstd",
+    }))
+    .unwrap();
+    assert!(!upload.existing);
+    assert_eq!(
+        upload.presigned_url.as_deref(),
+        Some("https://storage.example.test/session-history")
+    );
+    assert_eq!(
+        upload.encoding,
+        Some(prepare_history::SessionHistoryEncoding::Zstd)
+    );
+}
+
+#[test]
+fn generated_checkpoint_prepare_response_rejects_invalid_existing() {
+    for response in [
+        json!({"presignedUrl": "https://storage.example.test/session-history"}),
+        json!({"existing": "false"}),
+    ] {
+        assert!(serde_json::from_value::<prepare_history::Response>(response).is_err());
+    }
 }
 
 #[test]

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -22,8 +22,8 @@ fn build_artifact_snapshot_entry(
     version: &str,
     mount_path: &str,
     missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
-) -> checkpoints::RequestArtifactSnapshot {
-    checkpoints::RequestArtifactSnapshot {
+) -> checkpoints::ArtifactSnapshot {
+    checkpoints::ArtifactSnapshot {
         name: name.to_string(),
         version: version.to_string(),
         mount_path: mount_path.to_string(),
@@ -70,7 +70,7 @@ async fn snapshot_artifact_plan(
     http: &HttpClient,
     run_id: &str,
     plan: ArtifactSnapshotPlan<'_>,
-) -> Result<checkpoints::RequestArtifactSnapshot, AgentError> {
+) -> Result<checkpoints::ArtifactSnapshot, AgentError> {
     let (entry, files) = match plan {
         ArtifactSnapshotPlan::Snapshot { entry, files } => (entry, files),
         ArtifactSnapshotPlan::PreserveParentVersion { entry } => {
@@ -166,7 +166,7 @@ pub(super) async fn snapshot_artifact_entries(
     http: &HttpClient,
     run_id: &str,
     entries: &[env::ArtifactEnv],
-) -> Result<Option<Vec<checkpoints::RequestArtifactSnapshot>>, AgentError> {
+) -> Result<Option<Vec<checkpoints::ArtifactSnapshot>>, AgentError> {
     if entries.is_empty() {
         log_info!(
             LOG_TAG,

--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -265,12 +265,12 @@ async fn create_checkpoint_impl(
             "Invalid checkpoint API response",
         )
     })?;
-    let response = serde_json::from_value::<checkpoints::Response>(response).map_err(|error| {
+    let response = serde_json::from_value::<checkpoints::Response>(response).map_err(|_| {
         fail(
             mode,
             "checkpoint_api_call",
             api_start,
-            format!("Invalid checkpoint API response: {error}"),
+            "Invalid checkpoint API response",
         )
     })?;
 

--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -257,39 +257,44 @@ async fn create_checkpoint_impl(
         }
     };
 
-    // Validate response
-    let checkpoint_id = result
-        .as_ref()
-        .and_then(|v| v.get("checkpointId"))
-        .and_then(|v| v.as_str());
-
-    if let Some(id) = checkpoint_id {
-        if let Some(uploaded_history) = uploaded_history
-            && session_history::reconcile_live_history_after_checkpoint(
-                uploaded_history.live_history,
-            )
-        {
-            session_history::write_final_session_history_identity(
-                mode,
-                &uploaded_history.cli_agent_session_id,
-                &uploaded_history.history_hash,
-                uploaded_history.history_size,
-                &uploaded_history.history_source,
-                inputs.framework,
-                inputs.final_session_history_identity_file.as_ref(),
-            );
-        }
-        log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
-        record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
-        Ok(())
-    } else {
-        Err(fail(
+    let response = result.ok_or_else(|| {
+        fail(
             mode,
             "checkpoint_api_call",
             api_start,
             "Invalid checkpoint API response",
-        ))
+        )
+    })?;
+    let response = serde_json::from_value::<checkpoints::Response>(response).map_err(|error| {
+        fail(
+            mode,
+            "checkpoint_api_call",
+            api_start,
+            format!("Invalid checkpoint API response: {error}"),
+        )
+    })?;
+
+    if let Some(uploaded_history) = uploaded_history
+        && session_history::reconcile_live_history_after_checkpoint(uploaded_history.live_history)
+    {
+        session_history::write_final_session_history_identity(
+            mode,
+            &uploaded_history.cli_agent_session_id,
+            &uploaded_history.history_hash,
+            uploaded_history.history_size,
+            &uploaded_history.history_source,
+            inputs.framework,
+            inputs.final_session_history_identity_file.as_ref(),
+        );
     }
+    log_info!(
+        LOG_TAG,
+        "{} created successfully: {}",
+        mode.log_label(),
+        response.checkpoint_id
+    );
+    record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -372,7 +377,7 @@ mod tests {
         let checkpoint = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/checkpoints");
             then.status(200)
-                .json_body(json!({"checkpointId": "unreachable"}));
+                .json_body(json!({"checkpointId": "unreachable", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
         });
         let http = HttpClient::with_api_config(
             server.base_url(),
@@ -454,6 +459,7 @@ mod tests {
                 }));
             then.status(200).json_body(json!({
                 "presignedUrl": upload_url,
+                "existing": false,
                 "encoding": SESSION_HISTORY_ENCODING_ZSTD,
             }));
         });
@@ -472,7 +478,7 @@ mod tests {
                     "cliAgentSessionHistoryHash": history_hash,
                 }));
             then.status(200)
-                .json_body(json!({"checkpointId": "checkpoint-codex-zstd"}));
+                .json_body(json!({"checkpointId": "checkpoint-codex-zstd", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
         });
         let http = HttpClient::with_api_config(
             server.base_url(),

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -463,15 +463,15 @@ async fn upload_session_history(
                 record_sandbox_op("session_history_prepare", prep_start.elapsed(), true, None);
                 response
             }
-            Err(error) => {
-                let message = format!("Invalid prepare-history response: {error}");
+            Err(_) => {
+                let message = "Invalid prepare-history response";
                 record_sandbox_op(
                     "session_history_prepare",
                     prep_start.elapsed(),
                     false,
-                    Some(&message),
+                    Some(message),
                 );
-                return Err(AgentError::Checkpoint(message));
+                return Err(AgentError::Checkpoint(message.into()));
             }
         },
         Ok(None) => {

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -14,6 +14,7 @@ use api_contracts::generated::constants::runners::{
     SESSION_HISTORY_ENCODING_IDENTITY, SESSION_HISTORY_ENCODING_ZSTD,
     SESSION_HISTORY_GZIP_MIN_BYTES,
 };
+use api_contracts::generated::types::webhooks::agent::checkpoints::prepare_history;
 use bytes::Bytes;
 use guest_common::telemetry::{
     SandboxOpDimensions, record_sandbox_op, record_sandbox_op_with_dimensions,
@@ -27,7 +28,6 @@ use guest_session_prune::{
     select_claude_compact_generation_from_file_with_candidate_limit_for_test,
     select_codex_compact_generation, select_codex_compact_generation_with_candidate_limit_for_test,
 };
-use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::time::Duration;
@@ -254,10 +254,12 @@ struct DecodedSessionHistoryAnalysis {
 }
 
 impl SessionHistoryUpload {
-    fn requested_encoding(&self) -> &'static str {
+    fn requested_encoding(&self) -> prepare_history::SessionHistoryEncoding {
         match self.body {
-            SessionHistoryUploadBody::Identity(_) => SESSION_HISTORY_ENCODING_IDENTITY,
-            SessionHistoryUploadBody::Zstd(_) => SESSION_HISTORY_ENCODING_ZSTD,
+            SessionHistoryUploadBody::Identity(_) => {
+                prepare_history::SessionHistoryEncoding::Identity
+            }
+            SessionHistoryUploadBody::Zstd(_) => prepare_history::SessionHistoryEncoding::Zstd,
         }
     }
 
@@ -273,6 +275,16 @@ impl SessionHistoryUpload {
             SessionHistoryUploadBody::Identity(raw) => Bytes::from(raw),
             SessionHistoryUploadBody::Zstd(zstd) => Bytes::from(zstd),
         }
+    }
+}
+
+const fn session_history_encoding_label(
+    encoding: prepare_history::SessionHistoryEncoding,
+) -> &'static str {
+    match encoding {
+        prepare_history::SessionHistoryEncoding::Identity => SESSION_HISTORY_ENCODING_IDENTITY,
+        prepare_history::SessionHistoryEncoding::Gzip => SESSION_HISTORY_ENCODING_GZIP,
+        prepare_history::SessionHistoryEncoding::Zstd => SESSION_HISTORY_ENCODING_ZSTD,
     }
 }
 
@@ -433,25 +445,35 @@ async fn upload_session_history(
     let prep_start = std::time::Instant::now();
     let url = http.checkpoint_prepare_history_url()?;
     let requested_encoding = history_upload.requested_encoding();
+    let requested_encoding_label = session_history_encoding_label(requested_encoding);
     let encoded_size = history_upload.encoded_size();
+    let request = prepare_history::Request {
+        run_id: run_id.to_string(),
+        hash: history_hash.to_string(),
+        raw_size: history_upload.raw_size,
+        encoded_size,
+        encoding: Some(requested_encoding),
+    };
     let prep_resp = match http
-        .post_json(
-            url,
-            &json!({
-                "runId": run_id,
-                "hash": history_hash,
-                "rawSize": history_upload.raw_size,
-                "encodedSize": encoded_size,
-                "encoding": requested_encoding,
-            }),
-            constants::HTTP_MAX_ATTEMPTS,
-        )
+        .post_json(url, &request, constants::HTTP_MAX_ATTEMPTS)
         .await
     {
-        Ok(Some(v)) => {
-            record_sandbox_op("session_history_prepare", prep_start.elapsed(), true, None);
-            v
-        }
+        Ok(Some(value)) => match serde_json::from_value::<prepare_history::Response>(value) {
+            Ok(response) => {
+                record_sandbox_op("session_history_prepare", prep_start.elapsed(), true, None);
+                response
+            }
+            Err(error) => {
+                let message = format!("Invalid prepare-history response: {error}");
+                record_sandbox_op(
+                    "session_history_prepare",
+                    prep_start.elapsed(),
+                    false,
+                    Some(&message),
+                );
+                return Err(AgentError::Checkpoint(message));
+            }
+        },
         Ok(None) => {
             record_sandbox_op("session_history_prepare", prep_start.elapsed(), false, None);
             return Err(AgentError::Checkpoint(
@@ -464,20 +486,21 @@ async fn upload_session_history(
         }
     };
 
-    let existing = prep_resp
-        .get("existing")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let response_encoding = prep_resp.get("encoding").and_then(|v| v.as_str());
+    let existing = prep_resp.existing;
+    let response_encoding = prep_resp.encoding;
     // Existing content-addressed blobs retain their persisted encoding; no upload occurs.
     let zstd_response_encoding_is_compatible = response_encoding
-        == Some(SESSION_HISTORY_ENCODING_ZSTD)
+        == Some(prepare_history::SessionHistoryEncoding::Zstd)
         || (existing
             && matches!(
                 response_encoding,
-                Some(SESSION_HISTORY_ENCODING_IDENTITY | SESSION_HISTORY_ENCODING_GZIP)
+                Some(
+                    prepare_history::SessionHistoryEncoding::Identity
+                        | prepare_history::SessionHistoryEncoding::Gzip
+                )
             ));
-    if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD && !zstd_response_encoding_is_compatible
+    if requested_encoding == prepare_history::SessionHistoryEncoding::Zstd
+        && !zstd_response_encoding_is_compatible
     {
         return Err(AgentError::Checkpoint(
             "Prepare-history response did not acknowledge zstd session history".into(),
@@ -485,7 +508,9 @@ async fn upload_session_history(
     }
 
     if existing {
-        let accepted_encoding = response_encoding.unwrap_or(SESSION_HISTORY_ENCODING_IDENTITY);
+        let accepted_encoding = session_history_encoding_label(
+            response_encoding.unwrap_or(prepare_history::SessionHistoryEncoding::Identity),
+        );
         log_info!(
             LOG_TAG,
             "Session history already exists in S3 (deduplicated, encoding={accepted_encoding})"
@@ -493,22 +518,19 @@ async fn upload_session_history(
         return Ok(());
     }
 
-    let presigned_url = prep_resp
-        .get("presignedUrl")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            AgentError::Checkpoint("No presignedUrl in prepare-history response".into())
-        })?;
+    let presigned_url = prep_resp.presigned_url.ok_or_else(|| {
+        AgentError::Checkpoint("No presignedUrl in prepare-history response".into())
+    })?;
 
     let upload_bytes = history_upload.into_bytes();
 
     log_info!(
         LOG_TAG,
-        "Uploading session history to S3 (encoding={requested_encoding})..."
+        "Uploading session history to S3 (encoding={requested_encoding_label})..."
     );
     let upload_start = std::time::Instant::now();
     if let Err(e) = http
-        .put_presigned(presigned_url, upload_bytes, "application/octet-stream")
+        .put_presigned(&presigned_url, upload_bytes, "application/octet-stream")
         .await
     {
         record_sandbox_op(

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1771,7 +1771,7 @@ mod tests {
                 .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
             then.status(200)
                 .header("Content-Type", "application/json")
-                .json_body(json!({"checkpointId": "historyless-checkpoint"}));
+                .json_body(json!({"checkpointId": "historyless-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
         });
         let complete_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/complete");
@@ -1876,7 +1876,7 @@ mod tests {
                 .json_body_includes(r#"{"cliAgentSessionId":"recovery-session-from-main"}"#);
             then.status(200)
                 .header("Content-Type", "application/json")
-                .json_body(json!({"checkpointId": "checkpoint-from-main"}));
+                .json_body(json!({"checkpointId": "checkpoint-from-main", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
         });
         let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -181,7 +181,7 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
             });
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact"}));
+            .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime, &session_metadata).await?;

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -225,7 +225,7 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
             .json_body_includes(format!(r#"{{"cliAgentSessionId":"{thread_id}"}}"#));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "codex-derived-checkpoint"}));
+            .json_body(json!({"checkpointId": "codex-derived-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let config = fixture.config(&server.base_url(), "test-token")?;

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -129,7 +129,7 @@ async fn run_event_failure_case(
             .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "event-delivery-recovery-checkpoint"}));
+            .json_body(json!({"checkpointId": "event-delivery-recovery-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let output = common::command_output_with_timeout(

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -75,7 +75,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "execution-timeout-recovery-checkpoint"}));
+            .json_body(json!({"checkpointId": "execution-timeout-recovery-checkpoint", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let output = common::command_output_with_timeout(

--- a/crates/guest-agent/tests/integration/checkpoint/recovery.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/recovery.rs
@@ -39,7 +39,7 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
             .json_body_includes(r#"{"cliAgentSessionId":"recovery-session"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-recovery"}));
+            .json_body(json!({"checkpointId": "checkpoint-recovery", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
@@ -81,7 +81,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_claude_history() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-claude-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-invalid-claude-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_recovery_checkpoint(&runtime).await.unwrap();
@@ -115,7 +115,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-codex-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-invalid-codex-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_recovery_checkpoint(&runtime).await.unwrap();
@@ -180,7 +180,7 @@ async fn assert_recovery_checkpoint_ignores_legacy_history_marker(
             .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-derived-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-derived-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
@@ -233,7 +233,7 @@ async fn recovery_checkpoint_continues_without_partial_jsonl_history() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-partial-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-partial-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
@@ -276,7 +276,7 @@ async fn recovery_checkpoint_continues_without_non_utf8_session_history() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-non-utf8-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-non-utf8-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
@@ -351,7 +351,7 @@ async fn recovery_checkpoint_continues_when_derived_history_is_missing() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-missing-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-missing-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(
@@ -389,7 +389,7 @@ async fn recovery_checkpoint_continues_without_invalid_history_source() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-history-source"}));
+            .json_body(json!({"checkpointId": "checkpoint-invalid-history-source", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -76,7 +76,7 @@ async fn success_checkpoint_preserves_small_codex_history() {
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-unpruned-codex"}));
+            .json_body(json!({"checkpointId": "checkpoint-unpruned-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -96,6 +96,60 @@ async fn success_checkpoint_preserves_small_codex_history() {
         true,
     )
     .unwrap();
+}
+
+#[tokio::test]
+async fn checkpoint_rejects_prepare_response_without_existing_before_upload() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "abababab-abab-4bab-8bab-abababababab";
+    let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
+    std::fs::write(&history_path, &history).unwrap();
+    use_test_codex_home(&mut runtime, history_dir.path());
+
+    let upload_path = "/test/invalid-prepare-history-upload";
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url(upload_path),
+                "encoding": "identity",
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT).path(upload_path);
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200).json_body(json!({
+            "checkpointId": "unreachable",
+            "agentSessionId": "test-agent-session",
+            "conversationId": "test-conversation",
+        }));
+    });
+
+    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(
+        &runtime,
+        &checkpoint_session_metadata(&runtime),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid prepare-history response")
+    );
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
 }
 
 #[tokio::test]
@@ -129,7 +183,7 @@ async fn success_checkpoint_discards_oversized_claude_history_without_compact_bo
                 && body["cliAgentSessionHistoryDisposition"] == "discarded_oversized"
                 && body.get("cliAgentSessionHistoryHash").is_none()
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-discarded-claude"}))
+                json_http_response(200, json!({"checkpointId": "checkpoint-discarded-claude", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
             } else {
                 http_status(400)
             }
@@ -177,7 +231,7 @@ async fn success_checkpoint_discards_codex_history_that_jumps_past_hard_limit() 
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-discarded-codex"}));
+            .json_body(json!({"checkpointId": "checkpoint-discarded-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
@@ -223,7 +277,7 @@ async fn success_checkpoint_discards_codex_history_with_oversized_canonical_cand
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-discarded-candidate"}));
+            .json_body(json!({"checkpointId": "checkpoint-discarded-candidate", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
@@ -257,7 +311,7 @@ async fn checkpoint_continues_when_codex_history_is_missing() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-history-unavailable"}));
+            .json_body(json!({"checkpointId": "checkpoint-history-unavailable", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
@@ -269,6 +323,39 @@ async fn checkpoint_continues_when_codex_history_is_missing() {
         operation["action_type"] == "session_history_read" && operation["success"] == false
     }));
     assert!(!operations.contains("\"action_type\":\"session_history_prune\""));
+}
+
+#[tokio::test]
+async fn checkpoint_rejects_create_response_missing_required_identity() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "acacacac-acac-4cac-8cac-acacacacacac";
+    let home = tempfile::tempdir().unwrap();
+    use_test_codex_home(&mut runtime, home.path());
+    guest_agent::paths::write_private(session_id_file(), session_id).unwrap();
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "checkpointId": "checkpoint-invalid-response",
+                "conversationId": "test-conversation",
+            }));
+    });
+
+    let error = create_bounded_checkpoint(&runtime).await.unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid checkpoint API response")
+    );
+    checkpoint_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test]
@@ -289,7 +376,7 @@ async fn success_checkpoint_reports_invalid_local_history_as_unavailable() {
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-local-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-invalid-local-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let cases: [(&str, &[u8]); 2] = [
@@ -348,7 +435,7 @@ async fn success_checkpoint_reports_invalid_reused_zstd_history_as_unavailable()
             .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"unavailable"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-invalid-zstd-history"}));
+            .json_body(json!({"checkpointId": "checkpoint-invalid-zstd-history", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     create_bounded_checkpoint(&runtime).await.unwrap();
@@ -417,7 +504,7 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
             if std::fs::metadata(&checkpoint_history_path)
                 .is_ok_and(|metadata| metadata.len() == source_size)
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-claude"}))
+                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-claude", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
             } else {
                 http_status(500)
             }
@@ -509,7 +596,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
             if std::fs::metadata(&checkpoint_history_path)
                 .is_ok_and(|metadata| metadata.len() == source_size)
             {
-                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-codex"}))
+                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-codex", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}))
             } else {
                 http_status(500)
             }
@@ -582,7 +669,7 @@ async fn success_checkpoint_omits_identity_when_live_history_replacement_fails()
             .unwrap();
             json_http_response(
                 200,
-                json!({"checkpointId": "checkpoint-pruned-unreconciled"}),
+                json!({"checkpointId": "checkpoint-pruned-unreconciled", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}),
             )
         });
     });
@@ -689,7 +776,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata()
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-success-large"}));
+            .json_body(json!({"checkpointId": "checkpoint-success-large", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -764,7 +851,7 @@ async fn success_checkpoint_propagates_zstd_prepare_bad_request()
         when.method(POST).path("/api/webhooks/agent/checkpoints");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected"}));
+            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -823,7 +910,7 @@ async fn success_checkpoint_rejects_missing_zstd_encoding_acknowledgement()
         when.method(POST).path("/api/webhooks/agent/checkpoints");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected"}));
+            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -885,7 +972,7 @@ async fn success_checkpoint_rejects_new_zstd_with_mismatched_encoding_acknowledg
         when.method(POST).path("/api/webhooks/agent/checkpoints");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected"}));
+            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -950,7 +1037,7 @@ async fn success_checkpoint_accepts_existing_gzip_for_zstd_history()
             ));
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-existing-gzip"}));
+            .json_body(json!({"checkpointId": "checkpoint-existing-gzip", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -1005,7 +1092,7 @@ async fn success_checkpoint_propagates_zstd_auth_failure() -> Result<(), Box<dyn
         when.method(POST).path("/api/webhooks/agent/checkpoints");
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "unexpected"}));
+            .json_body(json!({"checkpointId": "unexpected", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(
@@ -1111,7 +1198,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
             .json_body_includes(r#"{"cliAgentSessionId":"captured-session"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "checkpoint-explicit-runtime"}));
+            .json_body(json!({"checkpointId": "checkpoint-explicit-runtime", "agentSessionId": "test-agent-session", "conversationId": "test-conversation"}));
     });
 
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -99,7 +99,7 @@ async fn success_checkpoint_preserves_small_codex_history() {
 }
 
 #[tokio::test]
-async fn checkpoint_rejects_prepare_response_without_existing_before_upload() {
+async fn checkpoint_rejects_mistyped_prepare_response_before_upload() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -112,6 +112,7 @@ async fn checkpoint_rejects_prepare_response_without_existing_before_upload() {
     use_test_codex_home(&mut runtime, history_dir.path());
 
     let upload_path = "/test/invalid-prepare-history-upload";
+    let sensitive_response_value = "sensitive-prepare-response-value";
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints/prepare-history");
@@ -119,6 +120,7 @@ async fn checkpoint_rejects_prepare_response_without_existing_before_upload() {
             .header("Content-Type", "application/json")
             .json_body(json!({
                 "presignedUrl": server.url(upload_path),
+                "existing": sensitive_response_value,
                 "encoding": "identity",
             }));
     });
@@ -142,11 +144,9 @@ async fn checkpoint_rejects_prepare_response_without_existing_before_upload() {
     .await
     .unwrap_err();
 
-    assert!(
-        error
-            .to_string()
-            .contains("Invalid prepare-history response")
-    );
+    let message = error.to_string();
+    assert!(message.contains("Invalid prepare-history response"));
+    assert!(!message.contains(sensitive_response_value));
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -153,6 +153,59 @@ async fn checkpoint_rejects_mistyped_prepare_response_before_upload() {
 }
 
 #[tokio::test]
+async fn checkpoint_rejects_prepare_response_without_upload_url() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "adadadad-adad-4dad-8dad-adadadadadad";
+    let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
+    std::fs::write(&history_path, &history).unwrap();
+    use_test_codex_home(&mut runtime, history_dir.path());
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "existing": false,
+                "encoding": "identity",
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT);
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200).json_body(json!({
+            "checkpointId": "unreachable",
+            "agentSessionId": "test-agent-session",
+            "conversationId": "test-conversation",
+        }));
+    });
+
+    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(
+        &runtime,
+        &checkpoint_session_metadata(&runtime),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("No presignedUrl in prepare-history response")
+    );
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
 async fn success_checkpoint_discards_oversized_claude_history_without_compact_boundary() {
     let api = SharedApiMock::new().await;
     let server = api.server();
@@ -710,9 +763,7 @@ async fn success_checkpoint_keeps_live_history_when_compact_commit_fails() {
             .json_body_includes(format!(
                 r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
             ));
-        then.status(200)
-            .header("Content-Type", "application/json")
-            .json_body(json!({}));
+        then.status(200).header("Content-Type", "application/json");
     });
 
     let error = create_bounded_checkpoint(&runtime).await.unwrap_err();

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -127,7 +127,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             HttpMockResponse::builder()
                 .status(scenario.checkpoint_status)
                 .header("Content-Type", "application/json")
-                .body(r#"{"checkpointId":"user-cancellation-recovery-checkpoint"}"#)
+                .body(r#"{"checkpointId":"user-cancellation-recovery-checkpoint","agentSessionId":"test-agent-session","conversationId":"test-conversation"}"#)
                 .build()
         });
     });

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -14,11 +14,13 @@ import { modelProviderCodexRuntimeConfigSchema } from "../../contracts/model-pro
 import {
   piLaunchConfigSchema,
   piModelConfigSchema,
+  sessionHistoryEncodingSchema,
   storageMountEntrySchema,
 } from "../../contracts/runners";
 import { fileEntryWithHashSchema } from "../../contracts/storages";
 import {
   webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../../contracts/webhooks";
@@ -66,7 +68,32 @@ const expectedBindings = [
   },
   {
     rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "ArtifactSnapshot",
+    direction: "request",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
     rustTypeName: "Request",
+    direction: "request",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "Request",
+    direction: "request",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "SessionHistoryEncoding",
     direction: "request",
   },
   {
@@ -205,6 +232,7 @@ describe("Rust type bindings", () => {
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod webhooks {");
     expect(firstRender).toContain("pub mod checkpoints {");
+    expect(firstRender).toContain("pub mod prepare_history {");
     expect(firstRender).toContain("pub mod prepare {");
     expect(firstRender).toContain("pub struct FileEntryWithHash {");
     expect(firstRender).toContain(
@@ -264,9 +292,14 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain(
       "/// Request body for creating a recoverable agent checkpoint.",
     );
-    expect(firstRender).toContain("pub struct RequestArtifactSnapshot {");
+    expect(firstRender).toContain("pub struct ArtifactSnapshot {");
+    expect(firstRender).not.toContain("pub struct RequestArtifactSnapshot {");
+    expect(firstRender).not.toContain("pub struct ResponseArtifactsItem {");
     expect(firstRender).toContain(
-      "pub artifact_snapshots: Option<Vec<RequestArtifactSnapshot>>,",
+      "pub artifact_snapshots: Option<Vec<ArtifactSnapshot>>,",
+    );
+    expect(firstRender).toContain(
+      "pub artifacts: Option<Vec<ArtifactSnapshot>>,",
     );
     expect(firstRender).toMatch(
       /pub missing_root_policy: Option<\n\s+crate::generated::types::runners::storage::ArtifactEntryMissingRootPolicy,\n\s+>,/,
@@ -280,6 +313,12 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain(
       "pub versions: std::collections::BTreeMap<String, String>,",
     );
+    expect(firstRender).toContain("pub enum SessionHistoryEncoding {");
+    expect(firstRender).toContain(
+      "pub encoding: Option<SessionHistoryEncoding>,",
+    );
+    expect(firstRender).toContain("pub raw_size: u64,");
+    expect(firstRender).toContain("pub encoded_size: u64,");
     expect(firstRender.match(/pub archive_size: Option<u64>,/g)).toHaveLength(
       1,
     );
@@ -441,6 +480,85 @@ describe("Rust type bindings", () => {
     );
 
     expect(checkpointPolicySchema).toEqual(runnerPolicySchema);
+  });
+
+  it("reuses canonical checkpoint artifact and encoding schemas", () => {
+    const checkpointModule = "webhooks/agent/checkpoints";
+    const prepareHistoryModule = "webhooks/agent/checkpoints/prepare_history";
+    const artifactSchema =
+      webhookCheckpointsContract.create.body.shape.artifactSnapshots.unwrap()
+        .element;
+    const responseArtifactSchema =
+      webhookCheckpointsContract.create.responses[200].shape.artifacts.unwrap()
+        .element;
+    const requestEncodingSchema =
+      webhookCheckpointsPrepareHistoryContract.prepare.body.shape.encoding.unwrap();
+    const responseEncodingSchema =
+      webhookCheckpointsPrepareHistoryContract.prepare.responses[200].shape.encoding.unwrap();
+    const artifactBinding: RustTypeBinding | undefined = rustTypeBindings.find(
+      ({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === checkpointModule &&
+          rustTypeName === "ArtifactSnapshot"
+        );
+      },
+    );
+    const checkpointRequestBinding: RustTypeBinding | undefined =
+      rustTypeBindings.find(({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === checkpointModule &&
+          rustTypeName === "Request"
+        );
+      });
+    const checkpointResponseBinding: RustTypeBinding | undefined =
+      rustTypeBindings.find(({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === checkpointModule &&
+          rustTypeName === "Response"
+        );
+      });
+    const encodingBinding: RustTypeBinding | undefined = rustTypeBindings.find(
+      ({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === prepareHistoryModule &&
+          rustTypeName === "SessionHistoryEncoding"
+        );
+      },
+    );
+    const prepareRequestBinding: RustTypeBinding | undefined =
+      rustTypeBindings.find(({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === prepareHistoryModule &&
+          rustTypeName === "Request"
+        );
+      });
+    const prepareResponseBinding: RustTypeBinding | undefined =
+      rustTypeBindings.find(({ rustModulePath, rustTypeName }) => {
+        return (
+          rustModulePath.join("/") === prepareHistoryModule &&
+          rustTypeName === "Response"
+        );
+      });
+
+    expect(responseArtifactSchema).toBe(artifactSchema);
+    expect(artifactBinding?.schema).toBe(artifactSchema);
+    expect(checkpointRequestBinding?.fieldTypeOverrides).toEqual({
+      artifactSnapshots: "Vec<ArtifactSnapshot>",
+    });
+    expect(checkpointResponseBinding?.fieldTypeOverrides).toEqual({
+      artifacts: "Vec<ArtifactSnapshot>",
+    });
+    expect(requestEncodingSchema).toBe(sessionHistoryEncodingSchema);
+    expect(responseEncodingSchema).toBe(sessionHistoryEncodingSchema);
+    expect(encodingBinding?.schema).toBe(sessionHistoryEncodingSchema);
+    expect(prepareRequestBinding?.fieldTypeOverrides).toEqual({
+      rawSize: "u64",
+      encodedSize: "u64",
+      encoding: "SessionHistoryEncoding",
+    });
+    expect(prepareResponseBinding?.fieldTypeOverrides).toEqual({
+      encoding: "SessionHistoryEncoding",
+    });
   });
 
   it("renders common JSON schema shapes", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -7,11 +7,13 @@ import {
   piLaunchConfigSchema,
   piModelConfigSchema,
   runnersModelProviderFailuresContract,
+  sessionHistoryEncodingSchema,
   storageMountEntrySchema,
 } from "../contracts/runners";
 import { fileEntryWithHashSchema } from "../contracts/storages";
 import {
   webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../contracts/webhooks";
@@ -87,6 +89,10 @@ export const rustTypeModuleDocs = [
   {
     rustModulePath: ["webhooks", "agent", "checkpoints"],
     rustDoc: ["DTOs for creating recoverable agent checkpoints."],
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustDoc: ["DTOs for preparing direct session-history uploads."],
   },
   {
     rustModulePath: ["webhooks", "agent", "storages"],
@@ -371,9 +377,11 @@ export const rustTypeBindings = [
     ],
   },
   {
-    schema: webhookCheckpointsContract.create.body,
+    schema:
+      webhookCheckpointsContract.create.body.shape.artifactSnapshots.unwrap()
+        .element,
     rustModulePath: ["webhooks", "agent", "checkpoints"],
-    rustTypeName: "Request",
+    rustTypeName: "ArtifactSnapshot",
     direction: "request",
     fieldTypeOverrides: {
       missingRootPolicy:
@@ -381,7 +389,7 @@ export const rustTypeBindings = [
     },
     declarations: [
       {
-        rustTypeName: "RequestArtifactSnapshot",
+        rustTypeName: "ArtifactSnapshot",
         rustDoc: ["Artifact version captured by an agent checkpoint."],
         fields: {
           name: ["User-facing artifact name referenced by the run."],
@@ -392,6 +400,17 @@ export const rustTypeBindings = [
           ],
         },
       },
+    ],
+  },
+  {
+    schema: webhookCheckpointsContract.create.body,
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "Request",
+    direction: "request",
+    fieldTypeOverrides: {
+      artifactSnapshots: "Vec<ArtifactSnapshot>",
+    },
+    declarations: [
       {
         rustTypeName: "RequestVolumeVersionsSnapshot",
         rustDoc: ["Volume versions captured by an agent checkpoint."],
@@ -434,6 +453,89 @@ export const rustTypeBindings = [
           volumeVersionsSnapshot: [
             "Optional volume versions captured by the checkpoint.",
           ],
+        },
+      },
+    ],
+  },
+  {
+    schema: webhookCheckpointsContract.create.responses[200],
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "Response",
+    direction: "response",
+    fieldTypeOverrides: {
+      artifacts: "Vec<ArtifactSnapshot>",
+    },
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["Response body returned after creating an agent checkpoint."],
+        fields: {
+          checkpointId: ["Created checkpoint identifier."],
+          agentSessionId: ["Agent session associated with the checkpoint."],
+          conversationId: ["Conversation captured by the checkpoint."],
+          artifacts: ["Optional artifact versions captured by the checkpoint."],
+          volumes: ["Optional volume versions captured by the checkpoint."],
+        },
+      },
+    ],
+  },
+  {
+    schema: sessionHistoryEncodingSchema,
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "SessionHistoryEncoding",
+    direction: "request",
+    declarations: [
+      {
+        rustTypeName: "SessionHistoryEncoding",
+        rustDoc: ["Encoding used for persisted CLI agent session history."],
+        variants: {
+          identity: ["Uncompressed session history bytes."],
+          gzip: ["Gzip-compressed session history bytes."],
+          zstd: ["Zstandard-compressed session history bytes."],
+        },
+      },
+    ],
+  },
+  {
+    schema: webhookCheckpointsPrepareHistoryContract.prepare.body,
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "Request",
+    direction: "request",
+    fieldTypeOverrides: {
+      rawSize: "u64",
+      encodedSize: "u64",
+      encoding: "SessionHistoryEncoding",
+    },
+    declarations: [
+      {
+        rustTypeName: "Request",
+        rustDoc: ["Request body for preparing a session-history upload."],
+        fields: {
+          runId: ["Agent run identifier bound to the sandbox token."],
+          hash: ["SHA-256 hash of the uncompressed session history."],
+          rawSize: ["Uncompressed session-history size in bytes."],
+          encodedSize: ["Encoded session-history size in bytes."],
+          encoding: ["Optional encoding used for the uploaded bytes."],
+        },
+      },
+    ],
+  },
+  {
+    schema: webhookCheckpointsPrepareHistoryContract.prepare.responses[200],
+    rustModulePath: ["webhooks", "agent", "checkpoints", "prepare_history"],
+    rustTypeName: "Response",
+    direction: "response",
+    fieldTypeOverrides: {
+      encoding: "SessionHistoryEncoding",
+    },
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["Response body returned when preparing session history."],
+        fields: {
+          presignedUrl: ["Optional presigned URL for uploading new content."],
+          existing: ["Whether the requested session history already exists."],
+          encoding: ["Optional encoding of the persisted session history."],
         },
       },
     ],


### PR DESCRIPTION
## Summary

- generate the checkpoint create response and prepare-history request/response Rust types from the canonical TypeScript contracts
- share generated artifact and session-history encoding types across the related payloads
- decode checkpoint webhook responses before guest-agent success, reconciliation, deduplication, or upload decisions
- update guest fixtures to canonical response shapes and cover invalid required fields at the HTTP boundary

## Behavior

Contract-valid checkpoint behavior, including identity/gzip/zstd compatibility and optional response fields, is unchanged. A create response missing required identity fields now fails instead of being accepted from `checkpointId` alone. A prepare-history response missing or mistyping required `existing` now fails before any upload. Decode failures use stable diagnostics without echoing values from the invalid response into logs or telemetry.

This does not change TypeScript API schemas, endpoint handlers, persistence, authentication, retry policy, or valid wire semantics.

## Validation

- `pnpm -F @okouai/api-contracts generate:rust` followed by a byte-stable second generation pass
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test` (604 tests)
- `pnpm knip --workspace @okouai/api-contracts`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p api-contracts -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p api-contracts -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- repository pre-commit hooks, including full Knip, TypeScript type checking, Rust workspace Clippy/docs/fmt, and file-size validation

Closes #29291
