### PR TITLE
feat(guest-agent): normalize provider events before sequencing

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -8,6 +8,7 @@
 //! - `command`: Claude Code command construction.
 //! - `diagnostics`: bounded stderr tail collection.
 //! - `event_delivery`: event sender watermark state.
+//! - `provider_event_normalization`: provider semantic arrays before sequencing.
 //! - `claude`: Claude result parsing and tool tracking.
 //! - `termination`: process-group termination FSM.
 //!
@@ -35,6 +36,7 @@ mod exec_boundary;
 mod line_reader;
 mod pi_rpc;
 mod process_group;
+mod provider_event_normalization;
 mod termination;
 
 pub use claude::{ClaudeResultStatus, ClaudeResultSummary};
@@ -835,31 +837,33 @@ impl<'a> CliEventIngestor<'a> {
         should_send_events: bool,
         event_tx: &EventDeliverySender,
     ) -> Result<(), AgentError> {
-        let sequence = self.seq;
-        self.seq += 1;
-        if should_send_events {
-            let event = events::prepare_event_for_delivery(event, sequence, masker);
-            if self.framework == env::Framework::Codex {
-                let prepared = codex_event_delivery::prepare_for_delivery(
-                    event,
-                    event_tx.max_serialized_event_bytes(),
-                )?;
-                if let Some(reduction) = prepared.reduction {
-                    log_warn!(
-                        LOG_TAG,
-                        "Codex event reduced for delivery: seq={} event_type={} item_type={} original_bytes={} delivered_bytes={} fields={} fallback={}",
-                        sequence,
-                        reduction.event_type,
-                        reduction.item_type,
-                        reduction.original_bytes,
-                        reduction.delivered_bytes,
-                        reduction.fields.join(","),
-                        reduction.fallback
-                    );
+        for event in provider_event_normalization::normalize_for_sequencing(self.framework, event) {
+            let sequence = self.seq;
+            self.seq += 1;
+            if should_send_events {
+                let event = events::prepare_event_for_delivery(event, sequence, masker);
+                if self.framework == env::Framework::Codex {
+                    let prepared = codex_event_delivery::prepare_for_delivery(
+                        event,
+                        event_tx.max_serialized_event_bytes(),
+                    )?;
+                    if let Some(reduction) = prepared.reduction {
+                        log_warn!(
+                            LOG_TAG,
+                            "Codex event reduced for delivery: seq={} event_type={} item_type={} original_bytes={} delivered_bytes={} fields={} fallback={}",
+                            sequence,
+                            reduction.event_type,
+                            reduction.item_type,
+                            reduction.original_bytes,
+                            reduction.delivered_bytes,
+                            reduction.fields.join(","),
+                            reduction.fallback
+                        );
+                    }
+                    event_tx.try_send_serialized(sequence, prepared.serialized)?;
+                } else {
+                    event_tx.try_send(sequence, event)?;
                 }
-                event_tx.try_send_serialized(sequence, prepared.serialized)?;
-            } else {
-                event_tx.try_send(sequence, event)?;
             }
         }
         Ok(())

--- a/crates/guest-agent/src/cli/provider_event_normalization.rs
+++ b/crates/guest-agent/src/cli/provider_event_normalization.rs
@@ -1,0 +1,83 @@
+//! Provider-owned semantic arrays flattened before canonical sequencing.
+
+use serde_json::Value;
+
+use crate::env::Framework;
+
+pub(super) fn normalize_for_sequencing(framework: Framework, event: Value) -> Vec<Value> {
+    match framework {
+        Framework::ClaudeCode => expand_claude_message_content(event),
+        Framework::Codex => expand_codex_file_changes(event),
+        Framework::Pi => vec![event],
+    }
+}
+
+fn expand_claude_message_content(event: Value) -> Vec<Value> {
+    let Value::Object(mut outer) = event else {
+        return vec![event];
+    };
+    if !matches!(
+        outer.get("type").and_then(Value::as_str),
+        Some("assistant" | "user")
+    ) {
+        return vec![Value::Object(outer)];
+    }
+
+    let Some(message) = outer.get_mut("message").and_then(Value::as_object_mut) else {
+        return vec![Value::Object(outer)];
+    };
+    let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) else {
+        return vec![Value::Object(outer)];
+    };
+    if content.len() <= 1 {
+        return vec![Value::Object(outer)];
+    }
+
+    let blocks = std::mem::take(content);
+    let message = message.clone();
+    blocks
+        .into_iter()
+        .map(|block| {
+            let mut normalized_outer = outer.clone();
+            let mut normalized_message = message.clone();
+            normalized_message.insert("content".to_string(), Value::Array(vec![block]));
+            normalized_outer.insert("message".to_string(), Value::Object(normalized_message));
+            Value::Object(normalized_outer)
+        })
+        .collect()
+}
+
+fn expand_codex_file_changes(event: Value) -> Vec<Value> {
+    let Value::Object(mut outer) = event else {
+        return vec![event];
+    };
+    if outer.get("type").and_then(Value::as_str) != Some("item.completed") {
+        return vec![Value::Object(outer)];
+    }
+
+    let Some(item) = outer.get_mut("item").and_then(Value::as_object_mut) else {
+        return vec![Value::Object(outer)];
+    };
+    if item.get("type").and_then(Value::as_str) != Some("file_change") {
+        return vec![Value::Object(outer)];
+    }
+    let Some(changes) = item.get_mut("changes").and_then(Value::as_array_mut) else {
+        return vec![Value::Object(outer)];
+    };
+    if changes.len() <= 1 {
+        return vec![Value::Object(outer)];
+    }
+
+    let changes = std::mem::take(changes);
+    let item = item.clone();
+    changes
+        .into_iter()
+        .map(|change| {
+            let mut normalized_outer = outer.clone();
+            let mut normalized_item = item.clone();
+            normalized_item.insert("changes".to_string(), Value::Array(vec![change]));
+            normalized_outer.insert("item".to_string(), Value::Object(normalized_item));
+            Value::Object(normalized_outer)
+        })
+        .collect()
+}

--- a/crates/guest-agent/tests/claude_provider_event_normalization.rs
+++ b/crates/guest-agent/tests/claude_provider_event_normalization.rs
@@ -1,0 +1,241 @@
+//! Claude content blocks receive independent canonical sequences while the
+//! original JSONL record remains the unit of local logging and metadata capture.
+
+mod common;
+
+use base64::Engine as _;
+use guest_agent::masker::SecretMasker;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+const SESSION_ID: &str = "00000000-0000-4000-8000-000000000041";
+const SECRET: &str = "provider-normalization-secret";
+
+#[tokio::test]
+async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+    let source_events = [
+        json!({
+            "type": "system",
+            "subtype": "init",
+            "session_id": SESSION_ID,
+            "model": "mock-claude"
+        }),
+        json!({
+            "type": "assistant",
+            "session_id": SESSION_ID,
+            "message": {
+                "id": "msg-provider-normalization",
+                "model": "mock-claude",
+                "role": "assistant",
+                "content": [
+                    { "type": "text", "text": format!("text A {SECRET}") },
+                    {
+                        "type": "tool_use",
+                        "id": "tool-use-a",
+                        "name": "Bash",
+                        "input": { "command": format!("printf {SECRET}") }
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tool-use-b",
+                        "name": "Read",
+                        "input": { "file_path": "README.md" }
+                    },
+                    { "type": "text", "text": "text B" },
+                    { "type": "text", "text": "text C" }
+                ]
+            }
+        }),
+        json!({
+            "type": "user",
+            "session_id": SESSION_ID,
+            "uuid": "user-provider-normalization",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-use-a",
+                        "content": format!("result A {SECRET}")
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-use-b",
+                        "content": "result B"
+                    }
+                ]
+            }
+        }),
+    ];
+    let prompt = format!(
+        "@ECHO@\n{}",
+        source_events
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        &run_id,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(SECRET);
+    let masker = SecretMasker::from_raw(&encoded_secret);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("Claude provider normalization should finish promptly")?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.control_error.is_none());
+    assert_eq!(result.last_event_sequence, Some(7));
+
+    server
+        .wait_for_quiet(Duration::from_millis(50), Duration::from_secs(5))
+        .await?;
+    let delivered = server
+        .requests()?
+        .into_iter()
+        .filter(|request| request.path == "/api/webhooks/agent/events")
+        .map(|request| serde_json::from_str::<Value>(&request.body))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flat_map(|payload| {
+            payload
+                .get("events")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(delivered.len(), 8);
+    assert_eq!(
+        delivered
+            .iter()
+            .map(|event| event["sequenceNumber"].as_u64())
+            .collect::<Vec<_>>(),
+        (0..8).map(Some).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        delivered
+            .iter()
+            .map(|event| event["type"].as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("system"),
+            Some("assistant"),
+            Some("assistant"),
+            Some("assistant"),
+            Some("assistant"),
+            Some("assistant"),
+            Some("user"),
+            Some("user"),
+        ]
+    );
+
+    let semantic_events = &delivered[1..];
+    assert!(semantic_events.iter().all(|event| {
+        event
+            .pointer("/message/content")
+            .and_then(Value::as_array)
+            .is_some_and(|content| content.len() == 1)
+    }));
+    assert_eq!(
+        semantic_events
+            .iter()
+            .map(|event| event
+                .pointer("/message/content/0/type")
+                .and_then(Value::as_str))
+            .collect::<Vec<_>>(),
+        vec![
+            Some("text"),
+            Some("tool_use"),
+            Some("tool_use"),
+            Some("text"),
+            Some("text"),
+            Some("tool_result"),
+            Some("tool_result"),
+        ]
+    );
+    assert!(delivered[1..6].iter().all(|event| {
+        event.pointer("/message/id").and_then(Value::as_str) == Some("msg-provider-normalization")
+            && event.pointer("/message/model").and_then(Value::as_str) == Some("mock-claude")
+    }));
+    assert_eq!(
+        delivered[2]
+            .pointer("/message/content/0/id")
+            .and_then(Value::as_str),
+        Some("tool-use-a")
+    );
+    assert_eq!(
+        delivered[3]
+            .pointer("/message/content/0/id")
+            .and_then(Value::as_str),
+        Some("tool-use-b")
+    );
+    assert_eq!(
+        delivered[6]
+            .pointer("/message/content/0/tool_use_id")
+            .and_then(Value::as_str),
+        Some("tool-use-a")
+    );
+    assert_eq!(
+        delivered[7]
+            .pointer("/message/content/0/tool_use_id")
+            .and_then(Value::as_str),
+        Some("tool-use-b")
+    );
+    let delivered_json = serde_json::to_string(&delivered)?;
+    assert!(!delivered_json.contains(SECRET));
+    assert!(delivered_json.contains("***"));
+
+    let local_events = read_jsonl(runtime.paths.agent_log_file())?;
+    assert_eq!(local_events, source_events.to_vec());
+    assert_eq!(
+        local_events[1]
+            .pointer("/message/content")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(5)
+    );
+    assert_eq!(
+        local_events[2]
+            .pointer("/message/content")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(2)
+    );
+    assert!(serde_json::to_string(&local_events)?.contains(SECRET));
+    assert_eq!(
+        std::fs::read_to_string(runtime.paths.session_id_file())?,
+        SESSION_ID
+    );
+
+    Ok(())
+}
+
+fn read_jsonl(path: &str) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    std::fs::read_to_string(path)?
+        .lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -57,7 +57,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
 
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
     assert!(result.control_error.is_none());
-    assert_eq!(result.last_event_sequence, Some(9));
+    assert_eq!(result.last_event_sequence, Some(11));
 
     server
         .wait_for_quiet(Duration::from_millis(50), Duration::from_secs(5))
@@ -87,7 +87,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
                 .unwrap_or_default()
         })
         .collect::<Vec<_>>();
