### PR TITLE
test(runner): carry containment cleanup evidence in exec results

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -478,6 +478,125 @@ grep -E -q '^cpu-pressure-complete throttled_periods=[1-9][0-9]*$' \
   <<<"$CPU_PRESSURE_RESULT" \
   || fail "CPU pressure did not report throttling"
 
+echo "--- Evidence: return mixed-identity pids.max cleanup through exec result ---"
+PID_EVIDENCE_COMMAND=$(cat <<'PYTHON'
+import errno
+import os
+import pathlib
+import signal
+
+relative = next(
+    line.removeprefix("0::").strip()
+    for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()
+    if line.startswith("0::")
+)
+if not relative.startswith("/vm0-exec/exec-") or not relative.endswith("/workload"):
+    raise RuntimeError(f"PID evidence is outside workload cgroup: {relative}")
+workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
+(workload / "pids.max").write_text("64")
+
+ready_read, ready_write = os.pipe()
+children = []
+while True:
+    try:
+        pid = os.fork()
+    except OSError as error:
+        if error.errno != errno.EAGAIN:
+            raise
+        break
+    if pid == 0:
+        os.close(ready_read)
+        os.setsid()
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        if len(children) % 2 == 0:
+            os.setgroups([])
+            os.setgid(1000)
+            os.setuid(1000)
+        null = os.open("/dev/null", os.O_RDWR)
+        for descriptor in (0, 1, 2):
+            os.dup2(null, descriptor)
+        if null > 2:
+            os.close(null)
+        os.write(ready_write, b"1")
+        os.close(ready_write)
+        while True:
+            signal.pause()
+    children.append(pid)
+
+os.close(ready_write)
+ready = b""
+while len(ready) < len(children):
+    chunk = os.read(ready_read, len(children) - len(ready))
+    if not chunk:
+        raise RuntimeError("PID-pressure readiness pipe closed early")
+    ready += chunk
+os.close(ready_read)
+events = dict(
+    line.split()
+    for line in (workload / "pids.events").read_text().splitlines()
+)
+if int(events.get("max", "0")) == 0:
+    raise RuntimeError("pids.max did not reject a workload fork")
+print(
+    "pid-evidence-ready "
+    f"children={len(children)} "
+    f"user_children={(len(children) + 1) // 2} "
+    f"root_children={len(children) // 2} "
+    f"max={events['max']}",
+    flush=True,
+)
+PYTHON
+)
+if ! PID_EVIDENCE_RESULT=$(sudo "$BIN_DIR/runner" exec \
+  --timeout 15 \
+  --sandbox "$PRESSURE_SANDBOX_ID" \
+  --sudo \
+  --show-diagnostic \
+  -- python3 -c "$PID_EVIDENCE_COMMAND" 2>&1); then
+  printf '%s\n' "$PID_EVIDENCE_RESULT"
+  fail "PID-pressure cleanup behavior failed before result evidence"
+fi
+printf '%s\n' "$PID_EVIDENCE_RESULT"
+PID_EVIDENCE_CHILDREN=$(sed -n \
+  's/^pid-evidence-ready children=\([0-9][0-9]*\) user_children=[1-9][0-9]* root_children=[1-9][0-9]* max=[1-9][0-9]*$/\1/p' \
+  <<<"$PID_EVIDENCE_RESULT")
+[ -n "$PID_EVIDENCE_CHILDREN" ] \
+  || fail "PID-pressure evidence did not reach the configured pids.max boundary"
+[ "$PID_EVIDENCE_CHILDREN" -ge 50 ] \
+  || fail "PID-pressure evidence created only ${PID_EVIDENCE_CHILDREN} children"
+PID_EVIDENCE_USER_CHILDREN=$(sed -n \
+  's/^pid-evidence-ready children=[0-9][0-9]* user_children=\([1-9][0-9]*\) root_children=[1-9][0-9]* max=[1-9][0-9]*$/\1/p' \
+  <<<"$PID_EVIDENCE_RESULT")
+PID_EVIDENCE_ROOT_CHILDREN=$(sed -n \
+  's/^pid-evidence-ready children=[0-9][0-9]* user_children=[1-9][0-9]* root_children=\([1-9][0-9]*\) max=[1-9][0-9]*$/\1/p' \
+  <<<"$PID_EVIDENCE_RESULT")
+[ -n "$PID_EVIDENCE_USER_CHILDREN" ] \
+  || fail "PID-pressure evidence did not create user-owned descendants"
+[ -n "$PID_EVIDENCE_ROOT_CHILDREN" ] \
+  || fail "PID-pressure evidence did not create root-owned descendants"
+PID_CLEANUP_LINE=$(printf '%s\n' "$PID_EVIDENCE_RESULT" \
+  | grep -F 'exec process containment cleaned' \
+  | grep -F 'descendants_observed=true' \
+  | grep -F 'cgroup_kill_used=true' \
+  | head -1) \
+  || fail "PID-pressure cleanup behavior passed, but its successful exec result produced no populated cgroup.kill cleanup evidence"
+PID_INITIAL_MEMBERS=$(sed -n \
+  's/.*initial_members=\([0-9][0-9]*\).*/\1/p' \
+  <<<"$PID_CLEANUP_LINE")
+[ -n "$PID_INITIAL_MEMBERS" ] \
+  || fail "PID-pressure cleanup result evidence omitted its initial member count"
+[ "$PID_INITIAL_MEMBERS" -ge 50 ] \
+  || fail "PID-pressure cleanup result evidence observed only ${PID_INITIAL_MEMBERS} members"
+PID_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' \
+  <<<"$PID_CLEANUP_LINE")
+[ -n "$PID_CLEANUP_MS" ] \
+  || fail "PID-pressure cleanup result evidence omitted cleanup latency"
+[ "$PID_CLEANUP_MS" -le 5000 ] \
+  || fail "PID-pressure cleanup exceeded 5s: ${PID_CLEANUP_MS}ms"
+LEAK_CLEANUP_MS=$PID_CLEANUP_MS
+[ "$LEAK_CLEANUP_MS" -le 2000 ] \
+  || fail "mixed-identity descendant cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
+
 echo "--- Pressure: cross the retired workload memory boundary through Guest reclaim ---"
 PRESSURE_API_SOCK="/run/vm0/sock/$PRESSURE_SANDBOX_ID/api.sock"
 BALLOON_BEFORE=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
