### PR TITLE
refactor(python): centralize upstream binding resolution

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -76,6 +76,13 @@ class UpstreamDestinationBinding:
     original_address: tuple[str, int] | None
 
 
+@dataclass(frozen=True, slots=True)
+class _DestinationBindingMatch:
+    """Selected binding evidence projected by the public matching helpers."""
+
+    endpoint: tuple[str, int] | None
+
+
 _bindings_by_server_id: dict[str, UpstreamDestinationBinding] = {}
 _server_ids_by_client_id: dict[str, set[str]] = {}
 _client_id_by_server_id: dict[str, str] = {}
@@ -404,6 +411,49 @@ def _client_binding_connected_endpoint(
     return connected_endpoint.address
 
 
+def _resolve_destination_binding(
+    flow: http.HTTPFlow,
+    *,
+    destination: NormalizedUpstreamDestination,
+    allowed_kinds: frozenset[BindingKind],
+) -> _DestinationBindingMatch | None:
+    server = flow.server_conn
+    server_id = _connection_id(server)
+    binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
+    if binding is not None:
+        if not _binding_matches(
+            binding,
+            host=destination.host,
+            port=destination.port,
+            allowed_kinds=allowed_kinds,
+        ) or not _server_binding_matches_current_destination(server, binding):
+            return None
+        return _DestinationBindingMatch(endpoint=binding.original_address)
+
+    if bool(getattr(server, "connected", False)):
+        matching_client_bindings = _matching_client_bindings(
+            flow.client_conn,
+            host=destination.host,
+            port=destination.port,
+            allowed_kinds=allowed_kinds,
+        )
+        endpoint = _client_binding_connected_endpoint(
+            client=flow.client_conn,
+            server=server,
+            port=destination.port,
+            bindings=matching_client_bindings,
+        )
+        return _DestinationBindingMatch(endpoint=endpoint) if endpoint is not None else None
+
+    if _address_matches(
+        destination.host,
+        destination.port,
+        getattr(server, "address", None),
+    ):
+        return _DestinationBindingMatch(endpoint=None)
+    return None
+
+
 def diagnostic_snapshot_for_flow(
     flow: http.HTTPFlow,
     *,
@@ -537,38 +587,13 @@ def flow_matches_normalized_destination(
     Callers that need durable admission must additionally require
     ``has_server_binding`` or go through the privileged binding path.
     """
-    server = flow.server_conn
-    server_id = _connection_id(server)
-    binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
-    if binding is not None:
-        return _binding_matches(
-            binding,
-            host=destination.host,
-            port=destination.port,
-            allowed_kinds=allowed_kinds,
-        ) and _server_binding_matches_current_destination(server, binding)
-
-    if bool(getattr(server, "connected", False)):
-        matching_client_bindings = _matching_client_bindings(
-            flow.client_conn,
-            host=destination.host,
-            port=destination.port,
+    return (
+        _resolve_destination_binding(
+            flow,
+            destination=destination,
             allowed_kinds=allowed_kinds,
         )
-        return (
-            _client_binding_connected_endpoint(
-                client=flow.client_conn,
-                server=server,
-                port=destination.port,
-                bindings=matching_client_bindings,
-            )
-            is not None
-        )
-
-    return _address_matches(
-        destination.host,
-        destination.port,
-        getattr(server, "address", None),
+        is not None
     )
 
 
@@ -614,47 +639,28 @@ def bound_destination_endpoint_for_flow(
 ) -> tuple[str, int] | None:
     """Return the concrete endpoint proven by a matching binding, if any.
 
-    Host-policy checks use this endpoint as connection evidence. A connected
-    fallback match returns the live authoritative endpoint, not a DNS result.
+    Host-policy checks use this endpoint as connection evidence. Direct server
+    bindings are decisive. Without a direct binding, a connected fallback
+    match returns the live authoritative endpoint, not a DNS result, while an
+    unconnected address-only match returns no concrete endpoint.
     """
     trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     if not trusted_host:
         return None
     try:
-        normalized_host = normalize_hostname(trusted_host)
+        destination = normalize_upstream_destination(
+            host=trusted_host,
+            port=flow.request.port,
+        )
     except (UnicodeError, ValueError):
         return None
 
-    port = flow.request.port
-    server = flow.server_conn
-    server_id = _connection_id(server)
-    binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
-    if (
-        binding is not None
-        and _binding_matches(
-            binding,
-            host=normalized_host,
-            port=port,
-            allowed_kinds=allowed_kinds,
-        )
-        and _server_binding_matches_current_destination(server, binding)
-    ):
-        return binding.original_address
-
-    matching_client_bindings = _matching_client_bindings(
-        flow.client_conn,
-        host=normalized_host,
-        port=port,
+    match = _resolve_destination_binding(
+        flow,
+        destination=destination,
         allowed_kinds=allowed_kinds,
     )
-    if bool(getattr(server, "connected", False)):
-        return _client_binding_connected_endpoint(
-            client=flow.client_conn,
-            server=server,
-            port=port,
-            bindings=matching_client_bindings,
-        )
-    return None
+    return match.endpoint if match is not None else None
 
 
 def binding_snapshot_for_tests() -> dict[str, UpstreamDestinationBinding]:

--- a/crates/runner/mitm-addon/tests/test_upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/tests/test_upstream_destination_binding.py
@@ -1,0 +1,131 @@
+"""Exercise the shared upstream binding resolution contract."""
+
+from mitmproxy import connection, http
+
+import flow_metadata_keys as metadata_keys
+import upstream_destination_binding
+from tests.upstream_connection_helpers import seed_server_binding
+
+_ALLOWED_KINDS: frozenset[upstream_destination_binding.BindingKind] = frozenset(("connector_auth",))
+
+
+def _assert_destination_resolution(
+    flow: http.HTTPFlow,
+    *,
+    host: str,
+    port: int,
+    matches: bool,
+    endpoint: tuple[str, int] | None,
+) -> None:
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = host
+    destination = upstream_destination_binding.normalize_upstream_destination(
+        host=host,
+        port=port,
+    )
+
+    assert (
+        upstream_destination_binding.flow_matches_normalized_destination(
+            flow,
+            destination=destination,
+            allowed_kinds=_ALLOWED_KINDS,
+        )
+        is matches
+    )
+    assert (
+        upstream_destination_binding.bound_destination_endpoint_for_flow(
+            flow,
+            allowed_kinds=_ALLOWED_KINDS,
+        )
+        == endpoint
+    )
+
+
+def test_matching_direct_binding_drives_both_projections(real_flow):
+    flow = real_flow(with_response=False, host="api.github.com")
+    flow.server_conn.address = ("203.0.113.10", 443)
+    flow.server_conn.peername = ("203.0.113.10", 443)
+    flow.server_conn.state = connection.ConnectionState.OPEN
+    seed_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=_ALLOWED_KINDS,
+        original_address=("203.0.113.10", 443),
+    )
+
+    _assert_destination_resolution(
+        flow,
+        host="api.github.com",
+        port=443,
+        matches=True,
+        endpoint=("203.0.113.10", 443),
+    )
+
+
+def test_mismatched_direct_binding_blocks_matching_client_fallback(real_flow):
+    flow = real_flow(with_response=False, host="api.github.com")
+    flow.server_conn.address = ("203.0.113.10", 443)
+    flow.server_conn.peername = ("203.0.113.10", 443)
+    flow.server_conn.state = connection.ConnectionState.OPEN
+    prior_server = connection.Server(address=("203.0.113.10", 443))
+    seed_server_binding(
+        prior_server,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=_ALLOWED_KINDS,
+        original_address=("203.0.113.10", 443),
+    )
+    seed_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="attacker.example.com",
+        port=443,
+        kinds=_ALLOWED_KINDS,
+        original_address=("203.0.113.10", 443),
+    )
+
+    _assert_destination_resolution(
+        flow,
+        host="api.github.com",
+        port=443,
+        matches=False,
+        endpoint=None,
+    )
+
+
+def test_connected_client_fallback_drives_both_projections_without_direct_binding(real_flow):
+    flow = real_flow(with_response=False, host="api.github.com")
+    flow.server_conn.address = ("203.0.113.10", 443)
+    flow.server_conn.peername = ("203.0.113.10", 443)
+    flow.server_conn.state = connection.ConnectionState.OPEN
+    prior_server = connection.Server(address=("203.0.113.10", 443))
+    seed_server_binding(
+        prior_server,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=_ALLOWED_KINDS,
+        original_address=("203.0.113.10", 443),
+    )
+
+    _assert_destination_resolution(
+        flow,
+        host="api.github.com",
+        port=443,
+        matches=True,
+        endpoint=("203.0.113.10", 443),
+    )
+
+
+def test_unconnected_address_match_has_no_concrete_endpoint(real_flow):
+    flow = real_flow(with_response=False, host="api.github.com")
+
+    _assert_destination_resolution(
+        flow,
+        host="api.github.com",
+        port=443,
+        matches=True,
+        endpoint=None,
+    )


### PR DESCRIPTION
## Summary

- centralize direct binding, connected same-client fallback, and unconnected address-only selection in one private resolver
- make boolean matching and concrete endpoint lookup project the same direct-binding precedence
- add four real-mitmproxy-flow cases covering both public projections across direct, fallback, and address-only states

## Behavior

When any direct server binding exists, a failed host, port, kind, or current-endpoint validation is now decisive for endpoint lookup as well as boolean matching. Same-client fallback remains available only when the current server has no direct binding. Unconnected normalized-address matches remain boolean success without manufacturing a concrete endpoint.

The public function signatures, binding storage and lifecycle, endpoint validation, TLS checks, callers, diagnostics, and retargeting behavior are unchanged. This PR changes no API, runner/backend protocol, queue payload, persisted state, database, dependency, environment, guest contract, or deployment rollout requirement.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused resolver, API direct-mismatch, and built-in host-policy tests: 19 passed
- `uv run --no-sync python -m pytest -q tests/`: 6631 passed
- pre-commit Ruff, file-size, and commitlint hooks

Closes #29292
