### PR TITLE
refactor(api): make agent draft writes compatibility-view safe

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -410,6 +410,10 @@ export default [
       // focused transaction proves Calendar watch reads and initial writes stay
       // legal on both sides of the transition-column migration.
       "src/signals/services/__tests__/google-calendar-watch-rollout.test.ts",
+      // A physical relation versus a compatibility view cannot be selected
+      // through the production API. This focused PostgreSQL test proves the
+      // exact Agent Draft writer through both rollout targets.
+      "src/signals/services/__tests__/agent-draft-write.service.test.ts",
       "src/signals/services/__tests__/workflow-automation-context.test.ts",
     ],
     rules: {
@@ -542,6 +546,10 @@ export default [
       // focused transaction proves Calendar watch reads and initial writes stay
       // legal on both sides of the transition-column migration.
       "src/signals/services/__tests__/google-calendar-watch-rollout.test.ts",
+      // A physical relation versus a compatibility view cannot be selected
+      // through the production API. This focused PostgreSQL test proves the
+      // exact Agent Draft writer through both rollout targets.
+      "src/signals/services/__tests__/agent-draft-write.service.test.ts",
     ],
     rules: {
       "no-restricted-imports": [

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-draft.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-draft.test.ts
@@ -121,6 +121,34 @@ describe("GET/PATCH /api/agents/:id/draft", () => {
       draftAttachments: [attachment],
     });
 
+    const updatedDraftUserMessage: UserMessageInputDocument = {
+      version: 1,
+      parts: [{ type: "text", text: "updated draft text" }],
+    };
+    await accept(
+      draftsClient().patch({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+        body: {
+          draftUserMessage: updatedDraftUserMessage,
+          draftAttachments: null,
+        },
+      }),
+      [204],
+    );
+
+    const updated = await accept(
+      draftsClient().get({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(updated.body).toStrictEqual({
+      draftUserMessage: updatedDraftUserMessage,
+      draftAttachments: null,
+    });
+
     await accept(
       draftsClient().patch({
         params: { id: fixture.agentId },
@@ -144,6 +172,45 @@ describe("GET/PATCH /api/agents/:id/draft", () => {
       draftUserMessage: null,
       draftAttachments: null,
     });
+  });
+
+  it("converges concurrent first writes without exposing a conflict", async () => {
+    const fixture = await seedAgent();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const concurrentDrafts: UserMessageInputDocument[] = [
+      {
+        version: 1,
+        parts: [{ type: "text", text: "concurrent draft A" }],
+      },
+      {
+        version: 1,
+        parts: [{ type: "text", text: "concurrent draft B" }],
+      },
+    ];
+
+    await Promise.all(
+      concurrentDrafts.map(async (draftUserMessage) => {
+        await accept(
+          draftsClient().patch({
+            params: { id: fixture.agentId },
+            headers: authHeaders(),
+            body: { draftUserMessage, draftAttachments: null },
+          }),
+          [204],
+        );
+      }),
+    );
+
+    const saved = await accept(
+      draftsClient().get({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(concurrentDrafts).toContainEqual(saved.body.draftUserMessage);
+    expect(saved.body.draftAttachments).toBeNull();
   });
 
   it("does not expose another user's draft on the same public agent", async () => {
@@ -177,6 +244,50 @@ describe("GET/PATCH /api/agents/:id/draft", () => {
     );
     expect(peerDraft.body).toStrictEqual({
       draftUserMessage: null,
+      draftAttachments: null,
+    });
+
+    const peerDraftUserMessage: UserMessageInputDocument = {
+      version: 1,
+      parts: [{ type: "text", text: "peer draft" }],
+    };
+    await accept(
+      draftsClient().patch({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+        body: {
+          draftUserMessage: peerDraftUserMessage,
+          draftAttachments: null,
+        },
+      }),
+      [204],
+    );
+
+    const savedPeerDraft = await accept(
+      draftsClient().get({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(savedPeerDraft.body).toStrictEqual({
+      draftUserMessage: peerDraftUserMessage,
+      draftAttachments: null,
+    });
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const ownerDraft = await accept(
+      draftsClient().get({
+        params: { id: fixture.agentId },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(ownerDraft.body).toStrictEqual({
+      draftUserMessage: {
+        version: 1,
+        parts: [{ type: "text", text: "owner draft" }],
+      },
       draftAttachments: null,
     });
   });

--- a/turbo/apps/api/src/signals/routes/agent-draft.ts
+++ b/turbo/apps/api/src/signals/routes/agent-draft.ts
@@ -10,6 +10,7 @@ import { db$, writeDb$ } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { notFound } from "../../lib/error";
 import { agentExists } from "../services/agent-data.service";
+import { persistAgentDraft } from "../services/agent-draft-write.service";
 import type { RouteEntry } from "../route-entry";
 
 const agentReadAuth = {
@@ -87,43 +88,15 @@ const patchAgentDraftInner$ = command(
     const draftAttachments = bodyResult.data.draftAttachments ?? null;
     const draftUserMessage = bodyResult.data.draftUserMessage;
     const writeDb = set(writeDb$);
-
-    if (
-      !draftUserMessage &&
-      !(draftAttachments && draftAttachments.length > 0)
-    ) {
-      await writeDb
-        .delete(agentDrafts)
-        .where(
-          and(
-            eq(agentDrafts.userId, auth.userId),
-            eq(agentDrafts.orgId, auth.orgId),
-            eq(agentDrafts.agentId, params.id),
-          ),
-        );
-      signal.throwIfAborted();
-      return { status: 204 as const, body: undefined };
-    }
-
     const updatedAt = nowDate();
-    await writeDb
-      .insert(agentDrafts)
-      .values({
-        userId: auth.userId,
-        orgId: auth.orgId,
-        agentId: params.id,
-        draftUserMessage,
-        draftAttachments,
-        updatedAt,
-      })
-      .onConflictDoUpdate({
-        target: [agentDrafts.userId, agentDrafts.orgId, agentDrafts.agentId],
-        set: {
-          draftUserMessage,
-          draftAttachments,
-          updatedAt,
-        },
-      });
+    await persistAgentDraft(writeDb, {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      agentId: params.id,
+      draftUserMessage,
+      draftAttachments,
+      updatedAt,
+    });
     signal.throwIfAborted();
 
     return { status: 204 as const, body: undefined };

--- a/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type {
+  AgentDraftAttachments,
+  AgentDraftUserMessage,
+} from "@okouai/db/jsonb-contracts/agent-draft";
+import { agentDrafts } from "@okouai/db/schema/agent-draft";
+import { and, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
+
+import type { ApiDb } from "../../../lib/db-types";
+import { env } from "../../../lib/env";
+import {
+  type AgentDraftWrite,
+  persistAgentDraft,
+} from "../agent-draft-write.service";
+
+type RelationTarget = "physical" | "view";
+
+interface RelationHarness {
+  readonly db: ApiDb;
+  readonly destroy: () => Promise<void>;
+}
+
+function qualifiedName(schemaName: string, relationName: string) {
+  return sql`${sql.identifier(schemaName)}.${sql.identifier(relationName)}`;
+}
+
+async function createRelationHarness(
+  target: RelationTarget,
+): Promise<RelationHarness> {
+  const adminPool = new Pool({
+    allowExitOnIdle: true,
+    connectionString: env("DATABASE_URL"),
+    max: 1,
+  });
+  const adminDb = drizzle(adminPool);
+  const schemaName = `agent_draft_${target}_${randomUUID().replaceAll("-", "")}`;
+  const draftRelation = qualifiedName(schemaName, "zero_agent_drafts");
+
+  await adminDb.execute(sql`CREATE SCHEMA ${sql.identifier(schemaName)}`);
+  if (target === "physical") {
+    await adminDb.execute(sql`
+      CREATE TABLE ${draftRelation}
+      (LIKE "public"."zero_agent_drafts" INCLUDING ALL)
+    `);
+  } else {
+    const backingRelation = qualifiedName(schemaName, "agent_drafts_backing");
+    await adminDb.execute(sql`
+      CREATE TABLE ${backingRelation}
+      (LIKE "public"."zero_agent_drafts" INCLUDING ALL)
+    `);
+    await adminDb.execute(sql`
+      CREATE VIEW ${draftRelation} AS
+      SELECT
+        "user_id",
+        "org_id",
+        "agent_id",
+        "draft_user_message",
+        "draft_attachments",
+        "created_at",
+        "updated_at"
+      FROM ${backingRelation}
+    `);
+  }
+
+  const pool = new Pool({
+    allowExitOnIdle: true,
+    connectionString: env("DATABASE_URL"),
+    max: 8,
+    options: `-c search_path=${schemaName},public`,
+  });
+  return {
+    db: drizzle(pool),
+    destroy: async () => {
+      await pool.end();
+      await adminDb.execute(
+        sql`DROP SCHEMA ${sql.identifier(schemaName)} CASCADE`,
+      );
+      await adminPool.end();
+    },
+  };
+}
+
+function draftUserMessage(text: string): AgentDraftUserMessage {
+  return {
+    version: 1,
+    parts: [{ type: "text", text }],
+  };
+}
+
+function draftWrite(
+  key: Pick<AgentDraftWrite, "userId" | "orgId" | "agentId">,
+  text: string,
+  updatedAt: Date,
+): AgentDraftWrite {
+  return {
+    ...key,
+    draftUserMessage: draftUserMessage(text),
+    draftAttachments: null,
+    updatedAt,
+  };
+}
+
+function selectDraft(
+  db: ApiDb,
+  key: Pick<AgentDraftWrite, "userId" | "orgId" | "agentId">,
+) {
+  return db
+    .select()
+    .from(agentDrafts)
+    .where(
+      and(
+        eq(agentDrafts.userId, key.userId),
+        eq(agentDrafts.orgId, key.orgId),
+        eq(agentDrafts.agentId, key.agentId),
+      ),
+    );
+}
+
+test("keeps Agent Draft runtime writes free of relation-specific conflict SQL", async () => {
+  const runtimeSources = await Promise.all([
+    readFile(
+      new URL("../agent-draft-write.service.ts", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../../routes/agent-draft.ts", import.meta.url), "utf8"),
+  ]);
+  const runtimeSource = runtimeSources.join("\n");
+
+  expect(runtimeSource).not.toMatch(
+    /\bonConflict(?:DoNothing|DoUpdate)\b|\bON\s+CONFLICT\b|\bMERGE\b/i,
+  );
+  expect(runtimeSource).not.toMatch(/\b(?:zero_agent_drafts|agent_drafts)\b/);
+});
+
+describe.each([
+  { label: "physical relation", target: "physical" as const },
+  { label: "simple auto-updatable view", target: "view" as const },
+])("Agent Draft writes through a $label", ({ target }) => {
+  let harness: RelationHarness;
+
+  beforeEach(async () => {
+    harness = await createRelationHarness(target);
+  });
+
+  afterEach(async () => {
+    await harness.destroy();
+  });
+
+  it("creates with the database timestamp default and updates in place", async () => {
+    const key = {
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      agentId: randomUUID(),
+    };
+    const firstUpdatedAt = new Date("2026-08-25T10:00:00.000Z");
+    const firstWrite = draftWrite(key, "first draft", firstUpdatedAt);
+
+    await persistAgentDraft(harness.db, firstWrite);
+
+    const [created] = await selectDraft(harness.db, firstWrite);
+    expect(created).toMatchObject({
+      ...key,
+      draftUserMessage: draftUserMessage("first draft"),
+      draftAttachments: null,
+      updatedAt: firstUpdatedAt,
+    });
+    expect(created?.createdAt).toBeInstanceOf(Date);
+
+    const secondUpdatedAt = new Date("2026-08-25T10:05:00.000Z");
+    const secondWrite = draftWrite(key, "updated draft", secondUpdatedAt);
+    await persistAgentDraft(harness.db, secondWrite);
+
+    const [updated] = await selectDraft(harness.db, secondWrite);
+    expect(updated).toMatchObject({
+      ...key,
+      draftUserMessage: draftUserMessage("updated draft"),
+      draftAttachments: null,
+      createdAt: created?.createdAt,
+      updatedAt: secondUpdatedAt,
+    });
+
+    await persistAgentDraft(harness.db, {
+      ...key,
+      draftUserMessage: null,
+      draftAttachments: null,
+      updatedAt: new Date("2026-08-25T10:10:00.000Z"),
+    });
+    await expect(selectDraft(harness.db, secondWrite)).resolves.toHaveLength(0);
+  });
+
+  it("converges concurrent first writes to one valid row", async () => {
+    const key = {
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      agentId: randomUUID(),
+    };
+    const writes = Array.from({ length: 8 }, (_, index) => {
+      return draftWrite(
+        key,
+        `concurrent draft ${index}`,
+        new Date(`2026-08-25T10:00:0${index}.000Z`),
+      );
+    });
+
+    await Promise.all(
+      writes.map(async (write) => {
+        await persistAgentDraft(harness.db, write);
+      }),
+    );
+
+    const rows = await selectDraft(harness.db, key);
+    expect(rows).toHaveLength(1);
+    expect(writes).toContainEqual(
+      expect.objectContaining({
+        draftUserMessage: rows[0]?.draftUserMessage,
+        updatedAt: rows[0]?.updatedAt,
+      }),
+    );
+  });
+
+  it("propagates non-unique constraint failures", async () => {
+    const attachments: AgentDraftAttachments = [
+      {
+        id: randomUUID(),
+        url: "https://cdn.example.com/draft-file.txt",
+        filename: "draft-file.txt",
+        contentType: "text/plain",
+        size: 123,
+      },
+    ];
+    const invalidWrite: AgentDraftWrite = {
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      agentId: randomUUID(),
+      draftUserMessage: null,
+      draftAttachments: attachments,
+      updatedAt: new Date("2026-08-25T10:10:00.000Z"),
+    };
+
+    await expect(
+      persistAgentDraft(harness.db, invalidWrite),
+    ).rejects.toMatchObject({ cause: { code: "23514" } });
+    await expect(selectDraft(harness.db, invalidWrite)).resolves.toHaveLength(
+      0,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
@@ -18,6 +18,10 @@ import {
   persistAgentDraft,
 } from "../agent-draft-write.service";
 
+// Production API callers cannot select whether the mapped relation is a table
+// or a compatibility view. This focused rollout exception crosses the endpoint
+// boundary only to prove the exact writer against both PostgreSQL targets;
+// route behavior remains covered through the real Agent Draft endpoints.
 type RelationTarget = "physical" | "view";
 
 interface RelationHarness {

--- a/turbo/apps/api/src/signals/services/agent-draft-write.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-draft-write.service.ts
@@ -1,0 +1,79 @@
+import type {
+  AgentDraftAttachments,
+  AgentDraftUserMessage,
+} from "@okouai/db/jsonb-contracts/agent-draft";
+import { agentDrafts } from "@okouai/db/schema/agent-draft";
+import { and, eq } from "drizzle-orm";
+
+import type { ApiDb } from "../../lib/db-types";
+import { isUniqueViolation } from "../../lib/pg-errors";
+import { settle } from "../utils";
+
+const MAX_AGENT_DRAFT_WRITE_ATTEMPTS = 2;
+
+export interface AgentDraftWrite {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly draftUserMessage: AgentDraftUserMessage | null;
+  readonly draftAttachments: AgentDraftAttachments | null;
+  readonly updatedAt: Date;
+}
+
+export async function persistAgentDraft(
+  db: ApiDb,
+  draft: AgentDraftWrite,
+): Promise<void> {
+  const keyPredicate = and(
+    eq(agentDrafts.userId, draft.userId),
+    eq(agentDrafts.orgId, draft.orgId),
+    eq(agentDrafts.agentId, draft.agentId),
+  );
+  if (
+    !draft.draftUserMessage &&
+    !(draft.draftAttachments && draft.draftAttachments.length > 0)
+  ) {
+    await db.delete(agentDrafts).where(keyPredicate);
+    return;
+  }
+
+  const update = {
+    draftUserMessage: draft.draftUserMessage,
+    draftAttachments: draft.draftAttachments,
+    updatedAt: draft.updatedAt,
+  };
+
+  for (
+    let attempt = 0;
+    attempt < MAX_AGENT_DRAFT_WRITE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const updated = await db
+      .update(agentDrafts)
+      .set(update)
+      .where(keyPredicate)
+      .returning({ agentId: agentDrafts.agentId });
+    if (updated.length > 0) {
+      return;
+    }
+
+    const inserted = await settle(
+      db.insert(agentDrafts).values({
+        userId: draft.userId,
+        orgId: draft.orgId,
+        agentId: draft.agentId,
+        ...update,
+      }),
+    );
+    if (inserted.ok) {
+      return;
+    }
+    if (
+      !isUniqueViolation(inserted.error) ||
+      attempt === MAX_AGENT_DRAFT_WRITE_ATTEMPTS - 1
+    ) {
+      throw inserted.error;
+    }
+    // Retry the full cycle in case the competing row is deleted first.
+  }
+}


### PR DESCRIPTION
## Summary

- seal every Agent Draft mutation behind one persistence helper
- replace `INSERT ... ON CONFLICT DO UPDATE` with update-first, insert-if-absent, and an exact `23505` bounded retry
- preserve create, update, clear, timestamp, and per-user behavior without changing the Drizzle physical mapping or API contract
- prove the exact production statements against a physical table and a simple auto-updatable compatibility view on real PostgreSQL, including concurrent first writes

Part of #29322 / Parent #28368

## Test plan

- `pnpm --filter api run lint`
- `pnpm --filter api run check-types`
- `pnpm exec knip --workspace api`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/services/__tests__/agent-draft-write.service.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/agent-draft.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/db exec vitest run src/__tests__/agent-draft.test.ts`

## Scope guard

- no migration, schema mapping, journal, snapshot, public contract, provider, Workflow, or unrelated upsert changes
- no production release or synthetic production writes
