### PR TITLE
feat(platform): show only the title on imported deck tiles

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3451,7 +3451,11 @@ describe("chat composer templates", () => {
       return found as HTMLElement;
     });
     expect(within(card).getByText("Brand system")).toBeInTheDocument();
-    expect(within(card).getByText("18 slides")).toBeInTheDocument();
+    // The tile caption carries the title alone: the slide count and the
+    // visibility marker both belong to the detail panel, which is one click
+    // away and has room to say them properly.
+    expect(within(card).queryByText("18 slides")).toBeNull();
+    expect(card.querySelector(".lucide-globe")).toBeNull();
     const coverImage = within(card).getByRole("img");
     expect(coverImage).toHaveAttribute(
       "src",

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5272,7 +5272,6 @@ function ImportedPptCardCaption({
 }: {
   template: PresentationTemplateSummary;
 }) {
-  const { t } = useTranslation();
   return (
     <div className={TEMPLATE_TILE_CAPTION}>
       <TooltipProvider delayDuration={300}>
@@ -5285,17 +5284,6 @@ function ImportedPptCardCaption({
           <TooltipContent side="bottom">{template.title}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-        {template.visibility === "public" ? (
-          <Globe size={12} aria-hidden="true" />
-        ) : null}
-        {t(
-          ($) => {
-            return $.artifacts.templates.importedSlides;
-          },
-          { count: template.pageCount },
-        )}
-      </span>
     </div>
   );
 }


### PR DESCRIPTION
## What

An uploaded deck's tile in the template picker carried a slide count and a visibility icon in its caption:

`VM0 Workshop` ... `🌐 15 slides`

No built-in template tile carries either. Neither answers the question a grid of thumbnails exists to answer — *which deck is this* — and both compete with the one element that does: the name.

This removes the whole meta span. The tile caption is now the title alone.

## Where those facts still live

Both are already in the detail panel, one click away, with room to state them properly:

- slide count — `3 slides` under the title
- visibility — the state line (`Only you can see and use it` / `Anyone in this workspace can use it`)

## Changes

- `chat-composer.tsx` — `ImportedPptCardCaption` drops the `ml-auto` meta span; the now-unused `useTranslation` call goes with it. `Globe` and the `importedSlides` key both remain in use elsewhere in the file, so neither the import nor the locale strings change.
- `chat-composer-template-picker.test.tsx` — the tile assertion flips from "shows 18 slides" to "shows the title, and neither the count nor the globe".

## Relationship to #29334

Independent. #29334 reworks the visibility control inside the detail panel and no longer touches this caption, so the two merge in either order without conflict.

## Verification

- `pnpm -F @okouai/app check-types` — pass
- `pnpm -F @okouai/app lint` — pass
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx` — 44/44 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)