### PR TITLE
fix(runner): increase default rootfs headroom

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -432,6 +432,8 @@ mod tests {
         let profile = runner_config.profiles.get("vm0/default").unwrap();
         assert_eq!(profile.rootfs_hash, rootfs_hash);
         assert_eq!(profile.snapshot_hash, snapshot_hash);
+        assert_eq!(profile.rootfs_disk_mb, 12288);
+        assert_eq!(profile.workspace_disk_mb, 16384);
     }
 
     fn args_with_concurrency_factor(factor: f64) -> ConfigArgs {

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -19,7 +19,7 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     static DEFAULT: ProfileDef = ProfileDef {
         vcpu: 2,
         memory_mb: 4096,
-        rootfs_disk_mb: 8192,
+        rootfs_disk_mb: 12288,
         workspace_disk_mb: 16384,
     };
 
@@ -54,7 +54,7 @@ mod tests {
         let def = get("vm0/default").unwrap();
         assert_eq!(def.vcpu, 2);
         assert_eq!(def.memory_mb, 4096);
-        assert_eq!(def.rootfs_disk_mb, 8192);
+        assert_eq!(def.rootfs_disk_mb, 12288);
         assert_eq!(def.workspace_disk_mb, 16384);
     }
 


### PR DESCRIPTION
## Summary

- increase the authoritative `vm0/default` rootfs capacity from 8 GiB to 12 GiB
- keep the default workspace capacity unchanged at 16 GiB
- verify that `runner config` propagates both default disk sizes into generated configuration

## Scope

This change uses the existing size-sensitive image hashes and sparse template/COW paths. It does
not change diagnostics, filesystem layout, workspace sizing, APIs, or persisted schemas.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3310 passed, 24 ignored; guest inventory test passed)
- repository pre-commit Rust formatting, Clippy, Rustdoc, and file-size hooks

Closes #29407
