### PR TITLE
chore(api): refresh preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #27599 rollback rotation on 2026-08-18)
+// (no-op API release marker refreshed for preview QA on 2026-08-25)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
Deployment fixture only. This refreshes the existing no-op API release marker comment so the PR provisions App and API Preview deployments for browser verification of workspace presentation-template visibility.

Runtime behavior is unchanged. **Do not merge as a product change** — close it once the verification thread is finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)