### PR TITLE
refactor: remove the video model selection feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -9,7 +9,6 @@ import { createHash, randomUUID } from "node:crypto";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -36,7 +35,6 @@ import {
   type AgentPhoneSendCapture,
 } from "./helpers/api-bdd-agentphone";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
@@ -549,18 +547,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const ap = createAgentPhoneBddApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
-    if (!actor.orgId) {
-      throw new Error("Expected a linked AgentPhone actor to own an org");
-    }
     // Ingress-created threads take the same creation-time media pin as web
     // threads, so this thread is the representative coverage for the ingress
     // wiring of that pin.
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.VideoModelSelection]: true },
-    );
-
     const smsMessageId = await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9698,11 +9698,6 @@ describe("CHAT-02: generation templates and attachments", () => {
     if (!actor.orgId) {
       throw new Error("Expected an org-scoped actor");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.VideoModelSelection]: true },
-    );
 
     // Run options are the composer's channel for video parameters now. They
     // ride one message, reach no table, and only enter the prompt when the
@@ -13585,13 +13580,8 @@ describe("CHAT-02: shared user message queue", () => {
   }, 90_000);
 });
 
-/**
- * Creation-time pinning follows the picker's own switch, so a video test has to
- * say which side of that switch it is on.
- */
-async function videoModelSelectionActor(args: {
-  readonly selectionEnabled: boolean;
-}): Promise<{
+/** Creation-time pinning is org-scoped, so a video test resolves the org too. */
+async function videoModelSelectionActor(): Promise<{
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly orgId: string;
@@ -13601,51 +13591,12 @@ async function videoModelSelectionActor(args: {
   if (!orgId) {
     throw new Error("Expected an entitled chat actor to own an org");
   }
-  await updateFeatureSwitchesForUser(
-    context,
-    { ...actor, orgId },
-    { [FeatureSwitchKey.VideoModelSelection]: args.selectionEnabled },
-  );
   return { actor, agentId, orgId };
 }
 
 describe("CHAT-02: run video model snapshot", () => {
-  it("leaves a thread unpinned while video model selection is disabled", async () => {
-    const { actor, agentId, orgId } = await videoModelSelectionActor({
-      selectionEnabled: false,
-    });
-
-    const anchor = await sendChatRun(actor, {
-      agentId,
-      prompt: "no video picker means nothing to freeze at creation",
-    });
-    await expect(readRunVideoModelFixture(anchor.runId)).resolves.toBe(
-      DEFAULT_VIDEO_MODEL,
-    );
-    await cancelChatRun(actor, anchor.runId);
-
-    // Without a pin the thread keeps following the live default, so a member
-    // default written later still reaches it.
-    await setOrgMemberVideoModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedVideoModel: "MiniMax-H3",
-    });
-    const followsDefault = await sendChatRun(actor, {
-      agentId,
-      threadId: anchor.threadId,
-      prompt: "an unpinned thread still follows the member default",
-    });
-    await expect(readRunVideoModelFixture(followsDefault.runId)).resolves.toBe(
-      "MiniMax-H3",
-    );
-    await cancelChatRun(actor, followsDefault.runId);
-  }, 90_000);
-
   it("pins a thread at creation and resolves later runs through that pin", async () => {
-    const { actor, agentId, orgId } = await videoModelSelectionActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId, orgId } = await videoModelSelectionActor();
 
     const catalogDefault = await sendChatRun(actor, {
       agentId,
@@ -13722,9 +13673,7 @@ describe("CHAT-02: run video model snapshot", () => {
   }, 90_000);
 
   it("still follows the member default for a thread that predates the pin", async () => {
-    const { actor, agentId, orgId } = await videoModelSelectionActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId, orgId } = await videoModelSelectionActor();
 
     const anchor = await sendChatRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -943,46 +943,9 @@ describe("POST /api/zero/chat-threads", () => {
     });
   });
 
-  it("leaves media models unpinned while neither picker is enabled", async () => {
+  it("pins the video model while the image picker is disabled", async () => {
     const fixture = await seedAgent();
     await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: false,
-      [FeatureSwitchKey.ImageModelSelection]: false,
-    });
-    await setMemberMediaDefaults(fixture);
-    const token = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      capabilities: ["chat-thread:read", "chat-thread:write"],
-    });
-
-    const response = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${token}` },
-        body: {
-          agentId: fixture.agentId,
-          title: "No media pickers enabled",
-          model: OTHER_WORKSPACE_MODEL,
-        },
-      }),
-      [201],
-    );
-
-    // A member who cannot reach either picker has no choice worth freezing, so
-    // the thread keeps following the live defaults. A written pin would also
-    // outlive a revert of this behavior.
-    await expect(
-      readCreatedThreadEvent(response.body.id, token),
-    ).resolves.toMatchObject({
-      selectedVideoModel: null,
-      selectedImageModel: null,
-    });
-  });
-
-  it("pins each media model whose picker is enabled", async () => {
-    const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
       [FeatureSwitchKey.ImageModelSelection]: false,
     });
     await setMemberMediaDefaults(fixture);
@@ -1004,8 +967,8 @@ describe("POST /api/zero/chat-threads", () => {
       [201],
     );
 
-    // Each switch gates its own pin: the video default freezes, the image one
-    // stays null while its own switch is off.
+    // The video default always freezes; the image one stays null while its own
+    // switch is off.
     await expect(
       readCreatedThreadEvent(response.body.id, token),
     ).resolves.toMatchObject({
@@ -1017,7 +980,6 @@ describe("POST /api/zero/chat-threads", () => {
   it("pins the member media defaults when the request omits them", async () => {
     const fixture = await seedAgent();
     await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
       [FeatureSwitchKey.ImageModelSelection]: true,
     });
     await setMemberMediaDefaults(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -9,7 +9,6 @@ import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 import type { OrgTier } from "@okouai/api-contracts/contracts/orgs";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
@@ -30,7 +29,6 @@ import { setRunVideoModelFixture } from "../../../test-fixtures/run-video-model"
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { seedCompose$, seedRun$ } from "./helpers/usage-state";
 import { createRouteMocks } from "./helpers/route-test";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 
 const context = testContext();
@@ -711,9 +709,6 @@ describe("POST /api/video-io/generate", () => {
       runId,
       selectedVideoModel: KLING_V3_4K_MODEL,
     });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
 
     let observedRequestUrl: string | null = null;
     let calledKling = false;
@@ -811,9 +806,6 @@ describe("POST /api/video-io/generate", () => {
       runId,
       selectedVideoModel: KLING_V3_4K_MODEL,
     });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
 
     let calledFal = false;
     server.use(
@@ -878,9 +870,6 @@ describe("POST /api/video-io/generate", () => {
       runId,
       selectedVideoModel: KLING_V3_4K_MODEL,
     });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
 
     let calledKling = false;
     let calledBytePlus = false;
@@ -939,9 +928,6 @@ describe("POST /api/video-io/generate", () => {
     await setRunVideoModelFixture({
       runId,
       selectedVideoModel: KLING_V3_4K_MODEL,
-    });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
     });
 
     let observedRequestUrl: string | null = null;
@@ -1032,9 +1018,6 @@ describe("POST /api/video-io/generate", () => {
       runId,
       selectedVideoModel: KLING_V3_4K_MODEL,
     });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
 
     let observedRequestUrl: string | null = null;
     server.use(
@@ -1095,75 +1078,6 @@ describe("POST /api/video-io/generate", () => {
     });
   });
 
-  it("keeps the request model when video model selection is disabled", async () => {
-    const fixture = await seedVideoFixture();
-    const { composeId } = await store.set(
-      seedCompose$,
-      { orgId: fixture.orgId, userId: fixture.userId },
-      context.signal,
-    );
-    const { runId } = await store.set(
-      seedRun$,
-      {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-        composeId,
-        triggerSource: "web",
-      },
-      context.signal,
-    );
-    await setRunVideoModelFixture({
-      runId,
-      selectedVideoModel: KLING_V3_4K_MODEL,
-    });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: false,
-    });
-
-    let calledVeo = false;
-    let calledKling = false;
-    server.use(
-      http.post(FAL_VEO_FAST_QUEUE_URL, () => {
-        calledVeo = true;
-        return HttpResponse.json({
-          request_id: "switch-off-veo-request",
-          status_url: FAL_STATUS_URL,
-          response_url: FAL_RESPONSE_URL,
-        });
-      }),
-      http.post(KLING_V3_4K_QUEUE_URL, () => {
-        calledKling = true;
-        return HttpResponse.json({
-          request_id: "unexpected-kling-request",
-          status_url: KLING_STATUS_URL,
-          response_url: KLING_RESPONSE_URL,
-        });
-      }),
-    );
-
-    const token = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      runId,
-    });
-    const app = createVideoIoTestApp(fixture.pricingResolution);
-    const response = await app.request("/api/video-io/generate", {
-      method: "POST",
-      headers: { authorization: `Bearer ${token}` },
-      body: JSON.stringify({
-        prompt: "a city at night",
-        model: "veo3.1-fast",
-        duration: "8s",
-        resolution: "1080p",
-        aspectRatio: "16:9",
-      }),
-    });
-
-    expect(response.status).toBe(202);
-    expect(calledVeo).toBeTruthy();
-    expect(calledKling).toBeFalsy();
-  });
-
   it("keeps the request model when the run video model snapshot is null", async () => {
     const fixture = await seedVideoFixture();
     const { composeId } = await store.set(
@@ -1182,9 +1096,6 @@ describe("POST /api/video-io/generate", () => {
       context.signal,
     );
     await setRunVideoModelFixture({ runId, selectedVideoModel: null });
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
 
     let calledFal = false;
     server.use(
@@ -1222,9 +1133,6 @@ describe("POST /api/video-io/generate", () => {
 
   it("keeps the request model for callers without a run ID", async () => {
     const fixture = await seedVideoFixture();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-    });
     mocks.clerk.session(fixture.userId, fixture.orgId);
     let calledMiniMax = false;
     server.use(

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -7,9 +7,7 @@ import {
 } from "@okouai/api-contracts/contracts/video-io-generate";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { VIDEO_MODEL_CONFIGS } from "@okouai/core/video-model-catalog";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   isVideoModelId,
   type VideoModelId,
@@ -58,7 +56,6 @@ import {
   isRunBuiltInAdmissionError,
   startRunBuiltInAdmission$,
 } from "../services/run-built-in-admission.service";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import type { AuthContext } from "../../types/auth";
 
 const videoBody$ = bodyResultOf(videoIoGenerateContract.post);
@@ -93,26 +90,10 @@ async function loadRunVideoModel(
 
 async function loadDefaultRunVideoModel(
   db: ReadonlyDb,
-  orgId: string,
-  userId: string,
   runId: string | undefined,
   signal: AbortSignal,
 ): Promise<VideoModelId | null> {
   if (!runId) {
-    return null;
-  }
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
-    db,
-    orgId,
-    userId,
-  );
-  signal.throwIfAborted();
-  if (
-    !isFeatureEnabled(
-      FeatureSwitchKey.VideoModelSelection,
-      featureSwitchContext,
-    )
-  ) {
     return null;
   }
   const runVideoModel = await loadRunVideoModel(db, runId);
@@ -434,13 +415,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       ? auth.runId
       : undefined;
   const publicBrand = resolveGenerationPublicBrand(auth, get(publicBrand$));
-  const runVideoModel = await loadDefaultRunVideoModel(
-    db,
-    auth.orgId,
-    auth.userId,
-    runId,
-    signal,
-  );
+  const runVideoModel = await loadDefaultRunVideoModel(db, runId, signal);
   // The run's model is a default, not an override: it applies only when the
   // request names no model of its own. A caller that asks for a specific model
   // — because the user asked for it in the prompt — gets that model.

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -434,7 +434,6 @@ interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
   readonly latestWebsiteTemplatesEnabled: boolean;
   readonly latestPresentationTemplatesEnabled: boolean;
-  readonly videoModelSelectionEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
   /**
    * Carried whole so thread creation can resolve its media pins without
@@ -1061,10 +1060,6 @@ async function resolveNormalSendFeatureSwitches(
       FeatureSwitchKey.LatestPresentationTemplates,
       context,
     ),
-    videoModelSelectionEnabled: isFeatureEnabled(
-      FeatureSwitchKey.VideoModelSelection,
-      context,
-    ),
     presentationTemplatesEnabled: isFeatureEnabled(
       FeatureSwitchKey.PresentationTemplates,
       context,
@@ -1101,11 +1096,7 @@ function resolveSelectedTemplateContext(
         featureSwitches.presentationTemplatesEnabled,
       mountedUserPresentationTemplateIds,
     }),
-    // Gated with the composer control that produces it, so a client that keeps
-    // sending the field after the switch is turned off stops being honoured.
-    videoRunOptions: featureSwitches.videoModelSelectionEnabled
-      ? (runtimeBody.runOptions?.video ?? null)
-      : null,
+    videoRunOptions: runtimeBody.runOptions?.video ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/chat-thread-media-model.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-media-model.service.ts
@@ -79,8 +79,9 @@ async function memberMediaModels(
 }
 
 /**
- * Member default, then catalog default, for each picker that is switched on.
- * For callers that already resolved this request's feature switches.
+ * Member default, then catalog default, for the video picker and for the image
+ * picker when it is switched on. For callers that already resolved this
+ * request's feature switches.
  */
 export async function resolveNewChatThreadMediaModels(
   db: Pick<ReadonlyDb, "select">,
@@ -90,23 +91,13 @@ export async function resolveNewChatThreadMediaModels(
     readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<NewChatThreadMediaModels> {
-  const videoEnabled = isFeatureEnabled(
-    FeatureSwitchKey.VideoModelSelection,
-    args.featureSwitchContext,
-  );
   const imageEnabled = isFeatureEnabled(
     FeatureSwitchKey.ImageModelSelection,
     args.featureSwitchContext,
   );
-  if (!videoEnabled && !imageEnabled) {
-    return { selectedVideoModel: null, selectedImageModel: null };
-  }
-
   const member = await memberMediaModels(db, args);
   return {
-    selectedVideoModel: videoEnabled
-      ? catalogedVideoModel(member.selectedVideoModel)
-      : null,
+    selectedVideoModel: catalogedVideoModel(member.selectedVideoModel),
     selectedImageModel: imageEnabled
       ? catalogedImageModel(member.selectedImageModel)
       : null,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2847,9 +2847,7 @@ function sendRuntimeOptions(
     runOptions: runOptionsFromModelProviderSelection(
       modelSelection,
       features[FeatureSwitchKey.CodexFastMode] ?? false,
-      (features[FeatureSwitchKey.VideoModelSelection] ?? false)
-        ? videoRunOptions
-        : undefined,
+      videoRunOptions,
     ),
     realAgentInPreviewEnabled:
       features[FeatureSwitchKey.RealAgentInPreview] ?? false,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -43,7 +43,6 @@ import {
   featureSwitch$,
   imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
-  videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import {
@@ -577,8 +576,7 @@ const sendNewThreadMessage$ = command(
     const imageModel = get(imageModelSelectionEnabled$)
       ? request.imageModel
       : undefined;
-    const videoModelEnabled = get(videoModelSelectionEnabled$);
-    const videoModel = videoModelEnabled ? request.videoModel : undefined;
+    const videoModel = request.videoModel;
     const { annotatedUserMessage, optimisticUserMessage } =
       annotatedMessagesForNewThread(
         request,
@@ -649,7 +647,7 @@ const sendNewThreadMessage$ = command(
       userMessage: annotatedUserMessage,
       computerUseHostId,
       cloudBrowserEnabled,
-      videoRunOptions: videoModelEnabled ? request.videoRunOptions : undefined,
+      videoRunOptions: request.videoRunOptions,
       sourceRunId: request.forward?.runId,
     });
     const sendResult = (async (): Promise<SendNewThreadMessageResult> => {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -51,10 +51,6 @@ export const imageRecognitionAvailable$ = computed((): boolean => {
   return true;
 });
 
-export const videoModelSelectionEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.VideoModelSelection] ?? false;
-});
-
 export const imageModelSelectionEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ImageModelSelection] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
@@ -14,7 +14,6 @@ import type { ChatForwardContext } from "../chat-page/chat-forward.ts";
 import {
   featureSwitch$,
   imageModelSelectionEnabled$,
-  videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
 import {
   updateUserModelPreference$,
@@ -96,9 +95,6 @@ const setVideoModel$ = command(
     videoModel: VideoModel | null,
     signal: AbortSignal,
   ): Promise<void> => {
-    if (!get(videoModelSelectionEnabled$)) {
-      return;
-    }
     set(setChatPageVideoModelSelection$, videoModel);
     const explicitDefaultActionEnabled =
       get(featureSwitch$)[FeatureSwitchKey.NewChatDefaultModelAction] ?? false;
@@ -207,16 +203,13 @@ function createAgentSubmitMessage(
       }
       const access = get(newThreadComputerAccess$);
       const imageModelEnabled = get(imageModelSelectionEnabled$);
-      const videoModelEnabled = get(videoModelSelectionEnabled$);
       const [hosts, imageModelPin, videoModelPin, connectorPreference] =
         await Promise.all([
           get(computerUseHosts$),
           imageModelEnabled
             ? get(chatPageImageModelPin$)
             : Promise.resolve(null),
-          videoModelEnabled
-            ? get(chatPageVideoModelPin$)
-            : Promise.resolve(null),
+          get(chatPageVideoModelPin$),
           get(connector.accounts.preferenceState$),
         ]);
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -334,11 +334,6 @@ describe("chat composer models", () => {
       featureSwitch: FeatureSwitchKey.ImageModelSelection,
       categoryTab: "Image",
     },
-    {
-      kind: "video",
-      featureSwitch: FeatureSwitchKey.VideoModelSelection,
-      categoryTab: "Video",
-    },
   ])(
     "keeps the model brand icon on the trigger when $kind model selection is enabled",
     async ({ featureSwitch, categoryTab }) => {
@@ -482,7 +477,6 @@ describe("chat composer models", () => {
       featureSwitches: {
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
         [FeatureSwitchKey.ImageModelSelection]: false,
-        [FeatureSwitchKey.VideoModelSelection]: false,
       },
       path: `/agents/${AGENT_ID}/chat`,
     });
@@ -497,7 +491,9 @@ describe("chat composer models", () => {
 
     await user.click(await findComposerModel("Claude Sonnet 4.6"));
     const modelPicker = await screen.findByRole("listbox");
-    expect(within(modelPicker).getByText("Models")).toBeInTheDocument();
+    // The always-present media panel replaces the "Models" section label with
+    // the category switch that holds this list.
+    await expect(findCategoryTab("Video")).resolves.toBeInTheDocument();
     expect(
       within(modelPicker).queryByText(
         "Default for new chats and new automations",
@@ -1931,13 +1927,11 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("edits thread override without loading user default model selection", async () => {
+  it("edits thread override without offering the new-chat default actions", async () => {
     const user = userEvent.setup({ delay: null });
-    let preferenceRequestStarted = false;
 
     mockOrgModelRoutes("claude-fable-5");
     context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
-      preferenceRequestStarted = true;
       return respond(200, {
         selectedModel: "claude-opus-4-8",
         serviceTier: null,
@@ -1963,7 +1957,6 @@ describe("chat composer models", () => {
       featureSwitches: {
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
         [FeatureSwitchKey.ImageModelSelection]: false,
-        [FeatureSwitchKey.VideoModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
     });
@@ -1974,7 +1967,6 @@ describe("chat composer models", () => {
       await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
     );
     await expectComposerModel("Claude Sonnet 4.6");
-    expect(preferenceRequestStarted).toBeFalsy();
     expect(
       screen.queryByText("Default for new chats and new automations"),
     ).not.toBeInTheDocument();
@@ -3750,7 +3742,6 @@ describe("chat composer image model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.ImageModelSelection]: true,
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -3978,7 +3969,6 @@ describe("chat composer image model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.ImageModelSelection]: true,
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -4062,7 +4052,6 @@ describe("chat composer image model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.ImageModelSelection]: false,
-        [FeatureSwitchKey.VideoModelSelection]: false,
       },
       path: `/agents/${AGENT_ID}/chat`,
     });
@@ -4120,7 +4109,6 @@ describe("chat composer image model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.ImageModelSelection]: true,
-        [FeatureSwitchKey.VideoModelSelection]: true,
       },
       path: `/chats/${THREAD_ID}`,
     });
@@ -4297,7 +4285,6 @@ describe("chat composer image model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.ImageModelSelection]: true,
-        [FeatureSwitchKey.VideoModelSelection]: true,
       },
       path: `/chats/${THREAD_ID}`,
     });
@@ -4494,7 +4481,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/agents/${AGENT_ID}/chat`,
     });
 
@@ -4575,7 +4561,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/agents/${AGENT_ID}/chat`,
     });
 
@@ -4604,54 +4589,6 @@ describe("chat composer video model", () => {
     });
   });
 
-  it("leaves new-chat video defaults disabled while the feature switch is off", async () => {
-    const user = userEvent.setup({ delay: null });
-    let preferenceUpdateCount = 0;
-    let createdThreadBody: { readonly videoModel?: string } | undefined;
-
-    mockOrgModelRoutes("claude-fable-5");
-    context.mocks.data.userModelPreference({
-      selectedModel: null,
-      serviceTier: null,
-      selectedVideoModel: "MiniMax-H3",
-      updatedAt: "2026-08-14T00:00:00Z",
-    });
-    context.mocks.api(
-      userModelPreferenceContract.update,
-      ({ body, respond }) => {
-        preferenceUpdateCount += 1;
-        return respond(200, {
-          ...body,
-          updatedAt: "2026-08-14T00:01:00Z",
-        });
-      },
-    );
-    mockAgent();
-    mockChatLifecycle(context, {
-      onThreadCreate: (body) => {
-        createdThreadBody = body;
-      },
-    });
-
-    detachedSetupPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: false },
-      path: `/agents/${AGENT_ID}/chat`,
-    });
-
-    await sendMessageInUI(
-      user,
-      (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement,
-      "Keep video model defaults disabled",
-    );
-
-    await waitFor(() => {
-      expect(createdThreadBody).toBeDefined();
-    });
-    expect(createdThreadBody?.videoModel).toBeUndefined();
-    expect(preferenceUpdateCount).toBe(0);
-  });
-
   it("pins a video model on the thread from the model picker", async () => {
     const user = userEvent.setup({ delay: null });
     context.mocks.browser.matchMedia(true);
@@ -4659,7 +4596,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4716,7 +4652,6 @@ describe("chat composer video model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.ImageModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
@@ -4775,7 +4710,6 @@ describe("chat composer video model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.ImageModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
@@ -4813,7 +4747,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4824,21 +4757,6 @@ describe("chat composer video model", () => {
       "aria-pressed",
       "true",
     );
-  });
-
-  it("hides the video model row while the feature switch is off", async () => {
-    const user = userEvent.setup({ delay: null });
-    mockVideoModelThread(null);
-
-    detachedSetupPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: false },
-      path: `/chats/${THREAD_ID}`,
-    });
-
-    await user.click(await findComposerModel("Claude Fable 5"));
-    await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ });
-    expect(videoCategoryTab()).toBeUndefined();
   });
 
   it("sends the video parameters chosen on the composer chip", async () => {
@@ -4857,7 +4775,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4908,7 +4825,6 @@ describe("chat composer video model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4975,7 +4891,6 @@ describe("chat composer video model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -5044,7 +4959,6 @@ describe("chat composer video model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -5113,7 +5027,6 @@ describe("chat composer video model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -541,9 +541,6 @@ describe("chat composer templates", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: {
-        [FeatureSwitchKey.VideoModelSelection]: true,
-      },
       path: `/chats/${THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -559,7 +559,6 @@ describe("zero sidebar", () => {
 
     setupSidebarPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: false },
       path: `/agents/${AGENT_ID}/chat`,
     });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -202,7 +202,6 @@ import {
   customConnectorMcpEnabled$,
   imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
-  videoModelSelectionEnabled$,
 } from "../../signals/external/feature-switch.ts";
 import {
   computerUseHosts$,
@@ -10011,13 +10010,11 @@ function ComposerExistingMediaModelPickerSlot({
   imageModelSignals,
   videoModelSignals,
   imageModelEnabled,
-  videoModelEnabled,
 }: {
   signals: ComposerSignals;
   imageModelSignals: ComposerImageModelSignals;
   videoModelSignals: ComposerVideoModelSignals;
   imageModelEnabled: boolean;
-  videoModelEnabled: boolean;
 }) {
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const selectedImageModel =
@@ -10037,16 +10034,13 @@ function ComposerExistingMediaModelPickerSlot({
           },
         }
       : undefined;
-  const videoModel: ComposerVideoModelPickerState | undefined =
-    videoModelEnabled
-      ? {
-          value: selectedVideoModel,
-          onChange: (next) => {
-            detach(setVideoModel(next, pageSignal), Reason.DomCallback);
-            setModelPickerOpen(false);
-          },
-        }
-      : undefined;
+  const videoModel: ComposerVideoModelPickerState = {
+    value: selectedVideoModel,
+    onChange: (next) => {
+      detach(setVideoModel(next, pageSignal), Reason.DomCallback);
+      setModelPickerOpen(false);
+    },
+  };
   return (
     <ComposerModelPickerSlotBase
       signals={signals}
@@ -10058,25 +10052,19 @@ function ComposerExistingMediaModelPickerSlot({
 
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const imageModelEnabled = useGet(imageModelSelectionEnabled$);
-  const videoModelEnabled = useGet(videoModelSelectionEnabled$);
   const imageModelSignals = signals.imageModel;
   const videoModelSignals = signals.videoModel;
-  if (
-    (imageModelEnabled || videoModelEnabled) &&
-    imageModelSignals &&
-    videoModelSignals
-  ) {
+  if (imageModelSignals && videoModelSignals) {
     return (
       <ComposerExistingMediaModelPickerSlot
         signals={signals}
         imageModelSignals={imageModelSignals}
         videoModelSignals={videoModelSignals}
         imageModelEnabled={imageModelEnabled}
-        videoModelEnabled={videoModelEnabled}
       />
     );
   }
-  if (videoModelEnabled && videoModelSignals) {
+  if (videoModelSignals) {
     return (
       <ComposerVideoModelPickerSlot
         signals={signals}
@@ -10299,7 +10287,6 @@ function ComposerTemporaryModelNoticeSlot({
 }) {
   const enabled = useGet(signals.model.temporaryModelNoticeEnabled$);
   const imageModelEnabled = useGet(imageModelSelectionEnabled$);
-  const videoModelEnabled = useGet(videoModelSelectionEnabled$);
   const mediaModelCategory = useGet(signals.model.mediaModelCategory$);
   const imageModelSignals = signals.imageModel;
   const videoModelSignals = signals.videoModel;
@@ -10319,11 +10306,7 @@ function ComposerTemporaryModelNoticeSlot({
       />
     );
   }
-  if (
-    videoModelEnabled &&
-    videoModelSignals &&
-    mediaModelCategory === "video"
-  ) {
+  if (videoModelSignals && mediaModelCategory === "video") {
     return (
       <ComposerTemporaryVideoModelNotice
         videoModelSignals={videoModelSignals}

--- a/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
@@ -26,7 +26,6 @@ import {
   videoRunOptionsPatch,
   videoRunOptionsText,
 } from "../../signals/okou-page/video-run-options.ts";
-import { videoModelSelectionEnabled$ } from "../../signals/external/feature-switch.ts";
 
 /**
  * Groups the settings so the pane reads as blocks rather than a run of loose
@@ -437,16 +436,10 @@ export function ComposerVideoOptionsChip({
 }: {
   readonly signals: ComposerSignals;
 }) {
-  const enabled = useGet(videoModelSelectionEnabled$);
   const desktopLayout = useGet(signals.model.desktopModelPickerLayout$);
   const mediaModelCategory = useGet(signals.model.mediaModelCategory$);
   const videoModelSignals = signals.videoModel;
-  if (
-    !enabled ||
-    !desktopLayout ||
-    mediaModelCategory !== "video" ||
-    !videoModelSignals
-  ) {
+  if (!desktopLayout || mediaModelCategory !== "video" || !videoModelSignals) {
     return null;
   }
   return (

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -107,7 +107,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
@@ -141,7 +140,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -71,7 +71,6 @@ export enum FeatureSwitchKey {
   ThreeColumnNav = "threeColumnNav",
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
-  VideoModelSelection = "videoModelSelection",
   ImageModelSelection = "imageModelSelection",
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -283,12 +283,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Send preview chat runs through real agent CLIs instead of preview mock runners.",
     enabled: false,
   },
-  [FeatureSwitchKey.VideoModelSelection]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Let the chat composer model picker pin the video model a chat thread generates with.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ImageModelSelection]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Terminal state

`fully-rolled-out`. On `main` the registry entry was `enabled: true` with no
`enabledOrgIdHashes`, so every org already ran the switched-on path. The
switched-on behaviour is kept permanently and every switched-off fallback is
deleted.

Introduced in `136547f33` — *feat(app): add video model selection to the model
picker* (#26910).

## Kept

- The composer model picker's Video category, its thread pin, and the video
  options chip.
- Creation-time pinning of the member's video default onto a new chat thread.
- The run's video model snapshot as the default for `POST /api/video-io/generate`.
- `runOptions.video` being honoured on a normal send.

## Deleted

- `FeatureSwitchKey.VideoModelSelection` and its registry entry.
- `videoModelSelectionEnabled$` (platform) and `videoModelSelectionEnabled`
  on `NormalSendFeatureSwitches` (api).
- The guard in `loadDefaultRunVideoModel`, which no longer needs `orgId`/`userId`
  or a feature-switch context load — one DB round trip fewer per video generation.
- The `!videoEnabled && !imageEnabled` early return in
  `resolveNewChatThreadMediaModels`; the video pin is now unconditional.
- The `videoModelEnabled` prop/branches in `ComposerModelPickerSlot`,
  `ComposerExistingMediaModelPickerSlot`, `ComposerTemporaryModelNoticeSlot`
  and `ComposerVideoOptionsChip`.

## Tests

Deleted (covered only the discarded switched-off behaviour):

- `keeps the request model when video model selection is disabled` — the
  neighbouring `... when the run video model snapshot is null` still covers
  "no pin means the request model wins".
- `leaves new-chat video defaults disabled while the feature switch is off`
- `hides the video model row while the feature switch is off`
- `leaves a thread unpinned while video model selection is disabled`
- `leaves media models unpinned while neither picker is enabled` — its
  remaining content duplicated `pins each media model whose picker is enabled`,
  which is retitled `pins the video model while the image picker is disabled`.

Rewritten to assert the permanent behaviour instead of deleting:

- `offers to make a temporary new-chat model choice the default below the composer`
  had forced both media switches off. With the media panel always present the
  picker renders the category switch instead of a `Models` section label
  (`showModelsLabel={!mediaModelPanel}`), so the anchor assertion now checks the
  Video category tab.
- `edits thread override without loading user default model selection` →
  `... without offering the new-chat default actions`. The always-on video
  picker resolves `effectiveVideoModel$`, which reads the member preference, so
  the "preference never fetched" assertion no longer describes any shipped
  path. The surviving assertions (no default row, no temporary notice) are the
  behaviour the test was protecting.

The `videoModelSelectionActor` bdd helper no longer takes `selectionEnabled`.

## Second-pass keyword sweep

`VideoModelSelection`, `videoModelSelection`, `videoModelSelectionEnabled`,
`videoModelEnabled`, `video-model-selection`, plus the symbols added by
#26910. Remaining hits are the feature's own permanent naming and are now
fully decoupled from the switch: `createVideoModelSelection`,
`setVideoModelSelection$`, `chatPageVideoModelSelection$`,
`setChatPageVideoModelSelection$`, `resetChatPageVideoModelSelection$`.

## Verification

| Check | Result |
| --- | --- |
| `pnpm check-types` | pass (14/14) |
| `pnpm lint` | pass, 0 errors (438 pre-existing warnings) |
| `pnpm knip` | exit 0, no unused files/exports/dependencies — baseline and after are both clean, so this cleanup left no orphans |
| `prettier --write` on changed files | clean |
| `git diff --check` | clean |
| `chat-composer-model-selection-and-providers.test.tsx` | 79/79 pass |
| `chat-composer-template-picker.test.tsx`, `sidebar.test.tsx`, `core/feature-switch.test.ts` | 150/150 pass |

Delegated to the PR pipeline: the `apps/api` suites. They need a Postgres on
`:5432` that this environment does not provide (`connect ECONNREFUSED
::1:5432` / `127.0.0.1:5432`, 12 tests skipped) — a pre-existing environment
limit unrelated to this diff.

## Note

Opened alongside the `imageModelSelection` cleanup. Both branch from the same
`main` and both touch `chat-composer.tsx`, `chat-thread-media-model.service.ts`,
`feature-switch.ts` and the shared composer test, so whichever merges second
will need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
