### PR TITLE
fix(platform): isolate connector popover row actions

### DIFF
--- a/turbo/apps/platform/src/views/components/loading-switch.tsx
+++ b/turbo/apps/platform/src/views/components/loading-switch.tsx
@@ -19,7 +19,7 @@ export function LoadingSwitch({
   size = "default",
 }: LoadingSwitchProps) {
   return (
-    <div
+    <span
       className={cn(
         "relative shrink-0 flex items-center",
         size === "sm" ? "h-4 w-7" : "h-5 w-9",
@@ -42,6 +42,6 @@ export function LoadingSwitch({
           )}
         />
       )}
-    </div>
+    </span>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -274,6 +274,51 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
+  it("uses permissioned connector content to toggle only access", async () => {
+    const user = userEvent.setup({ delay: null });
+    let authorizationWrites = 0;
+    mockThread();
+    mockConnectors([{ connectorSlug: "axiom", authMethod: "api-token" }]);
+    context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledConnectorSlugs: ["axiom"] });
+    });
+    context.mocks.api(userConnectorsContract.update, ({ body, respond }) => {
+      expect(body).toStrictEqual({
+        enabledConnectorSlugs: ["axiom"],
+        operation: "remove",
+      });
+      authorizationWrites += 1;
+      return respond(200, { enabledConnectorSlugs: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    await user.click(within(composer).getByLabelText("Connectors"));
+    const connectorName = await screen.findByText("Axiom");
+    const accessLabel = connectorName.closest("label");
+    if (!accessLabel?.control) {
+      throw new Error("Expected the Axiom label to target its access switch");
+    }
+    expect(
+      screen.getByLabelText("Configure Axiom permissions").closest("label"),
+    ).toBeNull();
+
+    await user.click(connectorName);
+
+    await waitFor(() => {
+      expect(authorizationWrites).toBe(1);
+    });
+    expect(
+      screen.queryByRole("dialog", { name: /Axiom permissions/u }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps one-account connector rows unchanged", async () => {
     const user = userEvent.setup({ delay: null });
     const account = githubAccount(
@@ -425,6 +470,18 @@ describe("chat composer connector connection", () => {
     const defaultMode = await screen.findByLabelText(
       "GitHub · Using default account: Work",
     );
+    const connectorName = screen.getByText("GitHub");
+    const accessLabel = connectorName.closest("label");
+    if (!accessLabel?.control) {
+      throw new Error("Expected the GitHub label to target its access switch");
+    }
+    expect(defaultMode.closest("label")).toBeNull();
+    await user.click(connectorName);
+    await waitFor(() => {
+      expect(authorizationWrites).toBe(1);
+    });
+    expect(screen.queryByText("Use default")).not.toBeInTheDocument();
+
     const summaryReadsBeforeSelection = summaryReads;
     await user.click(defaultMode);
     await expect(screen.findByText("Use default")).resolves.toBeInTheDocument();
@@ -457,7 +514,7 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(selectionClears).toBe(1);
     });
-    expect(authorizationWrites).toBe(0);
+    expect(authorizationWrites).toBe(1);
     expect(summaryReads).toBe(summaryReadsBeforeSelection);
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -359,6 +359,11 @@ describe("chat composer connector connection", () => {
     await expect(
       screen.findByLabelText("Remove GitHub"),
     ).resolves.toBeInTheDocument();
+    const accessLabel = screen.getByText("GitHub").closest("label");
+    if (!accessLabel?.control) {
+      throw new Error("Expected the GitHub label to target its access switch");
+    }
+    expect(accessLabel.previousElementSibling).toBeNull();
     expect(screen.queryByLabelText(/GitHub ·/u)).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -476,6 +476,10 @@ describe("chat composer connector connection", () => {
       throw new Error("Expected the GitHub label to target its access switch");
     }
     expect(defaultMode.closest("label")).toBeNull();
+    expect(
+      defaultMode.compareDocumentPosition(accessLabel.control) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     await user.click(connectorName);
     await waitFor(() => {
       expect(authorizationWrites).toBe(1);

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -7927,6 +7927,11 @@ function ComposerConnectorAccessRow({
 }) {
   return (
     <div className="flex items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
+      {actions ? (
+        <span className="order-2 flex shrink-0 items-center gap-2">
+          {actions}
+        </span>
+      ) : null}
       <label className="contents">
         <span className="order-1 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center">
           {icon}
@@ -7944,11 +7949,6 @@ function ComposerConnectorAccessRow({
           />
         </span>
       </label>
-      {actions ? (
-        <span className="order-2 flex shrink-0 items-center gap-2">
-          {actions}
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -7908,6 +7908,51 @@ function matchesComposerPopoverConnectorSearch(
     : matchesCustomConnectorSearch(search, item.connector);
 }
 
+function ComposerConnectorAccessRow({
+  icon,
+  connectorLabel,
+  actions,
+  checked,
+  loading,
+  onCheckedChange,
+  ariaLabel,
+}: {
+  readonly icon: ReactNode;
+  readonly connectorLabel: string;
+  readonly actions?: ReactNode;
+  readonly checked: boolean;
+  readonly loading: boolean;
+  readonly onCheckedChange: (checked: boolean) => void;
+  readonly ariaLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
+      <label className="contents">
+        <span className="order-1 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center">
+          {icon}
+        </span>
+        <span className="order-1 min-w-0 flex-1 cursor-pointer truncate text-sm text-foreground">
+          {connectorLabel}
+        </span>
+        <span className="order-3 shrink-0">
+          <LoadingSwitch
+            checked={checked}
+            onCheckedChange={onCheckedChange}
+            loading={loading}
+            ariaLabel={ariaLabel}
+            size="sm"
+          />
+        </span>
+      </label>
+      {actions ? (
+        <span className="order-2 flex shrink-0 items-center gap-2">
+          {actions}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 function ComposerConnectorAccountModeButton({
   connectorLabel,
   selectedConnection,
@@ -7961,9 +8006,7 @@ function ComposerConnectorAccountModeButton({
             explicit ? "text-foreground" : "text-muted-foreground",
           )}
           aria-label={accessibleLabel}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
+          onClick={() => {
             onOpen();
           }}
         >
@@ -8701,110 +8744,26 @@ function ConnectorsPopoverButton({
                           if (item.kind === "custom") {
                             const connector = item.connector;
                             return (
-                              <label
+                              <ComposerConnectorAccessRow
                                 key={connector.id}
-                                className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors"
-                              >
-                                <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                                icon={
                                   <CustomConnectorIcon
                                     id={connector.id}
                                     displayName={connector.displayName}
                                     size={16}
                                   />
-                                </span>
-                                <span className="text-sm flex-1 truncate text-foreground">
-                                  {connector.displayName}
-                                </span>
-                                {accountModeButton(item)}
-                                <LoadingSwitch
-                                  checked={connector.authorized}
-                                  onCheckedChange={onDomEventFn(
-                                    async (checked) => {
-                                      await onToggleCustom(
-                                        connector.id,
-                                        checked,
-                                      );
-                                    },
-                                  )}
-                                  loading={
-                                    savingCustomConnectorId === connector.id
-                                  }
-                                  ariaLabel={
-                                    connector.authorized
-                                      ? t(
-                                          ($) => {
-                                            return $.chat.connectors.remove;
-                                          },
-                                          {
-                                            connectorName:
-                                              connector.displayName,
-                                          },
-                                        )
-                                      : t(
-                                          ($) => {
-                                            return $.chat.connectors.add;
-                                          },
-                                          {
-                                            connectorName:
-                                              connector.displayName,
-                                          },
-                                        )
-                                  }
-                                  size="sm"
-                                />
-                              </label>
-                            );
-                          }
-                          const connector = item.connector;
-                          return (
-                            <label
-                              key={connector.slug}
-                              className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors"
-                            >
-                              <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-                                <ConnectorIcon
-                                  icon={connector.icon}
-                                  size={16}
-                                />
-                              </span>
-                              <span className="text-sm flex-1 truncate text-foreground">
-                                {connector.label}
-                              </span>
-                              {agentId &&
-                                connector.authorized &&
-                                connector.permissionSummary.hasPermissions && (
-                                  <Button
-                                    type="button"
-                                    onClick={(event) => {
-                                      event.preventDefault();
-                                      event.stopPropagation();
-                                      updateConnectorUi({
-                                        permissionConnectorSlug: connector.slug,
-                                      });
-                                    }}
-                                    aria-label={t(
-                                      ($) => {
-                                        return $.chat.connectors
-                                          .configurePermissions;
-                                      },
-                                      { connectorName: connector.label },
-                                    )}
-                                    variant="quiet"
-                                    size="icon-2xs"
-                                    className="shrink-0"
-                                  >
-                                    <SlidersHorizontal size={15} />
-                                  </Button>
-                                )}
-                              {accountModeButton(item)}
-                              <LoadingSwitch
+                                }
+                                connectorLabel={connector.displayName}
+                                actions={accountModeButton(item)}
                                 checked={connector.authorized}
                                 onCheckedChange={onDomEventFn(
                                   async (checked) => {
-                                    await onToggle(connector.slug, checked);
+                                    await onToggleCustom(connector.id, checked);
                                   },
                                 )}
-                                loading={savingConnectorSlug === connector.slug}
+                                loading={
+                                  savingCustomConnectorId === connector.id
+                                }
                                 ariaLabel={
                                   connector.authorized
                                     ? t(
@@ -8812,7 +8771,7 @@ function ConnectorsPopoverButton({
                                           return $.chat.connectors.remove;
                                         },
                                         {
-                                          connectorName: connector.label,
+                                          connectorName: connector.displayName,
                                         },
                                       )
                                     : t(
@@ -8820,13 +8779,80 @@ function ConnectorsPopoverButton({
                                           return $.chat.connectors.add;
                                         },
                                         {
-                                          connectorName: connector.label,
+                                          connectorName: connector.displayName,
                                         },
                                       )
                                 }
-                                size="sm"
                               />
-                            </label>
+                            );
+                          }
+                          const connector = item.connector;
+                          return (
+                            <ComposerConnectorAccessRow
+                              key={connector.slug}
+                              icon={
+                                <ConnectorIcon
+                                  icon={connector.icon}
+                                  size={16}
+                                />
+                              }
+                              connectorLabel={connector.label}
+                              actions={
+                                <>
+                                  {agentId &&
+                                    connector.authorized &&
+                                    connector.permissionSummary
+                                      .hasPermissions && (
+                                      <Button
+                                        type="button"
+                                        onClick={() => {
+                                          updateConnectorUi({
+                                            permissionConnectorSlug:
+                                              connector.slug,
+                                          });
+                                        }}
+                                        aria-label={t(
+                                          ($) => {
+                                            return $.chat.connectors
+                                              .configurePermissions;
+                                          },
+                                          { connectorName: connector.label },
+                                        )}
+                                        variant="quiet"
+                                        size="icon-2xs"
+                                        className="shrink-0"
+                                      >
+                                        <SlidersHorizontal size={15} />
+                                      </Button>
+                                    )}
+                                  {accountModeButton(item)}
+                                </>
+                              }
+                              checked={connector.authorized}
+                              onCheckedChange={onDomEventFn(async (checked) => {
+                                await onToggle(connector.slug, checked);
+                              })}
+                              loading={savingConnectorSlug === connector.slug}
+                              ariaLabel={
+                                connector.authorized
+                                  ? t(
+                                      ($) => {
+                                        return $.chat.connectors.remove;
+                                      },
+                                      {
+                                        connectorName: connector.label,
+                                      },
+                                    )
+                                  : t(
+                                      ($) => {
+                                        return $.chat.connectors.add;
+                                      },
+                                      {
+                                        connectorName: connector.label,
+                                      },
+                                    )
+                              }
+                            />
                           );
                         })}
                       </div>

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8787,6 +8787,11 @@ function ConnectorsPopoverButton({
                             );
                           }
                           const connector = item.connector;
+                          const accountAction = accountModeButton(item);
+                          const showPermissionAction =
+                            Boolean(agentId) &&
+                            connector.authorized &&
+                            connector.permissionSummary.hasPermissions;
                           return (
                             <ComposerConnectorAccessRow
                               key={connector.slug}
@@ -8798,11 +8803,9 @@ function ConnectorsPopoverButton({
                               }
                               connectorLabel={connector.label}
                               actions={
-                                <>
-                                  {agentId &&
-                                    connector.authorized &&
-                                    connector.permissionSummary
-                                      .hasPermissions && (
+                                showPermissionAction || accountAction ? (
+                                  <>
+                                    {showPermissionAction ? (
                                       <Button
                                         type="button"
                                         onClick={() => {
@@ -8824,9 +8827,10 @@ function ConnectorsPopoverButton({
                                       >
                                         <SlidersHorizontal size={15} />
                                       </Button>
-                                    )}
-                                  {accountModeButton(item)}
-                                </>
+                                    ) : null}
+                                    {accountAction}
+                                  </>
+                                ) : null
                               }
                               checked={connector.authorized}
                               onCheckedChange={onDomEventFn(async (checked) => {


### PR DESCRIPTION
## Summary

- separate connector access labels from permission and account action buttons
- reuse one access-row structure for built-in and custom connectors while preserving the existing one-line layout
- add page-level regressions for permission-bearing and multi-account connector rows

## Scope

- Platform UI only
- no API, database, runner, persistence, or rollout changes

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx` (17 passed)
- `pnpm knip --workspace @okouai/app`
- pre-commit full Turbo type check, Knip, formatting, and file-size checks

Closes #29424
