### PR TITLE
refactor: remove usage pack plans feature switch

### DIFF
--- a/e2e/playwright/tests/billing-payment.spec.ts
+++ b/e2e/playwright/tests/billing-payment.spec.ts
@@ -36,7 +36,6 @@ test("billing settings reflects limited free onboarding", async ({ page }) => {
 test("credit balance bars render with matching outer corner radii", async ({
   page,
 }) => {
-  await enableUsagePackPlans(page);
   await mockCreditBalance(page);
   await openCreditBalanceSettings(page);
 
@@ -68,26 +67,6 @@ test("credit balance bars render with matching outer corner radii", async ({
     lastOrgCreditRadii.bottomLeft,
   ]).toEqual(["0px", "0px", "0px", "0px"]);
 });
-
-async function enableUsagePackPlans(page: Page): Promise<void> {
-  await page.route("**/api/feature-switches", async (route) => {
-    const response = await route.fetch();
-    const body: unknown = await response.json();
-    if (!isRecord(body) || !isRecord(body.effectiveSwitches)) {
-      throw new Error("Feature switches returned an unexpected response");
-    }
-    await route.fulfill({
-      response,
-      json: {
-        ...body,
-        effectiveSwitches: {
-          ...body.effectiveSwitches,
-          usagePackPlans: true,
-        },
-      },
-    });
-  });
-}
 
 async function mockCreditBalance(page: Page): Promise<void> {
   await page.route("**/api/billing/status", async (route) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
+import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import {
   createAuthOrgAgentsBddApi,
   type ApiTestUser,
@@ -12,7 +12,6 @@ import {
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { manualHttpCustomConnectorCreateBody } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 
 /*
 helper gap:
@@ -41,15 +40,11 @@ function slug(prefix: string): string {
   return `${prefix}-${shortId()}`;
 }
 
-async function disableUsagePackPlans(actor: ApiTestUser): Promise<void> {
+function requiredOrgId(actor: ApiTestUser): string {
   if (!actor.orgId) {
     throw new Error("Expected an organization-scoped actor");
   }
-  await updateFeatureSwitchesForUser(
-    context,
-    { ...actor, orgId: actor.orgId },
-    { [FeatureSwitchKey.UsagePackPlans]: false },
-  );
+  return actor.orgId;
 }
 
 async function onboardAdmin(
@@ -246,7 +241,11 @@ describe("ORG-01 and ORG-02", () => {
   it("projects direct invitation redirects by request brand", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const admin = api.user();
-    await disableUsagePackPlans(admin);
+    await upsertOrgPlanEntitlementFixture({
+      orgId: requiredOrgId(admin),
+      memberInvitationAllowed: true,
+      memberInviteUsagePackRequired: false,
+    });
 
     const vm0Email = `vm0-invite-${shortId()}@example.test`;
     context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
@@ -281,7 +280,6 @@ describe("ORG-01 and ORG-02", () => {
 
   it("reads, updates, lists, invites, changes membership, handles requests, and leaves orgs through APIs", async () => {
     const admin = api.user();
-    await disableUsagePackPlans(admin);
     const member = api.user({
       orgId: admin.orgId,
       orgRole: "org:member",
@@ -298,6 +296,11 @@ describe("ORG-01 and ORG-02", () => {
     const requestId = `req_${shortId()}`;
 
     await onboardAdmin(admin, { slug: baseSlug, name: "BDD Org" });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: requiredOrgId(admin),
+      memberInvitationAllowed: true,
+      memberInviteUsagePackRequired: false,
+    });
     api.mockClerkOrg(admin, {
       slug: baseSlug,
       name: "BDD Org",

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -24,7 +24,6 @@ import {
 } from "@okouai/api-contracts/contracts/org-member-routes";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import type { OrgTier } from "@okouai/api-contracts/contracts/orgs";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isStaffOrg } from "@okouai/core/staff-org";
 import {
   webhookClerkContract,
@@ -57,10 +56,6 @@ import {
 } from "./helpers/stripe-billing-webhook";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createRouteMocks } from "./helpers/route-test";
-import {
-  deleteFeatureSwitchesForUser,
-  updateFeatureSwitchesForUser,
-} from "./helpers/feature-switches";
 import { webhooksStripeRoutes } from "../webhooks-stripe";
 import { readOrgAcquisitionAttributionFixture } from "../../../test-fixtures/org-metadata";
 import { webhooksClerkRoutes } from "../webhooks-clerk";
@@ -345,14 +340,6 @@ function authenticateOrg(
   mocks.clerk.session(fixture.userId, fixture.orgId, role);
 }
 
-async function disableUsagePackPlans(
-  fixture: BillingOrgFixture,
-): Promise<void> {
-  await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.UsagePackPlans]: false,
-  });
-}
-
 function mockClerkOrganization(fixture: BillingOrgFixture): void {
   context.mocks.clerk.organizations.getOrganization.mockResolvedValue({
     id: fixture.orgId,
@@ -431,9 +418,6 @@ async function prepareUsagePackCheckoutOrg(
   customerId: string,
 ): Promise<void> {
   await createStripeCustomerOrgForFixture(fixture, customerId);
-  await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.UsagePackPlans]: true,
-  });
   context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
     {
       data: [
@@ -2276,35 +2260,9 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     mockUsagePackCatalog();
   });
 
-  it("keeps the usage pack catalog behind the same feature switch", async () => {
-    const fixture = createOrgFixture();
-    authenticateOrg(fixture);
-    await disableUsagePackPlans(fixture);
-
-    const response = await accept(
-      setupApp({ context, routes: billingCheckoutRoutes })(
-        billingUsagePackCatalogContract,
-      ).get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [403],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Usage pack checkout is not enabled",
-        code: "FORBIDDEN",
-      },
-    });
-    expect(context.mocks.stripe.prices.retrieve).not.toHaveBeenCalled();
-  });
-
   it("returns the server-validated Stripe usage pack catalog", async () => {
     const fixture = createOrgFixture();
     authenticateOrg(fixture);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
 
     const response = await accept(
       setupApp({ context, routes: billingCheckoutRoutes })(
@@ -2349,51 +2307,13 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     });
   });
 
-  it("keeps usage pack checkout behind its feature switch", async () => {
-    const fixture = createOrgFixture();
-    authenticateOrg(fixture);
-    await disableUsagePackPlans(fixture);
-    const before = await readUsagePackState(fixture.orgId);
-
-    const response = await accept(
-      setupApp({ context, routes: billingCheckoutRoutes })(
-        billingUsagePackCheckoutContract,
-      ).create({
-        body: {
-          tier: "pro",
-          memberUsagePacks: [{ memberId: fixture.userId, usagePackUsd: 20 }],
-          successUrl: `${APP_ORIGIN}/billing?billing=success`,
-          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [403],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Usage pack checkout is not enabled",
-        code: "FORBIDDEN",
-      },
-    });
-    expect(
-      context.mocks.stripe.checkout.sessions.create,
-    ).not.toHaveBeenCalled();
-    expect(context.mocks.stripe.prices.retrieve).not.toHaveBeenCalled();
-    const after = await readUsagePackState(fixture.orgId);
-    expect(after.subscriptionCount).toBe(before.subscriptionCount);
-  });
-
-  it("checks out the new plan for an enabled organization", async () => {
+  it("checks out the new plan", async () => {
     const fixture = createOrgFixture();
     const memberIds = Array.from({ length: 101 }, (_, index) => {
       return index === 0 ? fixture.userId : `user_${randomUUID()}`;
     });
     const invitationId = `inv_${randomUUID()}`;
     const customerId = `cus_${randomUUID()}`;
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockImplementation(
       (args) => {
         const offset =
@@ -2575,9 +2495,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     authenticateOrg(fixture);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -2775,9 +2692,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
   it("recovers usage pack checkout from a transient Clerk rate limit", async () => {
     const fixture = createOrgFixture();
     const checkoutSessionId = `cs_${randomUUID()}`;
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.clerk.organizations.getOrganizationMembershipList
       .mockRejectedValueOnce(new ClerkApiResponseTestError(2))
@@ -2842,9 +2756,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("returns a non-cacheable 503 when Clerk rate limits persist", async () => {
     const fixture = createOrgFixture();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
       new ClerkApiResponseTestError(7),
@@ -2883,9 +2794,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("preserves non-rate-limit Clerk checkout failures", async () => {
     const fixture = createOrgFixture();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
       new Error("Clerk membership read failed"),
     );
@@ -2924,9 +2832,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
         readonly createdAt: number;
       }[];
     }>(context.signal);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
       new ClerkApiResponseTestError(1),
@@ -2978,9 +2883,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const controller = new AbortController();
     const retryStarted = createDeferredPromise<void>(context.signal);
     let retrySignal: AbortSignal | undefined;
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.signalTimers.delay.mockImplementation((_ms, options) => {
       const signal = options?.signal;
       if (!signal) {
@@ -3025,9 +2927,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     "configures the current %s plan after an Atom grant",
     async (tier) => {
       const fixture = await createUsagePackAtomGrantOrg(tier);
-      await updateFeatureSwitchesForUser(context, fixture, {
-        [FeatureSwitchKey.UsagePackPlans]: true,
-      });
       context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
         {
           data: [
@@ -3231,9 +3130,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const fixture = createOrgFixture();
     const customerId = `cus_${randomUUID()}`;
     await createStripeCustomerOrgForFixture(fixture, customerId);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -3442,9 +3338,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     authenticateOrg(fixture);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -3778,9 +3671,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const checkoutSessionId = `cs_${randomUUID()}`;
     const checkoutUrl = "https://checkout.stripe.test/aborted-usage-pack";
     authenticateOrg(fixture);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -3884,9 +3774,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const fixture = createOrgFixture();
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -3975,9 +3862,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const subscriptionId = `sub_${randomUUID()}`;
     const hostedInvoiceUrl =
       "https://invoice.stripe.com/usage-pack-authentication";
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -4088,9 +3972,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const fixture = createOrgFixture();
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -4239,9 +4120,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     const paymentMethodId = `pm_${randomUUID()}`;
     const checkoutSessionId = `cs_${randomUUID()}`;
     const checkoutUrl = "https://checkout.stripe.com/session/usage-pack-retry";
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -4380,9 +4258,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("rejects stale member selections before creating checkout", async () => {
     const fixture = createOrgFixture();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -5065,12 +4940,6 @@ describe("legacy subscription usage pack migration", () => {
     );
   }
 
-  async function enableMigration(fixture: BillingOrgFixture): Promise<void> {
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
-  }
-
   async function postMigrationInvoice(invoice: object): Promise<void> {
     const event = {
       id: `evt_migration_${randomUUID()}`,
@@ -5189,33 +5058,8 @@ describe("legacy subscription usage pack migration", () => {
     mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
   });
 
-  it("hides legacy migration while UsagePackPlans is disabled", async () => {
-    const fixture = await seedLegacyMigrationFixture({
-      tier: "pro",
-      orgId: `org_non_staff_${randomUUID()}`,
-    });
-    expect(isStaffOrg(fixture.orgId)).toBeFalsy();
-    await disableUsagePackPlans(fixture);
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
-      legacyMigrationSubscription(fixture),
-    );
-
-    const response = await accept(
-      migrationClient().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [403],
-    );
-
-    expect(response.body.error.message).toBe(
-      "Usage pack management is not enabled",
-    );
-    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
-  });
-
   it("rejects a Stripe subscription scheduled for cancellation", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       ...legacyMigrationSubscription(fixture),
       cancel_at_period_end: true,
@@ -5235,7 +5079,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("prevents an active legacy subscription from bypassing migration", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
 
     const response = await accept(
       setupApp({ context, routes: billingCheckoutRoutes })(
@@ -5262,7 +5105,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("keeps legacy state when the legacy item changes after preview", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
     mockMigrationStripe({
       fixture,
       packageQuantity: 1,
@@ -5312,7 +5154,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("schedules a legacy Pro-to-Team conversion at the billing boundary", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       targetTier: "team",
@@ -5440,7 +5281,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("revises a discounted scheduled migration and exposes its configuration", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       targetTier: "team",
@@ -5615,7 +5455,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("rejects tampered and stale migration revision previews", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
-    await enableMigration(fixture);
     mockMigrationStripe({
       fixture,
       packageQuantity: 1,
@@ -5725,7 +5564,6 @@ describe("legacy subscription usage pack migration", () => {
       tier: "team",
       orgId: `org_migration_preserved_${randomUUID()}`,
     });
-    await enableMigration(preservedFixture);
     mockMigrationStripe({
       fixture: preservedFixture,
       packageQuantity: 1,
@@ -5745,7 +5583,6 @@ describe("legacy subscription usage pack migration", () => {
     const preservedBefore = await readUsagePackState(preservedFixture.orgId);
 
     const fixture = await seedLegacyMigrationFixture({ tier: "team" });
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       packageQuantity: 1,
@@ -5805,7 +5642,6 @@ describe("legacy subscription usage pack migration", () => {
 
   it("syncs legacy cancellation when a subscription update invalidates migration", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "team" });
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       packageQuantity: 1,
@@ -5850,7 +5686,6 @@ describe("legacy subscription usage pack migration", () => {
     if (!fixture.invitation) {
       throw new Error("Expected a pending invitation fixture");
     }
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       packageQuantity: 2,
@@ -5931,7 +5766,6 @@ describe("legacy subscription usage pack migration", () => {
     if (!fixture.invitation) {
       throw new Error("Expected a pending invitation fixture");
     }
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       packageQuantity: 2,
@@ -6010,7 +5844,7 @@ describe("legacy subscription usage pack migration", () => {
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
   });
 
-  it("finishes a zero-amount Team conversion and invitation lifecycle after switch-off", async () => {
+  it("finishes a zero-amount Team conversion and invitation lifecycle", async () => {
     const fixture = await seedLegacyMigrationFixture({
       tier: "team",
       invitation: true,
@@ -6018,7 +5852,6 @@ describe("legacy subscription usage pack migration", () => {
     if (!fixture.invitation) {
       throw new Error("Expected a pending invitation fixture");
     }
-    await enableMigration(fixture);
     const stripe = mockMigrationStripe({
       fixture,
       packageQuantity: 2,
@@ -6037,9 +5870,6 @@ describe("legacy subscription usage pack migration", () => {
     );
     expect(confirmation.body.status).toBe("scheduled");
 
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
     stripe.startScheduledPhase();
     await postMigrationInvoice(stripe.invoice());
 
@@ -6406,9 +6236,6 @@ describe("usage pack allocation management", () => {
       });
     });
     authenticateOrg(fixture);
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     const quantities = new Map<string, number>();
     for (const allocation of allocations) {
       const priceId = priceIdForManagedUsagePack(allocation.usagePackUsd);
@@ -10693,7 +10520,7 @@ describe("usage pack allocation management", () => {
     expect(state.changes[0]?.status).toBe("previewed");
   });
 
-  it("applies a paid upgrade once with the preview proration date while the switch is off", async () => {
+  it("applies a paid upgrade once with the preview proration date", async () => {
     mockNow(new Date("2035-01-16T00:00:00.000Z"));
     onTestFinished(() => {
       clearMockNow();
@@ -10787,9 +10614,6 @@ describe("usage pack allocation management", () => {
     expect(beforePayment.allocations[0]?.usagePackUsd).toBe(20);
     expect(beforePayment.grants).toHaveLength(2);
 
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
     const paidInvoice = managedUsagePackUpgradeInvoice(fixture, {
       invoiceId: pendingInvoiceId,
       sourcePriceId: TEST_PRICE_USAGE_PACK_20,
@@ -10841,17 +10665,6 @@ describe("usage pack allocation management", () => {
         stripeInvoiceId: pendingInvoiceId,
       }),
     ]);
-
-    const disabled = await accept(
-      client.previewChange({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { memberId: sourceUserId, targetUsagePackUsd: 100 },
-      }),
-      [403],
-    );
-    expect(disabled.body.error.message).toBe(
-      "Usage pack management is not enabled",
-    );
   });
 
   it("completes an immediately paid upgrade during confirmation", async () => {
@@ -11651,11 +11464,6 @@ describe("usage pack allocation management", () => {
         return allocation.userId !== targetUserId;
       })?.userId ?? "";
     mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId: fixture.orgId, userId: adminUserId },
-      { [FeatureSwitchKey.UsagePackPlans]: false },
-    );
     context.mocks.clerk.users.getUserList.mockResolvedValue({
       data: [{ id: targetUserId }],
     });
@@ -11895,11 +11703,6 @@ describe("usage pack allocation management", () => {
       }),
     );
 
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId: fixture.orgId, userId: adminUserId },
-      { [FeatureSwitchKey.UsagePackPlans]: true },
-    );
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       managedUsagePackSubscription(
         fixture,
@@ -11955,9 +11758,6 @@ describe("usage pack allocation management", () => {
       action: "delete-refund-source",
       orgId: fixture.orgId,
       userId: targetUserId,
-    });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
     });
     context.mocks.clerk.users.getUserList.mockResolvedValue({
       data: [{ id: targetUserId }],
@@ -12111,9 +11911,6 @@ describe("usage pack allocation management", () => {
       action: "delete-refund-source",
       orgId: fixture.orgId,
       userId: targetUserId,
-    });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
     });
     context.mocks.clerk.users.getUserList.mockResolvedValue({
       data: [{ id: targetUserId }],
@@ -12507,9 +12304,6 @@ describe("usage pack allocation management", () => {
       const billing = await readBillingStatus(fixture);
       expect(billing.memberInviteUsagePackRequired).toBeFalsy();
 
-      await updateFeatureSwitchesForUser(context, fixture, {
-        [FeatureSwitchKey.UsagePackPlans]: true,
-      });
       context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
         { id: `inv_${randomUUID()}` },
       );
@@ -12526,45 +12320,7 @@ describe("usage pack allocation management", () => {
     },
   );
 
-  it("keeps package-free invites available when usage pack enrollment is disabled", async () => {
-    const fixture = await seedManagedUsagePack([
-      { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
-    ]);
-    const client = setupApp({ context, routes: orgInviteRoutes })(
-      orgInviteContract,
-    );
-    const blocked = await accept(
-      client.invite({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { email: "paid@example.test", role: "member" },
-      }),
-      [409],
-    );
-    expect(blocked.body.error.code).toBe("CONFLICT");
-    expect(
-      context.mocks.clerk.organizations.createOrganizationInvitation,
-    ).not.toHaveBeenCalled();
-    expect(
-      (await readBillingStatus(fixture)).memberInviteUsagePackRequired,
-    ).toBeTruthy();
-
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
-    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
-      { id: `inv_${randomUUID()}` },
-    );
-    const legacy = await accept(
-      client.invite({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { email: "legacy@example.test", role: "member" },
-      }),
-      [200],
-    );
-    expect(legacy.body.message).toContain("legacy@example.test");
-  });
-
-  it("blocks free plans only while usage pack plans are enabled", async () => {
+  it("blocks free plans from inviting members", async () => {
     const fixture = await seedManagedUsagePack([
       { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
     ]);
@@ -12589,31 +12345,13 @@ describe("usage pack allocation management", () => {
     expect(
       context.mocks.clerk.organizations.createOrganizationInvitation,
     ).not.toHaveBeenCalled();
-
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
-    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
-      { id: `inv_${randomUUID()}` },
-    );
-    const legacy = await accept(
-      client.invite({
-        headers: { authorization: "Bearer clerk-session" },
-        body: { email: "suspended@example.test", role: "member" },
-      }),
-      [200],
-    );
-    expect(legacy.body.message).toContain("suspended@example.test");
   });
 
-  it("honors the invitation feature switch for a non-staff org", async () => {
+  it("supports invitation purchase for a non-staff org", async () => {
     const fixture = createOrgFixture();
     expect(isStaffOrg(fixture.orgId)).toBeFalsy();
     authenticateOrg(fixture);
     await seedOrgMetadata({ orgId: fixture.orgId, tier: "pro", credits: 0 });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
 
     const response = await accept(
       setupApp({ context, routes: orgInviteRoutes })(
@@ -14371,12 +14109,6 @@ describe("usage pack allocation management", () => {
       orgId: purchase.fixture.orgId,
       userId: acceptedUserId,
     };
-    await updateFeatureSwitchesForUser(context, acceptedActor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
-    onTestFinished(async () => {
-      await deleteFeatureSwitchesForUser(context, acceptedActor);
-    });
     authenticateOrg(acceptedActor, "org:member");
     const credits = await accept(
       setupApp({ context, routes: billingUsagePackCreditsRoutes })(
@@ -14840,9 +14572,6 @@ describe("usage pack allocation management", () => {
     const purchase = await beginInvitationPurchase();
     const invitationId = `inv_expired_${randomUUID()}`;
     await payInvitationPurchase(purchase, invitationId);
-    await updateFeatureSwitchesForUser(context, purchase.fixture, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
     context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
       { data: [{ id: invitationId }] },
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -2309,6 +2309,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("checks out the new plan", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const memberIds = Array.from({ length: 101 }, (_, index) => {
       return index === 0 ? fixture.userId : `user_${randomUUID()}`;
     });
@@ -2691,6 +2692,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("recovers usage pack checkout from a transient Clerk rate limit", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const checkoutSessionId = `cs_${randomUUID()}`;
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.clerk.organizations.getOrganizationMembershipList
@@ -2756,6 +2758,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("returns a non-cacheable 503 when Clerk rate limits persist", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
       new ClerkApiResponseTestError(7),
@@ -2794,6 +2797,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("preserves non-rate-limit Clerk checkout failures", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
       new Error("Clerk membership read failed"),
     );
@@ -2824,6 +2828,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("stops sibling Clerk pagination after checkout directory exhaustion", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const invitationPage = createDeferredPromise<{
       readonly data: readonly {
         readonly id: string;
@@ -2880,6 +2885,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("stops Clerk retries when usage pack checkout is cancelled", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const controller = new AbortController();
     const retryStarted = createDeferredPromise<void>(context.signal);
     let retrySignal: AbortSignal | undefined;
@@ -3772,6 +3778,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("rejects a usage pack preview after a replacement retires its snapshot", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
@@ -3857,6 +3864,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("attempts the saved card for an open usage pack invoice", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     const subscriptionId = `sub_${randomUUID()}`;
@@ -3970,6 +3978,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("reuses a pending usage pack preview and creates one subscription", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
@@ -4116,6 +4125,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("reuses an open Checkout when repeated usage pack previews lose their saved card", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
     const checkoutSessionId = `cs_${randomUUID()}`;
@@ -4258,6 +4268,7 @@ describe("POST /api/billing/usage-pack-checkout", () => {
 
   it("rejects stale member selections before creating checkout", async () => {
     const fixture = createOrgFixture();
+    authenticateOrg(fixture);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
@@ -2,17 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { testUsageSettlementContract } from "@okouai/api-contracts/contracts/test-usage-settlement";
 import { billingUsagePackCreditsContract } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
-import {
-  deleteFeatureSwitchesForUser,
-  updateFeatureSwitchesForUser,
-} from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { testUsageSettlementRoutes } from "../test-usage-settlement";
 import {
@@ -146,41 +141,14 @@ function registerCleanup(
       settlementClient().cleanup({ body: { org_id: actor.orgId } }),
       [200],
     );
-    await deleteFeatureSwitchesForUser(context, actor);
   });
 }
 
 describe("GET /api/billing/usage-pack-credits", () => {
-  it("keeps member usage pack credits behind UsagePackPlans", async () => {
-    const actor = fixture();
-    registerCleanup(actor);
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
-    authenticate(actor);
-
-    const response = await accept(
-      creditsClient().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [403],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Usage pack credits are not enabled",
-        code: "FORBIDDEN",
-      },
-    });
-  });
-
   it("reports when the organization has no active usage pack", async () => {
     mockEnv("ENV", "development");
     const actor = fixture();
     registerCleanup(actor);
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     authenticate(actor);
 
     const response = await accept(
@@ -207,9 +175,6 @@ describe("GET /api/billing/usage-pack-credits", () => {
       `user_${randomUUID()}`,
     );
     registerCleanup(actor, usagePackSubscriptionId);
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
-    });
     authenticate(actor);
 
     const response = await accept(
@@ -239,9 +204,6 @@ describe("GET /api/billing/usage-pack-credits", () => {
       grantType: "bonus",
       amount: 10_000,
       expiresAt: "2026-09-10T00:00:00.000Z",
-    });
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
     });
     authenticate(actor);
 
@@ -300,9 +262,6 @@ describe("GET /api/billing/usage-pack-credits", () => {
       grantType: "bonus",
       amount: 1000,
       expiresAt: "2026-08-09T00:00:00.000Z",
-    });
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
     });
     authenticate(actor);
 
@@ -365,9 +324,6 @@ describe("GET /api/billing/usage-pack-credits", () => {
       grantType: "bonus",
       amount: 4350,
       expiresAt: "2026-09-10T00:00:00.000Z",
-    });
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.UsagePackPlans]: true,
     });
     authenticate(actor, "org:admin");
 

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -10,8 +10,6 @@ import {
   type UsagePackSubscriptionChangePreviewResponse,
 } from "@okouai/api-contracts/contracts/billing";
 import { adAttributionMetadataSchema } from "@okouai/api-contracts/contracts/acquisition-attribution";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
 
@@ -88,7 +86,6 @@ import {
   loadBillingOrganizationDirectory,
   loadBillingOrganizationMemberships,
 } from "../services/billing-clerk-directory.service";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { reconcilePaidStripeInvoice$ } from "../services/webhooks-stripe.service";
 import {
   mergeFirstTouchAttribution,
@@ -102,26 +99,6 @@ const adminRequired = Object.freeze({
   body: Object.freeze({
     error: Object.freeze({
       message: "Only org admins can manage billing",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
-
-const usagePackCheckoutDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Usage pack checkout is not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
-
-const usagePackManagementDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Usage pack management is not enabled",
       code: "FORBIDDEN",
     }),
   }),
@@ -755,20 +732,6 @@ const usagePackCheckoutAuthed$ = command(
       );
     }
 
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(FeatureSwitchKey.UsagePackPlans, {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return usagePackCheckoutDisabled;
-    }
-
     const db = get(db$);
     if (!(await usagePackPurchaseSerializationSchemaAvailable(db))) {
       return providerUnavailable("Usage pack billing is not ready");
@@ -890,20 +853,6 @@ const usagePackCatalogAuthed$ = command(
     if (auth.orgRole !== "admin") {
       return adminRequired;
     }
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(FeatureSwitchKey.UsagePackPlans, {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return usagePackCheckoutDisabled;
-    }
-
     const usagePacks = await loadUsagePackCatalog();
     signal.throwIfAborted();
     return { status: 200 as const, body: { usagePacks: [...usagePacks] } };
@@ -953,31 +902,14 @@ const usagePackCheckoutConfirm$ = command(
   },
 );
 
-const usagePackManagementAccess$ = command(
-  async ({ get }, signal: AbortSignal) => {
-    const auth = get(organizationAuthContext$);
-    if (auth.orgRole !== "admin") {
-      return { allowed: false as const, response: adminRequired };
-    }
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(FeatureSwitchKey.UsagePackPlans, {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return {
-        allowed: false as const,
-        response: usagePackManagementDisabled,
-      };
-    }
-    return { allowed: true as const, auth };
-  },
-);
+const usagePackManagementAccess$ = command(({ get }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return { allowed: false as const, response: adminRequired };
+  }
+  signal.throwIfAborted();
+  return { allowed: true as const, auth };
+});
 
 const usagePackManagementGetAuthed$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/routes/billing-usage-pack-credits.ts
+++ b/turbo/apps/api/src/signals/routes/billing-usage-pack-credits.ts
@@ -1,12 +1,9 @@
 import { command } from "ccstate";
 import { billingUsagePackCreditsContract } from "@okouai/api-contracts/contracts/billing";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { db$ } from "../external/db";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   getOrganizationUsagePackCreditBalances,
   getUsagePackCreditBalance,
@@ -14,32 +11,8 @@ import {
 } from "../services/usage-pack-credit.service";
 import type { RouteEntry } from "../route-entry";
 
-const usagePackCreditsDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Usage pack credits are not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
-
 const getUsagePackCredits$ = command(async ({ get }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  signal.throwIfAborted();
-  if (
-    !isFeatureEnabled(FeatureSwitchKey.UsagePackPlans, {
-      orgId: auth.orgId,
-      userId: auth.userId,
-      overrides,
-    })
-  ) {
-    return usagePackCreditsDisabled;
-  }
-
   const db = get(db$);
   const hasUsagePack = await hasActiveUsagePackAllocation(db, {
     orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -1,9 +1,7 @@
-import { command, computed, type Computed } from "ccstate";
+import { command } from "ccstate";
 import type { UsagePackUsd } from "@okouai/api-contracts/contracts/billing";
 import { orgInviteContract } from "@okouai/api-contracts/contracts/org-member-routes";
 import type { OrgRole } from "@okouai/api-contracts/contracts/org-members";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -23,7 +21,6 @@ import { clerk$ } from "../external/clerk";
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import {
   confirmUsagePackInvitationPurchase,
@@ -198,20 +195,6 @@ function invitationPurchaseError(args: {
 
 const inviteBody$ = bodyResultOf(orgInviteContract.invite);
 
-function usagePackInvitationsEnabled(
-  orgId: string,
-  userId: string,
-): Computed<Promise<boolean>> {
-  return computed(async (get) => {
-    const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
-    return isFeatureEnabled(FeatureSwitchKey.UsagePackPlans, {
-      orgId,
-      userId,
-      overrides,
-    });
-  });
-}
-
 const inviteInner$ = command(async ({ get }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.orgRole !== "admin") {
@@ -224,22 +207,19 @@ const inviteInner$ = command(async ({ get }, signal: AbortSignal) => {
     return body.response;
   }
 
-  if (await get(usagePackInvitationsEnabled(auth.orgId, auth.userId))) {
-    signal.throwIfAborted();
-    const db = get(db$);
-    const capabilities = await loadOrgPlanCapabilities(db, auth.orgId);
-    signal.throwIfAborted();
-    if (!capabilities?.memberInvitationAllowed) {
-      return memberInvitationUpgradeRequired;
+  const db = get(db$);
+  const capabilities = await loadOrgPlanCapabilities(db, auth.orgId);
+  signal.throwIfAborted();
+  if (!capabilities?.memberInvitationAllowed) {
+    return memberInvitationUpgradeRequired;
+  }
+  if (capabilities.memberInviteUsagePackRequired) {
+    if (!(await usagePackInvitationPurchaseSchemaAvailable(db))) {
+      return providerUnavailable("Usage pack invitations are not ready");
     }
-    if (capabilities?.memberInviteUsagePackRequired) {
-      if (!(await usagePackInvitationPurchaseSchemaAvailable(db))) {
-        return providerUnavailable("Usage pack invitations are not ready");
-      }
-      return conflict(
-        "A usage pack must be purchased before inviting this member",
-      );
-    }
+    return conflict(
+      "A usage pack must be purchased before inviting this member",
+    );
   }
 
   // Clerk side effect: sends the invitation email server-side.
@@ -321,17 +301,6 @@ const purchasePreviewInner$ = command(
     }
     if (!optionalEnv("STRIPE_SECRET_KEY")) {
       return providerUnavailable("Billing not configured");
-    }
-    if (!(await get(usagePackInvitationsEnabled(auth.orgId, auth.userId)))) {
-      return {
-        status: 403 as const,
-        body: {
-          error: {
-            message: "Usage pack invitations are not enabled",
-            code: "FORBIDDEN",
-          },
-        },
-      };
     }
     signal.throwIfAborted();
     const db = get(db$);
@@ -493,17 +462,6 @@ const purchaseConfirmInner$ = command(
     }
     if (!optionalEnv("STRIPE_SECRET_KEY")) {
       return providerUnavailable("Billing not configured");
-    }
-    if (!(await get(usagePackInvitationsEnabled(auth.orgId, auth.userId)))) {
-      return {
-        status: 403 as const,
-        body: {
-          error: {
-            message: "Usage pack invitations are not enabled",
-            code: "FORBIDDEN",
-          },
-        },
-      };
     }
     signal.throwIfAborted();
     const db = get(db$);

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4644,7 +4644,6 @@
         "usage": {
           "balanceDescription": "Was deinem Team noch zum Ausgeben bleibt.",
           "balanceTitle": "Credit-Guthaben",
-          "balanceUsageDescription": "Guthaben und Verbrauch deines Teams.",
           "usageDescription": "Ihre Credit-Nutzung über Chats, Automatisierungen und Kanäle hinweg.",
           "usageTitle": "Credit-Nutzung"
         }

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4636,7 +4636,6 @@
         "usage": {
           "balanceDescription": "What your team has left to spend.",
           "balanceTitle": "Credit balance",
-          "balanceUsageDescription": "Your team's credit balance and usage.",
           "usageDescription": "Your credit usage across chats, automations, and channels.",
           "usageTitle": "Credit usage"
         }

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4701,7 +4701,6 @@
         "usage": {
           "balanceDescription": "Lo que le queda a tu equipo para gastar.",
           "balanceTitle": "Saldo de créditos",
-          "balanceUsageDescription": "El saldo de créditos y el uso de tu equipo.",
           "usageDescription": "Tu consumo de créditos en conversaciones, automatizaciones y canales.",
           "usageTitle": "Consumo de créditos"
         }

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4701,7 +4701,6 @@
         "usage": {
           "balanceDescription": "Ce qu'il reste à dépenser à votre équipe.",
           "balanceTitle": "Solde de crédits",
-          "balanceUsageDescription": "Le solde de crédits et la consommation de votre équipe.",
           "usageDescription": "Votre utilisation des crédits dans les conversations, automatisations et canaux.",
           "usageTitle": "Utilisation des crédits"
         }

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4644,7 +4644,6 @@
         "usage": {
           "balanceDescription": "आपकी टीम के पास खर्च करने के लिए कितना बचा है।",
           "balanceTitle": "क्रेडिट शेष",
-          "balanceUsageDescription": "आपकी टीम का क्रेडिट बैलेंस और उपयोग।",
           "usageDescription": "चैट, ऑटोमेशन और चैनलों पर आपका क्रेडिट उपयोग।",
           "usageTitle": "क्रेडिट उपयोग"
         }

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4636,7 +4636,6 @@
         "usage": {
           "balanceDescription": "Sisa yang bisa dibelanjakan tim Anda.",
           "balanceTitle": "Saldo kredit",
-          "balanceUsageDescription": "Saldo kredit dan penggunaan tim Anda.",
           "usageDescription": "Penggunaan kredit Anda di seluruh chat, otomatisasi, dan channel.",
           "usageTitle": "Penggunaan kredit"
         }

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4701,7 +4701,6 @@
         "usage": {
           "balanceDescription": "Quanto resta da spendere al tuo team.",
           "balanceTitle": "Saldo del credito",
-          "balanceUsageDescription": "Il saldo dei crediti e l'utilizzo del tuo team.",
           "usageDescription": "Il tuo utilizzo del credito attraverso chat, automazioni e canali.",
           "usageTitle": "Utilizzo del credito"
         }

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4636,7 +4636,6 @@
         "usage": {
           "balanceDescription": "チームが使える残高です。",
           "balanceTitle": "クレジット残高",
-          "balanceUsageDescription": "チームのクレジット残高と使用量。",
           "usageDescription": "チャット、オートメーション、チャネル全体でのクレジットの使用状況。",
           "usageTitle": "クレジット使用量"
         }

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4636,7 +4636,6 @@
         "usage": {
           "balanceDescription": "팀이 사용할 수 있는 잔액입니다.",
           "balanceTitle": "크레딧 잔액",
-          "balanceUsageDescription": "팀의 크레딧 잔액 및 사용량입니다.",
           "usageDescription": "채팅, 자동화, 채널에서의 크레딧 사용량입니다.",
           "usageTitle": "크레딧 사용량"
         }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4701,7 +4701,6 @@
         "usage": {
           "balanceDescription": "O que resta para a sua equipe gastar.",
           "balanceTitle": "Saldo de créditos",
-          "balanceUsageDescription": "O saldo de créditos e o uso da sua equipe.",
           "usageDescription": "Seu uso de créditos em conversas, automações e canais.",
           "usageTitle": "Uso de créditos"
         }

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -27,7 +27,6 @@ import {
   type UsagePackMigrationStateResponse,
   type GoogleAdsPaidConversion,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { apiClient$ } from "../api-client.ts";
 import { replaceSearchParams$, searchParams$ } from "../route.ts";
@@ -51,7 +50,6 @@ import {
   fireGoogleAdsPaidConversion$,
 } from "../bootstrap/google-ads-paid-conversion.ts";
 import { currentLocale, i18n } from "../../i18n/index.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { refreshOrgMembers$ } from "../external/org-members.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";
 import {
@@ -486,9 +484,6 @@ export const usagePackManagementAsync$ = computed(async (get) => {
 export const usagePackMigrationAsync$ = computed(
   async (get): Promise<UsagePackMigrationStateResponse | null> => {
     get(usagePackMigrationReload$);
-    if (!get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans]) {
-      return null;
-    }
     const createClient = get(apiClient$);
     const client = createClient(billingUsagePackMigrationContract);
     const result = await accept(client.get(), [200, 403, 404, 409]);
@@ -525,18 +520,10 @@ interface AccountMenuCreditResources {
 }
 
 const readAccountMenuCreditResources$ = command(
-  (
-    { get },
-    options: {
-      readonly isAdmin: boolean;
-      readonly usagePackPlansEnabled: boolean;
-    },
-  ): AccountMenuCreditResources => {
+  ({ get }, isAdmin: boolean): AccountMenuCreditResources => {
     return {
-      billing: options.isAdmin ? get(billingStatusResource$) : null,
-      usagePack: options.usagePackPlansEnabled
-        ? get(usagePackCreditsResource$)
-        : null,
+      billing: isAdmin ? get(billingStatusResource$) : null,
+      usagePack: get(usagePackCreditsResource$),
     };
   },
 );
@@ -591,15 +578,9 @@ export const reloadAccountMenuCreditBalances$ = command(
     const foregroundReady = get(foregroundReady$);
     const isAdmin = await get(isOrgAdmin$);
     signal.throwIfAborted();
-    const usagePackPlansEnabled =
-      get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans] ?? false;
-    if (!isAdmin && !usagePackPlansEnabled) {
-      return;
-    }
-    const options = { isAdmin, usagePackPlansEnabled };
 
     if (!foregroundReady.pending) {
-      const resources = set(readAccountMenuCreditResources$, options);
+      const resources = set(readAccountMenuCreditResources$, isAdmin);
       const pendingResources = set(
         reloadSettledAccountMenuCreditResources$,
         resources,
@@ -616,11 +597,9 @@ export const reloadAccountMenuCreditBalances$ = command(
       if (isAdmin) {
         set(reloadAccountMenuBillingStatusResource$);
       }
-      if (usagePackPlansEnabled) {
-        set(reloadAccountMenuUsagePackCreditsResource$);
-      }
+      set(reloadAccountMenuUsagePackCreditsResource$);
     }
-    const resources = set(readAccountMenuCreditResources$, options);
+    const resources = set(readAccountMenuCreditResources$, isAdmin);
     await set(joinAccountMenuCreditResources$, resources, signal);
     signal.throwIfAborted();
   },

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -17,7 +17,6 @@ import type {
   OrgRole,
 } from "@okouai/api-contracts/contracts/org-members";
 import type { UsagePackUsd } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { isOrgAdmin$, org$, refreshOrg$ } from "../../org.ts";
 import { apiClient$ } from "../../api-client.ts";
@@ -25,7 +24,6 @@ import { clerk$, resolveAppAuthUrl } from "../../auth.ts";
 import { refreshOrgMembers$ } from "../../external/org-members.ts";
 import { accept } from "../../../lib/accept.ts";
 import { i18n } from "../../../i18n/index.ts";
-import { featureSwitch$ } from "../../external/feature-switch.ts";
 import {
   billingStatusAsync$,
   reloadBillingStatus$,
@@ -307,9 +305,6 @@ export const closeInvitePurchasePreview$ = command(({ set }) => {
 });
 
 export const memberUsagePackManagement$ = computed((get) => {
-  if (!get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans]) {
-    return null;
-  }
   return (async () => {
     if (!(await get(isOrgAdmin$))) {
       return null;

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -1,18 +1,15 @@
 import { command } from "ccstate";
 import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onboarding";
 import {
-  billingCheckoutContract,
   billingRedeemCodeContract,
   billingUsagePackCheckoutContract,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
 import { ROUTES } from "../route-paths.ts";
 import { billingStatusAsync$ } from "../okou-page/billing.ts";
 import { readStoredAdAttributionMetadata$ } from "../bootstrap/ad-attribution.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { reloadOnboardingStatus$ } from "../okou-page/onboarding.ts";
 import {
   ONBOARDING_CHECKOUT_STATE_PARAM,
@@ -119,49 +116,27 @@ export const prepareOnboardingVideoRun$ = command(
     const adAttribution = set(readStoredAdAttributionMetadata$);
     const successUrl = checkoutReturnUrl(input, "pro", checkoutState);
     const cancelUrl = checkoutReturnUrl(input, "canceled", checkoutState);
-    let checkoutUrl: string;
-    if (get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans]) {
-      const { userId } = await get(authenticatedIdentity$);
-      signal.throwIfAborted();
-      const client = get(apiClient$)(billingUsagePackCheckoutContract);
-      const result = await accept(
-        client.create({
-          body: {
-            tier: "pro",
-            memberUsagePacks: [{ memberId: userId, usagePackUsd: 20 }],
-            successUrl,
-            cancelUrl,
-            ...(adAttribution === undefined ? {} : { adAttribution }),
-          },
-          fetchOptions: { signal },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
-      if (!("url" in result.body)) {
-        throw new Error("Onboarding checkout unexpectedly returned a preview");
-      }
-      checkoutUrl = result.body.url;
-    } else {
-      const client = get(apiClient$)(billingCheckoutContract);
-      const result = await accept(
-        client.create({
-          body: {
-            tier: "pro",
-            successUrl,
-            cancelUrl,
-            ...(adAttribution === undefined ? {} : { adAttribution }),
-          },
-          fetchOptions: { signal },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
-      if (!("url" in result.body)) {
-        throw new Error("Onboarding checkout unexpectedly returned a preview");
-      }
-      checkoutUrl = result.body.url;
+    const { userId } = await get(authenticatedIdentity$);
+    signal.throwIfAborted();
+    const client = get(apiClient$)(billingUsagePackCheckoutContract);
+    const result = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          memberUsagePacks: [{ memberId: userId, usagePackUsd: 20 }],
+          successUrl,
+          cancelUrl,
+          ...(adAttribution === undefined ? {} : { adAttribution }),
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    if (!("url" in result.body)) {
+      throw new Error("Onboarding checkout unexpectedly returned a preview");
     }
+    const checkoutUrl = result.body.url;
     set(capturePaidOnboardingCheckoutCreated$, "onboarding_video");
     set(capturePaidOnboardingRedirectToStripe$, "onboarding_video");
     window.location.href = checkoutUrl;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2025,7 +2025,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: false },
     });
 
     await expectComposerModel("DeepSeek V4 Flash");
@@ -2045,7 +2044,7 @@ describe("chat composer models", () => {
       screen.getByRole("option", { name: /Claude Fable 5.*Pro/u }),
     );
     await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from "vitest";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fill } from "../../../__tests__/page-helper.ts";
 import {
   mockChatLifecycle,
@@ -28,8 +27,6 @@ import {
   chatComposerTextarea,
 } from "./chat-lifecycle-test-helpers.ts";
 import { billingStatus } from "./chat-composer-test-helpers.ts";
-
-const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function computerUseRow(switchName: string): HTMLElement {
   const row = screen
@@ -1450,7 +1447,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: LEGACY_PRICING,
     });
 
     await waitFor(() => {
@@ -1470,10 +1466,7 @@ describe("chat lifecycle", () => {
       );
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Compare plans" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("Upgrade or downgrade anytime."),
+        screen.getByRole("heading", { name: "Choose a plan" }),
       ).toBeInTheDocument();
     });
     await waitFor(() => {
@@ -1504,7 +1497,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: LEGACY_PRICING,
     });
 
     const voiceInput = await screen.findByLabelText("Voice input");
@@ -1518,7 +1510,7 @@ describe("chat lifecycle", () => {
       );
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Compare plans" }),
+        screen.getByRole("heading", { name: "Choose a plan" }),
       ).toBeInTheDocument();
     });
     expect(screen.queryByLabelText("Stop recording")).toBeNull();
@@ -1569,7 +1561,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: LEGACY_PRICING,
     });
 
     await user.click(await screen.findByLabelText("Voice input"));
@@ -1581,7 +1572,7 @@ describe("chat lifecycle", () => {
       );
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Compare plans" }),
+        screen.getByRole("heading", { name: "Choose a plan" }),
       ).toBeInTheDocument();
     });
   });
@@ -1671,7 +1662,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: LEGACY_PRICING,
     });
 
     await waitFor(() => {
@@ -1691,7 +1681,7 @@ describe("chat lifecycle", () => {
       );
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Compare plans" }),
+        screen.getByRole("heading", { name: "Choose a plan" }),
       ).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
@@ -39,18 +39,13 @@ function mockSlackStatus(overrides: Partial<SlackOrgStatus>): void {
 interface GrowthEntrySetupOptions {
   readonly growthEntryEnabled?: boolean;
   readonly role?: "admin" | "member";
-  readonly usagePackPlansEnabled?: boolean;
 }
 
 function setupGrowthEntry(
   slack: Partial<SlackOrgStatus>,
   options: GrowthEntrySetupOptions = {},
 ): void {
-  const {
-    growthEntryEnabled = true,
-    role = "admin",
-    usagePackPlansEnabled = false,
-  } = options;
+  const { growthEntryEnabled = true, role = "admin" } = options;
   mockAgent();
   context.mocks.data.org({
     id: "org_1",
@@ -63,7 +58,6 @@ function setupGrowthEntry(
     path: `/agents/${AGENT_ID}/chat`,
     featureSwitches: {
       [FeatureSwitchKey.HomeGrowthEntry]: growthEntryEnabled,
-      [FeatureSwitchKey.UsagePackPlans]: usagePackPlansEnabled,
     },
   });
 }
@@ -173,6 +167,14 @@ describe("home growth entry", () => {
 
   it("opens usage from the credit balance", async () => {
     const user = userEvent.setup();
+    context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
+      return respond(200, {
+        totalCredits: 0,
+        purchasedCredits: 0,
+        bonusCredits: 0,
+        creditGrants: [],
+      });
+    });
     setupGrowthEntry({ isConnected: true, isInstalled: true });
 
     await screen.findByTestId("growth-entry");
@@ -199,10 +201,7 @@ describe("home growth entry", () => {
         creditGrants: [],
       });
     });
-    setupGrowthEntry(
-      { isConnected: true, isInstalled: true },
-      { usagePackPlansEnabled: true },
-    );
+    setupGrowthEntry({ isConnected: true, isInstalled: true });
 
     await screen.findByTestId("growth-entry");
     expect(usagePackCreditRequests).toBe(0);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -1,6 +1,5 @@
 import {
   billingAutoRechargeContract,
-  billingCheckoutContract,
   billingUsagePackCatalogContract,
   billingUsagePackCheckoutContract,
   billingUsagePackManagementContract,
@@ -13,11 +12,9 @@ import {
   billingRestoreContract,
   billingStatusContract,
   type BillingStatusResponse,
-  type CheckoutRequest,
   type CreditCheckoutRequest,
   type UsagePackMigrationStateResponse,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "@okouai/ui/components/ui/sonner";
@@ -33,7 +30,6 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
-const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function queryButtonByText(
   text: string,
@@ -268,14 +264,10 @@ function mockBillingStory(): {
   };
 }
 
-async function openBillingTab(
-  path = "/?settings=billing",
-  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
+async function openBillingTab(path = "/?settings=billing"): Promise<void> {
   detachedSetupPage({
     context,
     path,
-    featureSwitches: { ...LEGACY_PRICING, ...featureSwitches },
   });
   await waitFor(() => {
     expect(
@@ -329,57 +321,7 @@ async function waitForAnimationFrame(): Promise<void> {
 }
 
 describe("organization billing settings", () => {
-  it("localizes plans, credit purchases, and currency in Portuguese", async () => {
-    let usagePackCatalogCalls = 0;
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Localized Org",
-      role: "admin",
-    });
-    context.mocks.data.userPreferences({ locale: "pt-BR" });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, {
-        ...activeProBillingStatus(),
-        canBuyCredits: true,
-        autoRechargeAllowed: true,
-      });
-    });
-    context.mocks.api(billingUsagePackCatalogContract.get, ({ respond }) => {
-      usagePackCatalogCalls += 1;
-      return respond(200, usagePackCatalogResponse());
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/?settings=billing",
-      featureSwitches: LEGACY_PRICING,
-    });
-
-    await waitFor(() => {
-      expect(document.documentElement.lang).toBe("pt-BR");
-      expect(
-        screen.getByRole("heading", { name: "Plano" }),
-      ).toBeInTheDocument();
-      expect(screen.getByText("Plano Pro")).toBeInTheDocument();
-      expect(screen.getByText("Métodos de pagamento")).toBeInTheDocument();
-      expect(
-        screen.getByRole("heading", { name: "Comprar créditos" }),
-      ).toBeInTheDocument();
-      expect(buttonByText("Compra rápida de US$ 20,00")).toBeInTheDocument();
-    });
-
-    click(buttonByText("Comparar todos os planos"));
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Comparar planos" }),
-      ).toBeInTheDocument();
-      expect(screen.queryByText("20.000 créditos / mês")).toBeNull();
-      expect(screen.getAllByText("/mês").length).toBeGreaterThan(0);
-    });
-    expect(usagePackCatalogCalls).toBe(0);
-  });
-
-  it("configures member usage behind the feature switch", async () => {
+  it("configures member usage", async () => {
     context.mocks.data.org({
       id: "org_1",
       name: "Usage Pack Org",
@@ -434,7 +376,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -831,7 +772,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Pro plan");
@@ -872,38 +812,6 @@ describe("organization billing settings", () => {
     expect(reviewDialog).toBeInTheDocument();
     expect(confirmButton).toHaveTextContent("Updating...");
     expect(confirmButton).toBeDisabled();
-  });
-
-  it("does not probe legacy migrations while usage packs are disabled", async () => {
-    let migrationCalls = 0;
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Legacy Team Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, activeTeamBillingStatus());
-    });
-    context.mocks.api(billingUsagePackMigrationContract.get, ({ respond }) => {
-      migrationCalls += 1;
-      return respond(200, {
-        tier: "team",
-        targetTier: null,
-        status: "eligible",
-        migrationId: null,
-        effectiveAt: "2026-09-01T00:00:00.000Z",
-        hostedInvoiceUrl: null,
-      });
-    });
-
-    await openBillingTab();
-
-    expect(screen.getByText("Team plan")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Move to member packages"),
-    ).not.toBeInTheDocument();
-    expect(queryButtonByText("Convert plan")).toBeUndefined();
-    expect(migrationCalls).toBe(0);
   });
 
   it("labels the current plan as legacy and offers both new plans", async () => {
@@ -960,7 +868,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Team plan");
@@ -1087,7 +994,6 @@ describe("organization billing settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=billing",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Legacy");
@@ -1127,7 +1033,6 @@ describe("organization billing settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=billing",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Pro plan");
@@ -1218,7 +1123,6 @@ describe("organization billing settings", () => {
           fullName: "Alex Chen",
           email: "alex@example.com",
         },
-        featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
       });
 
       await screen.findByText(`${planName} plan`);
@@ -1431,7 +1335,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Team plan");
@@ -1764,7 +1667,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -2050,7 +1952,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Pro plan");
@@ -2184,7 +2085,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Pro plan");
@@ -2343,7 +2243,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await screen.findByText("Pro plan");
@@ -2456,7 +2355,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -2627,7 +2525,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -2760,7 +2657,6 @@ describe("organization billing settings", () => {
         fullName: "Alex Chen",
         email: "alex@example.com",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -2891,7 +2787,7 @@ describe("organization billing settings", () => {
     });
   });
 
-  it("recovers from a billing load failure and starts an upgrade checkout", async () => {
+  it("recovers from a billing load failure", async () => {
     let statusCalls = 0;
     let failNextStatusRequest = false;
     const failedStatusRequestStarted = context.mocks.deferred<void>();
@@ -2917,12 +2813,6 @@ describe("organization billing settings", () => {
       }
       return respond(200, noActiveBillingStatus());
     });
-    context.mocks.api(billingCheckoutContract.create, ({ body, respond }) => {
-      return respond(200, {
-        url: `https://checkout.stripe.com/test-upgrade?tier=${body.tier}`,
-      });
-    });
-
     await openBillingTab();
 
     await waitFor(() => {
@@ -2946,28 +2836,6 @@ describe("organization billing settings", () => {
     await waitFor(() => {
       expect(screen.getByText("No active plan")).toBeInTheDocument();
       expect(screen.getByText("No active subscription")).toBeInTheDocument();
-    });
-
-    click(screen.getByText("Upgrade"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Compare plans")).toBeInTheDocument();
-    });
-
-    // A legacy plan pools its credits in the organization, so its card keeps
-    // the established legacy description instead of the per-member plan copy.
-    expect(
-      screen.getByText(
-        "More credits and concurrency for teams running AI agents every day.",
-      ),
-    ).toBeInTheDocument();
-
-    click(screen.getByText("Start with Team"));
-
-    await waitFor(() => {
-      expect(window.location.href).toBe(
-        "https://checkout.stripe.com/test-upgrade?tier=team",
-      );
     });
   });
 
@@ -3074,7 +2942,7 @@ describe("organization billing settings", () => {
     });
   });
 
-  it("shows custom tier access and disables Pro and Team checkout", async () => {
+  it("shows custom tier access without legacy checkout controls", async () => {
     context.mocks.data.org({
       id: "org_1",
       name: "Custom Org",
@@ -3096,23 +2964,6 @@ describe("organization billing settings", () => {
     });
     expect(screen.queryByText("Upgrade")).not.toBeInTheDocument();
     expect(screen.queryByText("Downgrade")).not.toBeInTheDocument();
-
-    click(screen.getByText("Compare all plans"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Custom workspaces cannot switch to Pro or Team checkout.",
-        ),
-      ).toBeInTheDocument();
-    });
-    const unavailableButtons = queryAllByRoleFast("button").filter((button) => {
-      return button.textContent?.trim() === "Unavailable";
-    });
-    expect(unavailableButtons).toHaveLength(2);
-    for (const button of unavailableButtons) {
-      expect(button).toBeDisabled();
-    }
   });
 
   it.each(["managed subscription", "scheduled migration"] as const)(
@@ -3162,9 +3013,7 @@ describe("organization billing settings", () => {
         );
       }
 
-      await openBillingTab("/?settings=billing", {
-        [FeatureSwitchKey.UsagePackPlans]: true,
-      });
+      await openBillingTab("/?settings=billing");
 
       await screen.findByText("Custom plan");
       if (source === "scheduled migration") {
@@ -4239,180 +4088,8 @@ describe("organization billing settings", () => {
         ).toBeInTheDocument();
       });
       expect(screen.queryByText("Restore plan")).not.toBeInTheDocument();
-
-      click(screen.getByText("Compare all plans"));
-
-      await waitFor(() => {
-        expect(screen.getByText("Compare plans")).toBeInTheDocument();
-        expect(screen.getByText("Current plan")).toBeInTheDocument();
-      });
-      expect(screen.queryByText("Restore plan")).not.toBeInTheDocument();
     },
   );
-
-  it("reviews a saved-card plan purchase in app and opens its unpaid invoice", async () => {
-    let requestedTier: "pro" | "team" | null = null;
-    let supportsInAppPreview: boolean | undefined;
-    let confirmationRequest: CheckoutRequest | null = null;
-    const hostedInvoiceUrl =
-      "https://invoice.stripe.com/plan-purchase-authentication";
-
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Plan Preview Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, activeProBillingStatus());
-    });
-    context.mocks.api(billingCheckoutContract.create, ({ body, respond }) => {
-      if (body.previewToken) {
-        confirmationRequest = body;
-        return respond(200, {
-          status: "pending_payment",
-          hostedInvoiceUrl,
-        });
-      }
-      requestedTier = body.tier;
-      supportsInAppPreview = body.supportsInAppPreview;
-      return respond(200, {
-        status: "preview",
-        purchaseType: "plan",
-        tier: body.tier,
-        immediateAmountCents: 16_000,
-        nextRecurringAmountCents: 16_000,
-        currency: "usd",
-        expiresAt: "2026-08-13T12:15:00.000Z",
-        previewToken: "plan-preview-token",
-      });
-    });
-
-    await openBillingTab("/?settings=billing");
-    const locationBeforePurchase = window.location.href;
-    click(screen.getByText("Upgrade"));
-    await screen.findByText("Compare plans");
-    click(buttonByText("Upgrade to Team"));
-
-    const reviewDialog = await screen.findByRole("dialog", {
-      name: "Upgrade to Team",
-    });
-    expect(within(reviewDialog).getByText("Today")).toBeInTheDocument();
-    expect(within(reviewDialog).getByText("Due now")).toBeInTheDocument();
-    expect(within(reviewDialog).getByText("Plan")).toBeInTheDocument();
-    expect(within(reviewDialog).getByText("Every month")).toBeInTheDocument();
-    expect(within(reviewDialog).getByText("Monthly total")).toBeInTheDocument();
-    expect(within(reviewDialog).getByText("Team")).toBeInTheDocument();
-    expect(within(reviewDialog).getAllByText("$160.00")).toHaveLength(2);
-    expect(requestedTier).toBe("team");
-    expect(supportsInAppPreview).toBeTruthy();
-    expect(window.location.href).toBe(locationBeforePurchase);
-
-    click(buttonByText("Upgrade to Team", reviewDialog));
-
-    await waitFor(() => {
-      expect(window.location.href).toBe(hostedInvoiceUrl);
-    });
-    expect(confirmationRequest).toMatchObject({
-      tier: "team",
-      supportsInAppPreview: true,
-      previewToken: "plan-preview-token",
-    });
-  });
-
-  it("refreshes invalid Plan previews from current and older billing APIs", async () => {
-    let previewCount = 0;
-    let confirmationCount = 0;
-    let confirmedPreviewToken: string | null = null;
-
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Plan Retry Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, activeProBillingStatus());
-    });
-    context.mocks.api(billingCheckoutContract.create, ({ body, respond }) => {
-      if (body.previewToken) {
-        confirmationCount += 1;
-        confirmedPreviewToken = body.previewToken;
-        if (confirmationCount === 1) {
-          previewCount += 1;
-          return respond(200, {
-            status: "preview",
-            purchaseType: "plan",
-            tier: body.tier,
-            immediateAmountCents: 15_000 + previewCount * 1000,
-            nextRecurringAmountCents: 15_000 + previewCount * 1000,
-            currency: "usd",
-            expiresAt: "2026-08-13T12:15:00.000Z",
-            previewToken: `plan-preview-token-${previewCount}`,
-          });
-        }
-        return confirmationCount === 2
-          ? respond(409, {
-              error: {
-                code: "CONFLICT",
-                message: "Plan purchase preview is no longer valid",
-              },
-            })
-          : respond(200, {
-              status: "completed",
-              hostedInvoiceUrl: null,
-            });
-      }
-      previewCount += 1;
-      return respond(200, {
-        status: "preview",
-        purchaseType: "plan",
-        tier: body.tier,
-        immediateAmountCents: 15_000 + previewCount * 1000,
-        nextRecurringAmountCents: 15_000 + previewCount * 1000,
-        currency: "usd",
-        expiresAt: "2026-08-13T12:15:00.000Z",
-        previewToken: `plan-preview-token-${previewCount}`,
-      });
-    });
-
-    await openBillingTab("/?settings=billing");
-    click(screen.getByText("Upgrade"));
-    await screen.findByText("Compare plans");
-    click(buttonByText("Upgrade to Team"));
-
-    const firstDialog = await screen.findByRole("dialog", {
-      name: "Upgrade to Team",
-    });
-    click(buttonByText("Upgrade to Team", firstDialog));
-    await screen.findAllByText("$170.00");
-    const refreshedDialog = await screen.findByRole("dialog", {
-      name: "Upgrade to Team",
-    });
-    expect(
-      within(refreshedDialog).queryByText(
-        "Could not prepare the subscription change. Try again.",
-      ),
-    ).not.toBeInTheDocument();
-    expect(within(refreshedDialog).getAllByText("$170.00")).toHaveLength(2);
-    expect(previewCount).toBe(2);
-    expect(confirmationCount).toBe(1);
-
-    click(buttonByText("Upgrade to Team", refreshedDialog));
-    await screen.findAllByText("$180.00");
-    const legacyRefreshedDialog = await screen.findByRole("dialog", {
-      name: "Upgrade to Team",
-    });
-    expect(previewCount).toBe(3);
-    expect(confirmationCount).toBe(2);
-
-    click(buttonByText("Upgrade to Team", legacyRefreshedDialog));
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Upgrade to Team" }),
-      ).not.toBeInTheDocument();
-    });
-    expect(confirmationCount).toBe(3);
-    expect(confirmedPreviewToken).toBe("plan-preview-token-3");
-  });
 
   it("previews and confirms a saved-billing credit purchase in the app", async () => {
     const checkoutReady = createDeferredPromise<void>(context.signal);
@@ -4570,7 +4247,7 @@ describe("organization billing settings", () => {
     expect(confirmationCount).toBe(1);
   });
 
-  it("manages plan changes, credit purchases, and auto-recharge settings", async () => {
+  it("manages credit purchases and auto-recharge settings", async () => {
     const billingStory = mockBillingStory();
     await openBillingTab("/?settings=billing");
 
@@ -4582,73 +4259,6 @@ describe("organization billing settings", () => {
     click(screen.getByText("Custom"));
     await fill(screen.getByLabelText("Custom dollar amount"), "35");
     expect(screen.getByText("Quick buy $35.00")).toBeInTheDocument();
-
-    click(screen.getByText("Compare all plans"));
-    await waitFor(() => {
-      expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      expect(screen.getByText("Team")).toBeInTheDocument();
-    });
-    click(screen.getByLabelText("Back"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Automatic top-ups")).toBeInTheDocument();
-    });
-
-    click(screen.getByText("Downgrade"));
-    const downgradeCancelDialog = await screen.findByRole("dialog", {
-      name: "Downgrade plan",
-    });
-    expect(
-      within(downgradeCancelDialog).getByText(
-        "Are you sure you want to cancel your Pro plan?",
-      ),
-    ).toBeInTheDocument();
-    click(buttonByText("Cancel", downgradeCancelDialog));
-
-    await waitFor(() => {
-      expect(screen.queryByText("Downgrade plan")).not.toBeInTheDocument();
-    });
-
-    click(screen.getByText("Downgrade"));
-    const downgradeConfirmDialog = await screen.findByRole("dialog", {
-      name: "Downgrade plan",
-    });
-    click(buttonByText("Cancel subscription", downgradeConfirmDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Restore plan")).toBeInTheDocument();
-      expect(
-        screen.getByText(/has been cancelled and will end on Apr 1, 2026/),
-      ).toBeInTheDocument();
-    });
-
-    click(screen.getByText("Restore plan"));
-    const restoreCancelDialog = await screen.findByRole("dialog", {
-      name: "Restore Pro plan?",
-    });
-    expect(
-      within(restoreCancelDialog).getByText(
-        /undo the scheduled cancellation for your Pro plan/,
-      ),
-    ).toBeInTheDocument();
-    click(buttonByText("Cancel", restoreCancelDialog));
-
-    await waitFor(() => {
-      expect(screen.queryByText("Restore Pro plan?")).not.toBeInTheDocument();
-    });
-
-    click(screen.getByText("Restore plan"));
-    const restoreConfirmDialog = await screen.findByRole("dialog", {
-      name: "Restore Pro plan?",
-    });
-    click(buttonByText("Restore plan", restoreConfirmDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Downgrade")).toBeInTheDocument();
-      expect(
-        screen.queryByText(/has been cancelled and will end on Apr 1, 2026/),
-      ).not.toBeInTheDocument();
-    });
 
     click(screen.getByLabelText("Enable auto-recharge"));
     await fill(
@@ -4695,226 +4305,5 @@ describe("organization billing settings", () => {
     expect(
       screen.queryByRole("dialog", { name: "Review credit purchase" }),
     ).not.toBeInTheDocument();
-  });
-
-  it("schedules and restores a team plan downgrade from the pricing page", async () => {
-    let billingStatus: BillingStatusResponse = {
-      ...activeTeamBillingStatus(),
-      concurrencyLimit: 15,
-      concurrencySubscriptions: [
-        {
-          id: "sub_team_downgrade_concurrency",
-          quantity: 5,
-          currentPeriodEnd: "2026-05-01T00:00:00Z",
-          cancelAtPeriodEnd: false,
-          canReduce: true,
-          canChangeInApp: true,
-        },
-      ],
-    };
-
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Team Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, billingStatus);
-    });
-    context.mocks.api(billingDowngradeContract.create, ({ body, respond }) => {
-      const targetTier = body.targetTier === "pro" ? "pro" : "limited-free-1";
-      billingStatus = {
-        ...billingStatus,
-        cancelAtPeriodEnd: targetTier === "limited-free-1",
-        canRestorePlan: true,
-        scheduledChange:
-          targetTier === "pro"
-            ? {
-                type: "downgrade",
-                targetTier: "pro",
-                effectiveDate: "2026-05-01T00:00:00Z",
-              }
-            : {
-                type: "cancel",
-                targetTier: "limited-free-1",
-                effectiveDate: "2026-05-01T00:00:00Z",
-              },
-      };
-      return respond(200, {
-        success: true,
-        effectiveDate: "2026-05-01T00:00:00Z",
-      });
-    });
-    context.mocks.api(billingRestoreContract.create, ({ respond }) => {
-      billingStatus = {
-        ...billingStatus,
-        cancelAtPeriodEnd: false,
-        canRestorePlan: false,
-        scheduledChange: null,
-      };
-      return respond(200, { status: "restored" });
-    });
-
-    await openBillingTab();
-
-    await waitFor(() => {
-      expect(screen.getByText("Team plan")).toBeInTheDocument();
-      expect(screen.getAllByText("Renews May 1, 2026")).toHaveLength(2);
-    });
-
-    click(screen.getByText("Downgrade"));
-    const downgradeDialog = await screen.findByRole("dialog", {
-      name: "Downgrade plan",
-    });
-    expect(
-      within(downgradeDialog).getByText("Choose which plan to downgrade to."),
-    ).toBeInTheDocument();
-    const proOption = within(downgradeDialog)
-      .getByText("Pro")
-      .closest("button");
-    if (!proOption) {
-      throw new Error("Pro downgrade option not found");
-    }
-    click(proOption);
-    expect(downgradeDialog).toHaveTextContent(
-      "Your paid concurrency (5 slots) will remain active until May 1, 2026, then end with your Team plan. Any slots added before then will end on the same date.",
-    );
-    click(buttonByText("Downgrade to Pro", downgradeDialog));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Downgrade scheduled. Your current plan stays active until May 1, 2026.",
-        ),
-      ).toBeInTheDocument();
-      expect(screen.getByText("Restore plan")).toBeInTheDocument();
-      expect(screen.getByText("Restore Team plan")).toBeInTheDocument();
-      expect(screen.getByText("Active until May 1, 2026")).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Your Team plan will downgrade to Pro on May 1, 2026.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    click(screen.getByText("Compare all plans"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      expect(
-        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
-      ).toBeGreaterThan(0);
-    });
-
-    click(screen.getByText("Restore plan"));
-    const restoreDialog = await screen.findByRole("dialog", {
-      name: "Restore Team plan?",
-    });
-    expect(
-      within(restoreDialog).getByText(
-        "This will cancel the scheduled downgrade to Pro. Your Team plan will continue renewing.",
-      ),
-    ).toBeInTheDocument();
-    expect(restoreDialog).toHaveTextContent(
-      "Your paid concurrency (5 slots) will remain active and continue renewing with your plan.",
-    );
-    click(buttonByText("Restore plan", restoreDialog));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Plan restored. Your subscription will renew normally.",
-        ),
-      ).toBeInTheDocument();
-      expect(screen.getByText("Current plan")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Downgrades to Pro on May 1, 2026"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("replaces a scheduled team cancellation with a downgrade to Pro", async () => {
-    let capturedTargetTier: string | null = null;
-    let billingStatus: BillingStatusResponse = {
-      ...activeTeamBillingStatus(),
-      cancelAtPeriodEnd: true,
-      canRestorePlan: true,
-      scheduledChange: {
-        type: "cancel",
-        targetTier: "limited-free-1",
-        effectiveDate: "2026-05-01T00:00:00Z",
-      },
-    };
-
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Team Cancel Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, billingStatus);
-    });
-    context.mocks.api(billingDowngradeContract.create, ({ body, respond }) => {
-      capturedTargetTier = body.targetTier;
-      billingStatus = {
-        ...billingStatus,
-        cancelAtPeriodEnd: false,
-        scheduledChange: {
-          type: "downgrade",
-          targetTier: "pro",
-          effectiveDate: "2026-05-01T00:00:00Z",
-        },
-      };
-      return respond(200, {
-        success: true,
-        effectiveDate: "2026-05-01T00:00:00Z",
-      });
-    });
-
-    await openBillingTab();
-
-    await waitFor(() => {
-      expect(screen.getByText("Restore plan")).toBeInTheDocument();
-      expect(
-        screen.getByText(/has been cancelled and will end on May 1, 2026/),
-      ).toBeInTheDocument();
-    });
-
-    click(screen.getByText("Compare all plans"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      expect(screen.getAllByText("Ends on May 1, 2026").length).toBeGreaterThan(
-        0,
-      );
-    });
-
-    click(buttonByText("Downgrade to Pro"));
-
-    const downgradeDialog = await screen.findByRole("dialog", {
-      name: "Downgrade plan",
-    });
-    expect(
-      within(downgradeDialog).getByText("Downgrade to Pro?"),
-    ).toBeInTheDocument();
-    expect(
-      within(downgradeDialog).getByText(
-        /After that, this workspace moves to Pro/u,
-      ),
-    ).toBeInTheDocument();
-
-    click(buttonByText("Downgrade to Pro", downgradeDialog));
-
-    await waitFor(() => {
-      expect(capturedTargetTier).toBe("pro");
-      expect(
-        screen.getByText(
-          "Downgrade scheduled. Your current plan stays active until May 1, 2026.",
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
-      ).toBeGreaterThan(0);
-    });
   });
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -10,7 +10,6 @@ import {
   billingUsagePackManagementContract,
   type BillingStatusResponse,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core";
 import { screen, waitFor, within } from "@testing-library/react";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { describe, expect, it } from "vitest";
@@ -24,7 +23,6 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
-const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
 
 function buttonByText(
   text: string,
@@ -348,11 +346,11 @@ function mockUsagePackCatalog(): void {
   });
 }
 
-async function openLegacyMembersTab(heading = "People"): Promise<void> {
+async function openMembersTab(heading = "People"): Promise<void> {
+  mockMemberInviteEntitlement(false);
   detachedSetupPage({
     context,
     path: "/?settings=people",
-    featureSwitches: LEGACY_PRICING,
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -371,7 +369,7 @@ function rowByEmail(email: string): HTMLElement {
 describe("organization members settings", () => {
   it("filters members and sends an invitation", async () => {
     mockMembersStory();
-    await openLegacyMembersTab();
+    await openMembersTab();
 
     expect(screen.getByText("Alice Admin")).toBeInTheDocument();
     expect(screen.getByText("bob@example.com")).toBeInTheDocument();
@@ -435,7 +433,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await waitFor(() => {
       expect(
@@ -571,7 +568,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
@@ -626,9 +622,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: {
-        [FeatureSwitchKey.UsagePackPlans]: true,
-      },
     });
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
 
@@ -681,7 +674,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
 
@@ -726,7 +718,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await screen.findByRole("heading", { name: "People" });
     click(buttonByText("Add member"));
@@ -792,7 +783,6 @@ describe("organization members settings", () => {
       detachedSetupPage({
         context,
         path: "/?settings=people",
-        featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
       });
       await waitFor(() => {
         expect(
@@ -837,7 +827,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await waitFor(() => {
       expect(
@@ -871,7 +860,7 @@ describe("organization members settings", () => {
 
   it("accepts and rejects membership requests", async () => {
     mockMembersStory();
-    await openLegacyMembersTab();
+    await openMembersTab();
 
     await fill(screen.getByPlaceholderText("Search"), "carol");
     await waitFor(() => {
@@ -913,7 +902,7 @@ describe("organization members settings", () => {
 
   it("changes roles, removes a member, and lets an admin self-demote", async () => {
     mockMembersStory();
-    await openLegacyMembersTab();
+    await openMembersTab();
 
     click(screen.getByLabelText("Actions for bob@example.com"));
     click(menuItemByText("Make admin"));
@@ -981,7 +970,6 @@ describe("organization members settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=people",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
 
@@ -1017,7 +1005,7 @@ describe("organization members settings", () => {
 
   it("cancels and confirms invitation revoke", async () => {
     mockMembersStory();
-    await openLegacyMembersTab();
+    await openMembersTab();
 
     await fill(screen.getByPlaceholderText("Search"), "pending");
     await waitFor(() => {
@@ -1061,7 +1049,7 @@ describe("organization members settings", () => {
       locale: "pt-BR",
       supportedLocales: ["en-US", "pt-BR"],
     });
-    await openLegacyMembersTab("Pessoas");
+    await openMembersTab("Pessoas");
 
     const settingsDialog = screen.getByRole("dialog", {
       name: "Configurações",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -15,7 +15,6 @@ import {
   type CreateModelProviderConnectionRequest,
   type ModelProviderConnectionResponse,
 } from "@okouai/api-contracts/contracts/model-provider-gateways";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -326,15 +325,10 @@ async function openProvidersTab(): Promise<void> {
   });
 }
 
-async function openModelSettings(
-  usagePackPlansEnabled: boolean,
-): Promise<void> {
+async function openModelSettings(): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=model",
-    featureSwitches: {
-      [FeatureSwitchKey.UsagePackPlans]: usagePackPlansEnabled,
-    },
   });
   await waitFor(() => {
     expect(
@@ -908,7 +902,7 @@ describe("organization model providers settings", () => {
     ).toHaveTextContent("GPT 5.6 Sol");
   });
 
-  it("opens compare plans for a limited-free-1 default Pro model", async () => {
+  it("opens the plan chooser for a limited-free-1 default Pro model", async () => {
     mockAdminOrg();
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: true });
     context.mocks.data.orgModelProviders([]);
@@ -926,14 +920,14 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings(false);
+    await openModelSettings();
 
     const defaultRow = screen.getByTestId("default-model-row");
     click(within(defaultRow).getByRole("combobox"));
     click(await screen.findByRole("option", { name: /Claude Fable 5.*Pro/u }));
 
     await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 
@@ -950,7 +944,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings(true);
+    await openModelSettings();
 
     click(buttonByText("Add model"));
     const dialog = screen.getByRole("dialog", { name: "Add model" });
@@ -961,7 +955,7 @@ describe("organization model providers settings", () => {
     });
     click(gptOption);
 
-    expect(screen.queryByRole("heading", { name: "Compare plans" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Choose a plan" })).toBeNull();
     expect(buttonByText("Upgrade to Pro", dialog)).toBeInTheDocument();
     click(buttonByText("Upgrade to Pro", dialog));
 
@@ -972,7 +966,7 @@ describe("organization model providers settings", () => {
     });
   });
 
-  it("opens compare plans when BYOK is unsupported", async () => {
+  it("opens the plan chooser when BYOK is unsupported", async () => {
     mockAdminOrg();
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: false });
     context.mocks.data.orgModelProviders([]);
@@ -984,7 +978,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings(false);
+    await openModelSettings();
 
     click(buttonByText("Add model"));
     await selectDialogModel("Claude Opus 4.8");
@@ -995,7 +989,7 @@ describe("organization model providers settings", () => {
     click(apiKeyRoute);
 
     await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 
@@ -1013,7 +1007,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openModelSettings(false);
+    await openModelSettings();
 
     click(buttonByText("Add model"));
     const dialog = screen.getByRole("dialog", { name: "Add model" });
@@ -1026,7 +1020,7 @@ describe("organization model providers settings", () => {
     click(screen.getByRole("radio", { name: /API key\s+Pro/u }));
 
     await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-usage-tab.test.tsx
@@ -5,7 +5,6 @@ import {
 } from "@okouai/api-contracts/contracts/billing";
 import { orgMembersContract } from "@okouai/api-contracts/contracts/org-member-routes";
 import { usageMembersContract } from "@okouai/api-contracts/contracts/usage";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -175,14 +174,10 @@ function mockUsageStory(): void {
   });
 }
 
-const NEW_PRICING = { [FeatureSwitchKey.UsagePackPlans]: true } as const;
-const LEGACY_PRICING = { [FeatureSwitchKey.UsagePackPlans]: false } as const;
-
 async function openCreditBalance(): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=usage",
-    featureSwitches: NEW_PRICING,
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -194,7 +189,6 @@ async function openCreditUsage(): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=usage-records",
-    featureSwitches: NEW_PRICING,
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -345,51 +339,6 @@ describe("organization usage settings", () => {
     expect(screen.queryByText("Dec 31, 2999")).toBeNull();
   });
 
-  it("keeps the usage records inside credit balance without the new pricing", async () => {
-    mockUsageStory();
-    detachedSetupPage({
-      context,
-      path: "/?settings=usage",
-      featureSwitches: LEGACY_PRICING,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("3,750 / 5,000 credits")).toBeInTheDocument();
-    });
-    // The previous single-section layout: collapsed additions, the Mine/Team
-    // tabs, and no separate records section to navigate to.
-    expect(screen.getByTestId("credit-grants-toggle")).toBeInTheDocument();
-    expect(screen.queryByTestId("credit-balance-see-usage")).toBeNull();
-    expect(screen.queryByTestId("credit-balance-buy-credits")).toBeNull();
-    expect(
-      queryAllByRoleFast("tab").some((element) => {
-        return element.textContent === "Team usage";
-      }),
-    ).toBeTruthy();
-    expect(
-      queryAllByRoleFast("button").some((element) => {
-        return element.textContent === "Credit usage";
-      }),
-    ).toBeFalsy();
-  });
-
-  it("falls back from the usage records deep link without the new pricing", async () => {
-    mockUsageStory();
-    detachedSetupPage({
-      context,
-      path: "/?settings=usage-records",
-      featureSwitches: LEGACY_PRICING,
-    });
-
-    const heading = await screen.findByRole("heading", { name: "Preference" });
-    expect(heading).toBeInTheDocument();
-    expect(
-      queryAllByRoleFast("button").some((element) => {
-        return element.textContent === "Credit usage";
-      }),
-    ).toBeFalsy();
-  });
-
   it("shows workspace member usage in the credit usage section", async () => {
     mockUsageStory();
     await openCreditUsage();
@@ -416,7 +365,6 @@ describe("organization usage settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=usage",
-      featureSwitches: NEW_PRICING,
     });
 
     await waitFor(() => {
@@ -441,7 +389,6 @@ describe("organization usage settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=usage-records",
-      featureSwitches: NEW_PRICING,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
@@ -385,9 +385,7 @@ describe("personal model providers settings", () => {
     context.mocks.data.personalModelProviders([]);
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: false });
 
-    await openModelSettings("Models", {
-      [FeatureSwitchKey.UsagePackPlans]: false,
-    });
+    await openModelSettings("Models");
 
     const claudeCodeRow = await screen.findByTestId(
       "oauth-card-claude-code-oauth-token",
@@ -405,7 +403,7 @@ describe("personal model providers settings", () => {
     click(claudeUpgrade);
 
     await expect(
-      screen.findByRole("heading", { name: "Compare plans" }),
+      screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -9,7 +9,6 @@ import {
   type UsageRecordResponse,
   type UsageRecordRow,
 } from "@okouai/api-contracts/contracts/usage-record";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
@@ -266,56 +265,19 @@ function mockPersonalUsageStory(
 }
 
 async function openUsageSettings(
-  usagePackPlansEnabled = true,
   section: "usage" | "usage-records" = "usage",
 ): Promise<void> {
   detachedSetupPage({
     context,
     path: `/?settings=${section}`,
-    featureSwitches: {
-      [FeatureSwitchKey.UsagePackPlans]: usagePackPlansEnabled,
-    },
   });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
-  if (!usagePackPlansEnabled) {
-    await screen.findByRole("heading", { name: "Preference" });
-  }
 }
 
 describe("personal usage settings", () => {
-  it("does not request or show usage pack credits when the switch is disabled", async () => {
-    mockPersonalUsageStory(usageRows(), "pro", false, "member");
-    let usagePackCreditRequests = 0;
-    context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
-      usagePackCreditRequests += 1;
-      return respond(200, {
-        totalCredits: 20_400,
-        purchasedCredits: 20_000,
-        bonusCredits: 400,
-        creditGrants: [],
-      });
-    });
-
-    await openUsageSettings(false);
-    // Without the new pricing a member has neither an organization balance nor
-    // a records section to open.
-    expect(
-      queryAllByRoleFast("button").some((button) => {
-        return button.textContent === "Credit balance";
-      }),
-    ).toBeFalsy();
-    expect(
-      queryAllByRoleFast("button").some((button) => {
-        return button.textContent === "Credit usage";
-      }),
-    ).toBeFalsy();
-    expect(screen.queryByTestId("usage-pack-credit-card")).toBeNull();
-    expect(usagePackCreditRequests).toBe(0);
-  });
-
-  it("shows the member's usage pack credit breakdown when the switch is enabled", async () => {
+  it("shows the member's usage pack credit breakdown", async () => {
     const user = userEvent.setup();
     mockPersonalUsageStory(usageRows(), "pro", false, "member");
     context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
@@ -345,7 +307,7 @@ describe("personal usage settings", () => {
       });
     });
 
-    await openUsageSettings(true);
+    await openUsageSettings();
 
     const card = await screen.findByTestId("usage-pack-credit-card");
     expect(within(card).getByText("Usage pack credits")).toBeInTheDocument();
@@ -400,7 +362,7 @@ describe("personal usage settings", () => {
       });
     });
 
-    await openUsageSettings(true);
+    await openUsageSettings();
 
     await waitFor(() => {
       expect(requests).toBe(1);
@@ -429,7 +391,7 @@ describe("personal usage settings", () => {
       });
     });
 
-    await openUsageSettings(true);
+    await openUsageSettings();
 
     const card = await screen.findByTestId("usage-pack-credit-card");
     expect(within(card).getByText("Usage pack credits")).toBeInTheDocument();
@@ -478,7 +440,7 @@ describe("personal usage settings", () => {
       });
     });
 
-    await openUsageSettings(true);
+    await openUsageSettings();
 
     const card = await screen.findByTestId("usage-pack-credit-card");
     await waitFor(() => {
@@ -555,7 +517,7 @@ describe("personal usage settings", () => {
       });
     });
 
-    await openUsageSettings(true);
+    await openUsageSettings();
 
     const card = await screen.findByTestId("usage-pack-credit-card");
     expect(within(card).getByText("Usage pack credits")).toBeInTheDocument();
@@ -665,7 +627,7 @@ describe("personal usage settings", () => {
 
   it("shows an illustrated empty state when the range has no usage", async () => {
     mockPersonalUsageStory([]);
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     const empty = await screen.findByTestId("usage-records-empty");
     expect(
@@ -686,7 +648,7 @@ describe("personal usage settings", () => {
   it("shows personal usage, loads more, and changes the usage range", async () => {
     const user = userEvent.setup();
     const requests = mockPersonalUsageStory();
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     await waitFor(() => {
       expect(screen.getByText("Quarterly planning chat")).toBeInTheDocument();
@@ -769,7 +731,7 @@ describe("personal usage settings", () => {
     });
     const requests = mockPersonalUsageStory(rows);
 
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     await expect(
       screen.findByText("Usage record 20"),
@@ -808,7 +770,7 @@ describe("personal usage settings", () => {
       return respond(200, personalUsagePage(rows, query.page, query.pageSize));
     });
 
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
     expect(screen.queryByText("Extended agent audit")).not.toBeInTheDocument();
 
     await user.click(screen.getByText("Load more"));
@@ -846,7 +808,7 @@ describe("personal usage settings", () => {
       ],
       "limited-free-1",
     );
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     await user.hover(screen.getByTestId("usage-kind-segment-model"));
 
@@ -876,7 +838,7 @@ describe("personal usage settings", () => {
         ],
       },
     ]);
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     await user.hover(screen.getByTestId("usage-kind-segment-video"));
 
@@ -892,7 +854,7 @@ describe("personal usage settings", () => {
 
   it("keeps keyboard focus styling on the usage title instead of the row", async () => {
     mockPersonalUsageStory();
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     const titleLink = await screen.findByText("Quarterly planning chat");
 
@@ -960,7 +922,7 @@ describe("personal usage settings", () => {
     });
     mockEmptyUsagePackCredits();
 
-    await openUsageSettings(true, "usage-records");
+    await openUsageSettings("usage-records");
 
     await waitFor(() => {
       expect(screen.getByText("Initial usage row")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-deep-link-handoff.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-deep-link-handoff.test.tsx
@@ -2,7 +2,6 @@ import {
   teamContract,
   type TeamComposeItem,
 } from "@okouai/api-contracts/contracts/team";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -39,7 +38,6 @@ describe("settings deep-link handoff", () => {
     detachedSetupPage({
       context,
       path: "/?settings=billing&billingView=plans",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await teamRequestStarted.promise;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -413,66 +413,6 @@ describe("zero sidebar account menu", () => {
     expect(within(accountButton).queryByRole("status")).toBeNull();
   });
 
-  it("does not request or show member usage pack credits when the switch is disabled", async () => {
-    mockMemberAccountSidebar();
-    let billingRequests = 0;
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      billingRequests += 1;
-      return respond(200, {
-        tier: "pro",
-        credits: 12_500,
-        onboardingPaymentPending: false,
-        subscriptionStatus: "active",
-        currentPeriodEnd: "2026-04-01T00:00:00Z",
-        cancelAtPeriodEnd: false,
-        scheduledChange: null,
-        hasSubscription: true,
-        autoRecharge: { enabled: false, threshold: null, amount: null },
-        creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
-        creditBreakdown: [],
-        creditGrants: [],
-        concurrencyLimit: 0,
-        concurrencySubscriptions: [],
-      });
-    });
-    let usagePackCreditRequests = 0;
-    context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
-      usagePackCreditRequests += 1;
-      return respond(200, {
-        totalCredits: 20_400,
-        purchasedCredits: 20_000,
-        bonusCredits: 400,
-        creditGrants: [],
-      });
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/chat`,
-      user: {
-        id: "test-user-123",
-        fullName: "Alex Rivera",
-        email: "alex.rivera@example.test",
-      },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: false },
-    });
-
-    await waitFor(() => {
-      expect(
-        context.mocks.ably.hasSubscription("billing:changed"),
-      ).toBeTruthy();
-      expect(billingRequests).toBeGreaterThan(0);
-    });
-    billingRequests = 0;
-    const menu = await openAccountMenu();
-    expect(within(menu).getByText("Settings")).toBeInTheDocument();
-    expect(
-      within(menu).queryByTestId("account-menu-credit-balance"),
-    ).toBeNull();
-    expect(billingRequests).toBe(0);
-    expect(usagePackCreditRequests).toBe(0);
-  });
-
   it("refreshes member usage pack credits without requesting org billing", async () => {
     mockMemberAccountSidebar();
     let usagePackCredits = 20_400;
@@ -515,7 +455,6 @@ describe("zero sidebar account menu", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     await waitFor(() => {
@@ -581,7 +520,6 @@ describe("zero sidebar account menu", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
       },
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
     const menu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -3,7 +3,6 @@
 import { useGet, useSet, useLastLoadable, type Loadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { FeatureSwitchKey } from "@okouai/core";
 import {
   ExternalLink,
   Crown,
@@ -94,7 +93,6 @@ import {
 } from "../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import { currentLocale, i18n } from "../../../../i18n/index.ts";
 import { formatLocalizedNumber, formatUsd } from "../../../../i18n/format.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { openSettingsUsagePackUpgrade$ } from "../../../../signals/okou-page/settings/settings-dialog.ts";
 import {
   UsagePackMigrationPage,
@@ -2614,11 +2612,8 @@ function BillingPricingPage({
   );
 }
 
-function shouldWaitForUsagePackMigration(
-  enabled: boolean,
-  loading: boolean,
-): boolean {
-  return enabled && loading;
+function shouldWaitForUsagePackMigration(loading: boolean): boolean {
+  return loading;
 }
 function canStartUsagePackCheckout(
   status: BillingStatusResponse | null,
@@ -2651,15 +2646,10 @@ function usagePackMigrationNeedsProgressPage(
    tab, including conversion from a legacy plan. The legacy pricing page and a
    migration that can only report progress still keep the tab sub-page. */
 function showsUsagePackPlanDialogs(
-  enabled: boolean,
   migrationLoading: boolean,
   migration: UsagePackMigrationStateResponse | null,
 ): boolean {
-  return (
-    enabled &&
-    !migrationLoading &&
-    !usagePackMigrationNeedsProgressPage(migration)
-  );
+  return !migrationLoading && !usagePackMigrationNeedsProgressPage(migration);
 }
 
 function usagePackMigrationConfigurable(
@@ -2782,7 +2772,6 @@ function UsagePackPricingFlowDialogs({
 
 export function OrgBillingTab() {
   const { t } = useTranslation();
-  const featureSwitches = useGet(featureSwitch$);
   const pricingOpen = useGet(billingSubPage$);
   const migrationOpen = useGet(billingMigrationSubPage$);
   const migrationTargetTier = useGet(billingMigrationTargetTier$);
@@ -2809,15 +2798,12 @@ export function OrgBillingTab() {
   );
   const statusLoadable = useLastLoadable(billingStatusAsync$);
   const migrationLoadable = useLastLoadable(usagePackMigrationAsync$);
-  const usagePackPlansEnabled =
-    featureSwitches[FeatureSwitchKey.UsagePackPlans];
   const loading = portalLoadable.state === "loading";
   const upgradeLoading = upgradeLoadable.state === "loading";
 
   const status = loadableDataOrNull(statusLoadable);
   const migration = loadableDataOrNull(migrationLoadable);
   const migrationLoading = shouldWaitForUsagePackMigration(
-    usagePackPlansEnabled,
     migrationLoadable.state === "loading",
   );
   const migrationInProgress = usagePackMigrationInProgress(migration);
@@ -2861,7 +2847,7 @@ export function OrgBillingTab() {
     handleReplaceCancellationWithPro,
   );
   const handleUpgrade = () => {
-    if (!usagePackPlansEnabled || currentTier !== "pro") {
+    if (currentTier !== "pro") {
       openPricingPage();
       return;
     }
@@ -2892,7 +2878,6 @@ export function OrgBillingTab() {
   };
 
   const usagePackPlanDialogs = showsUsagePackPlanDialogs(
-    usagePackPlansEnabled,
     migrationLoading,
     migration,
   );

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -40,7 +40,6 @@ import {
   orgRoleSchema,
   type OrgRole,
 } from "@okouai/api-contracts/contracts/org-members";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type {
   UsagePackCatalogItem,
   UsagePackManagementResponse,
@@ -58,7 +57,6 @@ import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { user$ } from "../../../../signals/auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { orgPlanCapabilities$ } from "../../../../signals/okou-page/org-plan-capabilities.ts";
 import {
   memberSearch$,
@@ -363,7 +361,6 @@ type InviteDialogMode =
   | "upgrade";
 
 function resolveInviteDialogMode(args: {
-  readonly usagePackPlansEnabled: boolean;
   readonly capabilities:
     | {
         readonly memberInvitationAllowed: boolean;
@@ -374,9 +371,6 @@ function resolveInviteDialogMode(args: {
   readonly catalogError: boolean;
   readonly usagePackConfigured: boolean;
 }): InviteDialogMode {
-  if (!args.usagePackPlansEnabled) {
-    return "direct";
-  }
   if (!args.capabilities) {
     return "loading";
   }
@@ -691,14 +685,12 @@ function InviteDialog() {
   const setRole = useSet(setInviteRole$);
   const usagePackUsd = useGet(inviteUsagePackUsd$);
   const setUsagePackUsd = useSet(setInviteUsagePackUsd$);
-  const featureSwitches = useGet(featureSwitch$);
   const capabilities = useLastResolved(orgPlanCapabilities$);
   const openBillingPlans = useSet(openSettingsBillingPlans$);
   const catalogLoadable = useLoadable(invitationUsagePackCatalog$);
   const usagePacks =
     catalogLoadable.state === "hasData" ? catalogLoadable.data : null;
   const mode = resolveInviteDialogMode({
-    usagePackPlansEnabled: featureSwitches[FeatureSwitchKey.UsagePackPlans],
     capabilities,
     catalogLoading: catalogLoadable.state === "loading",
     catalogError: catalogLoadable.state === "hasError",

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from "react";
-import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import type { OrgMember } from "@okouai/api-contracts/contracts/org-members";
 import type { UsagePackCreditsResponse } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { ArrowRight, ChevronRight, Users } from "lucide-react";
 import {
   Button,
@@ -12,9 +11,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  Tabs,
-  TabsList,
-  TabsTrigger,
 } from "@okouai/ui";
 import {
   Tooltip,
@@ -28,14 +24,8 @@ import {
   formatCreditDate,
   type CreditAddition,
 } from "../../org-manage/org-usage-tab.tsx";
-import {
-  PersonalUsageRecord,
-  TeamUsageRecord,
-  UsageRangeSelect,
-} from "../../preferences/personal-usage-record.tsx";
 import { UserAvatar } from "../../../../components/avatar.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
-import { featureSwitch$ } from "../../../../../signals/external/feature-switch.ts";
 import { orgMembers$ } from "../../../../../signals/external/org-members.ts";
 import { usagePackCreditsAsync$ } from "../../../../../signals/okou-page/billing.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/okou-page/settings/settings-dialog.ts";
@@ -44,15 +34,8 @@ import {
   setBillingSubPage$,
 } from "../../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import {
-  creditBalanceTab$,
-  myUsageRange$,
-  setCreditBalanceTab$,
-  setMyUsageRange$,
-  setTeamUsageRange$,
   setUsagePackMembersDialogOpen$,
-  teamUsageRange$,
   toggleUsagePackMemberAdditions$,
-  type CreditBalanceTab,
   usagePackMemberAdditionsExpandedMemberId$,
   usagePackMembersDialogOpen$,
 } from "../../../../../signals/okou-page/settings/personal-usage-record.ts";
@@ -569,16 +552,6 @@ export function CreditBalanceSection() {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const tab = useGet(creditBalanceTab$);
-  const setTab = useSet(setCreditBalanceTab$);
-  const myRange = useGet(myUsageRange$);
-  const teamRange = useGet(teamUsageRange$);
-  const setMyRange = useSet(setMyUsageRange$);
-  const setTeamRange = useSet(setTeamUsageRange$);
-  const features = useLastResolved(featureSwitch$);
-  const usagePackPlansEnabled =
-    features?.[FeatureSwitchKey.UsagePackPlans] ?? false;
-
   const goToComparePlans = () => {
     setActiveSection("billing");
     setBillingSubPage(true);
@@ -589,15 +562,13 @@ export function CreditBalanceSection() {
     setActiveSection("billing");
   };
 
-  const usagePackCreditCard = usagePackPlansEnabled ? (
-    <UsagePackCreditCard isAdmin={isAdmin} />
-  ) : null;
+  const usagePackCreditCard = <UsagePackCreditCard isAdmin={isAdmin} />;
 
   const creditCard = (
     <CreditBalanceCard
       onBuyCredits={goToBuyCredits}
       onComparePlans={goToComparePlans}
-      splitLayout={usagePackPlansEnabled}
+      splitLayout
     />
   );
 
@@ -605,48 +576,6 @@ export function CreditBalanceSection() {
   // balances remain available to organization admins.
   if (!isAdmin) {
     return <div>{usagePackCreditCard}</div>;
-  }
-
-  // Without the new pricing, the section still owns the usage records and the
-  // Mine/Team tabs that go with them.
-  if (!usagePackPlansEnabled) {
-    const activeRange = tab === "team" ? teamRange : myRange;
-    const setActiveRange = tab === "team" ? setTeamRange : setMyRange;
-    return (
-      <div className="flex flex-col gap-6">
-        {creditCard}
-        <div className="flex flex-col gap-4">
-          {/* One compact header row: tabs on the left, range filter on the right. */}
-          <div className="flex items-center justify-between gap-3">
-            <Tabs
-              value={tab}
-              onValueChange={(value) => {
-                setTab(value as CreditBalanceTab);
-              }}
-            >
-              <TabsList>
-                <TabsTrigger value="mine">
-                  {t(($) => {
-                    return $.usage.records.myUsage;
-                  })}
-                </TabsTrigger>
-                <TabsTrigger value="team">
-                  {t(($) => {
-                    return $.usage.records.teamUsage;
-                  })}
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <UsageRangeSelect value={activeRange} onChange={setActiveRange} />
-          </div>
-          {tab === "mine" ? (
-            <PersonalUsageRecord range={myRange} />
-          ) : (
-            <TeamUsageRecord range={teamRange} />
-          )}
-        </div>
-      </div>
-    );
   }
 
   return (

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -107,9 +107,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const showDebug = features[FeatureSwitchKey.OkouDebug] ?? false;
-  const usagePackPlansEnabled =
-    features[FeatureSwitchKey.UsagePackPlans] ?? false;
-  const showUsage = isAdmin || usagePackPlansEnabled;
   const sectionMeta = {
     preference: {
       title: t(($) => {
@@ -224,24 +221,16 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       return $.settings.dialog.groups.billing;
     }),
     items: [
-      ...(showUsage
-        ? [
-            {
-              id: "usage" as const,
-              label: sectionMeta.usage.title,
-              icon: Coins,
-            },
-          ]
-        : []),
-      ...(usagePackPlansEnabled
-        ? [
-            {
-              id: "usage-records" as const,
-              label: sectionMeta["usage-records"].title,
-              icon: History,
-            },
-          ]
-        : []),
+      {
+        id: "usage" as const,
+        label: sectionMeta.usage.title,
+        icon: Coins,
+      },
+      {
+        id: "usage-records" as const,
+        label: sectionMeta["usage-records"].title,
+        icon: History,
+      },
       ...(isAdmin
         ? [
             {
@@ -268,20 +257,10 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   // If the user lost admin while the dialog is open, fall back to a safe section
   const resolvedSection: SettingsSection =
     (!showDebug && activeSection === "debug") ||
-    (!showUsage && activeSection === "usage") ||
-    (!usagePackPlansEnabled && activeSection === "usage-records") ||
     (!isAdmin && isAdminOnlySettingsSection(activeSection))
       ? "preference"
       : activeSection;
-  const meta =
-    resolvedSection === "usage" && !usagePackPlansEnabled
-      ? {
-          title: sectionMeta.usage.title,
-          description: t(($) => {
-            return $.settings.dialog.sections.usage.balanceUsageDescription;
-          }),
-        }
-      : sectionMeta[resolvedSection];
+  const meta = sectionMeta[resolvedSection];
 
   const handleSectionChange = (section: SettingsSection) => {
     setActiveSection(section);

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -65,14 +65,6 @@ function useSlackInstalled(): boolean | null {
   return loadable.data.isInstalled || loadable.data.isConnected;
 }
 
-/** Organization credits without usage-pack credits. */
-function useOrganizationCreditLabel(): string | null {
-  const billingLoadable = useLastLoadable(billingStatusAsync$);
-  const orgCredits =
-    billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
-  return orgCredits === null ? null : formatLocalizedNumber(orgCredits);
-}
-
 function useCombinedCreditLabel(): string | null {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
   const usagePackLoadable = useLastLoadable(usagePackCreditsAsync$);
@@ -121,29 +113,13 @@ function CreditMenuItem({
   );
 }
 
-function OrganizationCreditMenuItem({
-  openCredits,
-}: {
-  openCredits: () => void;
-}) {
-  const creditLabel = useOrganizationCreditLabel();
-  return <CreditMenuItem creditLabel={creditLabel} openCredits={openCredits} />;
-}
-
 function CombinedCreditMenuItem({ openCredits }: { openCredits: () => void }) {
   const creditLabel = useCombinedCreditLabel();
   return <CreditMenuItem creditLabel={creditLabel} openCredits={openCredits} />;
 }
 
 function GrowthCreditMenuItem({ openCredits }: { openCredits: () => void }) {
-  const features = useLastResolved(featureSwitch$);
-  const usagePackPlansEnabled =
-    features?.[FeatureSwitchKey.UsagePackPlans] ?? false;
-  return usagePackPlansEnabled ? (
-    <CombinedCreditMenuItem openCredits={openCredits} />
-  ) : (
-    <OrganizationCreditMenuItem openCredits={openCredits} />
-  );
+  return <CombinedCreditMenuItem openCredits={openCredits} />;
 }
 
 function useGrowthActions() {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -304,14 +304,12 @@ function AccountUsageGroup({
   resetPending,
   subscriptionRowsCacheKey,
   subscriptionsEnabled,
-  usagePackPlansEnabled,
 }: {
   onOpenCreditBalance: () => void;
   onResetCodexUsage: (resetCredits: number | null) => void;
   resetPending: boolean;
   subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
   subscriptionsEnabled: boolean;
-  usagePackPlansEnabled: boolean;
 }) {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin =
@@ -319,15 +317,8 @@ function AccountUsageGroup({
 
   if (subscriptionsEnabled) {
     if (isAdmin) {
-      return usagePackPlansEnabled ? (
+      return (
         <AccountUsageGroupWithCombinedCredit
-          onOpenCreditBalance={onOpenCreditBalance}
-          onResetCodexUsage={onResetCodexUsage}
-          resetPending={resetPending}
-          subscriptionRowsCacheKey={subscriptionRowsCacheKey}
-        />
-      ) : (
-        <AccountUsageGroupWithCredit
           onOpenCreditBalance={onOpenCreditBalance}
           onResetCodexUsage={onResetCodexUsage}
           resetPending={resetPending}
@@ -335,15 +326,9 @@ function AccountUsageGroup({
         />
       );
     }
-    return usagePackPlansEnabled ? (
+    return (
       <AccountUsageGroupWithUsagePackCredit
         onOpenCreditBalance={onOpenCreditBalance}
-        onResetCodexUsage={onResetCodexUsage}
-        resetPending={resetPending}
-        subscriptionRowsCacheKey={subscriptionRowsCacheKey}
-      />
-    ) : (
-      <AccountSubscriptionsGroup
         onResetCodexUsage={onResetCodexUsage}
         resetPending={resetPending}
         subscriptionRowsCacheKey={subscriptionRowsCacheKey}
@@ -352,17 +337,15 @@ function AccountUsageGroup({
   }
 
   if (isAdmin) {
-    return usagePackPlansEnabled ? (
+    return (
       <AccountCombinedCreditBalanceGroup
         onOpenCreditBalance={onOpenCreditBalance}
       />
-    ) : (
-      <AccountCreditBalanceGroup onOpenCreditBalance={onOpenCreditBalance} />
     );
   }
-  return usagePackPlansEnabled ? (
+  return (
     <AccountUsagePackCreditGroup onOpenCreditBalance={onOpenCreditBalance} />
-  ) : null;
+  );
 }
 
 function useCombinedCreditBalance(): {
@@ -404,83 +387,6 @@ function useUsagePackCreditBalance(): {
     creditLabel: credits !== null ? formatCreditBalance(credits) : null,
     loading: creditsLoadable.state === "loading" && credits === null,
   };
-}
-
-function AccountCreditBalanceGroup({
-  onOpenCreditBalance,
-}: {
-  onOpenCreditBalance: () => void;
-}) {
-  const billingLoadable = useLastLoadable(billingStatusAsync$);
-
-  const credits =
-    billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
-  const loading = billingLoadable.state === "loading" && credits === null;
-  const creditLabel = credits !== null ? formatCreditBalance(credits) : null;
-
-  if (!loading && creditLabel === null) {
-    return null;
-  }
-
-  return (
-    <>
-      <CreditBalanceItem
-        creditLabel={creditLabel}
-        loading={loading}
-        onOpenCreditBalance={onOpenCreditBalance}
-      />
-      <DropdownMenuSeparator />
-    </>
-  );
-}
-
-function AccountUsageGroupWithCredit({
-  onOpenCreditBalance,
-  onResetCodexUsage,
-  resetPending,
-  subscriptionRowsCacheKey,
-}: {
-  onOpenCreditBalance: () => void;
-  onResetCodexUsage: (resetCredits: number | null) => void;
-  resetPending: boolean;
-  subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
-}) {
-  const billingLoadable = useLastLoadable(billingStatusAsync$);
-  const { loading: subscriptionsLoading, rows } = useSubscriptionUsageRows({
-    cacheKey: subscriptionRowsCacheKey,
-  });
-  const credits =
-    billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
-  const creditLoading = billingLoadable.state === "loading" && credits === null;
-  const creditLabel = credits !== null ? formatCreditBalance(credits) : null;
-  const showCredit = creditLoading || creditLabel !== null;
-  const showSubscriptions = subscriptionsLoading || rows.length > 0;
-
-  if (!showCredit && !showSubscriptions) {
-    return null;
-  }
-
-  return (
-    <>
-      {showCredit && (
-        <CreditBalanceItem
-          creditLabel={creditLabel}
-          loading={creditLoading}
-          onOpenCreditBalance={onOpenCreditBalance}
-        />
-      )}
-      {showCredit && showSubscriptions && <DropdownMenuSeparator />}
-      {showSubscriptions && (
-        <AccountMenuSubscriptionsPanel
-          loading={subscriptionsLoading}
-          onResetCodexUsage={onResetCodexUsage}
-          resetPending={resetPending}
-          rows={rows}
-        />
-      )}
-      <DropdownMenuSeparator />
-    </>
-  );
 }
 
 function AccountUsageGroupWithCombinedCredit({
@@ -593,37 +499,6 @@ function AccountCombinedCreditBalanceGroup({
         loading={loading}
         onOpenCreditBalance={onOpenCreditBalance}
         testId="account-menu-credit-balance"
-      />
-      <DropdownMenuSeparator />
-    </>
-  );
-}
-
-function AccountSubscriptionsGroup({
-  onResetCodexUsage,
-  resetPending,
-  subscriptionRowsCacheKey,
-}: {
-  onResetCodexUsage: (resetCredits: number | null) => void;
-  resetPending: boolean;
-  subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
-}) {
-  const { loading, rows } = useSubscriptionUsageRows({
-    cacheKey: subscriptionRowsCacheKey,
-  });
-  const showSubscriptions = loading || rows.length > 0;
-
-  if (!showSubscriptions) {
-    return null;
-  }
-
-  return (
-    <>
-      <AccountMenuSubscriptionsPanel
-        loading={loading}
-        onResetCodexUsage={onResetCodexUsage}
-        resetPending={resetPending}
-        rows={rows}
       />
       <DropdownMenuSeparator />
     </>
@@ -861,8 +736,6 @@ export function AccountDropdown({
   const labEnabled = features?.[FeatureSwitchKey.Lab] ?? false;
   const subscriptionsEnabled =
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
-  const usagePackPlansEnabled =
-    features?.[FeatureSwitchKey.UsagePackPlans] ?? false;
   // The three-column nav stacks the account mark under the workspace logo, so
   // it takes the same rounded square there and stays a circle everywhere else.
   const avatarShape =
@@ -1047,7 +920,6 @@ export function AccountDropdown({
               resetPending={actionPending}
               subscriptionRowsCacheKey={subscriptionRowsCacheKey}
               subscriptionsEnabled={subscriptionsEnabled}
-              usagePackPlansEnabled={usagePackPlansEnabled}
             />
           )}
           {!hidePreferences && (

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -10,7 +10,6 @@ import {
   billingCheckoutContract,
   billingUsagePackCheckoutContract,
 } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   connectorCatalogContract,
@@ -186,11 +185,9 @@ function mockCatalogItem({
   });
 }
 
-async function openMakePage(
-  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
+async function openMakePage(): Promise<void> {
   mockOnboardingNeeded();
-  detachedSetupPage({ context, path: "/onboarding", featureSwitches });
+  detachedSetupPage({ context, path: "/onboarding" });
   await expect(
     screen.findByRole("heading", {
       name: "What do you want to make first",
@@ -1163,18 +1160,21 @@ describe("onboarding flow", () => {
         generationType = templateTypeFromUserMessage(body.userMessage);
       },
     });
-    context.mocks.api(billingCheckoutContract.create, ({ body, respond }) => {
-      successUrl = body.successUrl;
-      cancelUrl = body.cancelUrl;
-      return respond(200, {
-        url: "https://checkout.stripe.com/test/onboarding-video",
-      });
-    });
+    context.mocks.api(
+      billingUsagePackCheckoutContract.create,
+      ({ body, respond }) => {
+        successUrl = body.successUrl;
+        cancelUrl = body.cancelUrl;
+        return respond(200, {
+          url: "https://checkout.stripe.com/test/onboarding-video",
+        });
+      },
+    );
     context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
       return respond(200, { completed: true });
     });
 
-    await openMakePage({ [FeatureSwitchKey.UsagePackPlans]: false });
+    await openMakePage();
     chooseMakeOption("Video production");
 
     await expect(
@@ -1247,9 +1247,8 @@ describe("onboarding flow", () => {
     });
   });
 
-  it("uses the new Pro plan with a $20 usage pack when enabled", async () => {
+  it("uses the Pro plan with a $20 usage pack", async () => {
     const template = firstItem(VIDEO_TEMPLATE_ITEMS);
-    let legacyCheckoutCalled = false;
     let usagePackCheckoutBody:
       | {
           readonly tier: "pro" | "team";
@@ -1259,12 +1258,6 @@ describe("onboarding flow", () => {
           }[];
         }
       | undefined;
-    context.mocks.api(billingCheckoutContract.create, ({ respond }) => {
-      legacyCheckoutCalled = true;
-      return respond(200, {
-        url: "https://checkout.stripe.com/test/legacy-onboarding-video",
-      });
-    });
     context.mocks.api(
       billingUsagePackCheckoutContract.create,
       ({ body, respond }) => {
@@ -1279,7 +1272,6 @@ describe("onboarding flow", () => {
     detachedSetupPage({
       context,
       path: "/onboarding",
-      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
     await expect(
       screen.findByRole("heading", {
@@ -1307,7 +1299,6 @@ describe("onboarding flow", () => {
         "https://checkout.stripe.com/test/usage-pack-onboarding-video",
       );
     });
-    expect(legacyCheckoutCalled).toBeFalsy();
     expect(usagePackCheckoutBody).toMatchObject({
       tier: "pro",
       memberUsagePacks: [{ memberId: "test-user-123", usagePackUsd: 20 }],

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -123,7 +123,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
       true,
     );
@@ -157,7 +156,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -49,8 +49,6 @@ export enum FeatureSwitchKey {
   CodexFastMode = "codexFastMode",
   NewChatDefaultModelAction = "newChatDefaultModelAction",
   RealAgentInPreview = "realAgentInPreview",
-  UsagePackPlans = "usagePackPlans",
-
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -328,12 +328,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the conversation locator rail beside long chat threads, with hover preview and click-to-jump.",
     enabled: false,
   },
-  [FeatureSwitchKey.UsagePackPlans]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Show the new Pro and Team plan UI with required monthly usage packs.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove `FeatureSwitchKey.UsagePackPlans` from the core registry and eliminate its API, platform, onboarding, and E2E gates.
- Preserve the fully rolled-out usage-pack behavior: usage-pack checkout/catalog/management/credits, plan migration, invitation entitlements, member packages, split usage views, and combined credit balances are now unconditional.
- Remove disabled-path 403 responses, legacy pricing/UI fallbacks, switch overrides, and tests that only exercised the retired branch. Update cross-surface billing recovery tests to assert the permanent `Choose a plan` flow.

## Rollout evidence

- Introduced by `c8022f6a1e8ddc02426d2bca4750038f379a5d33` / #25296.
- Globally enabled by `f83844e5aa` / #28771.
- Terminal state confirmed as fully rolled out for this cleanup.
- Final searches have zero matches for `usagePackPlans`, `UsagePackPlans`, feature-key variants, disabled/switch-off usage-pack paths, and retired pricing constants. Generic usage-pack plan domain code remains intentionally.

## Validation

- `git diff --check`
- Knip baseline and post-cleanup: clean for `apps/api`, `apps/platform`, and `packages/core`
- Type checks: API production/tests/bootstrap wiring, platform production/tests, core, and E2E
- Changed-file Oxlint, type-aware Oxlint, and ESLint: pass (one pre-existing platform `no-useless-spread` warning remains outside the edited hunk)
- Core feature-switch tests: 25 passed
- Platform billing tests: 44 passed
- Platform member tests: 14 passed
- Remaining affected platform test files: 245 scenarios verified; the nine legacy-heading failures found during the first pass were migrated to the permanent flow and then passed targeted reruns

## Local test blocker

The targeted API integration test could not start because this environment has no PostgreSQL listener:

```text
ECONNREFUSED ::1:5432
ECONNREFUSED 127.0.0.1:5432
```

The suite failed during database setup before executing its five tests. This PR is draft so the PR pipeline can complete that database-backed validation.
