### PR TITLE
fix: improve three-column sidebar usability

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -432,6 +432,7 @@
       "chat": "Chat",
       "collapse": "Seitenleiste einklappen",
       "expand": "Seitenleiste erweitern",
+      "hideChatList": "Chatliste ausblenden",
       "manage": "Verwalten",
       "mobile": {
         "invite": "Einladen",
@@ -455,6 +456,7 @@
         "works": "Kanäle"
       },
       "searchConversations": "Gespräche suchen",
+      "showChatList": "Chatliste anzeigen",
       "workspaceSwitcher": {
         "create": "Arbeitsbereich erstellen",
         "creating": "Wird erstellt…",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -432,6 +432,7 @@
       "chat": "Chat",
       "collapse": "Collapse sidebar",
       "expand": "Expand sidebar",
+      "hideChatList": "Hide chat list",
       "manage": "Manage",
       "mobile": {
         "invite": "Invite",
@@ -455,6 +456,7 @@
         "works": "Works"
       },
       "searchConversations": "Search conversations",
+      "showChatList": "Show chat list",
       "workspaceSwitcher": {
         "create": "Create workspace",
         "creating": "Creating…",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -446,6 +446,7 @@
       "chat": "Chat",
       "collapse": "Contraer barra lateral",
       "expand": "Expandir la barra lateral",
+      "hideChatList": "Ocultar lista de chats",
       "manage": "Gestionar",
       "mobile": {
         "invite": "Invitar",
@@ -469,6 +470,7 @@
         "works": "Integraciones"
       },
       "searchConversations": "Buscar conversaciones",
+      "showChatList": "Mostrar lista de chats",
       "workspaceSwitcher": {
         "create": "Crear espacio de trabajo",
         "creating": "Creando…",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -446,6 +446,7 @@
       "chat": "Chat",
       "collapse": "Réduire la barre latérale",
       "expand": "Développer la barre latérale",
+      "hideChatList": "Masquer la liste des chats",
       "manage": "Gérer",
       "mobile": {
         "invite": "Inviter",
@@ -469,6 +470,7 @@
         "works": "Travail"
       },
       "searchConversations": "Rechercher des conversations",
+      "showChatList": "Afficher la liste des chats",
       "workspaceSwitcher": {
         "create": "Créer un espace de travail",
         "creating": "Création…",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -432,6 +432,7 @@
       "chat": "चैट",
       "collapse": "साइडबार को संक्षिप्त करें",
       "expand": "साइडबार का विस्तार करें",
+      "hideChatList": "चैट सूची छिपाएं",
       "manage": "प्रबंधित करें",
       "mobile": {
         "invite": "आमंत्रित करें",
@@ -455,6 +456,7 @@
         "works": "काम करता है"
       },
       "searchConversations": "वार्तालाप खोजें",
+      "showChatList": "चैट सूची दिखाएं",
       "workspaceSwitcher": {
         "create": "वर्कस्पेस बनाएं",
         "creating": "बनाया जा रहा है...",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -432,6 +432,7 @@
       "chat": "Chat",
       "collapse": "Ciutkan sidebar",
       "expand": "Perluas sidebar",
+      "hideChatList": "Sembunyikan daftar chat",
       "manage": "Kelola",
       "mobile": {
         "invite": "Undang",
@@ -455,6 +456,7 @@
         "works": "Bekerja"
       },
       "searchConversations": "Cari percakapan",
+      "showChatList": "Tampilkan daftar chat",
       "workspaceSwitcher": {
         "create": "Buat ruang kerja",
         "creating": "Membuat…",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -446,6 +446,7 @@
       "chat": "Chat",
       "collapse": "Comprimi la barra laterale",
       "expand": "Espandi la barra laterale",
+      "hideChatList": "Nascondi elenco chat",
       "manage": "Gestisci",
       "mobile": {
         "invite": "Invita",
@@ -469,6 +470,7 @@
         "works": "Integrazioni"
       },
       "searchConversations": "Cerca conversazioni",
+      "showChatList": "Mostra elenco chat",
       "workspaceSwitcher": {
         "create": "Crea area di lavoro",
         "creating": "Creazione…",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -432,6 +432,7 @@
       "chat": "チャット",
       "collapse": "サイドバーを折りたたむ",
       "expand": "サイドバーを展開する",
+      "hideChatList": "チャットリストを非表示",
       "manage": "管理",
       "mobile": {
         "invite": "招待する",
@@ -455,6 +456,7 @@
         "works": "連携先"
       },
       "searchConversations": "会話を検索する",
+      "showChatList": "チャットリストを表示",
       "workspaceSwitcher": {
         "create": "ワークスペースの作成",
         "creating": "作成中…",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -432,6 +432,7 @@
       "chat": "채팅",
       "collapse": "사이드바 접기",
       "expand": "사이드바 펼치기",
+      "hideChatList": "채팅 목록 숨기기",
       "manage": "관리",
       "mobile": {
         "invite": "초대",
@@ -455,6 +456,7 @@
         "works": "작업"
       },
       "searchConversations": "대화 검색",
+      "showChatList": "채팅 목록 표시",
       "workspaceSwitcher": {
         "create": "워크스페이스 만들기",
         "creating": "만드는 중…",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -446,6 +446,7 @@
       "chat": "Chat",
       "collapse": "Recolher barra lateral",
       "expand": "Expandir barra lateral",
+      "hideChatList": "Ocultar lista de conversas",
       "manage": "Gerenciar",
       "mobile": {
         "invite": "Convidar",
@@ -469,6 +470,7 @@
         "works": "Trabalha"
       },
       "searchConversations": "Buscar conversas",
+      "showChatList": "Mostrar lista de conversas",
       "workspaceSwitcher": {
         "create": "Criar espaço de trabalho",
         "creating": "Criando…",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1006,6 +1006,12 @@ describe("zero sidebar", () => {
         within(threadRowByTitle("Draft brief")).getByLabelText("Draft"),
       ).toBeInTheDocument();
     });
+    expect(
+      within(threadRowByTitle("Incident notes")).getByLabelText("Unread"),
+    ).toHaveAttribute("role", "img");
+    expect(
+      within(threadRowByTitle("Draft brief")).getByLabelText("Draft"),
+    ).toHaveAttribute("role", "img");
 
     openThreadMenu("Release plan");
     click(menuItemByText("Pin chat"));
@@ -1695,7 +1701,7 @@ describe("zero sidebar", () => {
     // The chat list and pinned headers are the same control, so they must
     // carry the same resting tone. A full-strength resting tone also makes
     // the header's own group-hover class a no-op and drops the hover lift.
-    const restingTone = "text-sidebar-foreground/50";
+    const restingTone = "text-muted-foreground";
     expect(pinnedTitle).toHaveClass(restingTone);
     expect(chatTitle).toHaveClass(
       restingTone,
@@ -3323,6 +3329,73 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides only the three-column chat list and keeps search available", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    const rail = await screen.findByTestId("labeled-nav-rail");
+    const list = screen.getByTestId("chat-list-column");
+    const hideButton = within(list).getByLabelText("Hide chat list");
+    expect(hideButton).toHaveAttribute("aria-keyshortcuts", "Meta+B Control+B");
+
+    click(hideButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("chat-list-column")).not.toBeInTheDocument();
+    });
+    expect(rail).toBeInTheDocument();
+    const showButton = within(rail).getByLabelText("Show chat list");
+    expect(showButton).toHaveAttribute("aria-keyshortcuts", "Meta+B Control+B");
+
+    const composer = mountedComposer();
+    composer.focus();
+    const searchEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    composer.dispatchEvent(searchEvent);
+
+    expect(searchEvent.defaultPrevented).toBeTruthy();
+    const dialog = await screen.findByRole("dialog", {
+      name: "Search chats and messages...",
+    });
+    fireEvent.keyDown(dialog, { key: "Escape", code: "Escape" });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", {
+          name: "Search chats and messages...",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    const restoredComposer = mountedComposer();
+    restoredComposer.focus();
+    fireEvent.keyDown(restoredComposer, {
+      key: "b",
+      code: "KeyB",
+      keyCode: 66,
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-list-column")).toBeInTheDocument();
+      expect(
+        within(rail).queryByLabelText("Show chat list"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps the three-column chat list on one text and box inset", async () => {
     prepareDefaultAgent();
 
@@ -3356,7 +3429,14 @@ describe("zero sidebar", () => {
     // below it, which is what keeps the gap above the two section headers even.
     const pinnedLabel = within(pinnedSection).getByText("Pinned agents");
     expect(pinnedLabel).toHaveClass("flex", "h-8", "items-center", "pl-2");
+    expect(pinnedLabel).toHaveClass("text-muted-foreground");
     expect(pinnedLabel).not.toHaveClass("pb-2");
+
+    const chatTitle = within(list).getByText("Chats with Zero");
+    expect(chatTitle).toHaveClass("text-muted-foreground");
+    expect(
+      within(list).getByRole("region", { name: "Chat threads" }),
+    ).toBeInTheDocument();
 
     // The label row supplies that bottom gap, so the grid must not stack a
     // second one under the avatars.
@@ -3387,6 +3467,7 @@ describe("zero sidebar", () => {
     });
 
     expect(unread).toBeVisible();
+    expect(unread).toHaveAttribute("role", "img");
   });
 
   it("searches chats and messages in the three-column spotlight", async () => {
@@ -3919,6 +4000,9 @@ describe("zero sidebar", () => {
     const fourthAgent = pinnedAgentLink(grid, "Operations Agent");
     const fifthAgent = pinnedAgentLink(grid, "Analytics Agent");
 
+    expect(fourthAgent).toHaveAttribute("title", "Operations Agent");
+    expect(fifthAgent).toHaveAttribute("title", "Analytics Agent");
+
     expect(
       fourthAgent.compareDocumentPosition(pinAgent) &
         Node.DOCUMENT_POSITION_FOLLOWING,
@@ -4312,7 +4396,8 @@ describe("zero sidebar", () => {
       within(rail).getByRole("navigation", { name: "Barra lateral" }),
     ).toBeInTheDocument();
     expect(within(rail).getByText("Agentes")).toBeInTheDocument();
-    expect(within(rail).getByText("Fluxos de trabalho")).toBeInTheDocument();
+    const workflowsLink = within(rail).getByLabelText("Fluxos de trabalho");
+    expect(workflowsLink).toHaveAttribute("title", "Fluxos de trabalho");
     expect(within(rail).getByText("Conectores")).toBeInTheDocument();
     expect(within(rail).getByText("Artefatos")).toBeInTheDocument();
     expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1683,32 +1683,6 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("recedes both sidebar section headers at rest and lifts them on hover", async () => {
-    prepareDefaultAgent();
-    mockChatThreadSnapshot(() => {
-      return [createThread(EXISTING_THREAD_ID, "Release plan")];
-    });
-
-    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
-
-    const chatTitle = await waitFor(() => {
-      return within(sidebar()).getByText("Chats with Zero");
-    });
-    const pinnedTitle = within(
-      screen.getByTestId("pinned-section-header"),
-    ).getByText("Pinned");
-
-    // The chat list and pinned headers are the same control, so they must
-    // carry the same resting tone. A full-strength resting tone also makes
-    // the header's own group-hover class a no-op and drops the hover lift.
-    const restingTone = "text-muted-foreground";
-    expect(pinnedTitle).toHaveClass(restingTone);
-    expect(chatTitle).toHaveClass(
-      restingTone,
-      "group-hover:text-sidebar-foreground",
-    );
-  });
-
   it("leaves the footer as the only owner of the gap below the thread list", async () => {
     prepareDefaultAgent();
     mockChatThreadSnapshot(() => {
@@ -3429,14 +3403,8 @@ describe("zero sidebar", () => {
     // below it, which is what keeps the gap above the two section headers even.
     const pinnedLabel = within(pinnedSection).getByText("Pinned agents");
     expect(pinnedLabel).toHaveClass("flex", "h-8", "items-center", "pl-2");
-    expect(pinnedLabel).toHaveClass("text-muted-foreground");
     expect(pinnedLabel).not.toHaveClass("pb-2");
 
-    const chatTitle = within(list).getByText("Chats with Zero");
-    expect(chatTitle).toHaveClass("text-muted-foreground");
-    expect(
-      within(list).getByText("Start a conversation and it'll show up here"),
-    ).toHaveClass("text-muted-foreground");
     expect(
       within(list).getByRole("region", { name: "Chat threads" }),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3435,6 +3435,9 @@ describe("zero sidebar", () => {
     const chatTitle = within(list).getByText("Chats with Zero");
     expect(chatTitle).toHaveClass("text-muted-foreground");
     expect(
+      within(list).getByText("Start a conversation and it'll show up here"),
+    ).toHaveClass("text-muted-foreground");
+    expect(
       within(list).getByRole("region", { name: "Chat threads" }),
     ).toBeInTheDocument();
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-agent-row-actions.tsx
@@ -26,6 +26,7 @@ export function AgentUnreadIndicator() {
 
   return (
     <span
+      role="img"
       aria-label={t(($) => {
         return $.status.unread;
       })}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -313,6 +313,7 @@ function PinnedAgentGridCard({
   const setDropTarget = useSet(setPinnedAgentDropTarget$);
   const endDrag = useSet(endPinnedAgentDrag$);
   const [, moveAgent] = useLoadableSet(movePinnedAgent$);
+  const displayName = agent.displayName ?? agent.id;
 
   const isDragging = draggingAgentId === agent.id;
   const isDragInFlight = draggingAgentId !== null;
@@ -324,6 +325,7 @@ function PinnedAgentGridCard({
       pathname="/agents/:agentId/chat"
       options={{ pathParams: { agentId: agent.id } }}
       data-testid="pinned-agent-card"
+      title={displayName}
       draggable={isReorderable}
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = "move";
@@ -387,7 +389,7 @@ function PinnedAgentGridCard({
       <span className={`relative ${isDragging ? "opacity-0" : ""}`}>
         <AgentAvatarImg
           name={agent.id}
-          alt={agent.displayName ?? agent.id}
+          alt=""
           className="h-9 w-9 rounded-full object-cover object-top"
         />
         {hasUnread && (
@@ -401,7 +403,7 @@ function PinnedAgentGridCard({
           isPrimarySelected ? "font-medium" : ""
         } ${isDragging ? "opacity-0" : ""}`}
       >
-        {agent.displayName ?? agent.id}
+        {displayName}
       </span>
     </Link>
   );
@@ -555,7 +557,7 @@ export function PinnedAgentListSection({
 
     return (
       <div className="shrink-0" data-testid="pinned-agents-horizontal">
-        <span className="flex h-8 items-center pl-2 text-[13px] font-medium leading-4 text-sidebar-foreground/50">
+        <span className="flex h-8 items-center pl-2 text-[13px] font-medium leading-4 text-muted-foreground">
           {t(($) => {
             return $.sidebar.pinnedAgents;
           })}
@@ -602,7 +604,7 @@ export function PinnedAgentListSection({
           return setCollapsed(!collapsed);
         }}
       >
-        <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+        <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-muted-foreground group-hover:text-sidebar-foreground transition-colors">
           {t(($) => {
             return $.sidebar.pinned;
           })}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -50,6 +50,7 @@ export function OverlayScrollArea({
         onPointerDownCapture={onPointerDownCapture}
         onScroll={handleScroll}
         tabIndex={tabIndex}
+        role={ariaLabel ? "region" : undefined}
         aria-label={ariaLabel}
         data-testid={dataTestId}
       >

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -122,6 +122,7 @@ function SessionStateIndicator({
   if (state === "unread") {
     return (
       <span
+        role="img"
         aria-label={t(($) => {
           return $.chat.sidebar.unread;
         })}
@@ -131,6 +132,7 @@ function SessionStateIndicator({
   }
   return (
     <span
+      role="img"
       aria-label={t(($) => {
         return $.chat.sidebar.draft;
       })}
@@ -900,7 +902,7 @@ function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
         return setCollapsed(!collapsed);
       }}
     >
-      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-muted-foreground group-hover:text-sidebar-foreground transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <ChevronRight

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -673,7 +673,7 @@ function ChatThreads({
 
   if (threadCount === 0) {
     return (
-      <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
+      <p className="px-2 py-2 text-xs text-muted-foreground leading-relaxed">
         {unreadOnly
           ? t(($) => {
               return $.chat.sidebar.noUnread;

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -643,6 +643,7 @@ function LabeledRailLink({
       }}
       aria-label={label}
       aria-current={isActive ? "page" : undefined}
+      title={caption}
       className="group flex w-full flex-col items-center gap-1 no-underline"
     >
       <span
@@ -680,7 +681,57 @@ function LabeledRailLink({
   );
 }
 
+function ThreeColumnChatListToggle({
+  hidden,
+  tooltipSide,
+}: {
+  hidden: boolean;
+  tooltipSide: "bottom" | "right";
+}) {
+  const onToggle = useSidebarCollapseToggle();
+  const { t } = useTranslation();
+  const label = hidden
+    ? t(($) => {
+        return $.appShell.sidebar.showChatList;
+      })
+    : t(($) => {
+        return $.appShell.sidebar.hideChatList;
+      });
+  const shortcutLabel = getShortcutLabel("mod+b");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          onClick={onToggle}
+          aria-label={label}
+          aria-keyshortcuts="Meta+B Control+B"
+          variant="quiet"
+          size="icon-sm"
+        >
+          <PanelLeftClose
+            style={chatHeaderIconStyle}
+            size={17}
+            className={cn(
+              "transition-transform duration-200",
+              hidden && "rotate-180",
+            )}
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side={tooltipSide}>
+        <p className="text-xs">
+          {label}
+          <span aria-hidden="true">{` · ${shortcutLabel}`}</span>
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function LabeledNavRail() {
+  const chatListHidden = useGet(sidebarOff$);
   const activeId = useGet(activeRoute$);
   const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
   const onSelect = useNavSelect();
@@ -715,6 +766,13 @@ function LabeledNavRail() {
       <div className="mb-3 shrink-0">
         <OrgSwitcherCompact />
       </div>
+      {chatListHidden && (
+        <div className="mb-3 shrink-0">
+          <TooltipProvider delayDuration={200}>
+            <ThreeColumnChatListToggle hidden tooltipSide="right" />
+          </TooltipProvider>
+        </div>
+      )}
       <nav
         aria-label={t(($) => {
           return $.appShell.sidebar.ariaLabel;
@@ -792,80 +850,80 @@ function ChatListColumn() {
     );
   };
   return (
-    <>
-      <aside
-        data-testid="chat-list-column"
-        className="zero-nav hidden md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar"
-      >
-        <div className="flex shrink-0 items-center gap-1 px-3 pb-2 pt-3">
-          <span className="flex-1 pl-2 text-[15px] font-semibold text-sidebar-foreground">
-            {t(($) => {
-              return $.appShell.sidebar.chat;
-            })}
-          </span>
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  onClick={() => {
-                    openThreeColumnSearch();
-                  }}
-                  aria-label={searchLabel}
-                  aria-keyshortcuts="Meta+K Control+K"
-                  variant="quiet"
-                  size="icon-sm"
-                >
-                  <Search style={chatHeaderIconStyle} size={17} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p className="text-xs">
-                  {searchLabel}
-                  <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
-                </p>
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  onClick={onNewChat}
-                  disabled={!currentChatAgentId || newChatDisabled}
-                  aria-label={newChatLabel}
-                  variant="quiet"
-                  size="icon-sm"
-                >
-                  <Edit style={chatHeaderIconStyle} size={17} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p className="text-xs">{newChatLabel}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-1">
-          <PinnedAgentListSection layout="horizontal" />
-          <ChatThreadsSection
-            scrollSignals={threeColumnSidebarChatThreadScrollSignals}
-            showMarkAllRead
-          />
-        </div>
-        <div className="px-3 pb-3">
-          <SidebarUpgradeCard />
-        </div>
-      </aside>
-      <ThreeColumnSearchDialogContainer />
-    </>
+    <aside
+      data-testid="chat-list-column"
+      className="zero-nav hidden md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar"
+    >
+      <div className="flex shrink-0 items-center gap-1 px-3 pb-2 pt-3">
+        <span className="flex-1 pl-2 text-[15px] font-semibold text-sidebar-foreground">
+          {t(($) => {
+            return $.appShell.sidebar.chat;
+          })}
+        </span>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                onClick={() => {
+                  openThreeColumnSearch();
+                }}
+                aria-label={searchLabel}
+                aria-keyshortcuts="Meta+K Control+K"
+                variant="quiet"
+                size="icon-sm"
+              >
+                <Search style={chatHeaderIconStyle} size={17} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">
+                {searchLabel}
+                <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                onClick={onNewChat}
+                disabled={!currentChatAgentId || newChatDisabled}
+                aria-label={newChatLabel}
+                variant="quiet"
+                size="icon-sm"
+              >
+                <Edit style={chatHeaderIconStyle} size={17} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">{newChatLabel}</p>
+            </TooltipContent>
+          </Tooltip>
+          <ThreeColumnChatListToggle hidden={false} tooltipSide="bottom" />
+        </TooltipProvider>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-1">
+        <PinnedAgentListSection layout="horizontal" />
+        <ChatThreadsSection
+          scrollSignals={threeColumnSidebarChatThreadScrollSignals}
+          showMarkAllRead
+        />
+      </div>
+      <div className="px-3 pb-3">
+        <SidebarUpgradeCard />
+      </div>
+    </aside>
   );
 }
 
 function ThreeColumnNav() {
+  const chatListHidden = useGet(sidebarOff$);
   return (
     <>
       <LabeledNavRail />
-      <ChatListColumn />
+      {!chatListHidden && <ChatListColumn />}
+      <ThreeColumnSearchDialogContainer />
       {/* Reuse the full sidebar as the mobile drawer only. */}
       <ExpandedSidebar mobileOnly />
     </>


### PR DESCRIPTION
## Summary

- keep the 68px navigation rail visible when the three-column chat list is collapsed, with localized hide and restore controls and working keyboard shortcuts
- expose full pinned-agent and localized rail labels on hover
- fix sidebar indicator semantics, scroll-region labeling, section-label contrast, and empty-state contrast

## Testing

- focused sidebar regressions: 6 passed
- focused empty-state contrast regression: 1 passed
- pnpm exec prettier --check on all changed platform files
- pnpm exec oxlint on changed TypeScript files
- pnpm exec eslint on changed TypeScript files --max-warnings 0
- pnpm i18n:check
- pnpm check-types

## Preview QA

- verified https://pr-29448-app.omby.ai on head b1cca11122a015760dc83309a008f8c9d119bbc1 at 1440x900
- confirmed the rail remains 68px while the 300px chat list is removed and restored with Ctrl+B
- confirmed Ctrl+K search remains available while the chat list is hidden
- confirmed Portuguese Fluxos de trabalho is truncated at 55px, retains the full native title, and the pinned card retains its full title
- scoped axe WCAG 2 A/AA audit on the chat list: 0 violations