### PR TITLE
refactor(api): dual-read api backend url aliases

### DIFF
--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -56,6 +56,7 @@ vi.stubEnv("R2_HOSTED_SITES_SECRET_ACCESS_KEY", "test-hosted-sites-secret-key");
 vi.stubEnv("OKOU_PUBLIC_HOST_DOMAIN", "okou.app");
 vi.stubEnv("ZERO_HOST_DOMAIN", "sites.example.com");
 vi.stubEnv("ZERO_HOST_SCHEME", "https");
+vi.stubEnv("OKOU_API_BACKEND_URL", undefined);
 vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 vi.stubEnv("FEISHU_CALLBACK_BASE_URL", "http://localhost:3000");
 vi.stubEnv("VM0_WEB_URL", "http://localhost:3001");

--- a/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
@@ -1,0 +1,145 @@
+import { EVENT } from "@axiomhq/logging";
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../__tests__/test-context";
+import { apiBackendUrl } from "../api-backend-url";
+import { mockEnv } from "../env";
+import { getOAuthApiOrigin } from "../oauth-origin";
+
+const context = testContext();
+
+const CANONICAL_API_BACKEND_URL_KEY = "OKOU_API_BACKEND_URL";
+const LEGACY_API_BACKEND_URL_KEY = "VM0_API_BACKEND_URL";
+const API_BACKEND_URL_ALIAS_RESOLUTION_EVENT =
+  "api_backend_url_alias_resolution";
+const API_BACKEND_URL_LOG_CONTEXT = "ApiBackendUrl";
+
+type ApiBackendUrlAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "equal-dual";
+
+interface ApiBackendUrlAliasFixture {
+  readonly state: ApiBackendUrlAliasState;
+  readonly canonical: string | undefined;
+  readonly legacy: string | undefined;
+  readonly expected: string | undefined;
+}
+
+const API_BACKEND_URL_ALIAS_FIXTURES: readonly ApiBackendUrlAliasFixture[] = [
+  {
+    state: "absent",
+    canonical: undefined,
+    legacy: undefined,
+    expected: undefined,
+  },
+  {
+    state: "canonical-only",
+    canonical: "https://canonical-only.example.test",
+    legacy: undefined,
+    expected: "https://canonical-only.example.test",
+  },
+  {
+    state: "legacy-only",
+    canonical: undefined,
+    legacy: "https://legacy-only.example.test",
+    expected: "https://legacy-only.example.test",
+  },
+  {
+    state: "equal-dual",
+    canonical: "https://equal-dual.example.test",
+    legacy: "https://equal-dual.example.test",
+    expected: "https://equal-dual.example.test",
+  },
+];
+
+function configureAliases(
+  canonical: string | undefined,
+  legacy: string | undefined,
+): void {
+  mockEnv(CANONICAL_API_BACKEND_URL_KEY, canonical);
+  mockEnv(LEGACY_API_BACKEND_URL_KEY, legacy);
+}
+
+function aliasEvidence(state: string): Readonly<Record<string, unknown>> {
+  return {
+    [EVENT]: { source: "api" },
+    canonicalKey: CANONICAL_API_BACKEND_URL_KEY,
+    legacyKey: LEGACY_API_BACKEND_URL_KEY,
+    state,
+    context: API_BACKEND_URL_LOG_CONTEXT,
+  };
+}
+
+describe("API backend URL aliases", () => {
+  it("resolves the non-conflicting matrix with one value-free event per state", () => {
+    for (const fixture of API_BACKEND_URL_ALIAS_FIXTURES) {
+      configureAliases(fixture.canonical, fixture.legacy);
+      const logCount = context.mocks.axiomLogging.debug.mock.calls.length;
+
+      expect(apiBackendUrl()).toBe(fixture.expected);
+      expect(apiBackendUrl()).toBe(fixture.expected);
+
+      const calls = context.mocks.axiomLogging.debug.mock.calls.slice(logCount);
+      expect(calls).toStrictEqual([
+        [API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, aliasEvidence(fixture.state)],
+      ]);
+      const evidence = JSON.stringify(calls);
+      const containsConfiguredValue = [fixture.canonical, fixture.legacy]
+        .filter((value): value is string => {
+          return value !== undefined;
+        })
+        .some((value) => {
+          return evidence.includes(value);
+        });
+      expect(containsConfiguredValue).toBeFalsy();
+    }
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on conflicting aliases with bounded value-free diagnostics", () => {
+    const canonical = "https://canonical-url-must-not-leak.example.test";
+    const legacy = "https://legacy-url-must-not-leak.example.test";
+    const expectedMessage =
+      "API backend URL aliases conflict: canonicalKey=OKOU_API_BACKEND_URL legacyKey=VM0_API_BACKEND_URL state=conflicting-dual";
+    configureAliases(canonical, legacy);
+
+    expect(() => {
+      apiBackendUrl();
+    }).toThrow(expectedMessage);
+    expect(() => {
+      apiBackendUrl();
+    }).toThrow(expectedMessage);
+
+    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([
+      [
+        API_BACKEND_URL_ALIAS_RESOLUTION_EVENT,
+        aliasEvidence("conflicting-dual"),
+      ],
+    ]);
+    const diagnostics = JSON.stringify({
+      error: expectedMessage,
+      logs: context.mocks.axiomLogging.warn.mock.calls,
+    });
+    expect(diagnostics).not.toContain(canonical);
+    expect(diagnostics).not.toContain(legacy);
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+  });
+});
+
+describe("OAuth API origin", () => {
+  it("keeps OAuth configured-origin normalization and sibling/web fallbacks", () => {
+    const request = new Request("https://request.example.test/oauth");
+    configureAliases("https://api.vm0.ai/configured/path", undefined);
+    mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+    expect(getOAuthApiOrigin(request)).toBe("https://api.vm0.ai");
+
+    configureAliases(undefined, undefined);
+    mockEnv("VM0_WEB_URL", "https://www.vm6.ai");
+    expect(getOAuthApiOrigin(request)).toBe("https://api.vm6.ai");
+
+    mockEnv("VM0_WEB_URL", "https://external.example.test/path");
+    expect(getOAuthApiOrigin(request)).toBe("https://external.example.test");
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
@@ -6,8 +6,9 @@ import { internalApiBaseUrl } from "../internal-api-url";
 // Mocked env is reset after each test by the shared test setup
 // (src/__tests__/setup.ts calls clearMockedEnv in afterEach).
 describe("internalApiBaseUrl", () => {
-  it("uses VM0_API_BACKEND_URL when set so internal API calls skip www", () => {
-    mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
+  it("uses OKOU_API_BACKEND_URL when set so internal API calls skip www", () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("VM0_API_BACKEND_URL", undefined);
     mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
 
     expect(internalApiBaseUrl()).toBe("https://api.vm0.ai");
@@ -19,16 +20,18 @@ describe("internalApiBaseUrl", () => {
     ).toBe("https://api.vm0.ai/api/cron/aggregate-model-stats");
   });
 
-  it("defaults to the API backend origin in production when VM0_API_BACKEND_URL is unset", () => {
+  it("defaults to the API backend origin in production when both aliases are unset", () => {
     mockEnv("ENV", "production");
+    mockEnv("OKOU_API_BACKEND_URL", undefined);
     mockEnv("VM0_API_BACKEND_URL", undefined);
     mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
 
     expect(internalApiBaseUrl()).toBe("https://vm0-api.vm6.ai");
   });
 
-  it("falls back to VM0_WEB_URL outside production when VM0_API_BACKEND_URL is unset", () => {
+  it("falls back to VM0_WEB_URL outside production when both aliases are unset", () => {
     mockEnv("ENV", "development");
+    mockEnv("OKOU_API_BACKEND_URL", undefined);
     mockEnv("VM0_API_BACKEND_URL", undefined);
     mockEnv("VM0_WEB_URL", "https://tunnel-abc.vm0.dev");
 

--- a/turbo/apps/api/src/lib/api-backend-url.ts
+++ b/turbo/apps/api/src/lib/api-backend-url.ts
@@ -1,0 +1,69 @@
+import { env } from "./env";
+import { logger } from "./log";
+import { singleton } from "./singleton";
+
+const CANONICAL_API_BACKEND_URL_KEY = "OKOU_API_BACKEND_URL";
+const LEGACY_API_BACKEND_URL_KEY = "VM0_API_BACKEND_URL";
+const API_BACKEND_URL_ALIAS_RESOLUTION_EVENT =
+  "api_backend_url_alias_resolution";
+
+type ApiBackendUrlAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "equal-dual"
+  | "conflicting-dual";
+
+const log = logger("ApiBackendUrl");
+const reportedStates = singleton(() => {
+  return new Set<ApiBackendUrlAliasState>();
+});
+
+function reportResolution(state: ApiBackendUrlAliasState): void {
+  const states = reportedStates();
+  if (states.has(state)) {
+    return;
+  }
+  states.add(state);
+
+  const fields = {
+    canonicalKey: CANONICAL_API_BACKEND_URL_KEY,
+    legacyKey: LEGACY_API_BACKEND_URL_KEY,
+    state,
+  };
+  if (state === "conflicting-dual") {
+    log.warn(API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
+    return;
+  }
+  log.debug(API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
+}
+
+// This API-process compatibility boundary retains VM0_API_BACKEND_URL while
+// repository, deployment, preview, and local writers remain legacy-only.
+// Under #28914, remove the legacy input only after an exact release containing
+// this reader reached every supported API runtime, the supported rollback
+// target can start after writer cutover, and value-free telemetry reports zero
+// legacy-only and equal-dual resolutions through that rollback window.
+export function apiBackendUrl(): string | undefined {
+  const canonical = env(CANONICAL_API_BACKEND_URL_KEY);
+  const legacy = env(LEGACY_API_BACKEND_URL_KEY);
+
+  if (!canonical) {
+    const state = legacy ? "legacy-only" : "absent";
+    reportResolution(state);
+    return legacy;
+  }
+  if (!legacy) {
+    reportResolution("canonical-only");
+    return canonical;
+  }
+  if (canonical === legacy) {
+    reportResolution("equal-dual");
+    return canonical;
+  }
+
+  reportResolution("conflicting-dual");
+  throw new Error(
+    `API backend URL aliases conflict: canonicalKey=${CANONICAL_API_BACKEND_URL_KEY} legacyKey=${LEGACY_API_BACKEND_URL_KEY} state=conflicting-dual`,
+  );
+}

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -55,6 +55,7 @@ const SCHEMA = {
   // Direct origin of the API backend for self-dispatched internal callbacks
   // (`/api/internal/**`). Optional; when unset, production defaults to the API
   // backend origin and other environments fall back to VM0_WEB_URL.
+  OKOU_API_BACKEND_URL: z.url().optional(),
   VM0_API_BACKEND_URL: z.url().optional(),
   FEISHU_CALLBACK_BASE_URL: z.url(),
   VM0_WEB_URL: z.url(),

--- a/turbo/apps/api/src/lib/internal-api-url.ts
+++ b/turbo/apps/api/src/lib/internal-api-url.ts
@@ -1,10 +1,11 @@
+import { apiBackendUrl } from "./api-backend-url";
 import { env } from "./env";
 
 /**
  * Base origin for API-originated internal self-dispatch callback URLs
  * (`/api/internal/**`).
  *
- * Resolves to VM0_API_BACKEND_URL, the direct API backend origin. When unset,
+ * Resolves to the configured API backend origin. When unset,
  * production defaults to the known API backend origin so internal callbacks
  * never hop through the marketing surface at www.vm0.ai; other environments
  * fall back to VM0_WEB_URL, keeping local tunnels and tests usable.
@@ -13,7 +14,7 @@ import { env } from "./env";
  * callbacks must not be routed through it.
  */
 export function internalApiBaseUrl(): string {
-  const backendUrl = env("VM0_API_BACKEND_URL");
+  const backendUrl = apiBackendUrl();
   if (backendUrl) {
     return backendUrl;
   }

--- a/turbo/apps/api/src/lib/oauth-origin.ts
+++ b/turbo/apps/api/src/lib/oauth-origin.ts
@@ -1,3 +1,4 @@
+import { apiBackendUrl } from "./api-backend-url";
 import { env } from "./env";
 
 const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
@@ -103,7 +104,7 @@ export function getOAuthWebOrigin(_request: Request): string {
 }
 
 export function getOAuthApiOrigin(_request: Request): string {
-  const backendUrl = env("VM0_API_BACKEND_URL");
+  const backendUrl = apiBackendUrl();
   if (backendUrl) {
     const configuredApiOrigin = new URL(backendUrl).origin;
     if (isTrustedHostedOrigin(configuredApiOrigin, "api")) {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -966,6 +966,8 @@ describe("cron execute morning briefs", () => {
   });
 
   it("delivers an Okou brief from persisted schedule context when no connectors are connected", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("VM0_API_BACKEND_URL", undefined);
     context.mocks.resend.send.mockResolvedValue({
       data: { id: "resend-threads-only-brief" },
       error: null,
@@ -1041,6 +1043,14 @@ describe("cron execute morning briefs", () => {
       "https://app.okou.ai/chats/123e4567-e89b-12d3-a456-426614174000",
     );
     expect(email.html).not.toContain("evil.example.com");
+    const oneClickHeader = email.headers?.["List-Unsubscribe"];
+    expect(oneClickHeader).toBeDefined();
+    if (!oneClickHeader) {
+      throw new Error("Expected an Okou one-click unsubscribe header");
+    }
+    const oneClickUrl = new URL(oneClickHeader.slice(1, -1));
+    expect(oneClickUrl.origin).toBe("https://api.okou.ai");
+    expect(oneClickUrl.pathname).toBe("/api/email/morning-brief/unsubscribe");
     clearMockNow();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/email.test.ts
@@ -102,6 +102,8 @@ beforeEach(() => {
   mockEnv("RESEND_API_KEY", "test-resend-key");
   mockEnv("RESEND_WEBHOOK_SECRET", INBOUND_SECRET);
   mockEnv("RESEND_FROM_DOMAIN", "mail.example.com");
+  mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+  mockEnv("VM0_API_BACKEND_URL", undefined);
   // Resend pacing is not part of these transactional delivery assertions.
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
 });
@@ -228,6 +230,27 @@ describe("POST /api/email/inbound", () => {
     expect(resendMocks.send).toHaveBeenCalledWith(
       expect.objectContaining({ to: controlActor.email }),
     );
+    const sent = resendMocks.send.mock.calls[0]?.[0];
+    if (!sent) {
+      throw new Error("Expected a data-export email");
+    }
+    if (
+      typeof sent !== "object" ||
+      sent === null ||
+      !("headers" in sent) ||
+      typeof sent.headers !== "object" ||
+      sent.headers === null
+    ) {
+      throw new Error("Expected a one-click unsubscribe header");
+    }
+    const oneClickHeader = Reflect.get(sent.headers, "List-Unsubscribe");
+    if (typeof oneClickHeader !== "string") {
+      throw new Error("Expected a one-click unsubscribe header");
+    }
+    const oneClickUrl = new URL(oneClickHeader.slice(1, -1));
+    expect(oneClickUrl.origin).toBe("https://api.vm0.ai");
+    expect(oneClickUrl.pathname).toBe("/api/email/unsubscribe");
+    expect(oneClickUrl.searchParams.get("token")).toBeTruthy();
   });
 
   it("keeps bounced recipients out of transactional sends", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -697,7 +697,8 @@ describe("Feishu integration", () => {
   beforeEach(() => {
     oauthUserOpenId = "ou_oauth_user";
     mockEnv("APP_URL", APP_ORIGIN);
-    mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.test");
+    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.test");
+    mockEnv("VM0_API_BACKEND_URL", undefined);
     mockEnv("VM0_WEB_URL", "https://www.vm0.test");
     mockEnv("FEISHU_CALLBACK_BASE_URL", FEISHU_CALLBACK_ORIGIN);
     mockOptionalEnv("OPENROUTER_API_KEY", undefined);

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -120,6 +120,7 @@ const FAL_FLUX_2_PRO_ADDITIONAL_MEGAPIXEL_CREDITS = 18;
 const FAL_IDEOGRAM_4_TURBO_MEGAPIXEL_CREDITS = 9;
 const FAL_IDEOGRAM_4_BALANCED_MEGAPIXEL_CREDITS = 18;
 const FAL_IDEOGRAM_4_QUALITY_MEGAPIXEL_CREDITS = 30;
+const API_ORIGIN = "https://api.vm0.test";
 const WEB_ORIGIN = "https://www.vm0.test";
 const MISSING_PRICING_IMAGE_MODEL = "gpt-image-2";
 const IMAGE_PRICING_CATEGORIES = [
@@ -1144,6 +1145,8 @@ describe("POST /api/image-io/generate", () => {
   });
 
   it("generates image files on the Okou CDN for Okou run-scoped agent tokens", async () => {
+    mockEnv("OKOU_API_BACKEND_URL", API_ORIGIN);
+    mockEnv("VM0_API_BACKEND_URL", undefined);
     const fixture = await seedImageFixture({});
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,
@@ -1222,7 +1225,7 @@ describe("POST /api/image-io/generate", () => {
     });
     await flushWaitUntilForTest();
     const webhookUrl = new URL(readWebhookUrl(observedRequestUrl));
-    expect(webhookUrl.origin).toBe(WEB_ORIGIN);
+    expect(webhookUrl.origin).toBe(API_ORIGIN);
     expect(webhookUrl.pathname).toBe(
       `/api/webhooks/built-in-generations/fal/${generationId}`,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -9,7 +9,7 @@ import { expect } from "vitest";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -129,7 +129,8 @@ function configureGoogleCalendarApiMock(args: {
     incrementalCalls: 0,
   };
   let incrementalCallCount = 0;
-  mockOptionalEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
+  mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
+  mockEnv("VM0_API_BACKEND_URL", undefined);
   server.use(
     http.post(
       "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -394,7 +394,7 @@ function configureGoogleCalendarWatchMock(args?: {
     channelIds: [],
   };
   const calendarId = args?.calendarId ?? "primary";
-  mockOptionalEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
+  mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
   server.use(
     http.post(
       "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",

--- a/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-generation-provider-webhooks.service.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { apiBackendUrl } from "../../lib/api-backend-url";
 import { env } from "../../lib/env";
 
 type BuiltInGenerationProviderWebhookProvider = "fal" | "byteplus" | "minimax";
@@ -66,7 +67,7 @@ export function falBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/fal/${args.generationId}`,
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
   );
   baseUrl.searchParams.set(
     "token",
@@ -88,7 +89,7 @@ export function bytePlusBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/byteplus/${args.generationId}`,
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
   );
   baseUrl.searchParams.set(
     "token",
@@ -110,7 +111,7 @@ export function miniMaxBuiltInGenerationWebhookUrl(args: {
 }): string {
   const baseUrl = new URL(
     `/api/webhooks/built-in-generations/minimax/${args.generationId}`,
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
   );
   baseUrl.searchParams.set(
     "token",

--- a/turbo/apps/api/src/signals/services/email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/email-common.service.ts
@@ -19,6 +19,7 @@ import {
   publicBrandPresentation,
 } from "@okouai/core/public-brand";
 
+import { apiBackendUrl } from "../../lib/api-backend-url";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -146,7 +147,7 @@ function getResendClient(): Resend {
 
 function apiUrl(publicBrand: PublicBrand): string {
   return apiUrlForPublicBrand(
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
     publicBrand,
   );
 }

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -3,6 +3,7 @@ import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installatio
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { apiUrlForPublicBrand } from "@okouai/core/public-brand";
 
+import { apiBackendUrl } from "../../lib/api-backend-url";
 import { env } from "../../lib/env";
 import type { Db } from "../external/db";
 import { decryptPersistentSecretValue } from "./crypto.utils";
@@ -105,7 +106,7 @@ export function feishuOAuthAppCallbackUrl(): string {
 export function feishuOAuthConnectUrl(state: string): string {
   const url = new URL(
     "/api/feishu/oauth/connect",
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
   );
   url.searchParams.set("state", state);
   return url.toString();

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -17,7 +17,8 @@ import {
   workflowAutomations,
   workflows,
 } from "@okouai/db/schema/workflow";
-import { env, optionalEnv } from "../../lib/env";
+import { apiBackendUrl } from "../../lib/api-backend-url";
+import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { writeDb$, type Db } from "../external/db";
@@ -389,7 +390,7 @@ function calendarEventsUrl(calendarId: string): string {
 }
 
 function googleCalendarWebhookUrl(): string {
-  const baseUrl = optionalEnv("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL");
+  const baseUrl = apiBackendUrl() ?? env("VM0_WEB_URL");
   return new URL("/api/webhooks/google-calendar", baseUrl).toString();
 }
 

--- a/turbo/apps/api/src/signals/services/morning-brief-email-link.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-email-link.service.ts
@@ -5,6 +5,7 @@ import {
   appUrlForPublicBrand,
 } from "@okouai/core/public-brand";
 
+import { apiBackendUrl } from "../../lib/api-backend-url";
 import { env } from "../../lib/env";
 
 export const MORNING_BRIEF_PREHEADER =
@@ -36,7 +37,7 @@ export function buildMorningBriefUnsubscribeUrl(
   publicBrand: PublicBrand = "vm0",
 ): string {
   const apiUrl = apiUrlForPublicBrand(
-    env("VM0_API_BACKEND_URL") ?? env("VM0_WEB_URL"),
+    apiBackendUrl() ?? env("VM0_WEB_URL"),
     publicBrand,
   );
   return `${apiUrl}/api/email/morning-brief/unsubscribe?token=${buildToken(orgId, userId)}`;


### PR DESCRIPTION
## Summary

- add one centralized, value-free `OKOU_API_BACKEND_URL` / `VM0_API_BACKEND_URL` reader for the API process
- route all nine active production API consumers through it while preserving their existing unset fallback, trust, branding, path, query, and signing behavior
- cover the complete alias matrix and representative integrated consumers without changing any external writer or excluded deployable boundary

Closes #29377
Part of #28914 (Wave 40)

## Base and overlap evidence

- authoritative issue checkpoint was `main@c6005170c0c6b76c1a09cbb455c6534e0332adb5`; after subsequent mainline movement and the CI repair, the exact implementation base is `main@688fb07a5429bdac8c4ddbd5c8f121ebc72c31a5`
- final fully paginated scan: 25 open PRs, 402 changed-file records (18 from this PR and 384 from the other 24 open PRs)
- overlaps: #29337 only in an independent Feishu test area; #25722 only in `turbo/apps/api/src/lib/env.ts`
- #25722 remains open and unchanged at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`; its proposed Cloudflare readers are not active on `main`
- `.github/**`, release/rollback/Turbo writers, preview/E2E/local writers, Turbo CLI, Runner, Guest Agent, Guest Contracts, and production state are unchanged

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- focused API tests: alias matrix/OAuth, internal self-dispatch, email, signed image webhook, Google Calendar, Feishu, and Morning Brief routes
- semantic caller scan: no direct production `VM0_API_BACKEND_URL` read remains outside the compatibility reader
- boundary diff scan: no excluded writer or deployable component changed

The relevant Morning Brief route assertion reaches a pre-existing local runner-queue `404 Job not found in queue` before its changed URL assertion; the identical failure was reproduced on a pristine worktree at the exact base. One repaired Google Calendar integration case likewise reaches a pre-existing local `job undefined` runner-queue assertion after the changed URL path, reproduced identically on the pristine base. Protected PR CI remains authoritative for repository-wide gates.

## Fallbacks

- **Surface:** API-process backend URL readers only.
- **Retained legacy input:** `VM0_API_BACKEND_URL` remains accepted when `OKOU_API_BACKEND_URL` is absent; all consumer-specific `VM0_WEB_URL`, internal direct-origin, OAuth trust/sibling-origin, public-brand, path, query, and signing fallbacks remain unchanged.
- **Conflict and telemetry:** unequal dual values fail closed. Resolution telemetry is value-free, bounded to at most one event per state per API process, and distinguishes `absent`, `canonical-only`, `legacy-only`, `equal-dual`, and `conflicting-dual`.
- **Exact removal gate and rollback window:** under #28914, remove the legacy reader only after an exact release containing this reader has reached every supported API runtime, the immediately supported rollback target can still start after canonical writer cutover, and telemetry shows zero `legacy-only` and zero `equal-dual` resolutions throughout the supported rollback window.
