### PR TITLE
fix(auth): restore accessible brand action colors

### DIFF
--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -60,6 +60,37 @@ test("base, nested, refreshed, and legacy auth routes coexist on desktop", async
   }
 });
 
+test("primary and link actions retain accessible brand colors in both themes", async ({
+  page,
+}) => {
+  await openAuthV2(page, "/v2/sign-up");
+
+  const root = authV2Root(page);
+  const continueButton = root.getByRole("button", { name: "Continue" });
+  const currentSignUpLink = page.getByRole("link", {
+    name: "Use current sign-up",
+  });
+  const passwordVisibilityAction = root.getByRole("button", {
+    name: "Show password",
+  });
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await expect(continueButton).toHaveCSS("background-color", "rgb(208, 67, 1)");
+  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
+  await expect(currentSignUpLink).toHaveCSS("color", "rgb(208, 67, 1)");
+  await expect(passwordVisibilityAction).toHaveCSS("color", "rgb(21, 24, 30)");
+
+  await page.getByRole("button", { name: "Toggle theme" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect(continueButton).toHaveCSS("background-color", "rgb(208, 67, 1)");
+  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
+  await expect(currentSignUpLink).toHaveCSS("color", "rgb(239, 90, 15)");
+  await expect(passwordVisibilityAction).toHaveCSS(
+    "color",
+    "rgb(233, 234, 236)",
+  );
+});
+
 test.describe("localized mobile presentation", () => {
   test.use({
     colorScheme: "dark",

--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -66,7 +66,10 @@ test("primary and link actions retain accessible brand colors in both themes", a
   await openAuthV2(page, "/v2/sign-up");
 
   const root = authV2Root(page);
-  const continueButton = root.getByRole("button", { name: "Continue" });
+  const continueButton = root.getByRole("button", {
+    exact: true,
+    name: "Continue",
+  });
   const currentSignUpLink = page.getByRole("link", {
     name: "Use current sign-up",
   });

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -147,7 +147,7 @@ describe("auth v2 presentation", () => {
     const continueButton = buttonByText("Continue");
     expect(continueButton).toHaveClass(
       "bg-[#d04301]",
-      "text-white",
+      "text-[#ffffff]",
       "hover:bg-[#bb3c01]",
       "active:bg-[#af3801]",
     );

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -6,7 +6,6 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
-import { mockSignUpConfiguration } from "../../../__tests__/mock-auth.ts";
 import { platformVm0LogoImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -58,16 +57,6 @@ function buttonByLabel(label: string): HTMLButtonElement {
   });
   if (!(button instanceof HTMLButtonElement)) {
     throw new Error(`Button not found: ${label}`);
-  }
-  return button;
-}
-
-function buttonByText(text: string): HTMLButtonElement {
-  const button = queryAllByRoleFast("button").find((candidate) => {
-    return candidate.textContent?.trim() === text;
-  });
-  if (!(button instanceof HTMLButtonElement)) {
-    throw new Error(`Button not found: ${text}`);
   }
   return button;
 }
@@ -125,44 +114,11 @@ describe("auth v2 presentation", () => {
 
     expect(region).toContainElement(passwordVisibilityAction);
     expect(passwordVisibilityAction).toHaveAttribute("aria-pressed", "false");
-    expect(passwordVisibilityAction).toHaveClass("text-foreground");
     const currentSignUpAction = linkByText("Use current sign-up");
     expect(currentSignUpAction).toHaveAttribute("href", "/sign-up");
     expect(
       currentSignUpAction.closest('[data-testid="app-auth-v2"]'),
     ).toBeNull();
-  });
-
-  it("uses contrast-safe brand colors for primary actions and links", async () => {
-    mockSignUpConfiguration({
-      legalConsentEnabled: true,
-      privacyPolicyUrl: "https://vm0.ai/legal/privacy",
-      termsUrl: "https://vm0.ai/legal/terms",
-    });
-    setBrowserUrl("https://app.vm0.ai/v2/sign-up");
-
-    detachedSetupPage({ context, path: "/v2/sign-up" });
-
-    await screen.findByLabelText("Email address");
-    const continueButton = buttonByText("Continue");
-    expect(continueButton).toHaveClass(
-      "bg-[#d04301]",
-      "text-[#ffffff]",
-      "hover:bg-[#bb3c01]",
-      "active:bg-[#af3801]",
-    );
-
-    for (const link of [
-      linkByText("Terms of Service"),
-      linkByText("Sign in"),
-      linkByText("Use current sign-up"),
-    ]) {
-      expect(link).toHaveClass(
-        "text-[#d04301]",
-        "hover:text-[#bb3c01]",
-        "dark:text-[#ef5a0f]",
-      );
-    }
   });
 
   it("toggles themes with pointer and keyboard input while preserving focus", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -6,6 +6,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { mockSignUpConfiguration } from "../../../__tests__/mock-auth.ts";
 import { platformVm0LogoImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -57,6 +58,16 @@ function buttonByLabel(label: string): HTMLButtonElement {
   });
   if (!(button instanceof HTMLButtonElement)) {
     throw new Error(`Button not found: ${label}`);
+  }
+  return button;
+}
+
+function buttonByText(text: string): HTMLButtonElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim() === text;
+  });
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`);
   }
   return button;
 }
@@ -114,11 +125,44 @@ describe("auth v2 presentation", () => {
 
     expect(region).toContainElement(passwordVisibilityAction);
     expect(passwordVisibilityAction).toHaveAttribute("aria-pressed", "false");
+    expect(passwordVisibilityAction).toHaveClass("text-foreground");
     const currentSignUpAction = linkByText("Use current sign-up");
     expect(currentSignUpAction).toHaveAttribute("href", "/sign-up");
     expect(
       currentSignUpAction.closest('[data-testid="app-auth-v2"]'),
     ).toBeNull();
+  });
+
+  it("uses contrast-safe brand colors for primary actions and links", async () => {
+    mockSignUpConfiguration({
+      legalConsentEnabled: true,
+      privacyPolicyUrl: "https://vm0.ai/legal/privacy",
+      termsUrl: "https://vm0.ai/legal/terms",
+    });
+    setBrowserUrl("https://app.vm0.ai/v2/sign-up");
+
+    detachedSetupPage({ context, path: "/v2/sign-up" });
+
+    await screen.findByLabelText("Email address");
+    const continueButton = buttonByText("Continue");
+    expect(continueButton).toHaveClass(
+      "bg-[#d04301]",
+      "text-white",
+      "hover:bg-[#bb3c01]",
+      "active:bg-[#af3801]",
+    );
+
+    for (const link of [
+      linkByText("Terms of Service"),
+      linkByText("Sign in"),
+      linkByText("Use current sign-up"),
+    ]) {
+      expect(link).toHaveClass(
+        "text-[#d04301]",
+        "hover:text-[#bb3c01]",
+        "dark:text-[#ef5a0f]",
+      );
+    }
   });
 
   it("toggles themes with pointer and keyboard input while preserving focus", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -1,5 +1,5 @@
 export const AUTH_V2_PRIMARY_ACTION_CLASS =
-  "bg-[#d04301] text-[#ffffff] hover:bg-[#bb3c01] active:bg-[#af3801]";
+  "bg-[#d04301] text-on-filled hover:bg-[#bb3c01] active:bg-[#af3801]";
 
 export const AUTH_V2_LINK_ACTION_CLASS =
   "text-[#d04301] hover:text-[#bb3c01] active:text-[#af3801] dark:text-[#ef5a0f] dark:hover:text-[#f16b27] dark:active:text-[#f27435]";

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -1,0 +1,5 @@
+export const AUTH_V2_PRIMARY_ACTION_CLASS =
+  "bg-[#d04301] text-white hover:bg-[#bb3c01] active:bg-[#af3801]";
+
+export const AUTH_V2_LINK_ACTION_CLASS =
+  "text-[#d04301] hover:text-[#bb3c01] active:text-[#af3801] dark:text-[#ef5a0f] dark:hover:text-[#f16b27] dark:active:text-[#f27435]";

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -1,5 +1,5 @@
 export const AUTH_V2_PRIMARY_ACTION_CLASS =
-  "bg-[#d04301] text-white hover:bg-[#bb3c01] active:bg-[#af3801]";
+  "bg-[#d04301] text-[#ffffff] hover:bg-[#bb3c01] active:bg-[#af3801]";
 
 export const AUTH_V2_LINK_ACTION_CLASS =
   "text-[#d04301] hover:text-[#bb3c01] active:text-[#af3801] dark:text-[#ef5a0f] dark:hover:text-[#f16b27] dark:active:text-[#f27435]";

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-password-input.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-password-input.tsx
@@ -62,7 +62,7 @@ export function AuthV2PasswordInput({
         aria-controls={id}
         aria-label={label}
         aria-pressed={revealed}
-        className="absolute top-0 right-0"
+        className="absolute top-0 right-0 text-foreground"
         onClick={() => {
           setRevealed(id, !revealed);
         }}

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
@@ -6,22 +6,12 @@ import {
   CardHeader,
 } from "@okouai/ui";
 import { useSet } from "ccstate-react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { focusAuthV2HeadingRef$ } from "../../signals/auth-v2-presentation.ts";
 
 const AUTH_V2_TITLE_ID = "auth-v2-title";
 const AUTH_V2_DESCRIPTION_ID = "auth-v2-description";
-
-function authV2PageActionSemantics(): CSSProperties &
-  Record<`--${string}`, string> {
-  return {
-    "--color-primary": "var(--color-foreground)",
-    "--color-primary-foreground": "var(--color-background)",
-    "--color-primary-hover": "var(--color-foreground-hover)",
-    "--color-primary-pressed": "var(--color-foreground-pressed)",
-  };
-}
 
 interface AuthV2ShellProps {
   readonly announcement?: ReactNode;
@@ -47,17 +37,13 @@ export function AuthV2Shell({
   const focusHeading = useSet(focusAuthV2HeadingRef$);
 
   return (
-    <div
-      className="w-[calc(100%+0.5rem)] max-w-[25rem] shrink-0 space-y-4"
-      style={authV2PageActionSemantics()}
-    >
+    <div className="w-[calc(100%+0.5rem)] max-w-[25rem] shrink-0 space-y-4">
       <Card
         aria-describedby={description ? AUTH_V2_DESCRIPTION_ID : undefined}
         aria-labelledby={AUTH_V2_TITLE_ID}
         className="relative w-full rounded-[12px] border-border p-0 shadow-none"
         data-testid="app-auth-v2"
         role="region"
-        style={authV2PageActionSemantics()}
       >
         <div className="flex flex-col gap-8 px-10 py-8">
           <CardHeader className="items-center space-y-1 bg-transparent p-0 text-center">

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-submit-button.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-submit-button.tsx
@@ -1,5 +1,7 @@
-import { Button } from "@okouai/ui";
+import { Button, cn } from "@okouai/ui";
 import { Loader2 } from "lucide-react";
+
+import { AUTH_V2_PRIMARY_ACTION_CLASS } from "./auth-v2-action-styles.ts";
 
 export function AuthV2ActionGlyph() {
   return (
@@ -36,7 +38,7 @@ export function AuthV2SubmitButton({
     <Button
       aria-busy={busy}
       aria-label={label}
-      className="w-full text-[13px]"
+      className={cn("w-full text-[13px]", AUTH_V2_PRIMARY_ACTION_CLASS)}
       disabled={disabled}
       type="submit"
     >

--- a/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@okouai/ui";
+import { Button, cn } from "@okouai/ui";
 import { useGet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Loader2 } from "lucide-react";
@@ -10,6 +10,7 @@ import type {
 import type { AuthBrandContext } from "../../../signals/auth.ts";
 import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
+import { AUTH_V2_PRIMARY_ACTION_CLASS } from "../auth-v2-action-styles.ts";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
 import {
   type AuthV2ContinuationCopy,
@@ -136,7 +137,7 @@ function RecoveryContent({
     <Button
       aria-busy={restarting}
       aria-label={copy.recoveryAction}
-      className="w-full"
+      className={cn("w-full", AUTH_V2_PRIMARY_ACTION_CLASS)}
       disabled={restarting}
       onClick={() => {
         detach(

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -5,6 +5,7 @@ import type { AuthV2Navigation } from "../../../signals/auth-v2/navigation.ts";
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { Link } from "../../router/link.tsx";
+import { AUTH_V2_LINK_ACTION_CLASS } from "../auth-v2-action-styles.ts";
 import { AuthV2IdentityPreview } from "../auth-v2-identity-preview.tsx";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
 import {
@@ -62,7 +63,12 @@ export function AuthV2SignInCard({
       focusKey={focusKey}
       footer={
         <div className="flex justify-center">
-          <Button asChild size="sm" variant="link">
+          <Button
+            asChild
+            className={AUTH_V2_LINK_ACTION_CLASS}
+            size="sm"
+            variant="link"
+          >
             <Link
               pathname={ROUTES.signIn}
               options={{

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -14,6 +14,10 @@ import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
 import { Link } from "../../router/link.tsx";
+import {
+  AUTH_V2_LINK_ACTION_CLASS,
+  AUTH_V2_PRIMARY_ACTION_CLASS,
+} from "../auth-v2-action-styles.ts";
 import { AuthV2Divider } from "../auth-v2-divider.tsx";
 import { AuthV2ErrorAlert } from "../auth-v2-error-alert.tsx";
 import { AuthV2FieldError } from "../auth-v2-field-error.tsx";
@@ -429,7 +433,7 @@ function ChooseSessionStep({
         })}
       </div>
       <Button
-        className="w-full"
+        className={cn("w-full", AUTH_V2_LINK_ACTION_CLASS)}
         disabled={selectionLoadable.state === "loading"}
         type="button"
         variant="ghost"
@@ -541,7 +545,10 @@ function ChooseFactorStep({
         })}
       </div>
       <Button
-        className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+        className={cn(
+          "mx-auto h-auto w-fit p-0 text-sm leading-5",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         disabled={selectLoadable.state === "loading"}
         type="button"
         variant="link"
@@ -589,7 +596,10 @@ function PasswordStep({
           labelAction={
             resetFactor ? (
               <Button
-                className="h-auto p-0 text-[13px] leading-[17px]"
+                className={cn(
+                  "h-auto p-0 text-[13px] leading-[17px]",
+                  AUTH_V2_LINK_ACTION_CLASS,
+                )}
                 disabled={submitting}
                 type="button"
                 variant="link"
@@ -607,7 +617,10 @@ function PasswordStep({
         <AuthV2SubmitButton busy={submitting} label={copy.continue} />
       </form>
       <Button
-        className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+        className={cn(
+          "mx-auto h-auto w-fit p-0 text-sm leading-5",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         disabled={submitting}
         type="button"
         variant="link"
@@ -661,7 +674,7 @@ function PasswordRecoveryStep({
         <Button
           aria-busy={selectingFactorId === resetFactor.id}
           aria-label={copy.passwordResetMethod}
-          className="w-full text-[13px]"
+          className={cn("w-full text-[13px]", AUTH_V2_PRIMARY_ACTION_CLASS)}
           disabled={selecting}
           type="button"
           onClick={() => {
@@ -750,7 +763,10 @@ function PasswordRecoveryStep({
           </div>
         ) : null}
         <Button
-          className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+          className={cn(
+            "mx-auto h-auto w-fit p-0 text-sm leading-5",
+            AUTH_V2_LINK_ACTION_CLASS,
+          )}
           disabled={selecting}
           type="button"
           variant="link"
@@ -767,14 +783,20 @@ function HelpStep({ copy, signals }: SignInStepProps) {
   const back = useSet(signals.backFromHelp$);
   return (
     <div className="flex flex-col gap-4">
-      <Button className="w-full text-[13px]" asChild>
+      <Button
+        className={cn("w-full text-[13px]", AUTH_V2_PRIMARY_ACTION_CLASS)}
+        asChild
+      >
         <a href={copy.supportEmailHref}>
           {copy.emailSupport}
           <AuthV2ActionGlyph />
         </a>
       </Button>
       <Button
-        className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+        className={cn(
+          "mx-auto h-auto w-fit p-0 text-sm leading-5",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         type="button"
         variant="link"
         onClick={back}
@@ -874,6 +896,7 @@ function CodeStep({
               expired
                 ? "w-full"
                 : "mx-auto h-auto w-fit p-0 text-[13px] leading-[17px]",
+              AUTH_V2_LINK_ACTION_CLASS,
             )}
             disabled={operationPending || (coolingDown && !expired)}
             type="button"
@@ -922,7 +945,10 @@ function CodeStepBottomAction({
   if (factorKind === "email-code") {
     return (
       <Button
-        className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+        className={cn(
+          "mx-auto h-auto w-fit p-0 text-sm leading-5",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         disabled={disabled}
         type="button"
         variant="link"
@@ -937,7 +963,10 @@ function CodeStepBottomAction({
   }
   return (
     <Button
-      className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+      className={cn(
+        "mx-auto h-auto w-fit p-0 text-sm leading-5",
+        AUTH_V2_LINK_ACTION_CLASS,
+      )}
       disabled={disabled}
       type="button"
       variant="link"
@@ -1019,7 +1048,10 @@ function NewPasswordStep({ copy, signals }: SignInStepProps) {
         </div>
       </form>
       <Button
-        className="mx-auto h-auto w-fit p-0 text-sm leading-5"
+        className={cn(
+          "mx-auto h-auto w-fit p-0 text-sm leading-5",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         disabled={submitting}
         type="button"
         variant="link"
@@ -1065,11 +1097,11 @@ function TransferStep({
   const restart = useSet(signals.restart$);
   return (
     <div className="space-y-3">
-      <Button className="w-full" asChild>
+      <Button className={cn("w-full", AUTH_V2_PRIMARY_ACTION_CLASS)} asChild>
         <SignUpLink signUpHref={signUpHref}>{copy.signUp}</SignUpLink>
       </Button>
       <Button
-        className="w-full"
+        className={cn("w-full", AUTH_V2_LINK_ACTION_CLASS)}
         type="button"
         variant="ghost"
         onClick={restart}
@@ -1160,7 +1192,10 @@ export function SignInSwitch({
     <p className="text-center text-sm text-muted-foreground">
       {copy.noAccount}{" "}
       <SignUpLink
-        className="font-medium text-foreground underline underline-offset-4"
+        className={cn(
+          "font-medium underline underline-offset-4",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         signUpHref={signUpHref}
       >
         {copy.signUp}
@@ -1175,7 +1210,10 @@ export function SignInMethodsHelpFooter({ copy, signals }: SignInStepProps) {
     <p className="text-center text-sm text-muted-foreground">
       {copy.methodsHelpPrompt}{" "}
       <Button
-        className="h-auto p-0 font-medium text-foreground underline underline-offset-4"
+        className={cn(
+          "h-auto p-0 font-medium underline underline-offset-4",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         type="button"
         variant="link"
         onClick={showHelp}

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-card.tsx
@@ -6,6 +6,7 @@ import type { AuthV2SignUpSignals } from "../../../signals/auth-v2/sign-up-flow.
 import type { AuthBrandContext } from "../../../signals/auth.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { Link } from "../../router/link.tsx";
+import { AUTH_V2_LINK_ACTION_CLASS } from "../auth-v2-action-styles.ts";
 import { AuthV2IdentityPreview } from "../auth-v2-identity-preview.tsx";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
 import { SignUpCardContent, SignUpSwitch } from "./sign-up-content.tsx";
@@ -46,7 +47,12 @@ export function AuthV2SignUpCard({
       focusKey={focusKey}
       footer={
         <div className="flex justify-center">
-          <Button asChild size="sm" variant="link">
+          <Button
+            asChild
+            className={AUTH_V2_LINK_ACTION_CLASS}
+            size="sm"
+            variant="link"
+          >
             <Link
               options={{
                 hash: location.hash,

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
@@ -17,6 +17,10 @@ import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
 import { Link } from "../../router/link.tsx";
+import {
+  AUTH_V2_LINK_ACTION_CLASS,
+  AUTH_V2_PRIMARY_ACTION_CLASS,
+} from "../auth-v2-action-styles.ts";
 import { AuthV2Divider } from "../auth-v2-divider.tsx";
 import { AuthV2ErrorAlert } from "../auth-v2-error-alert.tsx";
 import { AuthV2FieldError } from "../auth-v2-field-error.tsx";
@@ -210,7 +214,10 @@ function LegalConsentText({
     if (href) {
       content.push(
         <a
-          className="font-medium underline underline-offset-4"
+          className={cn(
+            "font-medium underline underline-offset-4",
+            AUTH_V2_LINK_ACTION_CLASS,
+          )}
           href={href}
           key={`${token}-${index}`}
           rel="noreferrer"
@@ -655,6 +662,7 @@ function EmailCodeStep({
           className={cn(
             "w-full text-[13px]",
             !prepareFailed && !expired && "h-auto p-0 leading-[17px]",
+            AUTH_V2_LINK_ACTION_CLASS,
           )}
           disabled={operationPending || (coolingDown && !expired)}
           type="button"
@@ -717,7 +725,7 @@ function RestartAction({
     <Button
       aria-busy={restarting}
       aria-label={copy.restart}
-      className="w-full"
+      className={cn("w-full", variant === "ghost" && AUTH_V2_LINK_ACTION_CLASS)}
       disabled={restarting}
       type="button"
       variant={variant}
@@ -741,7 +749,7 @@ function RestartAction({
 function TransferStep({ copy, signInHref, signals }: SignUpStepProps) {
   return (
     <div className="space-y-3">
-      <Button className="w-full" asChild>
+      <Button className={cn("w-full", AUTH_V2_PRIMARY_ACTION_CLASS)} asChild>
         <SignInLink signInHref={signInHref}>{copy.signIn}</SignInLink>
       </Button>
       <RestartAction
@@ -763,7 +771,11 @@ function UnknownStep({ copy, signInHref, signals }: SignUpStepProps) {
         signals={signals}
         variant="outline"
       />
-      <Button className="w-full" asChild variant="ghost">
+      <Button
+        className={cn("w-full", AUTH_V2_LINK_ACTION_CLASS)}
+        asChild
+        variant="ghost"
+      >
         <SignInLink signInHref={signInHref}>{copy.signIn}</SignInLink>
       </Button>
     </div>
@@ -823,7 +835,10 @@ export function SignUpSwitch({
     <p className="text-center text-sm text-muted-foreground">
       {copy.alreadyHaveAccount}{" "}
       <SignInLink
-        className="font-medium text-foreground underline underline-offset-4"
+        className={cn(
+          "font-medium underline underline-offset-4",
+          AUTH_V2_LINK_ACTION_CLASS,
+        )}
         signInHref={signInHref}
       >
         {copy.signIn}


### PR DESCRIPTION
## Summary

- restore orange primary actions and text links across Auth v2 to match the existing Clerk UI direction
- use contrast-safe light and dark brand shades without changing global design tokens
- keep non-action controls, including password visibility, on neutral foreground colors

## Accessibility

- light primary/link `#d04301` on white: 4.68:1
- dark link `#ef5a0f` on `#222225`: 4.64:1

## Validation

- full workspace lint
- Knip
- non-App/API, App production/test, and API type checks
- Auth v2 presentation, sign-in, sign-up, and continuation tests (87 assertions)
- Prettier and targeted ESLint