### PR TITLE
refactor(runner): dual-read operator api url aliases

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -21,15 +21,16 @@
 /// processes by the guest-agent's curated child environment.
 pub const API_URL_ENV: &str = "VM0_API_BACKEND_URL";
 
-/// Canonical backend API URL alias accepted by guest readers during migration.
+/// Canonical backend API URL spelling shared by migration readers.
 ///
-/// This fallback is confined to the Runner-to-Guest-Agent bootstrap surface.
+/// The Guest Agent bootstrap reader and Runner operator parser reuse this exact
+/// spelling but have independent rollout floors. On the Runner-to-Guest surface,
 /// Runner writers keep using [`API_URL_ENV`], and the guest-agent keeps exposing
-/// that legacy spelling to managed CLI children. Remove the legacy reader only
+/// that legacy spelling to managed CLI children. Remove that legacy reader only
 /// after the exact production Runner plus embedded-Guest reader floor, complete
 /// pre-reader service and reusable-sandbox drain, supported rollback window,
-/// and value-free legacy-source-zero gates in #28914. The managed CLI-child
-/// spelling has its own later reader/support floor.
+/// and value-free legacy-source-zero gates in #28914. Runner operator input and
+/// managed CLI-child exposure each have their own later support floors.
 pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
 
 /// Stable run identifier used by guest-agent logs, telemetry, and runtime

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -41,8 +41,12 @@ pub struct ConfigArgs {
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 
-    /// vm0 API URL
-    #[arg(long, env = "VM0_API_BACKEND_URL")]
+    /// vm0 API URL (`OKOU_API_BACKEND_URL`; legacy: `VM0_API_BACKEND_URL`)
+    #[arg(
+        long,
+        env = crate::operator_api_url::clap_environment_name(),
+        hide_env_values = true
+    )]
     api_url: String,
     /// Runner authentication token (`OKOU_RUNNER_TOKEN`; legacy: `VM0_RUNNER_TOKEN`)
     #[arg(
