### PR TITLE
feat: make presentation templates org scoped

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -203,6 +203,7 @@ describe("OPS-01: feature switch routes", () => {
           switches: {
             [FeatureSwitchKey.ChatErrorRecovery]: true,
             [FeatureSwitchKey.BuiltInModelProviderFallback]: true,
+            [FeatureSwitchKey.PresentationTemplates]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -214,6 +215,9 @@ describe("OPS-01: feature switch routes", () => {
     ).toBeTruthy();
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
+    ).toBeTruthy();
+    expect(
+      ownerUpdate.body.switches[FeatureSwitchKey.PresentationTemplates],
     ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
@@ -227,6 +231,9 @@ describe("OPS-01: feature switch routes", () => {
     expect(
       peerRead.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
     ).toBeTruthy();
+    expect(
+      peerRead.body.switches[FeatureSwitchKey.PresentationTemplates],
+    ).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const outsiderRead = await accept(
@@ -239,6 +246,9 @@ describe("OPS-01: feature switch routes", () => {
     expect(
       outsiderRead.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
     ).toBeUndefined();
+    expect(
+      outsiderRead.body.switches[FeatureSwitchKey.PresentationTemplates],
+    ).toBeUndefined();
     const peerUpdate = await accept(
       featureSwitchesClient().update({
         headers: headersFor(peer),
@@ -246,6 +256,7 @@ describe("OPS-01: feature switch routes", () => {
           switches: {
             [FeatureSwitchKey.ChatErrorRecovery]: false,
             [FeatureSwitchKey.BuiltInModelProviderFallback]: false,
+            [FeatureSwitchKey.PresentationTemplates]: false,
           },
         },
       }),
@@ -256,6 +267,9 @@ describe("OPS-01: feature switch routes", () => {
     ).toBeFalsy();
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.BuiltInModelProviderFallback],
+    ).toBeFalsy();
+    expect(
+      peerUpdate.body.switches[FeatureSwitchKey.PresentationTemplates],
     ).toBeFalsy();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
@@ -271,6 +285,11 @@ describe("OPS-01: feature switch routes", () => {
     expect(
       ownerReadAfterPeerUpdate.body.switches[
         FeatureSwitchKey.BuiltInModelProviderFallback
+      ],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.PresentationTemplates
       ],
     ).toBeFalsy();
     expect(
@@ -294,6 +313,9 @@ describe("OPS-01: feature switch routes", () => {
       peerReadAfterDelete.body.switches[
         FeatureSwitchKey.BuiltInModelProviderFallback
       ],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.PresentationTemplates],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -16,6 +16,7 @@ const ORG_SCOPED_FEATURE_SWITCH_KEYS: readonly string[] = [
   FeatureSwitchKey.ChatErrorRecovery,
   FeatureSwitchKey.BuiltInModelProviderFallback,
   FeatureSwitchKey.PiLoop,
+  FeatureSwitchKey.PresentationTemplates,
 ];
 
 function isOrgScopedFeatureSwitchKey(key: string): boolean {


### PR DESCRIPTION
## Summary

- make `PresentationTemplates` eligible for organization-scoped feature switch overrides
- share the override with members of the same organization while keeping other organizations isolated
- cover organization update, read, and delete behavior through the feature-switch API integration test

## Rollout

This does not enable Presentation Templates globally. It allows the existing feature-switch API to store this switch at organization scope.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, app, and API type checks
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts`
