### PR TITLE
refactor: remove the image model selection feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -13861,9 +13861,8 @@ describe("CHAT-02: run video model snapshot", () => {
   }, 90_000);
 });
 
-async function imageModelSnapshotActor(args: {
-  readonly selectionEnabled: boolean;
-}): Promise<{
+/** The image snapshot is org-scoped, so these tests resolve the org too. */
+async function imageModelSnapshotActor(): Promise<{
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly orgId: string;
@@ -13874,60 +13873,12 @@ async function imageModelSnapshotActor(args: {
   if (!orgId) {
     throw new Error("Expected an entitled chat actor to own an org");
   }
-  await updateFeatureSwitchesForUser(
-    context,
-    { ...actor, orgId },
-    { [FeatureSwitchKey.ImageModelSelection]: args.selectionEnabled },
-  );
   return { actor, agentId, orgId, runnerGroup };
 }
 
 describe("CHAT-02: run image model snapshot", () => {
-  it("keeps the run snapshot null while image model selection is disabled", async () => {
-    const { actor, agentId, runnerGroup } = await imageModelSnapshotActor({
-      selectionEnabled: false,
-    });
-
-    const anchor = await sendChatRun(actor, {
-      agentId,
-      prompt: "image snapshot stays dormant for a new thread",
-    });
-    await expect(
-      readRunImageModelSnapshotFixture(anchor.runId),
-    ).resolves.toBeNull();
-    expect(
-      (await api.readRun(actor, anchor.runId)).appendSystemPrompt ?? "",
-    ).not.toContain("# Default built-in image model");
-    await cancelChatRun(actor, anchor.runId);
-
-    await chat.updateUserModelPreference(actor, null, "gpt-image-2");
-    await chat.updateThreadImageModel(
-      actor,
-      anchor.threadId,
-      "fal-ai/qwen-image",
-    );
-    const continued = await sendChatRun(actor, {
-      agentId,
-      threadId: anchor.threadId,
-      prompt: "image snapshot stays dormant for a continued thread",
-    });
-    await expect(
-      readRunImageModelSnapshotFixture(continued.runId),
-    ).resolves.toBeNull();
-    const { claim: disabledClaim } = await claimChatRun(
-      runnerGroup,
-      continued.runId,
-    );
-    expect(
-      claimEnvironment(disabledClaim)[DEFAULT_IMAGE_MODEL_ENV],
-    ).toBeUndefined();
-    await cancelChatRun(actor, continued.runId);
-  }, 90_000);
-
   it("resolves thread, member, and global image defaults into stable snapshots", async () => {
-    const { actor, agentId, runnerGroup } = await imageModelSnapshotActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId, runnerGroup } = await imageModelSnapshotActor();
 
     const globalDefault = await sendChatRun(actor, {
       agentId,
@@ -14021,9 +13972,7 @@ describe("CHAT-02: run image model snapshot", () => {
   }, 90_000);
 
   it("falls through image model IDs that the catalog no longer supports", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId, orgId } = await imageModelSnapshotActor();
     const retiredImageModel = "fal-ai/retired-image-model";
 
     const anchor = await sendChatRun(actor, {
@@ -14066,9 +14015,7 @@ describe("CHAT-02: run image model snapshot", () => {
   }, 90_000);
 
   it("persists the image snapshot when dispatch fails before runner start", async () => {
-    const { actor, agentId } = await imageModelSnapshotActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId } = await imageModelSnapshotActor();
     await chat.updateUserModelPreference(actor, null, "gpt-image-2");
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", undefined);
 
@@ -14091,9 +14038,7 @@ describe("CHAT-02: run image model snapshot", () => {
   }, 90_000);
 
   it("persists the resolved image model on a queued run", async () => {
-    const { actor, agentId } = await imageModelSnapshotActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId } = await imageModelSnapshotActor();
     await chat.updateUserModelPreference(actor, null, "fal-ai/qwen-image");
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
 
@@ -14125,9 +14070,7 @@ describe("CHAT-02: run image model snapshot", () => {
   }, 90_000);
 
   it("snapshots direct runs and re-resolves on session continuation", async () => {
-    const { actor, agentId } = await imageModelSnapshotActor({
-      selectionEnabled: true,
-    });
+    const { actor, agentId } = await imageModelSnapshotActor();
 
     const first = await api.createRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -943,11 +943,10 @@ describe("POST /api/zero/chat-threads", () => {
     });
   });
 
-  it("leaves media models unpinned while neither picker is enabled", async () => {
+  it("pins the image model while the video picker is disabled", async () => {
     const fixture = await seedAgent();
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.VideoModelSelection]: false,
-      [FeatureSwitchKey.ImageModelSelection]: false,
     });
     await setMemberMediaDefaults(fixture);
     const token = okouToken({
@@ -961,56 +960,20 @@ describe("POST /api/zero/chat-threads", () => {
         headers: { authorization: `Bearer ${token}` },
         body: {
           agentId: fixture.agentId,
-          title: "No media pickers enabled",
+          title: "Image picker only",
           model: OTHER_WORKSPACE_MODEL,
         },
       }),
       [201],
     );
 
-    // A member who cannot reach either picker has no choice worth freezing, so
-    // the thread keeps following the live defaults. A written pin would also
-    // outlive a revert of this behavior.
+    // The image default always freezes; the video one stays null while its own
+    // switch is off.
     await expect(
       readCreatedThreadEvent(response.body.id, token),
     ).resolves.toMatchObject({
       selectedVideoModel: null,
-      selectedImageModel: null,
-    });
-  });
-
-  it("pins each media model whose picker is enabled", async () => {
-    const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.VideoModelSelection]: true,
-      [FeatureSwitchKey.ImageModelSelection]: false,
-    });
-    await setMemberMediaDefaults(fixture);
-    const token = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      capabilities: ["chat-thread:read", "chat-thread:write"],
-    });
-
-    const response = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${token}` },
-        body: {
-          agentId: fixture.agentId,
-          title: "Video picker only",
-          model: OTHER_WORKSPACE_MODEL,
-        },
-      }),
-      [201],
-    );
-
-    // Each switch gates its own pin: the video default freezes, the image one
-    // stays null while its own switch is off.
-    await expect(
-      readCreatedThreadEvent(response.body.id, token),
-    ).resolves.toMatchObject({
-      selectedVideoModel: MEMBER_VIDEO_MODEL,
-      selectedImageModel: null,
+      selectedImageModel: MEMBER_IMAGE_MODEL,
     });
   });
 
@@ -1018,7 +981,6 @@ describe("POST /api/zero/chat-threads", () => {
     const fixture = await seedAgent();
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.VideoModelSelection]: true,
-      [FeatureSwitchKey.ImageModelSelection]: true,
     });
     await setMemberMediaDefaults(fixture);
     const token = okouToken({

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -8,7 +8,6 @@ import {
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
@@ -31,7 +30,6 @@ import {
 } from "../../../test-fixtures/system-config-seeds";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { seedCompose$, seedRun$ } from "./helpers/usage-state";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import {
   generatedStripeCustomerId,
   postUsageAllowanceInvoicePaid,
@@ -541,7 +539,6 @@ async function seedImageFixture(options: {
 async function seedImageRun(
   fixture: ImageFixture,
   options: {
-    readonly imageModelSelectionEnabled: boolean;
     readonly selectedImageModel: string | null;
   },
 ): Promise<{ readonly runId: string }> {
@@ -561,9 +558,6 @@ async function seedImageRun(
     context.signal,
   );
   await setRunImageModelFixture(runId, options.selectedImageModel);
-  await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.ImageModelSelection]: options.imageModelSelectionEnabled,
-  });
   return { runId };
 }
 
@@ -696,7 +690,6 @@ describe("POST /api/image-io/generate", () => {
       configured: QWEN_IMAGE_PRICING,
     });
     const { runId } = await seedImageRun(fixture, {
-      imageModelSelectionEnabled: true,
       selectedImageModel: "fal-ai/qwen-image",
     });
 
@@ -736,7 +729,6 @@ describe("POST /api/image-io/generate", () => {
       configured: [...GPT_IMAGE_1_PRICING, ...QWEN_IMAGE_PRICING],
     });
     const { runId } = await seedImageRun(fixture, {
-      imageModelSelectionEnabled: true,
       selectedImageModel: "fal-ai/qwen-image",
     });
     let gptCalls = 0;
@@ -829,7 +821,7 @@ describe("POST /api/image-io/generate", () => {
     expect(qwenCalls).toBe(0);
   });
 
-  it("keeps the global default for disabled, null, old, and session paths", async () => {
+  it("keeps the global default for null, old, and session paths", async () => {
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,
     });
@@ -849,17 +841,10 @@ describe("POST /api/image-io/generate", () => {
 
     const runCases = [
       {
-        imageModelSelectionEnabled: false,
-        selectedImageModel: "fal-ai/qwen-image",
-        prompt: "disabled switch",
-      },
-      {
-        imageModelSelectionEnabled: true,
         selectedImageModel: null,
         prompt: "null snapshot",
       },
       {
-        imageModelSelectionEnabled: true,
         selectedImageModel: "fal-ai/retired-image-model",
         prompt: "old snapshot",
       },
@@ -881,9 +866,6 @@ describe("POST /api/image-io/generate", () => {
     }
 
     const sessionFixture = await seedImageFixture({});
-    await updateFeatureSwitchesForUser(context, sessionFixture, {
-      [FeatureSwitchKey.ImageModelSelection]: true,
-    });
     mocks.clerk.session(sessionFixture.userId, sessionFixture.orgId);
     const sessionResponse = await app.request("/api/image-io/generate", {
       method: "POST",
@@ -892,7 +874,7 @@ describe("POST /api/image-io/generate", () => {
     });
     expect(sessionResponse.status).toBe(202);
 
-    expect(gptCalls).toBe(4);
+    expect(gptCalls).toBe(3);
     expect(qwenCalls).toBe(0);
   });
 

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -5,8 +5,6 @@ import { imageIoGenerateContract } from "@okouai/api-contracts/contracts/image-i
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 import { isImageModelId } from "@okouai/api-contracts/contracts/image-models";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   DEFAULT_IMAGE_MODEL,
   type ImageModel,
@@ -53,7 +51,6 @@ import {
   startRunBuiltInAdmission$,
   type RunBuiltInAdmission,
 } from "../services/run-built-in-admission.service";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 
 const L = logger("ImageGeneration");
 const imageBody$ = bodyResultOf(imageIoGenerateContract.post);
@@ -106,20 +103,6 @@ async function loadRunImageModelDefault(
     .limit(1);
   signal.throwIfAborted();
   if (!run) {
-    return null;
-  }
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
-    db,
-    orgId,
-    userId,
-  );
-  signal.throwIfAborted();
-  if (
-    !isFeatureEnabled(
-      FeatureSwitchKey.ImageModelSelection,
-      featureSwitchContext,
-    )
-  ) {
     return null;
   }
   return isImageModelId(run.selectedImageModel) ? run.selectedImageModel : null;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9296,7 +9296,6 @@ function prepareRunContext(
         orgId: args.orgId,
         userId: args.userId,
         chatThreadId: args.chatThreadId,
-        featureSwitchContext: bodyContext.featureSwitchContext,
       });
       signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/chat-thread-media-model.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-media-model.service.ts
@@ -79,8 +79,9 @@ async function memberMediaModels(
 }
 
 /**
- * Member default, then catalog default, for each picker that is switched on.
- * For callers that already resolved this request's feature switches.
+ * Member default, then catalog default, for the image picker and for the video
+ * picker when it is switched on. For callers that already resolved this
+ * request's feature switches.
  */
 export async function resolveNewChatThreadMediaModels(
   db: Pick<ReadonlyDb, "select">,
@@ -94,22 +95,12 @@ export async function resolveNewChatThreadMediaModels(
     FeatureSwitchKey.VideoModelSelection,
     args.featureSwitchContext,
   );
-  const imageEnabled = isFeatureEnabled(
-    FeatureSwitchKey.ImageModelSelection,
-    args.featureSwitchContext,
-  );
-  if (!videoEnabled && !imageEnabled) {
-    return { selectedVideoModel: null, selectedImageModel: null };
-  }
-
   const member = await memberMediaModels(db, args);
   return {
     selectedVideoModel: videoEnabled
       ? catalogedVideoModel(member.selectedVideoModel)
       : null,
-    selectedImageModel: imageEnabled
-      ? catalogedImageModel(member.selectedImageModel)
-      : null,
+    selectedImageModel: catalogedImageModel(member.selectedImageModel),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/image-model.service.ts
+++ b/turbo/apps/api/src/signals/services/image-model.service.ts
@@ -63,17 +63,7 @@ export async function resolveImageModelForRun(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly chatThreadId: string | undefined;
-  readonly featureSwitchContext: FeatureSwitchContext;
-}): Promise<ImageModel | null> {
-  if (
-    !isFeatureEnabled(
-      FeatureSwitchKey.ImageModelSelection,
-      args.featureSwitchContext,
-    )
-  ) {
-    return null;
-  }
-
+}): Promise<ImageModel> {
   if (args.chatThreadId !== undefined) {
     const threadPin = await threadImageModel(args.db, args.chatThreadId);
     if (threadPin !== null) {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -41,7 +41,6 @@ import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
 import {
   featureSwitch$,
-  imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
   videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
@@ -574,9 +573,7 @@ const sendNewThreadMessage$ = command(
     const features = get(featureSwitch$);
     // Pin only an explicit per-thread pick; an unpinned (null) thread follows
     // the member's live default, so changing the default later updates it.
-    const imageModel = get(imageModelSelectionEnabled$)
-      ? request.imageModel
-      : undefined;
+    const imageModel = request.imageModel;
     const videoModelEnabled = get(videoModelSelectionEnabled$);
     const videoModel = videoModelEnabled ? request.videoModel : undefined;
     const { annotatedUserMessage, optimisticUserMessage } =

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -55,10 +55,6 @@ export const videoModelSelectionEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.VideoModelSelection] ?? false;
 });
 
-export const imageModelSelectionEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.ImageModelSelection] ?? false;
-});
-
 export const composerImageAnnotationEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerImageAnnotation] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-composer-signals.ts
@@ -13,7 +13,6 @@ import {
 import type { ChatForwardContext } from "../chat-page/chat-forward.ts";
 import {
   featureSwitch$,
-  imageModelSelectionEnabled$,
   videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
 import {
@@ -127,9 +126,6 @@ const setImageModel$ = command(
     imageModel: ImageModel | null,
     signal: AbortSignal,
   ): Promise<void> => {
-    if (!get(imageModelSelectionEnabled$)) {
-      return;
-    }
     set(setChatPageImageModelSelection$, imageModel);
     const explicitDefaultActionEnabled =
       get(featureSwitch$)[FeatureSwitchKey.NewChatDefaultModelAction] ?? false;
@@ -206,14 +202,11 @@ function createAgentSubmitMessage(
         return false;
       }
       const access = get(newThreadComputerAccess$);
-      const imageModelEnabled = get(imageModelSelectionEnabled$);
       const videoModelEnabled = get(videoModelSelectionEnabled$);
       const [hosts, imageModelPin, videoModelPin, connectorPreference] =
         await Promise.all([
           get(computerUseHosts$),
-          imageModelEnabled
-            ? get(chatPageImageModelPin$)
-            : Promise.resolve(null),
+          get(chatPageImageModelPin$),
           videoModelEnabled
             ? get(chatPageVideoModelPin$)
             : Promise.resolve(null),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -330,11 +330,6 @@ describe("chat composer models", () => {
 
   it.each([
     {
-      kind: "image",
-      featureSwitch: FeatureSwitchKey.ImageModelSelection,
-      categoryTab: "Image",
-    },
-    {
       kind: "video",
       featureSwitch: FeatureSwitchKey.VideoModelSelection,
       categoryTab: "Video",
@@ -481,7 +476,6 @@ describe("chat composer models", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
-        [FeatureSwitchKey.ImageModelSelection]: false,
         [FeatureSwitchKey.VideoModelSelection]: false,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -497,7 +491,9 @@ describe("chat composer models", () => {
 
     await user.click(await findComposerModel("Claude Sonnet 4.6"));
     const modelPicker = await screen.findByRole("listbox");
-    expect(within(modelPicker).getByText("Models")).toBeInTheDocument();
+    // The always-present media panel replaces the "Models" section label with
+    // the category switch that holds this list.
+    await expect(findCategoryTab("Image")).resolves.toBeInTheDocument();
     expect(
       within(modelPicker).queryByText(
         "Default for new chats and new automations",
@@ -1830,21 +1826,14 @@ describe("chat composer models", () => {
     context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
       featureSwitchRequestStarted.resolve();
       await releaseFeatureSwitchResponse.promise;
-      return respond(200, {
-        switches: { [FeatureSwitchKey.ImageModelSelection]: true },
-        effectiveSwitches: {
-          [FeatureSwitchKey.ImageModelSelection]: true,
-        },
-      });
+      return respond(200, { switches: {}, effectiveSwitches: {} });
     });
     mockOrgModelRoutes("claude-fable-5");
     mockAgent();
 
     detachedSetupPage({
       context,
-      cachedFeatureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: false,
-      },
+      cachedFeatureSwitches: {},
       path: `/agents/${AGENT_ID}/chat`,
     });
 
@@ -1858,12 +1847,10 @@ describe("chat composer models", () => {
     await expect(
       screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
     ).resolves.toBeInTheDocument();
-    expect(categoryTab("Image")).toBeUndefined();
 
     releaseFeatureSwitchResponse.resolve();
 
     await waitFor(() => {
-      expect(categoryTab("Image")).toBeInTheDocument();
       expect(screen.getByRole("listbox")).toBeInTheDocument();
       expect(
         screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
@@ -1931,13 +1918,11 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("edits thread override without loading user default model selection", async () => {
+  it("edits thread override without offering the new-chat default actions", async () => {
     const user = userEvent.setup({ delay: null });
-    let preferenceRequestStarted = false;
 
     mockOrgModelRoutes("claude-fable-5");
     context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
-      preferenceRequestStarted = true;
       return respond(200, {
         selectedModel: "claude-opus-4-8",
         serviceTier: null,
@@ -1962,7 +1947,6 @@ describe("chat composer models", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
-        [FeatureSwitchKey.ImageModelSelection]: false,
         [FeatureSwitchKey.VideoModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
@@ -1974,7 +1958,6 @@ describe("chat composer models", () => {
       await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
     );
     await expectComposerModel("Claude Sonnet 4.6");
-    expect(preferenceRequestStarted).toBeFalsy();
     expect(
       screen.queryByText("Default for new chats and new automations"),
     ).not.toBeInTheDocument();
@@ -3671,7 +3654,6 @@ describe("chat composer image model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
       path: `/agents/${AGENT_ID}/chat`,
     });
 
@@ -3749,7 +3731,6 @@ describe("chat composer image model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: true,
         [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
@@ -3836,7 +3817,6 @@ describe("chat composer image model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
       path: `/agents/${AGENT_ID}/chat`,
     });
 
@@ -3897,7 +3877,6 @@ describe("chat composer image model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
       path: `/agents/${AGENT_ID}/chat`,
@@ -3977,7 +3956,6 @@ describe("chat composer image model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: true,
         [FeatureSwitchKey.VideoModelSelection]: true,
         [FeatureSwitchKey.NewChatDefaultModelAction]: true,
       },
@@ -4026,69 +4004,6 @@ describe("chat composer image model", () => {
     expect(updates).toStrictEqual([]);
   });
 
-  it("omits image UI, preference writes, and thread pins when disabled", async () => {
-    const user = userEvent.setup({ delay: null });
-    let preferenceUpdateCount = 0;
-    let createdThreadId: string | undefined;
-    let createdImageModel: string | undefined;
-    context.mocks.browser.matchMedia(true);
-
-    mockOrgModelRoutes("claude-fable-5");
-    context.mocks.data.userModelPreference({
-      selectedModel: null,
-      serviceTier: null,
-      selectedImageModel: "fal-ai/nano-banana-2",
-      updatedAt: "2026-08-18T00:00:00Z",
-    });
-    context.mocks.api(
-      userModelPreferenceContract.update,
-      ({ body, respond }) => {
-        preferenceUpdateCount += 1;
-        return respond(200, {
-          ...body,
-          updatedAt: "2026-08-18T00:01:00Z",
-        });
-      },
-    );
-    mockAgent();
-    mockChatLifecycle(context, {
-      onThreadCreate: (body) => {
-        createdThreadId = body.clientThreadId;
-        createdImageModel = body.imageModel;
-      },
-    });
-
-    detachedSetupPage({
-      context,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: false,
-        [FeatureSwitchKey.VideoModelSelection]: false,
-      },
-      path: `/agents/${AGENT_ID}/chat`,
-    });
-
-    await user.click(await findComposerModel("Claude Fable 5"));
-    await screen.findByRole("option", { name: /Claude Fable 5/ });
-    expect(imageCategoryTab()).toBeUndefined();
-    await user.keyboard("{Escape}");
-    await sendMessageInUI(
-      user,
-      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
-      "Keep image selection disabled",
-    );
-    await waitFor(() => {
-      expect(createdThreadId).toBeDefined();
-    });
-    expect(createdImageModel).toBeUndefined();
-    expect(preferenceUpdateCount).toBe(0);
-    if (!createdThreadId) {
-      throw new Error("Created thread id not captured");
-    }
-    expect(
-      context.store.get(eventDrivenChatThread(createdThreadId)),
-    ).toMatchObject({ selectedImageModel: null });
-  });
-
   it("shows the effective member default and pins an image model optimistically", async () => {
     const user = userEvent.setup({ delay: null });
     const updateGate = context.mocks.deferred<void>();
@@ -4119,7 +4034,6 @@ describe("chat composer image model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: true,
         [FeatureSwitchKey.VideoModelSelection]: true,
       },
       path: `/chats/${THREAD_ID}`,
@@ -4216,7 +4130,6 @@ describe("chat composer image model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4268,7 +4181,6 @@ describe("chat composer image model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -4296,7 +4208,6 @@ describe("chat composer image model", () => {
     detachedSetupPage({
       context,
       featureSwitches: {
-        [FeatureSwitchKey.ImageModelSelection]: true,
         [FeatureSwitchKey.VideoModelSelection]: true,
       },
       path: `/chats/${THREAD_ID}`,
@@ -4362,7 +4273,6 @@ describe("chat composer image model", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
       path: `/chats/${THREAD_ID}?sidebar=${OTHER_AGENT_THREAD_ID}`,
     });
 
@@ -4717,7 +4627,6 @@ describe("chat composer video model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.VideoModelSelection]: true,
-        [FeatureSwitchKey.ImageModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
     });
@@ -4739,8 +4648,8 @@ describe("chat composer video model", () => {
 
     await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ });
     expect(chatModelButton).toHaveAttribute("aria-expanded", "true");
-    // Only the categories the composer actually offers get a tab.
-    expect(categoryTab("Image")).toBeUndefined();
+    // Both media categories the composer offers get a tab.
+    await expect(findCategoryTab("Image")).resolves.toBeInTheDocument();
 
     // Switching category swaps the list without closing the popover.
     await user.click(await findCategoryTab("Video"));
@@ -4776,14 +4685,13 @@ describe("chat composer video model", () => {
       context,
       featureSwitches: {
         [FeatureSwitchKey.VideoModelSelection]: true,
-        [FeatureSwitchKey.ImageModelSelection]: false,
       },
       path: `/chats/${THREAD_ID}`,
     });
 
     await user.click(await findComposerModel("Claude Fable 5"));
-    // Only the categories the composer offers get a tab, on mobile too.
-    expect(categoryTab("Image")).toBeUndefined();
+    // Both media categories get a tab, on mobile too.
+    await expect(findCategoryTab("Image")).resolves.toBeInTheDocument();
     await user.click(await findCategoryTab("Video"));
     expect(videoPanelButton("MiniMax H3")).toHaveAttribute(
       "aria-pressed",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3728,7 +3728,6 @@ describe("zero sidebar", () => {
       path: `/chats/${EXISTING_THREAD_ID}`,
       featureSwitches: {
         [FeatureSwitchKey.ThreeColumnNav]: true,
-        [FeatureSwitchKey.ImageModelSelection]: true,
       },
     });
 
@@ -3787,7 +3786,6 @@ describe("zero sidebar", () => {
       path: `/chats/${EXISTING_THREAD_ID}`,
       featureSwitches: {
         [FeatureSwitchKey.ThreeColumnNav]: true,
-        [FeatureSwitchKey.ImageModelSelection]: true,
       },
     });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -200,7 +200,6 @@ import {
 import {
   codexFastModeEnabled$,
   customConnectorMcpEnabled$,
-  imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
   videoModelSelectionEnabled$,
 } from "../../signals/external/feature-switch.ts";
@@ -10010,13 +10009,11 @@ function ComposerExistingMediaModelPickerSlot({
   signals,
   imageModelSignals,
   videoModelSignals,
-  imageModelEnabled,
   videoModelEnabled,
 }: {
   signals: ComposerSignals;
   imageModelSignals: ComposerImageModelSignals;
   videoModelSignals: ComposerVideoModelSignals;
-  imageModelEnabled: boolean;
   videoModelEnabled: boolean;
 }) {
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
@@ -10027,16 +10024,13 @@ function ComposerExistingMediaModelPickerSlot({
   const setImageModel = useSet(imageModelSignals.setImageModel$);
   const setVideoModel = useSet(videoModelSignals.setVideoModel$);
   const pageSignal = useGet(pageSignal$);
-  const imageModel: ComposerImageModelPickerState | undefined =
-    imageModelEnabled
-      ? {
-          value: selectedImageModel,
-          onChange: (next) => {
-            detach(setImageModel(next, pageSignal), Reason.DomCallback);
-            setModelPickerOpen(false);
-          },
-        }
-      : undefined;
+  const imageModel: ComposerImageModelPickerState = {
+    value: selectedImageModel,
+    onChange: (next) => {
+      detach(setImageModel(next, pageSignal), Reason.DomCallback);
+      setModelPickerOpen(false);
+    },
+  };
   const videoModel: ComposerVideoModelPickerState | undefined =
     videoModelEnabled
       ? {
@@ -10057,21 +10051,15 @@ function ComposerExistingMediaModelPickerSlot({
 }
 
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
-  const imageModelEnabled = useGet(imageModelSelectionEnabled$);
   const videoModelEnabled = useGet(videoModelSelectionEnabled$);
   const imageModelSignals = signals.imageModel;
   const videoModelSignals = signals.videoModel;
-  if (
-    (imageModelEnabled || videoModelEnabled) &&
-    imageModelSignals &&
-    videoModelSignals
-  ) {
+  if (imageModelSignals && videoModelSignals) {
     return (
       <ComposerExistingMediaModelPickerSlot
         signals={signals}
         imageModelSignals={imageModelSignals}
         videoModelSignals={videoModelSignals}
-        imageModelEnabled={imageModelEnabled}
         videoModelEnabled={videoModelEnabled}
       />
     );
@@ -10298,7 +10286,6 @@ function ComposerTemporaryModelNoticeSlot({
   signals: ComposerSignals;
 }) {
   const enabled = useGet(signals.model.temporaryModelNoticeEnabled$);
-  const imageModelEnabled = useGet(imageModelSelectionEnabled$);
   const videoModelEnabled = useGet(videoModelSelectionEnabled$);
   const mediaModelCategory = useGet(signals.model.mediaModelCategory$);
   const imageModelSignals = signals.imageModel;
@@ -10308,11 +10295,7 @@ function ComposerTemporaryModelNoticeSlot({
   }
   // One notice at a time: it belongs to whichever model the composer is
   // currently pointed at, matching the pressed state of the two mode chips.
-  if (
-    imageModelEnabled &&
-    imageModelSignals &&
-    mediaModelCategory === "image"
-  ) {
+  if (imageModelSignals && mediaModelCategory === "image") {
     return (
       <ComposerTemporaryImageModelNotice
         imageModelSignals={imageModelSignals}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -108,7 +108,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );
@@ -142,7 +141,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
-    expect(otherOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -72,7 +72,6 @@ export enum FeatureSwitchKey {
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
   VideoModelSelection = "videoModelSelection",
-  ImageModelSelection = "imageModelSelection",
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",
   LatestWebsiteTemplates = "latestWebsiteTemplates",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -289,12 +289,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Let the chat composer model picker pin the video model a chat thread generates with.",
     enabled: true,
   },
-  [FeatureSwitchKey.ImageModelSelection]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Let the chat composer model picker choose the default built-in image model for a chat thread.",
-    enabled: true,
-  },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Terminal state

`fully-rolled-out`. On `main` the registry entry was `enabled: true` with no
`enabledOrgIdHashes`, so every org already ran the switched-on path. The
switched-on behaviour is kept permanently and every switched-off fallback is
deleted.

Introduced in `7087c6f37` — *feat(core): add image model catalog and selection
switch* (#27710).

## Kept

- The composer model picker's Image category and its thread pin.
- Creation-time pinning of the member's image default onto a new chat thread.
- `resolveImageModelForRun` resolving thread pin → member default →
  `DEFAULT_IMAGE_MODEL`, and the resulting run snapshot reaching the sandbox as
  the default built-in image model.
- The run's image model snapshot as the default for `POST /api/image-io/generate`.

## Deleted

- `FeatureSwitchKey.ImageModelSelection` and its registry entry.
- `imageModelSelectionEnabled$` (platform).
- The guard in `loadRunImageModelDefault`, which no longer loads a
  feature-switch context — one DB round trip fewer per image generation.
- The guard in `resolveImageModelForRun`. It can no longer return `null`, so its
  return type narrows from `ImageModel | null` to `ImageModel` and it drops the
  `featureSwitchContext` argument, matching the already-ungated
  `resolveVideoModelForRun` next to it.
- The `!videoEnabled && !imageEnabled` early return in
  `resolveNewChatThreadMediaModels`; the image pin is now unconditional.
- The `imageModelEnabled` prop/branches in `ComposerModelPickerSlot`,
  `ComposerExistingMediaModelPickerSlot` and `ComposerTemporaryModelNoticeSlot`.

## Tests

Deleted (covered only the discarded switched-off behaviour):

- `omits image UI, preference writes, and thread pins when disabled`
- `keeps the run snapshot null while image model selection is disabled`
- `leaves media models unpinned while neither picker is enabled` — its
  remaining content duplicated `pins each media model whose picker is enabled`,
  which is retitled `pins the image model while the video picker is disabled`.
- The `disabled switch` case in `keeps the global default for disabled, null,
  old, and session paths` (retitled `... for null, old, and session paths`).
  That case relied on the switch suppressing a valid run snapshot; without it
  the snapshot is honoured, so the expected `gptCalls` drops from 4 to 3.

Rewritten to assert the permanent behaviour instead of deleting:

- `offers to make a temporary new-chat model choice the default below the composer`
  had forced the media switches off. With the media panel always present the
  picker renders the category switch instead of a `Models` section label
  (`showModelsLabel={!mediaModelPanel}`), so the anchor assertion now checks the
  Image category tab.
- `edits thread override without loading user default model selection` →
  `... without offering the new-chat default actions`. The always-on image
  picker resolves the member preference, so the "preference never fetched"
  assertion no longer describes any shipped path. The surviving assertions
  (no default row, no temporary notice) are the behaviour the test was
  protecting.
- `keeps the agent chat model picker open while feature switches hydrate` used
  the Image tab appearing as its proof of a post-hydration re-render. Category
  tabs are no longer switch-driven, so the test now asserts the listbox and its
  options survive hydration, with the deferred `featureSwitches.get` still
  driving the in-flight window. Deliberately not retargeted at another switch —
  that would have coupled it to the sibling `videoModelSelection` cleanup.
- `switches category inside one popover opened from a single trigger` and
  `pins the visible fallback model to the current thread` asserted
  `categoryTab("Image")` was absent; the Image category is now always offered,
  so both assert its presence.

The `imageModelSnapshotActor` bdd helper and the `seedImageRun` fixture helper
no longer take `selectionEnabled` / `imageModelSelectionEnabled`.

## Second-pass keyword sweep

`ImageModelSelection`, `imageModelSelection`, `imageModelSelectionEnabled`,
`imageModelEnabled`, `image-model-selection`, plus the symbols added by
#27710. Remaining hits are the feature's own permanent naming and are now
fully decoupled from the switch: `createImageModelSelection`,
`setImageModelSelection$`, `chatPageImageModelSelection$`,
`setChatPageImageModelSelection$`, `resetChatPageImageModelSelection$`.

## Verification

| Check | Result |
| --- | --- |
| `pnpm check-types` | pass (14/14) |
| `pnpm lint` | pass, 0 errors (441 pre-existing warnings) |
| `pnpm knip` | exit 0, no unused files/exports/dependencies — baseline and after are both clean, so this cleanup left no orphans |
| `prettier --check` on changed files | clean |
| `git diff --check` | clean |
| `chat-composer-model-selection-and-providers.test.tsx` | 80/80 pass |
| `sidebar.test.tsx`, `core/feature-switch.test.ts` | 105/105 pass |

Delegated to the PR pipeline: the `apps/api` suites. They need a Postgres on
`:5432` that this environment does not provide (`connect ECONNREFUSED
::1:5432` / `127.0.0.1:5432`) — a pre-existing environment limit unrelated to
this diff.

## Note

Opened alongside the `videoModelSelection` cleanup. Both branch from the same
`main` and both touch `chat-composer.tsx`, `chat-thread-media-model.service.ts`,
`feature-switch.ts` and the shared composer test, so whichever merges second
will need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
