### PR TITLE
perf(runner): specialize guest state restore operation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1367,6 +1367,7 @@ name = "guest-reseed"
 version = "0.3.5"
 dependencies = [
  "libc",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/guest-reseed/Cargo.toml
+++ b/crates/guest-reseed/Cargo.toml
@@ -7,5 +7,8 @@ description = "Inject entropy and force CRNG reseed after Firecracker snapshot r
 [dependencies]
 libc.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/guest-reseed/src/lib.rs
+++ b/crates/guest-reseed/src/lib.rs
@@ -143,7 +143,13 @@ fn sync_timezone(timezone: &str) -> io::Result<bool> {
 }
 
 fn sync_timezone_at(root: &Path, timezone: &str) -> io::Result<bool> {
-    let zoneinfo = root.join("usr/share/zoneinfo").join(timezone);
+    // The previous shell command appended the validated name to the zoneinfo
+    // directory textually. Strip leading separators before `Path::join` so an
+    // accepted name such as `/UTC` keeps that behavior instead of replacing
+    // the trusted root prefix.
+    let zoneinfo = root
+        .join("usr/share/zoneinfo")
+        .join(timezone.trim_start_matches('/'));
     if !zoneinfo.is_file() {
         return Ok(false);
     }
@@ -702,5 +708,6 @@ mod tests {
             b"PATH=/usr/bin\nLANG=C\nTZ=Asia/Shanghai\n"
         );
         assert!(!sync_timezone_at(root.path(), "Mars/Olympus").unwrap());
+        assert!(!sync_timezone_at(root.path(), "/etc/passwd").unwrap());
     }
 }

--- a/crates/guest-reseed/src/lib.rs
+++ b/crates/guest-reseed/src/lib.rs
@@ -8,10 +8,12 @@
 //! the `RNDRESEEDCRNG` ioctl so restored VMs do not share identical random
 //! output.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, Read, Write};
+use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
+use std::path::Path;
 
 /// ioctl request code for RNDRESEEDCRNG.
 ///
@@ -21,6 +23,27 @@ use std::os::unix::io::AsRawFd;
 /// See `include/uapi/linux/random.h` in the kernel source.
 const RNDRESEEDCRNG: libc::Ioctl = 0x5207;
 const MAX_ENTROPY_BYTES: usize = 64 * 1024;
+const RESTORE_ENTROPY_BYTES: usize = 256;
+const RESTORE_MODE_ARG: &str = "--restore-state";
+const CLOCK_SYNC_FAILED_MARKER: &str = "guest clock sync failed";
+const RESEED_FAILED_MARKER: &str = "guest-reseed failed";
+const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
+const TIMEZONE_UNAVAILABLE_MARKER: &str = "guest timezone unavailable";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RestoreTimezoneMode {
+    None,
+    BestEffort,
+    Required,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct RestoreArgs {
+    seconds: u64,
+    nanoseconds: u32,
+    timezone_mode: RestoreTimezoneMode,
+    timezone: Option<String>,
+}
 
 fn read_entropy(mut input: impl Read) -> io::Result<Vec<u8>> {
     let mut entropy = Vec::new();
@@ -36,6 +59,25 @@ fn read_entropy(mut input: impl Read) -> io::Result<Vec<u8>> {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "entropy too large",
+        ));
+    }
+    Ok(entropy)
+}
+
+fn read_restore_entropy(mut input: impl Read) -> io::Result<[u8; RESTORE_ENTROPY_BYTES]> {
+    let mut entropy = [0u8; RESTORE_ENTROPY_BYTES];
+    input
+        .read_exact(&mut entropy)
+        .map_err(|error| io::Error::new(error.kind(), format!("read stdin: {error}")))?;
+    let mut trailing = [0u8; 1];
+    if input
+        .read(&mut trailing)
+        .map_err(|error| io::Error::new(error.kind(), format!("read stdin: {error}")))?
+        != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "restore entropy must contain exactly 256 bytes",
         ));
     }
     Ok(entropy)
@@ -69,47 +111,233 @@ fn reseed(entropy: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+fn set_realtime(seconds: u64, nanoseconds: u32) -> io::Result<()> {
+    let timestamp = libc::timespec {
+        tv_sec: seconds
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "seconds exceed time_t"))?,
+        tv_nsec: libc::c_long::from(nanoseconds),
+    };
+
+    // SAFETY: `timestamp` is fully initialized, nanoseconds are validated by
+    // the CLI parser, and CLOCK_REALTIME accepts a pointer to this structure.
+    if unsafe { libc::clock_settime(libc::CLOCK_REALTIME, &timestamp) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn is_safe_timezone_name(timezone: &str) -> bool {
+    !timezone.is_empty()
+        && timezone.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || byte == b'/'
+                || byte == b'_'
+                || byte == b'-'
+                || byte == b'+'
+        })
+}
+
+fn sync_timezone(timezone: &str) -> io::Result<bool> {
+    sync_timezone_at(Path::new("/"), timezone)
+}
+
+fn sync_timezone_at(root: &Path, timezone: &str) -> io::Result<bool> {
+    let zoneinfo = root.join("usr/share/zoneinfo").join(timezone);
+    if !zoneinfo.is_file() {
+        return Ok(false);
+    }
+
+    fs::write(root.join("etc/timezone"), format!("{timezone}\n"))?;
+    let localtime = root.join("etc/localtime");
+    match fs::symlink_metadata(&localtime) {
+        Ok(_) => fs::remove_file(&localtime)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    symlink(format!("/usr/share/zoneinfo/{timezone}"), &localtime)?;
+
+    let environment_path = root.join("etc/environment");
+    let environment = fs::read(&environment_path)?;
+    let mut updated = Vec::with_capacity(environment.len() + timezone.len() + 4);
+    for line in environment.split_inclusive(|byte| *byte == b'\n') {
+        if !line.starts_with(b"TZ=") {
+            updated.extend_from_slice(line);
+        }
+    }
+    if !updated.is_empty() && !updated.ends_with(b"\n") {
+        updated.push(b'\n');
+    }
+    updated.extend_from_slice(b"TZ=");
+    updated.extend_from_slice(timezone.as_bytes());
+    updated.push(b'\n');
+    fs::write(environment_path, updated)?;
+
+    Ok(true)
+}
+
+fn parse_restore_args(args: &[OsString]) -> Result<RestoreArgs, &'static str> {
+    if args.first().and_then(|arg| arg.to_str()) != Some(RESTORE_MODE_ARG) {
+        return Err("missing restore mode");
+    }
+    let seconds = args
+        .get(1)
+        .and_then(|arg| arg.to_str())
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or("invalid restore seconds")?;
+    let nanoseconds = args
+        .get(2)
+        .and_then(|arg| arg.to_str())
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|value| *value < 1_000_000_000)
+        .ok_or("invalid restore nanoseconds")?;
+    let timezone_mode = match args.get(3).and_then(|arg| arg.to_str()) {
+        Some("none") => RestoreTimezoneMode::None,
+        Some("best-effort") => RestoreTimezoneMode::BestEffort,
+        Some("required") => RestoreTimezoneMode::Required,
+        _ => return Err("invalid restore timezone mode"),
+    };
+    let timezone = args.get(4).and_then(|arg| arg.to_str());
+    match timezone_mode {
+        RestoreTimezoneMode::None if args.len() == 4 => Ok(RestoreArgs {
+            seconds,
+            nanoseconds,
+            timezone_mode,
+            timezone: None,
+        }),
+        RestoreTimezoneMode::BestEffort | RestoreTimezoneMode::Required
+            if args.len() == 5 && timezone.is_some_and(is_safe_timezone_name) =>
+        {
+            Ok(RestoreArgs {
+                seconds,
+                nanoseconds,
+                timezone_mode,
+                timezone: timezone.map(ToOwned::to_owned),
+            })
+        }
+        RestoreTimezoneMode::None => Err("restore timezone is not allowed for none mode"),
+        RestoreTimezoneMode::BestEffort | RestoreTimezoneMode::Required => {
+            Err("restore timezone is missing or invalid")
+        }
+    }
+}
+
 /// Runs the `guest-reseed` CLI.
 ///
 /// `args` must contain the command-line arguments after the executable name,
-/// matching `std::env::args_os().skip(1)`. The command accepts no arguments;
-/// use the following syntax:
+/// matching `std::env::args_os().skip(1)`. Entropy-only mode uses:
 ///
 /// ```text
 /// guest-reseed < entropy-bytes
 /// ```
 ///
-/// `input` supplies raw entropy bytes through stdin. The input must contain
-/// between 1 and 65,536 bytes, inclusive. `stderr` receives usage and runtime
+/// The fixed guest-state operation uses:
+///
+/// ```text
+/// guest-reseed --restore-state <seconds> <nanoseconds> \
+///   <none|best-effort|required> [timezone] < entropy-bytes
+/// ```
+///
+/// Entropy-only input must contain between 1 and 65,536 bytes. Restore input
+/// must contain exactly 256 bytes. `stderr` receives usage and runtime
 /// diagnostics.
 ///
 /// Valid input is written to `/dev/urandom`, then the kernel CRNG is force-
 /// reseeded through the `RNDRESEEDCRNG` ioctl. This operation requires
 /// `CAP_SYS_ADMIN`.
 ///
+/// Restore mode sets the realtime clock, reseeds the CRNG, then optionally
+/// applies the timezone. Required timezone failures return non-zero;
+/// best-effort application failures emit a marker and return success.
+///
 /// Returns process-style exit codes: `0` for success and `1` for argument,
-/// input, or reseed failures.
+/// input, clock, reseed, or required-timezone failures.
 pub fn run_cli<I, A>(input: impl Read, stderr: impl Write, args: I) -> i32
 where
     I: IntoIterator<Item = A>,
     A: AsRef<OsStr>,
 {
-    run_with_reseed(input, stderr, args, reseed)
+    run_with_operations(input, stderr, args, set_realtime, reseed, sync_timezone)
 }
 
-fn run_with_reseed<R, W, I, A, F>(input: R, mut stderr: W, args: I, reseed_fn: F) -> i32
+fn run_with_operations<R, W, I, A, C, S, T>(
+    input: R,
+    mut stderr: W,
+    args: I,
+    clock_fn: C,
+    reseed_fn: S,
+    timezone_fn: T,
+) -> i32
 where
     R: Read,
     W: Write,
     I: IntoIterator<Item = A>,
     A: AsRef<OsStr>,