-    assert_eq!(delivered.len(), 10);
+    assert_eq!(delivered.len(), 12);
     assert!(
         delivered
             .iter()
@@ -104,7 +104,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
             .iter()
             .map(|event| event["sequenceNumber"].as_u64())
             .collect::<Vec<_>>(),
-        (0..10).map(Some).collect::<Vec<_>>()
+        (0..12).map(Some).collect::<Vec<_>>()
     );
 
     for item_id in [
@@ -113,7 +113,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         "oversized-plan",
         "oversized-command",
         "oversized-file-change",
-        "oversized-structure",
+        "oversized-multi-change",
     ] {
         let event = delivered_item(&delivered, item_id)?;
         assert_eq!(event["item"]["id"], item_id);
@@ -176,15 +176,52 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
                 && text.contains(DELIVERY_MARKER))
     );
 
-    let structure = delivered_item(&delivered, "oversized-structure")?;
-    assert_eq!(structure["item"]["type"], "file_change");
-    assert_eq!(structure["item"]["status"], "completed");
+    let fallback_plan = delivered
+        .iter()
+        .find(|event| event["type"] == "turn.plan.updated")
+        .ok_or("oversized plan update was not delivered")?;
+    assert_eq!(fallback_plan["sequenceNumber"], 7);
     assert_eq!(
-        structure["item"]["changes"].as_array().map(Vec::len),
-        Some(1)
+        fallback_plan["plan"],
+        serde_json::json!([{
+            "step": FALLBACK_MARKER,
+            "status": "pending",
+        }])
     );
