### PR TITLE
fix(api): attribute shared axiom sdk failures

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -20,6 +20,13 @@ type SyncMock = Mock<(...args: unknown[]) => void>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 interface AxiomClientOptions {
   readonly onError?: (error: Error) => void;
+  readonly token?: string;
+}
+interface AxiomSdkClientMock {
+  readonly options: AxiomClientOptions;
+  readonly flush: AsyncMock;
+  readonly ingest: UnknownMock;
+  readonly query: AsyncMock;
 }
 interface BrowserUseCdpCommand {
   readonly id: number;
@@ -51,6 +58,7 @@ export interface ApiTestMocks {
   };
   readonly axiom: {
     readonly clientError: Mock<(error: Error) => void>;
+    readonly clients: AxiomSdkClientMock[];
     readonly flush: AsyncMock;
     readonly ingest: BooleanMock;
     readonly query: AsyncMock;
@@ -274,6 +282,7 @@ export interface ApiTestMocks {
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
     clientError: vi.fn<(error: Error) => void>(),
+    clients: [],
     flush: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     ingest: vi.fn<(...args: unknown[]) => boolean>(),
     query: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -1121,11 +1130,20 @@ vi.mock("@axiomhq/js", () => {
       apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
         options.onError?.(error);
       });
-      return {
-        flush: apiTestMocks.axiom.flush,
-        ingest: apiTestMocks.axiom.sdkIngest,
-        query: apiTestMocks.axiom.query,
+      const client: AxiomSdkClientMock = {
+        options,
+        flush: vi.fn((...args: unknown[]) => {
+          return apiTestMocks.axiom.flush(...args);
+        }),
+        ingest: vi.fn((...args: unknown[]) => {
+          return apiTestMocks.axiom.sdkIngest(...args);
+        }),
+        query: vi.fn((...args: unknown[]) => {
+          return apiTestMocks.axiom.query(...args);
+        }),
       };
+      apiTestMocks.axiom.clients.push(client);
+      return client;
     }),
   };
 });
@@ -1163,6 +1181,7 @@ export function resetApiTestMocks(): void {
     token: "test-ably-token",
   });
   apiTestMocks.axiom.clientError.mockReset();
+  apiTestMocks.axiom.clients.splice(0);
   apiTestMocks.axiom.flush.mockReset();
   apiTestMocks.axiom.ingest.mockReset();
   apiTestMocks.axiom.ingest.mockReturnValue(true);

--- a/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
@@ -1,9 +1,179 @@
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 
 import { getApiTestMocks } from "../../../__tests__/mocks";
