### PR TITLE
refactor(api): dual-read debug logging aliases

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -1,13 +1,256 @@
-import { describe, it, expect, vi, beforeEach, onTestFinished } from "vitest";
+import { createHash } from "node:crypto";
+
 import { EVENT } from "@axiomhq/logging";
+import { describe, it, expect, vi, beforeEach, onTestFinished } from "vitest";
+
+import { mockEnv, mockOptionalEnv } from "../env";
 import { flushLogs, logger, __resetForTest } from "../log";
 import { testContext } from "../../__tests__/test-context";
 
 const { axiom, axiomLogging, console: consoleOutput } = testContext().mocks;
 
+const CANONICAL_DEBUG_KEY = "OKOU_DEBUG";
+const LEGACY_DEBUG_KEY = "VM0_DEBUG";
+const DEBUG_ALIAS_RESOLUTION_EVENT = "debug_environment_alias_resolution";
+const DEBUG_ALIAS_LOG_CONTEXT = "DebugEnvironment";
+const DEBUG_ALIAS_CONFLICT_ERROR =
+  "Debug environment aliases conflict: canonicalKey=OKOU_DEBUG legacyKey=VM0_DEBUG state=conflicting-dual";
+
+type NonConflictingDebugAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "equal-dual";
+
+interface DebugAliasFixture {
+  readonly description: string;
+  readonly canonical: string | undefined;
+  readonly legacy: string | undefined;
+  readonly state: NonConflictingDebugAliasState;
+  readonly expectedLevel: "debug" | "info";
+}
+
+const DEBUG_ALIAS_FIXTURES: readonly DebugAliasFixture[] = [
+  {
+    description: "missing aliases",
+    canonical: undefined,
+    legacy: undefined,
+    state: "absent",
+    expectedLevel: "info",
+  },
+  {
+    description: "empty aliases",
+    canonical: "",
+    legacy: "",
+    state: "absent",
+    expectedLevel: "info",
+  },
+  {
+    description: "empty canonical and missing legacy aliases",
+    canonical: "",
+    legacy: undefined,
+    state: "absent",
+    expectedLevel: "info",
+  },
+  {
+    description: "missing canonical and empty legacy aliases",
+    canonical: undefined,
+    legacy: "",
+    state: "absent",
+    expectedLevel: "info",
+  },
+  {
+    description: "canonical-only alias",
+    canonical: "debug-matrix-target",
+    legacy: undefined,
+    state: "canonical-only",
+    expectedLevel: "debug",
+  },
+  {
+    description: "canonical alias with empty legacy",
+    canonical: "debug-matrix-target",
+    legacy: "",
+    state: "canonical-only",
+    expectedLevel: "debug",
+  },
+  {
+    description: "legacy-only alias",
+    canonical: undefined,
+    legacy: "debug-matrix-target",
+    state: "legacy-only",
+    expectedLevel: "debug",
+  },
+  {
+    description: "legacy alias with empty canonical",
+    canonical: "",
+    legacy: "debug-matrix-target",
+    state: "legacy-only",
+    expectedLevel: "debug",
+  },
+  {
+    description: "byte-equal dual aliases",
+    canonical: "debug-matrix-target",
+    legacy: "debug-matrix-target",
+    state: "equal-dual",
+    expectedLevel: "debug",
+  },
+];
+
+function configureDebugAliases(
+  canonical: string | undefined,
+  legacy: string | undefined,
+): void {
+  mockEnv(CANONICAL_DEBUG_KEY, canonical);
+  mockEnv(LEGACY_DEBUG_KEY, legacy);
+}
+
+function debugAliasEvidence(state: string): Readonly<Record<string, unknown>> {
+  return {
+    [EVENT]: { source: "api" },
+    canonicalKey: CANONICAL_DEBUG_KEY,
+    legacyKey: LEGACY_DEBUG_KEY,
+    state,
+    context: DEBUG_ALIAS_LOG_CONTEXT,
+  };
+}
+
 beforeEach(() => {
   __resetForTest();
   axiomLogging.flush.mockResolvedValue(undefined);
+});
+
+describe("debug environment aliases", () => {
+  it.each(DEBUG_ALIAS_FIXTURES)(
+    "resolves $description with bounded source evidence",
+    ({ canonical, legacy, state, expectedLevel }) => {
+      configureDebugAliases(canonical, legacy);
+      const debugLogCount = axiomLogging.debug.mock.calls.length;
+
+      expect(logger("debug-matrix-target").level).toBe(expectedLevel);
+      expect(logger("another-logger").level).toBe("info");
+
+      expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+        [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence(state)],
+      ]);
+      expect(axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed on byte-unequal aliases before pattern normalization", () => {
+    const canonical = `canonical-sentinel-${"x".repeat(113)}:*`;
+    const legacy = ` ${canonical} `;
+    configureDebugAliases(canonical, legacy);
+    const warnLogCount = axiomLogging.warn.mock.calls.length;
+
+    expect(() => {
+      logger("canonical-sentinel:child");
+    }).toThrow(DEBUG_ALIAS_CONFLICT_ERROR);
+    expect(() => {
+      logger("canonical-sentinel:child");
+    }).toThrow(DEBUG_ALIAS_CONFLICT_ERROR);
+
+    expect(axiomLogging.warn.mock.calls.slice(warnLogCount)).toStrictEqual([
+      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("conflicting-dual")],
+    ]);
+    expect(axiomLogging.debug).not.toHaveBeenCalled();
+
+    const diagnostics = JSON.stringify({
+      error: DEBUG_ALIAS_CONFLICT_ERROR,
+      logs: axiomLogging.warn.mock.calls,
+    });
+    const forbiddenDerivatives = [
+      canonical,
+      legacy,
+      String(canonical.length),
+      String(legacy.length),
+      createHash("sha256").update(canonical).digest("hex"),
+      createHash("sha256").update(legacy).digest("hex"),
+      JSON.stringify(canonical),
+      JSON.stringify(legacy),
+    ];
+    for (const derivative of forbiddenDerivatives) {
+      expect(diagnostics).not.toContain(derivative);
+    }
+  });
+
+  it.each([
+    {
+      description: "the global wildcard",
+      value: "*",
+      enabled: ["anything", "api:worker"],
+      disabled: [],
+    },
+    {
+      description: "a namespace-prefix wildcard",
+      value: "api:*",
+      enabled: ["api:worker", "api:"],
+      disabled: ["api", "apis:worker"],
+    },
+    {
+      description: "an exact logger name",
+      value: "ExactLogger",
+      enabled: ["ExactLogger"],
+      disabled: ["exactlogger", "ExactLogger:child"],
+    },
+    {
+      description: "trimmed comma-separated entries",
+      value: " exact-one, , api:*, exact-two, ",
+      enabled: ["exact-one", "api:child", "exact-two"],
+      disabled: ["exact", "other"],
+    },
+    {
+      description: "discarded empty entries",
+      value: " ,  , ",
+      enabled: [],
+      disabled: ["anything"],
+    },
+    {
+      description: "a non-matching pattern",
+      value: "another-logger",
+      enabled: [],
+      disabled: ["target-logger"],
+    },
+  ])("preserves $description behavior", ({ value, enabled, disabled }) => {
+    configureDebugAliases(value, undefined);
+
+    for (const name of enabled) {
+      expect(logger(name).level).toBe("debug");
+    }
+    for (const name of disabled) {
+      expect(logger(name).level).toBe("info");
+    }
+  });
+
+  it("keeps configuration and logger levels cached until the existing reset", () => {
+    configureDebugAliases("CachedLogger", undefined);
+    const debugLogCount = axiomLogging.debug.mock.calls.length;
+
+    const cached = logger("CachedLogger");
+    expect(cached.level).toBe("debug");
+    mockEnv(CANONICAL_DEBUG_KEY, "AfterResetLogger");
+
+    expect(logger("CachedLogger")).toBe(cached);
+    expect(logger("CachedLogger").level).toBe("debug");
+    expect(logger("AfterResetLogger").level).toBe("info");
+    expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
+    ]);
+
+    __resetForTest();
+
+    expect(logger("AfterResetLogger").level).toBe("debug");
+    expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
+      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
+    ]);
+  });
+
+  it("keeps the generic DEBUG convention unrelated", () => {
+    configureDebugAliases(undefined, undefined);
+    mockOptionalEnv("DEBUG", "*");
+
+    expect(logger("generic-debug-convention").level).toBe("info");
+  });
 });
 
 // ── logToAxiom dispatches to correct @axiomhq/logging level ─────────────────

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -50,6 +50,7 @@ const SCHEMA = {
   GIT_COMMIT_SHA: z.string(),
   ENV: z.enum(["production", "preview", "development"]),
   VITEST: z.enum(["true", "false"]).default("false"),
+  OKOU_DEBUG: z.string().default(""),
   VM0_DEBUG: z.string().default(""),
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().min(1).optional(),
   // Direct origin of the API backend for self-dispatched internal callbacks

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -28,6 +28,31 @@ const LOG_LEVEL_PRIORITY: Readonly<Record<Level, number>> = {
   [Level.Fatal]: 4,
 };
 
+const CANONICAL_DEBUG_KEY = "OKOU_DEBUG";
+const LEGACY_DEBUG_KEY = "VM0_DEBUG";
+const DEBUG_ALIAS_RESOLUTION_EVENT = "debug_environment_alias_resolution";
+const DEBUG_ALIAS_LOG_CONTEXT = "DebugEnvironment";
+const DEBUG_ALIAS_CONFLICT_ERROR =
+  "Debug environment aliases conflict: canonicalKey=OKOU_DEBUG legacyKey=VM0_DEBUG state=conflicting-dual";
+
+type DebugAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "equal-dual"
+  | "conflicting-dual";
+
+type DebugConfiguration =
+  | {
+      readonly state:
+        | "absent"
+        | "canonical-only"
+        | "legacy-only"
+        | "equal-dual";
+      readonly patterns: readonly string[];
+    }
+  | { readonly state: "conflicting-dual" };
+
 interface Logger {
   readonly debug: LogMethod;
   readonly info: LogMethod;
@@ -54,8 +79,7 @@ const loggerRegistry = singleton(() => {
   return new LoggerRegistry();
 });
 
-function getDebugPatterns(): string[] {
-  const value = env("VM0_DEBUG");
+function parseDebugPatterns(value: string | undefined): readonly string[] {
   if (!value) {
     return [];
   }
@@ -68,6 +92,66 @@ function getDebugPatterns(): string[] {
     .filter((pattern) => {
       return pattern.length > 0;
     });
+}
+
+function reportDebugAliasResolution(state: DebugAliasState): void {
+  logToAxiom(
+    state === "conflicting-dual" ? Level.Warn : Level.Debug,
+    DEBUG_ALIAS_LOG_CONTEXT,
+    [
+      DEBUG_ALIAS_RESOLUTION_EVENT,
+      {
+        canonicalKey: CANONICAL_DEBUG_KEY,
+        legacyKey: LEGACY_DEBUG_KEY,
+        state,
+      },
+    ],
+  );
+}
+
+function resolveDebugConfiguration(): DebugConfiguration {
+  const canonical = env(CANONICAL_DEBUG_KEY);
+  const legacy = env(LEGACY_DEBUG_KEY);
+
+  if (!canonical) {
+    const state = legacy ? "legacy-only" : "absent";
+    reportDebugAliasResolution(state);
+    return { state, patterns: parseDebugPatterns(legacy) };
+  }
+  if (!legacy) {
+    reportDebugAliasResolution("canonical-only");
+    return {
+      state: "canonical-only",
+      patterns: parseDebugPatterns(canonical),
+    };
+  }
+  if (canonical === legacy) {
+    reportDebugAliasResolution("equal-dual");
+    return {
+      state: "equal-dual",
+      patterns: parseDebugPatterns(canonical),
+    };
+  }
+
+  reportDebugAliasResolution("conflicting-dual");
+  return { state: "conflicting-dual" };
+}
+
+// This API-process compatibility boundary retains VM0_DEBUG while the preview
+// writer (.github/actions/web-api-env/action.yml), local development writer
+// (turbo/apps/api/scripts/dev.sh), and Turbo pass-through (turbo/turbo.json)
+// remain legacy-only. Under #28914, refresh stale Worker PR #25722 before the
+// later writer cutover, preserve a supported rollback target that accepts
+// VM0_DEBUG, and remove this fallback only after bounded source evidence shows
+// zero legacy-only and equal-dual resolutions through the rollback window.
+const debugConfiguration = singleton(resolveDebugConfiguration);
+
+function getDebugPatterns(): readonly string[] {
+  const configuration = debugConfiguration();
+  if (configuration.state === "conflicting-dual") {
+    throw new Error(DEBUG_ALIAS_CONFLICT_ERROR);
+  }
+  return configuration.patterns;
 }
 
 function matchesDebugPattern(name: string, pattern: string): boolean {
@@ -348,6 +432,7 @@ export function logger(name: string): Logger {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetForTest(): void {
+  debugConfiguration.reset();
   getAxiomLogger.reset();
   loggerRegistry.reset();
 }

--- a/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
@@ -131,16 +131,18 @@ describe("Stripe preview metadata job reference aliases", () => {
       expect(isCurrentStripePreviewMetadata(expectedMetadata)).toBeTruthy();
       expect(isCurrentStripePreviewMetadata(null)).toBe(jobRef === null);
 
-      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledTimes(3);
-      for (const call of context.mocks.axiomLogging.debug.mock.calls) {
+      const aliasResolutionCalls =
+        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+          return message === PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT;
+        });
+      expect(aliasResolutionCalls).toHaveLength(3);
+      for (const call of aliasResolutionCalls) {
         expect(call).toStrictEqual([
           PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
           aliasEvidence(state),
         ]);
       }
-      const evidence = JSON.stringify(
-        context.mocks.axiomLogging.debug.mock.calls,
-      );
+      const evidence = JSON.stringify(aliasResolutionCalls);
       const configuredValues = [canonical, legacy].filter(
         (value): value is string => {
           return Boolean(value);


### PR DESCRIPTION
## Summary

- add validated `OKOU_DEBUG` input beside retained `VM0_DEBUG` for the API process
- resolve the raw aliases once at the logging configuration boundary, fail closed on unequal non-empty dual input, and emit bounded fixed-state evidence without constructing a normal logger
- preserve empty handling, pattern parsing, wildcard/prefix/exact matching, logger caching, reset behavior, and the unrelated npm `DEBUG` convention
- scope an existing Stripe metadata test to its own telemetry event so the required one-time debug-alias evidence remains observable without changing that service's contract

## Verification

- `pnpm exec prettier --check apps/api/src/lib/env.ts apps/api/src/lib/log.ts apps/api/src/lib/__tests__/log.test.ts apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/lib/__tests__/log.test.ts src/signals/services/__tests__/stripe-preview-metadata.service.test.ts --reporter=dot --silent=passed-only` (66 passed)
- `pnpm exec knip --workspace apps/api`
- `git diff --check origin/main...HEAD`

Implementation started from the controller JIT base `main@958a8ef14998930f4c3da3dbdffde5071fbab767` after predecessor merge `0643e7fd75cf5ea2ef261a86ce3f43e2d98f5a1d`. Final review rebased onto current `main@b25dc18ae633cff097689ae3bfefd714f237abe8`; the intervening #29396 changes only agent-tool normalization files and does not overlap this boundary.

The final fully paginated overlap audit fetched all 337 declared changed-file records across 23 open PRs with no mismatch. Excluding this PR itself, #25722 remains the only overlap. The controller-base token inventory is exactly five `VM0_DEBUG` occurrences and zero `OKOU_DEBUG` occurrences. The operational inventory still consists of the three unchanged legacy writer/configuration surfaces, the retained legacy schema input, and the centralized compatibility reader; the canonical additions are limited to the API schema and centralized reader. No production API source outside that boundary directly reads either debug key. The diff contains four API files, including only the event-scoped Stripe test adjustment; all excluded deployment, Worker/Cloudflare, CLI, Runner, Guest, Desktop, guard, and production surfaces remain unchanged.

## Fallbacks

- Retained legacy input: `turbo/apps/api/src/lib/log.ts:resolveDebugConfiguration` accepts `VM0_DEBUG` through the centralized API logging compatibility boundary while official writers remain legacy-only.
- Current writer/configuration surfaces remain legacy-only and unchanged: preview deployment in `.github/actions/web-api-env/action.yml`, local API development in `turbo/apps/api/scripts/dev.sh`, and Turbo pass-through in `turbo/turbo.json`.
- Later writer cutover: a separate just-in-time child of #28914 must update the complete writer/configuration surface together and refresh any Worker surface that has become active; this PR does not perform that cutover.
- Supported rollback requirement: before writer cutover, record the exact deployed dual-reader artifact and a supported rollback target that still accepts `VM0_DEBUG`.
- Telemetry drain gate: preserve this dual reader until bounded source evidence reports zero `legacy-only` and zero `equal-dual` resolutions throughout the supported rollback window; legacy-reader removal remains a later PR.
- #25722 refresh: final review confirmed it is still open and stale at `2aed1f0de2a54db881ca266151c1362ea6c9dd62` with 185 changed files. Its proposed Worker allowlist contains `VM0_DEBUG` but not `OKOU_DEBUG`, and its unrelated Worker/Cloudflare environment and logger ownership changes were not imported.
- #28914 follow-up: the EPIC owns the later writer cutover, observation window, and separately reviewed legacy-reader removal.

Closes #29400