@@ -847,39 +966,12 @@ printf '%s\n' "$LOGS" \
   | grep -F 'reused=true' \
   >/dev/null \
   || fail "tool-group OOM follow-up did not reuse its sandbox"
-LEAK_LINE=$(printf '%s\n' "$LOGS" \
-  | grep -F 'exec process containment cleaned' \
-  | grep -F 'descendants_observed=true' \
-  | grep -F 'cgroup_kill_used=true' \
-  | head -1) \
-  || fail "missing populated cleanup that used cgroup.kill"
-
-LEAK_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$LEAK_LINE")
-[ -n "$LEAK_CLEANUP_MS" ] || fail "missing leaked cleanup latency"
-[ "$LEAK_CLEANUP_MS" -le 2000 ] \
-  || fail "leaked cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
-
 if grep -F 'process control latency exceeded calibrated bound' <<<"$LOGS" >/dev/null; then
   fail "process control exceeded the calibrated 750ms bound under pressure"
 fi
-PID_CLEANUP_LINE=$(printf '%s\n' "$LOGS" \
-  | grep -F 'exec process containment cleaned' \
-  | grep -F 'descendants_observed=true' \
-  | grep -F 'cgroup_kill_used=true' \
-  | sed -n 's/.*initial_members=\([0-9][0-9]*\).*/\1 &/p' \
-  | sort -nr \
-  | head -1) \
-  || fail "missing forced PID-pressure cleanup"
-PID_INITIAL_MEMBERS=${PID_CLEANUP_LINE%% *}
-[ "$PID_INITIAL_MEMBERS" -ge 50 ] \
-  || fail "PID-pressure cleanup observed only ${PID_INITIAL_MEMBERS} members"
-PID_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$PID_CLEANUP_LINE")
-[ -n "$PID_CLEANUP_MS" ] || fail "PID-pressure cleanup latency was not reported"
-[ "$PID_CLEANUP_MS" -le 5000 ] \
-  || fail "PID-pressure cleanup exceeded 5s: ${PID_CLEANUP_MS}ms"
 
 echo "PASS: detached user/root descendants were reclaimed"
-echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"
+echo "PASS: mixed-identity leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"
 echo "PASS: compressed CPU pressure kept process control and ${METRICS_COUNT} metric samples live"
 echo "PASS: Bash tool group OOM preserved the CLI, unrelated tool, and reuse in ${MEMORY_ELAPSED}s"
 echo "PASS: pids.max cleanup reclaimed ${PID_INITIAL_MEMBERS} members in ${PID_CLEANUP_MS}ms"

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -45,6 +45,10 @@ pub struct ExecArgs {
     #[arg(long)]
     sudo: bool,
 
+    /// Print the guest terminal diagnostic for ordinary process exits
+    #[arg(long)]
+    show_diagnostic: bool,
+
     /// Command to execute inside the sandbox (after `--`).
     ///
     /// Arguments are preserved as argv — pipes, redirects, globs, and
@@ -115,7 +119,7 @@ async fn run_exec_with_writers(
     {
         Ok(result) => {
             let _ = stdout.write_all(&result.stdout);
-            write_remote_exec_stderr(stderr, &result);
+            write_remote_exec_stderr(stderr, &result, args.show_diagnostic);
 
             Ok(remote_exec_exit_code(result.termination))
         }
@@ -141,11 +145,15 @@ fn remote_exec_exit_code(termination: ExecTermination) -> ExitCode {
     }
 }
 
-fn write_remote_exec_stderr(stderr: &mut impl Write, result: &RemoteExecResult) {
+fn write_remote_exec_stderr(
+    stderr: &mut impl Write,
+    result: &RemoteExecResult,
+    show_diagnostic: bool,
+) {
     let _ = stderr.write_all(&result.stderr);
     let mut line_open = !result.stderr.is_empty() && !result.stderr.ends_with(b"\n");
 
-    write_remote_exec_terminal_diagnostic(stderr, result, &mut line_open);
+    write_remote_exec_terminal_diagnostic(stderr, result, show_diagnostic, &mut line_open);
     if result.stdout_truncated {
         write_remote_exec_warning(stderr, &mut line_open, REMOTE_EXEC_STDOUT_TRUNCATED_WARNING);
     }
@@ -157,14 +165,16 @@ fn write_remote_exec_stderr(stderr: &mut impl Write, result: &RemoteExecResult) 
 fn write_remote_exec_terminal_diagnostic(
     stderr: &mut impl Write,
     result: &RemoteExecResult,
+    show_diagnostic: bool,
     line_open: &mut bool,
 ) {
-    let (fallback, include_diagnostic) = match result.termination {
+    let (fallback, include_terminal_diagnostic) = match result.termination {
         ExecTermination::Exited { .. } => (None, false),
         ExecTermination::TimedOut => (Some("Timeout"), false),
         ExecTermination::Cancelled => (Some("Cancelled"), true),
         ExecTermination::StartFailed | ExecTermination::WaitFailed => (None, true),
     };
+    let include_diagnostic = show_diagnostic || include_terminal_diagnostic;
 
     if result.stderr.is_empty() {
         if let Some(message) = fallback {
@@ -204,6 +214,7 @@ mod tests {
             sandbox: Some(sandbox_id.into()),
             timeout: 5,
             sudo: false,
+            show_diagnostic: false,
             command: command.split_whitespace().map(String::from).collect(),
         }
     }
@@ -214,6 +225,7 @@ mod tests {
             sandbox: Some("id".into()),
             timeout: 5,
             sudo: false,
+            show_diagnostic: false,
             command: command.into_iter().map(String::from).collect(),
         }
     }
@@ -269,6 +281,7 @@ mod tests {
             sandbox: Some("direct-sandbox".into()),
             timeout: 47,
             sudo: true,
+            show_diagnostic: false,
             command: vec!["echo".into(), "hello world".into()],
         };
 
@@ -387,7 +400,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(stderr, b"stderr clue\nwait failed\n");
     }
@@ -404,7 +417,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(stderr, b"stderr clue");
     }
@@ -421,7 +434,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(stderr, b"Cancelled\n");
     }
@@ -438,7 +451,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(stderr, b"Cancelled\ncancel diagnostic\n");
     }
@@ -455,9 +468,29 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(stderr, b"Timeout\n");
+    }
+
+    #[test]
+    fn successful_terminal_diagnostic_is_opt_in() {
+        let result = RemoteExecResult {
+            termination: ExecTermination::Exited { exit_code: 0 },
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            diagnostic: "containment evidence".into(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut default_stderr = Vec::new();
+        let mut diagnostic_stderr = Vec::new();
+
+        write_remote_exec_stderr(&mut default_stderr, &result, false);
+        write_remote_exec_stderr(&mut diagnostic_stderr, &result, true);
+
+        assert!(default_stderr.is_empty());
+        assert_eq!(diagnostic_stderr, b"containment evidence\n");
     }
 
     #[test]
@@ -472,7 +505,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(
             stderr,
@@ -492,7 +525,7 @@ mod tests {
         };
         let mut stderr = Vec::new();
 
-        write_remote_exec_stderr(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result, false);
 
         assert_eq!(
             stderr,

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -767,6 +767,17 @@ impl RunningExec {
         let containment_error = containment_result.as_ref().err().map(ToString::to_string);
         let (termination, diagnostic) =
             resolve_exec_result(outcome, request.lifecycle, containment_error.as_deref());
+        let containment_evidence = containment_result
+            .as_ref()
+            .ok()
+            .and_then(|evidence| evidence.as_deref());
+        let diagnostic = successful_containment_evidence_diagnostic(
+            request.lifecycle,
+            &request.label,
+            termination,
+            diagnostic,
+            containment_evidence,
+        );
 
         log_exec_terminal_if_notable(
             request,
@@ -829,6 +840,23 @@ fn resolve_exec_result(
     (termination, diagnostic)
 }
 
+fn successful_containment_evidence_diagnostic(
+    lifecycle: ExecOperationLifecycle,
+    label: &str,
+    termination: ExecTermination,
+    diagnostic: String,
+    containment_evidence: Option<&str>,
+) -> String {
+    if lifecycle != ExecOperationLifecycle::OneShot
+        || label != "runner-exec"
+        || !diagnostic.is_empty()
+        || !matches!(termination, ExecTermination::Exited { .. })
+    {
+        return diagnostic;
+    }
+    containment_evidence.unwrap_or_default().to_owned()
+}
+
 fn append_containment_cleanup_failure(diagnostic: &str, containment_error: Option<&str>) -> String {
     let Some(error) = containment_error else {
         return diagnostic.to_string();
@@ -843,8 +871,8 @@ fn append_containment_cleanup_failure(diagnostic: &str, containment_error: Optio
 fn cleanup_process_containment(
     process_containment: ExecProcessContainment,
     mode: ProcessContainmentCleanupMode,
-) -> Result<(), ProcessContainmentError> {
-    process_containment.cleanup(mode)
+) -> Result<Option<String>, ProcessContainmentError> {
+    process_containment.cleanup_with_evidence(mode)
 }
 
 pub(crate) fn start_exec_operation(
@@ -1931,6 +1959,62 @@ mod tests {
 
         assert_eq!(termination, ExecTermination::TimedOut);
         assert!(diagnostic.is_empty());
+    }
+
+    #[test]
+    fn successful_exec_result_carries_containment_evidence() {
+        let evidence = "exec process containment cleaned cgroup_kill_used=true";
+
+        assert_eq!(
+            successful_containment_evidence_diagnostic(
+                ExecOperationLifecycle::OneShot,
+                "runner-exec",
+                ExecTermination::Exited { exit_code: 0 },
+                String::new(),
+                Some(evidence),
+            ),
+            evidence
+        );
+    }
+
+    #[test]
+    fn containment_evidence_does_not_replace_terminal_failure_diagnostic() {
+        assert_eq!(
+            successful_containment_evidence_diagnostic(
+                ExecOperationLifecycle::OneShot,
+                "runner-exec",
+                ExecTermination::WaitFailed,
+                "wait failed".to_owned(),
+                Some("cleanup evidence"),
+            ),
+            "wait failed"
+        );
+    }
+
+    #[test]
+    fn containment_evidence_is_only_attached_to_one_shot_runner_exec_results() {
+        let evidence = Some("cleanup evidence");
+
+        assert_eq!(
+            successful_containment_evidence_diagnostic(
+                ExecOperationLifecycle::Supervised,
+                "runner-exec",
+                ExecTermination::Exited { exit_code: 0 },
+                String::new(),
+                evidence,
+            ),
+            ""
+        );
+        assert_eq!(
+            successful_containment_evidence_diagnostic(
+                ExecOperationLifecycle::OneShot,
+                "benchmark-exec",
+                ExecTermination::Exited { exit_code: 0 },
+                String::new(),
+                evidence,
+            ),
+            ""
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -212,11 +212,19 @@ impl ExecProcessContainment {
         self,
         mode: ProcessContainmentCleanupMode,
     ) -> Result<(), ProcessContainmentError> {
+        self.cleanup_with_evidence(mode).map(|_| ())
+    }
+
+    pub(crate) fn cleanup_with_evidence(
+        self,
+        mode: ProcessContainmentCleanupMode,
+    ) -> Result<Option<String>, ProcessContainmentError> {
         match self.backend {
             ContainmentBackend::Cgroup(guard) => guard.cleanup(mode),
-            ContainmentBackend::TestNoop => Ok(()),
+            ContainmentBackend::TestNoop => Ok(None),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(group_path) => fs::remove_dir(group_path)
+                .map(|()| None)
                 .map_err(|error| ProcessContainmentError::new("remove test cgroup", error)),
         }
     }
@@ -490,7 +498,10 @@ impl CgroupGuard {
         })
     }
 
-    fn cleanup(self, mode: ProcessContainmentCleanupMode) -> Result<(), ProcessContainmentError> {
+    fn cleanup(
+        self,
+        mode: ProcessContainmentCleanupMode,
+    ) -> Result<Option<String>, ProcessContainmentError> {
         let started = Instant::now();
         let CgroupGuard {
             group_name,
@@ -508,26 +519,17 @@ impl CgroupGuard {
         let result = cleanup_cgroup(&group_path, mode);
         match result {
             Ok(report) => {
-                // Healthy exec cleanup is a hot path. Emit diagnostics
-                // only when containment had work beyond removing an empty leaf.
-                if report.descendants_observed
-                    || report.cgroup_kill_used
-                    || report.graceful_errors > 0
-                {
-                    log(
-                        "INFO",
-                        &format!(
-                            "exec process containment cleaned group={group_name} mode={mode:?} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
-                            report.descendants_observed,
-                            report.cgroup_kill_used,
-                            report.initial_members,
-                            report.graceful_errors,
-                            create_elapsed.as_micros(),
-                            started.elapsed().as_millis()
-                        ),
-                    );
+                let evidence = cleanup_evidence_line(
+                    &group_name,
+                    mode,
+                    &report,
+                    create_elapsed,
+                    started.elapsed(),
+                );
+                if let Some(evidence) = evidence.as_deref() {
+                    log("INFO", evidence);
                 }
-                Ok(())
+                Ok(evidence)
             }
             Err(error) => {
                 log(
@@ -712,6 +714,29 @@ struct CleanupReport {
     cgroup_kill_used: bool,
     initial_members: usize,
     graceful_errors: usize,
+}
+
+fn cleanup_evidence_line(
+    group_name: &str,
+    mode: ProcessContainmentCleanupMode,
+    report: &CleanupReport,
+    create_elapsed: Duration,
+    cleanup_elapsed: Duration,
+) -> Option<String> {
+    // Healthy exec cleanup is a hot path. Produce evidence only when
+    // containment had work beyond removing an empty leaf.
+    if !report.descendants_observed && !report.cgroup_kill_used && report.graceful_errors == 0 {
+        return None;
+    }
+    Some(format!(
+        "exec process containment cleaned group={group_name} mode={mode:?} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
+        report.descendants_observed,
+        report.cgroup_kill_used,
+        report.initial_members,
+        report.graceful_errors,
+        create_elapsed.as_micros(),
+        cleanup_elapsed.as_millis()
+    ))
 }
 
 fn cleanup_cgroup(
@@ -1435,6 +1460,47 @@ mod tests {
         assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));
         assert_eq!(parse_populated("frozen 0\n"), None);
         assert_eq!(parse_populated("populated 2\n"), None);
+    }
+
+    #[test]
+    fn cleanup_evidence_reports_material_cgroup_kill() {
+        let evidence = cleanup_evidence_line(
+            "exec-7-1",
+            ProcessContainmentCleanupMode::Graceful,
+            &CleanupReport {
+                descendants_observed: true,
+                cgroup_kill_used: true,
+                initial_members: 61,
+                graceful_errors: 0,
+            },
+            Duration::from_micros(42),
+            Duration::from_millis(17),
+        )
+        .unwrap();
+
+        assert_eq!(
+            evidence,
+            "exec process containment cleaned group=exec-7-1 mode=Graceful descendants_observed=true cgroup_kill_used=true initial_members=61 graceful_errors=0 create_us=42 cleanup_ms=17"
+        );
+    }
+
+    #[test]
+    fn cleanup_evidence_omits_empty_healthy_cleanup() {
+        assert!(
+            cleanup_evidence_line(
+                "exec-8-1",
+                ProcessContainmentCleanupMode::Graceful,
+                &CleanupReport {
+                    descendants_observed: false,
+                    cgroup_kill_used: false,
+                    initial_members: 0,
+                    graceful_errors: 0,
+                },
+                Duration::ZERO,
+                Duration::ZERO,
+            )
+            .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the existing Firecracker serial cleanup log for operators while returning the same material-cleanup evidence on the owned one-shot runner-exec result channel
- add an opt-in runner exec --show-diagnostic boundary; default CLI output and all supervised-agent success diagnostics remain unchanged
- validate real mixed user/root SIGTERM-ignoring descendants at pids.max, cgroup.kill use, populated cleanup bounds, and sandbox reuse without journal timing

## First causal nondeterminism

Four authorized full Crates attempts on stable #29329 head 3c786c6cbbe28c9bc0009d3825ff87fdda08c3f1 selected dev-11.gcp.vm3.ai and passed every behavior before failing only the final serial-journal mechanism assertion. A real systemd-journald fixture confirmed that journalctl --after-cursor --follow --no-tail replays a post-cursor entry already committed before the follower starts, so the observer helper was not the first race.

The temporary diagnostic head then queried the complete failed invocation after teardown: 877 journal entries, zero cleanup records, and zero fence records. The same serial record exists on the passing dev-1 comparison. The first causal nondeterminism is therefore the host-specific absence of the Firecracker serial evidence channel, while the synchronous vsock result and all cleanup/reuse behavior complete successfully. The temporary diagnostic head is excluded from final validation.

## Scope and preserved contracts

- material cleanup formats the existing serial operator line once and returns that same line as evidence
- evidence is attached only to successful one-shot runner-exec results; supervised agents, storage helpers, error diagnostics, and default runner exec output are unchanged
- the behavior test uses a real Firecracker guest, creates mixed user/root detached descendants that ignore SIGTERM, crosses pids.max, requires descendants_observed=true and cgroup_kill_used=true, retains member and cleanup-latency bounds, and proves subsequent sandbox reuse
- no job retry, sleep, assertion retry, timeout increase, skip, or weakened assertion

## Local validation on final candidate

- cargo fmt --manifest-path crates/Cargo.toml --all --check
- bash -n and ShellCheck 0.11.0 for runner-behavior-process-containment.sh
- embedded PID evidence Python compile check
- crates-detect-workflow-test.sh
- rust-ci-memory-workflow-test.sh
- 2 process-containment evidence unit tests, release/no-default-features
- 3 exec-result evidence isolation unit tests, release/no-default-features
- vsock-guest production clippy
- runner release cargo check
- runner binary all-features clippy with one local build job

Repeated focused final-head Firecracker validation and protected CI are tracked below before merge.

Closes #29338
Unblocks #29329