### PR TITLE
test(e2e): cover connector account selection

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -414,6 +414,27 @@ unless bootstrap_steps.any? do |step|
   end
   raise "runner bootstrap must download the token artifact"
 end
+connector_accounts_step = bootstrap_steps.find do |step|
+  step["name"] == "Enable runner connector account coverage"
+end
+raise "missing runner connector account bootstrap" unless connector_accounts_step
+connector_accounts_script = connector_accounts_step.fetch("run")
+unless connector_accounts_step.fetch("shell") == "bash" &&
+    connector_accounts_script.include?('/api/feature-switches') &&
+    connector_accounts_script.include?(
+      '{"switches":{"connectorAccounts":true}}',
+    ) &&
+    connector_accounts_script.include?(
+      '.effectiveSwitches.connectorAccounts == true',
+    )
+  raise "runner connector account bootstrap must enable and verify the public feature switch"
+end
+unless connector_accounts_step.dig(
+    "env",
+    "VERCEL_AUTOMATION_BYPASS_SECRET",
+  ) == "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
+  raise "runner connector account bootstrap must receive the preview bypass secret"
+end
 model_defaults_step = bootstrap_steps.find do |step|
   step["name"] == "Reset runner model defaults"
 end

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2576,6 +2576,23 @@ jobs:
           echo "::add-mask::$token"
           echo "E2E_API_TOKEN=$token" >> "$GITHUB_ENV"
           echo "E2E_API_URL=$api_url" >> "$GITHUB_ENV"
+      - name: Enable runner connector account coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          headers=(-H "Authorization: Bearer ${E2E_API_TOKEN}" -H "Content-Type: application/json")
+          if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+            headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          fi
+
+          curl -fsS "${headers[@]}" \
+            -X POST \
+            -d '{"switches":{"connectorAccounts":true}}' \
+            "${E2E_API_URL}/api/feature-switches" \
+            | jq -e '.effectiveSwitches.connectorAccounts == true' \
+            >/dev/null
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Reset runner model defaults
         shell: bash
         run: |

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -350,11 +350,15 @@ EOF
     run jq -e \
         --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
         --arg sourceId "$default_connection_id" '
-            any(.firewalls[]?;
-                .kind == "inline" and
-                .customConnectorId == $customConnectorId and
-                .sourceId == $sourceId
-            )
+            ([
+                .firewalls[]?
+                | select(
+                    .kind == "inline" and
+                    .customConnectorId == $customConnectorId
+                )
+            ]) as $matches
+            | ($matches | length) == 1 and
+                $matches[0].sourceId == $sourceId
         ' <<<"$default_run_context"
     echo "$output"
     assert_success
@@ -488,11 +492,15 @@ EOF
     run jq -e \
         --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
         --arg sourceId "$selected_connection_id" '
-            any(.firewalls[]?;
-                .kind == "inline" and
-                .customConnectorId == $customConnectorId and
-                .sourceId == $sourceId
-            )
+            ([
+                .firewalls[]?
+                | select(
+                    .kind == "inline" and
+                    .customConnectorId == $customConnectorId
+                )
+            ]) as $matches
+            | ($matches | length) == 1 and
+                $matches[0].sourceId == $sourceId
         ' <<<"$selected_run_context"
     echo "$output"
     assert_success

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -8,6 +8,12 @@ setup() {
     runner_e2e_require_environment
     runner_e2e_setup_test
     CUSTOM_CONNECTOR_ID=""
+
+    local feature_switches
+    feature_switches="$(runner_api_curl "/api/feature-switches")"
+    jq -e '.effectiveSwitches.connectorAccounts == true' \
+        <<<"$feature_switches" \
+        >/dev/null
 }
 
 teardown() {

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -146,3 +146,384 @@ EOF
     echo "$output"
     assert_success
 }
