### PR TITLE
test: cover a shared template leaving an open picker when it turns private

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3962,6 +3962,69 @@ describe("chat composer templates", () => {
     await expectInlineTemplateInComposer("Fresh deck");
   });
 
+  it("drops a workspace template from an open picker once its owner makes it private", async () => {
+    const sharedTemplate = {
+      id: "3c7f1d84-5b2a-4e6f-8a90-1b2c3d4e5f61",
+      title: "Workspace brand",
+      sourceFilename: "workspace-brand.pptx",
+      coverUrl: "https://example.com/workspace-brand-cover.png",
+      pageCount: 6,
+      visibility: "public" as const,
+      canManage: false,
+      pageUrls: ["https://example.com/workspace-brand-cover.png"],
+      createdAt: "2026-08-23T03:00:00.000Z",
+      updatedAt: "2026-08-23T03:00:00.000Z",
+    };
+    setMockPresentationTemplates([sharedTemplate]);
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    const dialog = await waitFor(() => {
+      const card = document.querySelector(
+        `[data-imported-presentation-template="${sharedTemplate.id}"]`,
+      );
+      if (!(card instanceof HTMLElement)) {
+        throw new Error("Shared template card not found");
+      }
+      return screen.getByRole("dialog");
+    });
+
+    // The owner takes the deck back: the row leaves this member's catalog and
+    // the workspace channel says so while the picker is still open.
+    setMockPresentationTemplates([]);
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscriptionOnChannel(
+          "org:org_default",
+          "presentationTemplatesChanged",
+        ),
+      ).toBeTruthy();
+    });
+    context.mocks.ably.triggerOnChannel(
+      "org:org_default",
+      "presentationTemplatesChanged",
+    );
+
+    await waitFor(() => {
+      expect(
+        dialog.querySelector(
+          `[data-imported-presentation-template="${sharedTemplate.id}"]`,
+        ),
+      ).toBeNull();
+    });
+    expect(screen.getByRole("dialog")).toBe(dialog);
+  });
+
   it("scrubs every uploaded slide and manages an owned template from its detail view", async () => {
     const user = userEvent.setup({ delay: null });
     const imageDecodes = controlImportedTemplateImageDecodes([


### PR DESCRIPTION
## What

A workspace member watching the template picker must see a shared deck disappear the moment its owner makes it private again. The API side already asserts both directions of the visibility flip and the workspace broadcast, and the client side already covers the appearance direction, but the removal direction had no test.

## Why

The removal is the direction that can silently rot: the update route only reaches the org channel because it treats `previous.visibility === "public"` as workspace-visible, and nothing on the client pinned that a still-open picker reacts to it. A regression there leaves a member using a deck the owner already took back.

## Verification

- New test passes: `pnpm -F @okouai/platform exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx -t "drops a workspace template"`
- Negative control: with the `triggerOnChannel` line removed the test fails, so the card disappears because of the workspace broadcast rather than an incidental refetch.
- `turbo/apps/api/src/signals/routes/__tests__/presentation-template-publish.test.ts` re-run green (7/7) against a local Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)