### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -7430,34 +7430,6 @@ describe("usage pack allocation management", () => {
     });
   });
 
-  it("keeps invitation state safe before entitlement migrations", async () => {
-    const response = await usagePackStateAction({
-      action: "validate-pre-migration-compatibility",
-    });
-    expect(response).toStrictEqual({
-      action: "pre-migration-compatibility",
-      memberInviteUsagePackRequired: false,
-      preMemberInvitationMigration: {
-        memberInviteUsagePackRequired: true,
-        memberInvitationAllowed: true,
-      },
-      bonusPreparedRefunds: 0,
-    });
-  });
-
-  it("preserves purchased credits until migration 0898 is available", async () => {
-    const response = await accept(
-      setupApp({
-        context,
-        routes: testUsagePackSubscriptionStateRoutes,
-      })(testUsagePackSubscriptionStateContract).action({
-        body: { action: "prepare-pre-migration-purchased-refund" },
-      }),
-      [500],
-    );
-    expect(response.body).toStrictEqual({ error: "Internal server error" });
-  });
-
   it("previews a Team upgrade by replacing only the base plan item", async () => {
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);

--- a/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
@@ -1,4 +1,3 @@
-
 import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";

--- a/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 
 import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
@@ -28,7 +27,6 @@ import { type Db, writeDb$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { lockBillingPurchaseOrg } from "../services/billing-purchase-lock.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
-import { upsertOrgPlanEntitlement } from "../services/org-plan-entitlements.service";
 import { prepareUsagePackMemberCreditRefunds } from "../services/usage-pack-credit-refund.service";
 import { createDeferredPromise, onRejection } from "../utils";
 import {
@@ -125,12 +123,6 @@ const actionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("delete-refund-source"),
     orgId: z.string().min(1),
     userId: z.string().min(1),
-  }),
-  z.object({
-    action: z.literal("validate-pre-migration-compatibility"),
-  }),
-  z.object({
-    action: z.literal("prepare-pre-migration-purchased-refund"),
   }),
   z.object({
     action: z.literal("seed-legacy-migration"),
@@ -306,15 +298,6 @@ const actionResponseSchema = z.discriminatedUnion("action", [
     action: z.literal("billing-purchase-lock-state"),
     held: z.boolean(),
     waiterCount: z.number().int().nonnegative(),
-  }),
-  z.object({
-    action: z.literal("pre-migration-compatibility"),
-    memberInviteUsagePackRequired: z.boolean(),
-    preMemberInvitationMigration: z.object({
-      memberInviteUsagePackRequired: z.boolean(),
-      memberInvitationAllowed: z.boolean(),
-    }),
-    bonusPreparedRefunds: z.number().int().nonnegative(),
   }),
   z.object({ action: z.literal("ok") }),
 ]);
@@ -961,137 +944,6 @@ async function cleanupUsagePackState(
   });
 }
 
