### PR TITLE
refactor(guest-agent): rename debug http retry-delay key

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -31,7 +31,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[cfg(debug_assertions)]
-const TEST_DISABLE_HTTP_RETRY_DELAY_ENV: &str = "VM0_TEST_DISABLE_HTTP_RETRY_DELAY";
+const TEST_DISABLE_HTTP_RETRY_DELAY_ENV: &str = "OKOU_TEST_DISABLE_HTTP_RETRY_DELAY";
 const GUEST_AGENT_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const API_RESPONSE_BODY_TOO_LARGE_DIAGNOSTIC: &str =
     "VM0 API response body exceeds the configured limit";

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -135,7 +135,7 @@ async fn run_event_failure_case(
     let output = common::command_output_with_timeout(
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
             .env_clear()
-            .env("VM0_TEST_DISABLE_HTTP_RETRY_DELAY", "1")
+            .env("OKOU_TEST_DISABLE_HTTP_RETRY_DELAY", "1")
             .env(
                 "PATH",
                 std::env::var("PATH")


### PR DESCRIPTION
## Summary

- rename the debug-only Guest Agent HTTP retry-delay test key to `OKOU_TEST_DISABLE_HTTP_RETRY_DELAY`
- update the same-checkout event-delivery integration writer to the canonical key
- preserve presence-based debug behavior and the fixed release default

Closes #29383.

## Verification

- `cargo fmt --package guest-agent -- --check`
- `cargo clippy --package guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --package guest-agent --all-targets --all-features`
- `cargo check --release --package guest-agent --lib --bin guest-agent --all-features`
- `cargo doc --package guest-agent --all-features --no-deps`
- `cargo test --package guest-agent --test event_delivery_failure_recovery`
- repository-wide search: zero `VM0_TEST_DISABLE_HTTP_RETRY_DELAY` occurrences
- `crates/guest-agent/src/workload_containment.rs` unchanged from the reviewed base
