### PR TITLE
feat(api): add built-in model cooldown axiom event

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -470,6 +470,22 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
             ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
           }),
         ).resolves.toStrictEqual({ outcome: "recorded" });
+        expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+          "Built-in model provider failure report recorded",
+          expect.objectContaining({
+            type: "built_in_model_provider_cooldown",
+            context: "Runners",
+            runId: claimed.runId,
+            selectedModel: claimed.selectedModel,
+            providerType: primary.provider_type,
+            upstreamModel: primary.upstream_model,
+            failureKind,
+            retryAfterSeconds: cooldownSeconds,
+            unavailableUntil: new Date(
+              startedAt + cooldownSeconds * 1000,
+            ).toISOString(),
+          }),
+        );
         await expect(
           runs.readRun(claimed.actor, claimed.runId),
         ).resolves.toMatchObject({ status: "running" });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -470,7 +470,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
             ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
           }),
         ).resolves.toStrictEqual({ outcome: "recorded" });
-        expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+        expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
           "Built-in model provider failure report recorded",
           expect.objectContaining({
             type: "built_in_model_provider_cooldown",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2627,7 +2627,7 @@ const modelProviderFailureInner$ = command(
       retryAfterSeconds: cooldownSeconds,
     });
     signal.throwIfAborted();
-    L.debug("Built-in model provider failure report recorded", {
+    L.error("Built-in model provider failure report recorded", {
       type: "built_in_model_provider_cooldown",
       runId,
       selectedModel: run.selectedModel,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2628,6 +2628,7 @@ const modelProviderFailureInner$ = command(
     });
     signal.throwIfAborted();
     L.debug("Built-in model provider failure report recorded", {
+      type: "built_in_model_provider_cooldown",
       runId,
       selectedModel: run.selectedModel,
       providerType: run.modelRuntimeProvider,


### PR DESCRIPTION
## Summary

- emit an error-level Axiom application log with the stable `built_in_model_provider_cooldown` event type after an exact built-in model route cooldown is recorded
- assert the error level, event type, and operational context through the official runner failure-report API integration test

## Scope

- this PR does not configure the Axiom monitor or Slack notifier
- this PR does not add direct Slack delivery to the runner request path or change cooldown and fallback behavior

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/runners.ts apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts --silent=passed-only` (15 tests passed)
- pre-commit hooks: full Turbo Knip, 14 TypeScript check tasks, Prettier, file-size validation, and commitlint passed

The full API suite was also run twice. The first run passed 3,501 of 3,502 tests with one unrelated 5-second timeout. The second run passed 3,497 of 3,502 tests and exposed unrelated timeout and cross-test database-state isolation failures. After resetting the local database, the affected integration test above passed 15 of 15 tests.

Relates to #29360