-    assert_eq!(structure["item"]["changes"][0]["diff"], FALLBACK_MARKER);
-    assert!(structure["item"]["changes"][0].get("kind").is_none());
+    assert_eq!(fallback_plan["explanation"], FALLBACK_MARKER);
+
+    let multi_change = delivered_items(&delivered, "oversized-multi-change");
+    assert_eq!(multi_change.len(), 2);
+    assert_eq!(
+        multi_change
+            .iter()
+            .map(|event| event["sequenceNumber"].as_u64())
+            .collect::<Vec<_>>(),
+        vec![Some(8), Some(9)]
+    );
+    assert_eq!(
+        multi_change
+            .iter()
+            .map(|event| event["item"]["changes"][0]["path"].as_str())
+            .collect::<Vec<_>>(),
+        vec![Some("structure-a.txt"), Some("structure-b.txt")]
+    );
+    for (event, (head, tail)) in multi_change.iter().zip([
+        ("structure-a-head-***-", "-structure-a-tail"),
+        ("structure-b-head-***-", "-structure-b-tail"),
+    ]) {
+        assert_eq!(event["item"]["type"], "file_change");
+        assert_eq!(event["item"]["status"], "completed");
+        assert_eq!(event["item"]["changes"].as_array().map(Vec::len), Some(1));
+        assert_eq!(event["item"]["changes"][0]["kind"], "modify");
+        assert!(
+            event["item"]["changes"][0]["diff"]
+                .as_str()
+                .is_some_and(|text| text.starts_with(head)
+                    && text.ends_with(tail)
+                    && text.contains(DELIVERY_MARKER))
+        );
+    }
 
     let warning = delivered
         .iter()
