### PR TITLE
feat: pin hyperframes authoring source

### DIFF
--- a/turbo/packages/core/src/__tests__/hyperframes-source.spec.ts
+++ b/turbo/packages/core/src/__tests__/hyperframes-source.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HYPERFRAMES_AUTHORING_SOURCE,
+  HYPERFRAMES_RUNTIME,
+} from "../hyperframes-source";
+
+describe("HyperFrames source pins", () => {
+  it("keeps the official authoring source and published runtime explicit", () => {
+    expect(HYPERFRAMES_AUTHORING_SOURCE).toEqual({
+      repo: "heygen-com/hyperframes",
+      ref: "6eaa2cb64b280c51cadb3843ce190f6f0b7493cc",
+      entrySkillPath: "skills/hyperframes/SKILL.md",
+      workflowSkillPaths: {
+        productLaunchVideo: "skills/product-launch-video/SKILL.md",
+        facelessExplainer: "skills/faceless-explainer/SKILL.md",
+      },
+      blueprintIndexPath: "skills/hyperframes-animation/blueprints-index.md",
+      rulesIndexPath: "skills/hyperframes-animation/rules-index.md",
+    });
+    expect(HYPERFRAMES_AUTHORING_SOURCE.ref).toMatch(/^[0-9a-f]{40}$/u);
+    expect(HYPERFRAMES_RUNTIME).toEqual({
+      packageName: "hyperframes",
+      version: "0.8.14",
+      packageSpec: "hyperframes@0.8.14",
+    });
+  });
+});

--- a/turbo/packages/core/src/hyperframes-source.ts
+++ b/turbo/packages/core/src/hyperframes-source.ts
@@ -1,0 +1,22 @@
+/** Official HyperFrames authoring source used by vm0 video templates. */
+export const HYPERFRAMES_AUTHORING_SOURCE = {
+  repo: "heygen-com/hyperframes",
+  ref: "6eaa2cb64b280c51cadb3843ce190f6f0b7493cc",
+  entrySkillPath: "skills/hyperframes/SKILL.md",
+  workflowSkillPaths: {
+    productLaunchVideo: "skills/product-launch-video/SKILL.md",
+    facelessExplainer: "skills/faceless-explainer/SKILL.md",
+  },
+  blueprintIndexPath: "skills/hyperframes-animation/blueprints-index.md",
+  rulesIndexPath: "skills/hyperframes-animation/rules-index.md",
+} as const;
+
+/**
+ * The published CLI is versioned independently from the Git authoring source.
+ * Keep both pins explicit so a source update cannot silently change rendering.
+ */
+export const HYPERFRAMES_RUNTIME = {
+  packageName: "hyperframes",
+  version: "0.8.14",
+  packageSpec: "hyperframes@0.8.14",
+} as const;

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -30,6 +30,10 @@ export {
   type VideoTemplateItem,
 } from "./video-template-items";
 export {
+  HYPERFRAMES_AUTHORING_SOURCE,
+  HYPERFRAMES_RUNTIME,
+} from "./hyperframes-source";
+export {
   WEBSITE_TEMPLATE_ITEMS,
   findWebsiteTemplateItem,
   type WebsiteTemplateItem,


### PR DESCRIPTION
## Summary

- pin the official `heygen-com/hyperframes` authoring source to commit `6eaa2cb64b280c51cadb3843ce190f6f0b7493cc`
- pin the published `hyperframes@0.8.14` runtime independently from the Git source
- expose the canonical entry skill, supported workflow skills, blueprint index, and rules index from `@okouai/core`

## Verification

- `pnpm exec prettier --check packages/core/src/hyperframes-source.ts packages/core/src/__tests__/hyperframes-source.spec.ts packages/core/src/index.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/hyperframes-source.spec.ts`
- `pnpm knip --workspace @okouai/core`

## Follow-up

A stacked PR will consume this pin to wire the placeholder intro-video template flow behind a feature switch.