### PR TITLE
refactor: remove box connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -14,7 +14,6 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   "ahrefs\0oauth": FeatureSwitchKey.AhrefsConnector,
   "bentoml\0api-token": FeatureSwitchKey.BentomlConnector,
   "bill\0api-token": FeatureSwitchKey.BillConnector,
-  "box\0oauth": FeatureSwitchKey.BoxConnector,
   "cal-com\0api-token": FeatureSwitchKey.CalComConnector,
   "cal-com\0oauth": FeatureSwitchKey.CalComConnector,
   "canva\0oauth": FeatureSwitchKey.CanvaConnector,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -11,7 +11,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.BoxConnector, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
   });

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -8,7 +8,6 @@ export enum FeatureSwitchKey {
   AhrefsConnector = "ahrefsConnector",
   BillConnector = "billConnector",
   BentomlConnector = "bentomlConnector",
-  BoxConnector = "boxConnector",
   CanvaConnector = "canvaConnector",
   CalComConnector = "calComConnector",
   CopperConnector = "copperConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -58,11 +58,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the BentoML model serving connector",
     enabled: false,
   },
-  [FeatureSwitchKey.BoxConnector]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Enable the Box file storage connector",
-    enabled: true,
-  },
   [FeatureSwitchKey.CanvaConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the Canva design connector",


### PR DESCRIPTION
## Summary

- graduate `boxConnector` as fully rolled out
- remove the Box OAuth auth-method rollout association so discovery is unconditional
- remove the retired enum member, registry entry, and switch-specific test assertion

## Rollout decision

- Terminal state: `fully-rolled-out`
- Decision basis: Linghan confirmed the terminal state in the cleanup request on 2026-08-25
- Introducing commit: `b9806d5b496c53520c34cda130f5b6ed219957ac` (`feat: add Box OAuth connector`, #18270)
- Rollout-enabling commit: `59784c714a10f3e66ee4208fda67ea744cb5241f` (`feat(connectors): enable box oauth`, #28507)

## Behavior and history comparison

The introducing commit added the Box OAuth provider, connector metadata, firewall assets, icon, environment bindings, and a disabled feature switch. Its parent had no Box connector. Later commits moved the switch key into core and moved auth-method rollout ownership into the API (`590a2ff16c`, `11071e0563`, and `6670ff6f17`).

Before this cleanup, the Box OAuth method was mapped to an enabled switch. Catalog discovery therefore included it when `featureStates.boxConnector` was true. Unmapped auth methods follow the same visible path unconditionally. Removing the mapping permanently preserves the switch-on behavior while eliminating the closed-state discovery filter.

The permanent Box provider, OAuth implementation, firewall rules, icon, catalog fixture, environment bindings, and CI credentials remain unchanged.

## Search and Knip

- Exact searches for `BoxConnector`, exact `boxConnector`, the `"box\\0oauth"` rollout association, and the switch description have no remaining code matches.
- Second-pass keywords: `Box OAuth`, `BOX_OAUTH_CLIENT_ID`, `BOX_TOKEN`, Box provider/firewall/icon paths. Remaining matches are permanent connector implementation assets or historical changelog entries.
- Scoped Knip baseline for `@okouai/core` and `api`: clean.
- Scoped Knip after cleanup: clean.
- Scoped Knip after rebasing onto latest `main`: clean.

## Tests and verification

- Removed the switch-only globally-enabled assertion; no product behavior test was deleted or rewritten.
- Prettier check on all four changed files: passed.
- `git diff --check`: passed.
- `pnpm -F @okouai/core lint`: passed.
- `pnpm -F api lint`: passed (Oxlint emitted existing warnings in unrelated test files).
- `pnpm -F @okouai/core check-types`: passed.
- `pnpm -F api check-types`: passed.
- Core feature-switch test: 25 passed.
- API connector-catalog test: 32 passed.
- Full local Vitest was intentionally not run; the PR pipeline owns the complete suite.

## Pipeline

The PR pipeline should run the repository-wide required checks, including the full test and deployment validation selected by CI.
