### PR TITLE
feat: enable the latest website templates for everyone

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9802,48 +9802,50 @@ describe("CHAT-02: generation templates and attachments", () => {
       `Template: ${websiteTemplate.title} (${websiteTemplate.id})`,
     );
     expect(websitePrompt).toContain(
-      "okou resource pull template:black-slabs-v2 --dir ./generated/resources",
+      "okou resource pull template:black-slabs --dir ./generated/resources",
     );
     expect(websitePrompt).toContain(
-      `./generated/resources/${websiteTemplate.sourcePath}/render.mjs`,
+      "Image workflow: use supplied images first;",
     );
-    expect(websitePrompt).toContain("resolve-images.mjs");
-    expect(websitePrompt).not.toContain("use `seedream4` by default");
-    expect(websitePrompt).not.toContain("okou generate image-batch start");
-    expect(websitePrompt).toContain("okou host <output-dir> --site <slug>");
+    expect(websitePrompt).toMatch(
+      /npx --yes --package="\$\{CLI_PKG_URL\}" okou generate image-batch start <manifest\.tsv> <state-dir>/,
+    );
+    expect(websitePrompt).toMatch(
+      /npx --yes --package="\$\{CLI_PKG_URL\}" okou generate image-batch wait <state-dir>/,
+    );
+    expect(websitePrompt).not.toContain("tools/generate-images.mjs");
+    expect(websitePrompt).not.toContain("resolve-images.mjs");
+    expect(websitePrompt).not.toContain("render.mjs");
     await cancelChatRun(actor, website.runId);
 
+    // The rollout keeps its rollback lever: an override back to off restores
+    // the pre-cutover renderer guidance without a deployment.
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.LatestWebsiteTemplates]: true },
+      { [FeatureSwitchKey.LatestWebsiteTemplates]: false },
     );
-    const latestWebsite = await sendChatRun(actor, {
+    const previousWebsite = await sendChatRun(actor, {
       agentId,
-      prompt: "make a campaign landing page with the latest template",
+      prompt: "make a campaign landing page with the pre-cutover template",
       template: {
         type: "website",
         selection: { websiteTemplateId: websiteTemplate.id },
       },
     });
-    const latestWebsiteRun = await api.readRun(actor, latestWebsite.runId);
-    const latestWebsitePrompt = latestWebsiteRun.appendSystemPrompt ?? "";
-    expect(latestWebsitePrompt).toContain(
-      "okou resource pull template:black-slabs --dir ./generated/resources",
+    const previousWebsiteRun = await api.readRun(actor, previousWebsite.runId);
+    const previousWebsitePrompt = previousWebsiteRun.appendSystemPrompt ?? "";
+    expect(previousWebsitePrompt).toContain(
+      "okou resource pull template:black-slabs-v2 --dir ./generated/resources",
     );
-    expect(latestWebsitePrompt).toContain(
-      "Image workflow: use supplied images first;",
+    expect(previousWebsitePrompt).toContain(
+      `./generated/resources/${websiteTemplate.sourcePath}/render.mjs`,
     );
-    expect(latestWebsitePrompt).toMatch(
-      /npx --yes --package="\$\{CLI_PKG_URL\}" okou generate image-batch start <manifest\.tsv> <state-dir>/,
+    expect(previousWebsitePrompt).toContain("resolve-images.mjs");
+    expect(previousWebsitePrompt).toContain(
+      "okou host <output-dir> --site <slug>",
     );
-    expect(latestWebsitePrompt).toMatch(
-      /npx --yes --package="\$\{CLI_PKG_URL\}" okou generate image-batch wait <state-dir>/,
-    );
-    expect(latestWebsitePrompt).not.toContain("tools/generate-images.mjs");
-    expect(latestWebsitePrompt).not.toContain("resolve-images.mjs");
-    expect(latestWebsitePrompt).not.toContain("render.mjs");
-    await cancelChatRun(actor, latestWebsite.runId);
+    await cancelChatRun(actor, previousWebsite.runId);
   }, 90_000);
 
   it("uses R2 for archive-backed styles", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13740,29 +13740,29 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
         `https://${staticDomain}/okou-cli/test-commit/package.tgz`,
       );
       expect(r2Claim.environment?.[WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]).toBe(
-        "previous",
+        "latest",
       );
       await api.requestCancelRun(actor, r2Run.runId, [200]);
     },
   );
 
-  it("pins the latest Website template release into opted-in run contexts", async () => {
+  it("pins the pre-cutover Website release into opted-out run contexts", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.LatestWebsiteTemplates]: true,
+      [FeatureSwitchKey.LatestWebsiteTemplates]: false,
     });
 
     const run = await api.createRun(actor, {
       agentId,
-      prompt: "use the latest Website template release",
+      prompt: "use the pre-cutover Website template release",
       modelProvider: "anthropic-api-key",
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.environment?.[WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]).toBe(
-      "latest",
+      "previous",
     );
     await api.requestCancelRun(actor, run.runId, [200]);
   });