+
+@test "runner resolves an exact custom connector account on thread continuation" {
+    run create_runner_agent "runner-custom-connector-account-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local connector_slug="_runner-account-probe-${TEST_ID}"
+    local connector_payload
+    connector_payload=$(jq -nc \
+        --arg slug "$connector_slug" \
+        --arg prefix 'https://{{variables.host}}/' \
+        '{
+            slug: $slug,
+            kind: "http",
+            displayName: "Runner Account Probe",
+            prefixTemplates: [$prefix],
+            fields: [
+                {
+                    key: "probe_secret",
+                    label: "Probe secret",
+                    kind: "secret",
+                    required: true
+                },
+                {
+                    key: "host",
+                    label: "Host",
+                    kind: "variable",
+                    required: true
+                }
+            ],
+            headerInjections: [{
+                name: "X-Okou-Custom-Connector-Account-Probe",
+                valueTemplate: "{{secrets.probe_secret}}"
+            }],
+            queryInjections: [],
+            authMode: "manual"
+        }')
+    run runner_api_curl "/api/custom-connectors" \
+        -X POST \
+        -d "$connector_payload"
+    echo "$output"
+    assert_success
+    local public_surfaces="$output"$'\n'
+    CUSTOM_CONNECTOR_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
+
+    local default_secret selected_secret
+    default_secret="e2e-custom-default-$(_runner_uuid)"
+    selected_secret="e2e-custom-selected-$(_runner_uuid)"
+
+    local default_values_payload
+    default_values_payload=$(jq -nc \
+        --arg secret "$default_secret" \
+        '{
+            account: {intent: "add", displayName: "Default account"},
+            values: [
+                {key: "probe_secret", kind: "secret", value: $secret},
+                {key: "host", kind: "variable", value: "example.com"}
+            ]
+        }')
+    run runner_api_curl \
+        "/api/custom-connectors/${CUSTOM_CONNECTOR_ID}/values" \
+        -X PUT \
+        -d "$default_values_payload"
+    echo "$output"
+    assert_success
+    local default_account_response="$output"
+    public_surfaces+="$default_account_response"$'\n'
+    local default_connection_id
+    default_connection_id=$(jq -er \
+        '.connectedAccountId | select(type == "string" and length > 0)' \
+        <<<"$default_account_response")
+    run jq -e '
+        .connected == true and
+        .missingRequiredFields == [] and
+        (.configuredFieldKeys | sort) == ["host", "probe_secret"]
+    ' <<<"$default_account_response"
+    assert_success
+
+    local selected_values_payload
+    selected_values_payload=$(jq -nc \
+        --arg secret "$selected_secret" \
+        '{
+            account: {intent: "add", displayName: "Selected account"},
+            values: [
+                {key: "probe_secret", kind: "secret", value: $secret},
+                {key: "host", kind: "variable", value: "www.google.com"}
+            ]
+        }')
+    run runner_api_curl \
+        "/api/custom-connectors/${CUSTOM_CONNECTOR_ID}/values" \
+        -X PUT \
+        -d "$selected_values_payload"
+    echo "$output"
+    assert_success
+    local selected_account_response="$output"
+    public_surfaces+="$selected_account_response"$'\n'
+    local selected_connection_id
+    selected_connection_id=$(jq -er \
+        '.connectedAccountId | select(type == "string" and length > 0)' \
+        <<<"$selected_account_response")
+    [[ "$selected_connection_id" != "$default_connection_id" ]]
+
+    run runner_api_curl \
+        "/api/connector-accounts/connections?kind=custom&customConnectorId=${CUSTOM_CONNECTOR_ID}&limit=100"
+    echo "$output"
+    assert_success
+    local accounts_response="$output"
+    public_surfaces+="$accounts_response"$'\n'
+    run jq -e \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
+        --arg defaultConnectionId "$default_connection_id" \
+        --arg selectedConnectionId "$selected_connection_id" '
+            .nextCursor == null and
+            (.connections | length) == 2 and
+            any(.connections[];
+                .id == $defaultConnectionId and
+                .target == {
+                    kind: "custom",
+                    customConnectorId: $customConnectorId
+                } and
+                .displayName == "Default account" and
+                .isDefault == true and
+                .connectionStatus == "connected"
+            ) and
+            any(.connections[];
+                .id == $selectedConnectionId and
+                .target == {
+                    kind: "custom",
+                    customConnectorId: $customConnectorId
+                } and
+                .displayName == "Selected account" and
+                .isDefault == false and
+                .connectionStatus == "connected"
+            )
+        ' <<<"$accounts_response"
+    echo "$output"
+    assert_success
+
+    local grants_payload
+    grants_payload=$(jq -nc \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
+        '{
+            operation: "replace",
+            grants: [{
+                customConnectorId: $customConnectorId,
+                permissionNames: []
+            }]
+        }')
+    run runner_api_curl "/api/agents/${AGENT_ID}/custom-connectors" \
+        -X PUT \
+        -d "$grants_payload"
+    echo "$output"
+    assert_success
+    local grants_response="$output"
+    public_surfaces+="$grants_response"$'\n'
+
+    local default_marker="CUSTOM_CONNECTOR_DEFAULT_ACCOUNT_${TEST_ID}"
+    local default_prompt
+    default_prompt=$(cat <<EOF
+set -euo pipefail
+curl --silent --show-error --max-time 10 \\
+    --output /dev/null \\
+    'https://example.com/'
+printf '${default_marker}\\n'
+EOF
+)
+    run runner_e2e_start_chat_run "$AGENT_ID" "$default_prompt"
+    echo "$output"
+    assert_success
+    local first_send_response="$output"
+    public_surfaces+="$first_send_response"$'\n'
+    local first_run_id
+    first_run_id=$(jq -er \
+        '.runId | select(type == "string" and length > 0)' \
+        <<<"$first_send_response")
+    RUN_ID="$first_run_id"
+    THREAD_ID=$(jq -er \
+        '.threadId | select(type == "string" and length > 0)' \
+        <<<"$first_send_response")
+
+    run runner_wait_for_run "$first_run_id" 180
+    echo "$output"
+    assert_success
+    public_surfaces+="$output"$'\n'
+
+    run runner_e2e_wait_for_chat_text \
+        "$THREAD_ID" \
+        "$first_run_id" \
+        "$default_marker"
+    echo "$output"
+    assert_success
+    public_surfaces+="$output"$'\n'
+
+    run runner_api_curl "/api/runs/${first_run_id}/context"
+    echo "$output"
+    assert_success
+    local default_run_context="$output"
+    public_surfaces+="$default_run_context"$'\n'
+    run jq -e \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
+        --arg sourceId "$default_connection_id" '
+            any(.firewalls[]?;
+                .kind == "inline" and
+                .customConnectorId == $customConnectorId and
+                .sourceId == $sourceId
+            )
+        ' <<<"$default_run_context"
+    echo "$output"
+    assert_success
+
+    local compact_connector_id="${CUSTOM_CONNECTOR_ID//-/}"
+    local firewall_name="custom_connector_${compact_connector_id}"
+    local secret_key="CUSTOM_${compact_connector_id}_S_PROBE_SECRET"
+    local expected_secrets
+    expected_secrets=$(jq -nc --arg secretKey "$secret_key" '[$secretKey]')
+    run runner_e2e_wait_for_firewall_log \
+        "$first_run_id" \
+        "$firewall_name" \
+        example.com \
+        "$expected_secrets"
+    echo "$output"
+    assert_success
+    local default_network_logs="$output"
+    public_surfaces+="$default_network_logs"$'\n'
+    run jq -e --arg firewallName "$firewall_name" '
+        all(.[];
+            .firewall_name != $firewallName or
+            .host != "www.google.com"
+        )
+    ' <<<"$default_network_logs"
+    echo "$output"
+    assert_success
+
+    local selection_payload
+    selection_payload=$(jq -nc \
+        --arg connectionId "$selected_connection_id" \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
+        '{
+            connectionId: $connectionId,
+            target: {
+                kind: "custom",
+                customConnectorId: $customConnectorId
+            }
+        }')
+    run runner_api_curl \
+        "/api/chat-threads/${THREAD_ID}/connector-selections" \
+        -X PUT \
+        -d "$selection_payload"
+    echo "$output"
+    assert_success
+    local selection_response="$output"
+    public_surfaces+="$selection_response"$'\n'
+    run jq -e \
+        --arg connectionId "$selected_connection_id" \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" '
+            . == {
+                connectionId: $connectionId,
+                target: {
+                    kind: "custom",
+                    customConnectorId: $customConnectorId
+                }
+            }
+        ' <<<"$selection_response"
+    echo "$output"
+    assert_success
+
+    run runner_api_curl \
+        "/api/chat-threads/${THREAD_ID}/connector-selections"
+    echo "$output"
+    assert_success
+    local selection_read_response="$output"
+    public_surfaces+="$selection_read_response"$'\n'
+    run jq -e \
+        --arg connectionId "$selected_connection_id" \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" '
+            .selections == [{
+                connectionId: $connectionId,
+                target: {
+                    kind: "custom",
+                    customConnectorId: $customConnectorId
+                }
+            }] and
+            (.selectedConnections | length) == 1 and
+            .selectedConnections[0].id == $connectionId and
+            .selectedConnections[0].isDefault == false
+        ' <<<"$selection_read_response"
+    echo "$output"
+    assert_success
+
+    local selected_marker="CUSTOM_CONNECTOR_SELECTED_ACCOUNT_${TEST_ID}"
+    local selected_prompt
+    selected_prompt=$(cat <<EOF
+set -euo pipefail
+curl --silent --show-error --max-time 10 \\
+    --output /dev/null \\
+    'https://www.google.com/robots.txt'
+printf '${selected_marker}\\n'
+EOF
+)
+    run runner_e2e_continue_chat_run \
+        "$AGENT_ID" \
+        "$THREAD_ID" \
+        "$selected_prompt"
+    echo "$output"
+    assert_success
+    local selected_send_response="$output"
+    public_surfaces+="$selected_send_response"$'\n'
+    run jq -e \
+        --arg threadId "$THREAD_ID" \
+        --arg firstRunId "$first_run_id" '
+            .threadId == $threadId and
+            (.runId | type == "string" and length > 0) and
+            .runId != $firstRunId
+        ' <<<"$selected_send_response"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId' <<<"$selected_send_response")
+
+    run runner_wait_for_run "$RUN_ID" 180
+    echo "$output"
+    assert_success
+    public_surfaces+="$output"$'\n'
+
+    run runner_e2e_wait_for_chat_text \
+        "$THREAD_ID" \
+        "$RUN_ID" \
+        "$selected_marker"
+    echo "$output"
+    assert_success
+    public_surfaces+="$output"$'\n'
+
+    run runner_api_curl "/api/runs/${RUN_ID}/context"
+    echo "$output"
+    assert_success
+    local selected_run_context="$output"
+    public_surfaces+="$selected_run_context"$'\n'
+    run jq -e \
+        --arg customConnectorId "$CUSTOM_CONNECTOR_ID" \
+        --arg sourceId "$selected_connection_id" '
+            any(.firewalls[]?;
+                .kind == "inline" and
+                .customConnectorId == $customConnectorId and
+                .sourceId == $sourceId
+            )
+        ' <<<"$selected_run_context"
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_firewall_log \
+        "$RUN_ID" \
+        "$firewall_name" \
+        www.google.com \
+        "$expected_secrets"
+    echo "$output"
+    assert_success
+    local selected_network_logs="$output"
+    public_surfaces+="$selected_network_logs"$'\n'
+    run jq -e --arg firewallName "$firewall_name" '
+        all(.[];
+            .firewall_name != $firewallName or
+            .host != "example.com"
+        )
+    ' <<<"$selected_network_logs"
+    echo "$output"
+    assert_success
+
+    run runner_chat_event_rows "$THREAD_ID"
+    echo "$output"
+    assert_success
+    public_surfaces+="$output"$'\n'
+
+    local raw_secret
+    for raw_secret in "$default_secret" "$selected_secret"; do
+        if [[ "$public_surfaces" == *"$raw_secret"* ]]; then
+            fail "raw custom connector credential appeared in a public runner surface"
+        fi
+    done
+}


### PR DESCRIPTION
## Summary

- enable connector account behavior once for the shared Runner E2E identity before shard fan-out
- cover default and exact non-default custom connector accounts across thread continuation, run context, and firewall telemetry
- assert the public setup/runtime surfaces do not expose either raw account credential

## Scope

This adds one deployed custom HTTP connector happy path. It does not add browser interaction matrices, OAuth/MCP coverage, lifecycle error cases, deletion coverage, or product runtime/schema changes; those remain in deterministic integration tests.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (39 passed)
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t23-custom-connector.bats` (2 tests parsed)
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `turbo/node_modules/.bin/prettier --write .github/workflows/turbo.yml`
- `./scripts/check-file-size.sh .github/scripts/tests/turbo-playwright-runner-workflow-test.sh .github/workflows/turbo.yml e2e/tests/03-runner/run-t23-custom-connector.bats`
- `git diff --check`

The focused Ruby workflow structure test and shellcheck/actionlint validation require runtimes absent from the local container; PR CI will execute them together with the deployed Runner shard.

Closes #29397
Parent: #22832