-async function validatePreMigrationCompatibility(
-  db: Db,
-  signal: AbortSignal,
-): Promise<{
-  readonly memberInviteUsagePackRequired: boolean;
-  readonly preMemberInvitationMigration: {
-    readonly memberInviteUsagePackRequired: boolean;
-    readonly memberInvitationAllowed: boolean;
-  };
-  readonly bonusPreparedRefunds: number;
-}> {
-  const memberInviteUsagePackRequired = await db.transaction(async (tx) => {
-    await tx.execute(sql`SET LOCAL search_path = pg_temp, public`);
-    await tx.execute(sql`
-      CREATE TEMP TABLE org_plan_entitlements
-      (LIKE public.org_plan_entitlements INCLUDING ALL)
-      ON COMMIT DROP
-    `);
-    await tx.execute(
-      sql`ALTER TABLE org_plan_entitlements DROP COLUMN member_invite_usage_pack_required`,
-    );
-    const orgId = `org_pre_migration_${randomUUID()}`;
-    await upsertOrgPlanEntitlement(tx, {
-      orgId,
-      tier: "pro",
-      source: "org_metadata_bootstrap",
-      memberInviteUsagePackRequired: true,
-    });
-    await upsertOrgPlanEntitlement(tx, {
-      orgId,
-      tier: "team",
-      source: "org_metadata_bootstrap",
-      memberInviteUsagePackRequired: true,
-    });
-    const capabilities = await loadOrgPlanCapabilities(tx, orgId);
-    if (!capabilities) {
-      throw new Error("Pre-migration entitlement fixture was not written");
-    }
-    return capabilities.memberInviteUsagePackRequired;
-  });
-
-  const preMemberInvitationMigration = await db.transaction(async (tx) => {
-    await tx.execute(sql`SET LOCAL search_path = pg_temp, public`);
-    await tx.execute(sql`
-      CREATE TEMP TABLE org_plan_entitlements
-      (LIKE public.org_plan_entitlements INCLUDING ALL)
-      ON COMMIT DROP
-    `);
-    await tx.execute(
-      sql`ALTER TABLE org_plan_entitlements DROP COLUMN member_invitation_allowed`,
-    );
-    const orgId = `org_pre_member_invitation_${randomUUID()}`;
-    await upsertOrgPlanEntitlement(tx, {
-      orgId,
-      tier: "pro",
-      source: "org_metadata_bootstrap",
-      memberInviteUsagePackRequired: true,
-    });
-    await upsertOrgPlanEntitlement(tx, {
-      orgId,
-      tier: "team",
-      source: "org_metadata_bootstrap",
-      memberInviteUsagePackRequired: true,
-    });
-    const capabilities = await loadOrgPlanCapabilities(tx, orgId);
-    if (!capabilities) {
-      throw new Error(
-        "Pre-member-invitation entitlement fixture was not written",
-      );
-    }
-    return {
-      memberInviteUsagePackRequired: capabilities.memberInviteUsagePackRequired,
-      memberInvitationAllowed: capabilities.memberInvitationAllowed,
-    };
-  });
-
-  const refundState = await db.transaction(async (tx) => {
-    await tx.execute(sql`SET LOCAL search_path = pg_temp`);
-    await tx.execute(sql`
-      CREATE TEMP TABLE usage_pack_credit_grants
-      (LIKE public.usage_pack_credit_grants INCLUDING ALL)
-      ON COMMIT DROP
-    `);
-    const orgId = `org_pre_migration_${randomUUID()}`;
-    const bonusUserId = `user_bonus_${randomUUID()}`;
-    await tx.insert(usagePackCreditGrants).values({
-      orgId,
-      userId: bonusUserId,
-      grantType: "bonus",
-      idempotencyKey: `pre-migration:bonus:${randomUUID()}`,
-      originalAmount: 500,
-      remainingAmount: 500,
-      expiresAt: new Date("2999-01-01T00:00:00.000Z"),
-    });
-    const bonusPreparedRefunds = await prepareUsagePackMemberCreditRefunds(tx, {
-      orgId,
-      userId: bonusUserId,
-    });
-    return { bonusPreparedRefunds };
-  });
-  signal.throwIfAborted();
-  return {
-    memberInviteUsagePackRequired,
-    preMemberInvitationMigration,
-    ...refundState,
-  };
-}
-
-async function preparePreMigrationPurchasedRefund(db: Db): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx.execute(sql`SET LOCAL search_path = pg_temp`);
-    await tx.execute(sql`
-      CREATE TEMP TABLE usage_pack_credit_grants
-      (LIKE public.usage_pack_credit_grants INCLUDING ALL)
-      ON COMMIT DROP
-    `);
-    const orgId = `org_pre_migration_${randomUUID()}`;
-    const userId = `user_purchased_${randomUUID()}`;
-    await tx.insert(usagePackCreditGrants).values({
-      orgId,
-      userId,
-      grantType: "purchased",
-      idempotencyKey: `pre-migration:purchased:${randomUUID()}`,
-      originalAmount: 10_000,
-      remainingAmount: 5000,
-      expiresAt: new Date("2999-01-01T00:00:00.000Z"),
-    });
-    await prepareUsagePackMemberCreditRefunds(tx, { orgId, userId });
-  });
-}
-
 async function setGrantRemaining(
   db: Db,
   body: SetGrantRemainingBody,
@@ -1233,21 +1085,6 @@ const mutateTestUsagePackSubscriptionState$ = command(
         if (rows.length !== 1) {
           throw new Error("Expected one usage pack refund source to delete");
         }
-        return { status: 200 as const, body: { action: "ok" as const } };
-      }
-      case "validate-pre-migration-compatibility": {
-        const state = await validatePreMigrationCompatibility(db, signal);
-        return {
-          status: 200 as const,
-          body: {
-            action: "pre-migration-compatibility" as const,
-            ...state,
-          },
-        };
-      }
-      case "prepare-pre-migration-purchased-refund": {
-        await preparePreMigrationPurchasedRefund(db);
-        signal.throwIfAborted();
         return { status: 200 as const, body: { action: "ok" as const } };
       }
       case "seed-legacy-migration": {

--- a/turbo/apps/api/src/signals/services/feishu-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/feishu-chat-callback-payload.ts
@@ -19,9 +19,5 @@ export type FeishuDeliveryTarget = z.infer<typeof feishuDeliveryTargetSchema>;
 export const feishuChatCallbackPayloadSchema =
   feishuDeliveryTargetSchema.extend({
     chatEventId: z.string(),
-    // #27750 rollout fallback: callbacks persisted by the previous API omit
-    // the Host brand and may complete after an old runner/sandbox drains (up
-    // to 2h). Remove this optional field and the installation-brand read after
-    // all pre-#28935 callbacks and API rollback writers have drained.
-    publicBrand: publicBrandSchema.optional(),
+    publicBrand: publicBrandSchema,
   });

--- a/turbo/apps/api/src/signals/services/feishu-org-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/feishu-org-callback-payload.ts
@@ -21,11 +21,7 @@ export const feishuOrgCallbackPayloadSchema = z
     replyInThread: z.boolean().optional(),
     files: z.array(feishuOrgCallbackFileSchema).optional(),
     canonicalChatDelivery: z.boolean().optional(),
-    // #27750 rollout fallback: callbacks persisted by the previous API omit
-    // the Host brand and may complete after an old runner/sandbox drains (up
-    // to 2h). Remove this optional field and the installation-brand read after
-    // all pre-#28935 callbacks and API rollback writers have drained.
-    publicBrand: publicBrandSchema.optional(),
+    publicBrand: publicBrandSchema,
   })
   .passthrough();
 