@@ -55,6 +59,10 @@ pub struct ConfigArgs {
 
 #[cfg(test)]
 impl ConfigArgs {
+    pub(crate) fn api_url_for_test(&self) -> &str {
+        &self.api_url
+    }
+
     pub(crate) fn token_for_test(&self) -> &str {
         &self.token
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -260,8 +260,12 @@ pub struct StartArgs {
     /// Path to runner.yaml config file
     #[arg(long, short)]
     pub(crate) config: PathBuf,
-    /// vm0 API URL (overrides config)
-    #[arg(long, env = "VM0_API_BACKEND_URL")]
+    /// vm0 API URL (overrides config; `OKOU_API_BACKEND_URL`; legacy: `VM0_API_BACKEND_URL`)
+    #[arg(
+        long,
+        env = crate::operator_api_url::clap_environment_name(),
+        hide_env_values = true
+    )]
     api_url: Option<String>,
     /// Runner authentication token (overrides config; `OKOU_RUNNER_TOKEN`; legacy: `VM0_RUNNER_TOKEN`)
     #[arg(
@@ -277,6 +281,10 @@ pub struct StartArgs {
 
 #[cfg(test)]
 impl StartArgs {
+    pub(crate) fn api_url_for_test(&self) -> Option<&str> {
+        self.api_url.as_deref()
+    }
+
     pub(crate) fn token_for_test(&self) -> Option<&str> {
         self.token.as_deref()
     }
@@ -403,9 +411,11 @@ async fn run_start_with_home(
 
     // Validate required server fields
     if server.url.is_empty() {
-        return Err(RunnerError::Config(
-            "server.url is required (set in config or via --api-url / VM0_API_BACKEND_URL)".into(),
-        ));
+        return Err(RunnerError::Config(format!(
+            "server.url is required (set in config or via --api-url / {} / {})",
+            crate::operator_api_url::CANONICAL_ENV,
+            crate::operator_api_url::LEGACY_ENV
+        )));
     }
     server.url = config::normalize_api_base_url(&server.url)?;
     if server.token.is_empty() {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -95,8 +95,8 @@ pub struct RunnerConfig {
     /// least one entry; each profile name is also checked for format.
     pub profiles: BTreeMap<String, ProfileConfig>,
     /// Control-plane endpoint and auth token. May be omitted in the YAML if
-    /// `--api-url` / `--token` (or the corresponding environment aliases) are
-    /// supplied at `start` time.
+    /// `--api-url` / `--token` (or the corresponding canonical or legacy
+    /// environment aliases) are supplied at `start` time.
     pub server: Option<ServerConfig>,
 }
 
@@ -164,7 +164,7 @@ impl Default for SandboxConfig {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServerConfig {
     /// Base URL of the vm0 API (e.g. `https://api.example.com`). Overridable
-    /// via `--api-url` / `VM0_API_BACKEND_URL`.
+    /// via `--api-url` / `OKOU_API_BACKEND_URL` / `VM0_API_BACKEND_URL`.
     pub url: String,
     /// Runner auth token. Overridable via `--token` / `OKOU_RUNNER_TOKEN`, with
     /// `VM0_RUNNER_TOKEN` retained as a temporary legacy alias.

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -381,6 +381,24 @@ async fn load_for_start_applies_api_url_override_before_server_url_validation() 
 }
 
 #[tokio::test]
+async fn load_for_start_without_api_url_override_uses_runner_yaml() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml_with_default_profile(
+        r#"server:
+  url: https://yaml-api.example.com/prefix/
+  token: secret
+"#,
+    );
+    let config_path = fixture.write_config(&yaml).await;
+
+    let config = load_for_start(&config_path, None).await.unwrap();
+
+    let server = config.server.unwrap();
+    assert_eq!(server.url, "https://yaml-api.example.com/prefix");
+    assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
 async fn load_rejects_server_url_with_sensitive_components() {
     let fixture = ConfigFixture::new().await;
     let cases = [

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -36,6 +36,7 @@ mod network_log_manager;
 mod network_log_process;
 mod network_logs;
 mod object_download_policy;
+mod operator_api_url;
 mod org_name;
 mod parent_death;
 mod paths;
@@ -74,7 +75,7 @@ mod workspace_promotion;
 use std::path::Path;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::{FromArgMatches, Parser, Subcommand};
 use tracing_subscriber::Layer as _;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
@@ -91,17 +92,24 @@ struct Cli {
 }
 
 impl Cli {
-    fn parse_with_runner_token_aliases() -> Self {
-        Self::try_parse_with_runner_token_aliases_from(std::env::args_os())
+    fn parse_with_environment_aliases() -> Self {
+        Self::try_parse_with_environment_aliases_from(std::env::args_os())
             .unwrap_or_else(|error| error.exit())
     }
 
-    fn try_parse_with_runner_token_aliases_from<I, T>(args: I) -> Result<Self, clap::Error>
+    fn try_parse_with_environment_aliases_from<I, T>(args: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        let cli = <Self as Parser>::try_parse_from(args)?;
+        let mut matches = <Self as clap::CommandFactory>::command().try_get_matches_from(args)?;
+        let api_url_from_environment = matches.subcommand().is_some_and(|(name, subcommand)| {
+            matches!(name, "config" | "start")
+                && subcommand.value_source("api_url")
+                    == Some(clap::parser::ValueSource::EnvVariable)
+        });
+        let cli = Self::from_arg_matches_mut(&mut matches)
+            .map_err(|error| error.format(&mut <Self as clap::CommandFactory>::command()))?;
         if matches!(&cli.command, Command::Config(_) | Command::Start(_))
             && runner_token::environment_aliases_conflict()
         {
@@ -111,6 +119,16 @@ impl Cli {
                     "{} and {} cannot both be set",
                     runner_token::CANONICAL_ENV,
                     runner_token::LEGACY_ENV
+                ),
+            ));
+        }
+        if api_url_from_environment && operator_api_url::environment_aliases_conflict() {
+            return Err(<Self as clap::CommandFactory>::command().error(
+                clap::error::ErrorKind::ArgumentConflict,
+                format!(
+                    "{} and {} contain conflicting values",
+                    operator_api_url::CANONICAL_ENV,
+                    operator_api_url::LEGACY_ENV
                 ),
             ));
         }
@@ -273,7 +291,7 @@ async fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let cli = Cli::parse_with_runner_token_aliases();
+    let cli = Cli::parse_with_environment_aliases();
 
     // Axiom layer (dual-write with fmt). Returns None — zero overhead — when
     // AXIOM_TOKEN_TELEMETRY / AXIOM_DATASET_SUFFIX are unset.
@@ -359,12 +377,26 @@ mod tests {
     const HELP_TOKEN_CHILD_TEST: &str = "tests::runner_help_hides_token_environment_values_child";
     const TOKEN_ALIAS_CHILD_SCENARIO_ENV: &str = "RUNNER_TOKEN_ALIAS_CHILD_SCENARIO";
     const TOKEN_ALIAS_CHILD_TEST: &str = "tests::runner_token_environment_aliases_child";
+    const HELP_API_URL_CHILD_SCENARIO_ENV: &str = "RUNNER_HELP_API_URL_CHILD_SCENARIO";
+    const HELP_API_URL_CHILD_TEST: &str =
+        "tests::runner_help_hides_api_url_environment_values_child";
+    const API_URL_ALIAS_CHILD_SCENARIO_ENV: &str = "RUNNER_API_URL_ALIAS_CHILD_SCENARIO";
+    const API_URL_ALIAS_CHILD_TEST: &str = "tests::runner_api_url_environment_aliases_child";
+    const API_URL_NORMALIZATION_CHILD_SCENARIO_ENV: &str =
+        "RUNNER_API_URL_NORMALIZATION_CHILD_SCENARIO";
+    const API_URL_NORMALIZATION_CHILD_TEST: &str =
+        "tests::runner_api_url_environment_normalization_child";
     const CANONICAL_TOKEN_SENTINEL: &str = "canonical-sentinel-runner-token";
     const LEGACY_TOKEN_SENTINEL: &str = "legacy-sentinel-runner-token";
     const FLAG_TOKEN_SENTINEL: &str = "flag-sentinel-runner-token";
+    const CANONICAL_API_URL_SENTINEL: &str =
+        "https://canonical-api-url-sentinel.example.test/canonical/";
+    const LEGACY_API_URL_SENTINEL: &str = "https://legacy-api-url-sentinel.example.test/legacy/";
+    const EQUAL_API_URL_SENTINEL: &str = "https://equal-api-url-sentinel.example.test/equal/";
+    const FLAG_API_URL_SENTINEL: &str = "https://flag-api-url-sentinel.example.test/flag/";
 
     fn token_alias_child_env(case: &str) -> Vec<(&'static str, Option<&'static str>)> {
-        match case.strip_prefix("flag-").unwrap_or(case) {
+        let mut env = match case.strip_prefix("flag-").unwrap_or(case) {
             "canonical" => vec![
                 (runner_token::CANONICAL_ENV, Some(CANONICAL_TOKEN_SENTINEL)),
                 (runner_token::LEGACY_ENV, None),
@@ -382,6 +414,99 @@ mod tests {
                 (runner_token::LEGACY_ENV, None),
             ],
             unexpected => panic!("unexpected runner token alias case: {unexpected}"),
+        };
+        env.extend([
+            (operator_api_url::CANONICAL_ENV, None),
+            (operator_api_url::LEGACY_ENV, None),
+        ]);
+        env
+    }
+
+    fn api_url_alias_child_env(case: &str) -> Vec<(&'static str, Option<&'static str>)> {
+        let mut env = match case.strip_prefix("flag-").unwrap_or(case) {
+            "canonical" => vec![
+                (
+                    operator_api_url::CANONICAL_ENV,
+                    Some(CANONICAL_API_URL_SENTINEL),
+                ),
+                (operator_api_url::LEGACY_ENV, None),
+            ],
+            "legacy" => vec![
+                (operator_api_url::CANONICAL_ENV, None),
+                (operator_api_url::LEGACY_ENV, Some(LEGACY_API_URL_SENTINEL)),
+            ],
+            "equal" => vec![
+                (
+                    operator_api_url::CANONICAL_ENV,
+                    Some(EQUAL_API_URL_SENTINEL),
+                ),
+                (operator_api_url::LEGACY_ENV, Some(EQUAL_API_URL_SENTINEL)),
+            ],
+            "conflict" => vec![
+                (
+                    operator_api_url::CANONICAL_ENV,
+                    Some(CANONICAL_API_URL_SENTINEL),
+                ),
+                (operator_api_url::LEGACY_ENV, Some(LEGACY_API_URL_SENTINEL)),
+            ],
+            "neither" => vec![
+                (operator_api_url::CANONICAL_ENV, None),
+                (operator_api_url::LEGACY_ENV, None),
+            ],
+            unexpected => panic!("unexpected Runner API URL alias case: {unexpected}"),
+        };
+        env.extend([
+            (runner_token::CANONICAL_ENV, None),
+            (runner_token::LEGACY_ENV, None),
+        ]);
+        env
+    }
+
+    fn api_url_source_child_env(
+        source: &str,
+        value: &'static str,
+    ) -> Vec<(&'static str, Option<&'static str>)> {
+        let mut env = match source {
+            "canonical" => vec![
+                (operator_api_url::CANONICAL_ENV, Some(value)),
+                (operator_api_url::LEGACY_ENV, None),
+            ],
+            "legacy" => vec![
+                (operator_api_url::CANONICAL_ENV, None),
+                (operator_api_url::LEGACY_ENV, Some(value)),
+            ],
+            unexpected => panic!("unexpected Runner API URL source: {unexpected}"),
+        };
+        env.extend([
+            (runner_token::CANONICAL_ENV, None),
+            (runner_token::LEGACY_ENV, None),
+        ]);
+        env
+    }
+
+    fn api_url_normalization_input(case: &str) -> &'static str {
+        match case {
+            "invalid-scheme" => "ftp://scheme-api-url-sentinel.example.test",
+            "missing-host" => "https://",
+            "userinfo" => "https://api-user:api-password@userinfo-api-url-sentinel.example.test",
+            "query" => "https://query-api-url-sentinel.example.test/path?token=query-secret",
+            "fragment" => "https://fragment-api-url-sentinel.example.test/path#fragment-secret",
+            "trailing-slash" => "https://Trailing-API-URL-Sentinel.Example.Test/base/",
+            unexpected => panic!("unexpected Runner API URL normalization case: {unexpected}"),
+        }
+    }
+
+    fn assert_api_url_alias_values_hidden(output: &str) {
+        for sentinel in [
+            CANONICAL_API_URL_SENTINEL,
+            LEGACY_API_URL_SENTINEL,
+            EQUAL_API_URL_SENTINEL,
+            FLAG_API_URL_SENTINEL,
+        ] {
+            assert!(
+                !output.contains(sentinel),
+                "Runner API URL diagnostics must not expose {sentinel}: {output}"
+            );
         }
     }
 
@@ -410,6 +535,35 @@ mod tests {
         };
         if case.starts_with("flag-") {
             args.extend(["--token", FLAG_TOKEN_SENTINEL]);
+        }
+        args
+    }
+
+    fn runner_api_url_cli_args(subcommand: &str, case: &str) -> Vec<&'static str> {
+        let mut args = match subcommand {
+            "config" => vec![
+                "runner",
+                "config",
+                "--profile",
+                "vm0/default",
+                "--rootfs-hash",
+                "rootfs-hash",
+                "--snapshot-hash",
+                "snapshot-hash",
+                "--name",
+                "runner-test",
+                "--group",
+                "vm0/test",
+                "--runner-dirname",
+                "runner-test",
+                "--token",
+                "runner-token",
+            ],
+            "start" => vec!["runner", "start", "--config", "/tmp/runner.yaml"],
+            unexpected => panic!("unexpected Runner API URL subcommand: {unexpected}"),
+        };
+        if case.starts_with("flag-") {
+            args.extend(["--api-url", FLAG_API_URL_SENTINEL]);
         }
         args
     }
@@ -534,7 +688,7 @@ mod tests {
             "unexpected runner help token alias case: {case}"
         );
 
-        let error = Cli::try_parse_with_runner_token_aliases_from(["runner", subcommand, "--help"])
+        let error = Cli::try_parse_with_environment_aliases_from(["runner", subcommand, "--help"])
             .err()
             .expect("runner subcommand help should exit through clap");
         assert_eq!(
@@ -597,7 +751,7 @@ mod tests {
             .split_once(':')
             .expect("runner token scenario must contain subcommand and alias case");
         let parsed =
-            Cli::try_parse_with_runner_token_aliases_from(runner_token_cli_args(subcommand, case));
+            Cli::try_parse_with_environment_aliases_from(runner_token_cli_args(subcommand, case));
 
         if case == "conflict" {
             let error = parsed
@@ -630,6 +784,218 @@ mod tests {
             unexpected => panic!("unexpected runner token scenario case: {unexpected}"),
         };
         assert_eq!(token, expected, "unexpected token source for {scenario}");
+    }
+
+    #[tokio::test]
+    async fn runner_help_hides_api_url_environment_values() {
+        for subcommand in ["config", "start"] {
+            for case in ["canonical", "legacy", "equal", "conflict"] {
+                let scenario = format!("{subcommand}:{case}");
+                let child_env = api_url_alias_child_env(case);
+                run_ignored_child_test(
+                    HELP_API_URL_CHILD_TEST,
+                    (HELP_API_URL_CHILD_SCENARIO_ENV, &scenario),
+                    &child_env,
+                    Duration::from_secs(5),
+                )
+                .await;
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "spawned by runner_help_hides_api_url_environment_values"]
+    fn runner_help_hides_api_url_environment_values_child() {
+        let Ok(scenario) = std::env::var(HELP_API_URL_CHILD_SCENARIO_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((HELP_API_URL_CHILD_SCENARIO_ENV, &scenario)) {
+            return;
+        }
+        let (subcommand, case) = scenario
+            .split_once(':')
+            .expect("Runner API URL help scenario must contain subcommand and alias case");
+        assert!(matches!(subcommand, "config" | "start"));
+        assert!(matches!(
+            case,
+            "canonical" | "legacy" | "equal" | "conflict"
+        ));
+
+        let error = Cli::try_parse_with_environment_aliases_from(["runner", subcommand, "--help"])
+            .err()
+            .expect("runner subcommand help should exit through Clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+        assert!(
+            help.contains(operator_api_url::CANONICAL_ENV),
+            "{subcommand} help should identify the canonical API URL environment variable"
+        );
+        assert!(
+            help.contains(operator_api_url::LEGACY_ENV),
+            "{subcommand} help should identify the legacy API URL environment variable"
+        );
+        assert_api_url_alias_values_hidden(&help);
+    }
+
+    #[tokio::test]
+    async fn runner_config_and_start_resolve_api_url_environment_aliases() {
+        for subcommand in ["config", "start"] {
+            for case in [
+                "canonical",
+                "legacy",
+                "equal",
+                "conflict",
+                "flag-canonical",
+                "flag-legacy",
+                "flag-conflict",
+                "neither",
+            ] {
+                let scenario = format!("{subcommand}:{case}");
+                let child_env = api_url_alias_child_env(case);
+                run_ignored_child_test(
+                    API_URL_ALIAS_CHILD_TEST,
+                    (API_URL_ALIAS_CHILD_SCENARIO_ENV, &scenario),
+                    &child_env,
+                    Duration::from_secs(5),
+                )
+                .await;
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "spawned by runner_config_and_start_resolve_api_url_environment_aliases"]
+    fn runner_api_url_environment_aliases_child() {
+        let Ok(scenario) = std::env::var(API_URL_ALIAS_CHILD_SCENARIO_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((API_URL_ALIAS_CHILD_SCENARIO_ENV, &scenario)) {
+            return;
+        }
+        let (subcommand, case) = scenario
+            .split_once(':')
+            .expect("Runner API URL scenario must contain subcommand and alias case");
+        let parsed =
+            Cli::try_parse_with_environment_aliases_from(runner_api_url_cli_args(subcommand, case));
+
+        if case == "conflict" {
+            let error = parsed
+                .err()
+                .expect("unequal Runner API URL environment aliases must conflict");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            let output = error.to_string();
+            assert!(output.contains(operator_api_url::CANONICAL_ENV));
+            assert!(output.contains(operator_api_url::LEGACY_ENV));
+            assert_api_url_alias_values_hidden(&output);
+            return;
+        }
+        if subcommand == "config" && case == "neither" {
+            let error = parsed
+                .err()
+                .expect("runner config should still require an API URL source");
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument
+            );
+            assert_api_url_alias_values_hidden(&error.to_string());
+            return;
+        }
+
+        let cli = parsed.unwrap_or_else(|error| panic!("parse runner {scenario}: {error}"));
+        let api_url = match &cli.command {
+            Command::Config(args) => Some(args.api_url_for_test()),
+            Command::Start(args) => args.api_url_for_test(),
+            _ => panic!("Runner API URL scenario parsed an unexpected subcommand: {scenario}"),
+        };
+        let expected = match case {
+            "canonical" => Some(CANONICAL_API_URL_SENTINEL),
+            "legacy" => Some(LEGACY_API_URL_SENTINEL),
+            "equal" => Some(EQUAL_API_URL_SENTINEL),
+            "flag-canonical" | "flag-legacy" | "flag-conflict" => Some(FLAG_API_URL_SENTINEL),
+            "neither" => None,
+            unexpected => panic!("unexpected Runner API URL scenario case: {unexpected}"),
+        };
+        assert_eq!(
+            api_url, expected,
+            "unexpected API URL source for {scenario}"
+        );
+    }
+
+    #[tokio::test]
+    async fn runner_api_url_environment_aliases_use_existing_normalization() {
+        for source in ["canonical", "legacy"] {
+            for case in [
+                "invalid-scheme",
+                "missing-host",
+                "userinfo",
+                "query",
+                "fragment",
+                "trailing-slash",
+            ] {
+                let scenario = format!("{source}:{case}");
+                let child_env = api_url_source_child_env(source, api_url_normalization_input(case));
+                run_ignored_child_test(
+                    API_URL_NORMALIZATION_CHILD_TEST,
+                    (API_URL_NORMALIZATION_CHILD_SCENARIO_ENV, &scenario),
+                    &child_env,
+                    Duration::from_secs(5),
+                )
+                .await;
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "spawned by runner_api_url_environment_aliases_use_existing_normalization"]
+    fn runner_api_url_environment_normalization_child() {
+        let Ok(scenario) = std::env::var(API_URL_NORMALIZATION_CHILD_SCENARIO_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((
+            API_URL_NORMALIZATION_CHILD_SCENARIO_ENV,
+            &scenario,
+        )) {
+            return;
+        }
+        let (source, case) = scenario
+            .split_once(':')
+            .expect("Runner API URL normalization scenario must contain source and case");
+        assert!(matches!(source, "canonical" | "legacy"));
+        let input = api_url_normalization_input(case);
+        let cli = Cli::try_parse_with_environment_aliases_from(runner_api_url_cli_args(
+            "config",
+            "canonical",
+        ))
+        .unwrap_or_else(|error| panic!("parse Runner API URL normalization scenario: {error}"));
+        let Command::Config(args) = cli.command else {
+            panic!("Runner API URL normalization scenario parsed an unexpected subcommand");
+        };
+        assert_eq!(args.api_url_for_test(), input);
+
+        let normalized = config::normalize_api_base_url(args.api_url_for_test());
+        if case == "trailing-slash" {
+            assert_eq!(
+                normalized.unwrap(),
+                "https://trailing-api-url-sentinel.example.test/base"
+            );
+            return;
+        }
+
+        let expected = match case {
+            "invalid-scheme" => "http or https",
+            "missing-host" => "absolute http(s) URL",
+            "userinfo" => "credentials",
+            "query" => "query string",
+            "fragment" => "fragment",
+            unexpected => panic!("unexpected invalid Runner API URL case: {unexpected}"),
+        };
+        let error = normalized.expect_err("invalid Runner API URL should fail normalization");
+        let message = error.to_string();
+        assert!(message.contains(expected), "unexpected error: {message}");
+        assert!(
+            !message.contains(input),
+            "normalization error must not expose the raw API URL: {message}"
+        );
     }
 
     #[test]

--- a/crates/runner/src/operator_api_url.rs
+++ b/crates/runner/src/operator_api_url.rs
@@ -5,7 +5,9 @@ pub(crate) const LEGACY_ENV: &str = guest_contracts::env::API_URL_ENV;
 ///
 /// The spellings are shared with the Runner-to-Guest contract, but this reader
 /// has an independent rollout floor. External operator configuration keeps the
-/// legacy alias until #28914 separately proves it can be removed.
+/// legacy alias through the deployed Runner reader floor and supported rollback
+/// window. Remove it after the checked-in and supported external input inventory
+/// proves there is no legacy-only use; #28914 tracks that gate.
 pub(crate) fn clap_environment_name() -> &'static str {
     if std::env::var_os(CANONICAL_ENV).is_none() && std::env::var_os(LEGACY_ENV).is_some() {
         LEGACY_ENV

--- a/crates/runner/src/operator_api_url.rs
+++ b/crates/runner/src/operator_api_url.rs
@@ -1,0 +1,25 @@
+pub(crate) const CANONICAL_ENV: &str = guest_contracts::env::CANONICAL_API_URL_ENV;
+pub(crate) const LEGACY_ENV: &str = guest_contracts::env::API_URL_ENV;
+
+/// Select the Runner operator environment source that Clap binds to `--api-url`.
+///
+/// The spellings are shared with the Runner-to-Guest contract, but this reader
+/// has an independent rollout floor. External operator configuration keeps the
+/// legacy alias until #28914 separately proves it can be removed.
+pub(crate) fn clap_environment_name() -> &'static str {
+    if std::env::var_os(CANONICAL_ENV).is_none() && std::env::var_os(LEGACY_ENV).is_some() {
+        LEGACY_ENV
+    } else {
+        CANONICAL_ENV
+    }
+}
+
+pub(crate) fn environment_aliases_conflict() -> bool {
+    match (
+        std::env::var_os(CANONICAL_ENV),
+        std::env::var_os(LEGACY_ENV),
+    ) {
+        (Some(canonical), Some(legacy)) => canonical != legacy,
+        _ => false,
+    }
+}


### PR DESCRIPTION
## Summary

- accept `OKOU_API_BACKEND_URL` as a reader-only Runner operator alias for `runner config` and `runner start`
- preserve explicit `--api-url` precedence, equal-dual acceptance, unequal-dual fail-closed behavior, and the existing `runner.yaml` fallback
- keep help, conflict, and normalization diagnostics value-free while routing selected inputs through the existing URL normalizer

## Base

- `main@84295ac0c3d66185b90d59fc6afa3f79903aac9a`

## Verification

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy -p runner -p guest-contracts --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo check -p runner -p guest-contracts --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 RUSTDOCFLAGS='-D warnings' cargo doc -p runner -p guest-contracts --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 cargo test -p guest-contracts` (127 passed, 0 failed)
- `git diff --check`
- verified that Ansible, Runner-to-Guest bootstrap/writers, managed CLI-child exposure, API deployment, Turbo CLI, CI/E2E, devcontainer, and release/rollback configuration writers are unchanged

The single-job local link for the focused Runner test binary was OOM-killed without a code or test diagnostic on a 3.8 GiB, no-swap VM. Kernel evidence recorded `rustc` at 3,735,744 KiB anonymous RSS and a 4,012,109,824-byte cgroup peak. Strict all-targets/all-features Clippy and `cargo check` type-checked the new tests; protected PR CI is authoritative for Runner test execution.

## Fallbacks

- `crates/runner/src/operator_api_url.rs:clap_environment_name` — legacy `VM0_API_BACKEND_URL` remains accepted alongside canonical `OKOU_API_BACKEND_URL` for the Runner operator environment input used by `runner config` and `runner start`. Explicit `--api-url` remains rollback-safe, and `runner start` still uses `runner.yaml` when neither alias is present. Remove the legacy alias only after the deployed Runner reader floor, checked-in plus supported external/operator input inventory, and supported rollback window prove there is no legacy-only use. #28914 owns cutover and removal; this PR changes no writer or external configuration source.

Closes #29371
