### PR TITLE
feat(chat): make tool activity copy lifecycle-aware

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
@@ -220,7 +220,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
     await api.requestCancelRun(actor, runId, [200]);
   });
 
-  it("folds Claude starts and results across batches using the immutable true gate", async () => {
+  it("persists progressive Claude starts and past-tense results across batches", async () => {
     const chat = createChatFilesBddApi(context);
     const connectors = createConnectorBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -501,7 +501,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 1,
         action: "run",
         status: "pending",
-        summary: "Ran printf '%s' '***'",
+        summary: "Running printf '%s' '***'",
       },
       {
         sequenceNumber: 3,
@@ -513,7 +513,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 4,
         action: "read",
         status: "pending",
-        summary: "Read /workspace/***/read.ts",
+        summary: "Reading /workspace/***/read.ts",
       },
       {
         sequenceNumber: 5,
@@ -525,7 +525,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 6,
         action: "write",
         status: "pending",
-        summary: "Wrote /workspace/write.ts",
+        summary: "Writing /workspace/write.ts",
       },
       {
         sequenceNumber: 7,
@@ -537,7 +537,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 8,
         action: "edit",
         status: "pending",
-        summary: "Edited /workspace/edit.ts",
+        summary: "Editing /workspace/edit.ts",
       },
       {
         sequenceNumber: 9,
@@ -844,7 +844,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 0,
         action: "run",
         status: "pending",
-        summary: "Ran echo ***",
+        summary: "Running echo ***",
       },
       {
         sequenceNumber: 1,
@@ -868,7 +868,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
         sequenceNumber: 5,
         action: "run",
         status: "pending",
-        summary: "Ran printf codex-tool-v1",
+        summary: "Running printf codex-tool-v1",
       },
       {
         sequenceNumber: 6,

--- a/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
@@ -103,7 +103,7 @@ describe("agent tool event normalization", () => {
       providerOperationId: "claude-operation-1",
       action: "run",
       status: "pending",
-      summary: "Ran printf '***'",
+      summary: "Running printf '***'",
     });
     expect(
       normalizeAgentToolEvent(
@@ -112,7 +112,7 @@ describe("agent tool event normalization", () => {
           input: { file_path: " /workspace/a.ts " },
         }),
       ),
-    ).toMatchObject({ action: "read", summary: "Read /workspace/a.ts" });
+    ).toMatchObject({ action: "read", summary: "Reading /workspace/a.ts" });
     expect(
       normalizeAgentToolEvent(
         claudeToolUse({
@@ -120,7 +120,7 @@ describe("agent tool event normalization", () => {
           input: { file_path: "/workspace/b.ts" },
         }),
       ),
-    ).toMatchObject({ action: "write", summary: "Wrote /workspace/b.ts" });
+    ).toMatchObject({ action: "write", summary: "Writing /workspace/b.ts" });
     expect(
       normalizeAgentToolEvent(
         claudeToolUse({
@@ -128,7 +128,7 @@ describe("agent tool event normalization", () => {
           input: { file_path: "/workspace/c.ts" },
         }),
       ),
-    ).toMatchObject({ action: "edit", summary: "Edited /workspace/c.ts" });
+    ).toMatchObject({ action: "edit", summary: "Editing /workspace/c.ts" });
     expect(
       normalizeAgentToolEvent(
         claudeToolUse({
@@ -141,7 +141,7 @@ describe("agent tool event normalization", () => {
       ),
     ).toMatchObject({
       action: "edit",
-      summary: "Edited /workspace/notebook.ipynb",
+      summary: "Editing /workspace/notebook.ipynb",
     });
 
     expect(
@@ -208,7 +208,7 @@ describe("agent tool event normalization", () => {
         ).toMatchObject({
           action: "run",
           status: "pending",
-          summary: `Ran printf '%s\\n' "$HOME"`,
+          summary: `Running printf '%s\\n' "$HOME"`,
         });
       }
     }
@@ -222,7 +222,7 @@ describe("agent tool event normalization", () => {
       providerOperationId: "exec-8993fae2-8f50-4963-989c-3489ab724f2e",
       action: "run",
       status: "pending",
-      summary: "Ran printf codex-tool-v1",
+      summary: "Running printf codex-tool-v1",
     });
     if (started?.kind !== "correlated") {
       throw new Error("Expected the live Codex start to normalize");
@@ -296,7 +296,7 @@ describe("agent tool event normalization", () => {
       }),
     );
     expect(normalized).toMatchObject({
-      summary: `Read ${"a".repeat(233)}…`,
+      summary: `Reading ${"a".repeat(231)}…`,
     });
     if (normalized?.kind !== "correlated") {
       throw new Error("Expected a correlated Claude tool event");
@@ -356,7 +356,7 @@ describe("agent tool event normalization", () => {
       ),
     ).toMatchObject({
       summary:
-        "Ran printf '%s' \"exec '/usr/local/bin/guest-tool-exec' --shell\"",
+        "Running printf '%s' \"exec '/usr/local/bin/guest-tool-exec' --shell\"",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -26,7 +26,10 @@ import {
 } from "./chat-first-assistant-event-metric.service";
 import { chatThreadForRunFromDb } from "./chat-thread.service";
 import { writeRunMetadataInTransaction } from "./agent-run-metadata-write.service";
-import { normalizeAgentToolEvent } from "./agent-tool-event-normalization";
+import {
+  normalizeAgentToolEvent,
+  terminalToolSummary,
+} from "./agent-tool-event-normalization";
 import {
   toolUseIdForProviderOperation,
   toolUseIdForRunEvent,
@@ -40,7 +43,10 @@ interface OutputCandidate {
   readonly content: string;
 }
 
-type ToolOperationState = Pick<OutputToolPayload, "action" | "summary">;
+type ToolOperationState = Pick<
+  OutputToolPayload,
+  "action" | "status" | "summary"
+>;
 
 export interface MaterializedChatProjection {
   readonly thread: {
@@ -295,6 +301,7 @@ function assistantEventItems(args: {
       });
       toolOperations.set(toolUseId, {
         action: normalized.action,
+        status: normalized.status,
         summary: normalized.summary,
       });
       continue;
@@ -307,17 +314,35 @@ function assistantEventItems(args: {
     );
     const prior = toolOperations.get(toolUseId);
     if (normalized.kind === "correlated-terminal") {
-      const operation = prior ?? normalized.standaloneOperation;
-      if (operation === undefined) {
+      const sourceOperation =
+        prior ??
+        (normalized.standaloneOperation === undefined
+          ? undefined
+          : {
+              ...normalized.standaloneOperation,
+              status: normalized.status,
+            });
+      if (sourceOperation === undefined) {
         continue;
       }
+      const operation: ToolOperationState = {
+        action: sourceOperation.action,
+        status: normalized.status,
+        summary:
+          sourceOperation.status === "pending"
+            ? terminalToolSummary(
+                sourceOperation.action,
+                sourceOperation.summary,
+              )
+            : sourceOperation.summary,
+      };
       items.push({
         eventType: "output.tool",
         runEventSequenceNumber: event.sequenceNumber,
         runEventId,
         toolUseId,
         action: operation.action,
-        status: normalized.status,
+        status: operation.status,
         summary: operation.summary,
       });
       toolOperations.set(toolUseId, operation);
@@ -326,6 +351,7 @@ function assistantEventItems(args: {
 
     const operation = {
       action: normalized.action,
+      status: normalized.status,
       summary: normalized.summary,
     };
     items.push({
@@ -334,7 +360,7 @@ function assistantEventItems(args: {
       runEventId,
       toolUseId,
       action: operation.action,
-      status: normalized.status,
+      status: operation.status,
       summary: operation.summary,
     });
     toolOperations.set(toolUseId, operation);
@@ -361,6 +387,7 @@ async function priorToolOperationsForRun(
     const payload = outputToolPayloadSchema.parse(row.payload);
     operations.set(payload.toolUseId, {
       action: payload.action,
+      status: payload.status,
       summary: payload.summary,
     });
   }

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -4,6 +4,7 @@ import type { AgentEvent } from "../../lib/event-consumer/verify";
 
 type ToolAction = OutputToolPayload["action"];
 type ToolTerminalStatus = Exclude<OutputToolPayload["status"], "pending">;
+type ToolSummaryLifecycle = "pending" | "terminal";
 
 type NormalizedAgentToolEvent =
   | {
@@ -33,6 +34,12 @@ type NormalizedAgentToolEvent =
 
 const TOOL_SUMMARY_MAX_LENGTH = 240;
 const TOOL_SUMMARY_ELLIPSIS = "…";
+const TOOL_SUMMARY_VERB_BY_ACTION = {
+  run: { pending: "Running", terminal: "Ran" },
+  read: { pending: "Reading", terminal: "Read" },
+  write: { pending: "Writing", terminal: "Wrote" },
+  edit: { pending: "Editing", terminal: "Edited" },
+} satisfies Record<ToolAction, Record<ToolSummaryLifecycle, string>>;
 const MANAGED_TOOL_EXECUTABLE = "exec '/usr/local/bin/guest-tool-exec'";
 const MANAGED_TOOL_PREFIX = `${MANAGED_TOOL_EXECUTABLE} --shell "$0" -c `;
 
@@ -65,7 +72,11 @@ function truncateToolSummary(summary: string): string {
   return `${summary.slice(0, end)}${TOOL_SUMMARY_ELLIPSIS}`;
 }
 
-function toolSummary(verb: string, target: unknown): string | null {
+function toolSummary(
+  action: ToolAction,
+  lifecycle: ToolSummaryLifecycle,
+  target: unknown,
+): string | null {
   if (typeof target !== "string" || target.includes("\0")) {
     return null;
   }
@@ -73,7 +84,23 @@ function toolSummary(verb: string, target: unknown): string | null {
   if (normalizedTarget.length === 0) {
     return null;
   }
-  return truncateToolSummary(`${verb} ${normalizedTarget}`);
+  return truncateToolSummary(
+    `${TOOL_SUMMARY_VERB_BY_ACTION[action][lifecycle]} ${normalizedTarget}`,
+  );
+}
+
+/** Re-tense a persisted pending summary when a provider result omits its target. */
+export function terminalToolSummary(
+  action: OutputToolPayload["action"],
+  summary: string,
+): string {
+  const verbs = TOOL_SUMMARY_VERB_BY_ACTION[action];
+  const pendingPrefix = `${verbs.pending} `;
+  return summary.startsWith(pendingPrefix)
+    ? truncateToolSummary(
+        `${verbs.terminal} ${summary.slice(pendingPrefix.length)}`,
+      )
+    : summary;
 }
 
 /** Decode the exact single-quote dialect emitted by shell_quote::quote_shell_arg. */
@@ -261,29 +288,29 @@ function claudeToolUse(event: AgentEvent): NormalizedAgentToolEvent | null {
   let summary: string | null;
   if (typeof block.name === "string" && block.name.toLowerCase() === "bash") {
     action = "run";
-    summary = toolSummary("Ran", decodedToolCommand(input.command));
+    summary = toolSummary("run", "pending", decodedToolCommand(input.command));
   } else {
     switch (block.name) {
       case "Read": {
         action = "read";
-        summary = toolSummary("Read", input.file_path);
+        summary = toolSummary("read", "pending", input.file_path);
         break;
       }
       case "Write": {
         action = "write";
-        summary = toolSummary("Wrote", input.file_path);
+        summary = toolSummary("write", "pending", input.file_path);
         break;
       }
       case "Edit": {
         action = "edit";
-        summary = toolSummary("Edited", input.file_path);
+        summary = toolSummary("edit", "pending", input.file_path);
         break;
       }
       case "NotebookEdit": {
         action = "edit";
         summary =
-          toolSummary("Edited", input.notebook_path) ??
-          toolSummary("Edited", input.file_path);
+          toolSummary("edit", "pending", input.notebook_path) ??
+          toolSummary("edit", "pending", input.file_path);
         break;
       }
       default: {
@@ -364,7 +391,11 @@ function codexCommand(event: AgentEvent): NormalizedAgentToolEvent | null {
     return null;
   }
   if (event.type === "item.started") {
-    const summary = toolSummary("Ran", decodedToolCommand(item.command));
+    const summary = toolSummary(
+      "run",
+      "pending",
+      decodedToolCommand(item.command),
+    );
     if (item.status !== "in_progress" || summary === null) {
       return null;
     }
@@ -382,7 +413,11 @@ function codexCommand(event: AgentEvent): NormalizedAgentToolEvent | null {
   if (status === null) {
     return null;
   }
-  const summary = toolSummary("Ran", decodedToolCommand(item.command));
+  const summary = toolSummary(
+    "run",
+    "terminal",
+    decodedToolCommand(item.command),
+  );
   if (summary === null) {
     return null;
   }
@@ -449,10 +484,7 @@ function codexFile(event: AgentEvent): NormalizedAgentToolEvent | null {
     }
   }
 
-  const summary = toolSummary(
-    action === "read" ? "Read" : action === "write" ? "Wrote" : "Edited",
-    target,
-  );
+  const summary = toolSummary(action, "terminal", target);
   return summary === null
     ? null
     : { kind: "standalone", action, status, summary };

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -96,11 +96,12 @@ export function terminalToolSummary(
 ): string {
   const verbs = TOOL_SUMMARY_VERB_BY_ACTION[action];
   const pendingPrefix = `${verbs.pending} `;
-  return summary.startsWith(pendingPrefix)
-    ? truncateToolSummary(
-        `${verbs.terminal} ${summary.slice(pendingPrefix.length)}`,
-      )
-    : summary;
+  if (!summary.startsWith(pendingPrefix)) {
+    throw new Error(`Pending ${action} tool summary is not progressive`);
+  }
+  return truncateToolSummary(
+    `${verbs.terminal} ${summary.slice(pendingPrefix.length)}`,
+  );
 }
 
 /** Decode the exact single-quote dialect emitted by shell_quote::quote_shell_arg. */

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2307,9 +2307,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "Dateien geändert",
-        "read": "Dateien gelesen",
-        "run": "Befehle ausgeführt"
+        "changes": {
+          "pending": {
+            "plural": "Dateien werden geändert",
+            "singular": "Datei wird geändert"
+          },
+          "terminal": {
+            "plural": "Dateien geändert",
+            "singular": "Datei geändert"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Dateien werden gelesen",
+            "singular": "Datei wird gelesen"
+          },
+          "terminal": {
+            "plural": "Dateien gelesen",
+            "singular": "Datei gelesen"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Befehle werden ausgeführt",
+            "singular": "Befehl wird ausgeführt"
+          },
+          "terminal": {
+            "plural": "Befehle ausgeführt",
+            "singular": "Befehl ausgeführt"
+          }
+        }
       },
       "collapse": "Tool-Aktivität einklappen",
       "expand": "Tool-Aktivität ausklappen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2307,9 +2307,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "Changed files",
-        "read": "Read files",
-        "run": "Ran commands"
+        "changes": {
+          "pending": {
+            "plural": "Changing files",
+            "singular": "Changing a file"
+          },
+          "terminal": {
+            "plural": "Changed files",
+            "singular": "Changed a file"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Reading files",
+            "singular": "Reading a file"
+          },
+          "terminal": {
+            "plural": "Read files",
+            "singular": "Read a file"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Running commands",
+            "singular": "Running a command"
+          },
+          "terminal": {
+            "plural": "Ran commands",
+            "singular": "Ran a command"
+          }
+        }
       },
       "collapse": "Collapse tool activity",
       "expand": "Expand tool activity",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2351,9 +2351,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "Archivos modificados",
-        "read": "Archivos leídos",
-        "run": "Comandos ejecutados"
+        "changes": {
+          "pending": {
+            "plural": "Modificando archivos",
+            "singular": "Modificando un archivo"
+          },
+          "terminal": {
+            "plural": "Archivos modificados",
+            "singular": "Archivo modificado"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Leyendo archivos",
+            "singular": "Leyendo un archivo"
+          },
+          "terminal": {
+            "plural": "Archivos leídos",
+            "singular": "Archivo leído"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Ejecutando comandos",
+            "singular": "Ejecutando un comando"
+          },
+          "terminal": {
+            "plural": "Comandos ejecutados",
+            "singular": "Comando ejecutado"
+          }
+        }
       },
       "collapse": "Contraer actividad de herramientas",
       "expand": "Expandir actividad de herramientas",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2351,9 +2351,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "Fichiers modifiés",
-        "read": "Fichiers lus",
-        "run": "Commandes exécutées"
+        "changes": {
+          "pending": {
+            "plural": "Modification de fichiers",
+            "singular": "Modification d’un fichier"
+          },
+          "terminal": {
+            "plural": "Fichiers modifiés",
+            "singular": "Fichier modifié"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Lecture de fichiers",
+            "singular": "Lecture d’un fichier"
+          },
+          "terminal": {
+            "plural": "Fichiers lus",
+            "singular": "Fichier lu"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Exécution de commandes",
+            "singular": "Exécution d’une commande"
+          },
+          "terminal": {
+            "plural": "Commandes exécutées",
+            "singular": "Commande exécutée"
+          }
+        }
       },
       "collapse": "Réduire l’activité des outils",
       "expand": "Développer l’activité des outils",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2307,9 +2307,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "फ़ाइलें बदलीं",
-        "read": "फ़ाइलें पढ़ीं",
-        "run": "कमांड चलाए"
+        "changes": {
+          "pending": {
+            "plural": "फ़ाइलें बदल रहे हैं",
+            "singular": "एक फ़ाइल बदल रहे हैं"
+          },
+          "terminal": {
+            "plural": "फ़ाइलें बदलीं",
+            "singular": "एक फ़ाइल बदली"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "फ़ाइलें पढ़ रहे हैं",
+            "singular": "एक फ़ाइल पढ़ रहे हैं"
+          },
+          "terminal": {
+            "plural": "फ़ाइलें पढ़ीं",
+            "singular": "एक फ़ाइल पढ़ी"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "कमांड चला रहे हैं",
+            "singular": "एक कमांड चला रहे हैं"
+          },
+          "terminal": {
+            "plural": "कमांड चलाए",
+            "singular": "एक कमांड चलाया"
+          }
+        }
       },
       "collapse": "टूल गतिविधि संक्षिप्त करें",
       "expand": "टूल गतिविधि विस्तृत करें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2303,9 +2303,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "File diubah",
-        "read": "File dibaca",
-        "run": "Perintah dijalankan"
+        "changes": {
+          "pending": {
+            "plural": "Sedang mengubah file",
+            "singular": "Sedang mengubah sebuah file"
+          },
+          "terminal": {
+            "plural": "File telah diubah",
+            "singular": "Sebuah file telah diubah"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Sedang membaca file",
+            "singular": "Sedang membaca sebuah file"
+          },
+          "terminal": {
+            "plural": "File telah dibaca",
+            "singular": "Sebuah file telah dibaca"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Sedang menjalankan perintah",
+            "singular": "Sedang menjalankan sebuah perintah"
+          },
+          "terminal": {
+            "plural": "Perintah telah dijalankan",
+            "singular": "Sebuah perintah telah dijalankan"
+          }
+        }
       },
       "collapse": "Ciutkan aktivitas alat",
       "expand": "Luaskan aktivitas alat",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2351,9 +2351,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "File modificati",
-        "read": "File letti",
-        "run": "Comandi eseguiti"
+        "changes": {
+          "pending": {
+            "plural": "Modifica di file",
+            "singular": "Modifica di un file"
+          },
+          "terminal": {
+            "plural": "File modificati",
+            "singular": "File modificato"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Lettura di file",
+            "singular": "Lettura di un file"
+          },
+          "terminal": {
+            "plural": "File letti",
+            "singular": "File letto"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Esecuzione di comandi",
+            "singular": "Esecuzione di un comando"
+          },
+          "terminal": {
+            "plural": "Comandi eseguiti",
+            "singular": "Comando eseguito"
+          }
+        }
       },
       "collapse": "Comprimi attività strumenti",
       "expand": "Espandi attività strumenti",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2303,9 +2303,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "ファイルを変更",
-        "read": "ファイルを読み取り",
-        "run": "コマンドを実行"
+        "changes": {
+          "pending": {
+            "plural": "複数のファイルを変更中",
+            "singular": "ファイルを変更中"
+          },
+          "terminal": {
+            "plural": "複数のファイルを変更",
+            "singular": "ファイルを変更"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "複数のファイルを読み取り中",
+            "singular": "ファイルを読み取り中"
+          },
+          "terminal": {
+            "plural": "複数のファイルを読み取り",
+            "singular": "ファイルを読み取り"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "複数のコマンドを実行中",
+            "singular": "コマンドを実行中"
+          },
+          "terminal": {
+            "plural": "複数のコマンドを実行",
+            "singular": "コマンドを実行"
+          }
+        }
       },
       "collapse": "ツールアクティビティを折りたたむ",
       "expand": "ツールアクティビティを展開",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2303,9 +2303,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "파일 변경",
-        "read": "파일 읽음",
-        "run": "명령 실행"
+        "changes": {
+          "pending": {
+            "plural": "여러 파일 변경 중",
+            "singular": "파일 변경 중"
+          },
+          "terminal": {
+            "plural": "여러 파일 변경",
+            "singular": "파일 변경"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "여러 파일 읽는 중",
+            "singular": "파일 읽는 중"
+          },
+          "terminal": {
+            "plural": "여러 파일 읽음",
+            "singular": "파일 읽음"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "여러 명령 실행 중",
+            "singular": "명령 실행 중"
+          },
+          "terminal": {
+            "plural": "여러 명령 실행",
+            "singular": "명령 실행"
+          }
+        }
       },
       "collapse": "도구 활동 접기",
       "expand": "도구 활동 펼치기",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2351,9 +2351,36 @@
     },
     "toolActivity": {
       "categories": {
-        "changes": "Arquivos alterados",
-        "read": "Arquivos lidos",
-        "run": "Comandos executados"
+        "changes": {
+          "pending": {
+            "plural": "Alterando arquivos",
+            "singular": "Alterando um arquivo"
+          },
+          "terminal": {
+            "plural": "Arquivos alterados",
+            "singular": "Arquivo alterado"
+          }
+        },
+        "read": {
+          "pending": {
+            "plural": "Lendo arquivos",
+            "singular": "Lendo um arquivo"
+          },
+          "terminal": {
+            "plural": "Arquivos lidos",
+            "singular": "Arquivo lido"
+          }
+        },
+        "run": {
+          "pending": {
+            "plural": "Executando comandos",
+            "singular": "Executando um comando"
+          },
+          "terminal": {
+            "plural": "Comandos executados",
+            "singular": "Comando executado"
+          }
+        }
       },
       "collapse": "Recolher atividade de ferramentas",
       "expand": "Expandir atividade de ferramentas",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-tool-activity.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-tool-activity.test.tsx
@@ -38,6 +38,302 @@ function expectBefore(first: Element, second: Element): void {
   ).toBeTruthy();
 }
 
+function toolActivityCopyMatrixEvents(): MockChatEventInput[] {
+  let second = 0;
+  const createdAt = () => {
+    return `2026-08-25T11:00:${(second++).toString().padStart(2, "0")}Z`;
+  };
+  const separator = (id: string): MockChatEventInput => {
+    return {
+      id,
+      role: "assistant",
+      content: id,
+      runId: RUN_ID,
+      createdAt: createdAt(),
+    };
+  };
+  const operation = (
+    id: string,
+    toolUseId: string,
+    action: OutputToolPayload["action"],
+    status: OutputToolPayload["status"],
+    summary: string,
+  ): MockChatEventInput => {
+    return toolEvent({
+      id,
+      createdAt: createdAt(),
+      toolUseId,
+      action,
+      status,
+      summary,
+    });
+  };
+
+  return [
+    operation(
+      "matrix-pending-singular-run",
+      "matrix-pending-singular-run",
+      "run",
+      "pending",
+      "Running command-a",
+    ),
+    operation(
+      "matrix-pending-singular-read",
+      "matrix-pending-singular-read",
+      "read",
+      "pending",
+      "Reading file-a",
+    ),
+    operation(
+      "matrix-pending-singular-change",
+      "matrix-pending-singular-change",
+      "write",
+      "pending",
+      "Writing file-b",
+    ),
+    separator("matrix-separator-a"),
+    operation(
+      "matrix-pending-plural-run-a",
+      "matrix-pending-plural-run-a",
+      "run",
+      "pending",
+      "Running command-b",
+    ),
+    operation(
+      "matrix-pending-plural-run-b",
+      "matrix-pending-plural-run-b",
+      "run",
+      "pending",
+      "Running command-c",
+    ),
+    operation(
+      "matrix-pending-plural-read-a",
+      "matrix-pending-plural-read-a",
+      "read",
+      "pending",
+      "Reading file-c",
+    ),
+    operation(
+      "matrix-pending-plural-read-b",
+      "matrix-pending-plural-read-b",
+      "read",
+      "pending",
+      "Reading file-d",
+    ),
+    operation(
+      "matrix-pending-plural-change-a",
+      "matrix-pending-plural-change-a",
+      "write",
+      "pending",
+      "Writing file-e",
+    ),
+    operation(
+      "matrix-pending-plural-change-b",
+      "matrix-pending-plural-change-b",
+      "edit",
+      "pending",
+      "Editing file-f",
+    ),
+    separator("matrix-separator-b"),
+    operation(
+      "matrix-terminal-singular-run-pending",
+      "matrix-terminal-singular-run",
+      "run",
+      "pending",
+      "Running command-d",
+    ),
+    operation(
+      "matrix-terminal-singular-run-success",
+      "matrix-terminal-singular-run",
+      "run",
+      "success",
+      "Ran command-d",
+    ),
+    operation(
+      "matrix-terminal-singular-read",
+      "matrix-terminal-singular-read",
+      "read",
+      "error",
+      "Read file-g",
+    ),
+    operation(
+      "matrix-terminal-singular-change",
+      "matrix-terminal-singular-change",
+      "edit",
+      "cancelled",
+      "Edited file-h",
+    ),
+    separator("matrix-separator-c"),
+    operation(
+      "matrix-terminal-plural-run-a",
+      "matrix-terminal-plural-run-a",
+      "run",
+      "success",
+      "Ran command-e",
+    ),
+    operation(
+      "matrix-terminal-plural-run-b",
+      "matrix-terminal-plural-run-b",
+      "run",
+      "error",
+      "Ran command-f",
+    ),
+    operation(
+      "matrix-terminal-plural-read-a",
+      "matrix-terminal-plural-read-a",
+      "read",
+      "success",
+      "Read file-i",
+    ),
+    operation(
+      "matrix-terminal-plural-read-b",
+      "matrix-terminal-plural-read-b",
+      "read",
+      "cancelled",
+      "Read file-j",
+    ),
+    operation(
+      "matrix-terminal-plural-change-a",
+      "matrix-terminal-plural-change-a",
+      "write",
+      "success",
+      "Wrote file-k",
+    ),
+    operation(
+      "matrix-terminal-plural-change-b",
+      "matrix-terminal-plural-change-b",
+      "edit",
+      "error",
+      "Edited file-l",
+    ),
+  ];
+}
+
+const TOOL_ACTIVITY_LOCALE_CASES = [
+  {
+    locale: "en-US",
+    labels: [
+      ["Running a command", "Reading a file", "Changing a file"],
+      ["Running commands", "Reading files", "Changing files"],
+      ["Ran a command", "Read a file", "Changed a file"],
+      ["Ran commands", "Read files", "Changed files"],
+    ],
+  },
+  {
+    locale: "de-DE",
+    labels: [
+      ["Befehl wird ausgeführt", "Datei wird gelesen", "Datei wird geändert"],
+      [
+        "Befehle werden ausgeführt",
+        "Dateien werden gelesen",
+        "Dateien werden geändert",
+      ],
+      ["Befehl ausgeführt", "Datei gelesen", "Datei geändert"],
+      ["Befehle ausgeführt", "Dateien gelesen", "Dateien geändert"],
+    ],
+  },
+  {
+    locale: "es-ES",
+    labels: [
+      ["Ejecutando un comando", "Leyendo un archivo", "Modificando un archivo"],
+      ["Ejecutando comandos", "Leyendo archivos", "Modificando archivos"],
+      ["Comando ejecutado", "Archivo leído", "Archivo modificado"],
+      ["Comandos ejecutados", "Archivos leídos", "Archivos modificados"],
+    ],
+  },
+  {
+    locale: "fr-FR",
+    labels: [
+      [
+        "Exécution d’une commande",
+        "Lecture d’un fichier",
+        "Modification d’un fichier",
+      ],
+      [
+        "Exécution de commandes",
+        "Lecture de fichiers",
+        "Modification de fichiers",
+      ],
+      ["Commande exécutée", "Fichier lu", "Fichier modifié"],
+      ["Commandes exécutées", "Fichiers lus", "Fichiers modifiés"],
+    ],
+  },
+  {
+    locale: "hi-IN",
+    labels: [
+      ["एक कमांड चला रहे हैं", "एक फ़ाइल पढ़ रहे हैं", "एक फ़ाइल बदल रहे हैं"],
+      ["कमांड चला रहे हैं", "फ़ाइलें पढ़ रहे हैं", "फ़ाइलें बदल रहे हैं"],
+      ["एक कमांड चलाया", "एक फ़ाइल पढ़ी", "एक फ़ाइल बदली"],
+      ["कमांड चलाए", "फ़ाइलें पढ़ीं", "फ़ाइलें बदलीं"],
+    ],
+  },
+  {
+    locale: "id-ID",
+    labels: [
+      [
+        "Sedang menjalankan sebuah perintah",
+        "Sedang membaca sebuah file",
+        "Sedang mengubah sebuah file",
+      ],
+      [
+        "Sedang menjalankan perintah",
+        "Sedang membaca file",
+        "Sedang mengubah file",
+      ],
+      [
+        "Sebuah perintah telah dijalankan",
+        "Sebuah file telah dibaca",
+        "Sebuah file telah diubah",
+      ],
+      ["Perintah telah dijalankan", "File telah dibaca", "File telah diubah"],
+    ],
+  },
+  {
+    locale: "it-IT",
+    labels: [
+      ["Esecuzione di un comando", "Lettura di un file", "Modifica di un file"],
+      ["Esecuzione di comandi", "Lettura di file", "Modifica di file"],
+      ["Comando eseguito", "File letto", "File modificato"],
+      ["Comandi eseguiti", "File letti", "File modificati"],
+    ],
+  },
+  {
+    locale: "ja-JP",
+    labels: [
+      ["コマンドを実行中", "ファイルを読み取り中", "ファイルを変更中"],
+      [
+        "複数のコマンドを実行中",
+        "複数のファイルを読み取り中",
+        "複数のファイルを変更中",
+      ],
+      ["コマンドを実行", "ファイルを読み取り", "ファイルを変更"],
+      [
+        "複数のコマンドを実行",
+        "複数のファイルを読み取り",
+        "複数のファイルを変更",
+      ],
+    ],
+  },
+  {
+    locale: "ko-KR",
+    labels: [
+      ["명령 실행 중", "파일 읽는 중", "파일 변경 중"],
+      ["여러 명령 실행 중", "여러 파일 읽는 중", "여러 파일 변경 중"],
+      ["명령 실행", "파일 읽음", "파일 변경"],
+      ["여러 명령 실행", "여러 파일 읽음", "여러 파일 변경"],
+    ],
+  },
+  {
+    locale: "pt-BR",
+    labels: [
+      ["Executando um comando", "Lendo um arquivo", "Alterando um arquivo"],
+      ["Executando comandos", "Lendo arquivos", "Alterando arquivos"],
+      ["Comando executado", "Arquivo lido", "Arquivo alterado"],
+      ["Comandos executados", "Arquivos lidos", "Arquivos alterados"],
+    ],
+  },
+] as const;
+
 describe("chat tool activity", () => {
   it("keeps retained tool rows out of the rendered timeline while the switch is off", async () => {
     const threadId = "f7000000-0000-4000-a000-000000000002";
@@ -89,6 +385,55 @@ describe("chat tool activity", () => {
     expect(document.body).not.toHaveTextContent("switch-off-tool-use-id");
   });
 
+  it.each(TOOL_ACTIVITY_LOCALE_CASES)(
+    "renders the lifecycle and operation-number copy matrix in $locale",
+    async ({ locale, labels }) => {
+      const threadId = crypto.randomUUID();
+      context.mocks.data.userPreferences({ locale });
+      mockChatLifecycle(context, {
+        threadId,
+        activeRunIds: [RUN_ID],
+        chatEvents: toolActivityCopyMatrixEvents(),
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/chats/${threadId}`,
+        featureSwitches: { [FeatureSwitchKey.ChatToolActivity]: true },
+      });
+
+      await waitFor(() => {
+        expect(
+          document.querySelectorAll("[data-chat-tool-activity] > button"),
+        ).toHaveLength(labels.length);
+      });
+      const buttons = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-chat-tool-activity] > button",
+        ),
+      );
+      for (const [index, expectedLabels] of labels.entries()) {
+        const button = buttons[index]!;
+        for (const expectedLabel of expectedLabels) {
+          expect(button).toHaveTextContent(expectedLabel);
+        }
+        const text = button.textContent ?? "";
+        expect(text.indexOf(expectedLabels[0])).toBeLessThan(
+          text.indexOf(expectedLabels[1]),
+        );
+        expect(text.indexOf(expectedLabels[1])).toBeLessThan(
+          text.indexOf(expectedLabels[2]),
+        );
+      }
+      for (const button of buttons.slice(0, 2)) {
+        expect(button).toHaveTextContent(/…$/u);
+      }
+      for (const button of buttons.slice(2)) {
+        expect(button).not.toHaveTextContent(/…$/u);
+      }
+    },
+  );
+
   it("renders message-bound groups for all actions with accessible latest-state rows", async () => {
     const user = userEvent.setup();
     const threadId = "f7000000-0000-4000-a000-000000000003";
@@ -134,7 +479,7 @@ describe("chat tool activity", () => {
           toolUseId: "opaque-read-tool-use-id",
           action: "read",
           status: "pending",
-          summary: "Read src/auth/session.ts",
+          summary: "Reading src/auth/session.ts",
         }),
         {
           id: "tool-plan-message-b",
@@ -181,11 +526,18 @@ describe("chat tool activity", () => {
     expect(expandButtons).toHaveLength(2);
     expect(expandButtons[0]).toHaveAttribute("aria-expanded", "false");
     expect(expandButtons[1]).toHaveAttribute("aria-expanded", "false");
-    expect(expandButtons[0]).toHaveTextContent("Ran commands");
-    expect(expandButtons[0]).toHaveTextContent("Read files");
+    expect(expandButtons[0]).toHaveTextContent("Ran a command");
+    expect(expandButtons[0]).toHaveTextContent("Reading a file");
+    expect(expandButtons[0]).toHaveTextContent(/…$/u);
     expect(expandButtons[1]).toHaveTextContent("Changed files");
+    expect(expandButtons[1]).not.toHaveTextContent(/…$/u);
+    for (const button of expandButtons) {
+      expect(button).not.toHaveTextContent(
+        /Completed|Failed|Cancelled|In progress/u,
+      );
+    }
     expect(screen.queryByText("Ran git status --short")).toBeNull();
-    expect(screen.queryByText("Read src/auth/session.ts")).toBeNull();
+    expect(screen.queryByText("Reading src/auth/session.ts")).toBeNull();
 
     expectBefore(screen.getByText("Message A"), expandButtons[0]!);
     expectBefore(expandButtons[0]!, screen.getByText("Message B"));
@@ -197,11 +549,12 @@ describe("chat tool activity", () => {
     const firstCollapse = screen.getByLabelText("Collapse tool activity");
     expect(firstCollapse).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("Ran git status --short")).toBeInTheDocument();
-    expect(screen.getByText("Read src/auth/session.ts")).toBeInTheDocument();
+    expect(screen.getByText("Reading src/auth/session.ts")).toBeInTheDocument();
     expect(
       screen.queryByText("Running secret/provider command input"),
     ).toBeNull();
-    expect(screen.getByText("In progress")).toBeVisible();
+    expect(screen.getByRole("status")).toHaveTextContent("In progress");
+    expect(screen.getByText("In progress")).toHaveClass("sr-only");
     expect(screen.getByText("Completed")).toHaveClass("sr-only");
     expect(
       document.querySelector(
@@ -343,9 +696,12 @@ describe("chat tool activity", () => {
       featureSwitches: { [FeatureSwitchKey.ChatToolActivity]: true },
     });
 
-    await user.click(await screen.findByLabelText("Expand tool activity"));
+    const expandTool = await screen.findByLabelText("Expand tool activity");
+    expect(expandTool).toHaveTextContent("Running a command…");
+    await user.click(expandTool);
     expect(screen.getByText("Running pnpm lint")).toBeInTheDocument();
-    expect(screen.getByText("In progress")).toBeVisible();
+    expect(screen.getByRole("status")).toHaveTextContent("In progress");
+    expect(screen.getByText("In progress")).toHaveClass("sr-only");
 
     chatEvents.push(
       toolEvent({
@@ -365,6 +721,9 @@ describe("chat tool activity", () => {
       expect(screen.getByLabelText("Collapse tool activity")).toHaveAttribute(
         "aria-expanded",
         "true",
+      );
+      expect(screen.getByLabelText("Collapse tool activity")).toHaveTextContent(
+        "Ran a command",
       );
     });
     expect(screen.getAllByLabelText("Collapse tool activity")).toHaveLength(1);

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3719,23 +3719,62 @@ function toolActivityCategory(
 
 function toolActivityCategoryLabel(
   category: ToolActivityCategory,
+  operationCount: number,
+  hasPending: boolean,
   t: TFunction<"common">,
 ): string {
+  const singular = operationCount === 1;
   switch (category) {
     case "run": {
-      return t(($) => {
-        return $.chat.toolActivity.categories.run;
-      });
+      return hasPending
+        ? singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.run.pending.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.run.pending.plural;
+            })
+        : singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.run.terminal.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.run.terminal.plural;
+            });
     }
     case "read": {
-      return t(($) => {
-        return $.chat.toolActivity.categories.read;
-      });
+      return hasPending
+        ? singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.read.pending.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.read.pending.plural;
+            })
+        : singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.read.terminal.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.read.terminal.plural;
+            });
     }
     case "changes": {
-      return t(($) => {
-        return $.chat.toolActivity.categories.changes;
-      });
+      return hasPending
+        ? singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.changes.pending.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.changes.pending.plural;
+            })
+        : singular
+          ? t(($) => {
+              return $.chat.toolActivity.categories.changes.terminal.singular;
+            })
+          : t(($) => {
+              return $.chat.toolActivity.categories.changes.terminal.plural;
+            });
     }
   }
 }
@@ -3744,19 +3783,36 @@ function toolActivityGroupLabel(
   events: readonly ToolActivityEvent[],
   t: TFunction<"common">,
 ): string {
-  const seen = new Set<ToolActivityCategory>();
-  const labels = events.flatMap((event) => {
+  const categoryStates = new Map<
+    ToolActivityCategory,
+    { readonly operationCount: number; readonly hasPending: boolean }
+  >();
+  for (const event of events) {
     const category = toolActivityCategory(event.action);
-    if (seen.has(category)) {
-      return [];
-    }
-    seen.add(category);
-    return [toolActivityCategoryLabel(category, t)];
+    const prior = categoryStates.get(category);
+    categoryStates.set(category, {
+      operationCount: (prior?.operationCount ?? 0) + 1,
+      hasPending: (prior?.hasPending ?? false) || event.status === "pending",
+    });
+  }
+  const labels = Array.from(categoryStates, ([category, state]) => {
+    return toolActivityCategoryLabel(
+      category,
+      state.operationCount,
+      state.hasPending,
+      t,
+    );
   });
-  return new Intl.ListFormat(i18n.resolvedLanguage, {
+  const label = new Intl.ListFormat(i18n.resolvedLanguage, {
     style: "short",
     type: "conjunction",
   }).format(labels);
+  for (const state of categoryStates.values()) {
+    if (state.hasPending) {
+      return `${label}…`;
+    }
+  }
+  return label;
 }
 
 const TOOL_ACTIVITY_ICON_BY_ACTION = {
@@ -3790,6 +3846,13 @@ function ToolActivityStatus({
             });
   if (status === "success") {
     return <span className="sr-only">{label}</span>;
+  }
+  if (status === "pending") {
+    return (
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    );
   }
   return (
     <span


### PR DESCRIPTION
## Summary

- persist progressive pending and past-tense terminal summaries for Claude Code and Codex tool activity
- reconstruct later-batch Claude terminal copy from masked persisted lifecycle state without changing the public payload
- render per-category lifecycle-aware singular/plural collapsed copy across all supported locales while preserving accessible and restrained row status feedback

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/services/__tests__/agent-tool-event-normalization.test.ts src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts src/signals/routes/__tests__/chat-event-snapshot.test.ts --reporter=verbose`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/signals/chat-page/__tests__/chat-tool-activity-projection.test.ts src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts src/views/okou-page/__tests__/chat-tool-activity.test.tsx --reporter=verbose`

Fixes #29420