### PR TITLE
fix: keep the deck import message to the request itself

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/presentation-template-import.ts
+++ b/turbo/apps/platform/src/signals/okou-page/presentation-template-import.ts
@@ -1,6 +1,5 @@
 import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { presentationTemplateSkillInstruction } from "@okouai/core/presentation-template-skill";
 
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import type { ComposerSignals } from "./composer-signals.ts";
@@ -19,17 +18,17 @@ export const PRESENTATION_TEMPLATE_IMPORT_ACCEPT = ".pptx,.ppt,.pdf";
 /**
  * The message the deck is sent with.
  *
- * Opens as a plain sentence on purpose: importing a template is not a special
+ * One plain sentence on purpose: importing a template is not a special
  * protocol, it is a chat message with a file attached, and the user should be
- * able to read what was asked on their behalf in the thread they land in. The
- * pointer to the guide follows, because the guide is not a mounted skill the
- * run would otherwise find.
+ * able to read what was asked on their behalf in the thread they land in.
+ *
+ * How to reach the guide is deliberately absent. The agent tools prompt
+ * already carries it behind the same feature switch that offers this import,
+ * so repeating it here only spends the user's own message on instructions
+ * addressed to the run.
  */
 function presentationTemplateImportPrompt(): string {
-  return [
-    "Analyse this deck and save its visual language as a reusable presentation template.",
-    presentationTemplateSkillInstruction(),
-  ].join("\n\n");
+  return "Analyse this deck and save its visual language as a reusable presentation template.";
 }
 
 export const presentationTemplateImportEnabled$ = computed((get) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -4610,14 +4610,11 @@ describe("chat composer templates", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     await waitFor(() => {
-      expect(sentPrompt).toContain("reusable presentation template");
-      // The guide is not a mounted skill, so the message has to carry the
-      // private resource pull and its extracted entrypoint.
-      expect(sentPrompt).toContain(
-        "okou resource pull skill:presentation-reverse-template --dir ./generated/resources",
-      );
-      expect(sentPrompt).toContain(
-        "./generated/resources/reverse-template/SKILL.md",
+      // What the user sees in their own thread is the request they would have
+      // typed. How the run reaches the guide is carried by the agent tools
+      // prompt, so none of it leaks into the message sent on their behalf.
+      expect(sentPrompt).toBe(
+        "Analyse this deck and save its visual language as a reusable presentation template.",
       );
       expect(sentMessage?.parts).toContainEqual(
         expect.objectContaining({

--- a/turbo/packages/core/src/presentation-template-skill.ts
+++ b/turbo/packages/core/src/presentation-template-skill.ts
@@ -8,9 +8,10 @@ const PRESENTATION_TEMPLATE_RESOURCE_DIR = "./generated/resources";
 /**
  * Tell a run how to reach the guide.
  *
- * One sentence pair, used both by the import message the template picker sends
- * and by the standing agent-tools prompt, so a deck dropped in the chat box
- * reaches the same instructions as one picked through the dialog.
+ * One sentence pair, carried by the standing agent-tools prompt so that any
+ * deck reaches these instructions — dropped in the chat box, picked through
+ * the import dialog, or asked for in words — without a user-visible message
+ * having to spell the pull out.
  */
 export function presentationTemplateSkillInstruction(): string {
   const skillPath = `${PRESENTATION_TEMPLATE_RESOURCE_DIR}/${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH}/SKILL.md`;


### PR DESCRIPTION
## Problem

Importing a deck through the template picker sent this on the user's behalf:

> Analyse this deck and save its visual language as a reusable presentation template.
>
> Turning an uploaded deck (.pptx, .ppt, or .pdf) into a reusable presentation template follows the reverse-template guide, which is not mounted as a skill. Pull it first with `okou resource pull skill:presentation-reverse-template --dir ./generated/resources`, read `./generated/resources/reverse-template/SKILL.md`, and follow it exactly, including its page-rendering and publish steps.

The user lands in a thread whose first message is two thirds plumbing addressed to the run, not to them.

## Change

The message is now the request alone. The guide pointer stays exactly where it already was — `buildAgentToolsPrompt`, gated on `FeatureSwitchKey.PresentationTemplates`, the same switch that decides whether the import entry point is offered at all. Nothing is lost: a run that can receive an imported deck is a run whose system prompt already names the pull command and the SKILL.md path.

`presentationTemplateSkillInstruction()` is unchanged and now has a single caller.

## Coverage

- `chat-composer-template-picker.test.tsx` — the import test now asserts the sent prompt equals the sentence, so a future append is a failure rather than a passing `toContain`.
- `run-lifecycle.bdd.test.ts` (unchanged) already pins that the pull command and SKILL.md path reach `appendSystemPrompt` when the switch is on, and stay out when it is off. That is the test that keeps this change non-lossy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)