-    F: FnOnce(&[u8]) -> io::Result<()>,
+    C: FnOnce(u64, u32) -> io::Result<()>,
+    S: FnOnce(&[u8]) -> io::Result<()>,
+    T: FnOnce(&str) -> io::Result<bool>,
 {
-    if args.into_iter().next().is_some() {
-        let _ = writeln!(stderr, "usage: guest-reseed < entropy-bytes");
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_owned())
+        .collect::<Vec<_>>();
+    if args.is_empty() {
+        return run_entropy_only(input, &mut stderr, reseed_fn);
+    }
+
+    let restore = match parse_restore_args(&args) {
+        Ok(restore) => restore,
+        Err(error) => {
+            let _ = writeln!(stderr, "guest-reseed: {error}");
+            let _ = writeln!(
+                stderr,
+                "usage: guest-reseed --restore-state <seconds> <nanoseconds> <none|best-effort|required> [timezone] < entropy-bytes"
+            );
+            return 1;
+        }
+    };
+    let entropy = match read_restore_entropy(input) {
+        Ok(entropy) => entropy,
+        Err(error) => {
+            let _ = writeln!(stderr, "guest-reseed: {error}");
+            return 1;
+        }
+    };
+    if let Err(error) = clock_fn(restore.seconds, restore.nanoseconds) {
+        let _ = writeln!(stderr, "{CLOCK_SYNC_FAILED_MARKER}: {error}");
+        return 1;
+    }
+    if let Err(error) = reseed_fn(&entropy) {
+        let _ = writeln!(stderr, "{RESEED_FAILED_MARKER}: {error}");
         return 1;
     }
 
+    let Some(timezone) = restore.timezone.as_deref() else {
+        return 0;
+    };
+    match timezone_fn(timezone) {
+        Ok(true) => 0,
+        Ok(false) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => 0,
+        Ok(false) => {
+            let _ = writeln!(stderr, "{TIMEZONE_UNAVAILABLE_MARKER}");
+            1
+        }
+        Err(error) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => {
+            let _ = writeln!(stderr, "{TIMEZONE_SYNC_FAILED_MARKER}: {error}");
+            0
+        }
+        Err(error) => {
+            let _ = writeln!(stderr, "{TIMEZONE_SYNC_FAILED_MARKER}: {error}");
+            1
+        }
+    }
+}
+
+fn run_entropy_only(
+    input: impl Read,
+    mut stderr: impl Write,
+    reseed_fn: impl FnOnce(&[u8]) -> io::Result<()>,
+) -> i32 {
     let entropy = match read_entropy(input) {
         Ok(entropy) => entropy,
         Err(e) => {
@@ -128,9 +356,30 @@ where
 }
 
 #[cfg(test)]
+fn run_with_reseed<R, W, I, A, F>(input: R, stderr: W, args: I, reseed_fn: F) -> i32
+where
+    R: Read,
+    W: Write,
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+    F: FnOnce(&[u8]) -> io::Result<()>,
+{
+    let args = args.into_iter().collect::<Vec<_>>();
+    if !args.is_empty() {
+        let mut stderr = stderr;
+        let _ = writeln!(stderr, "usage: guest-reseed < entropy-bytes");
+        return 1;
+    }
+    run_entropy_only(input, stderr, reseed_fn)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::cell::Cell;
+    use std::cell::RefCell;
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
 
     #[test]
     fn read_entropy_accepts_raw_stdin_bytes() {
@@ -228,5 +477,230 @@ mod tests {
             String::from_utf8(stderr).unwrap(),
             "usage: guest-reseed < entropy-bytes\n"
         );
+    }
+
+    #[test]
+    fn restore_mode_runs_clock_reseed_and_timezone_in_order() {
+        let events = RefCell::new(Vec::new());
+        let entropy = [7u8; RESTORE_ENTROPY_BYTES];
+        let mut stderr = Vec::new();
+
+        let code = run_with_operations(
+            &entropy[..],
+            &mut stderr,
+            [
+                RESTORE_MODE_ARG,
+                "123",
+                "456000000",
+                "required",
+                "Asia/Shanghai",
+            ],
+            |seconds, nanoseconds| {
+                events
+                    .borrow_mut()
+                    .push(format!("clock:{seconds}:{nanoseconds}"));
+                Ok(())
+            },
+            |received| {
+                assert_eq!(received, entropy);
+                events.borrow_mut().push("reseed".to_string());
+                Ok(())
+            },
+            |timezone| {
+                events.borrow_mut().push(format!("timezone:{timezone}"));
+                Ok(true)
+            },
+        );
+
+        assert_eq!(code, 0);
+        assert!(stderr.is_empty());
+        assert_eq!(
+            events.into_inner(),
+            ["clock:123:456000000", "reseed", "timezone:Asia/Shanghai"]
+        );
+    }
+
+    #[test]
+    fn restore_mode_requires_exact_entropy_and_stops_before_clock() {
+        for entropy in [
+            vec![1; RESTORE_ENTROPY_BYTES - 1],
+            vec![1; RESTORE_ENTROPY_BYTES + 1],
+        ] {
+            let clock_called = Cell::new(false);
+            let mut stderr = Vec::new();
+            let code = run_with_operations(
+                &entropy[..],
+                &mut stderr,
+                [RESTORE_MODE_ARG, "123", "0", "none"],
+                |_, _| {
+                    clock_called.set(true);
+                    Ok(())
+                },
+                |_| Ok(()),
+                |_| Ok(true),
+            );
+
+            assert_eq!(code, 1);
+            assert!(!clock_called.get());
+            assert!(!stderr.is_empty());
+        }
+    }
+
+    #[test]
+    fn restore_mode_stops_after_clock_or_reseed_failure() {
+        let entropy = [3u8; RESTORE_ENTROPY_BYTES];
+        let reseed_called = Cell::new(false);
+        let timezone_called = Cell::new(false);
+        let mut stderr = Vec::new();
+        let code = run_with_operations(
+            &entropy[..],
+            &mut stderr,
+            [RESTORE_MODE_ARG, "123", "0", "required", "UTC"],
+            |_, _| Err(io::Error::other("clock denied")),
+            |_| {
+                reseed_called.set(true);
+                Ok(())
+            },
+            |_| {
+                timezone_called.set(true);
+                Ok(true)
+            },
+        );
+        assert_eq!(code, 1);
+        assert!(!reseed_called.get());
+        assert!(!timezone_called.get());
+        assert!(
+            String::from_utf8(stderr)
+                .unwrap()
+                .contains(CLOCK_SYNC_FAILED_MARKER)
+        );
+
+        let timezone_called = Cell::new(false);
+        let mut stderr = Vec::new();
+        let code = run_with_operations(
+            &entropy[..],
+            &mut stderr,
+            [RESTORE_MODE_ARG, "123", "0", "required", "UTC"],
+            |_, _| Ok(()),
+            |_| Err(io::Error::other("ioctl denied")),
+            |_| {
+                timezone_called.set(true);
+                Ok(true)
+            },
+        );
+        assert_eq!(code, 1);
+        assert!(!timezone_called.get());
+        assert!(
+            String::from_utf8(stderr)
+                .unwrap()
+                .contains(RESEED_FAILED_MARKER)
+        );
+    }
+
+    #[test]
+    fn restore_mode_preserves_required_and_best_effort_timezone_failures() {
+        let entropy = [5u8; RESTORE_ENTROPY_BYTES];
+        for (mode, timezone_result, expected_code, marker) in [
+            ("best-effort", Ok(false), 0, None),
+            (
+                "best-effort",
+                Err(io::Error::other("write denied")),
+                0,
+                Some(TIMEZONE_SYNC_FAILED_MARKER),
+            ),
+            ("required", Ok(false), 1, Some(TIMEZONE_UNAVAILABLE_MARKER)),
+            (
+                "required",
+                Err(io::Error::other("write denied")),
+                1,
+                Some(TIMEZONE_SYNC_FAILED_MARKER),
+            ),
+        ] {
+            let mut stderr = Vec::new();
+            let code = run_with_operations(
+                &entropy[..],
+                &mut stderr,
+                [RESTORE_MODE_ARG, "123", "0", mode, "UTC"],
+                |_, _| Ok(()),
+                |_| Ok(()),
+                |_| timezone_result,
+            );
+            let stderr = String::from_utf8(stderr).unwrap();
+
+            assert_eq!(code, expected_code, "mode={mode} stderr={stderr}");
+            if let Some(marker) = marker {
+                assert!(stderr.contains(marker), "mode={mode} stderr={stderr}");
+            } else {
+                assert!(stderr.is_empty(), "mode={mode} stderr={stderr}");
+            }
+        }
+    }
+
+    #[test]
+    fn restore_mode_rejects_invalid_timestamp_mode_and_timezone() {
+        let cases: &[&[&str]] = &[
+            &[RESTORE_MODE_ARG, "bad", "0", "none"],
+            &[RESTORE_MODE_ARG, "1", "1000000000", "none"],
+            &[RESTORE_MODE_ARG, "1", "0", "unknown"],
+            &[RESTORE_MODE_ARG, "1", "0", "none", "UTC"],
+            &[RESTORE_MODE_ARG, "1", "0", "required"],
+            &[RESTORE_MODE_ARG, "1", "0", "required", "../UTC"],
+        ];
+        let entropy = [8u8; RESTORE_ENTROPY_BYTES];
+
+        for args in cases {
+            let mut stderr = Vec::new();
+            let code = run_with_operations(
+                &entropy[..],
+                &mut stderr,
+                args.iter().copied(),
+                |_, _| Ok(()),
+                |_| Ok(()),
+                |_| Ok(true),
+            );
+
+            assert_eq!(code, 1, "args={args:?}");
+            assert!(
+                String::from_utf8(stderr).unwrap().contains("usage:"),
+                "args={args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn timezone_sync_updates_guest_files_in_order_compatible_shape() {
+        let root = tempfile::tempdir().unwrap();
+        let zone = root.path().join("usr/share/zoneinfo/Asia/Shanghai");
+        fs::create_dir_all(zone.parent().unwrap()).unwrap();
+        fs::write(&zone, b"zone").unwrap();
+        fs::create_dir_all(root.path().join("etc")).unwrap();
+        fs::write(root.path().join("etc/timezone"), b"UTC\n").unwrap();
+        fs::write(root.path().join("etc/localtime"), b"old").unwrap();
+        fs::write(
+            root.path().join("etc/environment"),
+            b"PATH=/usr/bin\nTZ=UTC\nLANG=C",
+        )
+        .unwrap();
+
+        assert!(sync_timezone_at(root.path(), "Asia/Shanghai").unwrap());
+
+        assert_eq!(
+            fs::read(root.path().join("etc/timezone")).unwrap(),
+            b"Asia/Shanghai\n"
+        );
+        let localtime = root.path().join("etc/localtime");
+        assert_eq!(
+            fs::read_link(&localtime).unwrap(),
+            Path::new("/usr/share/zoneinfo/Asia/Shanghai")
+        );
+        assert_eq!(
+            fs::symlink_metadata(localtime).unwrap().mode() & libc::S_IFMT,
+            libc::S_IFLNK
+        );
+        assert_eq!(
+            fs::read(root.path().join("etc/environment")).unwrap(),
+            b"PATH=/usr/bin\nLANG=C\nTZ=Asia/Shanghai\n"
+        );
+        assert!(!sync_timezone_at(root.path(), "Mars/Olympus").unwrap());
     }
 }

--- a/crates/guest-reseed/src/main.rs
+++ b/crates/guest-reseed/src/main.rs
@@ -4,19 +4,22 @@
 //! after snapshot restore on x86_64) does not work because the kernel driver
 //! only supports ACPI, and DeviceTree support requires kernel 6.10+.
 //!
-//! This binary is called by the runner executor immediately after snapshot
-//! restore to inject fresh host entropy from stdin and force an immediate CRNG
-//! reseed, ensuring each VM produces unique random output.
+//! This binary is called by the fixed guest-state operation immediately after
+//! snapshot restore. Its explicit restore mode repairs the frozen realtime
+//! clock, injects fresh host entropy, forces an immediate CRNG reseed, and then
+//! optionally applies the guest timezone.
 //!
 //! Usage: guest-reseed < entropy-bytes
+//!        guest-reseed --restore-state <seconds> <nanoseconds>
+//!          <none|best-effort|required> [timezone] < entropy-bytes
 //!
-//! The command accepts no arguments after the executable name and reads raw
-//! entropy bytes from stdin. Input must contain 1 through 65,536 bytes.
+//! Entropy-only mode accepts no arguments and reads 1 through 65,536 raw bytes
+//! from stdin. Restore mode reads exactly 256 raw bytes.
 //!
 //! Entropy is written to /dev/urandom, then the CRNG is force-reseeded via the
-//! RNDRESEEDCRNG ioctl. Requires CAP_SYS_ADMIN (run as root). The command
-//! returns 0 on success and 1 for argument, input, or reseed failures; stderr
-//! receives diagnostics.
+//! RNDRESEEDCRNG ioctl. Restore mode also needs permission to set realtime and
+//! update `/etc`. The command returns 0 on success and 1 for argument, input,
+//! clock, reseed, or required-timezone failures; stderr receives diagnostics.
 
 fn main() {
     std::process::exit(guest_reseed::run_cli(

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -767,10 +767,9 @@ mod tests {
                     "workspace_device='/dev/vdb'",
                     sandbox_exec_error(self.primary_error().unwrap()),
                 ),
-                Self::GuestRestoreFailure => overrides.add_exec_error_matcher(
-                    "guest-reseed",
+                Self::GuestRestoreFailure => overrides.push_guest_state_restore_result(Err(
                     sandbox_exec_error(self.primary_error().unwrap()),
-                ),
+                )),
                 Self::ExecFailure => overrides.add_exec_error_matcher(
                     BENCHMARK_LIFECYCLE_COMMAND,
                     sandbox_exec_error(self.primary_error().unwrap()),

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -38,12 +38,15 @@ fn claimed_context(run_id: RunId, reuse_key: &str, timezone: Option<&str>) -> Ex
     context
 }
 
-fn guest_restore_commands(overrides: &sandbox_mock::MockSandboxOverrides) -> Vec<String> {
+fn guest_restore_timezones(overrides: &sandbox_mock::MockSandboxOverrides) -> Vec<Option<String>> {
     overrides
-        .exec_calls()
+        .guest_state_restore_calls()
         .into_iter()
-        .filter(|call| call.cmd.contains("guest-reseed"))
-        .map(|call| call.cmd)
+        .map(|call| match call.timezone {
+            sandbox_mock::GuestStateRestoreTimezoneCall::None => None,
+            sandbox_mock::GuestStateRestoreTimezoneCall::BestEffort(timezone)
+            | sandbox_mock::GuestStateRestoreTimezoneCall::Required(timezone) => Some(timezone),
+        })
         .collect()
 }
 
@@ -123,13 +126,12 @@ async fn exact_reuse_restores_guest_while_claim_is_blocked() {
     );
     assert!(
         overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await,
         "guest restore did not run while claim was blocked"
     );
-    let restore_commands = guest_restore_commands(&overrides);
-    assert_eq!(restore_commands.len(), 1);
-    assert!(restore_commands[0].contains("/usr/share/zoneinfo/Asia/Shanghai"));
+    let restore_timezones = guest_restore_timezones(&overrides);
+    assert_eq!(restore_timezones, [Some("Asia/Shanghai".into())]);
     assert_eq!(overrides.unpark_call_count(), 1);
     assert!(
         overrides.start_process_calls().is_empty(),
@@ -151,7 +153,7 @@ async fn exact_reuse_restores_guest_while_claim_is_blocked() {
         .expect("exact-reuse run should complete after claim release");
     assert_eq!(completion.sandbox_id, Some(sandbox_id));
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    assert_eq!(guest_restore_commands(&overrides).len(), 1);
+    assert_eq!(guest_restore_timezones(&overrides).len(), 1);
     assert!(timezone_correction_commands(&overrides).is_empty());
 
     shutdown(&env, run_handle).await;
@@ -207,9 +209,8 @@ async fn assert_timezone_transition_with(
         .expect("timezone transition run should complete");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
 
-    let restores = guest_restore_commands(&overrides);
-    assert_eq!(restores.len(), 1);
-    assert!(restores[0].contains(&format!("/usr/share/zoneinfo/{expected_restore_zone}")));
+    let restores = guest_restore_timezones(&overrides);
+    assert_eq!(restores, [Some(expected_restore_zone.to_owned())]);
     let corrections = timezone_correction_commands(&overrides);
     match expected_correction_zone {
         Some(zone) => {
@@ -339,7 +340,7 @@ async fn unknown_previous_timezone_keeps_restore_after_claim() {
         .await
         .expect("unknown prediction should retain ordinary exact reuse");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    assert_eq!(guest_restore_commands(&overrides).len(), 1);
+    assert_eq!(guest_restore_timezones(&overrides).len(), 1);
 
     shutdown(&env, run_handle).await;
 }
@@ -393,10 +394,8 @@ async fn unknown_claimed_timezone_repeats_authoritative_guest_restore() {
         .await
         .expect("unknown claimed timezone should complete through full restore fallback");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    let restores = guest_restore_commands(&overrides);
-    assert_eq!(restores.len(), 2);
-    assert!(restores[0].contains("/usr/share/zoneinfo/Asia/Shanghai"));
-    assert!(!restores[1].contains("/usr/share/zoneinfo/"));
+    let restores = guest_restore_timezones(&overrides);
+    assert_eq!(restores, [Some("Asia/Shanghai".into()), None]);
 
     shutdown(&env, run_handle).await;
 }
@@ -445,7 +444,7 @@ async fn unavailable_claim_reparks_speculative_sandbox() {
     );
     assert!(
         overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await
     );
     env.handle.unblock_claims();
@@ -595,7 +594,7 @@ async fn mismatched_claim_run_id_reparks_speculative_sandbox() {
     );
     assert!(
         overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await
     );
     env.handle.unblock_claims();
@@ -664,7 +663,7 @@ async fn cancellation_during_claim_completes_without_starting_agent_and_reparks(
     );
     assert!(
         overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await
     );
     let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
@@ -732,11 +731,6 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
         .wait_entered(1, Duration::from_secs(5))
         .await
         .unwrap();
-    exec_gate.release_one();
-    exec_gate
-        .wait_entered(2, Duration::from_secs(5))
-        .await
-        .unwrap();
     let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     assert!(cancellation.request_cooperative_user_cancellation().await);
 
@@ -748,7 +742,7 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
 
     exec_gate.release_one();
     exec_gate
-        .wait_entered(3, Duration::from_secs(5))
+        .wait_entered(2, Duration::from_secs(5))
         .await
         .unwrap();
     exec_gate.release_one();
@@ -966,7 +960,7 @@ async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
     );
     assert!(
         overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await
     );
     assert!(env.parking_gate.soft_drain());
@@ -1026,7 +1020,7 @@ async fn duplicate_repark_keeps_newer_idle_sandbox_and_destroys_speculation() {
     );
     assert!(
         original_overrides
-            .wait_exec_call_count(1, Duration::from_secs(5))
+            .wait_guest_state_restore_call_count(1, Duration::from_secs(5))
             .await
     );
 
@@ -1207,12 +1201,11 @@ async fn speculative_guest_restore_failure_destroys_before_fresh_fallback() {
         GuestTimezoneIntent::Default,
         None,
         |overrides| {
-            overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
-                pattern: "guest-reseed".into(),
-                exit_code: 1,
-                stdout: Vec::new(),
-                stderr: b"guest-reseed failed".to_vec(),
-            });
+            overrides.push_guest_state_restore_result(Ok(sandbox::ExecResult::new(
+                1,
+                Vec::new(),
+                b"guest-reseed failed".to_vec(),
+            )));
         },
     )
     .await;
@@ -1224,14 +1217,11 @@ async fn speculative_guest_restore_transport_failure_destroys_before_fresh_fallb
         GuestTimezoneIntent::Default,
         None,
         |overrides| {
-            overrides.add_exec_error_matcher(
-                "guest-reseed",
-                sandbox::SandboxError::Operation {
-                    operation: sandbox::SandboxOperation::Exec,
-                    reason: sandbox::SandboxOperationReason::Guest,
-                    message: "simulated guest restore transport failure".into(),
-                },
-            );
+            overrides.push_guest_state_restore_result(Err(sandbox::SandboxError::Operation {
+                operation: sandbox::SandboxOperation::Exec,
+                reason: sandbox::SandboxOperationReason::Guest,
+                message: "simulated guest restore transport failure".into(),
+            }));
         },
     )
     .await;

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -1,6 +1,9 @@
 //! Guest state repair helpers used before agent execution.
 
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, Sandbox};
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestStateRestoreRequest,
+    GuestStateRestoreTimezone, Sandbox,
+};
 
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use crate::guest_timezone::{GuestTimezoneIntent, is_shell_safe_name};
@@ -31,20 +34,16 @@ fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
     }
 }
 
-fn host_unix_timestamp_secs() -> String {
-    format!(
-        "{:.3}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs_f64()
-    )
+fn host_unix_timestamp() -> std::time::Duration {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
 }
 
-fn read_host_entropy() -> RunnerResult<Vec<u8>> {
+fn read_host_entropy() -> RunnerResult<[u8; ENTROPY_SIZE]> {
     use std::io::Read;
 
-    let mut entropy = vec![0u8; ENTROPY_SIZE];
+    let mut entropy = [0u8; ENTROPY_SIZE];
     std::fs::File::open("/dev/urandom")
         .and_then(|mut f| f.read_exact(&mut entropy))
         .map_err(|e| RunnerError::Internal(format!("read host entropy: {e}")))?;
@@ -67,21 +66,6 @@ fn timezone_sync_body(tz: &str) -> String {
 fn timezone_sync_command(tz: &str) -> String {
     let body = timezone_sync_body(tz);
     format!("if test -f /usr/share/zoneinfo/{tz}; then {body}; fi")
-}
-
-fn timezone_sync_best_effort_command(tz: &str) -> String {
-    let body = timezone_sync_body(tz);
-    format!(
-        "if test -f /usr/share/zoneinfo/{tz}; then {{ {body}; }} || echo \"{TIMEZONE_SYNC_FAILED_MARKER}\" >&2; fi"
-    )
-}
-
-fn timezone_sync_required_command(tz: &str) -> String {
-    let body = timezone_sync_body(tz);
-    format!(
-        "test -f /usr/share/zoneinfo/{tz} || {{ echo \"{TIMEZONE_UNAVAILABLE_MARKER}\" >&2; exit 1; }}\n\
-         {{ {body}; }} || {{ status=$?; echo \"{TIMEZONE_SYNC_FAILED_MARKER}\" >&2; exit \"$status\"; }}"
-    )
 }
 
 fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {
@@ -110,7 +94,8 @@ fn log_embedded_timezone_failure(run_id: RunId, tz: &str, result: &sandbox::Exec
     );
 }
 
-/// Restores snapshot-sensitive guest state in one exec before the agent starts.
+/// Restores snapshot-sensitive guest state in one fixed operation before the
+/// agent starts.
 ///
 /// On ARM64 with kernel 6.1, VMGenID does not work (the driver only supports
 /// ACPI; DeviceTree support requires kernel 6.10+). All VMs restored from the
@@ -162,36 +147,21 @@ async fn restore_guest_state_inner(
     sandbox: &dyn Sandbox,
     timezone: Option<GuestTimezone<'_>>,
 ) -> RunnerResult<()> {
-    let timestamp = host_unix_timestamp_secs();
+    let timestamp = host_unix_timestamp();
     let entropy = read_host_entropy()?;
-    let mut cmd = format!(
-        r#"date -s "@{timestamp}" || {{ status=$?; echo "guest clock sync failed" >&2; exit "$status"; }}
-guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}"#
-    );
-    if let Some(timezone) = timezone {
-        cmd.push('\n');
-        match timezone {
-            GuestTimezone::BestEffort { name, .. } => {
-                cmd.push_str(&timezone_sync_best_effort_command(name));
-            }
-            GuestTimezone::Required { name } => {
-                cmd.push_str(&timezone_sync_required_command(name));
-            }
-        }
-    }
+    let request_timezone = match timezone {
+        None => GuestStateRestoreTimezone::None,
+        Some(GuestTimezone::BestEffort { name, .. }) => GuestStateRestoreTimezone::BestEffort(name),
+        Some(GuestTimezone::Required { name }) => GuestStateRestoreTimezone::Required(name),
+    };
     let result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: true,
-                expected_exit_codes: &[],
-                stdin_bytes: Some(&entropy),
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "guest-state-restore",
-        )
+        .restore_guest_state(&GuestStateRestoreRequest {
+            unix_seconds: timestamp.as_secs(),
+            unix_nanoseconds: timestamp.subsec_nanos(),
+            entropy: &entropy,
+            timezone: request_timezone,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+        })
         .await?;
 
     if let Some(GuestTimezone::Required { name }) = timezone

--- a/crates/runner/src/executor/tests/agent_run_tests/guest_setup.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/guest_setup.rs
@@ -3,7 +3,7 @@ use crate::executor::tests::support::{minimal_context, test_executor_config, tes
 use crate::types::SandboxReuseResult;
 
 #[tokio::test]
-async fn run_in_sandbox_folds_timezone_sync_into_restore_exec() {
+async fn run_in_sandbox_folds_timezone_sync_into_fixed_restore_operation() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
@@ -27,25 +27,17 @@ async fn run_in_sandbox_folds_timezone_sync_into_restore_exec() {
     .await
     .unwrap();
 
-    let exec_calls = sandbox.exec_calls();
-    let restore_calls = exec_calls
-        .iter()
-        .filter(|call| call.cmd.contains("guest-reseed"))
-        .collect::<Vec<_>>();
+    let restore_calls = sandbox.guest_state_restore_calls();
     assert_eq!(
         restore_calls.len(),
         1,
-        "restore should run once; calls: {exec_calls:?}"
+        "restore should run once; calls: {restore_calls:?}"
     );
-    let restore_command = &restore_calls[0].cmd;
-    assert!(
-        restore_command.contains("if test -f /usr/share/zoneinfo/Asia/Shanghai"),
-        "restore should include timezone sync; command: {restore_command}"
+    assert_eq!(
+        restore_calls[0].timezone,
+        sandbox_mock::GuestStateRestoreTimezoneCall::BestEffort("Asia/Shanghai".into())
     );
-    assert!(
-        restore_command.contains("guest timezone sync failed"),
-        "timezone sync should remain best-effort; command: {restore_command}"
-    );
+    let exec_calls = sandbox.exec_calls();
     let standalone_timezone_calls = exec_calls
         .iter()
         .filter(|call| {
@@ -56,14 +48,6 @@ async fn run_in_sandbox_folds_timezone_sync_into_restore_exec() {
     assert!(
         standalone_timezone_calls.is_empty(),
         "restore path should not run a separate timezone exec; calls: {exec_calls:?}"
-    );
-    assert_eq!(
-        exec_calls
-            .iter()
-            .filter(|call| call.cmd.contains("/usr/share/zoneinfo/Asia/Shanghai"))
-            .count(),
-        1,
-        "timezone sync should appear in exactly one exec; calls: {exec_calls:?}"
     );
 }
 
@@ -99,10 +83,5 @@ async fn run_in_sandbox_runs_standalone_timezone_sync_without_restore_exec() {
             .starts_with("if test -f /usr/share/zoneinfo/Asia/Shanghai")),
         "fresh path should keep standalone timezone sync; calls: {exec_calls:?}"
     );
-    assert!(
-        exec_calls
-            .iter()
-            .all(|call| !call.cmd.contains("guest-reseed")),
-        "fresh path should not run guest state restore; calls: {exec_calls:?}"
-    );
+    assert!(sandbox.guest_state_restore_calls().is_empty());
 }

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -1,5 +1,5 @@
 use sandbox::{ExecResult, ExecTermination, Sandbox};
-use sandbox_mock::MockSandbox;
+use sandbox_mock::{GuestStateRestoreTimezoneCall, MockSandbox};
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 
@@ -12,90 +12,56 @@ use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 #[tokio::test]
-async fn restore_guest_state_combines_clock_sync_and_reseed() {
+async fn restore_guest_state_uses_fixed_restore_operation() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
 
     restore_guest_state(&sandbox, &ctx).await.unwrap();
 
-    let calls = sandbox.exec_calls();
+    let calls = sandbox.guest_state_restore_calls();
     assert_eq!(calls.len(), 1);
-    let clock_sync_index = calls[0]
-        .cmd
-        .find("date -s \"@")
-        .expect("guest state restore should sync the clock first");
-    let reseed_index = calls[0]
-        .cmd
-        .find("guest-reseed")
-        .expect("guest state restore should reseed entropy");
-    assert!(clock_sync_index < reseed_index);
-    assert!(calls[0].cmd.contains("guest clock sync failed"));
-    assert!(calls[0].cmd.contains("guest-reseed failed"));
-    assert!(calls[0].cmd.contains("/usr/share/zoneinfo/UTC"));
-    assert!(calls[0].cmd.contains("echo 'TZ=UTC' >> /etc/environment"));
-    assert!(calls[0].sudo);
-    let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
-    assert_eq!(stdin_bytes.len(), 256);
+    assert!(calls[0].unix_seconds > 0);
+    assert!(calls[0].unix_nanoseconds < 1_000_000_000);
+    assert_eq!(calls[0].entropy_len, 256);
+    assert_eq!(
+        calls[0].timezone,
+        GuestStateRestoreTimezoneCall::BestEffort("UTC".into())
+    );
+    assert_eq!(calls[0].timeout, super::super::DEFAULT_EXEC_TIMEOUT);
+    assert!(sandbox.exec_calls().is_empty());
 }
 
 #[tokio::test]
-async fn restore_guest_state_folds_timezone_sync_into_restore_exec() {
+async fn restore_guest_state_passes_best_effort_timezone_to_fixed_operation() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.user_timezone = Some("Asia/Shanghai".into());
 
     restore_guest_state(&sandbox, &ctx).await.unwrap();
 
-    let calls = sandbox.exec_calls();
+    let calls = sandbox.guest_state_restore_calls();
     assert_eq!(calls.len(), 1);
-    let command = &calls[0].cmd;
-    let clock_sync_index = command
-        .find("date -s \"@")
-        .expect("guest state restore should sync the clock first");
-    let reseed_index = command
-        .find("guest-reseed")
-        .expect("guest state restore should reseed entropy");
-    let timezone_index = command
-        .find("echo 'Asia/Shanghai' > /etc/timezone")
-        .expect("guest state restore should include timezone sync");
-    assert!(clock_sync_index < reseed_index);
-    assert!(reseed_index < timezone_index);
-    assert!(command.contains("guest clock sync failed"));
-    assert!(command.contains("guest-reseed failed"));
-    assert!(command.contains("guest timezone sync failed"));
-    assert!(
-        command.contains(
-            "if test -f /usr/share/zoneinfo/Asia/Shanghai; then { echo 'Asia/Shanghai' > /etc/timezone"
-        ),
-        "unexpected command: {command}"
+    assert_eq!(
+        calls[0].timezone,
+        GuestStateRestoreTimezoneCall::BestEffort("Asia/Shanghai".into())
     );
-    assert!(calls[0].sudo);
-    let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
-    assert_eq!(stdin_bytes.len(), 256);
+    assert!(sandbox.exec_calls().is_empty());
 }
 
 #[tokio::test]
-async fn restore_guest_state_with_explicit_timezone_requires_zone_in_restore_exec() {
+async fn restore_guest_state_with_explicit_timezone_requires_zone_in_fixed_operation() {
     let sandbox = MockSandbox::new("test");
 
     restore_guest_state_with_timezone(&sandbox, "UTC")
         .await
         .unwrap();
 
-    let calls = sandbox.exec_calls();
+    let calls = sandbox.guest_state_restore_calls();
     assert_eq!(calls.len(), 1);
-    let command = &calls[0].cmd;
-    assert!(command.contains("date -s \"@"));
-    assert!(command.contains("guest-reseed"));
-    assert!(
-        command.contains(
-            "test -f /usr/share/zoneinfo/UTC || { echo \"guest timezone unavailable\" >&2; exit 1; }"
-        ),
-        "unexpected command: {command}"
+    assert_eq!(
+        calls[0].timezone,
+        GuestStateRestoreTimezoneCall::Required("UTC".into())
     );
-    assert!(command.contains("echo 'TZ=UTC' >> /etc/environment"));
-    assert!(command.contains("guest timezone sync failed"));
-    assert!(command.contains("exit \"$status\""));
 }
 
 #[tokio::test]
@@ -151,7 +117,7 @@ async fn restore_guest_state_with_explicit_timezone_rejects_invalid_timezone_bef
             && !message.contains("IANA"),
         "unexpected error: {message}"
     );
-    assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.guest_state_restore_calls().is_empty());
 }
 
 #[tokio::test]
@@ -162,12 +128,9 @@ async fn restore_guest_state_rejects_invalid_timezone_without_extra_exec() {
 
     restore_guest_state(&sandbox, &ctx).await.unwrap();
 
-    let calls = sandbox.exec_calls();
+    let calls = sandbox.guest_state_restore_calls();
     assert_eq!(calls.len(), 1);
-    assert!(calls[0].cmd.contains("date -s \"@"));
-    assert!(calls[0].cmd.contains("guest-reseed"));
-    assert!(!calls[0].cmd.contains("UTC;id"));
-    assert!(!calls[0].cmd.contains("guest timezone sync failed"));
+    assert_eq!(calls[0].timezone, GuestStateRestoreTimezoneCall::None);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -246,12 +246,11 @@ async fn execute_inner_does_not_prefetch_after_early_guest_state_failure() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
-        pattern: "guest-reseed".to_string(),
-        exit_code: 64,
-        stdout: Vec::new(),
-        stderr: b"restore denied".to_vec(),
-    });
+    overrides.push_guest_state_restore_result(Ok(sandbox::ExecResult::new(
+        64,
+        Vec::new(),
+        b"restore denied".to_vec(),
+    )));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let params = JobParams {
         restore_guest_state: true,

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -267,6 +267,13 @@ impl Sandbox for ObservedStartSandbox {
         self.inner.apply_storage_manifest(request).await
     }
 
+    async fn restore_guest_state(
+        &self,
+        request: &sandbox::GuestStateRestoreRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.restore_guest_state(request).await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         self.inner.read_file(path, max_bytes).await
     }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3803,6 +3803,13 @@ mod tests {
             self.inner.apply_storage_manifest(request).await
         }
 
+        async fn restore_guest_state(
+            &self,
+            request: &sandbox::GuestStateRestoreRequest<'_>,
+        ) -> sandbox::Result<sandbox::ExecResult> {
+            self.inner.restore_guest_state(request).await
+        }
+
         async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
             self.inner.read_file(path, max_bytes).await
         }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -153,6 +153,13 @@ impl Sandbox for PostCopyGateSandbox {
         self.inner.apply_storage_manifest(request).await
     }
 
+    async fn restore_guest_state(
+        &self,
+        request: &sandbox::GuestStateRestoreRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.restore_guest_state(request).await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         self.inner.read_file(path, max_bytes).await
     }
@@ -242,6 +249,13 @@ impl Sandbox for PanicExecSandbox {
         _request: &sandbox::StorageManifestRequest<'_>,
     ) -> sandbox::Result<ExecResult> {
         panic!("unused apply_storage_manifest");
+    }
+
+    async fn restore_guest_state(
+        &self,
+        _request: &sandbox::GuestStateRestoreRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        panic!("unused restore_guest_state");
     }
 
     async fn read_file(&self, _path: &str, _max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestMemorySnapshot,
     GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
-    ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
+    GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
+    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
     ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
     ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkHandoff,
     SandboxFinalExecParkHandoffOutcome, SandboxFinalExecParkHandoffPoint,
@@ -25,10 +26,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use vsock_host::{
     ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, FrameWriteObserver,
-    GuestStorageManifestResult, NormalOperationFence, NormalOperationFenceRejection,
-    SupervisedExecControl, SupervisedExecRequest, VsockHost,
+    GuestStateRestoreResult, GuestStorageManifestResult, NormalOperationFence,
+    NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest, VsockHost,
 };
-use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
+use vsock_proto::{
+    ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy,
+    GuestStateRestoreTimezone as VsockGuestStateRestoreTimezone,
+};
 
 use crate::api::BalloonStatistics;
 use crate::duration::duration_ms;
@@ -2430,6 +2434,39 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
+    async fn restore_guest_state(
+        &self,
+        request: &GuestStateRestoreRequest<'_>,
+    ) -> sandbox::Result<ExecResult> {
+        let operation = SandboxOperation::Exec;
+        let timeout_ms = request.timeout_ms();
+        let timezone = match request.timezone {
+            GuestStateRestoreTimezone::None => VsockGuestStateRestoreTimezone::None,
+            GuestStateRestoreTimezone::BestEffort(timezone) => {
+                VsockGuestStateRestoreTimezone::BestEffort(timezone)
+            }
+            GuestStateRestoreTimezone::Required(timezone) => {
+                VsockGuestStateRestoreTimezone::Required(timezone)
+            }
+        };
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            validate_exec_capture_timeout(timeout_ms)?;
+            guest
+                .guest_state_restore(
+                    request.unix_seconds,
+                    request.unix_nanoseconds,
+                    request.entropy,
+                    timezone,
+                    timeout_ms,
+                    Duration::from_millis(u64::from(timeout_ms) + 5_000),
+                )
+                .await
+                .map(guest_state_restore_exec_result)
+        })
+        .await
+    }
+
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
         let operation = SandboxOperation::ReadFile;
 
@@ -2645,6 +2682,18 @@ fn storage_manifest_exec_result(result: GuestStorageManifestResult) -> ExecResul
         stderr: result.stderr,
         diagnostic: result.diagnostic,
         stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
+    }
+}
+
+fn guest_state_restore_exec_result(result: GuestStateRestoreResult) -> ExecResult {
+    ExecResult {
+        termination: exec_termination_from_vsock_termination(result.termination),
+        guest_duration_ms: Some(result.duration_ms),
+        stdout: Vec::new(),
+        stderr: result.stderr,
+        diagnostic: result.diagnostic,
+        stdout_truncated: false,
         stderr_truncated: result.stderr_truncated,
     }
 }

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2515,6 +2515,63 @@ async fn apply_storage_manifest_preserves_terminal_metadata() {
     assert_eq!(result.diagnostic, "containment cleanup failed");
 }
 
+#[tokio::test]
+async fn restore_guest_state_preserves_fixed_request_and_terminal_metadata() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let entropy = [0xA5; 256];
+    let request = GuestStateRestoreRequest {
+        unix_seconds: 1_778_000_000,
+        unix_nanoseconds: 123_000_000,
+        entropy: &entropy,
+        timezone: GuestStateRestoreTimezone::Required("Asia/Shanghai"),
+        timeout: Duration::from_secs(5),
+    };
+
+    let restore = sandbox.restore_guest_state(&request);
+    let respond = async {
+        let request = read_vsock_message(&mut guest).await;
+        assert_eq!(request.msg_type, vsock_proto::MSG_GUEST_STATE_RESTORE);
+        let decoded = vsock_proto::decode_guest_state_restore_request(&request.payload).unwrap();
+        assert_eq!(decoded.timeout_ms, 5_000);
+        assert_eq!(decoded.unix_seconds, 1_778_000_000);
+        assert_eq!(decoded.unix_nanoseconds, 123_000_000);
+        assert_eq!(decoded.entropy, entropy);
+        assert_eq!(
+            decoded.timezone,
+            vsock_proto::GuestStateRestoreTimezone::Required("Asia/Shanghai")
+        );
+
+        let payload = vsock_proto::encode_guest_state_restore_result(
+            vsock_proto::ExecTermination::WaitFailed,
+            19,
+            vsock_proto::ExecCapturedOutput::Captured {
+                bytes: b"err",
+                truncated: true,
+            },
+            "containment cleanup failed",
+        )
+        .unwrap();
+        let response = vsock_proto::encode(
+            vsock_proto::MSG_GUEST_STATE_RESTORE_RESULT,
+            request.seq,
+            &payload,
+        )
+        .unwrap();
+        guest.write_all(&response).await.unwrap();
+    };
+    let (result, ()) = tokio::join!(restore, respond);
+    let result = result.unwrap();
+
+    assert_eq!(result.termination, ExecTermination::WaitFailed);
+    assert_eq!(result.guest_duration_ms, Some(19));
+    assert!(result.stdout.is_empty());
+    assert_eq!(result.stderr, b"err");
+    assert!(!result.stdout_truncated);
+    assert!(result.stderr_truncated);
+    assert_eq!(result.diagnostic, "containment cleanup failed");
+}
+
 #[test]
 fn exec_result_from_operation_result_maps_terminal_edge_states() {
     for (termination, diagnostic, input_stderr, expected_termination) in [

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -70,6 +70,34 @@ pub struct StorageManifestCall {
     pub timeout: Duration,
 }
 
+/// Owned timezone behavior recorded for a fixed guest-state restore call.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GuestStateRestoreTimezoneCall {
+    /// The request left the timezone unchanged.
+    None,
+    /// The request used best-effort timezone synchronization.
+    BestEffort(String),
+    /// The request required timezone synchronization.
+    Required(String),
+}
+
+/// Captured fixed guest-state restore request fields.
+///
+/// Entropy contents are intentionally omitted from observations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuestStateRestoreCall {
+    /// Whole Unix timestamp seconds supplied to the fixed helper.
+    pub unix_seconds: u64,
+    /// Nanoseconds within the timestamp second.
+    pub unix_nanoseconds: u32,
+    /// Entropy payload length without the entropy bytes themselves.
+    pub entropy_len: usize,
+    /// Requested timezone behavior.
+    pub timezone: GuestStateRestoreTimezoneCall,
+    /// Helper timeout supplied by the caller.
+    pub timeout: Duration,
+}
+
 /// Captured `start_process` request fields recorded for test assertions.
 ///
 /// Unlike [`ExecCall`], this record captures environment values as well as

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -30,9 +30,9 @@ mod snapshot;
 mod support;
 
 pub use call_records::{
-    CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, ReadFileCall,
-    RemoteExecCall, StartProcessCall, StorageManifestCall, WaitProcessCall, WriteFileCall,
-    WriteFilesCall,
+    CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall, GuestStateRestoreTimezoneCall,
+    ProcessCancelCall, ProcessControlCall, ReadFileCall, RemoteExecCall, StartProcessCall,
+    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 pub use control::MockSandboxControl;
 pub use factory_runtime::{MockRuntimeProvider, MockSandboxFactory, MockSandboxRuntime};

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -6,8 +6,9 @@ use ::sandbox::*;
 use tokio_util::sync::CancellationToken;
 
 use crate::call_records::{
-    CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, StartProcessCall,
-    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
+    CopyFileCall, ExecCall, ExecMatcher, GuestStateRestoreCall, ProcessCancelCall,
+    ProcessControlCall, StartProcessCall, StorageManifestCall, WaitProcessCall, WriteFileCall,
+    WriteFilesCall,
 };
 use crate::lifecycle::{DestroyBehavior, LifecycleBehaviors, MockLifecycleGate};
 use crate::support::LockIgnoringPoison;
@@ -40,6 +41,12 @@ pub(crate) struct ExecOverrideState {
     pub(crate) calls: Mutex<Vec<ExecCall>>,
     /// Recorded fixed storage-manifest calls across all attached sandboxes.
     pub(crate) storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
+    /// Recorded fixed guest-state restore calls across all attached sandboxes.
+    pub(crate) guest_state_restore_calls: Mutex<Vec<GuestStateRestoreCall>>,
+    /// FIFO results for fixed guest-state restore operations.
+    pub(crate) guest_state_restore_results: Mutex<VecDeque<Result<ExecResult>>>,
+    /// Wakes tests after a guest-state restore call is recorded.
+    pub(crate) guest_state_restore_call_notify: tokio::sync::Notify,
     /// Wakes tests after an exec call is recorded.
     pub(crate) call_notify: tokio::sync::Notify,
     /// Optional gate entered after every exec call is recorded but before its
@@ -460,6 +467,54 @@ impl MockSandboxOverrides {
             .storage_manifest_calls
             .lock_ignoring_poison()
             .clone()
+    }
+
+    /// Queue a result for the next fixed guest-state restore operation.
+    pub fn push_guest_state_restore_result(&self, result: Result<ExecResult>) {
+        self.exec
+            .guest_state_restore_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    /// Return fixed guest-state restore calls across all attached sandboxes.
+    pub fn guest_state_restore_calls(&self) -> Vec<GuestStateRestoreCall> {
+        self.exec
+            .guest_state_restore_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Wait until at least `expected` guest-state restore calls are recorded.
+    pub async fn wait_guest_state_restore_call_count(
+        &self,
+        expected: usize,
+        timeout: Duration,
+    ) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.exec.guest_state_restore_call_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self
+                .exec
+                .guest_state_restore_calls
+                .lock_ignoring_poison()
+                .len()
+                >= expected
+            {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return false;
+            }
+        }
     }
 
     /// Wait until at least `expected` exec calls have been recorded.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -10,8 +10,9 @@ use ::sandbox::*;
 use async_trait::async_trait;
 
 use crate::call_records::{
-    CopyFileCall, ExecCall, ProcessCancelCall, ProcessControlCall, ReadFileCall, StartProcessCall,
-    StorageManifestCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
+    CopyFileCall, ExecCall, GuestStateRestoreCall, GuestStateRestoreTimezoneCall,
+    ProcessCancelCall, ProcessControlCall, ReadFileCall, StartProcessCall, StorageManifestCall,
+    WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
 use crate::overrides::{ExecMatcherOutcome, MockSandboxOverrides};
@@ -36,6 +37,7 @@ pub struct MockSandbox {
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     exec_calls: Mutex<Vec<ExecCall>>,
     storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
+    guest_state_restore_calls: Mutex<Vec<GuestStateRestoreCall>>,
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     read_file_calls: Mutex<Vec<ReadFileCall>>,
     copy_file_results: Mutex<VecDeque<Result<Vec<u8>>>>,
@@ -78,6 +80,7 @@ impl MockSandbox {
             exec_results: Mutex::new(VecDeque::new()),
             exec_calls: Mutex::new(Vec::new()),
             storage_manifest_calls: Mutex::new(Vec::new()),
+            guest_state_restore_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             read_file_calls: Mutex::new(Vec::new()),
             copy_file_results: Mutex::new(VecDeque::new()),
@@ -229,6 +232,13 @@ impl MockSandbox {
     /// Return this sandbox's recorded fixed storage-manifest calls.
     pub fn storage_manifest_calls(&self) -> Vec<StorageManifestCall> {
         self.storage_manifest_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return this sandbox's recorded fixed guest-state restore calls.
+    pub fn guest_state_restore_calls(&self) -> Vec<GuestStateRestoreCall> {
+        self.guest_state_restore_calls
+            .lock_ignoring_poison()
+            .clone()
     }
 
     /// Queue a small file read result. Results are consumed in FIFO order.
@@ -610,6 +620,57 @@ impl Sandbox for MockSandbox {
             .pop_front()
             .unwrap_or_else(|| Ok(default_exec_result()))?;
         Ok(apply_exec_output_limits(result, EXEC_OUTPUT_LIMIT_1_MIB))
+    }
+
+    async fn restore_guest_state(
+        &self,
+        request: &GuestStateRestoreRequest<'_>,
+    ) -> Result<ExecResult> {
+        let timezone = match request.timezone {
+            GuestStateRestoreTimezone::None => GuestStateRestoreTimezoneCall::None,
+            GuestStateRestoreTimezone::BestEffort(timezone) => {
+                GuestStateRestoreTimezoneCall::BestEffort(timezone.to_owned())
+            }
+            GuestStateRestoreTimezone::Required(timezone) => {
+                GuestStateRestoreTimezoneCall::Required(timezone.to_owned())
+            }
+        };
+        let call = GuestStateRestoreCall {
+            unix_seconds: request.unix_seconds,
+            unix_nanoseconds: request.unix_nanoseconds,
+            entropy_len: request.entropy.len(),
+            timezone,
+            timeout: request.timeout,
+        };
+        self.guest_state_restore_calls
+            .lock_ignoring_poison()
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .exec
+                .guest_state_restore_calls
+                .lock_ignoring_poison()
+                .push(call);
+            overrides
+                .exec
+                .guest_state_restore_call_notify
+                .notify_waiters();
+        }
+        let result = self
+            .exec_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .or_else(|| {
+                self.overrides.as_ref().and_then(|overrides| {
+                    overrides
+                        .exec
+                        .guest_state_restore_results
+                        .lock_ignoring_poison()
+                        .pop_front()
+                })
+            })
+            .unwrap_or_else(|| Ok(default_exec_result()))?;
+        Ok(apply_exec_output_limits(result, EXEC_OUTPUT_LIMIT_64_KIB))
     }
 
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>> {

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -58,8 +58,9 @@ pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
     GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessControlOutcomeFuture,
-    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlFailureKind,
-    ProcessControlGuestStatus, ProcessControlMode, ProcessControlOutcome, ProcessControlWriteState,
-    ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest,
-    StorageManifestRequest, WriteFileEntry,
+    GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone,
+    ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
+    ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
+    ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest, StorageManifestRequest,
+    WriteFileEntry,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -9,8 +9,9 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
-    StartProcessRequest, StorageManifestRequest, WriteFileEntry,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle,
+    GuestStateRestoreRequest, ProcessExit, StartProcessRequest, StorageManifestRequest,
+    WriteFileEntry,
 };
 
 /// Eligibility result after a sandbox successfully reaches the parked state.
@@ -733,6 +734,17 @@ pub trait Sandbox: Send + Sync + Any {
     async fn apply_storage_manifest(
         &self,
         request: &StorageManifestRequest<'_>,
+    ) -> Result<ExecResult>;
+
+    /// Restore snapshot-sensitive clock, CRNG, and optional timezone state
+    /// through the provider's fixed guest helper operation.
+    ///
+    /// Implementations must preserve helper timeout and cancellation, bounded
+    /// stderr capture, structured termination, and backend-crash
+    /// classification. The entropy payload is always exactly 256 bytes.
+    async fn restore_guest_state(
+        &self,
+        request: &GuestStateRestoreRequest<'_>,
     ) -> Result<ExecResult>;
 
     /// Read a small file from the guest.

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -93,6 +93,45 @@ pub struct StorageManifestRequest<'a> {
     pub timeout: Duration,
 }
 
+/// Timezone behavior for a fixed guest-state restore operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GuestStateRestoreTimezone<'a> {
+    /// Leave the guest timezone unchanged.
+    None,
+    /// Attempt timezone synchronization without failing the restore.
+    BestEffort(&'a str),
+    /// Require timezone synchronization to succeed.
+    Required(&'a str),
+}
+
+/// Request to restore snapshot-sensitive guest state through a fixed helper.
+///
+/// The provider selects the executable, root identity, arguments, containment,
+/// and output bounds. Callers supply only the state values consumed by that
+/// operation.
+pub struct GuestStateRestoreRequest<'a> {
+    /// Whole Unix timestamp seconds applied to the guest realtime clock.
+    pub unix_seconds: u64,
+    /// Nanoseconds within the Unix timestamp second.
+    pub unix_nanoseconds: u32,
+    /// Exact host entropy payload mixed into the guest CRNG.
+    pub entropy: &'a [u8; 256],
+    /// Optional guest timezone behavior.
+    pub timezone: GuestStateRestoreTimezone<'a>,
+    /// Guest-side helper timeout.
+    pub timeout: Duration,
+}
+
+impl GuestStateRestoreRequest<'_> {
+    /// Return the timeout as milliseconds, saturating at `u32::MAX`.
+    ///
+    /// Non-zero sub-millisecond durations round up to 1ms so callers do not
+    /// accidentally turn a bounded operation into a zero-timeout request.
+    pub fn timeout_ms(&self) -> u32 {
+        duration_ms(self.timeout)
+    }
+}
+
 impl StorageManifestRequest<'_> {
     /// Return the timeout as milliseconds, saturating at `u32::MAX`.
     ///

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -8,9 +8,10 @@ use std::time::{Duration, Instant};
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, BorrowedRawMessage, DecodeWithError, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_STORAGE_MANIFEST, MSG_MEMORY_SNAPSHOT,
-    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
-    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
+    MSG_GUEST_DNS_READINESS, MSG_GUEST_STATE_RESTORE, MSG_GUEST_STORAGE_MANIFEST,
+    MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
+    MSG_WRITE_FILE, MSG_WRITE_FILES,
 };
 
 use crate::error::to_io_error;
@@ -22,6 +23,10 @@ use crate::exec_operation::{
 use crate::file_write_worker::{FileWriteKind, FileWriteSubmitError, FileWriteWorker};
 use crate::guest_dns_readiness::{
     GuestDnsReadinessProgram, GuestDnsReadinessSubmitError, GuestDnsReadinessWorker,
+};
+use crate::guest_state_restore::{
+    GuestStateRestoreProgram, GuestStateRestoreSubmission, GuestStateRestoreSubmitError,
+    GuestStateRestoreWorker,
 };
 use crate::guest_storage_manifest::{
     GuestStorageManifestProgram, GuestStorageManifestSubmission, GuestStorageManifestSubmitError,
@@ -134,6 +139,7 @@ fn is_real_host_work_message(msg_type: u8) -> bool {
             | MSG_WRITE_FILE
             | MSG_WRITE_FILES
             | MSG_GUEST_DNS_READINESS
+            | MSG_GUEST_STATE_RESTORE
             | MSG_GUEST_STORAGE_MANIFEST
             | MSG_QUIESCE_OPERATIONS
             | MSG_RESUME_OPERATIONS
@@ -298,6 +304,7 @@ struct ConnectionDispatcher {
     connection_cancel: Arc<AtomicBool>,
     file_write_worker: FileWriteWorker,
     guest_dns_readiness_worker: GuestDnsReadinessWorker,
+    guest_state_restore_worker: GuestStateRestoreWorker,
     guest_storage_manifest_worker: GuestStorageManifestWorker,
     exec_operation_registry: ExecOperationRegistry,
     exec_control_registry: ExecControlRegistry,
@@ -313,6 +320,7 @@ impl ConnectionDispatcher {
         process_containment_mode: ProcessContainmentMode,
         exec_drain_deadline: Duration,
         guest_dns_readiness_program: GuestDnsReadinessProgram,
+        guest_state_restore_program: GuestStateRestoreProgram,
         guest_storage_manifest_program: GuestStorageManifestProgram,
     ) -> io::Result<Self> {
         let file_write_worker =
@@ -329,11 +337,18 @@ impl ConnectionDispatcher {
             process_containment_mode,
             exec_drain_deadline,
         );
+        let guest_state_restore_worker = GuestStateRestoreWorker::start(
+            writer.clone(),
+            Arc::clone(&connection_cancel),
+            guest_state_restore_program,
+            exec_drain_deadline,
+        );
         Ok(Self {
             writer,
             connection_cancel,
             file_write_worker,
             guest_dns_readiness_worker,
+            guest_state_restore_worker,
             guest_storage_manifest_worker,
             exec_operation_registry: ExecOperationRegistry::default(),
             exec_control_registry: ExecControlRegistry::default(),
@@ -351,6 +366,7 @@ impl ConnectionDispatcher {
             MSG_WRITE_FILE => self.handle_file_write(msg, FileWriteKind::File)?,
             MSG_WRITE_FILES => self.handle_file_write(msg, FileWriteKind::Files)?,
             MSG_GUEST_DNS_READINESS => self.handle_guest_dns_readiness(msg)?,
+            MSG_GUEST_STATE_RESTORE => self.handle_guest_state_restore(msg)?,
             MSG_GUEST_STORAGE_MANIFEST => self.handle_guest_storage_manifest(msg)?,
             MSG_QUIESCE_OPERATIONS => self.handle_quiesce_operations(msg)?,
             MSG_RESUME_OPERATIONS => self.handle_resume_operations(msg)?,
@@ -607,6 +623,63 @@ impl ConnectionDispatcher {
         }
     }
 
+    fn handle_guest_state_restore(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "guest state restore", &self.writer)? {
+            return Ok(());
+        }
+        if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
+            return Ok(());
+        }
+        let decoded = match vsock_proto::decode_guest_state_restore_request(msg.payload) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
+        let Some(admission) = self.guest_state_restore_worker.try_admit() else {
+            send_error_response(
+                msg.seq,
+                "guest state restore operation already active",
+                &self.writer,
+            )?;
+            return Ok(());
+        };
+        let Some(operation_guard) =
+            acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
+        else {
+            return Ok(());
+        };
+        match self.guest_state_restore_worker.submit(
+            GuestStateRestoreSubmission {
+                seq: msg.seq,
+                timeout_ms: decoded.timeout_ms,
+                unix_seconds: decoded.unix_seconds,
+                unix_nanoseconds: decoded.unix_nanoseconds,
+                entropy: decoded.entropy,
+                timezone: decoded.timezone,
+            },
+            operation_guard,
+            admission,
+        ) {
+            Ok(()) => Ok(()),
+            Err(GuestStateRestoreSubmitError::Busy) => send_error_response(
+                msg.seq,
+                "guest state restore operation already active",
+                &self.writer,
+            ),
+            Err(GuestStateRestoreSubmitError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "guest state restore worker stopped",
+            )),
+            Err(GuestStateRestoreSubmitError::Start(error)) => send_error_response(
+                msg.seq,
+                &format!("failed to start guest state restore worker: {error}"),
+                &self.writer,
+            ),
+        }
+    }
+
     fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         handle_quiesce_operations(
             msg.seq,
@@ -741,6 +814,7 @@ pub fn handle_connection_with_test_dns_readiness_program(
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
         GuestDnsReadinessProgram::for_test(program),
+        GuestStateRestoreProgram::production(),
         GuestStorageManifestProgram::production(),
     )
 }
@@ -756,7 +830,24 @@ pub fn handle_connection_with_test_storage_manifest_program(
         ProcessContainmentMode::TestNoop,
         EXEC_OUTPUT_DRAIN_DEADLINE,
         GuestDnsReadinessProgram::production(),
+        GuestStateRestoreProgram::production(),
         GuestStorageManifestProgram::for_test(program),
+    )
+}
+
+/// Handles a host-side test connection with a test guest-state helper.
+#[doc(hidden)]
+pub fn handle_connection_with_test_guest_state_restore_program(
+    stream: UnixStream,
+    program: std::path::PathBuf,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_program(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
+        GuestDnsReadinessProgram::production(),
+        GuestStateRestoreProgram::for_test(program),
+        GuestStorageManifestProgram::production(),
     )
 }
 
@@ -781,6 +872,7 @@ fn handle_connection_with_mode_and_exec_drain_deadline(
         process_containment_mode,
         exec_drain_deadline,
         GuestDnsReadinessProgram::production(),
+        GuestStateRestoreProgram::production(),
         GuestStorageManifestProgram::production(),
     )
 }
@@ -790,6 +882,7 @@ fn handle_connection_with_mode_and_program(
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
     guest_dns_readiness_program: GuestDnsReadinessProgram,
+    guest_state_restore_program: GuestStateRestoreProgram,
     guest_storage_manifest_program: GuestStorageManifestProgram,
 ) -> io::Result<()> {
     match handle_connection_with_outcome(
@@ -797,6 +890,7 @@ fn handle_connection_with_mode_and_program(
         process_containment_mode,
         exec_drain_deadline,
         guest_dns_readiness_program,
+        guest_state_restore_program,
         guest_storage_manifest_program,
     ) {
         Ok(_) => Ok(()),
@@ -809,6 +903,7 @@ fn handle_connection_with_outcome(
     process_containment_mode: ProcessContainmentMode,
     exec_drain_deadline: Duration,
     guest_dns_readiness_program: GuestDnsReadinessProgram,
+    guest_state_restore_program: GuestStateRestoreProgram,
     guest_storage_manifest_program: GuestStorageManifestProgram,
 ) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
@@ -838,6 +933,7 @@ fn handle_connection_with_outcome(
         process_containment_mode,
         exec_drain_deadline,
         guest_dns_readiness_program,
+        guest_state_restore_program,
         guest_storage_manifest_program,
     )
     .map_err(|error| session.failure(error))?;
@@ -987,6 +1083,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
                         GuestDnsReadinessProgram::production(),
+                        GuestStateRestoreProgram::production(),
                         GuestStorageManifestProgram::production(),
                     )
                 })
@@ -1001,6 +1098,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                         process_containment_mode,
                         EXEC_OUTPUT_DRAIN_DEADLINE,
                         GuestDnsReadinessProgram::production(),
+                        GuestStateRestoreProgram::production(),
                         GuestStorageManifestProgram::production(),
                     )
                 })

--- a/crates/vsock-guest/src/guest_state_restore.rs
+++ b/crates/vsock-guest/src/guest_state_restore.rs
@@ -1,0 +1,535 @@
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES,
+    GuestStateRestoreTimezone,
+};
+
+use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
+use crate::error::to_io_error;
+use crate::log::log;
+use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
+use crate::quiesce::OperationGuard;
+use crate::wait::{
+    WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
+};
+use crate::worker_ownership::{
+    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
+};
+use crate::writer::GuestWriter;
+
+const PRODUCTION_PROGRAM: &str = "/sbin/guest-reseed";
+const THREAD_WORKER: &str = "vsock-guest-state-restore";
+const THREAD_STDIN: &str = "vsock-guest-state-stdin";
+const THREAD_STDERR: &str = "vsock-guest-state-stderr";
+const MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
+
+#[derive(Clone)]
+pub(crate) enum GuestStateRestoreProgram {
+    Production,
+    Test(PathBuf),
+}
+
+impl GuestStateRestoreProgram {
+    pub(crate) fn production() -> Self {
+        Self::Production
+    }
+
+    pub(crate) fn for_test(path: PathBuf) -> Self {
+        Self::Test(path)
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Self::Production => Path::new(PRODUCTION_PROGRAM),
+            Self::Test(path) => path,
+        }
+    }
+}
+
+pub(crate) enum GuestStateRestoreSubmitError {
+    Busy,
+    Disconnected,
+    Start(io::Error),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum OwnedTimezone {
+    None,
+    BestEffort(String),
+    Required(String),
+}
+
+impl OwnedTimezone {
+    fn from_borrowed(timezone: GuestStateRestoreTimezone<'_>) -> Self {
+        match timezone {
+            GuestStateRestoreTimezone::None => Self::None,
+            GuestStateRestoreTimezone::BestEffort(name) => Self::BestEffort(name.to_owned()),
+            GuestStateRestoreTimezone::Required(name) => Self::Required(name.to_owned()),
+        }
+    }
+
+    fn append_args(&self, command: &mut Command) {
+        match self {
+            Self::None => {
+                command.arg("none");
+            }
+            Self::BestEffort(name) => {
+                command.arg("best-effort").arg(name);
+            }
+            Self::Required(name) => {
+                command.arg("required").arg(name);
+            }
+        }
+    }
+}
+
+struct GuestStateRestoreRequest {
+    seq: u32,
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: Vec<u8>,
+    timezone: OwnedTimezone,
+    operation_guard: OperationGuard,
+    admission: SingleActivePermit,
+}
+
+pub(crate) struct GuestStateRestoreWorker {
+    state: Mutex<GuestStateRestoreWorkerState>,
+    writer: GuestWriter,
+    program: GuestStateRestoreProgram,
+    admission: SingleActiveAdmission,
+    connection_cancel: Arc<AtomicBool>,
+    drain_deadline: Duration,
+}
+
+struct GuestStateRestoreWorkerState {
+    sender: Option<SyncSender<GuestStateRestoreRequest>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl GuestStateRestoreWorker {
+    pub(crate) fn start(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+        program: GuestStateRestoreProgram,
+        drain_deadline: Duration,
+    ) -> Self {
+        Self {
+            state: Mutex::new(GuestStateRestoreWorkerState {
+                sender: None,
+                handle: None,
+            }),
+            writer,
+            program,
+            admission: SingleActiveAdmission::new(),
+            connection_cancel,
+            drain_deadline,
+        }
+    }
+
+    pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
+        self.admission.try_acquire()
+    }
+
+    pub(crate) fn submit(
+        &self,
+        submission: GuestStateRestoreSubmission<'_>,
+        operation_guard: OperationGuard,
+        admission: SingleActivePermit,
+    ) -> Result<(), GuestStateRestoreSubmitError> {
+        let sender = self.sender()?;
+        let request = GuestStateRestoreRequest {
+            seq: submission.seq,
+            timeout_ms: submission.timeout_ms,
+            unix_seconds: submission.unix_seconds,
+            unix_nanoseconds: submission.unix_nanoseconds,
+            entropy: submission.entropy.to_vec(),
+            timezone: OwnedTimezone::from_borrowed(submission.timezone),
+            operation_guard,
+            admission,
+        };
+        match sender.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(GuestStateRestoreSubmitError::Busy),
+            Err(TrySendError::Disconnected(_)) => Err(GuestStateRestoreSubmitError::Disconnected),
+        }
+    }
+
+    fn sender(&self) -> Result<SyncSender<GuestStateRestoreRequest>, GuestStateRestoreSubmitError> {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        if let Some(sender) = &state.sender {
+            return Ok(sender.clone());
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let writer = self.writer.clone();
+        let worker_cancel = Arc::clone(&self.connection_cancel);
+        let program = self.program.clone();
+        let drain_deadline = self.drain_deadline;
+        let handle = thread::Builder::new()
+            .name(THREAD_WORKER.to_string())
+            .spawn(move || {
+                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
+                while let Ok(request) = receiver.recv() {
+                    if let Err(error) =
+                        handle_request(request, &writer, &worker_cancel, &program, drain_deadline)
+                    {
+                        log(
+                            "ERROR",
+                            &format!("guest state restore worker failed: {error}"),
+                        );
+                        break;
+                    }
+                }
+            })
+            .map_err(GuestStateRestoreSubmitError::Start)?;
+        state.sender = Some(sender.clone());
+        state.handle = Some(handle);
+        Ok(sender)
+    }
+}
+
+pub(crate) struct GuestStateRestoreSubmission<'a> {
+    pub(crate) seq: u32,
+    pub(crate) timeout_ms: u32,
+    pub(crate) unix_seconds: u64,
+    pub(crate) unix_nanoseconds: u32,
+    pub(crate) entropy: &'a [u8],
+    pub(crate) timezone: GuestStateRestoreTimezone<'a>,
+}
+
+impl Drop for GuestStateRestoreWorker {
+    fn drop(&mut self) {
+        self.connection_cancel.store(true, Ordering::Release);
+        let state = self
+            .state
+            .get_mut()
+            .unwrap_or_else(|error| error.into_inner());
+        drop(state.sender.take());
+        if let Some(handle) = state.handle.take()
+            && handle.join().is_err()
+        {
+            log("ERROR", "guest state restore worker panicked");
+        }
+    }
+}
+
+struct GuestStateRestoreOutput {
+    termination: ExecTermination,
+    duration_ms: u32,
+    stderr: BoundedDrainResult,
+    diagnostic: String,
+}
+
+fn handle_request(
+    request: GuestStateRestoreRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+    program: &GuestStateRestoreProgram,
+    drain_deadline: Duration,
+) -> io::Result<()> {
+    let GuestStateRestoreRequest {
+        seq,
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+        operation_guard,
+        admission,
+    } = request;
+    let output = run_restore(RunRestoreInput {
+        program: program.path(),
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+        connection_cancel,
+        drain_deadline,
+    });
+    let stderr = captured_output(&output.stderr);
+    let mut frame = Vec::new();
+    vsock_proto::encode_guest_state_restore_result_frame_into(
+        &mut frame,
+        seq,
+        output.termination,
+        output.duration_ms,
+        stderr,
+        &output.diagnostic,
+    )
+    .map_err(to_io_error)?;
+
+    writer
+        .write_frame_after_lock_unless_cancelled(&frame, connection_cancel, || {
+            operation_guard.release();
+            drop(admission);
+        })
+        .map(|_| ())
+}
+
+struct RunRestoreInput<'a> {
+    program: &'a Path,
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: Vec<u8>,
+    timezone: OwnedTimezone,
+    connection_cancel: &'a AtomicBool,
+    drain_deadline: Duration,
+}
+
+fn run_restore(input: RunRestoreInput<'_>) -> GuestStateRestoreOutput {
+    let RunRestoreInput {
+        program,
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+        connection_cancel,
+        drain_deadline,
+    } = input;
+    let started = Instant::now();
+    let drain_cancel = match DrainCancellation::new() {
+        Ok(cancel) => Arc::new(cancel),
+        Err(error) => {
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("failed to initialize guest state stderr cancellation: {error}"),
+            );
+        }
+    };
+    let mut command = Command::new(program);
+    // This is a bundled fixed-purpose root helper, not caller-supplied
+    // workload. A dedicated process group preserves timeout, disconnect, and
+    // descendant cleanup without paying generic workload-cgroup setup on every
+    // sandbox restore.
+    command
+        .arg("--restore-state")
+        .arg(unix_seconds.to_string())
+        .arg(unix_nanoseconds.to_string());
+    timezone.append_args(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    if let Err(error) = crate::user::apply_command_identity(&mut command, true) {
+        return failed_output(
+            ExecTermination::StartFailed,
+            started,
+            format!("failed to select root identity for guest state helper: {error}"),
+        );
+    }
+    let mut child = match spawn_in_own_process_group(&mut command) {
+        Ok(child) => child,
+        Err(error) => {
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("failed to start guest state helper: {error}"),
+            );
+        }
+    };
+
+    let Some(stdin) = child.stdin.take() else {
+        return abort_spawned(child, started, "guest state helper stdin pipe missing");
+    };
+    let Some(stderr) = child.stderr.take() else {
+        drop(stdin);
+        return abort_spawned(child, started, "guest state helper stderr pipe missing");
+    };
+
+    let (drain_done_tx, drain_done_rx) = mpsc::channel();
+    let stderr_drain = match spawn_stderr(stderr, Arc::clone(&drain_cancel), drain_done_tx) {
+        Ok(drain) => drain,
+        Err(error) => {
+            drop(stdin);
+            kill_and_reap_child(child);
+            return failed_output(
+                ExecTermination::WaitFailed,
+                started,
+                format!("failed to start guest state stderr drain: {error}"),
+            );
+        }
+    };
+    let stdin_writer = match spawn_stdin(stdin, entropy) {
+        Ok(writer) => writer,
+        Err(error) => {
+            drain_cancel.cancel();
+            kill_and_reap_child(child);
+            let _ = stderr_drain.join();
+            return failed_output(
+                ExecTermination::WaitFailed,
+                started,
+                format!("failed to start guest state stdin writer: {error}"),
+            );
+        }
+    };
+
+    let outcome = wait_with_kill_timeout_or_connection_cancelled(
+        child,
+        timeout_ms,
+        connection_cancel,
+        // Reap the full group before an exited leader can release its process
+        // group identity, so helper descendants cannot outlive restore.
+        || true,
+    );
+    let cancellation_observed = connection_cancel.load(Ordering::Acquire);
+    let stdin_result = stdin_writer.join();
+    if !matches!(outcome, WaitOutcome::Exited(_)) || cancellation_observed {
+        drain_cancel.cancel();
+    }
+    let completed = await_drain_deadline(&drain_done_rx, 1, &drain_cancel, drain_deadline);
+    let stderr_result = stderr_drain.join();
+    let drains_incomplete = completed < 1 || stderr_result.is_err();
+    let mut stderr = stderr_result.unwrap_or_default();
+    if drains_incomplete {
+        stderr.capture_truncated = true;
+    }
+    if stderr.captured.is_none() {
+        stderr.captured = Some(Vec::new());
+    }
+
+    let (termination, diagnostic) = match outcome {
+        WaitOutcome::Exited(status) => (
+            ExecTermination::Exited {
+                exit_code: extract_exit_code(status),
+            },
+            String::new(),
+        ),
+        WaitOutcome::TimedOut => (ExecTermination::TimedOut, String::new()),
+        WaitOutcome::Cancelled => (ExecTermination::Cancelled, String::new()),
+        WaitOutcome::WaitFailed(message) => (
+            ExecTermination::WaitFailed,
+            format!("failed to wait for guest state helper: {message}"),
+        ),
+    };
+    if let Err(error) = stdin_result
+        && matches!(termination, ExecTermination::Exited { .. })
+    {
+        log(
+            "WARN",
+            &format!("guest state helper stdin writer finished with error: {error}"),
+        );
+    }
+    GuestStateRestoreOutput {
+        termination,
+        duration_ms: elapsed_ms(started),
+        stderr,
+        diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
+    }
+}
+
+fn abort_spawned(child: Child, started: Instant, diagnostic: &str) -> GuestStateRestoreOutput {
+    kill_and_reap_child(child);
+    failed_output(ExecTermination::WaitFailed, started, diagnostic.to_string())
+}
+
+struct DrainHandle {
+    handle: JoinHandle<()>,
+    result_rx: mpsc::Receiver<BoundedDrainResult>,
+}
+
+impl DrainHandle {
+    fn join(self) -> Result<BoundedDrainResult, ()> {
+        if self.handle.join().is_err() {
+            return Err(());
+        }
+        self.result_rx.recv().map_err(|_| ())
+    }
+}
+
+fn spawn_stderr(
+    pipe: impl Into<std::os::fd::OwnedFd> + Send + 'static,
+    cancel: Arc<DrainCancellation>,
+    done_tx: mpsc::Sender<()>,
+) -> io::Result<DrainHandle> {
+    let (result_tx, result_rx) = mpsc::channel();
+    let handle = thread::Builder::new()
+        .name(THREAD_STDERR.to_string())
+        .spawn(move || {
+            let result = drain_bounded_cancellable(
+                pipe,
+                &cancel,
+                Some(GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES),
+                None,
+                |_, _| true,
+            );
+            let _ = result_tx.send(result);
+            let _ = done_tx.send(());
+        })?;
+    Ok(DrainHandle { handle, result_rx })
+}
+
+struct StdinWriter {
+    handle: JoinHandle<io::Result<()>>,
+}
+
+impl StdinWriter {
+    fn join(self) -> io::Result<()> {
+        self.handle
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+    }
+}
+
+fn spawn_stdin(mut stdin: ChildStdin, entropy: Vec<u8>) -> io::Result<StdinWriter> {
+    let handle = thread::Builder::new()
+        .name(THREAD_STDIN.to_string())
+        .spawn(move || {
+            let result = stdin.write_all(&entropy);
+            drop(stdin);
+            result
+        })?;
+    Ok(StdinWriter { handle })
+}
+
+fn failed_output(
+    termination: ExecTermination,
+    started: Instant,
+    diagnostic: String,
+) -> GuestStateRestoreOutput {
+    GuestStateRestoreOutput {
+        termination,
+        duration_ms: elapsed_ms(started),
+        stderr: BoundedDrainResult {
+            captured: Some(Vec::new()),
+            capture_truncated: false,
+        },
+        diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
+    }
+}
+
+fn captured_output(result: &BoundedDrainResult) -> ExecCapturedOutput<'_> {
+    ExecCapturedOutput::Captured {
+        bytes: result.captured.as_deref().unwrap_or_default(),
+        truncated: result.capture_truncated,
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u32 {
+    u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX)
+}
+
+fn truncate_utf8(mut value: String, limit: usize) -> String {
+    if value.len() <= limit {
+        return value;
+    }
+    let mut end = limit;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    value
+}

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -13,6 +13,7 @@ mod exec_control;
 mod exec_operation;
 mod file_write_worker;
 mod guest_dns_readiness;
+mod guest_state_restore;
 mod guest_storage_manifest;
 mod handlers;
 mod log;
@@ -31,6 +32,7 @@ mod worker_ownership;
 mod writer;
 
 pub use connection::handle_connection_with_test_dns_readiness_program;
+pub use connection::handle_connection_with_test_guest_state_restore_program;
 pub use connection::handle_connection_with_test_storage_manifest_program;
 pub use connection::{
     connect_unix, connect_vsock, handle_connection,

--- a/crates/vsock-guest/tests/connection/guest_state_restore.rs
+++ b/crates/vsock-guest/tests/connection/guest_state_restore.rs
@@ -1,0 +1,230 @@
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, GuestStateRestoreTimezone, MSG_GUEST_STATE_RESTORE,
+    MSG_GUEST_STATE_RESTORE_RESULT, MSG_OPERATIONS_QUIESCED,
+};
+
+use super::support::*;
+
+fn create_program(body: &str) -> (tempfile::TempDir, PathBuf) {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("guest-reseed-test");
+    std::fs::write(&path, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+    (directory, path)
+}
+
+fn entropy() -> [u8; 256] {
+    [b'x'; 256]
+}
+
+fn send_request(
+    stream: &mut impl Write,
+    seq: u32,
+    timeout_ms: u32,
+    timezone: GuestStateRestoreTimezone<'_>,
+) {
+    let payload = vsock_proto::encode_guest_state_restore_request(
+        timeout_ms,
+        1_778_000_000,
+        123_000_000,
+        &entropy(),
+        timezone,
+    )
+    .unwrap();
+    let frame = vsock_proto::encode(MSG_GUEST_STATE_RESTORE, seq, &payload).unwrap();
+    stream.write_all(&frame).unwrap();
+}
+
+struct TestResult {
+    termination: ExecTermination,
+    stderr: Vec<u8>,
+    stderr_truncated: bool,
+    diagnostic: String,
+}
+
+fn read_result(stream: &mut impl std::io::Read, seq: u32) -> TestResult {
+    let message = read_message(stream);
+    assert_eq!(message.msg_type, MSG_GUEST_STATE_RESTORE_RESULT);
+    assert_eq!(message.seq, seq);
+    let decoded = vsock_proto::decode_guest_state_restore_result(&message.payload).unwrap();
+    let (stderr, stderr_truncated) = match decoded.stderr {
+        ExecCapturedOutput::Captured { bytes, truncated } => (bytes.to_vec(), truncated),
+        ExecCapturedOutput::Discarded => panic!("guest state stderr must be captured"),
+    };
+    TestResult {
+        termination: decoded.termination,
+        stderr,
+        stderr_truncated,
+        diagnostic: decoded.diagnostic.to_owned(),
+    }
+}
+
+fn slow_program(pid_path: &Path) -> String {
+    format!(
+        "printf '%s' \"$$\" > '{}'; cat >/dev/null; sleep 60",
+        pid_path.display()
+    )
+}
+
+#[test]
+fn guest_state_restore_runs_fixed_root_helper_argv_and_entropy_stdin() {
+    let (_directory, program) = create_program(
+        r#"
+[ "$1" = "--restore-state" ]
+[ "$2" = "1778000000" ]
+[ "$3" = "123000000" ]
+[ "$4" = "required" ]
+[ "$5" = "Asia/Shanghai" ]
+[ "$(wc -c)" = "256" ]
+printf 'helper stderr\n' >&2
+"#,
+    );
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    send_request(
+        &mut host_stream,
+        501,
+        1_000,
+        GuestStateRestoreTimezone::Required("Asia/Shanghai"),
+    );
+    let result = read_result(&mut host_stream, 501);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.stderr, b"helper stderr\n");
+    assert!(!result.stderr_truncated);
+    assert!(result.diagnostic.is_empty());
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_state_restore_returns_nonzero_exit_and_bounded_stderr() {
+    let output_bytes = vsock_proto::GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES + 1_024;
+    let (_directory, program) = create_program(&format!(
+        "cat >/dev/null; head -c {output_bytes} /dev/zero | tr '\\000' y >&2; exit 7"
+    ));
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    send_request(
+        &mut host_stream,
+        502,
+        5_000,
+        GuestStateRestoreTimezone::None,
+    );
+    let result = read_result(&mut host_stream, 502);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 7 });
+    assert_eq!(
+        result.stderr.len(),
+        vsock_proto::GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES
+    );
+    assert!(result.stderr_truncated);
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_state_restore_timeout_kills_and_reaps_process_group() {
+    let pid_path = unique_pid_path("guest-state-timeout");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    send_request(&mut host_stream, 503, 20, GuestStateRestoreTimezone::None);
+    let pid = process_guard.read_pid();
+    let result = read_result(&mut host_stream, 503);
+
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    wait_for_pid_exit(pid, "guest state restore timeout");
+    process_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_state_restore_natural_exit_cleans_descendants() {
+    let pid_path = unique_pid_path("guest-state-natural-exit");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&format!(
+        "cat >/dev/null; sleep 60 & printf '%s' \"$!\" > '{}'",
+        pid_path.as_str()
+    ));
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    send_request(
+        &mut host_stream,
+        504,
+        1_000,
+        GuestStateRestoreTimezone::None,
+    );
+    let pid = process_guard.read_pid();
+    let result = read_result(&mut host_stream, 504);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    wait_for_pid_exit(pid, "guest state restore natural exit");
+    process_guard.disarm();
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_state_restore_disconnect_and_busy_rejection_clean_active_process() {
+    let pid_path = unique_pid_path("guest-state-disconnect");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    send_request(
+        &mut host_stream,
+        505,
+        60_000,
+        GuestStateRestoreTimezone::None,
+    );
+    let pid = process_guard.read_pid();
+    send_request(
+        &mut host_stream,
+        506,
+        1_000,
+        GuestStateRestoreTimezone::None,
+    );
+    let error = read_error_response(&mut host_stream, 506);
+    assert!(error.contains("already active"));
+
+    drop(host_stream);
+    join_guest_connection(handle);
+    wait_for_pid_exit(pid, "guest state restore disconnect");
+    process_guard.disarm();
+}
+
+#[test]
+fn guest_state_restore_validates_request_and_obeys_quiesce_gate() {
+    let marker = unique_tmp_path("guest-state-quiesce", ".marker");
+    let (_directory, program) = create_program(&format!("touch '{}'; exit 0", marker.as_str()));
+    let (handle, mut host_stream) =
+        start_guest_connection_with_guest_state_restore_program(program);
+
+    let malformed = vsock_proto::encode(MSG_GUEST_STATE_RESTORE, 507, b"bad").unwrap();
+    host_stream.write_all(&malformed).unwrap();
+    let malformed_error = read_error_response(&mut host_stream, 507);
+    assert!(malformed_error.contains("timeout_ms truncated"));
+
+    send_quiesce_operations(&mut host_stream, 508);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    send_request(
+        &mut host_stream,
+        509,
+        1_000,
+        GuestStateRestoreTimezone::None,
+    );
+    let quiesce_error = read_error_response(&mut host_stream, 509);
+    assert!(quiesce_error.contains("operations are quiescing"));
+    assert!(!Path::new(marker.as_str()).exists());
+
+    finish_guest_connection(handle, host_stream);
+}

--- a/crates/vsock-guest/tests/connection/main.rs
+++ b/crates/vsock-guest/tests/connection/main.rs
@@ -16,6 +16,7 @@ mod exec_output;
 mod exec_stdin;
 mod exec_validation;
 mod guest_dns_readiness;
+mod guest_state_restore;
 mod guest_storage_manifest;
 mod quiesce;
 mod reconnect;

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use vsock_guest::{
     handle_connection_with_test_dns_readiness_program,
+    handle_connection_with_test_guest_state_restore_program,
     handle_connection_with_test_process_containment,
     handle_connection_with_test_process_containment_and_exec_drain_deadline,
     handle_connection_with_test_storage_manifest_program,
@@ -54,6 +55,14 @@ pub(crate) fn start_guest_connection_with_storage_manifest_program(
 ) -> (GuestConnectionHandle, UnixStream) {
     start_guest_connection_with_handler(move |stream| {
         handle_connection_with_test_storage_manifest_program(stream, program)
+    })
+}
+
+pub(crate) fn start_guest_connection_with_guest_state_restore_program(
+    program: std::path::PathBuf,
+) -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler(move |stream| {
+        handle_connection_with_test_guest_state_restore_program(stream, program)
     })
 }
 
@@ -151,7 +160,8 @@ fn read_guest_ready_with_timeout(stream: &mut UnixStream, timeout: Duration) {
         .set_read_timeout(Some(timeout))
         .expect("set guest connection readiness read timeout");
     let context = format!("guest connection readiness failed before {timeout:?} deadline");
-    let _ = read_message_with_context(stream, &context);
+    let ready = read_message_with_context(stream, &context);
+    assert_eq!(ready.msg_type, vsock_proto::MSG_READY);
 }
 
 pub(crate) fn finish_guest_connection(handle: GuestConnectionHandle, host_stream: UnixStream) {

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use connection::{
     join_guest_connection, listener_has_pending_connection, read_guest_ready,
     start_guest_connection, start_guest_connection_with_dns_readiness_program,
     start_guest_connection_with_exec_drain_deadline,
+    start_guest_connection_with_guest_state_restore_program,
     start_guest_connection_with_storage_manifest_program, wait_for_guest_connection,
 };
 pub(crate) use exec::{

--- a/crates/vsock-host/src/guest_state_restore.rs
+++ b/crates/vsock-host/src/guest_state_restore.rs
@@ -1,0 +1,112 @@
+use std::io;
+use std::time::Duration;
+
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, GuestStateRestoreTimezone, MSG_ERROR,
+    MSG_GUEST_STATE_RESTORE_RESULT, decode_guest_state_restore_result,
+    encode_guest_state_restore_request_frame_into,
+};
+
+use crate::{
+    FrameWriteObserver, VsockHost, normal_request_on_shared_with_write_observer_frame_builder,
+};
+
+const TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_GUEST_STATE_RESTORE_RESULT];
+
+/// Owned result of the fixed guest-state restore helper.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuestStateRestoreResult {
+    /// Terminal process state.
+    pub termination: ExecTermination,
+    /// Guest-observed helper duration in milliseconds.
+    pub duration_ms: u32,
+    /// Retained helper stderr bytes.
+    pub stderr: Vec<u8>,
+    /// Whether stderr exceeded its fixed capture bound.
+    pub stderr_truncated: bool,
+    /// Bounded process or internal diagnostic.
+    pub diagnostic: String,
+}
+
+impl VsockHost {
+    /// Restore snapshot-sensitive clock, CRNG, and optional timezone state.
+    ///
+    /// The guest chooses the executable, argv shape, root identity,
+    /// containment, and output bounds. `request_timeout` covers request
+    /// encoding/write and the terminal-result wait. This is a tracked normal
+    /// operation; abandoning it after the write boundary makes the connection
+    /// non-parkable.
+    pub async fn guest_state_restore(
+        &self,
+        unix_seconds: u64,
+        unix_nanoseconds: u32,
+        entropy: &[u8],
+        timezone: GuestStateRestoreTimezone<'_>,
+        process_timeout_ms: u32,
+        request_timeout: Duration,
+    ) -> io::Result<GuestStateRestoreResult> {
+        let response = normal_request_on_shared_with_write_observer_frame_builder(
+            &self.shared,
+            TERMINAL_MSG_TYPES,
+            request_timeout,
+            FrameWriteObserver::noop(),
+            |seq, frame| {
+                encode_guest_state_restore_request_frame_into(
+                    frame,
+                    seq,
+                    process_timeout_ms,
+                    unix_seconds,
+                    unix_nanoseconds,
+                    entropy,
+                    timezone,
+                )
+                .map_err(protocol_invalid_input)
+            },
+        )
+        .await?;
+
+        if response.msg_type == MSG_ERROR {
+            let message =
+                vsock_proto::decode_error(&response.payload).map_err(protocol_invalid_data)?;
+            return Err(io::Error::other(message.to_owned()));
+        }
+        if response.msg_type != MSG_GUEST_STATE_RESTORE_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unexpected guest state restore response type: 0x{:02X}",
+                    response.msg_type
+                ),
+            ));
+        }
+
+        let decoded =
+            decode_guest_state_restore_result(&response.payload).map_err(protocol_invalid_data)?;
+        let (stderr, stderr_truncated) = owned_capture(decoded.stderr)?;
+        Ok(GuestStateRestoreResult {
+            termination: decoded.termination,
+            duration_ms: decoded.duration_ms,
+            stderr,
+            stderr_truncated,
+            diagnostic: decoded.diagnostic.to_owned(),
+        })
+    }
+}
+
+fn owned_capture(output: ExecCapturedOutput<'_>) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        ExecCapturedOutput::Captured { bytes, truncated } => Ok((bytes.to_vec(), truncated)),
+        ExecCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "guest state restore result discarded stderr",
+        )),
+    }
+}
+
+fn protocol_invalid_input(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+}
+
+fn protocol_invalid_data(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -71,6 +71,7 @@ mod connection;
 mod exec_operation;
 mod file;
 mod guest_dns_readiness;
+mod guest_state_restore;
 mod guest_storage_manifest;
 mod operation_tracker;
 #[cfg(test)]
@@ -100,6 +101,7 @@ pub use exec_operation::{
 };
 pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
 pub use guest_dns_readiness::GuestDnsReadinessResult;
+pub use guest_state_restore::GuestStateRestoreResult;
 pub use guest_storage_manifest::GuestStorageManifestResult;
 
 /// Observer called when a request frame reaches the guest-write boundary.

--- a/crates/vsock-host/src/tests/guest_state_restore.rs
+++ b/crates/vsock-host/src/tests/guest_state_restore.rs
@@ -1,0 +1,176 @@
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use vsock_proto::{
+    ExecCapturedOutput, ExecTermination, GuestStateRestoreTimezone, MSG_GUEST_STATE_RESTORE,
+    MSG_GUEST_STATE_RESTORE_RESULT,
+};
+
+use crate::operation_tracker::NormalOperationReadiness;
+use crate::tests::support::{
+    MockGuest, host_from_stream, make_pair, normal_operation_readiness, pending_request_count,
+};
+
+fn entropy() -> [u8; 256] {
+    std::array::from_fn(|index| index as u8)
+}
+
+fn success_payload() -> Vec<u8> {
+    vsock_proto::encode_guest_state_restore_result(
+        ExecTermination::Exited { exit_code: 0 },
+        17,
+        ExecCapturedOutput::Captured {
+            bytes: b"guest timezone sync failed",
+            truncated: true,
+        },
+        "",
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn guest_state_restore_sends_fixed_request_and_decodes_result() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let expected_entropy = entropy();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STATE_RESTORE).await;
+        let decoded = vsock_proto::decode_guest_state_restore_request(&request.payload).unwrap();
+        assert_eq!(decoded.timeout_ms, 300_000);
+        assert_eq!(decoded.unix_seconds, 1_778_000_000);
+        assert_eq!(decoded.unix_nanoseconds, 123_000_000);
+        assert_eq!(decoded.entropy, expected_entropy);
+        assert_eq!(
+            decoded.timezone,
+            GuestStateRestoreTimezone::Required("Asia/Shanghai")
+        );
+        guest
+            .send_response(
+                MSG_GUEST_STATE_RESTORE_RESULT,
+                request.seq,
+                &success_payload(),
+            )
+            .await;
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let result = host
+        .guest_state_restore(
+            1_778_000_000,
+            123_000_000,
+            &entropy(),
+            GuestStateRestoreTimezone::Required("Asia/Shanghai"),
+            300_000,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.duration_ms, 17);
+    assert_eq!(result.stderr, b"guest timezone sync failed");
+    assert!(result.stderr_truncated);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_state_restore_surfaces_guest_error_and_malformed_result() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let request = guest.expect_message(MSG_GUEST_STATE_RESTORE).await;
+        guest
+            .send_error_response(request.seq, "guest operations are quiescing")
+            .await;
+        let request = guest.expect_message(MSG_GUEST_STATE_RESTORE).await;
+        guest
+            .send_response(MSG_GUEST_STATE_RESTORE_RESULT, request.seq, &[0xFF])
+            .await;
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+
+    let error = host
+        .guest_state_restore(
+            1,
+            0,
+            &entropy(),
+            GuestStateRestoreTimezone::None,
+            1,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("guest operations are quiescing"));
+
+    let error = host
+        .guest_state_restore(
+            1,
+            0,
+            &entropy(),
+            GuestStateRestoreTimezone::None,
+            1,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_state_restore_timeout_abandons_connection_for_parking() {
+    let (host_stream, guest_stream) = make_pair();
+    let (request_tx, request_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        let _request = guest.expect_message(MSG_GUEST_STATE_RESTORE).await;
+        request_tx.send(()).unwrap();
+        release_rx.await.unwrap();
+    });
+    let host = Arc::new(host_from_stream(host_stream).await.unwrap());
+    let request_host = Arc::clone(&host);
+    let request = tokio::spawn(async move {
+        request_host
+            .guest_state_restore(
+                1,
+                0,
+                &entropy(),
+                GuestStateRestoreTimezone::None,
+                1,
+                Duration::from_millis(20),
+            )
+            .await
+    });
+    request_rx.await.unwrap();
+
+    let error = request.await.unwrap().unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}

--- a/crates/vsock-host/src/tests/mod.rs
+++ b/crates/vsock-host/src/tests/mod.rs
@@ -4,4 +4,5 @@ mod connection;
 mod exec_operation;
 mod file;
 mod guest_dns_readiness;
+mod guest_state_restore;
 mod guest_storage_manifest;

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! | Type | Direction | Name              | Payload |
 //! |------|-----------|-------------------|---------|
-//! | 0x00 | G→H       | ready             | (empty) |
+//! | 0x00 | G→H       | ready             | empty for legacy guests, otherwise `[8B capability_bits]` |
 //! | 0x01 | H→G       | ping              | (empty) |
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | shutdown          | (empty) |
@@ -214,6 +214,14 @@ pub use payloads::guest_dns_readiness::{
     encode_guest_dns_readiness_request, encode_guest_dns_readiness_request_frame_into,
     encode_guest_dns_readiness_result,
 };
+pub use payloads::guest_state_restore::{
+    DecodedGuestStateRestoreRequest, GUEST_STATE_RESTORE_ENTROPY_BYTES,
+    GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES, GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES,
+    GuestStateRestoreTimezone, decode_guest_state_restore_request,
+    decode_guest_state_restore_result, encode_guest_state_restore_request,
+    encode_guest_state_restore_request_frame_into, encode_guest_state_restore_result,
+    encode_guest_state_restore_result_frame_into,
+};
 pub use payloads::guest_storage_manifest::{
     DecodedGuestStorageManifestRequest, GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES,
     GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
@@ -235,10 +243,11 @@ pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
     MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
     MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_GUEST_STORAGE_MANIFEST,
-    MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
-    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
-    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT,
-    WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
+    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_GUEST_STATE_RESTORE,
+    MSG_GUEST_STATE_RESTORE_RESULT, MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT,
+    MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
+    MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
+    WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types currently occupy the contiguous range `0x00..=0x19`
+//! Non-error message types currently occupy the contiguous range `0x00..=0x1B`
 //! in allocation order. Existing values are stable wire assignments: do not
 //! renumber or reuse them. Allocate new non-error messages at the next unused
 //! value below `0xFF`, even when related operations are not adjacent. `0xFF` is
@@ -55,13 +55,15 @@
 //! | 0x17 | G→H       | guest_dns_readiness_result | `[termination][4B duration_ms][1B flags][2B answer_len][answer][2B diagnostic_len][diagnostic]` |
 //! | 0x18 | H→G       | guest_storage_manifest | `[4B positive timeout_ms][2B run_id_len][run_id][2B runtime_dir_len][runtime_dir][4B manifest_len][manifest]` |
 //! | 0x19 | G→H       | guest_storage_manifest_result | same payload as `exec_result`, with both streams captured and bounded to 1 MiB each |
+//! | 0x1A | H→G       | guest_state_restore | `[4B positive timeout_ms][8B unix_seconds][4B unix_nanoseconds][1B timezone_mode][2B timezone_len][timezone][256B entropy]` |
+//! | 0x1B | G→H       | guest_state_restore_result | same payload as `exec_result`, with empty stdout and stderr bounded to 64 KiB |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
 //! covers `write_file`, `write_files`, `exec_start`, `exec_cancel`,
-//! `exec_control`, `guest_dns_readiness`, and `guest_storage_manifest`;
-//! operation replies reuse the
-//! original non-zero request sequence. `exec_output.output_seq` is per exec
+//! `exec_control`, `guest_dns_readiness`, `guest_storage_manifest`, and
+//! `guest_state_restore`; operation replies reuse the original non-zero request
+//! sequence. `exec_output.output_seq` is per exec
 //! operation and starts at 0, incrementing by 1 for each output frame across
 //! stdout and stderr.
 //! `write_file_result.success` / `write_files_result.success` use 0=false and

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! | Type | Direction | Name              | Payload |
 //! |------|-----------|-------------------|---------|
-//! | 0x00 | G→H       | ready             | empty for legacy guests, otherwise `[8B capability_bits]` |
+//! | 0x00 | G→H       | ready             | (empty) |
 //! | 0x01 | H→G       | ping              | (empty) |
 //! | 0x02 | G→H       | pong              | (empty) |
 //! | 0x03 | H→G       | shutdown          | (empty) |

--- a/crates/vsock-proto/src/payloads/guest_state_restore.rs
+++ b/crates/vsock-proto/src/payloads/guest_state_restore.rs
@@ -431,6 +431,17 @@ mod tests {
             )
             .is_err()
         );
+        let oversized_timezone = "A".repeat(GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES + 1);
+        assert!(
+            encode_guest_state_restore_request(
+                1,
+                1,
+                0,
+                &entropy,
+                GuestStateRestoreTimezone::Required(&oversized_timezone)
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -441,6 +452,34 @@ mod tests {
                 .unwrap();
         payload[16] = TIMEZONE_REQUIRED;
         assert!(decode_guest_state_restore_request(&payload).is_err());
+
+        let mut invalid_mode =
+            encode_guest_state_restore_request(1, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+                .unwrap();
+        invalid_mode[16] = u8::MAX;
+        assert!(decode_guest_state_restore_request(&invalid_mode).is_err());
+
+        let mut none_with_name = encode_guest_state_restore_request(
+            1,
+            1,
+            0,
+            &entropy,
+            GuestStateRestoreTimezone::BestEffort("UTC"),
+        )
+        .unwrap();
+        none_with_name[16] = TIMEZONE_NONE;
+        assert!(decode_guest_state_restore_request(&none_with_name).is_err());
+
+        let mut invalid_utf8 = encode_guest_state_restore_request(
+            1,
+            1,
+            0,
+            &entropy,
+            GuestStateRestoreTimezone::Required("A"),
+        )
+        .unwrap();
+        invalid_utf8[19] = u8::MAX;
+        assert!(decode_guest_state_restore_request(&invalid_utf8).is_err());
 
         let mut truncated = payload;
         truncated.pop();

--- a/crates/vsock-proto/src/payloads/guest_state_restore.rs
+++ b/crates/vsock-proto/src/payloads/guest_state_restore.rs
@@ -1,0 +1,496 @@
+use crate::ProtocolError;
+use crate::frame::encode_into;
+use crate::read::{
+    checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, expect_consumed,
+    read_slice, read_str, read_u8, read_u16, read_u32, read_u64,
+};
+use crate::wire::{MSG_GUEST_STATE_RESTORE, MSG_GUEST_STATE_RESTORE_RESULT};
+use crate::{DecodedExecResult, ExecCapturedOutput, ExecTermination};
+
+/// Exact entropy byte count required by snapshot-sensitive guest restore.
+pub const GUEST_STATE_RESTORE_ENTROPY_BYTES: usize = 256;
+
+/// Maximum encoded timezone name accepted by the fixed restore operation.
+pub const GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES: usize = 255;
+
+/// Fixed stderr capture bound for the guest-state helper.
+pub const GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES: usize = 64 * 1024;
+
+const TIMEZONE_NONE: u8 = 0;
+const TIMEZONE_BEST_EFFORT: u8 = 1;
+const TIMEZONE_REQUIRED: u8 = 2;
+
+/// Typed timezone behavior for the fixed guest-state restore operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GuestStateRestoreTimezone<'a> {
+    /// Do not change timezone state.
+    None,
+    /// Apply the timezone when available without failing the restore.
+    BestEffort(&'a str),
+    /// Require the timezone to exist and apply successfully.
+    Required(&'a str),
+}
+
+/// Decoded fixed guest-state restore request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DecodedGuestStateRestoreRequest<'a> {
+    /// Positive child-process timeout in milliseconds.
+    pub timeout_ms: u32,
+    /// Host realtime seconds since the Unix epoch.
+    pub unix_seconds: u64,
+    /// Fractional host realtime nanoseconds.
+    pub unix_nanoseconds: u32,
+    /// Exactly 256 host entropy bytes.
+    pub entropy: &'a [u8],
+    /// Optional timezone behavior.
+    pub timezone: GuestStateRestoreTimezone<'a>,
+}
+
+/// Encode a fixed guest-state restore request payload.
+pub fn encode_guest_state_restore_request(
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: &[u8],
+    timezone: GuestStateRestoreTimezone<'_>,
+) -> Result<Vec<u8>, ProtocolError> {
+    let timezone_length = validate_request(
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+    )?;
+    let payload_len = request_payload_len(timezone)?;
+    let mut payload = Vec::with_capacity(payload_len);
+    append_request_payload(
+        &mut payload,
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+        timezone_length,
+    );
+    Ok(payload)
+}
+
+/// Encode a full fixed guest-state restore request frame into `frame`.
+pub fn encode_guest_state_restore_request_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: &[u8],
+    timezone: GuestStateRestoreTimezone<'_>,
+) -> Result<(), ProtocolError> {
+    let timezone_length = validate_request(
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+    )?;
+    let payload_len = request_payload_len(timezone)?;
+    encode_into(frame, MSG_GUEST_STATE_RESTORE, seq, payload_len, |frame| {
+        append_request_payload(
+            frame,
+            timeout_ms,
+            unix_seconds,
+            unix_nanoseconds,
+            entropy,
+            timezone,
+            timezone_length,
+        )
+    })
+}
+
+/// Decode a fixed guest-state restore request payload.
+pub fn decode_guest_state_restore_request(
+    payload: &[u8],
+) -> Result<DecodedGuestStateRestoreRequest<'_>, ProtocolError> {
+    let mut offset = 0;
+    let timeout_ms = read_u32(
+        payload,
+        &mut offset,
+        "guest_state_restore timeout_ms truncated",
+    )?;
+    let unix_seconds = read_u64(
+        payload,
+        &mut offset,
+        "guest_state_restore unix_seconds truncated",
+    )?;
+    let unix_nanoseconds = read_u32(
+        payload,
+        &mut offset,
+        "guest_state_restore unix_nanoseconds truncated",
+    )?;
+    let timezone_mode = read_u8(
+        payload,
+        &mut offset,
+        "guest_state_restore timezone_mode truncated",
+    )?;
+    let timezone_len = usize::from(read_u16(
+        payload,
+        &mut offset,
+        "guest_state_restore timezone_len truncated",
+    )?);
+    let timezone_name = read_str(
+        payload,
+        &mut offset,
+        timezone_len,
+        "guest_state_restore timezone truncated",
+        "guest_state_restore timezone invalid UTF-8",
+    )?;
+    let entropy = read_slice(
+        payload,
+        &mut offset,
+        GUEST_STATE_RESTORE_ENTROPY_BYTES,
+        "guest_state_restore entropy truncated",
+    )?;
+    expect_consumed(payload, offset, "guest_state_restore trailing bytes")?;
+    let timezone = decode_timezone(timezone_mode, timezone_name)?;
+    validate_request(
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+    )?;
+    Ok(DecodedGuestStateRestoreRequest {
+        timeout_ms,
+        unix_seconds,
+        unix_nanoseconds,
+        entropy,
+        timezone,
+    })
+}
+
+/// Encode a fixed guest-state restore terminal result payload.
+pub fn encode_guest_state_restore_result(
+    termination: ExecTermination,
+    duration_ms: u32,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<Vec<u8>, ProtocolError> {
+    validate_stderr(stderr)?;
+    crate::encode_exec_result(
+        termination,
+        duration_ms,
+        ExecCapturedOutput::Captured {
+            bytes: &[],
+            truncated: false,
+        },
+        stderr,
+        diagnostic,
+    )
+}
+
+/// Encode a full fixed guest-state restore terminal result frame.
+pub fn encode_guest_state_restore_result_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    termination: ExecTermination,
+    duration_ms: u32,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<(), ProtocolError> {
+    let payload = encode_guest_state_restore_result(termination, duration_ms, stderr, diagnostic)?;
+    encode_into(
+        frame,
+        MSG_GUEST_STATE_RESTORE_RESULT,
+        seq,
+        payload.len(),
+        |frame| frame.extend_from_slice(&payload),
+    )
+}
+
+/// Decode a fixed guest-state restore terminal result payload.
+pub fn decode_guest_state_restore_result(
+    payload: &[u8],
+) -> Result<DecodedExecResult<'_>, ProtocolError> {
+    let decoded = crate::decode_exec_result(payload)?;
+    match decoded.stdout {
+        ExecCapturedOutput::Captured {
+            bytes: [],
+            truncated: false,
+        } => {}
+        _ => {
+            return Err(ProtocolError::InvalidPayload(
+                "guest_state_restore_result stdout must be empty captured output",
+            ));
+        }
+    }
+    validate_stderr(decoded.stderr)?;
+    Ok(decoded)
+}
+
+fn validate_request(
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: &[u8],
+    timezone: GuestStateRestoreTimezone<'_>,
+) -> Result<u16, ProtocolError> {
+    if timeout_ms == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore timeout_ms must be positive",
+        ));
+    }
+    if unix_seconds > i64::MAX as u64 {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore unix_seconds exceed signed time range",
+        ));
+    }
+    if unix_nanoseconds >= 1_000_000_000 {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore unix_nanoseconds must be below one second",
+        ));
+    }
+    if entropy.len() != GUEST_STATE_RESTORE_ENTROPY_BYTES {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore entropy must contain exactly 256 bytes",
+        ));
+    }
+    let timezone_name = timezone_name(timezone);
+    if timezone_name.len() > GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "timezone",
+            timezone_name.len(),
+        ));
+    }
+    if !timezone_name.is_empty() && !is_safe_timezone_name(timezone_name) {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore timezone contains unsafe characters",
+        ));
+    }
+    let length = ensure_u16_len("timezone", timezone_name.len())?;
+    ensure_payload_fits_message(request_payload_len(timezone)?)?;
+    Ok(length)
+}
+
+fn request_payload_len(timezone: GuestStateRestoreTimezone<'_>) -> Result<usize, ProtocolError> {
+    let fixed = 4usize + 8 + 4 + 1 + 2 + GUEST_STATE_RESTORE_ENTROPY_BYTES;
+    checked_payload_len_add(fixed, timezone_name(timezone).len())
+}
+
+fn append_request_payload(
+    payload: &mut Vec<u8>,
+    timeout_ms: u32,
+    unix_seconds: u64,
+    unix_nanoseconds: u32,
+    entropy: &[u8],
+    timezone: GuestStateRestoreTimezone<'_>,
+    timezone_length: u16,
+) {
+    payload.extend_from_slice(&timeout_ms.to_be_bytes());
+    payload.extend_from_slice(&unix_seconds.to_be_bytes());
+    payload.extend_from_slice(&unix_nanoseconds.to_be_bytes());
+    payload.push(timezone_tag(timezone));
+    payload.extend_from_slice(&timezone_length.to_be_bytes());
+    payload.extend_from_slice(timezone_name(timezone).as_bytes());
+    payload.extend_from_slice(entropy);
+}
+
+fn timezone_tag(timezone: GuestStateRestoreTimezone<'_>) -> u8 {
+    match timezone {
+        GuestStateRestoreTimezone::None => TIMEZONE_NONE,
+        GuestStateRestoreTimezone::BestEffort(_) => TIMEZONE_BEST_EFFORT,
+        GuestStateRestoreTimezone::Required(_) => TIMEZONE_REQUIRED,
+    }
+}
+
+fn timezone_name(timezone: GuestStateRestoreTimezone<'_>) -> &str {
+    match timezone {
+        GuestStateRestoreTimezone::None => "",
+        GuestStateRestoreTimezone::BestEffort(name) | GuestStateRestoreTimezone::Required(name) => {
+            name
+        }
+    }
+}
+
+fn decode_timezone(mode: u8, name: &str) -> Result<GuestStateRestoreTimezone<'_>, ProtocolError> {
+    match (mode, name) {
+        (TIMEZONE_NONE, "") => Ok(GuestStateRestoreTimezone::None),
+        (TIMEZONE_BEST_EFFORT, "") | (TIMEZONE_REQUIRED, "") => Err(ProtocolError::InvalidPayload(
+            "guest_state_restore timezone must not be empty",
+        )),
+        (TIMEZONE_BEST_EFFORT, name) => Ok(GuestStateRestoreTimezone::BestEffort(name)),
+        (TIMEZONE_REQUIRED, name) => Ok(GuestStateRestoreTimezone::Required(name)),
+        (TIMEZONE_NONE, _) => Err(ProtocolError::InvalidPayload(
+            "guest_state_restore none timezone mode requires an empty name",
+        )),
+        _ => Err(ProtocolError::InvalidPayload(
+            "guest_state_restore timezone mode is invalid",
+        )),
+    }
+}
+
+fn is_safe_timezone_name(timezone: &str) -> bool {
+    timezone.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || byte == b'/' || byte == b'_' || byte == b'-' || byte == b'+'
+    })
+}
+
+fn validate_stderr(stderr: ExecCapturedOutput<'_>) -> Result<(), ProtocolError> {
+    match stderr {
+        ExecCapturedOutput::Captured { bytes, .. }
+            if bytes.len() <= GUEST_STATE_RESTORE_OUTPUT_LIMIT_BYTES =>
+        {
+            Ok(())
+        }
+        ExecCapturedOutput::Captured { bytes, .. } => {
+            Err(ProtocolError::PayloadTooLarge("stderr", bytes.len()))
+        }
+        ExecCapturedOutput::Discarded => Err(ProtocolError::InvalidPayload(
+            "guest_state_restore_result stderr must be captured",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entropy() -> [u8; GUEST_STATE_RESTORE_ENTROPY_BYTES] {
+        std::array::from_fn(|index| index as u8)
+    }
+
+    #[test]
+    fn request_round_trip_preserves_fixed_inputs() {
+        for timezone in [
+            GuestStateRestoreTimezone::None,
+            GuestStateRestoreTimezone::BestEffort("Asia/Shanghai"),
+            GuestStateRestoreTimezone::Required("Etc/GMT+1"),
+        ] {
+            let entropy = entropy();
+            let payload = encode_guest_state_restore_request(
+                300_000,
+                1_778_000_000,
+                123_000_000,
+                &entropy,
+                timezone,
+            )
+            .unwrap();
+
+            let decoded = decode_guest_state_restore_request(&payload).unwrap();
+
+            assert_eq!(decoded.timeout_ms, 300_000);
+            assert_eq!(decoded.unix_seconds, 1_778_000_000);
+            assert_eq!(decoded.unix_nanoseconds, 123_000_000);
+            assert_eq!(decoded.entropy, entropy);
+            assert_eq!(decoded.timezone, timezone);
+        }
+    }
+
+    #[test]
+    fn request_rejects_invalid_fixed_inputs() {
+        let entropy = entropy();
+        assert!(
+            encode_guest_state_restore_request(0, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+                .is_err()
+        );
+        assert!(
+            encode_guest_state_restore_request(
+                1,
+                i64::MAX as u64 + 1,
+                0,
+                &entropy,
+                GuestStateRestoreTimezone::None
+            )
+            .is_err()
+        );
+        assert!(
+            encode_guest_state_restore_request(
+                1,
+                1,
+                1_000_000_000,
+                &entropy,
+                GuestStateRestoreTimezone::None
+            )
+            .is_err()
+        );
+        assert!(
+            encode_guest_state_restore_request(
+                1,
+                1,
+                0,
+                &entropy[..255],
+                GuestStateRestoreTimezone::None
+            )
+            .is_err()
+        );
+        assert!(
+            encode_guest_state_restore_request(
+                1,
+                1,
+                0,
+                &entropy,
+                GuestStateRestoreTimezone::Required("../UTC")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn request_decoder_rejects_bad_mode_length_and_trailing_bytes() {
+        let entropy = entropy();
+        let mut payload =
+            encode_guest_state_restore_request(1, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+                .unwrap();
+        payload[16] = TIMEZONE_REQUIRED;
+        assert!(decode_guest_state_restore_request(&payload).is_err());
+
+        let mut truncated = payload;
+        truncated.pop();
+        assert!(decode_guest_state_restore_request(&truncated).is_err());
+
+        let mut trailing =
+            encode_guest_state_restore_request(1, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+                .unwrap();
+        trailing.push(0);
+        assert!(decode_guest_state_restore_request(&trailing).is_err());
+    }
+
+    #[test]
+    fn result_round_trip_requires_empty_stdout_and_bounded_stderr() {
+        let stderr = ExecCapturedOutput::Captured {
+            bytes: b"guest-reseed failed",
+            truncated: false,
+        };
+        let payload = encode_guest_state_restore_result(
+            ExecTermination::Exited { exit_code: 1 },
+            17,
+            stderr,
+            "diagnostic",
+        )
+        .unwrap();
+
+        let decoded = decode_guest_state_restore_result(&payload).unwrap();
+        assert_eq!(
+            decoded.termination,
+            ExecTermination::Exited { exit_code: 1 }
+        );
+        assert_eq!(decoded.duration_ms, 17);
+        assert_eq!(
+            decoded.stdout,
+            ExecCapturedOutput::Captured {
+                bytes: &[],
+                truncated: false
+            }
+        );
+        assert_eq!(decoded.stderr, stderr);
+        assert_eq!(decoded.diagnostic, "diagnostic");
+
+        assert!(
+            encode_guest_state_restore_result(
+                ExecTermination::WaitFailed,
+                0,
+                ExecCapturedOutput::Discarded,
+                ""
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/vsock-proto/src/payloads/guest_state_restore.rs
+++ b/crates/vsock-proto/src/payloads/guest_state_restore.rs
@@ -32,7 +32,7 @@ pub enum GuestStateRestoreTimezone<'a> {
 }
 
 /// Decoded fixed guest-state restore request.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct DecodedGuestStateRestoreRequest<'a> {
     /// Positive child-process timeout in milliseconds.
     pub timeout_ms: u32,
@@ -44,6 +44,19 @@ pub struct DecodedGuestStateRestoreRequest<'a> {
     pub entropy: &'a [u8],
     /// Optional timezone behavior.
     pub timezone: GuestStateRestoreTimezone<'a>,
+}
+
+impl std::fmt::Debug for DecodedGuestStateRestoreRequest<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DecodedGuestStateRestoreRequest")
+            .field("timeout_ms", &self.timeout_ms)
+            .field("unix_seconds", &self.unix_seconds)
+            .field("unix_nanoseconds", &self.unix_nanoseconds)
+            .field("entropy_len", &self.entropy.len())
+            .field("timezone", &self.timezone)
+            .finish()
+    }
 }
 
 /// Encode a fixed guest-state restore request payload.
@@ -382,6 +395,19 @@ mod tests {
             assert_eq!(decoded.entropy, entropy);
             assert_eq!(decoded.timezone, timezone);
         }
+    }
+
+    #[test]
+    fn request_debug_redacts_entropy_contents() {
+        let entropy = [222; GUEST_STATE_RESTORE_ENTROPY_BYTES];
+        let payload =
+            encode_guest_state_restore_request(1, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+                .unwrap();
+        let decoded = decode_guest_state_restore_request(&payload).unwrap();
+
+        let debug = format!("{decoded:?}");
+        assert!(debug.contains("entropy_len: 256"), "debug={debug}");
+        assert!(!debug.contains("222, 222"), "debug={debug}");
     }
 
     #[test]

--- a/crates/vsock-proto/src/payloads/mod.rs
+++ b/crates/vsock-proto/src/payloads/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod exec_operation;
 pub(crate) mod guest_dns_readiness;
+pub(crate) mod guest_state_restore;
 pub(crate) mod guest_storage_manifest;
 pub(crate) mod memory_snapshot;
 pub(crate) mod process_termination;

--- a/crates/vsock-proto/src/read.rs
+++ b/crates/vsock-proto/src/read.rs
@@ -20,6 +20,13 @@ pub(crate) fn read_u32_at(data: &[u8], offset: usize) -> Option<u32> {
     Some(u32::from_be_bytes(bytes))
 }
 
+/// Read a `u64` from `data` at `offset`. Returns `None` if out of bounds.
+pub(crate) fn read_u64_at(data: &[u8], offset: usize) -> Option<u64> {
+    let end = offset.checked_add(8)?;
+    let bytes: [u8; 8] = data.get(offset..end)?.try_into().ok()?;
+    Some(u64::from_be_bytes(bytes))
+}
+
 /// Read an `i32` from `data` at `offset`. Returns `None` if out of bounds.
 pub(crate) fn read_i32_at(data: &[u8], offset: usize) -> Option<i32> {
     let end = offset.checked_add(4)?;
@@ -98,6 +105,16 @@ pub(crate) fn read_u32(
 ) -> Result<u32, ProtocolError> {
     let value = read_u32_at(payload, *offset).ok_or(ProtocolError::InvalidPayload(err))?;
     *offset += 4;
+    Ok(value)
+}
+
+pub(crate) fn read_u64(
+    payload: &[u8],
+    offset: &mut usize,
+    err: &'static str,
+) -> Result<u64, ProtocolError> {
+    let value = read_u64_at(payload, *offset).ok_or(ProtocolError::InvalidPayload(err))?;
+    *offset += 8;
     Ok(value)
 }
 

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -95,6 +95,12 @@ pub const MSG_GUEST_STORAGE_MANIFEST: u8 = 0x18;
 /// Guest-to-host result of applying a bounded storage manifest.
 pub const MSG_GUEST_STORAGE_MANIFEST_RESULT: u8 = 0x19;
 
+/// Host-to-guest request to restore bounded snapshot-sensitive guest state.
+pub const MSG_GUEST_STATE_RESTORE: u8 = 0x1A;
+
+/// Guest-to-host result of restoring snapshot-sensitive guest state.
+pub const MSG_GUEST_STATE_RESTORE_RESULT: u8 = 0x1B;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -169,6 +175,12 @@ mod tests {
                 "MSG_GUEST_STORAGE_MANIFEST_RESULT",
                 MSG_GUEST_STORAGE_MANIFEST_RESULT,
                 0x19,
+            ),
+            ("MSG_GUEST_STATE_RESTORE", MSG_GUEST_STATE_RESTORE, 0x1A),
+            (
+                "MSG_GUEST_STATE_RESTORE_RESULT",
+                MSG_GUEST_STATE_RESTORE_RESULT,
+                0x1B,
             ),
             ("MSG_ERROR", MSG_ERROR, 0xFF),
         ];


### PR DESCRIPTION
## Summary

- replace generic privileged shell exec for combined guest state restore with a typed fixed-purpose sandbox/vsock operation
- extend the bundled `guest-reseed` helper to set realtime, mix exactly 256 entropy bytes, and apply optional timezone state in the existing order
- run the trusted helper in a dedicated process group with bounded stderr, timeout/disconnect cancellation, descendant cleanup, operation fencing, and parking safety
- preserve Runner failure markers, required versus best-effort timezone behavior, recovery, speculation, and telemetry contracts

## Performance

Controlled `runner benchmark` samples on the same `local-1.aws.vm3.ai` host and `vm0/default` profile:

| Revision | Samples | p50 | p90 |
| --- | --- | ---: | ---: |
| `main` generic exec | 69, 68, 29, 73, 69 ms | 69 ms | 73 ms |
| fixed operation | 9, 8, 7, 8, 8 ms | 8 ms | 9 ms |

This reduces guest restore p50 by 61 ms (88.4%) and p90 by 64 ms (87.7%).

## Deployment boundary

Runner and bundled guest binaries ship in one runner artifact per `docs/deployment-compatibility.md`; no mixed-version capability negotiation or generic-exec fallback is included. Guest binary changes produce matching new rootfs/snapshot hashes.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- Clippy with `-D warnings` for all affected crates, targets, and features
- Rust docs for all affected crates
- affected guest/protocol/host/sandbox test suites
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3305 passed, 21 ignored)
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection` (93 passed)
- aarch64 musl release build, bundled rootfs/snapshot creation, deployment readiness, and repeated real Firecracker benchmark

Closes #29364

Parent context: #24203
