### PR TITLE
refactor(api): dual-write debug logging aliases

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -322,6 +322,7 @@ runs:
         add_secret VAPID_PRIVATE_KEY VAPID_PRIVATE_KEY
         add_env CONCURRENT_RUN_LIMIT_CAP "$concurrent_run_limit_cap"
         if [[ "$INPUT_ENVIRONMENT" == "preview" ]]; then
+          add_env OKOU_DEBUG "*"
           add_env VM0_DEBUG "*"
         fi
         add_var CLAUDE_CODE_VERSION_URL CLAUDE_CODE_VERSION_URL

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -123,6 +123,21 @@ assert_preview_job_ref_aliases_absent() {
   assert_env_key_absent "$env_file" VM0_PREVIEW_JOB_REF
 }
 
+assert_debug_aliases_equal_dual() {
+  local env_file="$1"
+  assert_env_key_count "$env_file" OKOU_DEBUG 1
+  assert_env_key_count "$env_file" VM0_DEBUG 1
+  assert_env_value "$env_file" OKOU_DEBUG "*"
+  assert_env_value "$env_file" VM0_DEBUG "*"
+  assert_env_values_equal "$env_file" OKOU_DEBUG VM0_DEBUG
+}
+
+assert_debug_aliases_absent() {
+  local env_file="$1"
+  assert_env_key_absent "$env_file" OKOU_DEBUG
+  assert_env_key_absent "$env_file" VM0_DEBUG
+}
+
 assert_zero_keys_with_live_readers_absent() {
   local env_file="$1"
   local key
@@ -435,6 +450,7 @@ success_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${succ
 assert_contains "$success_output" "Rendered"
 assert_no_fixture_secret_values "$success_output"
 assert_zero_keys_with_live_readers_absent "$success_env_file"
+assert_debug_aliases_equal_dual "$success_env_file"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
@@ -516,6 +532,7 @@ preview_web_output="$(run_action "$(build_doppler_secrets_json)" "$preview_web_d
 preview_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${preview_web_dir}/github-output")"
 assert_contains "$preview_web_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$preview_web_env_file"
+assert_debug_aliases_equal_dual "$preview_web_env_file"
 
 empty_job_ref_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_job_ref_dir")
@@ -523,6 +540,7 @@ empty_job_ref_output="$(run_action "$(build_doppler_secrets_json)" "$empty_job_r
 empty_job_ref_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_job_ref_dir}/github-output")"
 assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
+assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -531,6 +549,7 @@ empty_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_
 assert_contains "$empty_output" "Rendered"
 assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
+assert_debug_aliases_equal_dual "$empty_env_file"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -546,6 +565,7 @@ production_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' 
 assert_contains "$production_web_output" "Rendered"
 assert_no_fixture_secret_values "$production_web_output"
 assert_zero_keys_with_live_readers_absent "$production_web_env_file"
+assert_debug_aliases_absent "$production_web_env_file"
 assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
 assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
@@ -571,6 +591,7 @@ production_api_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' 
 assert_contains "$production_api_output" "Rendered"
 assert_no_fixture_secret_values "$production_api_output"
 assert_zero_keys_with_live_readers_absent "$production_api_env_file"
+assert_debug_aliases_absent "$production_api_env_file"
 assert_env_value "$production_api_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
 assert_env_value "$production_api_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"

--- a/turbo/apps/api/scripts/dev.sh
+++ b/turbo/apps/api/scripts/dev.sh
@@ -191,6 +191,7 @@ start_clerk_webhook_forwarding
 
 cd "$API_APP_DIR"
 env \
+  OKOU_DEBUG='*' \
   VM0_DEBUG='*' \
   FEISHU_CALLBACK_BASE_URL="$TUNNEL_URL" \
   FINICITY_WEBHOOK_BASE_URL="$TUNNEL_URL" \

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -137,13 +137,12 @@ function resolveDebugConfiguration(): DebugConfiguration {
   return { state: "conflicting-dual" };
 }
 
-// This API-process compatibility boundary retains VM0_DEBUG while the preview
-// writer (.github/actions/web-api-env/action.yml), local development writer
-// (turbo/apps/api/scripts/dev.sh), and Turbo pass-through (turbo/turbo.json)
-// remain legacy-only. Under #28914, refresh stale Worker PR #25722 before the
-// later writer cutover, preserve a supported rollback target that accepts
-// VM0_DEBUG, and remove this fallback only after bounded source evidence shows
-// zero legacy-only and equal-dual resolutions through the rollback window.
+// The preview and local-development writers now emit byte-equal OKOU_DEBUG and
+// VM0_DEBUG values, with Turbo passing both aliases. VM0_DEBUG remains for API
+// rollback artifacts whose reader is legacy-only. Under #28914, refresh stale
+// Worker PR #25722 before the later canonical-only writer cutover, then retain
+// this resolver until bounded source evidence records zero legacy-only and
+// equal-dual states throughout the supported rollback window.
 const debugConfiguration = singleton(resolveDebugConfiguration);
 
 function getDebugPatterns(): readonly string[] {

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -8,6 +8,7 @@
     "DB_POOL_IDLE_TIMEOUT_MS",
     "DB_POOL_CONNECT_TIMEOUT_MS",
     "DB_DRIVER",
+    "OKOU_DEBUG",
     "VM0_DEBUG",
     "DEV",
     "NODE_ENV",


### PR DESCRIPTION
## Summary

- Emit adjacent, byte-equal `OKOU_DEBUG=*` and retained `VM0_DEBUG=*` values from the existing preview action writer.
- Launch the local API with the same adjacent pair and pass both aliases through Turbo.
- Extend the focused action test to require each preview alias exactly once with equal values and to keep both aliases absent in production output.
- Update only the compatibility comment around the existing fail-closed reader; resolver, pattern, logger, and telemetry behavior are unchanged.

## Base and overlap evidence

- Initial refreshed clean base: `ea0a806fa2e79622e470da9be77d2e04cb059299` (newer than the dispatched `58d54e8a286baa603835b7659d7dd8052066b02b`).
- Final refreshed PR base after `main` advanced during implementation: `89521f769af74c43034f04e5f7decc537ebff628`.
- Final current-head pagination audit: 22 open PRs, 316 GitHub-declared changed files, 316 fetched files, and zero pagination mismatches. Excluding this PR itself, the only semantic overlap remains #25722.
- Only #25722 overlaps this boundary. It remains open at head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, last updated `2026-08-13T15:03:45Z`, with 185 files and GitHub state `DIRTY` / `CONFLICTING`. Its proposed Worker allowlist still contains `VM0_DEBUG` but not `OKOU_DEBUG`, so this PR does not import any Worker or Cloudflare scope.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; existing unrelated Oxlint warnings only)
- `pnpm knip` (passed; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Bash syntax and ShellCheck for the touched shell paths and extracted composite-action script
- `bash .github/scripts/tests/web-api-env-action-test.sh`
- JSON parsing plus focused Turbo exactly-once/adjacency assertions
- Focused static assertion for the adjacent, equal local-development pair
- `pnpm exec prettier --check --ignore-unknown ...`
- `DATABASE_URL=... pnpm --filter api exec vitest run src/lib/__tests__/log.test.ts` (55/55 tests passed)
- Final exact-token inventory and excluded-scope diff audit

## Expected source states

- Production remains `absent` because this change preserves the existing preview-only action gate.
- Newly rendered preview and local-development API environments become `equal-dual`.
- Existing old previews and checked-out scripts can remain `legacy-only` until they retire naturally.
- No official writer becomes `canonical-only`; `conflicting-dual` remains fail-closed.

## Fallbacks

- **Retained fallback output:** The preview action, local API launcher, and Turbo pass-through retain `VM0_DEBUG` beside byte-equal `OKOU_DEBUG`. Reverting this PR restores the prior legacy-only writers without requiring a reader change.
- **Rollback compatibility:** The retained byte-identical legacy value keeps old API rollback artifacts whose reader understands only `VM0_DEBUG` operational. The relevant old rollback target is API `v1.491.0` at `686d369f99193080d18d8314fedaafe70097708b`.
- **Production reader floor:** API `v1.492.0` at exact release SHA `b3dc486122df415801b32c47038939e09392bd00` is the proven production floor containing the dual fail-closed reader from #29402; deployment `6095372633` reported `api/production` success for that SHA.
- **Compatibility window:** Keep equal dual output for the full supported API rollback window and while supported old preview deployments or checked-out writer/rerun paths may still be legacy-only.
- **Later canonical-only writer issue:** A separate just-in-time child issue under #28914 must prove that no supported old-only API reader or old writer/rerun path remains before removing `VM0_DEBUG` from any writer or pass-through.
- **Reader removal gate:** After that later writer cutover, retain the dual reader until bounded source-state evidence records zero `legacy-only` and zero `equal-dual` states throughout the supported rollback window. This PR makes no telemetry-zero claim.
- **Mandatory Worker refresh trigger:** If stale PR #25722 changes, lands, or is rebased before canonical-only work, refresh its complete Worker allowlist, runtime projection, writer, and reader surface; its current legacy-only allowlist must add `OKOU_DEBUG` for byte-equal dual behavior.

Closes #29409

Parent EPIC: #28914