@@ -202,14 +239,37 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
     assert!(local_text.contains(SECRET));
     assert!(!local_text.contains(DELIVERY_MARKER));
     assert!(local_agent.get("vm0_delivery").is_none());
+    let local_plan = local_events
+        .iter()
+        .find(|event| event["type"] == "turn.plan.updated")
+        .ok_or("local oversized plan update was not recorded")?;
+    assert_eq!(local_plan["plan"].as_array().map(Vec::len), Some(75_000));
+    assert!(!serde_json::to_string(local_plan)?.contains(FALLBACK_MARKER));
+    let local_multi_change = delivered_item(&local_events, "oversized-multi-change")?;
+    assert_eq!(
+        local_multi_change["item"]["changes"]
+            .as_array()
+            .map(Vec::len),
+        Some(2)
+    );
+    assert!(
+        local_multi_change["item"]["changes"]
+            .as_array()
+            .is_some_and(|changes| changes.iter().all(|change| {
+                change["diff"]
+                    .as_str()
+                    .is_some_and(|diff| diff.contains(SECRET) && !diff.contains(DELIVERY_MARKER))
+            }))
+    );
 
     let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
     assert_eq!(
         system_log
             .matches("Codex event reduced for delivery")
             .count(),
-        6
+        8
     );
+    assert!(system_log.contains("event_type=turn.plan.updated"));
     assert!(system_log.contains("fallback=true"));
     assert!(!system_log.contains(SECRET));
     assert!(!system_log.contains("agent-head"));
