### PR TITLE
refactor(teams): drop the zero prefix from the card action key and bot handler

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -539,7 +539,7 @@ async function switchTeamsAgent(args: {
       text: "",
       entities: [],
       value: {
-        zeroTeamsAction: "switch_agent",
+        okouTeamsAction: "switch_agent",
         selectedAgentId: args.agentId,
       },
     }),

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -2035,7 +2035,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         id: activityIds.switchSubmit,
         text: "",
         value: {
-          zeroTeamsAction: "switch_agent",
+          okouTeamsAction: "switch_agent",
           selectedAgentId: switchAgent.agentId,
         },
       }),
@@ -2047,7 +2047,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     expect(switchSubmitBody).toMatchObject({
       activity: {
         value: {
-          zeroTeamsAction: "switch_agent",
+          okouTeamsAction: "switch_agent",
           selectedAgentId: switchAgent.agentId,
         },
       },
@@ -2059,7 +2059,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         id: activityIds.modelSubmit,
         text: "",
         value: {
-          zeroTeamsAction: "switch_model",
+          okouTeamsAction: "switch_model",
           selectedModel: "claude-sonnet-5",
         },
       }),
@@ -2071,7 +2071,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     expect(modelSubmitBody).toMatchObject({
       activity: {
         value: {
-          zeroTeamsAction: "switch_model",
+          okouTeamsAction: "switch_model",
           selectedModel: "claude-sonnet-5",
         },
       },
@@ -2133,7 +2133,7 @@ describe("POST /api/webhooks/teams/bot", () => {
               {
                 type: "Action.Submit",
                 title: "Switch",
-                data: { zeroTeamsAction: "switch_agent" },
+                data: { okouTeamsAction: "switch_agent" },
               },
             ],
           },
@@ -2165,7 +2165,7 @@ describe("POST /api/webhooks/teams/bot", () => {
               {
                 type: "Action.Submit",
                 title: "Switch",
-                data: { zeroTeamsAction: "switch_model" },
+                data: { okouTeamsAction: "switch_model" },
               },
             ],
           },
@@ -2321,7 +2321,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         id: activityIds.switchAgent,
         text: "",
         value: {
-          zeroTeamsAction: "switch_agent",
+          okouTeamsAction: "switch_agent",
           selectedAgentId: supportAgent.agentId,
         },
       }),
@@ -2362,7 +2362,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         id: activityIds.switchModel,
         text: "",
         value: {
-          zeroTeamsAction: "switch_model",
+          okouTeamsAction: "switch_model",
           selectedModel: "gpt-5.6-sol",
         },
       }),
@@ -2599,7 +2599,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         id: switchActivityId,
         text: "",
         value: {
-          zeroTeamsAction: "switch_agent",
+          okouTeamsAction: "switch_agent",
           selectedAgentId: supportAgent.agentId,
         },
       }),

--- a/turbo/apps/api/src/signals/routes/teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/teams-bot.ts
@@ -334,146 +334,137 @@ const dispatchTeamsMessageAndReply$ = command(
   },
 );
 
-const handleZeroTeamsBot$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const request = get(request$);
-    const publicBrand = get(publicBrand$);
-    const apiStartTime = now();
-    const bodyText = await request.text();
-    signal.throwIfAborted();
+const handleTeamsBot$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  const publicBrand = get(publicBrand$);
+  const apiStartTime = now();
+  const bodyText = await request.text();
+  signal.throwIfAborted();
 
-    const body = safeJsonParse(bodyText);
-    const normalized = normalizeTeamsActivity(body);
-    if (!normalized.ok) {
-      return errorResponse(400, normalized.error, "BAD_REQUEST");
-    }
+  const body = safeJsonParse(bodyText);
+  const normalized = normalizeTeamsActivity(body);
+  if (!normalized.ok) {
+    return errorResponse(400, normalized.error, "BAD_REQUEST");
+  }
 
-    const serviceUrl =
-      normalized.activity.kind === "unsupported"
-        ? readTeamsActivityServiceUrl(body)
-        : normalized.activity.serviceUrl;
-    if (!serviceUrl) {
-      return errorResponse(
-        400,
-        "Missing Teams activity serviceUrl",
-        "BAD_REQUEST",
-      );
-    }
+  const serviceUrl =
+    normalized.activity.kind === "unsupported"
+      ? readTeamsActivityServiceUrl(body)
+      : normalized.activity.serviceUrl;
+  if (!serviceUrl) {
+    return errorResponse(
+      400,
+      "Missing Teams activity serviceUrl",
+      "BAD_REQUEST",
+    );
+  }
 
