### PR TITLE
refactor(guest): dual-read mock binary path aliases

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -216,6 +216,36 @@ fn guest_agent_tuning_env_or_empty(
     Ok(value)
 }
 
+/// Resolve one optional test/debug mock binary path alias pair at the single
+/// process-env capture boundary. Canonical aliases are reader-only during
+/// #28914 Stage 1; all existing test/debug writers remain legacy-only.
+fn mock_binary_path_env(
+    canonical_key: &'static str,
+    legacy_key: &'static str,
+) -> Result<Option<String>, String> {
+    let canonical = std::env::var(canonical_key).ok();
+    let legacy = std::env::var(legacy_key).ok();
+
+    let (value, source) = match (canonical, legacy) {
+        (None, None) => return Ok(None),
+        (Some(value), None) => (value, "canonical-only"),
+        (None, Some(value)) => (value, "legacy-only"),
+        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(_), Some(_)) => {
+            return Err(format!(
+                "conflicting mock binary path environment aliases: \
+                 canonical_key={canonical_key} legacy_key={legacy_key} state=conflict"
+            ));
+        }
+    };
+
+    log_info!(
+        LOG_TAG,
+        "mock_binary_path_env_source key={canonical_key} source={source}"
+    );
+    Ok(Some(value))
+}
+
 #[derive(Clone, Copy)]
 enum RunMetadataEnvSource {
     CanonicalOnly,
@@ -294,7 +324,7 @@ impl Framework {
 
 /// Production install location for the mock-claude binary. Exposed so
 /// tests can assert against a single source of truth when the
-/// `VM0_MOCK_CLAUDE_PATH` env override is unset.
+/// mock Claude path aliases are absent or non-Unicode.
 pub const DEFAULT_MOCK_CLAUDE_PATH: &str = "/usr/local/bin/guest-mock-claude";
 
 /// Production install location for the mock-codex binary, mirroring
@@ -415,7 +445,7 @@ pub struct GuestConfigRaw {
     pub api_start_time: String,
     pub agent_execution_timeout_secs: String,
     pub use_mock_claude: String,
-    /// Optional `VM0_MOCK_CLAUDE_PATH` executable override.
+    /// Optional canonical or legacy mock Claude executable override.
     ///
     /// [`Self::from_process_env`] captures an absent or non-Unicode value as
     /// `None` and a present empty value as `Some("")`. [`GuestConfig::from_raw`]
@@ -425,7 +455,7 @@ pub struct GuestConfigRaw {
     pub user_env_file: String,
     pub run_payload_file: String,
     pub use_mock_codex: String,
-    /// Optional `VM0_MOCK_CODEX_PATH` executable override.
+    /// Optional canonical or legacy mock Codex executable override.
     ///
     /// [`Self::from_process_env`] captures an absent or non-Unicode value as
     /// `None` and a present empty value as `Some("")`. [`GuestConfig::from_raw`]
@@ -526,12 +556,18 @@ impl GuestConfigRaw {
             )?,
             agent_execution_timeout_secs: agent_execution_timeout_env_or_empty()?,
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
-            mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
+            mock_claude_path: mock_binary_path_env(
+                guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+                guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+            )?,
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
             user_env_file,
             run_payload_file,
             use_mock_codex: env_or_empty(guest_contracts::env::USE_MOCK_CODEX_ENV),
-            mock_codex_path: std::env::var(guest_contracts::env::MOCK_CODEX_PATH_ENV).ok(),
+            mock_codex_path: mock_binary_path_env(
+                guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+                guest_contracts::env::MOCK_CODEX_PATH_ENV,
+            )?,
             home: std::env::var("HOME").ok(),
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,

--- a/crates/guest-agent/tests/mock_binary_path_env_aliases.rs
+++ b/crates/guest-agent/tests/mock_binary_path_env_aliases.rs
@@ -1,0 +1,452 @@
+//! Mock binary path aliases are resolved once at the process-env boundary.
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
+use std::path::Path;
+
+use guest_agent::env::{
+    DEFAULT_MOCK_CLAUDE_PATH, DEFAULT_MOCK_CODEX_PATH, GuestConfig, GuestConfigRaw,
+};
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CANONICAL_PATH: &str = "/tmp/canonical-mock-path-must-not-leak";
+const LEGACY_PATH: &str = "/tmp/legacy-mock-path-must-not-leak";
+const SHARED_PATH: &str = "/tmp/shared-mock-path-must-not-leak";
+const PATH_VALUES: [&str; 3] = [CANONICAL_PATH, LEGACY_PATH, SHARED_PATH];
+const SOURCE_EVENT: &str = "mock_binary_path_env_source";
+
+#[derive(Clone, Copy)]
+enum AliasInput {
+    Absent,
+    Readable(&'static str),
+    NonUnicode,
+}
+
+#[derive(Clone, Copy)]
+struct SuccessCase {
+    name: &'static str,
+    canonical: AliasInput,
+    legacy: AliasInput,
+    expected_raw: Option<&'static str>,
+    expected_source: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct ConflictCase {
+    name: &'static str,
+    canonical: &'static str,
+    legacy: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct MockPathEnvPair {
+    name: &'static str,
+    canonical: &'static str,
+    legacy: &'static str,
+    raw_value: for<'a> fn(&'a GuestConfigRaw) -> Option<&'a str>,
+    configured_value: for<'a> fn(&'a GuestConfig) -> &'a str,
+    default_path: &'static str,
+}
+
+const SUCCESS_CASES: [SuccessCase; 14] = [
+    SuccessCase {
+        name: "both-absent",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Absent,
+        expected_raw: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-only",
+        canonical: AliasInput::Readable(CANONICAL_PATH),
+        legacy: AliasInput::Absent,
+        expected_raw: Some(CANONICAL_PATH),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(LEGACY_PATH),
+        expected_raw: Some(LEGACY_PATH),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual",
+        canonical: AliasInput::Readable(SHARED_PATH),
+        legacy: AliasInput::Readable(SHARED_PATH),
+        expected_raw: Some(SHARED_PATH),
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-empty-only",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Absent,
+        expected_raw: Some(""),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::Readable(""),
+        expected_raw: Some(""),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "equal-dual-empty",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::Readable(""),
+        expected_raw: Some(""),
+        expected_source: Some("dual"),
+    },
+    SuccessCase {
+        name: "canonical-non-unicode-only",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Absent,
+        expected_raw: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "legacy-non-unicode-only",
+        canonical: AliasInput::Absent,
+        legacy: AliasInput::NonUnicode,
+        expected_raw: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "both-non-unicode",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::NonUnicode,
+        expected_raw: None,
+        expected_source: None,
+    },
+    SuccessCase {
+        name: "canonical-with-unreadable-legacy",
+        canonical: AliasInput::Readable(CANONICAL_PATH),
+        legacy: AliasInput::NonUnicode,
+        expected_raw: Some(CANONICAL_PATH),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(LEGACY_PATH),
+        expected_raw: Some(LEGACY_PATH),
+        expected_source: Some("legacy-only"),
+    },
+    SuccessCase {
+        name: "canonical-empty-with-unreadable-legacy",
+        canonical: AliasInput::Readable(""),
+        legacy: AliasInput::NonUnicode,
+        expected_raw: Some(""),
+        expected_source: Some("canonical-only"),
+    },
+    SuccessCase {
+        name: "legacy-empty-with-unreadable-canonical",
+        canonical: AliasInput::NonUnicode,
+        legacy: AliasInput::Readable(""),
+        expected_raw: Some(""),
+        expected_source: Some("legacy-only"),
+    },
+];
+
+const CONFLICT_CASES: [ConflictCase; 3] = [
+    ConflictCase {
+        name: "different-readable-values",
+        canonical: CANONICAL_PATH,
+        legacy: LEGACY_PATH,
+    },
+    ConflictCase {
+        name: "canonical-empty-legacy-non-empty",
+        canonical: "",
+        legacy: LEGACY_PATH,
+    },
+    ConflictCase {
+        name: "canonical-non-empty-legacy-empty",
+        canonical: CANONICAL_PATH,
+        legacy: "",
+    },
+];
+
+fn raw_mock_claude_path(raw: &GuestConfigRaw) -> Option<&str> {
+    raw.mock_claude_path.as_deref()
+}
+
+fn configured_mock_claude_path(config: &GuestConfig) -> &str {
+    &config.mock_claude_path
+}
+
+fn raw_mock_codex_path(raw: &GuestConfigRaw) -> Option<&str> {
+    raw.mock_codex_path.as_deref()
+}
+
+fn configured_mock_codex_path(config: &GuestConfig) -> &str {
+    &config.mock_codex_path
+}
+
+const MOCK_PATH_ENV_PAIRS: [MockPathEnvPair; 2] = [
+    MockPathEnvPair {
+        name: "claude",
+        canonical: guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+        legacy: guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+        raw_value: raw_mock_claude_path,
+        configured_value: configured_mock_claude_path,
+        default_path: DEFAULT_MOCK_CLAUDE_PATH,
+    },
+    MockPathEnvPair {
+        name: "codex",
+        canonical: guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+        legacy: guest_contracts::env::MOCK_CODEX_PATH_ENV,
+        raw_value: raw_mock_codex_path,
+        configured_value: configured_mock_codex_path,
+        default_path: DEFAULT_MOCK_CODEX_PATH,
+    },
+];
+
+fn set_test_env(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env(key: impl AsRef<OsStr>) {
+    // SAFETY: this integration test binary contains exactly one test, and the
+    // test does not start threads while configuring or capturing process env.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+fn apply_alias(key: &str, input: AliasInput) {
+    remove_test_env(key);
+    match input {
+        AliasInput::Absent => {}
+        AliasInput::Readable(value) => set_test_env(key, value),
+        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+    }
+}
+
+fn clear_mock_path_env() {
+    for pair in MOCK_PATH_ENV_PAIRS {
+        remove_test_env(pair.canonical);
+        remove_test_env(pair.legacy);
+    }
+}
+
+fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
+    guest_common::log::set_system_log_file(log_path);
+    let raw = GuestConfigRaw::from_process_env();
+    guest_common::log::clear_system_log_file();
+    let log = match std::fs::read_to_string(log_path) {
+        Ok(log) => log,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    Ok((raw, log))
+}
+
+fn assert_value_free(text: &str, context: &str) {
+    for path in PATH_VALUES {
+        assert!(
+            !text.contains(path),
+            "{context} exposed mock binary path value material"
+        );
+    }
+}
+
+fn assert_source_evidence(log: &str, pair: MockPathEnvPair, case: SuccessCase) {
+    assert_value_free(log, case.name);
+    let source_messages = log
+        .lines()
+        .filter(|line| line.contains(SOURCE_EVENT))
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .collect::<Vec<_>>();
+
+    match case.expected_source {
+        Some(source) => {
+            let expected = format!("{SOURCE_EVENT} key={} source={source}", pair.canonical);
+            assert_eq!(
+                source_messages,
+                [expected.as_str()],
+                "{} {} emitted incorrect fixed source evidence",
+                pair.name,
+                case.name
+            );
+        }
+        None => assert!(
+            source_messages.is_empty(),
+            "{} {} emitted source evidence for unreadable aliases",
+            pair.name,
+            case.name
+        ),
+    }
+}
+
+fn materialize_config(
+    tmp: &Path,
+    pair: MockPathEnvPair,
+    case_name: &str,
+    raw: GuestConfigRaw,
+) -> Result<GuestConfig, String> {
+    let runtime_dir = tmp.join(format!("{}-{case_name}-runtime", pair.name));
+    let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&payload_dir)
+        .map_err(|error| format!("create payload directory: {error}"))?;
+    let payload = serde_json::to_vec(&guest_contracts::env::RunPayload::default())
+        .map_err(|error| format!("serialize run payload: {error}"))?;
+    std::fs::write(&payload_path, payload)
+        .map_err(|error| format!("write run payload: {error}"))?;
+
+    GuestConfig::from_raw(GuestConfigRaw {
+        run_id: format!("mock-path-alias-{}-{case_name}", pair.name),
+        home: Some(tmp.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir),
+        run_payload_file: payload_path.to_string_lossy().into_owned(),
+        ..raw
+    })
+}
+
+fn expected_conflict_error(pair: MockPathEnvPair) -> String {
+    format!(
+        "conflicting mock binary path environment aliases: canonical_key={} \
+         legacy_key={} state=conflict",
+        pair.canonical, pair.legacy
+    )
+}
+
+fn assert_success_matrix(tmp: &Path, pair: MockPathEnvPair) -> TestResult {
+    for case in SUCCESS_CASES {
+        clear_mock_path_env();
+        apply_alias(pair.canonical, case.canonical);
+        apply_alias(pair.legacy, case.legacy);
+        let log_path = tmp.join(format!("{}-{}.log", pair.name, case.name));
+        let (raw, log) = capture_raw(&log_path)?;
+        let raw = raw.map_err(std::io::Error::other)?;
+
+        assert_eq!(
+            (pair.raw_value)(&raw),
+            case.expected_raw,
+            "{} {} resolved the wrong raw path state",
+            pair.name,
+            case.name
+        );
+        assert_source_evidence(&log, pair, case);
+
+        let config =
+            materialize_config(tmp, pair, case.name, raw).map_err(std::io::Error::other)?;
+        let expected_configured = case.expected_raw.unwrap_or(pair.default_path);
+        assert_eq!(
+            (pair.configured_value)(&config),
+            expected_configured,
+            "{} {} changed existing default or empty-path behavior",
+            pair.name,
+            case.name
+        );
+    }
+    Ok(())
+}
+
+fn assert_conflicts_fail_closed(tmp: &Path, pair: MockPathEnvPair) -> TestResult {
+    let expected_error = expected_conflict_error(pair);
+    for case in CONFLICT_CASES {
+        clear_mock_path_env();
+        set_test_env(pair.canonical, case.canonical);
+        set_test_env(pair.legacy, case.legacy);
+        let log_path = tmp.join(format!("{}-{}.log", pair.name, case.name));
+        let (raw, log) = capture_raw(&log_path)?;
+        let error = match raw {
+            Ok(_) => {
+                return Err(std::io::Error::other(format!(
+                    "{} {} accepted conflicting readable aliases",
+                    pair.name, case.name
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error, expected_error,
+            "{} {} returned the wrong fixed conflict error",
+            pair.name, case.name
+        );
+        assert_value_free(&error, case.name);
+        assert_value_free(&log, case.name);
+        assert!(
+            !log.contains(SOURCE_EVENT),
+            "{} {} emitted success evidence for a conflict",
+            pair.name,
+            case.name
+        );
+    }
+    Ok(())
+}
+
+fn assert_conflict_precedes_private_file_consumption(
+    tmp: &Path,
+    pair: MockPathEnvPair,
+) -> TestResult {
+    clear_mock_path_env();
+    let runtime_dir = tmp.join(format!("{}-capture-boundary-runtime", pair.name));
+    let payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let payload_path = payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&payload_dir)?;
+    std::fs::write(
+        &payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+    )?;
+
+    for key in [
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+    ] {
+        remove_test_env(key);
+    }
+    set_test_env(
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        &runtime_dir,
+    );
+    set_test_env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, &payload_path);
+    set_test_env(pair.canonical, CANONICAL_PATH);
+    set_test_env(pair.legacy, LEGACY_PATH);
+
+    let error = match GuestConfig::from_process_env() {
+        Ok(_) => {
+            return Err(std::io::Error::other(format!(
+                "{} conflict reached configuration materialization",
+                pair.name
+            ))
+            .into());
+        }
+        Err(error) => error,
+    };
+    assert_eq!(error, expected_conflict_error(pair));
+    assert_value_free(&error, pair.name);
+    assert!(
+        payload_path.exists(),
+        "{} conflict consumed the private run payload",
+        pair.name
+    );
+    Ok(())
+}
+
+#[test]
+fn process_env_dual_reads_mock_binary_path_aliases_without_value_leaks() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+
+    for pair in MOCK_PATH_ENV_PAIRS {
+        assert_success_matrix(tmp.path(), pair)?;
+        assert_conflicts_fail_closed(tmp.path(), pair)?;
+        assert_conflict_precedes_private_file_consumption(tmp.path(), pair)?;
+    }
+
+    clear_mock_path_env();
+    Ok(())
+}

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -459,10 +459,24 @@ pub const USE_MOCK_CODEX_ENV: &str = "USE_MOCK_CODEX";
 /// Unset means the guest-agent uses its compiled default mock binary path.
 pub const MOCK_CLAUDE_PATH_ENV: &str = "VM0_MOCK_CLAUDE_PATH";
 
+/// Canonical mock Claude binary path alias accepted by guest readers.
+///
+/// Existing test/debug writers keep using [`MOCK_CLAUDE_PATH_ENV`] until the
+/// reader floor, rollback window, and legacy-read-zero gates in #28914 are
+/// complete.
+pub const CANONICAL_MOCK_CLAUDE_PATH_ENV: &str = "OKOU_MOCK_CLAUDE_PATH";
+
 /// Optional test/debug override for the mock Codex binary path.
 ///
 /// Unset means the guest-agent uses its compiled default mock binary path.
 pub const MOCK_CODEX_PATH_ENV: &str = "VM0_MOCK_CODEX_PATH";
+
+/// Canonical mock Codex binary path alias accepted by guest readers.
+///
+/// Existing test/debug writers keep using [`MOCK_CODEX_PATH_ENV`] until the
+/// reader floor, rollback window, and legacy-read-zero gates in #28914 are
+/// complete.
+pub const CANONICAL_MOCK_CODEX_PATH_ENV: &str = "OKOU_MOCK_CODEX_PATH";
 
 /// Retired runner bootstrap key that must remain protected at the user-env
 /// boundary.
@@ -628,6 +642,10 @@ mod tests {
             CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
             "OKOU_POST_RESULT_SIGKILL_GRACE_SECS"
         );
+        assert_eq!(MOCK_CLAUDE_PATH_ENV, "VM0_MOCK_CLAUDE_PATH");
+        assert_eq!(CANONICAL_MOCK_CLAUDE_PATH_ENV, "OKOU_MOCK_CLAUDE_PATH");
+        assert_eq!(MOCK_CODEX_PATH_ENV, "VM0_MOCK_CODEX_PATH");
+        assert_eq!(CANONICAL_MOCK_CODEX_PATH_ENV, "OKOU_MOCK_CODEX_PATH");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add OKOU_MOCK_CLAUDE_PATH and OKOU_MOCK_CODEX_PATH as reader-only canonical aliases
- resolve each canonical/legacy pair once at the Guest Agent process-environment capture boundary
- preserve absent, non-Unicode, empty, equal-dual, and fail-closed conflict semantics with bounded value-free telemetry
- cover both pairs with complete process-isolated alias matrices

## Compatibility boundaries

- all 14 existing VM0_MOCK_CLAUDE_PATH / VM0_MOCK_CODEX_PATH integration writers remain unchanged
- USE_MOCK_CLAUDE, USE_MOCK_CODEX, default binary paths, Runner/API/workflows/configuration/secrets, namespace guards, and legacy readers are unchanged
- this is the reader-foundation stage only

## Fallbacks

- crates/guest-agent/src/env.rs:mock_binary_path_env — accepts the legacy VM0_MOCK_CLAUDE_PATH and VM0_MOCK_CODEX_PATH test/debug writer contract while introducing the canonical OKOU aliases. Surface: staged Guest Agent environment-namespace migration under #28914. Remove legacy reads only after the reader floor, canonical writer cutover, applicable rollback/drain window, and legacy-read-zero evidence are complete; follow-up: #28914.

## Verification

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features -- -D warnings
- cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-features --no-deps
- cargo test --manifest-path crates/Cargo.toml -p guest-contracts
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test mock_binary_path_env_aliases
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib env::tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test api_url_env_aliases --test api_token_env_aliases --test private_payload_file_env_aliases --test agent_execution_timeout_env_aliases --test guest_agent_tuning_env_aliases

## Review anchors

- worktree base: c6005170c0c6b76c1a09cbb455c6534e0332adb5
- implementation head: 6a049b6b4e43621ef2add232303503b4096aba19
- final pre-PR audit: 22 open PRs / 320 fully paginated changed-file records; only #25722 is file-adjacent, its exact diff is unchanged and has no mock-path semantic overlap

Closes #29380