--- a/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
@@ -148,7 +148,6 @@ async function loadFeishuChatDeliveryContext(
     .select({
       feishuOpenId: feishuOrgConnections.feishuOpenId,
       defaultAgentId: feishuOrgInstallations.defaultAgentId,
-      publicBrand: feishuOrgInstallations.publicBrand,
     })
     .from(feishuChatThreadRoutes)
     .innerJoin(
@@ -319,10 +318,7 @@ async function deliverClaimedFeishuChatCallback(
   if (!binding) {
     return "skipped_revoked";
   }
-  // Paired with feishuChatCallbackPayloadSchema's bounded #27750 rollout
-  // fallback; the binding brand is read only for callbacks from the previous
-  // API and is removable after those callbacks and rollback writers drain.
-  const publicBrand = payload.publicBrand ?? binding.publicBrand;
+  const publicBrand = payload.publicBrand;
 
   const [mentionerCount, featureContext] = await Promise.all([
     countFeishuMentioners({

--- a/turbo/apps/api/src/signals/services/internal-feishu-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-org-run-callback.service.ts
@@ -194,7 +194,6 @@ async function handleFeishuCallback(
     .select({
       orgId: feishuOrgInstallations.orgId,
       defaultAgentId: feishuOrgInstallations.defaultAgentId,
-      publicBrand: feishuOrgInstallations.publicBrand,
     })
     .from(feishuOrgInstallations)
     .where(
@@ -208,11 +207,7 @@ async function handleFeishuCallback(
   if (!installation) {
     return { success: false, error: "Feishu installation not found" };
   }
-  // Paired with feishuOrgCallbackPayloadSchema's bounded #27750 rollout
-  // fallback; the installation brand is read only for callbacks from the
-  // previous API and is removable after those callbacks and rollback writers
-  // drain.
-  const publicBrand = payload.publicBrand ?? installation.publicBrand;
+  const publicBrand = payload.publicBrand;
   const connection = await loadFeishuCallbackConnection(args.db, payload);
   signal.throwIfAborted();
   if (!connection) {

--- a/turbo/apps/api/src/signals/services/org-plan-entitlement-read.service.ts
+++ b/turbo/apps/api/src/signals/services/org-plan-entitlement-read.service.ts
@@ -1,9 +1,8 @@
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@okouai/db/schema/org-plan-entitlement";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import type { Db } from "../external/db";
-import { pgBooleanDecoder } from "../../lib/db-structured-result";
 
 type ReadDb = Pick<Db, "select">;
 
@@ -29,18 +28,9 @@ const CAPABILITY_SELECTION = {
   baseConcurrencyLimit: orgPlanEntitlements.baseConcurrencyLimit,
   canBuyConcurrency: orgPlanEntitlements.canBuyConcurrency,
   canBuyCredits: orgPlanEntitlements.canBuyCredits,
-  memberInviteUsagePackRequired: sql`
-    COALESCE(
-      (to_jsonb(${orgPlanEntitlements}) ->> 'member_invite_usage_pack_required')::boolean,
-      false
-    )
-  `.mapWith(pgBooleanDecoder),
-  memberInvitationAllowed: sql`
-      COALESCE(
-        (to_jsonb(${orgPlanEntitlements}) ->> 'member_invitation_allowed')::boolean,
-        ${orgPlanEntitlements.planKey} IN ('pro', 'team', 'custom')
-      )
-    `.mapWith(pgBooleanDecoder),
+  memberInviteUsagePackRequired:
+    orgPlanEntitlements.memberInviteUsagePackRequired,
+  memberInvitationAllowed: orgPlanEntitlements.memberInvitationAllowed,
   autoRechargeAllowed: orgPlanEntitlements.autoRechargeAllowed,
   supportByok: orgPlanEntitlements.supportByok,
   restrictedVm0Models: orgPlanEntitlements.restrictedVm0Models,
@@ -51,56 +41,6 @@ const CAPABILITY_SELECTION = {
   audioDailyRateLimit: orgPlanEntitlements.audioDailyRateLimit,
   audioDailyDurationSeconds: orgPlanEntitlements.audioDailyDurationSeconds,
 } as const;
-
-export async function memberInviteUsagePackEntitlementSchemaAvailable(
-  db: ReadDb,
-): Promise<boolean> {
-  // A new API can deploy before migration 0898 during the DB/API rollout
-  // window. Remove this probe after 0898 is guaranteed across that window.
-  const [state] = await db
-    .select({
-      available: sql`
-        EXISTS (
-          SELECT 1
-          FROM pg_catalog.pg_attribute
-          WHERE attrelid = to_regclass('org_plan_entitlements')
-            AND attname = 'member_invite_usage_pack_required'
-            AND NOT attisdropped
-        )
-      `.mapWith(pgBooleanDecoder),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  if (!state) {
-    throw new Error("Member invite usage pack schema probe returned no row");
-  }
-  return state.available;
-}
-
-export async function memberInvitationEntitlementSchemaAvailable(
-  db: ReadDb,
-): Promise<boolean> {
-  // A new API can deploy before migration 0901 during the DB/API rollout
-  // window. Remove this probe after 0901 is guaranteed across that window.
-  const [state] = await db
-    .select({
-      available: sql`
-        EXISTS (
-          SELECT 1
-          FROM pg_catalog.pg_attribute
-          WHERE attrelid = to_regclass('org_plan_entitlements')
-            AND attname = 'member_invitation_allowed'
-            AND NOT attisdropped
-        )
-      `.mapWith(pgBooleanDecoder),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  if (!state) {
-    throw new Error("Member invitation schema probe returned no row");
-  }
-  return state.available;
-}
 
 function runtimeStatusForEntitlement(
   status: string,

--- a/turbo/apps/api/src/signals/services/org-plan-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/org-plan-entitlements.service.ts
@@ -2,133 +2,11 @@ import type { OrgTier } from "@okouai/api-contracts/contracts/orgs";
 import type { OrgPlanEntitlementSourceMetadata } from "@okouai/db/jsonb-contracts/org-plan-entitlement";
 import { orgPlanEntitlements } from "@okouai/db/schema/org-plan-entitlement";
 import { eq } from "drizzle-orm";
-import {
-  boolean,
-  integer,
-  jsonb,
-  pgTable,
-  text,
-  timestamp,
-  varchar,
-} from "drizzle-orm/pg-core";
-
 import { nowDate } from "../../lib/time";
 import { ORG_PLAN_ENTITLEMENT_TIER_VALUES } from "./org-plan-entitlement-tier-values";
-import {
-  memberInvitationEntitlementSchemaAvailable,
-  memberInviteUsagePackEntitlementSchemaAvailable,
-} from "./org-plan-entitlement-read.service";
 import type { Tx } from "../../lib/db-types";
 
 type WriteTx = Tx;
-
-// Drizzle names every column declared by an insert table, even when a value is
-// omitted. This runtime-only shape keeps pre-0898 writes from naming the new
-// column during the DB/API rollout window. Remove it with the schema probe once
-// migration 0898 is guaranteed everywhere and the rollback window closes.
-const orgPlanEntitlementsBeforeMemberInviteUsagePack = pgTable(
-  "org_plan_entitlements",
-  {
-    orgId: text("org_id").primaryKey(),
-    planKey: text("plan_key").notNull(),
-    planRank: integer("plan_rank").notNull(),
-    source: varchar("source", { length: 50 }).notNull(),
-    status: varchar("status", { length: 30 }).notNull().default("active"),
-    baseConcurrencyLimit: integer("base_concurrency_limit")
-      .notNull()
-      .default(0),
-    canBuyConcurrency: boolean("can_buy_concurrency").notNull().default(false),
-    canBuyCredits: boolean("can_buy_credits").notNull().default(false),
-    autoRechargeAllowed: boolean("auto_recharge_allowed")
-      .notNull()
-      .default(false),
-    supportByok: boolean("support_byok").notNull().default(false),
-    restrictedVm0Models: boolean("restricted_vm0_models")
-      .notNull()
-      .default(true),
-    videoGenerationAllowed: boolean("video_generation_allowed")
-      .notNull()
-      .default(false),
-    workflowWebhookTriggerAllowed: boolean("workflow_webhook_trigger_allowed")
-      .notNull()
-      .default(false),
-    audioLifetimeLimit: integer("audio_lifetime_limit"),
-    audioDailyRateLimit: integer("audio_daily_rate_limit").notNull().default(0),
-    audioDailyDurationSeconds: integer("audio_daily_duration_seconds")
-      .notNull()
-      .default(0),
-    stripeSubscriptionId: text("stripe_subscription_id"),
-    stripeProductId: text("stripe_product_id"),
-    stripePriceId: text("stripe_price_id"),
-    currentPeriodStart: timestamp("current_period_start"),
-    currentPeriodEnd: timestamp("current_period_end"),
-    cancelAt: timestamp("cancel_at"),
-    expiresAt: timestamp("expires_at"),
-    metadataVersion: text("metadata_version").notNull().default("1"),
-    metadataHash: text("metadata_hash"),
-    sourceMetadata: jsonb("source_metadata")
-      .$type<OrgPlanEntitlementSourceMetadata>()
-      .notNull()
-      .default({}),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at").defaultNow().notNull(),
-  },
-);
-
-// This shape keeps new API writes compatible while migration 0901 rolls out.
-// Migration 0898 is preserved here so usage-pack invitation state continues to
-// update throughout the independent DB/API deployment window.
-const orgPlanEntitlementsBeforeMemberInvitationAllowed = pgTable(
-  "org_plan_entitlements",
-  {
-    orgId: text("org_id").primaryKey(),
-    planKey: text("plan_key").notNull(),
-    planRank: integer("plan_rank").notNull(),
-    source: varchar("source", { length: 50 }).notNull(),
-    status: varchar("status", { length: 30 }).notNull().default("active"),
-    baseConcurrencyLimit: integer("base_concurrency_limit")
-      .notNull()
-      .default(0),
-    canBuyConcurrency: boolean("can_buy_concurrency").notNull().default(false),
-    canBuyCredits: boolean("can_buy_credits").notNull().default(false),
-    memberInviteUsagePackRequired: boolean("member_invite_usage_pack_required")
-      .notNull()
-      .default(false),
-    autoRechargeAllowed: boolean("auto_recharge_allowed")
-      .notNull()
-      .default(false),
-    supportByok: boolean("support_byok").notNull().default(false),
-    restrictedVm0Models: boolean("restricted_vm0_models")
-      .notNull()
-      .default(true),
-    videoGenerationAllowed: boolean("video_generation_allowed")
-      .notNull()
-      .default(false),
-    workflowWebhookTriggerAllowed: boolean("workflow_webhook_trigger_allowed")
-      .notNull()
-      .default(false),
-    audioLifetimeLimit: integer("audio_lifetime_limit"),
-    audioDailyRateLimit: integer("audio_daily_rate_limit").notNull().default(0),
-    audioDailyDurationSeconds: integer("audio_daily_duration_seconds")
-      .notNull()
-      .default(0),
-    stripeSubscriptionId: text("stripe_subscription_id"),
-    stripeProductId: text("stripe_product_id"),
-    stripePriceId: text("stripe_price_id"),
-    currentPeriodStart: timestamp("current_period_start"),
-    currentPeriodEnd: timestamp("current_period_end"),
-    cancelAt: timestamp("cancel_at"),
-    expiresAt: timestamp("expires_at"),
-    metadataVersion: text("metadata_version").notNull().default("1"),
-    metadataHash: text("metadata_hash"),
-    sourceMetadata: jsonb("source_metadata")
-      .$type<OrgPlanEntitlementSourceMetadata>()
-      .notNull()
-      .default({}),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at").defaultNow().notNull(),
-  },
-);
 
 interface UpsertOrgPlanEntitlementArgs {
   readonly orgId: string;
@@ -214,10 +92,6 @@ export async function upsertOrgPlanEntitlement(
     tx,
     args,
   );
-  const memberInviteUsagePackRequiredAvailable =
-    await memberInviteUsagePackEntitlementSchemaAvailable(tx);
-  const memberInvitationAllowedAvailable =
-    await memberInvitationEntitlementSchemaAvailable(tx);
   const memberInviteUsagePackRequired =
     args.memberInviteUsagePackRequired ?? false;
   const values = {
@@ -229,12 +103,8 @@ export async function upsertOrgPlanEntitlement(
     baseConcurrencyLimit: limits.baseConcurrencyLimit,
     canBuyConcurrency: limits.canBuyConcurrency,
     canBuyCredits: limits.canBuyCredits,
-    ...(memberInviteUsagePackRequiredAvailable
-      ? { memberInviteUsagePackRequired }
-      : {}),
-    ...(memberInvitationAllowedAvailable
-      ? { memberInvitationAllowed: limits.memberInvitationAllowed }
-      : {}),
+    memberInviteUsagePackRequired,
+    memberInvitationAllowed: limits.memberInvitationAllowed,
     autoRechargeAllowed: limits.autoRechargeAllowed,
     supportByok: limits.supportByok,
     restrictedVm0Models: limits.restrictedVm0Models,
@@ -252,17 +122,11 @@ export async function upsertOrgPlanEntitlement(
     sourceMetadata: stripeSubscriptionSnapshot.sourceMetadata,
     updatedAt,
   };
-  const insertTable = !memberInviteUsagePackRequiredAvailable
-    ? orgPlanEntitlementsBeforeMemberInviteUsagePack
-    : memberInvitationAllowedAvailable
-      ? orgPlanEntitlements
-      : orgPlanEntitlementsBeforeMemberInvitationAllowed;
-
   await tx
-    .insert(insertTable)
+    .insert(orgPlanEntitlements)
     .values(values)
     .onConflictDoUpdate({
-      target: insertTable.orgId,
+      target: orgPlanEntitlements.orgId,
       set: {
         planKey: values.planKey,
         planRank: values.planRank,
@@ -271,12 +135,8 @@ export async function upsertOrgPlanEntitlement(
         baseConcurrencyLimit: values.baseConcurrencyLimit,
         canBuyConcurrency: values.canBuyConcurrency,
         canBuyCredits: values.canBuyCredits,
-        ...(memberInviteUsagePackRequiredAvailable
-          ? { memberInviteUsagePackRequired }
-          : {}),
-        ...(memberInvitationAllowedAvailable
-          ? { memberInvitationAllowed: limits.memberInvitationAllowed }
-          : {}),
+        memberInviteUsagePackRequired,
+        memberInvitationAllowed: limits.memberInvitationAllowed,
         autoRechargeAllowed: values.autoRechargeAllowed,
         supportByok: values.supportByok,
         restrictedVm0Models: values.restrictedVm0Models,

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -48,10 +48,7 @@ import {
 } from "../external/stripe-client";
 import { settle } from "../utils";
 import { createUsagePackCreditGrant } from "./usage-pack-credit.service";
-import {
-  assertUsagePackMemberCreditRefundReady,
-  prepareUsagePackMemberCreditRefunds,
-} from "./usage-pack-credit-refund.service";
+import { prepareUsagePackMemberCreditRefunds } from "./usage-pack-credit-refund.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import {
@@ -1797,14 +1794,12 @@ export async function reserveUsagePackMemberRemoval(
   signal: AbortSignal,
 ): Promise<string | null> {
   if (!(await usagePackAllocationChangeSchemaAvailable(db))) {
-    await assertUsagePackMemberCreditRefundReady(db, args);
     return null;
   }
   signal.throwIfAborted();
   const at = nowDate();
   const reservationId = await db.transaction(async (tx) => {
     await lockUsagePackBillingOrg(tx, args.orgId);
-    await assertUsagePackMemberCreditRefundReady(tx, args);
     await expireStaleUsagePackPreviews(tx, args.orgId, at);
     const [allocation] = await tx
       .select()

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -4,9 +4,8 @@ import {
   type UsagePackCreditRefundSourceType,
 } from "@okouai/db/schema/usage-pack-credit-refund";
 import { usagePackInvitationPurchases } from "@okouai/db/schema/usage-pack-subscription";
-import { and, asc, eq, gt, inArray, like, lt, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, like, lt, or } from "drizzle-orm";
 
-import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
@@ -44,21 +43,6 @@ export type UsagePackCreditRefundSource =
       readonly amountCents: number;
     };
 
-async function usagePackCreditRefundSchemaAvailable(
-  db: Pick<Db, "select">,
-): Promise<boolean> {
-  const [state] = await db
-    .select({
-      available:
-        sql`to_regclass('usage_pack_credit_refunds') IS NOT NULL`.mapWith(
-          pgBooleanDecoder,
-        ),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  return state?.available ?? false;
-}
-
 function refundableUsagePackCreditGrantCondition(
   args: { readonly orgId: string; readonly userId: string },
   at: Date,
@@ -70,32 +54,6 @@ function refundableUsagePackCreditGrantCondition(
     gt(usagePackCreditGrants.remainingAmount, 0),
     gt(usagePackCreditGrants.expiresAt, at),
   );
-}
-
-async function requireUsagePackCreditRefundSchema(
-  db: Pick<Db, "select">,
-): Promise<void> {
-  if (await usagePackCreditRefundSchemaAvailable(db)) {
-    return;
-  }
-  // Member removal must preserve refundable credits until migration 0898 is
-  // available. Remove this guard after 0898 is guaranteed across the DB/API
-  // rollout window.
-  throw new Error("Usage pack credit refund schema is not available");
-}
-
-export async function assertUsagePackMemberCreditRefundReady(
-  db: Pick<Db, "select">,
-  args: { readonly orgId: string; readonly userId: string },
-): Promise<void> {
-  const [grant] = await db
-    .select({ id: usagePackCreditGrants.id })
-    .from(usagePackCreditGrants)
-    .where(refundableUsagePackCreditGrantCondition(args, nowDate()))
-    .limit(1);
-  if (grant) {
-    await requireUsagePackCreditRefundSchema(db);
-  }
 }
 
 function sourceColumns(source: UsagePackCreditRefundSource): {
@@ -151,9 +109,6 @@ export async function ensureUsagePackCreditRefundSource(
     readonly source: UsagePackCreditRefundSource;
   },
 ): Promise<void> {
-  if (!(await usagePackCreditRefundSchemaAvailable(db))) {
-    return;
-  }
   const source = sourceColumns(args.source);
   const [inserted] = await db
     .insert(usagePackCreditRefunds)
@@ -291,7 +246,6 @@ export async function prepareUsagePackMemberCreditRefunds(
   db: CreditRefundStore,
   args: { readonly orgId: string; readonly userId: string },
 ): Promise<number> {
-  await assertUsagePackMemberCreditRefundReady(db, args);
   const at = nowDate();
   const grants = await db
     .select()
@@ -814,9 +768,6 @@ export async function refundUsagePackMemberCredits(
   args: { readonly orgId: string; readonly userId: string },
   signal: AbortSignal,
 ): Promise<number> {
-  if (!(await usagePackCreditRefundSchemaAvailable(db))) {
-    return 0;
-  }
   signal.throwIfAborted();
   const refunds = await db
     .select()
@@ -842,9 +793,6 @@ export async function reconcileUsagePackCreditRefunds(
   scope: BillingReconciliationScope | undefined,
   signal: AbortSignal,
 ): Promise<number> {
-  if (!(await usagePackCreditRefundSchemaAvailable(db))) {
-    return 0;
-  }
   signal.throwIfAborted();
   const refunds = await db
     .select()

--- a/turbo/apps/platform/src/signals/okou-page/feishu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/feishu.ts
@@ -45,10 +45,9 @@ export const feishuOrgData$ = computed(
 
 export interface FeishuBotInstallation extends Omit<
   FeishuInstallationStatus,
-  "connectUrl" | "id" | "oauthRedirectUrl" | "publicBrand" | "setupCompleted"
+  "connectUrl" | "id" | "oauthRedirectUrl" | "setupCompleted"
 > {
   readonly id: string | null;
-  readonly publicBrand: NonNullable<FeishuInstallationStatus["publicBrand"]>;
   readonly connectUrl: string | null;
   readonly oauthRedirectUrl: string | null;
   readonly setupCompleted: boolean;
@@ -59,15 +58,10 @@ const internalInstallations$ = state<FeishuBotInstallation[] | null>(null);
 export const feishuInstallations$ = computed(
   async (get): Promise<FeishuBotInstallation[]> => {
     const data = await get(feishuOrgData$);
-    // #27750 rollout fallback: a newly loaded app can briefly target the
-    // previous API, whose status response omits both publicBrand fields. Remove
-    // these defaults and require the contract fields after that API is no
-    // longer serving or retained for rollback.
     if (data.installations) {
       return data.installations.map((installation) => {
         return {
           ...installation,
-          publicBrand: installation.publicBrand ?? data.publicBrand ?? "vm0",
           connectUrl: installation.connectUrl ?? null,
           oauthRedirectUrl: installation.oauthRedirectUrl ?? null,
           setupCompleted:
@@ -86,7 +80,7 @@ export const feishuInstallations$ = computed(
     return [
       {
         id: data.installationId ?? null,
-        publicBrand: data.publicBrand ?? "vm0",
+        publicBrand: data.publicBrand,
         isConnected: data.isConnected,
         connectedUserName: data.connectedUserName ?? null,
         appId: data.appId,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/works-page.test.tsx
@@ -94,6 +94,7 @@ function mockTeamsAPI(overrides: Partial<TeamsConnectStatus> = {}): void {
 
 function mockFeishuAPI(overrides: Partial<FeishuConnectStatus> = {}): void {
   const defaults: FeishuConnectStatus = {
+    publicBrand: "vm0",
     isConnected: false,
     isInstalled: false,
     isAdmin: true,
@@ -186,6 +187,7 @@ describe("works page", () => {
     context.mocks.api(feishuConnectContract.getStatus, async ({ respond }) => {
       await responseReady.promise;
       return respond(200, {
+        publicBrand: "vm0",
         isConnected: false,
         isInstalled: false,
         isAdmin: true,
@@ -491,6 +493,7 @@ describe("works page", () => {
       defaultAgentName: "Okou",
       installations: [
         {
+          publicBrand: "vm0",
           id: "00000000-0000-4000-8000-000000000001",
           isConnected: true,
           connectedUserName: "Feishu User",
@@ -687,6 +690,7 @@ describe("works page", () => {
       defaultAgentName: "Okou",
       installations: [
         {
+          publicBrand: "vm0",
           id: installationId,
           isConnected: false,
           appId: "cli_member",
@@ -733,6 +737,7 @@ describe("works page", () => {
       defaultAgentName: "Okou",
       installations: [
         {
+          publicBrand: "vm0",
           id: installationId,
           isConnected: true,
           appId: "cli_completed_admin",
@@ -856,6 +861,7 @@ describe("works page", () => {
       defaultAgentName: "Okou",
       installations: [
         {
+          publicBrand: "vm0",
           id: installationId,
           isConnected: true,
           appId: "cli_member",
@@ -902,6 +908,7 @@ describe("works page", () => {
       defaultAgentName: "Okou",
       installations: [
         {
+          publicBrand: "vm0",
           id: installationId,
           isConnected: false,
           appId: "cli_member_connect",
@@ -943,6 +950,7 @@ describe("works page", () => {
     context.mocks.api(feishuConnectContract.getStatus, ({ respond }) => {
       const installation = {
         id: installationId,
+        publicBrand: "vm0" as const,
         isConnected,
         appId: "cli_feishu",
         callbackUrl: `https://api.vm0.test/api/okou/feishu/events/${installationId}`,
@@ -955,6 +963,7 @@ describe("works page", () => {
         defaultAgentName: "Okou",
       };
       return respond(200, {
+        publicBrand: "vm0",
         isConnected,
         isInstalled: true,
         isAdmin: true,

--- a/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
@@ -49,12 +49,7 @@ export const FEISHU_OAUTH_SCOPES = [
 
 const feishuInstallationStatusSchema = z.object({
   id: z.string().uuid(),
-  /**
-   * #27750 rollout fallback for new app clients reading the previous API.
-   * Make required after that API is no longer serving or retained for
-   * rollback.
-   */
-  publicBrand: publicBrandSchema.optional(),
+  publicBrand: publicBrandSchema,
   isConnected: z.boolean(),
   connectedUserName: z.string().nullable().optional(),
   appId: z.string(),
@@ -74,12 +69,8 @@ const feishuInstallationStatusSchema = z.object({
 });
 
 const feishuConnectStatusSchema = z.object({
-  /**
-   * Product brand of the Host that initiated this status flow. Optional only
-   * for the #27750 new-app-to-previous-API rollout; make required after that
-   * API is no longer serving or retained for rollback.
-   */
-  publicBrand: publicBrandSchema.optional(),
+  /** Product brand of the Host that initiated this status flow. */
+  publicBrand: publicBrandSchema,
   isInstalled: z.boolean(),
   isConnected: z.boolean(),
   connectedUserName: z.string().nullable().optional(),


### PR DESCRIPTION
Removes two rollout-compatibility cohorts whose production windows have closed. No behavior change for supported App, CLI, Runner, or API consumers.

## Cohort 1 — migration 0898/0904 entitlement rollout guards

**Old boundary:** a new API could reach production before `org_plan_entitlements.member_invite_usage_pack_required` (migration `0898`), `org_plan_entitlements.member_invitation_allowed` (migration `0904`), or the `usage_pack_credit_refunds` table (migration `0898`) existed, so the API probed `pg_attribute` / `to_regclass` at runtime, wrote through two runtime-only shadow `pgTable` shapes that omit the new columns, read the new columns through `to_jsonb(...) ->> '<column>'` with a `COALESCE` default, and refused member-removal refunds when the refund table was absent.

**New boundary:** the columns and table are unconditionally present; reads use the real Drizzle columns and writes use the real table.

Removed:
- `memberInviteUsagePackEntitlementSchemaAvailable`, `memberInvitationEntitlementSchemaAvailable`
- `orgPlanEntitlementsBeforeMemberInviteUsagePack`, `orgPlanEntitlementsBeforeMemberInvitationAllowed` and the `insertTable` selection
- the conditional spreads in the `upsertOrgPlanEntitlement` insert and `onConflictDoUpdate` sets
- the two `to_jsonb` / `COALESCE` capability reads
- `usagePackCreditRefundSchemaAvailable`, `requireUsagePackCreditRefundSchema`, `assertUsagePackMemberCreditRefundReady` and its 3 call sites, plus the 2 early-return probes in `refundUsagePackMemberCredits` / `reconcileUsagePackCreditRefunds` and the write probe in `ensureUsagePackCreditRefundSource`
- the `validate-pre-migration-compatibility` and `prepare-pre-migration-purchased-refund` test-only route actions, their response contract variant, their two helpers, and the two tests that only assert pre-migration behavior

**Window:** canonical window 1 — DB migration completed, replacement API rollout healthy, +4 s.

**Rollout evidence (observed):**
- `0898` merged `2026-08-11T09:02:29Z`; `0904` merged `2026-08-11T10:58:39Z`.
- `promote-api-production` in `.github/workflows/release-please.yml` runs `pnpm -F @okouai/db db:migrate` against production and deploys the API artifact from the same runner only after migrations succeed.
- First `api/production` deployment containing `0904` (and therefore `0898`): `24d315dec0c9cc3bf3161617c3b0735994a29120`, `in_progress 2026-08-11T11:45:59Z`, **`success 2026-08-11T11:46:30Z`**.
- **137** further successful `api/production` deployments have run `db:migrate` since, the latest being `686d369f99`, `success 2026-08-25T17:26:58Z`.
- Elapsed versus the window: **14 days 9 h**.

**Axiom evidence (read-only):**

- Dataset: `vm0-web-logs-prod`. Range: `2026-08-11T11:46:30Z` → `2026-08-25T21:00:00Z` (explicit `startTime`/`endTime`).
- `message contains "Usage pack credit refund schema is not available"` → **0 events**.
- Coverage check on the same range and dataset: `level == "error" and message contains "Unhandled request error"` returns a populated distribution, including schema-shaped failures such as `column "run_group_id" of relation "zero_runs" does not exist` (3) and `column "vm0_model_key_id" of relation "agent_runs" does not exist` (1). Route-thrown errors are therefore captured with their message text on this dataset, so the zero count is a covered observation rather than an uninstrumented gap.
- Daily volume sanity check (`2026-08-24T21:00:00Z` → `2026-08-25T21:00:00Z`): `info` 1550, `warn` 269, `error` 111.

**MaskDB:** not usable as evidence here. `vm0-prod-ro` returns a stale cached projection of `org_plan_entitlements` that is missing `can_buy_credits`, `workflow_webhook_trigger_allowed`, `member_invite_usage_pack_required`, and `member_invitation_allowed`, and still reports `usage_pack_credit_refunds` as absent. Recorded as an evidence gap; the deployment-pipeline and Axiom evidence above stand on their own.

**Persisted data:** none. The columns and table are additive and stay in place; only the runtime probes and shadow write shapes are removed.

## Cohort 2 — Feishu #27750 dual-brand rollout fallbacks

**Old boundary:** during the additive #28935 rollout the previous API could persist Feishu run callbacks without `publicBrand` and could answer the Feishu connect status without `publicBrand`, so consumers fell back to the installation/binding brand and the app defaulted to `"vm0"`.

**New boundary:** `publicBrand` is required on both persisted Feishu callback payloads and on both Feishu connect status schemas.

Removed:
- `publicBrand: publicBrandSchema.optional()` → required in `feishu-chat-callback-payload.ts` and `feishu-org-callback-payload.ts`
- `payload.publicBrand ?? binding.publicBrand` and `payload.publicBrand ?? installation.publicBrand`, plus the now-unused `publicBrand` selections in both callback services
- `publicBrand` optional → required on `feishuInstallationStatusSchema` and `feishuConnectStatusSchema`
- the app-side `installation.publicBrand ?? data.publicBrand ?? "vm0"` and `data.publicBrand ?? "vm0"` defaults and the `NonNullable<...>` interface override

**Window:** latest applicable expiry — canonical window 3 (CLI/Sandbox, 2 h) for in-flight callbacks, and the previous API leaving service and the rollback target for the contract change.

**Rollout evidence (observed):**
- #28935 merged `2026-08-24T14:23:12Z`.
- `git merge-base --is-ancestor` confirms #28935's merge commit is contained in `api/production` deployment `d751eed41c`, created `2026-08-24T22:19:58Z`.
- The preceding production API (`5cdeba4b32`) was marked `inactive` at `2026-08-24T22:20:22Z`. Elapsed at the time of this change: **~23 h**, against a 2 h maximum sandbox/run lifetime.
- **9** further `api/production` deployments have been promoted since, so the pre-#28935 build is no longer the rollback target.
- The equivalent Slack cohort was removed by #29312 (merged `2026-08-25T09:55:25Z`, closing #28937) on the same evidence shape.

**Axiom evidence:** no Feishu error signature appears in the `Unhandled request error` distribution over `2026-08-11T11:46:30Z` → `2026-08-25T21:00:00Z` on `vm0-web-logs-prod`.

**Persisted data:** both Feishu callback payload writers always set `publicBrand` on current `main` (`requiredQueuedFeishuPublicBrand` for `feishu:org`, a required `PublicBrand` argument for `feishu:chat`). Callbacks reach a terminal state within the run lifetime, so no retained row is decoded by these schemas.

## Explicitly deferred

- `feishu_chat_ingress.public_brand`, `chat_feishu_context.public_brand`, and `feishu_org_connections.public_brand` remain nullable and their read fallbacks (`canonical-feishu-ingress-processor`, `feishu-queued-launch-context`, `feishu-welcome`) are kept. Those columns legitimately still hold `NULL` for rows retained from before the column existed, which is persisted-history compatibility rather than a drained rollout window.
- `builtInGenerationPublicBrand`'s missing-brand fallback is kept; #28449 records that pre-brand jobs have been observed in `running` state and that the request metadata is masked.
- The `#29362` chat-event schema v5/v6 fallbacks are kept; #29361 landed on 2026-08-25 and none of its gates has passed.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F api lint`, `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F @okouai/api-contracts check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F api exec vitest run` on `billing-checkout` (204), `billing-usage-pack-credits` + `usage-pack-subscription-lifecycle` + `cron-billing-entitlements` + `org-delete-billing` + `usage-pack-invitation-rollout` + `usage-pack-purchase-rollout` (44), `billing-status` + `auth-org-agents.bdd` (44), `feishu-integration` + `feishu-oauth-state` (46) — all passing against a local Postgres with `timezone=UTC`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/works-page.test.tsx` (25 passing)

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
