### PR TITLE
fix(mitm-addon): preserve path base precedence

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -41,8 +41,6 @@ _FORBIDDEN_AUTHORITY_HOST_CHARS = frozenset("#%/<>?@[\\]^|[]")
 _FORBIDDEN_RUNTIME_AUTHORITY_HOST_CHARS = _FORBIDDEN_AUTHORITY_HOST_CHARS | frozenset("{}")
 _PERCENT_DECODED_AUTHORITY_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61")
 _VALID_BASE_SCHEMES = frozenset(("http", "https"))
-_BASE_PATH_SCORE_MULTIPLIER = 1_000_000
-_BASE_AUTHORITY_SCORE_MULTIPLIER = 100
 _BASE_LITERAL_SEGMENT_SCORE = 1_000
 _BASE_MIXED_PARAM_SEGMENT_SCORE = 100
 _BASE_PLAIN_PARAM_SEGMENT_SCORE = 10
@@ -67,11 +65,17 @@ class _BaseUrlParts(NamedTuple):
         return f"{self.hostname}:{self.port}"
 
 
+class _BaseSpecificity(NamedTuple):
+    path: int
+    authority: int
+    static_bonus: int
+
+
 class _CompiledBase(NamedTuple):
     raw: str
     parts: _BaseUrlParts
     has_params: bool
-    specificity: int
+    specificity: _BaseSpecificity
     has_query_or_fragment: bool
     raw_syntax_malformed: bool
     param_parse_malformed: bool
@@ -522,7 +526,7 @@ def _base_specificity(
     has_params: bool,
     host_segments: tuple[ParsedSegment, ...],
     path_segments: tuple[ParsedSegment, ...],
-) -> int:
+) -> _BaseSpecificity:
     if has_params:
         authority_score = _score_base_segments(host_segments)
         path_score = _score_base_path(parts.path, path_segments)
@@ -534,11 +538,7 @@ def _base_specificity(
         path_score = _score_static_base_path(parts.path)
         static_bonus = _BASE_STATIC_SCORE_BONUS
 
-    return (
-        path_score * _BASE_PATH_SCORE_MULTIPLIER
-        + authority_score * _BASE_AUTHORITY_SCORE_MULTIPLIER
-        + static_bonus
-    )
+    return _BaseSpecificity(path_score, authority_score, static_bonus)
 
 
 def _compile_base(raw_base: str) -> _CompiledBase | None:

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -22,6 +22,7 @@ from firewall_auth_config import auth_config_injects_ordinary_upstream_credentia
 from firewall_matching import base_url as _firewall_base_url
 from firewall_matching import patterns as _firewall_patterns
 from firewall_matching.base_url import (
+    _BaseSpecificity,
     _BaseUrlParts,
     _compile_firewall_config_base,
     _CompiledBase,
@@ -1217,7 +1218,7 @@ class _FirewallMatchCollection:
     )
 
     api_matches: list[_MatchedApi]
-    best_base_specificity: int | None
+    best_base_specificity: _BaseSpecificity | None
     best_rule_specificity: _PathSpecificity | None
     winning_rule_api_orders: set[int]
 
@@ -1267,7 +1268,7 @@ class _FirewallDecisionState:
 
     allowed_match: _AllowedRuleMatch | None
     base_match: _BaseMatch | None
-    best_base_specificity: int | None
+    best_base_specificity: _BaseSpecificity | None
     denied_match: _BlockMatch | None
     # Dict keys act as an ordered set of first-seen denied permission names.
     denied_permission_names: dict[str, None]

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_base_specificity_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_base_specificity_precedence.py
@@ -481,6 +481,55 @@ def test_parameterized_path_base_deny_blocks_earlier_root_allow():
     assert result.reason == "permission_denied"
 
 
+@pytest.mark.parametrize(
+    "specific_first",
+    [False, True],
+    ids=["broad-first", "specific-first"],
+)
+def test_path_base_deny_blocks_long_static_host_allow_in_both_orders(specific_first):
+    host = ".".join(["a"] * 100 + ["com"])
+    path_base = "https://{sub+}.com/{tenant}"
+    apis = [
+        {
+            "base": f"https://{host}",
+            "auth": {"headers": {"Authorization": "Bearer root"}},
+            "permissions": [
+                {"name": "root", "rules": ["ANY /{path+}"]},
+            ],
+        },
+        {
+            "base": path_base,
+            "auth": {"headers": {"Authorization": "Bearer restricted"}},
+            "permissions": [
+                {"name": "restricted", "rules": ["GET /delete"]},
+            ],
+        },
+    ]
+    ordered_apis = list(reversed(apis)) if specific_first else apis
+    fws = wrap_firewalls(ordered_apis, name="example")
+    policies = {
+        "example": {
+            "allow": ["root"],
+            "deny": ["restricted"],
+            "unknownPolicy": "deny",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        f"https://{host}/admin/delete",
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.base == path_base
+    assert result.name == "example"
+    assert result.path == "/delete"
+    assert result.permissions == ("restricted",)
+    assert result.reason == "permission_denied"
+
+
 def test_base_specificity_wins_before_rule_specificity():
     fws = wrap_firewalls(
         [


### PR DESCRIPTION
## Summary

- represent compiled firewall base specificity as a lexicographic key ordered by path, authority, and static-base bonus
- prevent long accepted hostnames from carrying authority scores into the path-precedence dimension
- cover the fail-closed result in both API declaration orders through the production compiled matcher

## Scope

- keeps hostname validation, matcher selection flow, permission reduction, and existing component scores unchanged
- does not change APIs, persisted data, protocols, dependencies, or deployment compatibility

## Validation

- `uv run --no-sync python -m pytest tests/test_compiled_firewall_base_specificity_precedence.py` (23 passed)
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6629 passed)
- lefthook pre-commit and commitlint

Closes #29297