@@ -223,6 +283,13 @@ fn delivered_item<'a>(events: &'a [Value], item_id: &str) -> Result<&'a Value, S
         .iter()
         .find(|event| event.pointer("/item/id").and_then(Value::as_str) == Some(item_id))
         .ok_or_else(|| format!("missing item {item_id}"))
+}
+
+fn delivered_items<'a>(events: &'a [Value], item_id: &str) -> Vec<&'a Value> {
+    events
+        .iter()
+        .filter(|event| event.pointer("/item/id").and_then(Value::as_str) == Some(item_id))
+        .collect()
 }
 
 fn read_jsonl(path: &str) -> Result<Vec<Value>, Box<dyn std::error::Error>> {

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -246,19 +246,42 @@ pub(super) fn write_oversized_delivery_notifications<W: Write>(
     write_json_line(
         output,
         &json!({
+            "method": "turn/plan/updated",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "explanation": "oversized structural plan",
+                "plan": (0..75_000).map(|index| json!({
+                    "step": format!("step-{index:06}-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz"),
+                    "status": "pending",
+                })).collect::<Vec<_>>(),
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
             "method": "item/completed",
             "params": {
                 "threadId": thread_id,
                 "turnId": turn_id,
-                "completedAtMs": completed_at_ms + 5,
+                "completedAtMs": completed_at_ms + 6,
                 "item": {
-                    "id": "oversized-structure",
+                    "id": "oversized-multi-change",
                     "type": "fileChange",
                     "status": "completed",
-                    "changes": (0..75_000).map(|index| json!({
-                        "path": format!("path-{index:06}-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz"),
-                        "kind": "modify",
-                    })).collect::<Vec<_>>(),
+                    "changes": [
+                        {
+                            "path": "structure-a.txt",
+                            "kind": "modify",
+                            "diff": format!("structure-a-head-{secret}-{large}-structure-a-tail"),
+                        },
+                        {
+                            "path": "structure-b.txt",
+                            "kind": "modify",
+                            "diff": format!("structure-b-head-{secret}-{large}-structure-b-tail"),
+                        }
+                    ],
                 }
             }
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3356,6 +3356,121 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     expect(chatOutputAxiomQueryCalls()).toHaveLength(0);
   }, 90_000);
 
+  it("persists normalized Claude text blocks independently across tool-only sequences", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "persist normalized Claude blocks",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    const events = [
+      {
+        type: "assistant" as const,
+        sequenceNumber: 0,
+        message: {
+          id: "msg_bdd_normalized_claude",
+          content: [{ type: "text" as const, text: "text A" }],
+        },
+      },
+      {
+        type: "assistant" as const,
+        sequenceNumber: 1,
+        message: {
+          id: "msg_bdd_normalized_claude",
+          content: [
+            {
+              type: "tool_use" as const,
+              id: "tool_bdd_normalized_claude",
+              name: "Read",
+              input: { file_path: "README.md" },
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant" as const,
+        sequenceNumber: 2,
+        message: {
+          id: "msg_bdd_normalized_claude",
+          content: [{ type: "text" as const, text: "text B" }],
+        },
+      },
+      {
+        type: "assistant" as const,
+        sequenceNumber: 3,
+        message: {
+          id: "msg_bdd_normalized_claude",
+          content: [{ type: "text" as const, text: "text C" }],
+        },
+      },
+    ];
+    await webhooks.requestAgentEvents(
+      { runId: run.runId, events },
+      sandboxHeaders,
+      [200],
+    );
+    await webhooks.requestAgentEvents(
+      { runId: run.runId, events },
+      sandboxHeaders,
+      [200],
+    );
+    context.mocks.axiom.query.mockClear();
+    context.mocks.axiomLogging.warn.mockClear();
+
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 3,
+    });
+    const messages = await waitForThreadMessages(
+      actor,
+      run.threadId,
+      (threadMessages) => {
+        return eventBackedContents(threadMessages, run.runId).length === 3;
+      },
+    );
+    const persisted = eventBackedContents(messages.events, run.runId).sort(
+      (left, right) => {
+        return (
+          (left.sequenceNumber ?? Number.MAX_SAFE_INTEGER) -
+          (right.sequenceNumber ?? Number.MAX_SAFE_INTEGER)
+        );
+      },
+    );
+    expect(
+      persisted.map((message) => {
+        return {
+          content: message.content,
+          runEventId: message.runEventId,
+          sequenceNumber: message.sequenceNumber,
+        };
+      }),
+    ).toStrictEqual([
+      { content: "text A", runEventId: "event:0", sequenceNumber: 0 },
+      { content: "text B", runEventId: "event:2", sequenceNumber: 2 },
+      { content: "text C", runEventId: "event:3", sequenceNumber: 3 },
+    ]);
+    expect(
+      new Set(
+        persisted.map((message) => {
+          return message.id;
+        }),
+      ).size,
+    ).toBe(3);
+    expect(chatOutputAxiomQueryCalls()).toHaveLength(0);
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.some(([message, fields]) => {
+        return (
+          message ===
+            "Run output projection is incomplete at terminal callback" &&
+          isRecord(fields) &&
+          fields.runId === run.runId
+        );
+      }),
+    ).toBeFalsy();
+  }, 90_000);
+
   it("returns 503 when the required DB output projection is locked", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const run = await startChatRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15814,7 +15814,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       return message.eventType === "output.message" && message.runId === runId;
     });
     expect(firstAssistant?.id).toBe(
-      assistantEventIdForRunEvent(runId, "msg_bdd_1"),
+      assistantEventIdForRunEvent(runId, "event:1"),
     );
     expect(firstAssistant?.content).toBe("Hello from BDD events");
     expect(
@@ -16020,13 +16020,15 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       }),
     ).toHaveLength(3);
 