@@ -14097,7 +14097,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       OKOU_AGENT_ID: agent.agentId,
       OKOU_TOKEN: claim.environment?.OKOU_TOKEN,
       CLI_PKG_URL: "https://static.vm0.io/okou-cli/test-commit/package.tgz",
-      [WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]: "previous",
+      [WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]: "latest",
     });
     for (const [key, value] of Object.entries(
       claim.platformEnvironment ?? {},

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -157,7 +157,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HomeGrowthEntry]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -319,8 +319,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Use the latest built-in Website template archives, independent registry, and seedream4 default instead of the pre-cutover release.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.LatestPresentationTemplates]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
Step 1 of 2. This PR only flips the default; the code removal is #29442 and stays blocked until this is live and verified.

## What changes

`FeatureSwitchKey.LatestWebsiteTemplates` goes from `enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to `enabled: true` — GA, per the repo's own feature-switch guidance.

Nothing else moves. Both sides of every branch the switch selects stay in the code:

- `generation-template-prompt.ts` still builds either the direct-HTML guidance or the renderer guidance.
- `resource-registry.ts` still carries `PREVIOUS_WEBSITE_TEMPLATE_PACKAGES` and the `archiveVersion` parameter.
- `agent-run-create.service.ts` still writes `OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION` from the switch.
- The CLI still reads that env.

## Why this is separate from the removal

Two reasons, both about keeping an escape hatch during the risky window:

1. **Revert cost.** Rolling this back is one line and one deploy. Rolling back the combined change would mean restoring deleted registry maps, the env plumbing, and the CLI helper.
2. **No-deploy mitigation.** While the switch exists, a specific org or user that hits a problem can be put back on the pre-cutover path through `POST /api/feature-switches` immediately, without waiting for a release.

## Known rollout risk

Prompts steered into an **already-running** run (`active-input-prompt.service.ts` — "steered into a run that is already executing, whose volumes were fixed when it was created") are built by the current API, but that sandbox's CLI and its `OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION` were fixed when the run was created. A run created before this deploy by a not-yet-enrolled user therefore has `previous` baked in, while a website template steered into it afterwards would carry the latest guidance and the latest SHA. The agent would pull the pre-cutover renderer package and find no `SKILL.md` or `tools/compose.mjs`.

This is inherent to the rollout, not to the later removal: it exists for as long as pre-deploy runs stay alive, and it is what the run-context drain in #26672 covers. Newly created runs are not affected — `CLI_PKG_URL` is commit-addressed to the deploying commit and `deploy-cli` gates the API deploy, so a new run always pairs its prompt with the CLI from the same commit.

The override lever above is the mitigation if this shows up in practice.

## Test changes

The tests that encoded the old default were flipped rather than deleted:

- `run-lifecycle.bdd.test.ts`: the default run-context environment now asserts `latest`; `pins the latest Website template release into opted-in run contexts` became `pins the pre-cutover Website release into opted-out run contexts`, which now covers the rollback lever.
- `chat-events.bdd.test.ts`: the default website chat run now asserts the direct-HTML prompt; the switched case now overrides back to `false` and asserts the renderer prompt.
- `feature-switch.test.ts`: `otherOrgStates[LatestWebsiteTemplates]` is now `true`.

## Verification

| Check | Result |
| --- | --- |
| `pnpm -F @okouai/core exec vitest run` | 19 files / 206 tests pass |
| `pnpm -F api run check-types` (7-step chain, incl. `tsconfig.tests.json`) | pass |
| `pnpm -F api run lint`, `pnpm -F @okouai/core run lint` | pass |
| `prettier --write` on changed files | clean |
| `git diff --check` | clean |

`apps/api` vitest could not run here: the sandbox has no PostgreSQL server or binaries, so every API suite fails at startup with `connect ECONNREFUSED 127.0.0.1:5432` before any test executes. Pre-existing environment limitation, unrelated to this diff. The edited API tests type-check and lint; their execution is left to CI.
