### PR TITLE
fix(social): warn only on invalid provider input

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -313,6 +313,12 @@ function providerHandler(
   return method === "GET" ? http.get(url, response) : http.post(url, response);
 }
 
+function managedSocialKitWarningCalls(): unknown[][] {
+  return context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+    return message === "Managed SocialKit request failed";
+  });
+}
+
 describe("managed SocialKit route", () => {
   it("pins the reviewed 38-tool inventory and typed inputs", () => {
     expect(
@@ -1187,28 +1193,74 @@ describe("managed SocialKit route", () => {
     const pricing = await setupConfiguredPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
+    const invalidInputWarnings = [
+      [
+        "Managed SocialKit request failed",
+        expect.objectContaining({
+          context: "ManagedSocialKit",
+          tool: "youtube_transcript",
+          path: "/youtube/transcript",
+          failureKind: "http_error",
+          httpStatus: 400,
+        }),
+      ],
+    ];
+    const noWarnings: readonly unknown[] = [];
     const cases = [
-      [400, "raw invalid input payload", 400, "SOCIALKIT_INVALID_INPUT"],
-      [401, "raw missing key payload", 502, "SOCIALKIT_AUTH_ERROR"],
-      [403, "Invalid Access key", 502, "SOCIALKIT_AUTH_ERROR"],
+      [
+        400,
+        "raw invalid input payload",
+        400,
+        "SOCIALKIT_INVALID_INPUT",
+        invalidInputWarnings,
+      ],
+      [401, "raw missing key payload", 502, "SOCIALKIT_AUTH_ERROR", noWarnings],
+      [403, "Invalid Access key", 502, "SOCIALKIT_AUTH_ERROR", noWarnings],
       [
         403,
         "Request limit exceeded for this month",
         503,
         "SOCIALKIT_QUOTA_EXHAUSTED",
+        noWarnings,
       ],
-      [403, "unexpected forbidden response", 502, "SOCIALKIT_UPSTREAM_ERROR"],
+      [
+        403,
+        "unexpected forbidden response",
+        502,
+        "SOCIALKIT_UPSTREAM_ERROR",
+        noWarnings,
+      ],
       [
         404,
         "raw missing content payload",
         404,
         "SOCIALKIT_CONTENT_UNAVAILABLE",
+        noWarnings,
       ],
-      [429, "raw rate limit payload", 502, "SOCIALKIT_RATE_LIMITED"],
-      [500, "raw provider failure payload", 502, "SOCIALKIT_UPSTREAM_ERROR"],
+      [
+        429,
+        "raw rate limit payload",
+        502,
+        "SOCIALKIT_RATE_LIMITED",
+        noWarnings,
+      ],
+      [
+        500,
+        "raw provider failure payload",
+        502,
+        "SOCIALKIT_UPSTREAM_ERROR",
+        noWarnings,
+      ],
     ] as const;
 
-    for (const [providerStatus, providerMessage, apiStatus, code] of cases) {
+    for (const [
+      providerStatus,
+      providerMessage,
+      apiStatus,
+      code,
+      expectedWarnings,
+    ] of cases) {
+      context.mocks.axiomLogging.warn.mockClear();
       server.use(
         providerHandler("GET", "/youtube/transcript", () => {
           return HttpResponse.json(
@@ -1225,6 +1277,7 @@ describe("managed SocialKit route", () => {
       expect(response.status).toBe(apiStatus);
       expect(body).toMatchObject({ error: { code } });
       expect(JSON.stringify(body)).not.toContain(providerMessage);
+      expect(managedSocialKitWarningCalls()).toStrictEqual(expectedWarnings);
     }
     await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
@@ -1253,6 +1306,7 @@ describe("managed SocialKit route", () => {
     ];
 
     for (const responseFactory of invalidResponses) {
+      context.mocks.axiomLogging.warn.mockClear();
       server.use(
         providerHandler("GET", "/youtube/transcript", responseFactory),
       );
@@ -1266,6 +1320,7 @@ describe("managed SocialKit route", () => {
       expectApiError(response.body);
       expect(response.body.error.code).toBe("SOCIALKIT_INVALID_RESPONSE");
       expect(JSON.stringify(response.body)).not.toContain("test-socialkit-key");
+      expect(managedSocialKitWarningCalls()).toStrictEqual([]);
     }
     await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
@@ -1301,6 +1356,7 @@ describe("managed SocialKit route", () => {
     ];
 
     for (const responseFactory of responses) {
+      context.mocks.axiomLogging.warn.mockClear();
       server.use(
         providerHandler("GET", "/youtube/transcript", responseFactory),
       );
@@ -1313,6 +1369,7 @@ describe("managed SocialKit route", () => {
       );
       expectApiError(response.body);
       expect(response.body.error.code).toBe("SOCIALKIT_OUTPUT_TOO_LARGE");
+      expect(managedSocialKitWarningCalls()).toStrictEqual([]);
     }
     await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
@@ -1324,6 +1381,7 @@ describe("managed SocialKit route", () => {
     await fundActor(actor);
     const beforeCredits = await credits(actor);
 
+    context.mocks.axiomLogging.warn.mockClear();
     server.use(
       providerHandler("GET", "/youtube/transcript", () => {
         const stream = new ReadableStream<Uint8Array>({
@@ -1343,7 +1401,9 @@ describe("managed SocialKit route", () => {
     );
     expectApiError(timeout.body);
     expect(timeout.body.error.code).toBe("SOCIALKIT_REQUEST_TIMEOUT");
+    expect(managedSocialKitWarningCalls()).toStrictEqual([]);
 
+    context.mocks.axiomLogging.warn.mockClear();
     server.use(
       providerHandler("GET", "/youtube/transcript", () => {
         return HttpResponse.error();
@@ -1358,6 +1418,7 @@ describe("managed SocialKit route", () => {
     );
     expectApiError(network.body);
     expect(network.body.error.code).toBe("SOCIALKIT_UPSTREAM_ERROR");
+    expect(managedSocialKitWarningCalls()).toStrictEqual([]);
     await expect(credits(actor)).resolves.toBe(beforeCredits);
   });
 

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -29,14 +29,6 @@ const SOCIALKIT_TIMEOUT_MS = 240_000;
 const MAX_SOCIALKIT_RESPONSE_BYTES = 4 * 1024 * 1024;
 const L = logger("ManagedSocialKit");
 
-type ProviderFailureKind =
-  | "credential_leak"
-  | "http_error"
-  | "invalid_response"
-  | "network"
-  | "response_too_large"
-  | "timeout";
-
 type ErrorStatus = 400 | 404 | 502 | 503;
 
 interface SocialKitErrorResponse {
@@ -108,19 +100,6 @@ function invalidResponse(): SocialKitErrorResponse {
     "SocialKit returned an invalid response",
     "SOCIALKIT_INVALID_RESPONSE",
   );
-}
-
-function logProviderFailure(
-  tool: ManagedSocialKitTool,
-  failureKind: ProviderFailureKind,
-  httpStatus?: number,
-): void {
-  L.warn("Managed SocialKit request failed", {
-    tool: tool.name,
-    path: tool.path,
-    failureKind,
-    ...(httpStatus === undefined ? {} : { httpStatus }),
-  });
 }
 
 function providerErrorMessage(body: unknown): string | undefined {
@@ -251,7 +230,6 @@ async function fetchSocialKit(
         MAX_SOCIALKIT_RESPONSE_BYTES,
       );
       if (textResult.kind === "too_large") {
-        logProviderFailure(tool, "response_too_large", response.status);
         return errorResult(
           badGateway(
             "SocialKit response is too large",
@@ -276,12 +254,10 @@ async function fetchSocialKit(
       error instanceof Error &&
       (error.name === "AbortError" || error.name === "TimeoutError")
     ) {
-      logProviderFailure(tool, "timeout");
       return errorResult(
         badGateway("SocialKit request timed out", "SOCIALKIT_REQUEST_TIMEOUT"),
       );
     }
-    logProviderFailure(tool, "network");
     return errorResult(
       badGateway("SocialKit request failed", "SOCIALKIT_UPSTREAM_ERROR"),
     );
@@ -290,7 +266,14 @@ async function fetchSocialKit(
     return settled.value;
   }
   if (!settled.value.response.ok) {
-    logProviderFailure(tool, "http_error", settled.value.response.status);
+    if (settled.value.response.status === 400) {
+      L.warn("Managed SocialKit request failed", {
+        tool: tool.name,
+        path: tool.path,
+        failureKind: "http_error",
+        httpStatus: settled.value.response.status,
+      });
+    }
     return errorResult(
       providerHttpError(settled.value.response.status, settled.value.body),
     );
@@ -528,10 +511,6 @@ async function completeSocialKitRequest(
     args.tool,
   );
   if (!parsed.ok) {
-    const failureKind = parsed.credentialLeak
-      ? "credential_leak"
-      : "invalid_response";
-    logProviderFailure(args.tool, failureKind);
     return invalidResponse();
   }
   const creditsCharged = await args.recordUsage(parsed.billingQuantity);

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -297,29 +297,29 @@ function providerResult(
       readonly collection: SocialKitResponse["collection"];
       readonly billingQuantity: number;
     }
-  | { readonly ok: false; readonly credentialLeak: boolean } {
+  | { readonly ok: false } {
   if (
     !isRecord(body) ||
     body.success !== true ||
     !("data" in body) ||
     body.data === undefined
   ) {
-    return { ok: false, credentialLeak: false };
+    return { ok: false };
   }
   const serialized = JSON.stringify(body.data);
   if (serialized === undefined) {
-    return { ok: false, credentialLeak: false };
+    return { ok: false };
   }
   if (serialized.includes(accessKey)) {
-    return { ok: false, credentialLeak: true };
+    return { ok: false };
   }
   const result = tool.resultSchema.safeParse(body.data);
   if (!result.success) {
-    return { ok: false, credentialLeak: false };
+    return { ok: false };
   }
   const collection = validatedCollection(result.data, request, tool);
   if (collection === undefined) {
-    return { ok: false, credentialLeak: false };
+    return { ok: false };
   }
   const billingQuantity = tool.collection?.itemsPerBillingUnit
     ? Math.max(


### PR DESCRIPTION
## Summary

- emit the managed SocialKit warning only when the provider rejects request parameters with HTTP 400
- keep response mapping, billing behavior, and response redaction unchanged
- cover warning policy across provider HTTP failures, malformed or oversized responses, timeouts, and network failures

## Exclusions

- no changes to public API response codes or error payloads
- no changes to usage charging or provider credential handling

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/social.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks: Prettier, repository Knip, repository TypeScript checks, file-size validation, and commitlint

Closes #29417