+    // Repeating an already persisted canonical sequence is idempotent even if
+    // the redelivered payload differs.
     await webhooks.requestAgentEvents(
       {
         runId,
         events: [
           {
             type: "assistant",
-            sequenceNumber: 11,
+            sequenceNumber: 1,
             message: {
               id: "msg_bdd_1",
               content: [{ type: "text", text: "Duplicate text" }],
@@ -16039,7 +16041,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     );
     await flushWaitUntilForTest();
     const afterDuplicate = await chat.listThreadEvents(actor, threadId);
-    const duplicatedMessageId = assistantEventIdForRunEvent(runId, "msg_bdd_1");
+    const duplicatedMessageId = assistantEventIdForRunEvent(runId, "event:1");
     const matchingDuplicateRows = afterDuplicate.events.filter((message) => {
       return (
         message.eventType === "output.message" &&

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -154,11 +154,6 @@ function latestCandidate(
 }
 
 function eventOutputId(event: AgentEvent): string {
-  const message = recordOf(event.message);
-  if (typeof message?.id === "string") {
-    return message.id;
-  }
-
   const item = recordOf(event.item);
   if (typeof item?.id === "string") {
     return item.id;


### PR DESCRIPTION
## Summary

- normalize complete Claude assistant and user content blocks before canonical sequence allocation without changing raw-line logging, metadata capture, diagnostics, or tool correlation
- normalize completed Codex multi-change file events into one independently masked and delivery-bounded event per change while preserving source order
- derive Claude Chat run-event identity from canonical sequence so same-message text blocks persist independently and duplicate canonical deliveries remain idempotent

## Verification

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test claude_provider_event_normalization --test codex_app_server_oversized_event_delivery --test event_delivery_singleton
- pnpm -F api check-types
- pnpm -F api lint
- targeted Vitest cases for normalized Claude persistence and lifecycle idempotence

Closes #29341
Part of #29244