### PR TITLE
feat: materialize provider tool activity

### DIFF
--- a/crates/guest-agent/tests/claude_provider_event_normalization.rs
+++ b/crates/guest-agent/tests/claude_provider_event_normalization.rs
@@ -37,7 +37,11 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
                         "type": "tool_use",
                         "id": "tool-use-a",
                         "name": "Bash",
-                        "input": { "command": format!("printf {SECRET}") }
+                        "input": {
+                            "command": format!(
+                                "exec '/usr/local/bin/guest-tool-exec' --shell \"$0\" -c 'printf {SECRET}'"
+                            )
+                        }
                     },
                     {
                         "type": "tool_use",
@@ -185,6 +189,12 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
             .pointer("/message/content/0/id")
             .and_then(Value::as_str),
         Some("tool-use-a")
+    );
+    assert_eq!(
+        delivered[2]
+            .pointer("/message/content/0/input/command")
+            .and_then(Value::as_str),
+        Some("exec '/usr/local/bin/guest-tool-exec' --shell \"$0\" -c 'printf ***'")
     );
     assert_eq!(
         delivered[3]

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -389,6 +389,11 @@ export default [
     // exceptions. Route tests cover constructible behavior, while these exact
     // transition inputs are not available through production APIs.
     files: [
+      // Provider wrapper decoding, surrogate-safe bounds, and opaque UUIDv5
+      // identities are exact pure contracts required by #29367. Route tests
+      // cover their persisted behavior, while this corpus pins the parser and
+      // namespace values independently from database state.
+      "src/signals/services/__tests__/agent-tool-event-normalization.test.ts",
       // Content hashes are a byte-identical cryptographic contract shared with
       // guest-agent; route behavior cannot pin the serializer's full corpus.
       "src/signals/services/__tests__/storage-content-hash.service.test.ts",
@@ -523,6 +528,11 @@ export default [
       // Central test lifecycle owns connection-pool teardown; it does not
       // construct or assert API behavior.
       "src/__tests__/test-context.ts",
+      // Provider wrapper decoding, surrogate-safe bounds, and opaque UUIDv5
+      // identities are exact pure contracts required by #29367. Route tests
+      // cover their persisted behavior, while this corpus pins the parser and
+      // namespace values independently from database state.
+      "src/signals/services/__tests__/agent-tool-event-normalization.test.ts",
       // A finite event-type matrix locks persisted payload rendering and
       // policy lookup byte-for-byte; individual provider routes cannot cover
       // every lookup-table row without duplicating the contract under test.

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
@@ -1,0 +1,889 @@
+import { randomUUID } from "node:crypto";
+
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { v5 as uuidv5 } from "uuid";
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+
+const context = testContext();
+const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
+
+function assistantEventIdForRunEvent(
+  runId: string,
+  runEventId: string,
+): string {
+  return uuidv5(`${runId}:${runEventId}`, ASSISTANT_EVENT_ID_NAMESPACE);
+}
+
+function quoteShellArgumentForFixture(value: string): string {
+  return `'${value.replaceAll("'", String.raw`'\''`)}'`;
+}
+
+function quoteDoubleShellArgumentForFixture(value: string): string {
+  const escape = String.fromCodePoint(92);
+  let quoted = '"';
+  for (const character of value) {
+    if (
+      character === escape ||
+      character === '"' ||
+      character === "$" ||
+      character === "`"
+    ) {
+      quoted += escape;
+    }
+    quoted += character;
+  }
+  return `${quoted}"`;
+}
+
+function managedCommand(command: string): string {
+  return `exec '/usr/local/bin/guest-tool-exec' --shell "$0" -c ${quoteShellArgumentForFixture(command)}`;
+}
+
+async function entitledToolRunActor(): Promise<{
+  readonly actor: ApiTestUser;
+  readonly agentId: string;
+  readonly runnerGroup: string;
+  readonly api: ReturnType<typeof createRunsApi>;
+}> {
+  const bdd = createBddApi(context);
+  const api = createRunsApi(context);
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  const runnerGroup = api.configureRunnerGroup();
+  await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: `Tool materialization ${randomUUID().slice(0, 8)}`,
+    description: "Exercises append-only provider tool materialization.",
+    visibility: "private",
+  });
+  return { actor, agentId: agent.agentId, runnerGroup, api };
+}
+
+async function sendChatRunMessage(
+  actor: ApiTestUser,
+  agentId: string,
+  prompt: string,
+): Promise<{ readonly runId: string; readonly threadId: string }> {
+  const chat = createChatFilesBddApi(context);
+  const sent = await chat.requestSendEvent(actor, { agentId, prompt }, [201]);
+  if (sent.status !== 201 || sent.body.runId === null) {
+    throw new Error("Expected chat send to create a Run");
+  }
+  return { runId: sent.body.runId, threadId: sent.body.threadId };
+}
+
+async function claimRun(
+  api: ReturnType<typeof createRunsApi>,
+  runId: string,
+  runnerGroup: string,
+) {
+  await api.heartbeatRunner(runnerGroup);
+  return await api.claimRunnerJob(runId);
+}
+
+describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
+  it("uses the immutable false Run gate while preserving transcript identities", async () => {
+    const chat = createChatFilesBddApi(context);
+    const connectors = createConnectorBddApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup, api } = await entitledToolRunActor();
+
+    const { runId, threadId } = await sendChatRunMessage(
+      actor,
+      agentId,
+      "disabled tool activity",
+    );
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ChatToolActivity]: true,
+    });
+    const claim = await claimRun(api, runId, runnerGroup);
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 0,
+            message: {
+              id: "claude-message-gate",
+              content: [{ type: "text", text: "Gate-safe message" }],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "disabled-claude-tool",
+                  name: "Bash",
+                  input: { command: managedCommand("echo disabled") },
+                },
+              ],
+            },
+          },
+          {
+            type: "item.completed",
+            sequenceNumber: 2,
+            item: {
+              id: "disabled-codex-thinking",
+              type: "reasoning",
+              text: "Gate-safe thinking",
+            },
+          },
+          {
+            type: "item.completed",
+            sequenceNumber: 3,
+            item: {
+              id: "disabled-codex-tool",
+              type: "command_execution",
+              status: "completed",
+              command: "pwd",
+              exit_code: 0,
+            },
+          },
+        ],
+      },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    const events = (await chat.listThreadEvents(actor, threadId)).events.filter(
+      (event) => {
+        return event.runId === runId;
+      },
+    );
+    expect(
+      events.filter((event) => {
+        return event.eventType === "output.tool";
+      }),
+    ).toHaveLength(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        id: assistantEventIdForRunEvent(runId, "event:0"),
+        eventType: "output.message",
+        content: "Gate-safe message",
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        id: assistantEventIdForRunEvent(runId, "disabled-codex-thinking"),
+        eventType: "output.thinking",
+        thinking: "Gate-safe thinking",
+      }),
+    );
+
+    await api.requestCancelRun(actor, runId, [200]);
+  });
+
+  it("folds Claude starts and results across batches using the immutable true gate", async () => {
+    const chat = createChatFilesBddApi(context);
+    const connectors = createConnectorBddApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup, api } = await entitledToolRunActor();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ChatToolActivity]: true,
+    });
+    const { runId, threadId } = await sendChatRunMessage(
+      actor,
+      agentId,
+      "enabled Claude tool activity",
+    );
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ChatToolActivity]: false,
+    });
+    const claim = await claimRun(api, runId, runnerGroup);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+    const maskedCommand = managedCommand("printf '%s' '***'");
+    const orderedBatch = [
+      {
+        type: "assistant",
+        sequenceNumber: 2,
+        message: { content: [{ type: "text", text: "text B" }] },
+      },
+      {
+        type: "assistant",
+        sequenceNumber: 0,
+        message: { content: [{ type: "text", text: "text A" }] },
+      },
+      {
+        type: "assistant",
+        sequenceNumber: 1,
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "claude-bash-provider-id",
+              name: "Bash",
+              input: {
+                command: maskedCommand,
+                description: "CLAUDE_CALL_INPUT_SECRET",
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    context.mocks.ably.publish.mockClear();
+    await webhooks.requestAgentEvents(
+      { runId, events: orderedBatch },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+
+    await webhooks.requestAgentEvents(
+      { runId, events: orderedBatch },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "user",
+            sequenceNumber: 3,
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "claude-bash-provider-id",
+                  is_error: false,
+                  content: "CLAUDE_RESULT_SECRET",
+                  error: "CLAUDE_RAW_ERROR",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(2);
+
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 4,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "claude-read-provider-id",
+                  name: "Read",
+                  input: { file_path: "/workspace/***/read.ts" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(3);
+
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "user",
+            sequenceNumber: 5,
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "claude-read-provider-id",
+                  is_error: true,
+                  content: "CLAUDE_READ_RESULT_SECRET",
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 6,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "claude-write-provider-id",
+                  name: "Write",
+                  input: { file_path: "/workspace/write.ts" },
+                },
+              ],
+            },
+          },
+          {
+            type: "user",
+            sequenceNumber: 7,
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "claude-write-provider-id",
+                  content: "CLAUDE_WRITE_CONTENT_SECRET",
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 8,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "claude-edit-provider-id",
+                  name: "Edit",
+                  input: { file_path: "/workspace/edit.ts" },
+                },
+              ],
+            },
+          },
+          {
+            type: "user",
+            sequenceNumber: 9,
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "claude-edit-provider-id",
+                  content: "CLAUDE_EDIT_DIFF_SECRET",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(4);
+
+    await webhooks.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 10,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "unsupported-search",
+                  name: "Search",
+                  input: { query: "unsupported" },
+                },
+              ],
+            },
+          },
+          {
+            type: "user",
+            sequenceNumber: 11,
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "orphan-provider-id",
+                  content: "ORPHAN_RESULT_SECRET",
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 12,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "malformed-command",
+                  name: "Bash",
+                  input: { command: "/bin/bash -lc 'unterminated" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(4);
+
+    const redactedRows = await chat.listThreadEventRows(actor, threadId);
+    expect(
+      redactedRows.filter((row) => {
+        return row.eventType === "output.tool";
+      }),
+    ).toHaveLength(0);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ChatToolActivity]: true,
+    });
+    const rows = await chat.listThreadEventRows(actor, threadId);
+    const toolRows = rows.filter((row) => {
+      return row.eventType === "output.tool";
+    });
+    expect(toolRows).toHaveLength(8);
+    expect(
+      toolRows.map((row) => {
+        return {
+          sequenceNumber: row.runEventSequenceNumber,
+          action: row.payload.action,
+          status: row.payload.status,
+          summary: row.payload.summary,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        sequenceNumber: 1,
+        action: "run",
+        status: "pending",
+        summary: "Ran printf '%s' '***'",
+      },
+      {
+        sequenceNumber: 3,
+        action: "run",
+        status: "success",
+        summary: "Ran printf '%s' '***'",
+      },
+      {
+        sequenceNumber: 4,
+        action: "read",
+        status: "pending",
+        summary: "Read /workspace/***/read.ts",
+      },
+      {
+        sequenceNumber: 5,
+        action: "read",
+        status: "error",
+        summary: "Read /workspace/***/read.ts",
+      },
+      {
+        sequenceNumber: 6,
+        action: "write",
+        status: "pending",
+        summary: "Wrote /workspace/write.ts",
+      },
+      {
+        sequenceNumber: 7,
+        action: "write",
+        status: "success",
+        summary: "Wrote /workspace/write.ts",
+      },
+      {
+        sequenceNumber: 8,
+        action: "edit",
+        status: "pending",
+        summary: "Edited /workspace/edit.ts",
+      },
+      {
+        sequenceNumber: 9,
+        action: "edit",
+        status: "success",
+        summary: "Edited /workspace/edit.ts",
+      },
+    ]);
+    expect(toolRows[0]?.payload.toolUseId).toBe(toolRows[1]?.payload.toolUseId);
+    expect(toolRows[2]?.payload.toolUseId).toBe(toolRows[3]?.payload.toolUseId);
+    expect(
+      new Set(
+        toolRows.map((row) => {
+          return row.id;
+        }),
+      ).size,
+    ).toBe(8);
+    for (const row of toolRows) {
+      expect(Object.keys(row.payload).sort()).toStrictEqual([
+        "action",
+        "status",
+        "summary",
+        "toolUseId",
+      ]);
+      expect(row.runEventId).toBe(`tool:event:${row.runEventSequenceNumber}`);
+    }
+
+    const projected = (
+      await chat.listThreadEvents(actor, threadId)
+    ).events.filter((event) => {
+      return (
+        event.runId === runId &&
+        (event.eventType === "output.message" ||
+          event.eventType === "output.tool")
+      );
+    });
+    expect(
+      projected.slice(0, 3).map((event) => {
+        return {
+          type: event.eventType,
+          sequenceNumber: event.sequenceNumber,
+        };
+      }),
+    ).toStrictEqual([
+      { type: "output.message", sequenceNumber: 0 },
+      { type: "output.tool", sequenceNumber: 1 },
+      { type: "output.message", sequenceNumber: 2 },
+    ]);
+
+    const projectedToolEvents = projected.filter((event) => {
+      return event.eventType === "output.tool";
+    });
+    expect(projectedToolEvents).toHaveLength(8);
+    const serializedRows = JSON.stringify({ toolRows, projectedToolEvents });
+    for (const forbidden of [
+      "claude-bash-provider-id",
+      "claude-read-provider-id",
+      "claude-write-provider-id",
+      "claude-edit-provider-id",
+      "CLAUDE_CALL_INPUT_SECRET",
+      "CLAUDE_RESULT_SECRET",
+      "CLAUDE_RAW_ERROR",
+      "CLAUDE_READ_RESULT_SECRET",
+      "CLAUDE_WRITE_CONTENT_SECRET",
+      "CLAUDE_EDIT_DIFF_SECRET",
+      "/usr/local/bin/guest-tool-exec",
+    ]) {
+      expect(serializedRows).not.toContain(forbidden);
+    }
+
+    await api.requestCancelRun(actor, runId, [200]);
+  });
+
+  it("materializes Codex command lifecycle and completed-only file snapshots idempotently", async () => {
+    const chat = createChatFilesBddApi(context);
+    const connectors = createConnectorBddApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup, api } = await entitledToolRunActor();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ChatToolActivity]: true,
+    });
+    const { runId, threadId } = await sendChatRunMessage(
+      actor,
+      agentId,
+      "enabled Codex tool activity",
+    );
+    const claim = await claimRun(api, runId, runnerGroup);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+    const wrapped = `/bin/bash -lc ${quoteDoubleShellArgumentForFixture(
+      managedCommand("echo ***"),
+    )}`;
+    const batch = [
+      {
+        type: "item.completed",
+        sequenceNumber: 1,
+        item: {
+          id: "codex-shared-command-provider-id",
+          type: "command_execution",
+          status: "completed",
+          command: "echo TERMINAL_COMMAND_MUST_NOT_REPLACE_START",
+          exit_code: 0,
+          aggregated_output: "CODEX_STDOUT_SECRET",
+        },
+      },
+      {
+        type: "item.started",
+        sequenceNumber: 0,
+        item: {
+          id: "codex-shared-command-provider-id",
+          type: "command_execution",
+          status: "in_progress",
+          command: wrapped,
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 2,
+        item: {
+          id: "codex-failed-command-provider-id",
+          type: "command_execution",
+          status: "completed",
+          command: "false",
+          exit_code: 7,
+          aggregated_output: "CODEX_STDERR_SECRET",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 3,
+        item: {
+          id: "codex-declined-command-provider-id",
+          type: "command_execution",
+          status: "declined",
+          command: "dangerous-command",
+          error: "CODEX_RAW_ERROR_SECRET",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 4,
+        item: {
+          id: "codex-file-read-provider-id",
+          type: "file_read",
+          status: "completed",
+          path: "/workspace/***/read.txt",
+          result: "CODEX_READ_RESULT_SECRET",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 5,
+        item: {
+          id: "codex-file-write-provider-id",
+          type: "file_write",
+          status: "failed",
+          path: "/workspace/write.txt",
+          content: "CODEX_FILE_CONTENT_SECRET",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 6,
+        item: {
+          id: "codex-file-edit-provider-id",
+          type: "file_edit",
+          status: "declined",
+          path: "/workspace/edit.txt",
+          diff: "CODEX_EDIT_DIFF_SECRET",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 7,
+        item: {
+          id: "codex-sibling-change-provider-id",
+          type: "file_change",
+          status: "completed",
+          changes: [
+            {
+              path: "/workspace/added.txt",
+              kind: "add",
+              diff: "CODEX_ADD_DIFF_SECRET",
+            },
+          ],
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 8,
+        item: {
+          id: "codex-sibling-change-provider-id",
+          type: "file_change",
+          status: "completed",
+          changes: [
+            {
+              path: "/workspace/modified.txt",
+              kind: "modify",
+              diff: "CODEX_MODIFY_DIFF_SECRET",
+            },
+          ],
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 9,
+        item: {
+          id: "codex-sibling-change-provider-id",
+          type: "file_change",
+          status: "completed",
+          changes: [{ path: "/workspace/deleted.txt", kind: "delete" }],
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 10,
+        item: {
+          id: "codex-mcp-provider-id",
+          type: "mcp_tool_call",
+          status: "completed",
+          path: "/workspace/ignored.txt",
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 11,
+        item: {
+          id: "codex-malformed-wrapper-provider-id",
+          type: "command_execution",
+          status: "completed",
+          command: "/bin/bash -c 'unterminated",
+          exit_code: 0,
+        },
+      },
+      {
+        type: "item.completed",
+        sequenceNumber: 12,
+        item: {
+          id: "codex-image-provider-id",
+          type: "image_view",
+          status: "completed",
+          path: "/workspace/ignored.png",
+        },
+      },
+    ];
+
+    context.mocks.ably.publish.mockClear();
+    await webhooks.requestAgentEvents({ runId, events: batch }, headers, [200]);
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+
+    context.mocks.ably.publish.mockClear();
+    await webhooks.requestAgentEvents({ runId, events: batch }, headers, [200]);
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+
+    const rows = await chat.listThreadEventRows(actor, threadId);
+    const toolRows = rows.filter((row) => {
+      return row.eventType === "output.tool";
+    });
+    expect(toolRows).toHaveLength(9);
+    expect(
+      toolRows.map((row) => {
+        return {
+          sequenceNumber: row.runEventSequenceNumber,
+          action: row.payload.action,
+          status: row.payload.status,
+          summary: row.payload.summary,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        sequenceNumber: 0,
+        action: "run",
+        status: "pending",
+        summary: "Ran echo ***",
+      },
+      {
+        sequenceNumber: 1,
+        action: "run",
+        status: "success",
+        summary: "Ran echo ***",
+      },
+      {
+        sequenceNumber: 2,
+        action: "run",
+        status: "error",
+        summary: "Ran false",
+      },
+      {
+        sequenceNumber: 3,
+        action: "run",
+        status: "cancelled",
+        summary: "Ran dangerous-command",
+      },
+      {
+        sequenceNumber: 4,
+        action: "read",
+        status: "success",
+        summary: "Read /workspace/***/read.txt",
+      },
+      {
+        sequenceNumber: 5,
+        action: "write",
+        status: "error",
+        summary: "Wrote /workspace/write.txt",
+      },
+      {
+        sequenceNumber: 6,
+        action: "edit",
+        status: "cancelled",
+        summary: "Edited /workspace/edit.txt",
+      },
+      {
+        sequenceNumber: 7,
+        action: "write",
+        status: "success",
+        summary: "Wrote /workspace/added.txt",
+      },
+      {
+        sequenceNumber: 8,
+        action: "edit",
+        status: "success",
+        summary: "Edited /workspace/modified.txt",
+      },
+    ]);
+    expect(toolRows[0]?.payload.toolUseId).toBe(toolRows[1]?.payload.toolUseId);
+    expect(toolRows[0]?.id).not.toBe(toolRows[1]?.id);
+    expect(toolRows[7]?.payload.toolUseId).not.toBe(
+      toolRows[8]?.payload.toolUseId,
+    );
+    expect(
+      new Set(
+        toolRows.map((row) => {
+          return row.id;
+        }),
+      ).size,
+    ).toBe(9);
+    expect(
+      new Set(
+        toolRows.map((row) => {
+          return row.runEventId;
+        }),
+      ).size,
+    ).toBe(9);
+    for (const row of toolRows) {
+      expect(Object.keys(row.payload).sort()).toStrictEqual([
+        "action",
+        "status",
+        "summary",
+        "toolUseId",
+      ]);
+    }
+
+    const projectedToolEvents = (
+      await chat.listThreadEvents(actor, threadId)
+    ).events.filter((event) => {
+      return event.runId === runId && event.eventType === "output.tool";
+    });
+    expect(projectedToolEvents).toHaveLength(9);
+    const serializedRows = JSON.stringify({ toolRows, projectedToolEvents });
+    for (const forbidden of [
+      "codex-shared-command-provider-id",
+      "codex-sibling-change-provider-id",
+      "TERMINAL_COMMAND_MUST_NOT_REPLACE_START",
+      "CODEX_STDOUT_SECRET",
+      "CODEX_STDERR_SECRET",
+      "CODEX_RAW_ERROR_SECRET",
+      "CODEX_READ_RESULT_SECRET",
+      "CODEX_FILE_CONTENT_SECRET",
+      "CODEX_EDIT_DIFF_SECRET",
+      "CODEX_ADD_DIFF_SECRET",
+      "CODEX_MODIFY_DIFF_SECRET",
+      "/usr/local/bin/guest-tool-exec",
+    ]) {
+      expect(serializedRows).not.toContain(forbidden);
+    }
+
+    await api.requestCancelRun(actor, runId, [200]);
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentEvent } from "../../../lib/event-consumer/verify";
+import { normalizeAgentToolEvent } from "../agent-tool-event-normalization";
+import {
+  assistantEventIdForRunEvent,
+  toolEventIdForRunEvent,
+  toolUseIdForProviderOperation,
+  toolUseIdForRunEvent,
+} from "../assistant-event-id";
+
+const RUN_ID = "8de6b4bf-d92a-4599-bde7-614e72552365";
+
+function agentEvent(
+  sequenceNumber: number,
+  event: { readonly type: string; readonly [key: string]: unknown },
+): AgentEvent {
+  return { ...event, sequenceNumber };
+}
+
+function quoteShellArgumentForFixture(value: string): string {
+  return `'${value.replaceAll("'", String.raw`'\''`)}'`;
+}
+
+function quoteDoubleShellArgumentForFixture(value: string): string {
+  const escape = String.fromCodePoint(92);
+  let quoted = '"';
+  for (const character of value) {
+    if (
+      character === escape ||
+      character === '"' ||
+      character === "$" ||
+      character === "`"
+    ) {
+      quoted += escape;
+    }
+    quoted += character;
+  }
+  return `${quoted}"`;
+}
+
+function claudeToolUse(args: {
+  readonly id?: string;
+  readonly name: string;
+  readonly input: Record<string, unknown>;
+}): AgentEvent {
+  return agentEvent(1, {
+    type: "assistant",
+    message: {
+      content: [
+        {
+          type: "tool_use",
+          id: args.id ?? "claude-operation-1",
+          name: args.name,
+          input: args.input,
+        },
+      ],
+    },
+  });
+}
+
+function codexItem(
+  eventType: "item.started" | "item.completed",
+  item: Record<string, unknown>,
+): AgentEvent {
+  return agentEvent(1, { type: eventType, item });
+}
+
+describe("agent tool event normalization", () => {
+  it("maps the exact Claude Code V1 actions and result status", () => {
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "bAsH",
+          input: { command: "  printf\t'***'\n  " },
+        }),
+      ),
+    ).toStrictEqual({
+      kind: "correlated",
+      provider: "claude",
+      providerOperationId: "claude-operation-1",
+      action: "run",
+      status: "pending",
+      summary: "Ran printf '***'",
+    });
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "Read",
+          input: { file_path: " /workspace/a.ts " },
+        }),
+      ),
+    ).toMatchObject({ action: "read", summary: "Read /workspace/a.ts" });
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "Write",
+          input: { file_path: "/workspace/b.ts" },
+        }),
+      ),
+    ).toMatchObject({ action: "write", summary: "Wrote /workspace/b.ts" });
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "Edit",
+          input: { file_path: "/workspace/c.ts" },
+        }),
+      ),
+    ).toMatchObject({ action: "edit", summary: "Edited /workspace/c.ts" });
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "NotebookEdit",
+          input: {
+            notebook_path: "  ",
+            file_path: "/workspace/notebook.ipynb",
+          },
+        }),
+      ),
+    ).toMatchObject({
+      action: "edit",
+      summary: "Edited /workspace/notebook.ipynb",
+    });
+
+    expect(
+      normalizeAgentToolEvent(
+        agentEvent(2, {
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "claude-operation-1",
+                is_error: true,
+                content: "raw error must not be projected",
+              },
+            ],
+          },
+        }),
+      ),
+    ).toStrictEqual({
+      kind: "correlated-terminal",
+      provider: "claude",
+      providerOperationId: "claude-operation-1",
+      status: "error",
+    });
+    expect(
+      normalizeAgentToolEvent(
+        agentEvent(3, {
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "claude-operation-1",
+                is_error: false,
+              },
+            ],
+          },
+        }),
+      ),
+    ).toMatchObject({ status: "success" });
+  });
+
+  it("round-trips the exact managed and outer Codex command wrappers", () => {
+    const command = `printf '%s\\n' "$HOME"`;
+    const managed = `exec '/usr/local/bin/guest-tool-exec' --shell "$0" -c ${quoteShellArgumentForFixture(command)}`;
+    expect(managed).toBe(
+      `exec '/usr/local/bin/guest-tool-exec' --shell "$0" -c 'printf '\\''%s\\n'\\'' "$HOME"'`,
+    );
+
+    for (const option of ["-c", "-lc"] as const) {
+      for (const outerArgument of [
+        quoteDoubleShellArgumentForFixture(managed),
+        quoteShellArgumentForFixture(managed),
+      ]) {
+        expect(
+          normalizeAgentToolEvent(
+            codexItem("item.started", {
+              id: `codex-${option}`,
+              type: "command_execution",
+              status: "in_progress",
+              command: `/bin/bash ${option} ${outerArgument}`,
+            }),
+          ),
+        ).toMatchObject({
+          action: "run",
+          status: "pending",
+          summary: `Ran printf '%s\\n' "$HOME"`,
+        });
+      }
+    }
+  });
+
+  it("bounds summaries without splitting surrogate pairs", () => {
+    const normalized = normalizeAgentToolEvent(
+      claudeToolUse({
+        name: "Read",
+        input: { file_path: `${"a".repeat(233)}😀tail` },
+      }),
+    );
+    expect(normalized).toMatchObject({
+      summary: `Read ${"a".repeat(233)}…`,
+    });
+    if (normalized?.kind !== "correlated") {
+      throw new Error("Expected a correlated Claude tool event");
+    }
+    expect(normalized.summary.length).toBeLessThanOrEqual(240);
+    expect(normalized.summary.match(/…/gu)).toHaveLength(1);
+  });
+
+  it("omits malformed, unsafe, multi-block, and unsupported Claude operations", () => {
+    for (const event of [
+      claudeToolUse({ name: "Search", input: { query: "needle" } }),
+      claudeToolUse({ name: "Read", input: { file_path: "   " } }),
+      claudeToolUse({ name: "Read", input: { file_path: "bad\0path" } }),
+      claudeToolUse({ id: " ", name: "Read", input: { file_path: "a" } }),
+      claudeToolUse({
+        name: "Bash",
+        input: { command: "/bin/bash -lc 'unterminated" },
+      }),
+      claudeToolUse({
+        name: "Bash",
+        input: { command: '/bin/bash -lc "echo $HOME"' },
+      }),
+      claudeToolUse({
+        name: "Bash",
+        input: {
+          command:
+            "exec '/usr/local/bin/guest-tool-exec' --wrong \"$0\" -c 'pwd'",
+        },
+      }),
+      agentEvent(2, {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "multi-1",
+              name: "Read",
+              input: { file_path: "a" },
+            },
+            { type: "text", text: "not normalized" },
+          ],
+        },
+      }),
+    ]) {
+      expect(normalizeAgentToolEvent(event)).toBeNull();
+    }
+
+    expect(
+      normalizeAgentToolEvent(
+        claudeToolUse({
+          name: "Bash",
+          input: {
+            command:
+              "printf '%s' \"exec '/usr/local/bin/guest-tool-exec' --shell\"",
+          },
+        }),
+      ),
+    ).toMatchObject({
+      summary:
+        "Ran printf '%s' \"exec '/usr/local/bin/guest-tool-exec' --shell\"",
+    });
+  });
+
+  it("maps Codex command and completed-only file status without generic fallbacks", () => {
+    const completedCommand = {
+      id: "codex-command",
+      type: "command_execution",
+      status: "completed",
+      command: "pwd",
+    };
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", { ...completedCommand, exit_code: 0 }),
+      ),
+    ).toMatchObject({
+      kind: "correlated-terminal",
+      provider: "codex",
+      status: "success",
+      standaloneOperation: { action: "run", summary: "Ran pwd" },
+    });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", { ...completedCommand, exit_code: 9 }),
+      ),
+    ).toMatchObject({ status: "error" });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          ...completedCommand,
+          status: "failed",
+          error: { message: "raw failure" },
+        }),
+      ),
+    ).toMatchObject({ status: "error" });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          ...completedCommand,
+          status: "declined",
+        }),
+      ),
+    ).toMatchObject({ status: "cancelled" });
+
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          id: "read-1",
+          type: "file_read",
+          status: "completed",
+          path: "/workspace/read.ts",
+        }),
+      ),
+    ).toStrictEqual({
+      kind: "standalone",
+      action: "read",
+      status: "success",
+      summary: "Read /workspace/read.ts",
+    });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          id: "write-1",
+          type: "file_write",
+          status: "failed",
+          path: "/workspace/write.ts",
+        }),
+      ),
+    ).toMatchObject({ action: "write", status: "error" });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          id: "edit-1",
+          type: "file_edit",
+          status: "declined",
+          path: "/workspace/edit.ts",
+        }),
+      ),
+    ).toMatchObject({ action: "edit", status: "cancelled" });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          id: "change-1",
+          type: "file_change",
+          status: "completed",
+          changes: [
+            { path: "/workspace/add.ts", kind: "add", diff: "raw diff" },
+          ],
+        }),
+      ),
+    ).toMatchObject({ action: "write", summary: "Wrote /workspace/add.ts" });
+    expect(
+      normalizeAgentToolEvent(
+        codexItem("item.completed", {
+          id: "change-1",
+          type: "file_change",
+          status: "completed",
+          changes: [{ path: "/workspace/modify.ts", kind: "modify" }],
+        }),
+      ),
+    ).toMatchObject({
+      action: "edit",
+      summary: "Edited /workspace/modify.ts",
+    });
+
+    for (const item of [
+      {
+        id: "delete",
+        type: "file_change",
+        status: "completed",
+        changes: [{ path: "a", kind: "delete" }],
+      },
+      {
+        id: "multi",
+        type: "file_change",
+        status: "completed",
+        changes: [
+          { path: "a", kind: "add" },
+          { path: "b", kind: "modify" },
+        ],
+      },
+      { id: "mcp", type: "mcp_tool_call", status: "completed", path: "a" },
+      { id: "image", type: "image_view", status: "completed", path: "a" },
+      { id: "unknown", type: "file_read", status: "in_progress", path: "a" },
+    ]) {
+      expect(
+        normalizeAgentToolEvent(codexItem("item.completed", item)),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("tool event identity", () => {
+  it("keeps transcript, tool row, and operation identities independent", () => {
+    const transcriptId = assistantEventIdForRunEvent(RUN_ID, "event:4");
+    const pendingRowId = toolEventIdForRunEvent(RUN_ID, "tool:event:4");
+    const terminalRowId = toolEventIdForRunEvent(RUN_ID, "tool:event:5");
+    const claudeOperationId = toolUseIdForProviderOperation(
+      RUN_ID,
+      "claude",
+      "provider-operation-secret",
+    );
+    const codexOperationId = toolUseIdForProviderOperation(
+      RUN_ID,
+      "codex",
+      "provider-operation-secret",
+    );
+
+    expect(transcriptId).toBe("ae848beb-761a-548f-8929-874f825c4b37");
+    expect(pendingRowId).toBe("20054cbd-fac3-585a-8641-99a881e3900e");
+    expect(terminalRowId).toBe("49421189-5dd4-5ae0-ac08-a0082d3d6054");
+    expect(claudeOperationId).toBe("08d34bde-5278-578f-abe8-40db282e07e8");
+    expect(codexOperationId).toBe("0e4b47d0-9cbc-5cc3-92f0-a104ff36c7ae");
+    expect(toolUseIdForRunEvent(RUN_ID, "tool:event:4")).toBe(
+      "b3becca3-07cc-5c26-ae7c-d11be4562765",
+    );
+    expect(assistantEventIdForRunEvent(RUN_ID, "event:4")).toBe(transcriptId);
+    expect(toolEventIdForRunEvent(RUN_ID, "tool:event:4")).toBe(pendingRowId);
+    expect(pendingRowId).not.toBe(terminalRowId);
+    expect(pendingRowId).not.toBe(transcriptId);
+    expect(claudeOperationId).not.toBe(codexOperationId);
+    expect(claudeOperationId).not.toContain("provider-operation-secret");
+    expect(toolUseIdForRunEvent(RUN_ID, "tool:event:4")).not.toBe(
+      toolUseIdForRunEvent(RUN_ID, "tool:event:5"),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
@@ -383,6 +383,7 @@ describe("agent tool event normalization", () => {
       },
       { id: "mcp", type: "mcp_tool_call", status: "completed", path: "a" },
       { id: "image", type: "image_view", status: "completed", path: "a" },
+      { id: " ", type: "file_read", status: "completed", path: "a" },
       {
         id: "malformed-command",
         type: "command_execution",

--- a/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
@@ -383,6 +383,13 @@ describe("agent tool event normalization", () => {
       },
       { id: "mcp", type: "mcp_tool_call", status: "completed", path: "a" },
       { id: "image", type: "image_view", status: "completed", path: "a" },
+      {
+        id: "malformed-command",
+        type: "command_execution",
+        status: "completed",
+        command: "/bin/bash -lc 'unterminated",
+        exit_code: 0,
+      },
       { id: "unknown", type: "file_read", status: "in_progress", path: "a" },
     ]) {
       expect(

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -386,7 +386,12 @@ async function insertRunOutputChatEvents(
     .where(eq(agentRuns.id, payload.runId))
     .limit(1);
   signal.throwIfAborted();
-  const toolActivityEnabled = run?.chatToolActivityEnabled === true;
+  if (run === undefined) {
+    throw new Error(
+      `Run ${payload.runId} is missing during output materialization`,
+    );
+  }
+  const toolActivityEnabled = run.chatToolActivityEnabled;
   const priorToolOperations = toolActivityEnabled
     ? await priorToolOperationsForRun(tx, payload.runId, signal)
     : new Map<string, ToolOperationState>();

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -1,6 +1,11 @@
+import {
+  outputToolPayloadSchema,
+  type OutputToolPayload,
+} from "@okouai/api-contracts/contracts/chat-events";
 import { command } from "ccstate";
-import { and, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import { chatEvents } from "@okouai/db/schema/chat-event";
 import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
 
 import type {
@@ -21,6 +26,11 @@ import {
 } from "./chat-first-assistant-event-metric.service";
 import { chatThreadForRunFromDb } from "./chat-thread.service";
 import { writeRunMetadataInTransaction } from "./agent-run-metadata-write.service";
+import { normalizeAgentToolEvent } from "./agent-tool-event-normalization";
+import {
+  toolUseIdForProviderOperation,
+  toolUseIdForRunEvent,
+} from "./assistant-event-id";
 
 const INITIAL_PROCESSED_THROUGH_SEQUENCE = -1;
 const RUN_OUTPUT_PROJECTION_LOCK_TIMEOUT = "1s";
@@ -29,6 +39,8 @@ interface OutputCandidate {
   readonly sequenceNumber: number;
   readonly content: string;
 }
+
+type ToolOperationState = Pick<OutputToolPayload, "action" | "summary">;
 
 export interface MaterializedChatProjection {
   readonly thread: {
@@ -223,10 +235,21 @@ function nextStoredProjectionSequenceState(
   );
 }
 
-function assistantEventItems(
-  events: readonly AgentEvent[],
-): InsertAssistantEventsInput["items"] {
+function toolRunEventId(sequenceNumber: number): string {
+  return `tool:event:${sequenceNumber}`;
+}
+
+function assistantEventItems(args: {
+  readonly events: readonly AgentEvent[];
+  readonly runId: string;
+  readonly toolActivityEnabled: boolean;
+  readonly priorToolOperations: ReadonlyMap<string, ToolOperationState>;
+}): InsertAssistantEventsInput["items"] {
   const items: InsertAssistantEventsInput["items"][number][] = [];
+  const toolOperations = new Map(args.priorToolOperations);
+  const events = [...args.events].sort((left, right) => {
+    return left.sequenceNumber - right.sequenceNumber;
+  });
   for (const event of events) {
     const messageText = assistantMessageText(event);
     if (messageText !== null) {
@@ -240,18 +263,149 @@ function assistantEventItems(
     }
 
     const reasoningText = codexReasoningText(event);
-    if (reasoningText === null) {
+    if (reasoningText !== null) {
+      items.push({
+        eventType: "output.thinking",
+        runEventSequenceNumber: event.sequenceNumber,
+        thinking: reasoningText,
+        runEventId: eventOutputId(event),
+      });
       continue;
     }
 
+    if (!args.toolActivityEnabled) {
+      continue;
+    }
+    const normalized = normalizeAgentToolEvent(event);
+    if (normalized === null) {
+      continue;
+    }
+
+    const runEventId = toolRunEventId(event.sequenceNumber);
+    if (normalized.kind === "standalone") {
+      const toolUseId = toolUseIdForRunEvent(args.runId, runEventId);
+      items.push({
+        eventType: "output.tool",
+        runEventSequenceNumber: event.sequenceNumber,
+        runEventId,
+        toolUseId,
+        action: normalized.action,
+        status: normalized.status,
+        summary: normalized.summary,
+      });
+      toolOperations.set(toolUseId, {
+        action: normalized.action,
+        summary: normalized.summary,
+      });
+      continue;
+    }
+
+    const toolUseId = toolUseIdForProviderOperation(
+      args.runId,
+      normalized.provider,
+      normalized.providerOperationId,
+    );
+    const prior = toolOperations.get(toolUseId);
+    if (normalized.kind === "correlated-terminal") {
+      const operation = prior ?? normalized.standaloneOperation;
+      if (operation === undefined) {
+        continue;
+      }
+      items.push({
+        eventType: "output.tool",
+        runEventSequenceNumber: event.sequenceNumber,
+        runEventId,
+        toolUseId,
+        action: operation.action,
+        status: normalized.status,
+        summary: operation.summary,
+      });
+      toolOperations.set(toolUseId, operation);
+      continue;
+    }
+
+    const operation = {
+      action: normalized.action,
+      summary: normalized.summary,
+    };
     items.push({
-      eventType: "output.thinking",
+      eventType: "output.tool",
       runEventSequenceNumber: event.sequenceNumber,
-      thinking: reasoningText,
-      runEventId: eventOutputId(event),
+      runEventId,
+      toolUseId,
+      action: operation.action,
+      status: normalized.status,
+      summary: operation.summary,
     });
+    toolOperations.set(toolUseId, operation);
   }
   return items;
+}
+
+async function priorToolOperationsForRun(
+  tx: Tx,
+  runId: string,
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, ToolOperationState>> {
+  const rows = await tx
+    .select({ payload: chatEvents.payload })
+    .from(chatEvents)
+    .where(
+      and(eq(chatEvents.runId, runId), eq(chatEvents.eventType, "output.tool")),
+    )
+    .orderBy(asc(chatEvents.seqId));
+  signal.throwIfAborted();
+
+  const operations = new Map<string, ToolOperationState>();
+  for (const row of rows) {
+    const payload = outputToolPayloadSchema.parse(row.payload);
+    operations.set(payload.toolUseId, {
+      action: payload.action,
+      summary: payload.summary,
+    });
+  }
+  return operations;
+}
+
+interface AssistantEventInsertion {
+  readonly insertedRowCount: number;
+  readonly shouldAttemptFirstAssistantEventClaim: boolean;
+}
+
+async function insertRunOutputChatEvents(
+  tx: Tx,
+  payload: EventConsumerPayload,
+  thread: MaterializedChatProjection["thread"],
+  signal: AbortSignal,
+): Promise<AssistantEventInsertion> {
+  const [run] = await tx
+    .select({
+      chatToolActivityEnabled: agentRuns.chatToolActivityEnabled,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, payload.runId))
+    .limit(1);
+  signal.throwIfAborted();
+  const toolActivityEnabled = run?.chatToolActivityEnabled === true;
+  const priorToolOperations = toolActivityEnabled
+    ? await priorToolOperationsForRun(tx, payload.runId, signal)
+    : new Map<string, ToolOperationState>();
+  const assistantItems = assistantEventItems({
+    events: payload.events,
+    runId: payload.runId,
+    toolActivityEnabled,
+    priorToolOperations,
+  });
+  return await insertAssistantEventsInTransaction(
+    tx,
+    {
+      runId: payload.runId,
+      threadId: thread.chatThreadId,
+      userId: thread.userId,
+      items: assistantItems,
+    },
+    signal,
+  );
 }
 
 async function lockRunOutputProjection(
@@ -277,7 +431,6 @@ async function materializeRunOutputEvents(
   payload: EventConsumerPayload,
   signal: AbortSignal,
 ): Promise<MaterializedChatProjection | null> {
-  const assistantItems = assistantEventItems(payload.events);
   const latestResult = latestCandidate(payload.events, resultText);
   const latestOutput = latestCandidate(payload.events, callbackOutputText);
 
@@ -290,14 +443,10 @@ async function materializeRunOutputEvents(
     let insertedRowCount = 0;
     let shouldAttemptFirstAssistantEventClaim = false;
     if (thread) {
-      const insertion = await insertAssistantEventsInTransaction(
+      const insertion = await insertRunOutputChatEvents(
         tx,
-        {
-          runId: payload.runId,
-          threadId: thread.chatThreadId,
-          userId: thread.userId,
-          items: assistantItems,
-        },
+        payload,
+        thread,
         signal,
       );
       insertedRowCount = insertion.insertedRowCount;

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -346,6 +346,9 @@ function codexFile(event: AgentEvent): NormalizedAgentToolEvent | null {
   if (item === null) {
     return null;
   }
+  if (nonBlankProviderId(item.id) === null) {
+    return null;
+  }
   const status = codexTerminalStatus(item);
   if (status === null) {
     return null;

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -326,14 +326,15 @@ function codexCommand(event: AgentEvent): NormalizedAgentToolEvent | null {
     return null;
   }
   const summary = toolSummary("Ran", decodedToolCommand(item.command));
+  if (summary === null) {
+    return null;
+  }
   return {
     kind: "correlated-terminal",
     provider: "codex",
     providerOperationId,
     status,
-    ...(summary === null
-      ? {}
-      : { standaloneOperation: { action: "run", summary } }),
+    standaloneOperation: { action: "run", summary },
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -1,0 +1,410 @@
+import type { OutputToolPayload } from "@okouai/api-contracts/contracts/chat-events";
+
+import type { AgentEvent } from "../../lib/event-consumer/verify";
+
+type ToolAction = OutputToolPayload["action"];
+type ToolTerminalStatus = Exclude<OutputToolPayload["status"], "pending">;
+
+type NormalizedAgentToolEvent =
+  | {
+      readonly kind: "correlated";
+      readonly provider: "claude" | "codex";
+      readonly providerOperationId: string;
+      readonly action: ToolAction;
+      readonly status: "pending";
+      readonly summary: string;
+    }
+  | {
+      readonly kind: "correlated-terminal";
+      readonly provider: "claude" | "codex";
+      readonly providerOperationId: string;
+      readonly status: ToolTerminalStatus;
+      readonly standaloneOperation?: {
+        readonly action: ToolAction;
+        readonly summary: string;
+      };
+    }
+  | {
+      readonly kind: "standalone";
+      readonly action: ToolAction;
+      readonly status: ToolTerminalStatus;
+      readonly summary: string;
+    };
+
+const TOOL_SUMMARY_MAX_LENGTH = 240;
+const TOOL_SUMMARY_ELLIPSIS = "…";
+const MANAGED_TOOL_EXECUTABLE = "exec '/usr/local/bin/guest-tool-exec'";
+const MANAGED_TOOL_PREFIX = `${MANAGED_TOOL_EXECUTABLE} --shell "$0" -c `;
+
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonBlankProviderId(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function truncateToolSummary(summary: string): string {
+  if (summary.length <= TOOL_SUMMARY_MAX_LENGTH) {
+    return summary;
+  }
+
+  let end = TOOL_SUMMARY_MAX_LENGTH - TOOL_SUMMARY_ELLIPSIS.length;
+  const precedingCodeUnit = summary.charCodeAt(end - 1);
+  const followingCodeUnit = summary.charCodeAt(end);
+  if (
+    precedingCodeUnit >= 55_296 &&
+    precedingCodeUnit <= 56_319 &&
+    followingCodeUnit >= 56_320 &&
+    followingCodeUnit <= 57_343
+  ) {
+    end--;
+  }
+  return `${summary.slice(0, end)}${TOOL_SUMMARY_ELLIPSIS}`;
+}
+
+function toolSummary(verb: string, target: unknown): string | null {
+  if (typeof target !== "string" || target.includes("\0")) {
+    return null;
+  }
+  const normalizedTarget = target.trim().replace(/\s+/gu, " ");
+  if (normalizedTarget.length === 0) {
+    return null;
+  }
+  return truncateToolSummary(`${verb} ${normalizedTarget}`);
+}
+
+/** Decode the exact single-quote dialect emitted by shell_quote::quote_shell_arg. */
+function decodeCanonicalSingleQuotedWord(value: string): string | null {
+  if (!value.startsWith("'")) {
+    return null;
+  }
+
+  let decoded = "";
+  let cursor = 1;
+  for (;;) {
+    const closingQuote = value.indexOf("'", cursor);
+    if (closingQuote === -1) {
+      return null;
+    }
+    decoded += value.slice(cursor, closingQuote);
+    if (closingQuote === value.length - 1) {
+      return decoded;
+    }
+    if (value.slice(closingQuote + 1, closingQuote + 4) !== String.raw`\''`) {
+      return null;
+    }
+    decoded += "'";
+    cursor = closingQuote + 4;
+  }
+}
+
+/** Decode one strictly bounded shell word used as the outer bash command argument. */
+function decodeOuterShellWord(value: string): string | null {
+  const singleQuoted = decodeCanonicalSingleQuotedWord(value);
+  if (singleQuoted !== null) {
+    return singleQuoted;
+  }
+
+  if (value.startsWith('"')) {
+    let decoded = "";
+    for (let index = 1; index < value.length; index++) {
+      const character = value[index]!;
+      if (character === '"') {
+        return index === value.length - 1 ? decoded : null;
+      }
+      if (character === "$" || character === "`") {
+        return null;
+      }
+      if (character !== "\\") {
+        decoded += character;
+        continue;
+      }
+      const escaped = value[++index];
+      if (escaped === undefined) {
+        return null;
+      }
+      if (escaped === "\n") {
+        continue;
+      }
+      if (
+        escaped === "\\" ||
+        escaped === '"' ||
+        escaped === "$" ||
+        escaped === "`"
+      ) {
+        decoded += escaped;
+      } else {
+        decoded += `\\${escaped}`;
+      }
+    }
+    return null;
+  }
+
+  return /^[A-Za-z0-9_@%+=:,./-]+$/u.test(value) ? value : null;
+}
+
+function decodedToolCommand(value: unknown): string | null {
+  if (typeof value !== "string" || value.includes("\0")) {
+    return null;
+  }
+  let command = value.trim();
+  if (command.length === 0) {
+    return null;
+  }
+
+  const outer = /^\/bin\/bash -(?:c|lc) ([\s\S]+)$/u.exec(command);
+  if (outer) {
+    const decodedOuter = decodeOuterShellWord(outer[1]!);
+    if (decodedOuter === null) {
+      return null;
+    }
+    command = decodedOuter;
+  } else if (/^\/bin\/bash -(?:c|lc)(?:\s|$)/u.test(command)) {
+    return null;
+  }
+
+  if (command.startsWith(MANAGED_TOOL_PREFIX)) {
+    return decodeCanonicalSingleQuotedWord(
+      command.slice(MANAGED_TOOL_PREFIX.length),
+    );
+  }
+  if (command.startsWith(MANAGED_TOOL_EXECUTABLE)) {
+    return null;
+  }
+  return command;
+}
+
+function claudeContentBlock(event: AgentEvent): Record<string, unknown> | null {
+  const message = recordOf(event.message);
+  const content = message?.content;
+  if (!Array.isArray(content) || content.length !== 1) {
+    return null;
+  }
+  return recordOf(content[0]);
+}
+
+function claudeToolUse(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "assistant") {
+    return null;
+  }
+  const block = claudeContentBlock(event);
+  if (block?.type !== "tool_use") {
+    return null;
+  }
+  const providerOperationId = nonBlankProviderId(block.id);
+  const input = recordOf(block.input);
+  if (providerOperationId === null || input === null) {
+    return null;
+  }
+
+  let action: ToolAction;
+  let summary: string | null;
+  if (typeof block.name === "string" && block.name.toLowerCase() === "bash") {
+    action = "run";
+    summary = toolSummary("Ran", decodedToolCommand(input.command));
+  } else {
+    switch (block.name) {
+      case "Read": {
+        action = "read";
+        summary = toolSummary("Read", input.file_path);
+        break;
+      }
+      case "Write": {
+        action = "write";
+        summary = toolSummary("Wrote", input.file_path);
+        break;
+      }
+      case "Edit": {
+        action = "edit";
+        summary = toolSummary("Edited", input.file_path);
+        break;
+      }
+      case "NotebookEdit": {
+        action = "edit";
+        summary =
+          toolSummary("Edited", input.notebook_path) ??
+          toolSummary("Edited", input.file_path);
+        break;
+      }
+      default: {
+        return null;
+      }
+    }
+  }
+  if (summary === null) {
+    return null;
+  }
+  return {
+    kind: "correlated",
+    provider: "claude",
+    providerOperationId,
+    action,
+    status: "pending",
+    summary,
+  };
+}
+
+function claudeToolResult(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "user") {
+    return null;
+  }
+  const block = claudeContentBlock(event);
+  if (block?.type !== "tool_result") {
+    return null;
+  }
+  const providerOperationId = nonBlankProviderId(block.tool_use_id);
+  if (providerOperationId === null) {
+    return null;
+  }
+  return {
+    kind: "correlated-terminal",
+    provider: "claude",
+    providerOperationId,
+    status: block.is_error === true ? "error" : "success",
+  };
+}
+
+function hasNormalizedErrorSignal(item: Record<string, unknown>): boolean {
+  return ["error", "failure_reason", "failureReason"].some((field) => {
+    return Object.hasOwn(item, field) && item[field] !== null;
+  });
+}
+
+function codexTerminalStatus(
+  item: Record<string, unknown>,
+): ToolTerminalStatus | null {
+  if (item.status === "declined") {
+    return "cancelled";
+  }
+  if (item.status === "failed") {
+    return "error";
+  }
+  if (item.status !== "completed") {
+    return null;
+  }
+  if (Object.hasOwn(item, "exit_code") && typeof item.exit_code !== "number") {
+    return null;
+  }
+  return (typeof item.exit_code === "number" && item.exit_code !== 0) ||
+    hasNormalizedErrorSignal(item)
+    ? "error"
+    : "success";
+}
+
+function codexCommand(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "item.started" && event.type !== "item.completed") {
+    return null;
+  }
+  const item = recordOf(event.item);
+  if (item?.type !== "command_execution") {
+    return null;
+  }
+  const providerOperationId = nonBlankProviderId(item.id);
+  if (providerOperationId === null) {
+    return null;
+  }
+  if (event.type === "item.started") {
+    const summary = toolSummary("Ran", decodedToolCommand(item.command));
+    if (item.status !== "in_progress" || summary === null) {
+      return null;
+    }
+    return {
+      kind: "correlated",
+      provider: "codex",
+      providerOperationId,
+      action: "run",
+      status: "pending",
+      summary,
+    };
+  }
+
+  const status = codexTerminalStatus(item);
+  if (status === null) {
+    return null;
+  }
+  const summary = toolSummary("Ran", decodedToolCommand(item.command));
+  return {
+    kind: "correlated-terminal",
+    provider: "codex",
+    providerOperationId,
+    status,
+    ...(summary === null
+      ? {}
+      : { standaloneOperation: { action: "run", summary } }),
+  };
+}
+
+function codexFile(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "item.completed") {
+    return null;
+  }
+  const item = recordOf(event.item);
+  if (item === null) {
+    return null;
+  }
+  const status = codexTerminalStatus(item);
+  if (status === null) {
+    return null;
+  }
+
+  let action: ToolAction;
+  let target: unknown;
+  switch (item.type) {
+    case "file_read": {
+      action = "read";
+      target = item.path;
+      break;
+    }
+    case "file_write": {
+      action = "write";
+      target = item.path;
+      break;
+    }
+    case "file_edit": {
+      action = "edit";
+      target = item.path;
+      break;
+    }
+    case "file_change": {
+      if (!Array.isArray(item.changes) || item.changes.length !== 1) {
+        return null;
+      }
+      const change = recordOf(item.changes[0]);
+      if (change?.kind === "add") {
+        action = "write";
+      } else if (change?.kind === "modify") {
+        action = "edit";
+      } else {
+        return null;
+      }
+      target = change.path;
+      break;
+    }
+    default: {
+      return null;
+    }
+  }
+
+  const summary = toolSummary(
+    action === "read" ? "Read" : action === "write" ? "Wrote" : "Edited",
+    target,
+  );
+  return summary === null
+    ? null
+    : { kind: "standalone", action, status, summary };
+}
+
+/** Normalize one already-masked, already-sequenced provider event. */
+export function normalizeAgentToolEvent(
+  event: AgentEvent,
+): NormalizedAgentToolEvent | null {
+  return (
+    claudeToolUse(event) ??
+    claudeToolResult(event) ??
+    codexCommand(event) ??
+    codexFile(event)
+  );
+}

--- a/turbo/apps/api/src/signals/services/assistant-event-id.ts
+++ b/turbo/apps/api/src/signals/services/assistant-event-id.ts
@@ -7,12 +7,42 @@ const INTEGRATION_COMPLETION_FALLBACK_EVENT_ID_NAMESPACE =
   "d1cbb152-c744-432a-8cbe-ff7846ef11b7";
 const RUN_TIME_BUDGET_EVENT_ID_NAMESPACE =
   "354e77a2-8a0a-48f3-9414-97a5ea08727f";
+const TOOL_EVENT_ID_NAMESPACE = "cd50cb06-c328-4ff0-b6b5-a152b8970d3f";
+const TOOL_USE_ID_NAMESPACE = "6915e503-2e60-4455-9674-93d28248e751";
 
 export function assistantEventIdForRunEvent(
   runId: string,
   runEventId: string,
 ): string {
   return uuidv5(`${runId}:${runEventId}`, ASSISTANT_EVENT_ID_NAMESPACE);
+}
+
+/** Tool snapshots use a row namespace independent from transcript outputs. */
+export function toolEventIdForRunEvent(
+  runId: string,
+  runEventId: string,
+): string {
+  return uuidv5(`${runId}:${runEventId}`, TOOL_EVENT_ID_NAMESPACE);
+}
+
+/** Provider IDs are derivation seeds only; the returned correlation is opaque. */
+export function toolUseIdForProviderOperation(
+  runId: string,
+  provider: "claude" | "codex",
+  providerOperationId: string,
+): string {
+  return uuidv5(
+    `${provider}:${runId}:${providerOperationId}`,
+    TOOL_USE_ID_NAMESPACE,
+  );
+}
+
+/** Completed-only operations correlate to their canonical event, not item IDs. */
+export function toolUseIdForRunEvent(
+  runId: string,
+  runEventId: string,
+): string {
+  return uuidv5(`event:${runId}:${runEventId}`, TOOL_USE_ID_NAMESPACE);
 }
 
 export function followupsEventIdForRun(runId: string): string {

--- a/turbo/apps/api/src/signals/services/chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-shared.service.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import type { OutputToolPayload } from "@okouai/api-contracts/contracts/chat-events";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -17,7 +18,10 @@ import { alias } from "drizzle-orm/pg-core";
 import { writeDb$, type Db } from "../external/db";
 import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { nowDate } from "../../lib/time";
-import { assistantEventIdForRunEvent } from "./assistant-event-id";
+import {
+  assistantEventIdForRunEvent,
+  toolEventIdForRunEvent,
+} from "./assistant-event-id";
 import { insertChatEvents } from "./chat-event.service";
 import {
   chatEventTypeIn,
@@ -73,7 +77,12 @@ type InsertAssistantEventItem =
       readonly runEventSequenceNumber: number;
       readonly thinking: string;
       readonly runEventId: string;
-    };
+    }
+  | (OutputToolPayload & {
+      readonly eventType: "output.tool";
+      readonly runEventSequenceNumber: number;
+      readonly runEventId: string;
+    });
 
 export interface InsertAssistantEventsInput {
   readonly runId: string;
@@ -214,24 +223,38 @@ export async function insertAssistantEventsInTransaction(
     tx,
     args.items.map((item) => {
       const eventIdentity = {
-        id: assistantEventIdForRunEvent(args.runId, item.runEventId),
+        id:
+          item.eventType === "output.tool"
+            ? toolEventIdForRunEvent(args.runId, item.runEventId)
+            : assistantEventIdForRunEvent(args.runId, item.runEventId),
         chatThreadId: args.threadId,
         runId: args.runId,
         runGroupId: runContext.goalId,
         runEventSequenceNumber: item.runEventSequenceNumber,
         runEventId: item.runEventId,
       };
-      return item.eventType === "output.message"
-        ? {
-            ...eventIdentity,
-            eventType: item.eventType,
-            content: item.content,
-          }
-        : {
-            ...eventIdentity,
-            eventType: item.eventType,
-            thinking: item.thinking,
-          };
+      if (item.eventType === "output.message") {
+        return {
+          ...eventIdentity,
+          eventType: item.eventType,
+          content: item.content,
+        };
+      }
+      if (item.eventType === "output.thinking") {
+        return {
+          ...eventIdentity,
+          eventType: item.eventType,
+          thinking: item.thinking,
+        };
+      }
+      return {
+        ...eventIdentity,
+        eventType: item.eventType,
+        toolUseId: item.toolUseId,
+        action: item.action,
+        status: item.status,
+        summary: item.summary,
+      };
     }),
   );
   signal.throwIfAborted();


### PR DESCRIPTION
Closes #29367

Provider-materialization stage of [#29244](https://github.com/vm0-ai/vm0/issues/29244).

## summary

- normalize the V1 Claude Code and Codex run/read/write/edit mappings into strict `output.tool` snapshots
- keep snapshot row identity independent from opaque operation correlation, including shared Codex item IDs and split file changes
- recover Claude and Codex lifecycle state from append-only tool snapshots inside the existing advisory-locked transaction
- gate writes only on the Run-captured `chatToolActivityEnabled` value and preserve the current delivery kill switch
- derive bounded wrapper-free summaries only from already-masked canonical fields

## verification

- scoped Prettier, Oxlint, type-aware Oxlint, ESLint, Knip, API core/test type checks
- pure normalization and deterministic identity tests: 6 passed
- DB-backed provider materialization route tests: 3 passed
- existing run lifecycle regression: 1 passed
- guest-agent mask/sequencing integration test: 1 passed
- guest-tool-exec wrapper producer test: 1 passed
- Rust formatting and `git diff --check`

## fallbacks

No new fallback is introduced. The feature remains default-off and staff-targeted, Run creation keeps the immutable write decision, and the existing current-switch delivery redaction remains the emergency kill switch.
