### PR TITLE
refactor(guest-agent): dual-read api backend url aliases

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -7,8 +7,9 @@ use super::CliRuntimeConfig;
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_SHELL: &str = "/bin/bash";
 // The sandbox CLI needs the same API origin as the guest-agent in local
-// development. Keep runner-visible env intentionally narrow: tokens and other
-// VM0 bootstrap controls must stay private to the guest-agent.
+// development. During #28914 reader Stage 1, keep this legacy spelling until
+// the separate managed-CLI reader/support floor permits a child-writer cutover.
+// Tokens and all other bootstrap controls must stay private to the guest-agent.
 const RUNNER_VISIBLE_API_URL_ENV_KEY: &str = guest_contracts::env::API_URL_ENV;
 const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
     "USER",

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -30,6 +30,38 @@ fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
 }
 
+/// Resolve the Runner-to-Guest Agent API URL at the single process-env capture
+/// boundary. The canonical alias is reader-only during #28914 Stage 1; Runner
+/// writers and managed CLI-child exposure remain [`guest_contracts::env::API_URL_ENV`].
+/// Remove the legacy reader only after the exact production Runner plus
+/// embedded-Guest reader floor, complete pre-reader service and reusable-sandbox
+/// drain, supported rollback window, and value-free legacy-source-zero gates.
+fn api_url_env_or_empty() -> Result<String, String> {
+    let canonical_key = guest_contracts::env::CANONICAL_API_URL_ENV;
+    let legacy_key = guest_contracts::env::API_URL_ENV;
+    let canonical = std::env::var(canonical_key).ok();
+    let legacy = std::env::var(legacy_key).ok();
+
+    let (value, source) = match (canonical, legacy) {
+        (None, None) => return Ok(String::new()),
+        (Some(value), None) => (value, "canonical-only"),
+        (None, Some(value)) => (value, "legacy-only"),
+        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(_), Some(_)) => {
+            return Err(format!(
+                "conflicting API backend URL environment aliases: canonical_key={canonical_key} \
+                 legacy_key={legacy_key} state=conflict"
+            ));
+        }
+    };
+
+    log_info!(
+        LOG_TAG,
+        "api_url_env_source key={canonical_key} source={source}"
+    );
+    Ok(value)
+}
+
 #[derive(Clone, Copy)]
 enum PrivatePayloadFileEnvSource {
     CanonicalOnly,
@@ -430,6 +462,7 @@ impl GuestConfigRaw {
         guest_runtime_dir: guest_contracts::runtime_paths::GuestRuntimeDirEnvResolution,
     ) -> Result<Self, String> {
         let (guest_runtime_dir, _source) = guest_runtime_dir.into_parts();
+        let api_url = api_url_env_or_empty()?;
 
         let stuck_tool_timeout_secs = guest_agent_tuning_env_or_empty(
             guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
@@ -468,7 +501,7 @@ impl GuestConfigRaw {
 
         Ok(Self {
             run_id: env_or_empty(guest_contracts::env::RUN_ID_ENV),
-            api_url: env_or_empty(guest_contracts::env::API_URL_ENV),
+            api_url,
             api_token: api_token_env_or_empty()?,
             sandbox_id: run_metadata_env_or_empty(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -1,0 +1,451 @@
+//! API backend URL aliases are resolved once in this process-isolated test binary.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
+use std::path::Path;
+
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::http::HttpClient;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CANONICAL_URL: &str = "https://canonical-api-url-must-not-leak.example.test/private-path";
+const LEGACY_URL: &str = "https://legacy-api-url-must-not-leak.example.test/private-path";
+const SHARED_URL: &str = "https://shared-api-url-must-not-leak.example.test/private-path";
+const API_TOKEN: &str = "api-url-test-token-must-not-leak";
+const VALUE_MARKERS: [&str; 4] = [
+    "canonical-api-url-must-not-leak",
+    "legacy-api-url-must-not-leak",
+    "shared-api-url-must-not-leak",
+    API_TOKEN,
+];
+const SOURCE_EVENT: &str = "api_url_env_source";
+
+#[derive(Clone, Copy)]
+enum AliasInput {
+    Absent,
+    Readable(&'static str),
+    NonUnicode,
+}
+
+#[derive(Clone, Copy)]
+struct SuccessCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_value: &'static str,
+    expected_source: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct ConflictCase {
+    name: &'static str,
+    canonical: &'static str,
+    legacy: &'static str,
+}
+
+const SUCCESS_CASES: [SuccessCase; 14] = [
+    SuccessCase {
+        name: "both-absent",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-only",
+        canonical: AliasInput::Readable(CANONICAL_URL),
+        legacy: AliasInput::Absent,
+        expected_value: CANONICAL_URL,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(LEGACY_URL),
+        expected_value: LEGACY_URL,
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual",
+        canonical: AliasInput::Readable(SHARED_URL),
+        legacy: AliasInput::Readable(SHARED_URL),
+        expected_value: SHARED_URL,
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-empty-only",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-non-unicode-only",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Absent,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "legacy-non-unicode-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "both-non-unicode",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-with-unreadable-legacy",
+        canonical: AliasInput::Readable(CANONICAL_URL),
+        legacy: AliasInput::NonUnicode,
+        expected_value: CANONICAL_URL,
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(LEGACY_URL),
+        expected_value: LEGACY_URL,
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "canonical-empty-with-unreadable-legacy",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::NonUnicode,
+        expected_value: "",
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(""),
+        expected_value: "",
+        expected_source: Some("legacy-only"),
+    },
+];
+
+const CONFLICT_CASES: [ConflictCase; 3] = [
+    ConflictCase {
+        name: "different-readable-values",
+        canonical: CANONICAL_URL,
+        legacy: LEGACY_URL,
+    },
+    ConflictCase {
+        name: "canonical-empty-legacy-non-empty",
+        canonical: "",
+        legacy: LEGACY_URL,
+    },
+    ConflictCase {
+        name: "canonical-non-empty-legacy-empty",
+        canonical: CANONICAL_URL,
+        legacy: "",
+    },
+];
+
+fn set_test_env(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env(key: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+fn apply_alias(key: &str, input: AliasInput) {
+    remove_test_env(key);
+    match input {
+        AliasInput::Absent => {}
+        AliasInput::Readable(value) => set_test_env(key, value),
+        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+    }
+}
+
+fn clear_api_url_env() {
+    remove_test_env(guest_contracts::env::CANONICAL_API_URL_ENV);
+    remove_test_env(guest_contracts::env::API_URL_ENV);
+}
+
+fn clear_api_token_env() {
+    remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
+    remove_test_env(guest_contracts::env::API_TOKEN_ENV);
+}
+
+fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
+    guest_common::log::set_system_log_file(log_path);
+    let raw = GuestConfigRaw::from_process_env();
+    guest_common::log::clear_system_log_file();
+    let log = match std::fs::read_to_string(log_path) {
+        Ok(log) => log,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    Ok((raw, log))
+}
+
+fn assert_value_free(text: &str, context: &str) {
+    for marker in VALUE_MARKERS {
+        assert!(
+            !text.contains(marker),
+            "{context} exposed API URL or token value material"
+        );
+    }
+}
+
+fn assert_source_evidence(log: &str, case: SuccessCase) {
+    assert_value_free(log, case.name);
+    let source_messages = log
+        .lines()
+        .filter(|line| line.contains(SOURCE_EVENT))
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .collect::<Vec<_>>();
+
+    match case.expected_source {
+        Some(source) => {
+            let expected = format!(
+                "{SOURCE_EVENT} key={} source={source}",
+                guest_contracts::env::CANONICAL_API_URL_ENV
+            );
+            assert_eq!(
+                source_messages,
+                [expected.as_str()],
+                "{} emitted incorrect fixed source evidence",
+                case.name
+            );
+        }
+        None => assert!(
+            source_messages.is_empty(),
+            "{} emitted source evidence for unreadable aliases",
+            case.name
+        ),
+    }
+}
+
+fn materialize_config(
+    tmp: &Path,
+    scenario: &str,
+    raw: GuestConfigRaw,
+) -> Result<GuestConfig, String> {
+    let runtime_dir = tmp.join(format!("{scenario}-runtime"));
+    let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&payload_dir)
+        .map_err(|error| format!("create payload directory: {error}"))?;
+    let payload = serde_json::to_vec(&guest_contracts::env::RunPayload::default())
+        .map_err(|error| format!("serialize run payload: {error}"))?;
+    std::fs::write(&payload_path, payload)
+        .map_err(|error| format!("write run payload: {error}"))?;
+
+    GuestConfig::from_raw(GuestConfigRaw {
+        run_id: format!("api-url-alias-{scenario}"),
+        home: Some(tmp.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir),
+        run_payload_file: payload_path.to_string_lossy().into_owned(),
+        ..raw
+    })
+}
+
+fn assert_http_semantics(tmp: &Path, case: SuccessCase, raw: GuestConfigRaw) -> TestResult {
+    let mut without_token = raw.clone();
+    without_token.api_token.clear();
+    let disabled_config =
+        materialize_config(tmp, &format!("{}-http-disabled", case.name), without_token)
+            .map_err(std::io::Error::other)?;
+    let disabled = HttpClient::for_config(&disabled_config)?;
+    assert!(
+        !disabled.has_api(),
+        "{} enabled API HTTP without a token",
+        case.name
+    );
+
+    let mut with_token = raw;
+    with_token.api_token = API_TOKEN.to_string();
+    let enabled_config =
+        materialize_config(tmp, &format!("{}-http-enabled", case.name), with_token)
+            .map_err(std::io::Error::other)?;
+    if case.expected_value.is_empty() {
+        let error = match HttpClient::for_config(&enabled_config) {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} enabled API HTTP without a URL",
+                    case.name
+                ))
+                .into());
+            }
+            Err(error) => error.to_string(),
+        };
+        assert_value_free(&error, case.name);
+        assert!(
+            error.contains(guest_contracts::env::API_URL_ENV),
+            "{} changed the missing API URL diagnostic: {error}",
+            case.name
+        );
+    } else {
+        let enabled = HttpClient::for_config(&enabled_config)?;
+        assert!(enabled.has_api(), "{} disabled valid API HTTP", case.name);
+    }
+    Ok(())
+}
+
+fn expected_conflict_error() -> String {
+    format!(
+        "conflicting API backend URL environment aliases: canonical_key={} \
+         legacy_key={} state=conflict",
+        guest_contracts::env::CANONICAL_API_URL_ENV,
+        guest_contracts::env::API_URL_ENV
+    )
+}
+
+fn assert_conflict_precedes_private_payload_consumption(tmp: &Path) -> TestResult {
+    let runtime_dir = tmp.join("conflict-private-payload-runtime");
+    let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
+    let user_env_path = user_env_dir.join(guest_contracts::env::USER_ENV_FILENAME);
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::create_dir_all(&run_payload_dir)?;
+    std::fs::write(
+        &user_env_path,
+        serde_json::to_vec(&std::collections::HashMap::from([(
+            "CUSTOM_USER_ENV",
+            "private-user-value",
+        )]))?,
+    )?;
+    std::fs::write(
+        &run_payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+    )?;
+
+    for key in [
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+        guest_contracts::env::USER_ENV_FILE_ENV,
+        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+    ] {
+        remove_test_env(key);
+    }
+    set_test_env(
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        &runtime_dir,
+    );
+    set_test_env(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);
+    set_test_env(
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+        &run_payload_path,
+    );
+    set_test_env(guest_contracts::env::RUN_ID_ENV, "api-url-conflict");
+    set_test_env("HOME", tmp);
+    set_test_env(guest_contracts::env::CANONICAL_API_URL_ENV, CANONICAL_URL);
+    set_test_env(guest_contracts::env::API_URL_ENV, LEGACY_URL);
+
+    let log_path = tmp.join("conflict-before-private-payload.log");
+    guest_common::log::set_system_log_file(&log_path);
+    let error = match GuestConfig::from_process_env() {
+        Ok(_) => return Err("API URL conflict consumed private payloads".into()),
+        Err(error) => error,
+    };
+    guest_common::log::clear_system_log_file();
+    let log = std::fs::read_to_string(log_path).unwrap_or_default();
+
+    assert_eq!(error, expected_conflict_error());
+    assert_value_free(&error, "private-payload-conflict-error");
+    assert_value_free(&log, "private-payload-conflict-log");
+    assert!(!log.contains(SOURCE_EVENT));
+    assert!(user_env_path.exists(), "conflict consumed private user env");
+    assert!(
+        run_payload_path.exists(),
+        "conflict consumed private run payload"
+    );
+    Ok(())
+}
+
+#[test]
+fn process_env_dual_reads_api_url_aliases_without_value_leaks() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    clear_api_token_env();
+
+    for case in SUCCESS_CASES {
+        apply_alias(guest_contracts::env::CANONICAL_API_URL_ENV, case.canonical);
+        apply_alias(guest_contracts::env::API_URL_ENV, case.legacy);
+        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+        let raw = match raw {
+            Ok(raw) => raw,
+            Err(error) => {
+                assert_value_free(&error, case.name);
+                return Err(std::io::Error::other(format!(
+                    "{} unexpectedly rejected a readable state",
+                    case.name
+                ))
+                .into());
+            }
+        };
+        assert_eq!(
+            raw.api_url, case.expected_value,
+            "{} resolved the wrong API URL state",
+            case.name
+        );
+        assert_source_evidence(&log, case);
+        assert_http_semantics(tmp.path(), case, raw)?;
+    }
+
+    let expected_error = expected_conflict_error();
+    for case in CONFLICT_CASES {
+        set_test_env(guest_contracts::env::CANONICAL_API_URL_ENV, case.canonical);
+        set_test_env(guest_contracts::env::API_URL_ENV, case.legacy);
+        let (raw, log) = capture_raw(&tmp.path().join(format!("{}.log", case.name)))?;
+        let error = match raw {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} accepted conflicting readable aliases",
+                    case.name
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+        assert_eq!(error, expected_error);
+        assert_value_free(&error, case.name);
+        assert_value_free(&log, case.name);
+        assert!(
+            !log.contains(SOURCE_EVENT),
+            "{} emitted success evidence for a conflict",
+            case.name
+        );
+    }
+
+    assert_conflict_precedes_private_payload_consumption(tmp.path())?;
+    clear_api_url_env();
+    clear_api_token_env();
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -25,6 +25,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+        std::env::remove_var(guest_contracts::env::API_URL_ENV);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV, "300");
         for (canonical, legacy) in [
             (
@@ -112,6 +117,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         Some(std::time::Duration::from_secs(60))
     );
     assert_eq!(runtime.config.stuck_tool_timeout_secs, 300);
+    assert_eq!(runtime.config.api_url, "http://127.0.0.1:1");
     assert_eq!(
         runtime.config.post_result_sigterm_grace,
         std::time::Duration::from_secs(3)
@@ -141,6 +147,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     unsafe {
         std::env::set_var("VM0_PROMPT", "stale prompt after runtime construction");
         std::env::set_var("VM0_API_BACKEND_URL", "https://stale-api.example.invalid");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "https://stale-canonical-api.example.invalid",
+        );
         std::env::set_var("HOME", tmp.path().join("stale-home"));
         for key in [
             guest_contracts::env::USER_ENV_FILE_ENV,
@@ -185,6 +195,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         cli_env.get("VM0_API_BACKEND_URL").map(String::as_str),
         Some("http://127.0.0.1:1")
     );
+    assert!(
+        !cli_env.contains_key(guest_contracts::env::CANONICAL_API_URL_ENV),
+        "Claude child env contains the reader-only canonical API URL alias"
+    );
     assert_eq!(
         cli_env.get("HOME").map(String::as_str),
         Some(user_home_str.as_str())
@@ -218,6 +232,16 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(cli_env.contains_key("PATH"));
 
     assert!(!cli_env.contains_key("VM0_SECRET_VALUES"));
+    for key in [
+        guest_contracts::env::API_TOKEN_ENV,
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+        guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
+    ] {
+        assert!(
+            !cli_env.contains_key(key),
+            "Claude child env contains sensitive bootstrap key {key}"
+        );
+    }
     for key in [
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
@@ -302,6 +326,11 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             .exists()
     );
 
+    unsafe {
+        // The remaining cases construct fresh runtimes; leave them with the
+        // legacy-only setup supplied by `common::setup_env`.
+        std::env::remove_var(guest_contracts::env::CANONICAL_API_URL_ENV);
+    }
     assert_home_value_reaches_claude(
         &mock,
         &tmp.path().join("relative-home-case"),

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -21,6 +21,17 @@
 /// processes by the guest-agent's curated child environment.
 pub const API_URL_ENV: &str = "VM0_API_BACKEND_URL";
 
+/// Canonical backend API URL alias accepted by guest readers during migration.
+///
+/// This fallback is confined to the Runner-to-Guest-Agent bootstrap surface.
+/// Runner writers keep using [`API_URL_ENV`], and the guest-agent keeps exposing
+/// that legacy spelling to managed CLI children. Remove the legacy reader only
+/// after the exact production Runner plus embedded-Guest reader floor, complete
+/// pre-reader service and reusable-sandbox drain, supported rollback window,
+/// and value-free legacy-source-zero gates in #28914. The managed CLI-child
+/// spelling has its own later reader/support floor.
+pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
+
 /// Stable run identifier used by guest-agent logs, telemetry, and runtime
 /// file path resolution.
 pub const RUN_ID_ENV: &str = "OKOU_RUN_ID";
@@ -557,6 +568,7 @@ mod tests {
     #[test]
     fn contract_names_match_wire_values() {
         assert_eq!(API_URL_ENV, "VM0_API_BACKEND_URL");
+        assert_eq!(CANONICAL_API_URL_ENV, "OKOU_API_BACKEND_URL");
         assert_eq!(RUN_ID_ENV, "OKOU_RUN_ID");
         assert_eq!(API_TOKEN_ENV, "VM0_API_TOKEN");
         assert_eq!(CANONICAL_API_TOKEN_ENV, "OKOU_API_TOKEN");
@@ -791,6 +803,7 @@ mod tests {
     fn runner_owned_key_detection_covers_bootstrap_namespaces() {
         for key in [
             API_URL_ENV,
+            CANONICAL_API_URL_ENV,
             RUN_ID_ENV,
             API_TOKEN_ENV,
             CANONICAL_API_TOKEN_ENV,
@@ -860,7 +873,12 @@ mod tests {
                 "canonical reader alias {key} must not become a local tuning input"
             );
         }
-        assert!(!is_guest_agent_tuning_env_key(API_URL_ENV));
+        for key in [API_URL_ENV, CANONICAL_API_URL_ENV] {
+            assert!(
+                !is_guest_agent_tuning_env_key(key),
+                "API URL bootstrap key {key} must not become a local tuning input"
+            );
+        }
     }
 
     /// Contract sources scanned for declared environment key constants.

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -489,6 +489,22 @@ fn build_env_json_required_keys() {
 }
 
 #[test]
+fn build_env_json_keeps_api_url_writer_legacy_only() {
+    let ctx = minimal_context();
+    let env = build_env_for_test(&ctx, "https://api.example.com");
+
+    assert_eq!(
+        env.get(guest_contracts::env::API_URL_ENV)
+            .map(String::as_str),
+        Some("https://api.example.com")
+    );
+    assert!(
+        !env.contains_key(guest_contracts::env::CANONICAL_API_URL_ENV),
+        "Runner bootstrap writer emitted the reader-only canonical API URL alias"
+    );
+}
+
+#[test]
 fn build_env_json_sandbox_reuse_result_wire_format() {
     let ctx = minimal_context();
     let sid = SandboxId::new_v4().to_string();


### PR DESCRIPTION
## Summary

- add the reader-only `OKOU_API_BACKEND_URL` contract and resolve it with `VM0_API_BACKEND_URL` exactly once at Guest Agent process bootstrap
- accept absent/unreadable, canonical-only, legacy-only, and equal-dual states while failing unequal readable aliases before private payload consumption with fixed value-free diagnostics
- emit one value-free source event per readable bootstrap and preserve Runner writer plus managed CLI-child exposure as legacy-only
- cover the process-isolated alias matrix, private-file ordering, HTTP enabled/disabled semantics, Runner writer containment, runner-owned classification, and CLI-child containment

## Scope

- the sole production Runner writer in `crates/runner/src/executor/env.rs` is unchanged and continues to emit only `VM0_API_BACKEND_URL`
- the curated managed CLI child still receives only `VM0_API_BACKEND_URL`; canonical URL and sensitive bootstrap keys remain absent
- Runner operator aliases, API process/deployment configuration, Turbo CLI overrides, `VM0_WEB_URL`, CI/E2E/devcontainer/browser transport, allowlists, and release workflows are unchanged
- a fresh fully paginated scan at `2026-08-25T14:15:13Z` covered 19 open PRs and all 325 changed files. Since the issue-time 20/378 snapshot, #29361 and #29343 merged and #29366 opened. Only stale #25722 overlaps two changed paths and the adjacent audited Runner writer path; its exact hunks remain limited to unrelated Cloudflare Access constants, host injection, and tests.

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features`
- `cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts` (116 unit tests plus integration and doc tests passed)
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test api_url_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test http_env_missing_api_url`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_runtime_missing_api_url`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test no_api_mode`
- Runner writer regression local status: **not executed**. `cargo test --manifest-path crates/Cargo.toml -p runner build_env_json_keeps_api_url_writer_legacy_only` reached the Runner test-binary link and exited 137 under a `3,997,175,808`-byte cgroup memory limit; the recorded peak was approximately 4.0 GB and `oom_kill` increased. A required `CARGO_BUILD_JOBS=1` retry reached the same link-stage OOM. Protected PR CI is authoritative for executing this regression.

## Fallbacks

- `crates/guest-agent/src/env.rs:api_url_env_or_empty` — lets a new Guest Agent accept the current legacy Runner bootstrap or the future canonical bootstrap while rejecting conflicting readable values. Surface: existing Runner / reusable sandbox. Gate: establish the exact production Runner plus embedded-Guest reader floor, completely drain pre-reader services and reusable sandboxes (including the two-hour guest runtime budget plus bounded finalization), retain supported rollback, and observe value-free legacy-only source counts through that rollback window. Remove the legacy reader branch, migration contract, and fallback tests together after legacy-only reads remain zero; follow-up #28914. The Runner writer remains legacy-only in this PR, and the managed CLI-child spelling has a separate later CLI reader/support floor.

Closes #29363