+import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+
+function sdkClientForDataset(
+  mocks: ReturnType<typeof getApiTestMocks>,
+  dataset: string,
+) {
+  const client = mocks.axiom.clients.find((candidate) => {
+    return candidate.ingest.mock.calls.some(([actualDataset]) => {
+      return actualDataset === dataset;
+    });
+  });
+  if (!client) {
+    throw new Error(`Expected Axiom SDK client for ${dataset}`);
+  }
+  return client;
+}
+
+describe("shared SDK ingestion", () => {
+  it("attributes dataset failures and flushes every selected client", async () => {
+    const { flushAxiom, ingestToAxiom } =
+      await vi.importActual<typeof import("../axiom")>("../axiom");
+    const mocks = getApiTestMocks();
+    const restoreConsole = mocks.console.capture();
+    onTestFinished(restoreConsole);
+
+    const telemetryToken = "xaat-private-telemetry-token";
+    const sessionsToken = "xaat-private-sessions-token";
+    const requestDataset = "vm0-request-log-shared-test";
+    const contextDataset = "vm0-run-context-shared-test";
+    const sessionsDataset = "vm0-agent-run-events-shared-test";
+    const requestPayload = "private-request-payload";
+    const secondRequestPayload = "private-second-request-payload";
+    const contextPayload = "private-context-payload";
+    const sessionsPayload = "private-sessions-payload";
+    mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", telemetryToken);
+    mockOptionalEnv("AXIOM_TOKEN_SESSIONS", sessionsToken);
+
+    expect(
+      ingestToAxiom(requestDataset, [{ value: requestPayload }]),
+    ).toBeTruthy();
+    expect(
+      ingestToAxiom(contextDataset, [{ value: contextPayload }]),
+    ).toBeTruthy();
+    expect(
+      ingestToAxiom(sessionsDataset, [{ value: sessionsPayload }]),
+    ).toBeTruthy();
+    expect(
+      ingestToAxiom(requestDataset, [{ value: secondRequestPayload }]),
+    ).toBeTruthy();
+
+    const requestClient = sdkClientForDataset(mocks, requestDataset);
+    const contextClient = sdkClientForDataset(mocks, contextDataset);
+    const sessionsClient = sdkClientForDataset(mocks, sessionsDataset);
+    expect(
+      mocks.axiom.clients.filter((client) => {
+        return client.ingest.mock.calls.length > 0;
+      }),
+    ).toHaveLength(3);
+    expect(requestClient.options.token).toBe(telemetryToken);
+    expect(contextClient.options.token).toBe(telemetryToken);
+    expect(sessionsClient.options.token).toBe(sessionsToken);
+    expect(requestClient.ingest.mock.calls).toStrictEqual([
+      [requestDataset, [{ value: requestPayload }]],
+      [requestDataset, [{ value: secondRequestPayload }]],
+    ]);
+
+    const requestError = new Error("The operation was aborted due to timeout");
+    requestError.name = "TimeoutError";
+    const contextError = new Error("connection refused");
+    const requestOnError = requestClient.options.onError;
+    const contextOnError = contextClient.options.onError;
+    if (!requestOnError || !contextOnError) {
+      throw new Error("Expected dataset-bound Axiom error callbacks");
+    }
+    requestOnError(requestError);
+    contextOnError(contextError);
+
+    const operationLogs = mocks.axiomLogging.error.mock.calls.filter(
+      ([message]) => {
+        return message === "Axiom client operation failed";
+      },
+    );
+    expect(operationLogs).toStrictEqual([
+      [
+        "Axiom client operation failed",
+        expect.objectContaining({
+          client: "telemetry",
+          dataset: requestDataset,
+          failureKind: "timeout",
+          error: requestError,
+        }),
+      ],
+      [
+        "Axiom client operation failed",
+        expect.objectContaining({
+          client: "telemetry",
+          dataset: contextDataset,
+          failureKind: "transport_error",
+          error: contextError,
+        }),
+      ],
+    ]);
+    const serializedOperationLogs = JSON.stringify(operationLogs);
+    for (const secret of [
+      telemetryToken,
+      sessionsToken,
+      requestPayload,
+      secondRequestPayload,
+      contextPayload,
+      sessionsPayload,
+    ]) {
+      expect(serializedOperationLogs).not.toContain(secret);
+    }
+
+    const flushController = new AbortController();
+    onTestFinished(() => {
+      flushController.abort();
+    });
+    const requestFlush = createDeferredPromise<void>(flushController.signal);
+    const contextFlush = createDeferredPromise<void>(flushController.signal);
+    requestClient.flush.mockReturnValueOnce(requestFlush.promise);
+    contextClient.flush.mockReturnValueOnce(contextFlush.promise);
+    sessionsClient.flush.mockResolvedValue(undefined);
+    const telemetryFlush = flushAxiom({ client: "telemetry" });
+    expect(requestClient.flush).toHaveBeenCalledOnce();
+    expect(contextClient.flush).toHaveBeenCalledOnce();
+    expect(sessionsClient.flush).not.toHaveBeenCalled();
+    requestFlush.resolve();
+    contextFlush.resolve();
+    await expect(telemetryFlush).resolves.toBeUndefined();
+
+    requestClient.flush.mockClear();
+    contextClient.flush.mockClear();
+    sessionsClient.flush.mockClear();
+    await expect(flushAxiom({ client: "sessions" })).resolves.toBeUndefined();
+    expect(requestClient.flush).not.toHaveBeenCalled();
+    expect(contextClient.flush).not.toHaveBeenCalled();
+    expect(sessionsClient.flush).toHaveBeenCalledOnce();
+
+    requestClient.flush.mockClear();
+    contextClient.flush.mockClear();
+    sessionsClient.flush.mockClear();
+    mocks.axiom.flush.mockResolvedValue(undefined);
+    await expect(flushAxiom()).resolves.toBeUndefined();
+    expect(requestClient.flush).toHaveBeenCalledOnce();
+    expect(contextClient.flush).toHaveBeenCalledOnce();
+    expect(sessionsClient.flush).toHaveBeenCalledOnce();
+
+    requestClient.flush.mockClear();
+    contextClient.flush.mockClear();
+    sessionsClient.flush.mockClear();
+    mocks.axiomLogging.error.mockClear();
+    const flushError = new Error("flush rejected");
+    requestClient.flush.mockRejectedValueOnce(flushError);
+    contextClient.flush.mockResolvedValueOnce(undefined);
+    await expect(flushAxiom({ client: "telemetry" })).resolves.toBeUndefined();
+    expect(requestClient.flush).toHaveBeenCalledOnce();
+    expect(contextClient.flush).toHaveBeenCalledOnce();
+    expect(sessionsClient.flush).not.toHaveBeenCalled();
+    expect(mocks.axiomLogging.error).toHaveBeenCalledWith(
+      "Axiom client flush failed",
+      expect.objectContaining({
+        client: "telemetry",
+        dataset: requestDataset,
+        error: flushError,
+      }),
+    );
+  });
+});
 
 describe("queryAxiom", () => {
   it("keeps the Axiom match timestamp when event data contains _time", async () => {

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -25,11 +25,22 @@ const AXIOM_TRANSPORT_ERROR_MESSAGES = {
 
 const L = logger("api:axiom");
 
-function logClientError(client: "sessions" | "telemetry", error: Error): void {
-  L.error("Axiom client operation failed", { client, error });
+type AxiomClientName = "sessions" | "telemetry";
+
+function logClientError(
+  client: AxiomClientName,
+  error: Error,
+  dataset?: string,
+): void {
+  L.error("Axiom client operation failed", {
+    client,
+    ...(dataset === undefined ? {} : { dataset }),
+    failureKind: error.name === "TimeoutError" ? "timeout" : "transport_error",
+    error,
+  });
 }
 
-const sessionsAxiomClient = singleton(() => {
+const sessionsAxiomQueryClient = singleton(() => {
   return new Axiom({
     token: env("AXIOM_TOKEN_SESSIONS"),
     onError: (error) => {
@@ -38,13 +49,20 @@ const sessionsAxiomClient = singleton(() => {
   });
 });
 
-const telemetryAxiomClient = singleton(() => {
+const telemetryAxiomQueryClient = singleton(() => {
   return new Axiom({
     token: env("AXIOM_TOKEN_TELEMETRY"),
     onError: (error) => {
       logClientError("telemetry", error);
     },
   });
+});
+
+const axiomIngestClients = singleton(() => {
+  return {
+    sessions: new Map<string, Axiom>(),
+    telemetry: new Map<string, Axiom>(),
+  };
 });
 
 export function getDatasetName(base: string): string {
@@ -54,20 +72,34 @@ export function getDatasetName(base: string): string {
 function axiomClientForApl(apl: string): Axiom {
   const tokenEnvName = getAxiomTokenEnvNameForApl(apl);
   if (tokenEnvName === "AXIOM_TOKEN_SESSIONS") {
-    return sessionsAxiomClient();
+    return sessionsAxiomQueryClient();
   }
-  return telemetryAxiomClient();
+  return telemetryAxiomQueryClient();
 }
 
 function axiomClientForDataset(dataset: string): Axiom | null {
   const tokenEnvName = getAxiomTokenEnvNameForDataset(dataset);
-  if (!optionalEnv(tokenEnvName)) {
+  const token = optionalEnv(tokenEnvName);
+  if (!token) {
     return null;
   }
-  if (tokenEnvName === "AXIOM_TOKEN_SESSIONS") {
-    return sessionsAxiomClient();
+
+  const clientName: AxiomClientName =
+    tokenEnvName === "AXIOM_TOKEN_SESSIONS" ? "sessions" : "telemetry";
+  const clients = axiomIngestClients()[clientName];
+  const existing = clients.get(dataset);
+  if (existing) {
+    return existing;
   }
-  return telemetryAxiomClient();
+
+  const client = new Axiom({
+    token,
+    onError: (error) => {
+      logClientError(clientName, error, dataset);
+    },
+  });
+  clients.set(dataset, client);
+  return client;
 }
 
 export function ingestToAxiom(
@@ -336,33 +368,43 @@ export async function ingestAxiomDirect(
 }
 
 interface FlushAxiomOptions {
-  readonly client?: "all" | "sessions" | "telemetry";
+  readonly client?: "all" | AxiomClientName;
 }
 
 export async function flushAxiom(
   options: FlushAxiomOptions = {},
 ): Promise<void> {
-  const client = options.client ?? "all";
+  const selectedClient = options.client ?? "all";
   const flushes: {
-    readonly name: string;
-    readonly promise?: Promise<void>;
+    readonly client: AxiomClientName;
+    readonly dataset: string;
+    readonly promise: Promise<void>;
   }[] = [];
+  const clients = axiomIngestClients();
 
-  if (client === "all" || client === "sessions") {
-    flushes.push({
-      name: "sessions",
-      promise: optionalEnv("AXIOM_TOKEN_SESSIONS")
-        ? sessionsAxiomClient().flush()
-        : undefined,
-    });
+  if (
+    (selectedClient === "all" || selectedClient === "sessions") &&
+    optionalEnv("AXIOM_TOKEN_SESSIONS")
+  ) {
+    for (const [dataset, client] of clients.sessions) {
+      flushes.push({
+        client: "sessions",
+        dataset,
+        promise: client.flush(),
+      });
+    }
   }
-  if (client === "all" || client === "telemetry") {
-    flushes.push({
-      name: "telemetry",
-      promise: optionalEnv("AXIOM_TOKEN_TELEMETRY")
-        ? telemetryAxiomClient().flush()
-        : undefined,
-    });
+  if (
+    (selectedClient === "all" || selectedClient === "telemetry") &&
+    optionalEnv("AXIOM_TOKEN_TELEMETRY")
+  ) {
+    for (const [dataset, client] of clients.telemetry) {
+      flushes.push({
+        client: "telemetry",
+        dataset,
+        promise: client.flush(),
+      });
+    }
   }
 
   const results = await Promise.allSettled(
@@ -373,7 +415,8 @@ export async function flushAxiom(
   for (const [index, result] of results.entries()) {
     if (result.status === "rejected") {
       L.error("Axiom client flush failed", {
-        client: flushes[index]?.name ?? "unknown",
+        client: flushes[index]?.client ?? "unknown",
+        dataset: flushes[index]?.dataset ?? "unknown",
         error: result.reason,
       });
     }


### PR DESCRIPTION
## Summary

- bind shared Axiom SDK ingestion clients to individual datasets so asynchronous SDK failures carry exact client and dataset context
- classify callback failures as timeouts or transport errors without logging tokens or payloads
- flush every registered dataset client for the selected token class while preserving best-effort failure isolation

## Scope

- does not add run-level attribution to SDK batches because one batch can contain events from multiple runs
- does not change direct Axiom ingestion or query behavior
- does not close the delivery parent issue

## Validation

- `pnpm exec prettier --check apps/api/src/__tests__/mocks.ts apps/api/src/signals/external/__tests__/axiom.test.ts apps/api/src/signals/external/axiom.ts`
- targeted Oxlint, type-aware Oxlint, and ESLint checks for the three changed files
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/external/__tests__/axiom.test.ts --reporter=verbose`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts --silent=passed-only`
- `pnpm knip --workspace api`
- pre-commit full-workspace `pnpm knip` and `pnpm check-types`

The full `pnpm -F api lint` command still reports pre-existing warnings in unrelated API test files; all lint layers pass for the changed files.

Closes #29425

Parent context: #28261
