### PR TITLE
fix(vsock): bound file write response waits

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
 name = "vsock-host"
 version = "0.17.93"
 dependencies = [
+ "guest-contracts",
  "nix",
  "sandbox",
  "shell-quote",

--- a/crates/guest-contracts/src/file_write.rs
+++ b/crates/guest-contracts/src/file_write.rs
@@ -7,8 +7,8 @@ use crate::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 /// Maximum time the guest waits for its file-write helper process.
 pub const WRITE_FILE_HELPER_TIMEOUT_MS: u32 = 30_000;
 
-/// Duration form of [`WRITE_FILE_HELPER_TIMEOUT_MS`] for budget composition.
-pub const WRITE_FILE_HELPER_TIMEOUT: Duration = Duration::from_secs(30);
+// Duration form of `WRITE_FILE_HELPER_TIMEOUT_MS` for budget composition.
+const WRITE_FILE_HELPER_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum time the guest spends writing one terminal protocol frame.
 ///
@@ -16,9 +16,9 @@ pub const WRITE_FILE_HELPER_TIMEOUT: Duration = Duration::from_secs(30);
 /// response, so this remains a connection-wide frame deadline.
 pub const GUEST_FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(10);
 
-/// Host-side allowance for request-frame construction, transmission, guest
-/// dispatch, and scheduling beyond the guest's configured processing budgets.
-pub const WRITE_FILE_TRANSPORT_HEADROOM: Duration = Duration::from_secs(15);
+// Host-side allowance for request-frame construction, transmission, guest
+// dispatch, and scheduling beyond the guest's configured processing budgets.
+const WRITE_FILE_TRANSPORT_HEADROOM: Duration = Duration::from_secs(15);
 
 /// End-to-end host deadline for one file-write request frame and its terminal
 /// response.

--- a/crates/guest-contracts/src/file_write.rs
+++ b/crates/guest-contracts/src/file_write.rs
@@ -1,0 +1,42 @@
+//! Shared guest file-write timing budgets.
+
+use std::time::Duration;
+
+use crate::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
+
+/// Maximum time the guest waits for its file-write helper process.
+pub const WRITE_FILE_HELPER_TIMEOUT_MS: u32 = 30_000;
+
+/// Duration form of [`WRITE_FILE_HELPER_TIMEOUT_MS`] for budget composition.
+pub const WRITE_FILE_HELPER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum time the guest spends writing one terminal protocol frame.
+///
+/// File-write results share the connection writer with every other guest
+/// response, so this remains a connection-wide frame deadline.
+pub const GUEST_FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Host-side allowance for request-frame construction, transmission, guest
+/// dispatch, and scheduling beyond the guest's configured processing budgets.
+pub const WRITE_FILE_TRANSPORT_HEADROOM: Duration = Duration::from_secs(15);
+
+/// End-to-end host deadline for one file-write request frame and its terminal
+/// response.
+pub const WRITE_FILE_REQUEST_DEADLINE: Duration = Duration::from_secs(60);
+
+const WRITE_FILE_CONFIGURED_GUEST_BUDGET: Duration = WRITE_FILE_HELPER_TIMEOUT
+    .saturating_add(EXEC_OUTPUT_DRAIN_DEADLINE)
+    .saturating_add(GUEST_FRAME_WRITE_DEADLINE);
+
+const _: () = assert!(
+    WRITE_FILE_HELPER_TIMEOUT.as_millis() == WRITE_FILE_HELPER_TIMEOUT_MS as u128,
+    "file-write helper duration and millisecond arguments must stay aligned"
+);
+
+const _: () = assert!(
+    WRITE_FILE_REQUEST_DEADLINE.as_nanos()
+        == WRITE_FILE_CONFIGURED_GUEST_BUDGET
+            .saturating_add(WRITE_FILE_TRANSPORT_HEADROOM)
+            .as_nanos(),
+    "file-write request deadline must cover guest work plus transport headroom"
+);

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -15,6 +15,7 @@ pub mod env;
 pub mod epoch_milliseconds;
 pub mod exec_limits;
 pub mod exec_terminal;
+pub mod file_write;
 pub mod process_containment;
 pub mod reuse_preparation;
 pub mod runtime_paths;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -91,6 +91,24 @@ const STORAGE_DOWNLOAD_FAILED: &str = "storage-download-failed";
 const SESSION_HISTORY_IDENTITY_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
 const USER_CANCELLATION_CONTROL_PAYLOAD: &[u8] = br#"{"type":"user-cancellation"}"#;
 
+fn private_write_timeout_stage(error: &RunnerError) -> Option<&'static str> {
+    let RunnerError::Sandbox(sandbox::SandboxError::OperationTimeout {
+        operation: sandbox::SandboxOperation::WriteFile,
+        stage,
+        ..
+    }) = error
+    else {
+        return None;
+    };
+    Some(match stage {
+        sandbox::SandboxOperationTimeoutStage::BeforeFrameWrite => "before_frame_write",
+        sandbox::SandboxOperationTimeoutStage::FrameWrite => "frame_write",
+        sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse => {
+            "await_terminal_response"
+        }
+    })
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SessionHistoryIdentityReason {
     FinalizeMetadataPathUnresolved,
@@ -2005,11 +2023,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             user_env_file
         }
         Err(error) => {
-            telemetry.record(
+            telemetry.record_with_outcome(
                 "runner_user_env_write",
                 user_env_started.elapsed(),
                 false,
                 None,
+                private_write_timeout_stage(&error),
             );
             return Err(error);
         }
@@ -2052,11 +2071,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             path
         }
         Err(error) => {
-            telemetry.record(
+            telemetry.record_with_outcome(
                 "runner_run_payload_write",
                 run_payload_write_started.elapsed(),
                 false,
                 None,
+                private_write_timeout_stage(&error),
             );
             return Err(error);
         }

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -6,10 +8,10 @@ use sandbox::{
     CopyFileOptions, ExecRequest, ExecResult, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
     SandboxFactory, SandboxId, SandboxInitializationPhase, SandboxNbdCowCreateOutcome,
-    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxStartObserver,
-    SandboxStartStage, StartProcessRequest,
+    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxOperation,
+    SandboxOperationTimeoutStage, SandboxStartObserver, SandboxStartStage, StartProcessRequest,
 };
-use sandbox_mock::MockSandboxFactory;
+use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
 use super::super::telemetry::{
     RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_to_spawn, record_reuse_result,
@@ -21,7 +23,8 @@ use super::super::{
     execute_job_with_prepared_notifier,
 };
 use super::support::{
-    default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
+    context_with_env, default_params, make_reusable_idle_sandbox, minimal_context,
+    test_executor_config,
 };
 use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::http::{HttpClient, HttpClientConfig};
@@ -149,6 +152,18 @@ fn assert_action_outcome(
         .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
     assert_eq!(op.1, success, "{action} success flag");
     assert_eq!(op.2.as_deref(), error, "{action} error");
+}
+
+fn assert_action_bounded_outcome(telemetry: &JobTelemetry, action: &str, expected_outcome: &str) {
+    let operations = telemetry.pending_ops_with_outcome_snapshot();
+    let operation = operations
+        .iter()
+        .find(|operation| operation.0 == action)
+        .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {operations:?}"));
+    assert!(!operation.1, "{action} success flag");
+    assert_eq!(operation.2.as_deref(), Some(expected_outcome));
+    assert_eq!(operation.3, None, "{action} reason");
+    assert_action_outcome(telemetry, action, false, None);
 }
 
 fn assert_action_duration(telemetry: &JobTelemetry, action: &str, duration_ms: u64) {
@@ -1235,6 +1250,79 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     assert_lacks_action(&telemetry, "workspace_drive_mount");
     assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec");
     assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
+}
+
+async fn assert_reused_private_write_timeout_telemetry(
+    context: crate::types::ExecutionContext,
+    expected_action: &str,
+    stage: SandboxOperationTimeoutStage,
+    expected_outcome: &str,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let sandbox = Box::new(MockSandbox::with_overrides(
+        "private-write-timeout",
+        Arc::clone(&overrides),
+    ));
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+    overrides.push_private_write_file_result(Err(SandboxError::OperationTimeout {
+        operation: SandboxOperation::WriteFile,
+        stage,
+        timeout_ms: 60_000,
+    }));
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (outcome, telemetry) = execute_job_reuse_with_hooks(
+        idle_sandbox,
+        context,
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+
+    assert!(outcome.failure.is_some());
+    assert!(outcome.sandbox.is_some());
+    assert_action_bounded_outcome(&telemetry, expected_action, expected_outcome);
+    assert_lacks_action(&telemetry, "runner_agent_start_process");
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.private_write_file_calls().len(), 1);
+}
+
+#[tokio::test]
+async fn reused_user_env_write_timeout_records_bounded_stage_before_agent_start() {
+    let context = context_with_env(HashMap::from([(
+        "CUSTOM_ENV".to_string(),
+        "value".to_string(),
+    )]));
+
+    assert_reused_private_write_timeout_telemetry(
+        context,
+        "runner_user_env_write",
+        SandboxOperationTimeoutStage::FrameWrite,
+        "frame_write",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reused_run_payload_write_timeout_records_bounded_stage_before_agent_start() {
+    assert_reused_private_write_timeout_telemetry(
+        minimal_context(),
+        "runner_run_payload_write",
+        SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+        "await_terminal_response",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -19,8 +19,8 @@ use super::super::telemetry::{
 use super::super::{
     ExactReuseSpeculationTiming, ExecutionHooks, FinalizingHandoffOutcome, NewSandboxDispatch,
     RunnerPreSpawnConcurrency, RunnerPreSpawnOperationTiming, RunnerPreSpawnTiming,
-    SessionHistoryRestorePlan, execute_job, execute_job_reuse, execute_job_reuse_with_hooks,
-    execute_job_with_prepared_notifier,
+    SandboxReuseDisposition, SandboxReuseRejection, SessionHistoryRestorePlan, execute_job,
+    execute_job_reuse, execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
 };
 use super::support::{
     context_with_env, default_params, make_reusable_idle_sandbox, minimal_context,
@@ -156,10 +156,14 @@ fn assert_action_outcome(
 
 fn assert_action_bounded_outcome(telemetry: &JobTelemetry, action: &str, expected_outcome: &str) {
     let operations = telemetry.pending_ops_with_outcome_snapshot();
-    let operation = operations
-        .iter()
-        .find(|operation| operation.0 == action)
+    let mut matching = operations.iter().filter(|operation| operation.0 == action);
+    let operation = matching
+        .next()
         .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {operations:?}"));
+    assert!(
+        matching.next().is_none(),
+        "expected one telemetry action {action}, got: {operations:?}"
+    );
     assert!(!operation.1, "{action} success flag");
     assert_eq!(operation.2.as_deref(), Some(expected_outcome));
     assert_eq!(operation.3, None, "{action} reason");
@@ -1292,6 +1296,10 @@ async fn assert_reused_private_write_timeout_telemetry(
 
     assert!(outcome.failure.is_some());
     assert!(outcome.sandbox.is_some());
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain)
+    );
     assert_action_bounded_outcome(&telemetry, expected_action, expected_outcome);
     assert_lacks_action(&telemetry, "runner_agent_start_process");
     assert!(overrides.start_process_calls().is_empty());

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -701,6 +701,27 @@ impl FirecrackerSandbox {
         if backend_crashed {
             return Self::backend_crashed_error(operation);
         }
+        if let Some(timeout) = error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<vsock_host::RequestTimeoutError>())
+        {
+            let stage = match timeout.stage() {
+                vsock_host::RequestTimeoutStage::BeforeFrameWrite => {
+                    sandbox::SandboxOperationTimeoutStage::BeforeFrameWrite
+                }
+                vsock_host::RequestTimeoutStage::FrameWrite => {
+                    sandbox::SandboxOperationTimeoutStage::FrameWrite
+                }
+                vsock_host::RequestTimeoutStage::AwaitingTerminalResponse => {
+                    sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse
+                }
+            };
+            return SandboxError::OperationTimeout {
+                operation,
+                stage,
+                timeout_ms: u64::try_from(timeout.timeout().as_millis()).unwrap_or(u64::MAX),
+            };
+        }
         let reason = if error.kind() == io::ErrorKind::TimedOut {
             SandboxOperationReason::Timeout
         } else {

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2181,6 +2181,35 @@ fn operation_error_classifies_io_timeout() {
 }
 
 #[test]
+fn operation_error_preserves_typed_request_timeout_stage() {
+    let timeout = vsock_host::RequestTimeoutError::new(
+        vsock_host::RequestTimeoutStage::AwaitingTerminalResponse,
+        Duration::from_secs(60),
+    );
+    let err = FirecrackerSandbox::operation_error(
+        SandboxOperation::WriteFile,
+        io::Error::new(io::ErrorKind::TimedOut, timeout),
+        false,
+    );
+
+    match err {
+        SandboxError::OperationTimeout {
+            operation,
+            stage,
+            timeout_ms,
+        } => {
+            assert_eq!(operation, SandboxOperation::WriteFile);
+            assert_eq!(
+                stage,
+                sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse
+            );
+            assert_eq!(timeout_ms, 60_000);
+        }
+        other => panic!("expected typed operation timeout, got {other:?}"),
+    }
+}
+
+#[test]
 fn operation_error_classifies_non_timeout_as_guest() {
     let err = FirecrackerSandbox::operation_error(
         SandboxOperation::Exec,

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -53,6 +53,17 @@ pub enum SandboxError {
         message: String,
     },
 
+    /// A running sandbox operation exhausted a typed request deadline.
+    #[error("sandbox {operation} failed (timeout {stage} after {timeout_ms} ms)")]
+    OperationTimeout {
+        /// Operation whose request timed out.
+        operation: SandboxOperation,
+        /// Host-observed request stage at timeout.
+        stage: SandboxOperationTimeoutStage,
+        /// Configured end-to-end request budget in milliseconds.
+        timeout_ms: u64,
+    },
+
     /// Parking or unparking an idle sandbox failed.
     #[error("sandbox {transition} failed: {message}")]
     IdleTransition {
@@ -143,6 +154,27 @@ pub enum SandboxOperationReason {
     Timeout,
     /// The operation failed for another reason.
     Other,
+}
+
+/// Host-observed request stage for a typed sandbox operation timeout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxOperationTimeoutStage {
+    /// The request frame had not reached its write boundary.
+    BeforeFrameWrite,
+    /// The request frame write had started and may be partial.
+    FrameWrite,
+    /// The request frame completed but no terminal response arrived.
+    AwaitingTerminalResponse,
+}
+
+impl fmt::Display for SandboxOperationTimeoutStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BeforeFrameWrite => f.write_str("before frame write"),
+            Self::FrameWrite => f.write_str("during frame write"),
+            Self::AwaitingTerminalResponse => f.write_str("awaiting terminal response"),
+        }
+    }
 }
 
 impl fmt::Display for SandboxOperationReason {

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -37,7 +37,7 @@ pub use control::{
 pub use error::{
     Result, SandboxError, SandboxGuestDnsReadinessReason, SandboxIdleTransition,
     SandboxInitializationPhase, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason,
+    SandboxOperationReason, SandboxOperationTimeoutStage,
 };
 pub use factory::{
     SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxNbdCowCreateOutcome,

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -1,6 +1,6 @@
 use sandbox::{
     SandboxError, SandboxIdleTransition, SandboxInitializationPhase, SandboxInvalidStateContext,
-    SandboxOperation, SandboxOperationReason,
+    SandboxOperation, SandboxOperationReason, SandboxOperationTimeoutStage,
 };
 
 #[test]
@@ -38,6 +38,31 @@ fn operation_error_exposes_operation_and_reason() {
             assert_eq!(message, "disk full");
         }
         other => panic!("expected operation error, got {other:?}"),
+    }
+}
+
+#[test]
+fn operation_timeout_exposes_bounded_request_context() {
+    let err = SandboxError::OperationTimeout {
+        operation: SandboxOperation::WriteFile,
+        stage: SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+        timeout_ms: 60_000,
+    };
+
+    match err {
+        SandboxError::OperationTimeout {
+            operation,
+            stage,
+            timeout_ms,
+        } => {
+            assert_eq!(operation, SandboxOperation::WriteFile);
+            assert_eq!(
+                stage,
+                SandboxOperationTimeoutStage::AwaitingTerminalResponse
+            );
+            assert_eq!(timeout_ms, 60_000);
+        }
+        other => panic!("expected operation timeout, got {other:?}"),
     }
 }
 
@@ -97,6 +122,20 @@ fn display_includes_category_and_message() {
     assert!(text.contains("wait process"), "got: {text}");
     assert!(text.contains("backend crashed"), "got: {text}");
     assert!(text.contains("firecracker process crashed"), "got: {text}");
+}
+
+#[test]
+fn operation_timeout_display_contains_only_typed_context() {
+    let err = SandboxError::OperationTimeout {
+        operation: SandboxOperation::WriteFile,
+        stage: SandboxOperationTimeoutStage::FrameWrite,
+        timeout_ms: 60_000,
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "sandbox write file failed (timeout during frame write after 60000 ms)"
+    );
 }
 
 #[test]

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
+use guest_contracts::file_write::WRITE_FILE_HELPER_TIMEOUT_MS;
 use vsock_proto::{
     self, BorrowedRawMessage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
     MSG_WRITE_FILES_RESULT,
@@ -25,7 +26,6 @@ use crate::wait::{
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
-const WRITE_TIMEOUT_MS: u32 = 30_000;
 const GUEST_WRITE_FILE_PATH: &str = "/sbin/guest-write-file";
 #[cfg(any(debug_assertions, feature = "test-support"))]
 static DEBUG_GUEST_WRITE_FILE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
@@ -106,7 +106,13 @@ fn wait_write_file_child<S>(
 where
     S: ThreadSpawner,
 {
-    wait_write_file_child_with_timeout(child, content, WRITE_TIMEOUT_MS, connection_cancel, spawner)
+    wait_write_file_child_with_timeout(
+        child,
+        content,
+        WRITE_FILE_HELPER_TIMEOUT_MS,
+        connection_cancel,
+        spawner,
+    )
 }
 
 fn wait_write_file_child_with_timeout<S>(

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-const WRITE_DEADLINE: Duration = Duration::from_secs(10);
+use guest_contracts::file_write::GUEST_FRAME_WRITE_DEADLINE;
 
 /// Shared guest-to-host frame writer.
 ///
@@ -26,7 +26,7 @@ impl GuestWriter {
     }
 
     pub(crate) fn write_frame(&self, frame: &[u8]) -> io::Result<()> {
-        self.write_frame_with_deadline(frame, WRITE_DEADLINE)
+        self.write_frame_with_deadline(frame, GUEST_FRAME_WRITE_DEADLINE)
     }
 
     pub(crate) fn shutdown(&self) {
@@ -57,7 +57,7 @@ impl GuestWriter {
     where
         F: FnOnce(),
     {
-        self.write_frame_with_deadline_after_lock(frame, WRITE_DEADLINE, after_lock)
+        self.write_frame_with_deadline_after_lock(frame, GUEST_FRAME_WRITE_DEADLINE, after_lock)
     }
 
     /// Release operation ownership at the writer boundary, then send the
@@ -76,7 +76,7 @@ impl GuestWriter {
         if cancelled.load(Ordering::Acquire) {
             return Ok(false);
         }
-        let result = send_frame(stream.as_raw_fd(), frame, WRITE_DEADLINE);
+        let result = send_frame(stream.as_raw_fd(), frame, GUEST_FRAME_WRITE_DEADLINE);
         if result.is_err() {
             let _ = stream.shutdown(Shutdown::Both);
         }
@@ -93,7 +93,7 @@ impl GuestWriter {
     {
         let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
         let frame = build_frame()?;
-        let result = send_frame(stream.as_raw_fd(), &frame, WRITE_DEADLINE);
+        let result = send_frame(stream.as_raw_fd(), &frame, GUEST_FRAME_WRITE_DEADLINE);
         if result.is_err() {
             let _ = stream.shutdown(Shutdown::Both);
         }

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Vsock host client for Firecracker VM communication"
 
 [dependencies]
+guest-contracts.workspace = true
 nix = { workspace = true, features = ["net"] }
 sandbox.workspace = true
 shell-quote.workspace = true

--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
@@ -15,7 +16,7 @@ use crate::operation_tracker::{
     NormalOperationRejection, NormalOperationToken, NormalOperationTransitionError,
     NormalOperationTransitionHandle,
 };
-use crate::{FrameWriteObserver, VsockHost};
+use crate::{FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, VsockHost};
 
 use super::{ConnectionState, PendingNormalOperation, PendingResponse, RouteId, Shared};
 
@@ -28,6 +29,34 @@ pub(crate) struct RequestWriteGuard {
     shared: Arc<Shared>,
     write_started: bool,
     write_returned: bool,
+}
+
+#[derive(Debug, Default)]
+struct RequestWriteProgress {
+    stage: AtomicU8,
+}
+
+impl RequestWriteProgress {
+    const BEFORE_FRAME_WRITE: u8 = 0;
+    const FRAME_WRITE: u8 = 1;
+    const AWAITING_TERMINAL_RESPONSE: u8 = 2;
+
+    fn mark_frame_write(&self) {
+        self.stage.store(Self::FRAME_WRITE, Ordering::Release);
+    }
+
+    fn mark_awaiting_terminal_response(&self) {
+        self.stage
+            .store(Self::AWAITING_TERMINAL_RESPONSE, Ordering::Release);
+    }
+
+    fn timeout_stage(&self) -> RequestTimeoutStage {
+        match self.stage.load(Ordering::Acquire) {
+            Self::BEFORE_FRAME_WRITE => RequestTimeoutStage::BeforeFrameWrite,
+            Self::FRAME_WRITE => RequestTimeoutStage::FrameWrite,
+            _ => RequestTimeoutStage::AwaitingTerminalResponse,
+        }
+    }
 }
 
 impl PendingRequestGuard {
@@ -119,35 +148,54 @@ async fn request_on_shared(
     timeout: Duration,
 ) -> io::Result<RawMessage> {
     if timeout.is_zero() {
-        return Err(request_timeout_error());
+        return Err(request_timeout_error(
+            RequestTimeoutStage::BeforeFrameWrite,
+            timeout,
+        ));
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
-    request_raw_on_shared(shared, msg_type, payload, deadline).await
+    request_raw_on_shared(shared, msg_type, payload, deadline, timeout).await
 }
 
 async fn write_request_frame(
     shared: &Arc<Shared>,
     data: &[u8],
     before_write: impl FnOnce() -> io::Result<()>,
+    progress: &RequestWriteProgress,
 ) -> io::Result<()> {
     let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
     let mut writer = shared.writer.lock().await;
     before_write()?;
+    progress.mark_frame_write();
     write_guard.mark_started();
     if let Err(error) = writer.write_all(data).await {
         write_guard.mark_returned();
         shared.poison_connection();
         return Err(error);
     }
+    progress.mark_awaiting_terminal_response();
     write_guard.mark_returned();
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) async fn write_request_frame_with_builder(
     shared: &Arc<Shared>,
     seq: u32,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
     before_write: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let progress = RequestWriteProgress::default();
+    write_request_frame_with_builder_and_progress(shared, seq, build_frame, before_write, &progress)
+        .await
+}
+
+async fn write_request_frame_with_builder_and_progress(
+    shared: &Arc<Shared>,
+    seq: u32,
+    build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
+    before_write: impl FnOnce() -> io::Result<()>,
+    progress: &RequestWriteProgress,
 ) -> io::Result<()> {
     let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
     let frame_builder_guard = shared.frame_builder.lock().await;
@@ -155,6 +203,7 @@ pub(crate) async fn write_request_frame_with_builder(
     build_frame(seq, &mut frame)?;
     let mut writer = shared.writer.lock().await;
     before_write()?;
+    progress.mark_frame_write();
     write_guard.mark_started();
     let result = writer.write_all(&frame).await;
     if let Err(error) = result {
@@ -168,6 +217,7 @@ pub(crate) async fn write_request_frame_with_builder(
     drop(writer);
     drop(frame);
     drop(frame_builder_guard);
+    progress.mark_awaiting_terminal_response();
     write_guard.mark_returned();
     Ok(())
 }
@@ -210,6 +260,7 @@ async fn write_registered_request_and_wait(
     shared: &Arc<Shared>,
     data: &[u8],
     deadline: Instant,
+    timeout: Duration,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
@@ -217,11 +268,15 @@ async fn write_registered_request_and_wait(
     // or cancellation before reader_loop dispatches a response. The write
     // helper separately poisons the connection if cancellation interrupts an
     // in-progress frame write.
-    time::timeout_at(deadline, write_request_frame(shared, data, before_write))
-        .await
-        .map_err(|_| request_timeout_error())??;
+    let progress = RequestWriteProgress::default();
+    time::timeout_at(
+        deadline,
+        write_request_frame(shared, data, before_write, &progress),
+    )
+    .await
+    .map_err(|_| request_timeout_error(progress.timeout_stage(), timeout))??;
 
-    await_pending_response(rx, deadline).await
+    await_pending_response(rx, deadline, timeout).await
 }
 
 async fn write_registered_request_and_wait_with_frame_builder(
@@ -229,22 +284,31 @@ async fn write_registered_request_and_wait_with_frame_builder(
     seq: u32,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
     deadline: Instant,
+    timeout: Duration,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
+    let progress = RequestWriteProgress::default();
     time::timeout_at(
         deadline,
-        write_request_frame_with_builder(shared, seq, build_frame, before_write),
+        write_request_frame_with_builder_and_progress(
+            shared,
+            seq,
+            build_frame,
+            before_write,
+            &progress,
+        ),
     )
     .await
-    .map_err(|_| request_timeout_error())??;
+    .map_err(|_| request_timeout_error(progress.timeout_stage(), timeout))??;
 
-    await_pending_response(rx, deadline).await
+    await_pending_response(rx, deadline, timeout).await
 }
 
 async fn await_pending_response(
     rx: oneshot::Receiver<RawMessage>,
     deadline: Instant,
+    timeout: Duration,
 ) -> io::Result<RawMessage> {
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
     // `Err(RecvError)` when `close()` drops the `Connected` variant. The
@@ -258,13 +322,19 @@ async fn await_pending_response(
             ))
         }
         _ = time::sleep_until(deadline) => {
-            Err(request_timeout_error())
+            Err(request_timeout_error(
+                RequestTimeoutStage::AwaitingTerminalResponse,
+                timeout,
+            ))
         }
     }
 }
 
-fn request_timeout_error() -> io::Error {
-    io::Error::new(io::ErrorKind::TimedOut, "request timeout")
+fn request_timeout_error(stage: RequestTimeoutStage, timeout: Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        RequestTimeoutError::new(stage, timeout),
+    )
 }
 
 async fn request_raw_on_shared(
@@ -272,6 +342,7 @@ async fn request_raw_on_shared(
     msg_type: u8,
     payload: &[u8],
     deadline: Instant,
+    timeout: Duration,
 ) -> io::Result<RawMessage> {
     let (route_id, rx) = register_pending_response(shared, |route_id, tx| {
         Ok(PendingResponse {
@@ -285,7 +356,7 @@ async fn request_raw_on_shared(
     let seq = route_id.wire_seq();
     let data = encode_request_frame(msg_type, seq, payload)?;
 
-    write_registered_request_and_wait(shared, &data, deadline, || Ok(()), rx).await
+    write_registered_request_and_wait(shared, &data, deadline, timeout, || Ok(()), rx).await
 }
 
 pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
@@ -296,7 +367,10 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
     if timeout.is_zero() {
-        return Err(request_timeout_error());
+        return Err(request_timeout_error(
+            RequestTimeoutStage::BeforeFrameWrite,
+            timeout,
+        ));
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
     let normal_operation = shared.reserve_normal_operation()?;
@@ -316,6 +390,7 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
         seq,
         build_frame,
         deadline,
+        timeout,
         || {
             mark_pending_normal_operation_possible_guest_write(shared, route_id, |_| Ok(()))?;
             write_observer.record_write_start()
@@ -334,7 +409,10 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
     if timeout.is_zero() {
-        return Err(request_timeout_error());
+        return Err(request_timeout_error(
+            RequestTimeoutStage::BeforeFrameWrite,
+            timeout,
+        ));
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
     let (route_id, rx) = register_pending_response(shared, |route_id, tx| {
@@ -355,6 +433,7 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
         seq,
         build_frame,
         deadline,
+        timeout,
         || {
             mark_pending_normal_operation_possible_guest_write(shared, route_id, |_| Ok(()))?;
             write_observer.record_write_start()

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::{fmt, io};
 
+use guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE;
 use shell_quote::quote_shell_arg;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES_RESULT};
 
@@ -701,7 +702,7 @@ impl VsockHost {
             .acquire_shared_many(files.iter().map(|file| file.path))
             .await;
         let _file_write_guard = self.shared.file_write_gate.lock().await;
-        let timeout = Duration::from_secs(300);
+        let timeout = WRITE_FILE_REQUEST_DEADLINE;
         let resp = normal_request_on_shared_with_write_observer_frame_builder(
             &self.shared,
             WRITE_FILES_TERMINAL_MSG_TYPES,
@@ -746,7 +747,7 @@ impl VsockHost {
         validate_write_file_chunk_request(request)?;
 
         let _file_write_guard = self.shared.file_write_gate.lock().await;
-        let timeout = Duration::from_secs(300);
+        let timeout = WRITE_FILE_REQUEST_DEADLINE;
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {
                 normal_request_on_shared_with_write_observer_frame_builder(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -76,6 +76,7 @@ mod operation_tracker;
 #[cfg(test)]
 mod tests;
 
+use std::fmt;
 use std::io;
 use std::os::unix::io::RawFd;
 use std::sync::Arc;
@@ -101,6 +102,59 @@ pub use exec_operation::{
 pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
 pub use guest_dns_readiness::GuestDnsReadinessResult;
 pub use guest_storage_manifest::GuestStorageManifestResult;
+
+/// Host-observed stage at which a request deadline expired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestTimeoutStage {
+    /// The request frame had not reached its write boundary.
+    BeforeFrameWrite,
+    /// The request frame write had started and may be partial.
+    FrameWrite,
+    /// The request frame completed but no terminal response arrived.
+    AwaitingTerminalResponse,
+}
+
+impl fmt::Display for RequestTimeoutStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BeforeFrameWrite => f.write_str("before frame write"),
+            Self::FrameWrite => f.write_str("during frame write"),
+            Self::AwaitingTerminalResponse => f.write_str("awaiting terminal response"),
+        }
+    }
+}
+
+/// Typed request deadline error carried inside [`io::ErrorKind::TimedOut`].
+#[derive(Debug)]
+pub struct RequestTimeoutError {
+    stage: RequestTimeoutStage,
+    timeout: Duration,
+}
+
+impl RequestTimeoutError {
+    /// Create a timeout error for an observed request stage and total budget.
+    pub const fn new(stage: RequestTimeoutStage, timeout: Duration) -> Self {
+        Self { stage, timeout }
+    }
+
+    /// Return the request stage observed when the deadline expired.
+    pub const fn stage(&self) -> RequestTimeoutStage {
+        self.stage
+    }
+
+    /// Return the configured end-to-end request timeout.
+    pub const fn timeout(&self) -> Duration {
+        self.timeout
+    }
+}
+
+impl fmt::Display for RequestTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("request timeout")
+    }
+}
+
+impl std::error::Error for RequestTimeoutError {}
 
 /// Observer called when a request frame reaches the guest-write boundary.
 ///

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -114,16 +114,6 @@ pub enum RequestTimeoutStage {
     AwaitingTerminalResponse,
 }
 
-impl fmt::Display for RequestTimeoutStage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::BeforeFrameWrite => f.write_str("before frame write"),
-            Self::FrameWrite => f.write_str("during frame write"),
-            Self::AwaitingTerminalResponse => f.write_str("awaiting terminal response"),
-        }
-    }
-}
-
 /// Typed request deadline error carried inside [`io::ErrorKind::TimedOut`].
 #[derive(Debug)]
 pub struct RequestTimeoutError {

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -23,14 +23,27 @@ use super::support::{
     spawn_write_files,
 };
 use crate::{
-    FrameWriteObserver, WriteFileEntry,
+    FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, WriteFileEntry,
     file::test_support::{WRITE_FILES_BATCH_CONTENT_LIMIT, WRITE_FILES_BATCH_FILE_LIMIT},
     operation_tracker::NormalOperationReadiness,
 };
 
-// Public file APIs intentionally use a fixed 300-second request timeout. Use
+// Public file APIs use the shared production request timeout. Use
 // their shared request seam here so timeout lifecycle coverage remains fast.
 const FRAME_BUILDER_REQUEST_TIMEOUT: Duration = Duration::from_millis(50);
+
+fn assert_request_timeout(
+    error: &io::Error,
+    expected_stage: RequestTimeoutStage,
+    expected_timeout: Duration,
+) {
+    let timeout = error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<RequestTimeoutError>())
+        .unwrap_or_else(|| panic!("expected typed request timeout, got {error:?}"));
+    assert_eq!(timeout.stage(), expected_stage);
+    assert_eq!(timeout.timeout(), expected_timeout);
+}
 
 async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
     std::future::poll_fn(|cx| {
@@ -810,6 +823,7 @@ async fn write_file_frame_builder_request_zero_timeout_does_not_send_frame() {
     .unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(&err, RequestTimeoutStage::BeforeFrameWrite, Duration::ZERO);
     assert_eq!(build_count.load(Ordering::SeqCst), 0);
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     assert_eq!(pending_request_count(&host), 0);
@@ -868,6 +882,11 @@ async fn write_file_frame_builder_request_times_out_waiting_for_builder() {
         .unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::BeforeFrameWrite,
+        FRAME_BUILDER_REQUEST_TIMEOUT,
+    );
     assert_eq!(build_count.load(Ordering::SeqCst), 0);
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     assert_eq!(pending_request_count(&host), 0);
@@ -921,6 +940,11 @@ async fn write_file_frame_builder_request_blocked_write_poisons_connection() {
         .unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::FrameWrite,
+        FRAME_BUILDER_REQUEST_TIMEOUT,
+    );
     assert!(!is_connected(&host));
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
@@ -929,6 +953,53 @@ async fn write_file_frame_builder_request_blocked_write_poisons_connection() {
     );
     assert!(host.shared.writer.try_lock().is_ok());
     assert!(host.shared.frame_builder.try_lock().is_ok());
+}
+
+#[tokio::test]
+async fn write_private_file_missing_terminal_response_uses_shared_deadline_and_fails_closed() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    tokio::time::pause();
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.write_private_file("/tmp/private-input.json", b"payload")
+                .await
+        })
+    };
+
+    let write = expect_write_file(&mut guest).await;
+    assert!(write.private);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    tokio::time::advance(guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE).await;
+    let error = write_task.await.unwrap().unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(
+        &error,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE,
+    );
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let later_error = host
+        .write_file("/tmp/later.txt", b"later", false)
+        .await
+        .unwrap_err();
+    assert_eq!(later_error.kind(), io::ErrorKind::ConnectionReset);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(read) => panic!("timed-out write must not be retried; read {read} bytes"),
+        Err(error) => panic!("unexpected guest read after timeout: {error}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -341,7 +341,7 @@ async fn write_file_chunked_connection_close_while_waiting_for_writer_returns_co
 
 #[tokio::test]
 async fn write_file_chunked_frame_builder_request_times_out_waiting_for_writer() {
-    // The public chunked-write path fixes each request timeout at 300 seconds,
+    // The public chunked-write path uses the shared production request timeout,
     // so exercise its composite request seam with a practical test deadline.
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary

- replace the fixed 300-second file-write wait with a shared 60-second end-to-end budget derived from guest helper, drain, frame-write, and transport allowances
- preserve the observed timeout stage across vsock and sandbox errors, then attach its bounded label to the existing runner private-write telemetry actions
- keep uncertain writes fail-closed: clear the pending route, mark the connection non-parkable, and never retry the request on the same connection

## Evidence boundary

#29224 proves that explicit cancellation now wakes idle guest drain workers, but the destroyed production sandboxes prevent attributing the three historical stalls to the former polling behavior. This PR closes the still-reproducible general case: a complete private-write request whose terminal response never reaches the host router can no longer consume the unexplained five-minute deadline, and its last host-observed stage is retained for diagnosis.

## Scope

- no vsock wire-format or persisted-state changes
- no automatic retry or fresh-sandbox recovery; those require a separate policy decision because the guest may already have applied the write

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p guest-contracts -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p runner --all-features`
- `cargo test -p guest-contracts -p vsock-host -p vsock-guest -p sandbox -p sandbox-fc -p runner --all-targets --all-features`

Closes #29406