-    const auth = await verifyTeamsBotAuthorization(
-      {
-        authorization: get(authorization$),
-        serviceUrl,
-        channelId: readTeamsActivityChannelId(body),
-      },
+  const auth = await verifyTeamsBotAuthorization(
+    {
+      authorization: get(authorization$),
+      serviceUrl,
+      channelId: readTeamsActivityChannelId(body),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (!auth.ok) {
+    return errorResponse(auth.status, auth.message, authErrorCode(auth.status));
+  }
+
+  const activityResult = await set(
+    recordTeamsInstallationActivity$,
+    { activity: normalized.activity },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (activityResult.kind === "removed" && activityResult.orgId) {
+    await set(
+      publishTeamsChanged$,
+      { orgId: activityResult.orgId, userIds: activityResult.userIds },
       signal,
     );
     signal.throwIfAborted();
-
-    if (!auth.ok) {
-      return errorResponse(
-        auth.status,
-        auth.message,
-        authErrorCode(auth.status),
-      );
-    }
-
-    const activityResult = await set(
-      recordTeamsInstallationActivity$,
-      { activity: normalized.activity },
+  }
+  if (activityResult.kind === "upserted" && activityResult.installation.orgId) {
+    await set(
+      publishTeamsChanged$,
+      { orgId: activityResult.installation.orgId },
       signal,
     );
     signal.throwIfAborted();
+  }
 
-    if (activityResult.kind === "removed" && activityResult.orgId) {
-      await set(
-        publishTeamsChanged$,
-        { orgId: activityResult.orgId, userIds: activityResult.userIds },
-        signal,
-      );
-      signal.throwIfAborted();
-    }
-    if (
-      activityResult.kind === "upserted" &&
-      activityResult.installation.orgId
-    ) {
-      await set(
-        publishTeamsChanged$,
-        { orgId: activityResult.installation.orgId },
-        signal,
-      );
-      signal.throwIfAborted();
-    }
-
-    const installation =
-      activityResult.kind === "upserted" ? activityResult.installation : null;
-    const timing = new ApiDispatchTimingCollector();
-    timing.recordElapsed(
-      "api_dispatch_pre_create_zero_teams_entrypoint_gap",
-      "nested",
-      apiStartTime,
+  const installation =
+    activityResult.kind === "upserted" ? activityResult.installation : null;
+  const timing = new ApiDispatchTimingCollector();
+  timing.recordElapsed(
+    "api_dispatch_pre_create_zero_teams_entrypoint_gap",
+    "nested",
+    apiStartTime,
+  );
+  if (normalized.activity.kind === "message") {
+    waitUntil(
+      tapError(
+        set(
+          dispatchTeamsMessageAndReply$,
+          {
+            activity: normalized.activity,
+            installation,
+            publicBrand,
+            apiStartTime,
+            timing,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("Error handling Teams message activity", { error });
+        },
+      ),
     );
-    if (normalized.activity.kind === "message") {
-      waitUntil(
-        tapError(
-          set(
-            dispatchTeamsMessageAndReply$,
-            {
-              activity: normalized.activity,
-              installation,
-              publicBrand,
-              apiStartTime,
-              timing,
-            },
-            signal,
-          ),
-          (error) => {
-            L.error("Error handling Teams message activity", { error });
-          },
-        ),
-      );
-    }
+  }
 
-    if (
-      teamsInstallWelcomeActivity(normalized.activity) &&
-      activityResult.kind === "upserted"
-    ) {
-      waitUntil(
-        tapError(
-          set(
-            sendTeamsInstallWelcome$,
-            {
-              activity: normalized.activity,
-              installation: activityResult.installation,
-              publicBrand,
-            },
-            signal,
-          ),
-          (error) => {
-            L.error("Error sending Teams install welcome", { error });
+  if (
+    teamsInstallWelcomeActivity(normalized.activity) &&
+    activityResult.kind === "upserted"
+  ) {
+    waitUntil(
+      tapError(
+        set(
+          sendTeamsInstallWelcome$,
+          {
+            activity: normalized.activity,
+            installation: activityResult.installation,
+            publicBrand,
           },
+          signal,
         ),
-      );
-    }
+        (error) => {
+          L.error("Error sending Teams install welcome", { error });
+        },
+      ),
+    );
+  }
 
-    return {
-      status: 200 as const,
-      body: {
-        ok: true as const,
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      activity: normalized.activity,
+      connectUrl: buildTeamsConnectUrlForActivity({
         activity: normalized.activity,
-        connectUrl: buildTeamsConnectUrlForActivity({
-          activity: normalized.activity,
-          publicBrand,
-          installation,
-        }),
-      },
-    };
-  },
-);
+        publicBrand,
+        installation,
+      }),
+    },
+  };
+});
 
 export const teamsBotRoutes: readonly RouteEntry[] = [
   {
     route: teamsBotContract.post,
-    handler: handleZeroTeamsBot$,
+    handler: handleTeamsBot$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
@@ -17,7 +17,7 @@ import {
 } from "./test-endpoint-helpers";
 
 const DEFAULT_SERVICE_URL = "https://smba.trafficmanager.net/amer/";
-const DEFAULT_BOT_ID = "28:e2e-zero-bot";
+const DEFAULT_BOT_ID = "28:e2e-okou-bot";
 const DEFAULT_BOT_NAME = "Zero";
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
@@ -86,7 +86,7 @@ const TEAMS_SUPPORTED_COMMANDS_TEXT =
   "`help`, `connect`, `disconnect`, `switch`, `model`";
 const TEAMS_AGENT_PICKER_MAX_OPTIONS = 100;
 const TEAMS_MODEL_PICKER_MAX_OPTIONS = 100;
-const TEAMS_CARD_ACTION_KEY = "zeroTeamsAction";
+const TEAMS_CARD_ACTION_KEY = "okouTeamsAction";
 const TEAMS_AGENT_PICKER_ACTION = "switch_agent";
 const TEAMS_MODEL_PICKER_ACTION = "switch_model";
 const TEAMS_AGENT_PICKER_INPUT_ID = "selectedAgentId";


### PR DESCRIPTION
Part of #26873.

Closes #29333.

## What changed

| Location | Before | After |
|---|---|---|
| `services/teams-dispatch.service.ts:89` | `"zeroTeamsAction"` | `"okouTeamsAction"` |
| `routes/teams-bot.ts:337` (referenced at `:477`) | `handleZeroTeamsBot$` | `handleTeamsBot$` |
| `routes/test-teams-dispatch-probe.ts:20` | `"28:e2e-zero-bot"` | `"28:e2e-okou-bot"` |

The card action key literal is also updated in the ten test fixtures that assert it — nine in `__tests__/teams-bot.test.ts` and one in `__tests__/internal-callbacks-teams.test.ts`.

## Why the card action key needs no dual-read

`TEAMS_CARD_ACTION_KEY` is embedded in adaptive cards sent to Microsoft Teams and echoed back on `Action.Submit`, so a rename would normally require a dual-read window: a stale card already sitting in a channel would carry the old key and resolve to `null` in `teamsCardAction()`.

Production state on 2026-08-25 removes that risk, as recorded in the issue:

- `teams_org_connections` — 4 rows, all staff (`@vm0.ai` / `@okou.ai`)
- `chat_teams_context` — 0 rows; no Teams message has ever been ingested
- `teams_user_agent_preferences` — 0 rows; the picker this key drives has never been used successfully

No external tenant, no message history, no recorded picker use. Worst case, a staff member scrolls back to an old card and a click does nothing — resend the card.

## Formatting note

`routes/teams-bot.ts` shows a larger diff than the two-token rename implies. `handleTeamsBot$` is short enough that the `command(async (...) => {` call now fits within Prettier's 80-column limit, so Prettier collapses the wrapper and de-indents the whole handler body. Verified against the lockfile's Prettier 3.8.1: the only substantive changes in that file are the two identifier occurrences; everything else is mechanical re-indentation.

## Deliberately unchanged

- **Dual-brand Teams surface.** `teamsIdentity()` returns `assistantName: "Zero" | "Okou"` by `publicBrand`, and `parseTeamsBotCommand()` accepts both `zero` and `okou` prefixes. The `name: "Zero"`, `<at>Zero</at>`, `publicBrand: "vm0"` and `https://app.vm0.test` fixtures exercise the live VM0 brand path and stay.
- **`routes/teams-oauth.ts:181`** keeps `/api/zero/teams/oauth/callback`; the file comment records that it retires with `api.vm0.ai` under #26701.
- **Two metric names** — `api_dispatch_pre_create_zero_teams_entrypoint_gap` (`routes/teams-bot.ts:412`) and `api_dispatch_pre_create_zero_teams_create_run` (`services/teams-dispatch.service.ts:1803`). Unlike a logger tag, a metric name is part of the emitted data; renaming it splits the time series so historical and new points cannot be aggregated in one query, and breaks dashboards and alerts built on the old name.

## Out of scope, flagged for follow-up

`routes/test-teams-state.ts:42` holds a second, independent `DEFAULT_BOT_ID = "28:e2e-zero-bot"`. The issue's rename table names only the probe constant, so this PR leaves it alone. The two constants are not compared anywhere — the dispatch service never reads the activity `recipient` — so the divergence is cosmetic and does not affect the e2e flow. Worth a separate slice if the epic wants the e2e fixtures fully de-branded.

## Conflict note

#29315 is in flight and also edits `services/teams-dispatch.service.ts` (logger tag renames). The two changes are disjoint within the file; a rebase may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
