### PR TITLE
fix(composer): keep the flat note chrome stable while typing

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -721,7 +721,6 @@ function createFlatFeedbackItemNodeView(
 
 function buildFeedbackItemChrome(
   quote: string,
-  showPlaceholder: boolean,
   onRemove: () => void,
 ): HTMLElement {
   const { quoteDom, quoteText, removeButton } = createFeedbackQuoteChip();
@@ -735,22 +734,14 @@ function buildFeedbackItemChrome(
     event.preventDefault();
   });
   removeButton.addEventListener("click", onRemove);
-  if (showPlaceholder) {
-    quoteDom.classList.add("relative");
-    const placeholder = document.createElement("span");
-    // The chip row is 32px plus the item's 6px gap; the first paragraph adds
-    // 4px of top padding, so the placeholder sits at 42px over its text.
-    placeholder.className =
-      "pointer-events-none absolute left-1 top-[42px] w-max " +
-      "text-[0.9375rem] leading-snug text-muted-foreground/40";
-    placeholder.setAttribute("aria-hidden", "true");
-    placeholder.textContent = i18n.t(($) => {
-      return $.chat.feedback.placeholder;
-    });
-    quoteDom.append(placeholder);
-  }
   return quoteDom;
 }
+
+// Rendered through ::before so an empty note never gains or loses real DOM
+// nodes: the placeholder text lives in an attribute and appears via CSS.
+const FLAT_PLACEHOLDER_PARAGRAPH_CLASS =
+  "before:pointer-events-none before:float-left before:h-0 " +
+  "before:text-muted-foreground/40 before:content-[attr(data-placeholder)]";
 
 function buildFeedbackChromeDecorations(
   doc: ProseMirrorNode,
@@ -766,19 +757,20 @@ function buildFeedbackChromeDecorations(
       continue;
     }
     const { feedbackId, quote } = feedbackItemNodeAttributes(child);
-    const showPlaceholder = nodeText(child).length === 0;
     decorations.push(
       Decoration.widget(
         childPosition + 1,
         () => {
-          return buildFeedbackItemChrome(quote, showPlaceholder, () => {
+          return buildFeedbackItemChrome(quote, () => {
             runtime.removeFeedback(feedbackId);
           });
         },
         {
-          // The key carries everything the DOM is built from, so the widget
-          // is only recreated when its content actually changes.
-          key: `feedback-chrome-${feedbackId}-${showPlaceholder ? "empty" : "filled"}-${i18n.language}`,
+          // The key must stay stable while the user types: recreating the
+          // widget replaces a contenteditable=false element right next to the
+          // caret, and WebKit loses the caret when that happens at an IME
+          // composition boundary (typing or backspacing the first character).
+          key: `feedback-chrome-${feedbackId}-${i18n.language}`,
           side: -2,
           ignoreSelection: true,
           stopEvent: () => {
@@ -787,6 +779,20 @@ function buildFeedbackChromeDecorations(
         },
       ),
     );
+    if (nodeText(child).length === 0) {
+      decorations.push(
+        Decoration.node(
+          childPosition + 1,
+          childPosition + 1 + child.child(0).nodeSize,
+          {
+            class: FLAT_PLACEHOLDER_PARAGRAPH_CLASS,
+            "data-placeholder": i18n.t(($) => {
+              return $.chat.feedback.placeholder;
+            }),
+          },
+        ),
+      );
+    }
   }
   return DecorationSet.create(doc, decorations);
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -1557,9 +1557,13 @@ describe("chat inline feedback", () => {
     // The flat block is its own content element: no nested note wrapper.
     expect(note.dataset.feedbackItem).toBe("");
     expect(note.querySelector("[data-feedback-note]")).toBeNull();
-    // The chrome widget carries the quote chip and the empty-note placeholder.
+    // The chrome widget carries the quote chip; the empty-note placeholder is
+    // an attribute the paragraph renders through ::before, so typing never
+    // inserts or removes DOM around the caret.
     expect(note).toHaveTextContent(assistantReply);
-    expect(note).toHaveTextContent("What should change about this?");
+    expect(
+      note.querySelector<HTMLElement>(":scope > p")?.dataset.placeholder,
+    ).toBe("What should change about this?");
 
     await user.click(note);
     pastePlainText(note, "Make the dates explicit");
@@ -1567,7 +1571,9 @@ describe("chat inline feedback", () => {
       expect(note).toHaveTextContent("Make the dates explicit");
     });
     await waitFor(() => {
-      expect(note).not.toHaveTextContent("What should change about this?");
+      expect(
+        note.querySelector<HTMLElement>(":scope > p")?.dataset.placeholder,
+      ).toBeUndefined();
     });
 
     await user.click(screen.getByLabelText("Send"));
@@ -1576,6 +1582,38 @@ describe("chat inline feedback", () => {
     });
     expect(sentMessages[0]?.prompt).toContain("Make the dates explicit");
     expect(sentMessages[0]?.prompt).toContain(assistantReply);
+  });
+
+  it("keeps the chrome widget's identity while the note empties and refills", async () => {
+    // Recreating the widget swaps a contenteditable=false element right next
+    // to the caret; at an IME composition boundary WebKit loses the caret.
+    // The widget must survive both transitions with the same DOM element.
+    const user = userEvent.setup({ delay: null });
+    const { assistantReply } = await setupFlatFeedbackNoteThread("stable");
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const note = await findFeedbackNote();
+    const chrome = note.firstElementChild;
+    if (!(chrome instanceof HTMLElement) || chrome.tagName === "P") {
+      throw new Error("Chrome widget not found");
+    }
+
+    await user.click(note);
+    pastePlainText(note, "z");
+    await waitFor(() => {
+      expect(note).toHaveTextContent("z");
+    });
+    expect(note.firstElementChild).toBe(chrome);
+
+    await replaceFeedbackNote(note, "{Backspace}");
+    await waitFor(() => {
+      expect(
+        note.querySelector<HTMLElement>(":scope > p")?.dataset.placeholder,
+      ).toBe("What should change about this?");
+    });
+    expect(note.firstElementChild).toBe(chrome);
   });
 
   it("stays editable after the flat quote block is damaged in place", async () => {


### PR DESCRIPTION
## Summary

First dogfood regression on the flat quote block (#29137): quote → type one uncommitted pinyin character → press Backspace → **the caret disappears**.

## Cause

The chrome widget's decoration key encoded the note's empty/filled state:

```
feedback-chrome-<id>-<empty|filled>-<lang>
```

So the widget was torn down and recreated at exactly two moments: when the first character arrived (empty→filled) and when the last one was deleted (filled→empty). Both are IME composition boundaries, and the rebuild replaces a `contenteditable="false"` element immediately before the caret's paragraph. Bench-verified: the widget rebuilds twice across a type-one-delete-one round trip. Chromium's selection survives the churn; WebKit loses the caret when the churn lands on a cancelled composition — the same "DOM churn adjacent to a live IME composition" hazard class as #27787 itself.

## Fix

- **Stable widget key** (`feedback-chrome-<id>-<lang>`): the chip element keeps its identity for the lifetime of the quote; typing never rebuilds it.
- **Placeholder leaves the widget**: the empty note's paragraph gets a node decoration carrying the localized text in `data-placeholder`, rendered through `::before` (the pattern Tiptap's official Placeholder extension uses). The placeholder appearing/disappearing is now a class+attribute flip on the paragraph — no DOM nodes are inserted or removed around the caret, and the fixed 42px offset hack is replaced by in-flow positioning.

## Verification

- `chat-inline-feedback.test.tsx` — 35 passed; new regression test asserts the chrome element keeps its **identity** (same DOM node) while the note goes empty → filled → empty
- negative control: reintroducing the empty state into the widget key makes the new test fail
- placeholder assertions updated to the attribute-driven form (`data-placeholder` present on the empty note's paragraph, absent once text exists)
- `check-types`, `lint`, `knip` — clean
- device verification: quote → type one pinyin character without committing → Backspace — the caret must stay visible; then compose normally and send

Related to #27787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)