### PR TITLE
perf(api): scope connector runtime refresh catalog loads

### DIFF
--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -571,10 +571,20 @@ impl ConnectorRuntimeSyncCore {
                     return false;
                 }
                 transport_retry_attempted = true;
+                let request = &error.request;
                 warn!(
                     run_id = %run_id,
                     targets = ?target_identities(&active_targets),
                     error = %error,
+                    endpoint = request.endpoint_label,
+                    method = %request.method,
+                    host = %request.host,
+                    path = %request.path,
+                    client_request_id = %request.client_request_id,
+                    client_session_id = %request.client_session_id,
+                    client_version = %request.client_version,
+                    failure_kind = error.failure_kind.as_str(),
+                    error_summary = %error.summary,
                     attempt = 1,
                     max_attempts = 2,
                     will_retry = true,
@@ -593,13 +603,33 @@ impl ConnectorRuntimeSyncCore {
                 return false;
             }
             Err(error) => {
-                warn!(
-                    run_id = %run_id,
-                    targets = ?target_identities(&active_targets),
-                    error = %error,
-                    transport_retry_attempted,
-                    "connector runtime sync failed; retaining last-known-good state"
-                );
+                if let RunnerError::ApiTransport(api_error) = &error {
+                    let request = &api_error.request;
+                    warn!(
+                        run_id = %run_id,
+                        targets = ?target_identities(&active_targets),
+                        error = %error,
+                        endpoint = request.endpoint_label,
+                        method = %request.method,
+                        host = %request.host,
+                        path = %request.path,
+                        client_request_id = %request.client_request_id,
+                        client_session_id = %request.client_session_id,
+                        client_version = %request.client_version,
+                        failure_kind = api_error.failure_kind.as_str(),
+                        error_summary = %api_error.summary,
+                        transport_retry_attempted,
+                        "connector runtime sync failed; retaining last-known-good state"
+                    );
+                } else {
+                    warn!(
+                        run_id = %run_id,
+                        targets = ?target_identities(&active_targets),
+                        error = %error,
+                        transport_retry_attempted,
+                        "connector runtime sync failed; retaining last-known-good state"
+                    );
+                }
                 self.schedule_sync_retries_for_registration(
                     run_id,
                     &active_targets,
@@ -2266,6 +2296,54 @@ mod tests {
             .get(field)
             .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
         assert_eq!(actual, expected, "event={event:#?}");
+    }
+
+    fn assert_connector_transport_fields(event: &CapturedEvent, api_url: &str, run_id: RunId) {
+        assert_connector_field(event, "endpoint", "connector runtime sync");
+        assert_connector_field(event, "method", "POST");
+        assert_connector_field(
+            event,
+            "path",
+            &format!("/api/runners/runs/{run_id}/connector-runtime/sync"),
+        );
+        assert_connector_field(event, "client_session_id", "runner-session-test");
+        assert_connector_field(event, "client_version", env!("CARGO_PKG_VERSION"));
+        let host = event
+            .fields
+            .get("host")
+            .unwrap_or_else(|| panic!("missing field host; event={event:#?}"));
+        assert!(
+            host.starts_with("127.0.0.1:"),
+            "host should include only host and port; event={event:#?}"
+        );
+        let failure_kind = event
+            .fields
+            .get("failure_kind")
+            .unwrap_or_else(|| panic!("missing field failure_kind; event={event:#?}"));
+        assert!(
+            ["timeout", "connect", "request", "body", "unknown"].contains(&failure_kind.as_str()),
+            "unexpected failure kind; event={event:#?}"
+        );
+        let error_summary = event
+            .fields
+            .get("error_summary")
+            .unwrap_or_else(|| panic!("missing field error_summary; event={event:#?}"));
+        assert!(!error_summary.is_empty(), "event={event:#?}");
+        let client_request_id = event
+            .fields
+            .get("client_request_id")
+            .unwrap_or_else(|| panic!("missing field client_request_id; event={event:#?}"));
+        uuid::Uuid::parse_str(client_request_id).expect("client_request_id should be a UUID");
+
+        let event_debug = format!("{event:#?}");
+        assert!(
+            !event_debug.contains(api_url),
+            "event should not include full URL: {event_debug}"
+        );
+        assert!(
+            !event_debug.contains("runner-token") && !event_debug.contains(r#"\"connectorSlug\""#),
+            "event should not include bearer token or request body: {event_debug}"
+        );
     }
 
     fn active_run_connector_runtime_state(
@@ -5171,7 +5249,7 @@ mod tests {
         let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
         let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
+            api_client_for_url(api_url.clone()),
             run_id,
             &["slack"],
         )
@@ -5258,6 +5336,7 @@ mod tests {
         assert_connector_field(retry, "attempt", "1");
         assert_connector_field(retry, "max_attempts", "2");
         assert_connector_field(retry, "will_retry", "true");
+        assert_connector_transport_fields(retry, &api_url, run_id);
         for message in [
             "connector runtime sync failed; retaining last-known-good state",
             "retained last-known-good connector runtime state; scheduled sync retry",
@@ -5289,8 +5368,9 @@ mod tests {
             RawHttpAction::Respond(json_response("200 OK", &response_body)),
         ])
         .await;
+        let api_url = server.url();
         let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(server.url()),
+            api_client_for_url(api_url.clone()),
             run_id,
             &["slack"],
         )
@@ -5325,6 +5405,7 @@ mod tests {
             "connector runtime sync failed; retaining last-known-good state",
         );
         assert_connector_field(failure, "transport_retry_attempted", "true");
+        assert_connector_transport_fields(failure, &api_url, run_id);
         assert_connector_field(
             captured_event(
                 &events,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -60,12 +60,14 @@ import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
   clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements,
+  corruptApiTestConnectorCatalogActiveSnapshotPayload,
   corruptApiTestConnectorCatalogRuntimeProjectionDigest,
   corruptApiTestConnectorCatalogRuntimeProjectionPayload,
   deleteApiTestConnectorCatalogCompatibility,
   deleteApiTestConnectorCatalogRuntimeProjectionRow,
   expireApiTestConnectorCatalogRuntimeProjectionAuthority,
   installApiTestConnectorCatalog,
+  mockApiTestConnectorProviderConfiguration,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogFilteredAuthMethods,
@@ -9133,6 +9135,78 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       { targets: [larkTarget] },
     );
     expect(exactRuntimeWithSibling).toMatchObject({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "available",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("uses exact runtime projections and authoritative fallback for builtin sync", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    const connected = await connectors.connectManualGrant(
+      actor,
+      "lark",
+      "api-token",
+      {
+        appId: "lark-projection-app-id",
+        appSecret: "lark-projection-app-secret",
+      },
+    );
+    await api.enableAgentConnectors(actor, agentId, ["lark"]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "refresh lark through exact runtime projections",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const larkTarget = claim.connectorRuntimeTargets.find((target) => {
+      return target.kind === "builtin" && target.connectorSlug === "lark";
+    });
+    if (!larkTarget || larkTarget.kind !== "builtin") {
+      throw new Error("Expected the lark runtime target");
+    }
+    expect(larkTarget.sourceId).toBe(connected.id);
+
+    onTestFinished(async () => {
+      mockApiTestConnectorProviderConfiguration();
+      await installApiTestConnectorCatalog();
+    });
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-runtime-sync-projection-${randomUUID()}`,
+      runtimeProjection: true,
+    });
+    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("slack");
+    await corruptApiTestConnectorCatalogActiveSnapshotPayload();
+
+    const [projectedRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [larkTarget],
+    });
+    expect(projectedRuntime).toMatchObject({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "available",
+    });
+
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-runtime-sync-fallback-${randomUUID()}`,
+      runtimeProjection: true,
+    });
+    await corruptApiTestConnectorCatalogRuntimeProjectionDigest("lark");
+
+    const [fallbackRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [larkTarget],
+    });
+    expect(fallbackRuntime).toMatchObject({
       target: { kind: "builtin", connectorSlug: "lark" },
       state: "available",
     });

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -1,10 +1,11 @@
 import { performance } from "node:perf_hooks";
 
 import { now } from "../../lib/time";
-import type {
-  ApiDispatchTimingActionType,
-  ApiDispatchTimingCollector,
-  ApiDispatchTimingDimensions,
+import {
+  measureApiDispatchTiming,
+  type ApiDispatchTimingActionType,
+  type ApiDispatchTimingCollector,
+  type ApiDispatchTimingDimensions,
 } from "./api-dispatch-timing.service";
 import type {
   ConnectorCatalogRuntimeProjectionFallbackReason,
@@ -201,7 +202,7 @@ export class ConnectorCatalogLoadTiming {
   private materializedConnectorCount: number | undefined;
 
   constructor(
-    private readonly collector: ApiDispatchTimingCollector,
+    private readonly collector: ApiDispatchTimingCollector | undefined,
     private readonly requestedConnectorCount: number | undefined,
     private readonly metadataConnectorCount: number | undefined = undefined,
   ) {}
@@ -264,19 +265,38 @@ export class ConnectorCatalogLoadTiming {
     actionType: ApiDispatchTimingActionType,
     operation: () => T | Promise<T>,
   ): Promise<T> {
-    return await this.collector.measure(actionType, "nested", operation);
+    return await measureApiDispatchTiming(
+      this.collector,
+      actionType,
+      "nested",
+      operation,
+    );
   }
 
   measureSync<T>(
     actionType: ApiDispatchTimingActionType,
     operation: () => T,
   ): T {
+    if (!this.collector) {
+      return operation();
+    }
     return this.collector.measureSync(actionType, "nested", operation);
   }
 
   measureProjectionRowValidation<T>(
     operation: (timing: ConnectorCatalogRuntimeProjectionValidationTiming) => T,
   ): T {
+    const collector = this.collector;
+    if (!collector) {
+      return operation({
+        measureParse<T>(phaseOperation: () => T): T {
+          return phaseOperation();
+        },
+        measureDigest<T>(phaseOperation: () => T): T {
+          return phaseOperation();
+        },
+      });
+    }
     let parseDurationMs = 0;
     let digestDurationMs = 0;
     const measurePhase = <T>(
@@ -313,13 +333,13 @@ export class ConnectorCatalogLoadTiming {
         // Validation short-circuits per requested connector. Accumulate its
         // interleaved phases instead of reordering work or logging per row.
         const finishedAt = now();
-        this.collector.recordDuration(
+        collector.recordDuration(
           "api_dispatch_connector_catalog_parse_projection_rows",
           "nested",
           parseDurationMs,
           finishedAt,
         );
-        this.collector.recordDuration(
+        collector.recordDuration(
           "api_dispatch_connector_catalog_verify_projection_row_digests",
           "nested",
           digestDurationMs,
@@ -334,7 +354,8 @@ export class ConnectorCatalogLoadTiming {
   }
 
   async measureComplete<T>(operation: () => T | Promise<T>): Promise<T> {
-    return await this.collector.measure(
+    return await measureApiDispatchTiming(
+      this.collector,
       "api_dispatch_connector_catalog_load_runtime_snapshot",
       "nested",
       operation,

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -1067,7 +1067,7 @@ function clearRuntimeSelectionInFlight(
 export async function loadConnectorRuntimeSelection(
   db: ReadonlyDb,
   options: {
-    readonly timing: ApiDispatchTimingCollector;
+    readonly timing?: ApiDispatchTimingCollector;
     readonly requestedConnectorSlugs: readonly ConnectorSlug[];
     readonly metadataConnectorSlugs?: readonly ConnectorSlug[];
   },

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -18,7 +18,10 @@ import {
   loadEffectiveCustomConnectorPermissionBundle,
   type CustomConnectorRuntimeDataRows,
 } from "./agent-run-create.service";
-import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import {
+  loadConnectorRuntimeSelection,
+  loadConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveActiveNetworkPolicyRefreshes } from "./user-permission-grants.service";
 import { loadCustomConnectorRuntimeData } from "./custom-connector.service";
@@ -276,9 +279,11 @@ export async function resolveConnectorRuntimeTargets(args: {
   const customRegistrations = args.targets.flatMap((target) => {
     return target.kind === "custom" ? [target] : [];
   });
-  const builtinCatalogSnapshot =
+  const builtinCatalogSelection =
     builtinConnectorSlugs.length > 0
-      ? await loadConnectorRuntimeSnapshot(args.db)
+      ? await loadConnectorRuntimeSelection(args.db, {
+          requestedConnectorSlugs: builtinConnectorSlugs,
+        })
       : undefined;
   const [builtinRefreshes, builtinAccountResolutions, customSnapshot] =
     await Promise.all([
@@ -286,7 +291,7 @@ export async function resolveConnectorRuntimeTargets(args: {
         args.db,
         args.scope,
         builtinConnectorSlugs,
-        builtinCatalogSnapshot,
+        builtinCatalogSelection,
       ),
       resolveConnectorAccounts(args.db, {
         orgId: args.scope.orgId,
@@ -348,9 +353,9 @@ export async function resolveConnectorRuntimeTargets(args: {
       connectorAccountTargetKey(target),
     );
     const credentialAccess =
-      accountResolution?.kind === "resolved" && builtinCatalogSnapshot
+      accountResolution?.kind === "resolved" && builtinCatalogSelection
         ? resolveConnectorCredentialAccess({
-            snapshot: builtinCatalogSnapshot,
+            snapshot: builtinCatalogSelection,
             stored: {
               authMethodId: accountResolution.account.authMethod,
               connectorId: accountResolution.account.connectorId,

--- a/turbo/apps/api/src/signals/services/user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/user-permission-grants.service.ts
@@ -34,9 +34,12 @@ import {
 } from "./firewall-network-policy.service";
 import {
   loadConnectorRuntimeSnapshot,
-  type ConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSelection,
 } from "./connector-catalog-runtime.service";
-import type { ConnectorServerFirewallCatalog } from "./connector-server-firewall-catalog.service";
+import type {
+  ConnectorServerFirewallCatalog,
+  ConnectorServerFirewallMetadataCatalog,
+} from "./connector-server-firewall-catalog.service";
 import { connectorCatalogSource } from "./connector-catalog-source";
 import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
 import { SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION } from "./connector-catalog-artifacts/artifacts";
@@ -280,7 +283,7 @@ function resolvedConnectorFirewallPolicies(
 }
 
 export function networkPolicyRefreshConnectorSlugs(
-  catalog: ConnectorServerFirewallCatalog,
+  catalog: ConnectorServerFirewallMetadataCatalog,
   connectorSlugs: readonly string[],
 ): string[] {
   return [
@@ -296,7 +299,7 @@ export async function resolveActiveNetworkPolicyRefreshes(
   db: ReadonlyDb,
   scope: UserPermissionGrantScope,
   connectorSlugs: readonly string[],
-  preloadedSnapshot?: ConnectorRuntimeSnapshot,
+  preloadedSnapshot?: ConnectorRuntimeSelection,
   checkedAt: Date = nowDate(),
 ): Promise<readonly ActiveNetworkPolicyRefresh[]> {
   if (connectorSlugs.length === 0) {

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -494,6 +494,33 @@ export async function replaceApiTestConnectorCatalogStoredBytes(args: {
   });
 }
 
+export async function corruptApiTestConnectorCatalogActiveSnapshotPayload(): Promise<void> {
+  const identity = await currentApiTestConnectorCatalogIdentity();
+  const db = store.set(writeDb$);
+  const updated = await db
+    .update(connectorCatalogActiveSnapshot)
+    .set({ catalogGzip: Buffer.from("invalid-gzip", "utf8") })
+    .where(
+      and(
+        eq(connectorCatalogActiveSnapshot.sourceId, identity.sourceId),
+        eq(
+          connectorCatalogActiveSnapshot.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(
+          connectorCatalogActiveSnapshot.catalogVersion,
+          identity.catalogVersion,
+        ),
+        eq(
+          connectorCatalogActiveSnapshot.catalogDigest,
+          identity.catalogDigest,
+        ),
+      ),
+    )
+    .returning({ sourceId: connectorCatalogActiveSnapshot.sourceId });
+  requireSingleCatalogMutation(updated, "active snapshot payload corruption");
+}
+
 export async function invalidateApiTestConnectorCatalogCompatibility(): Promise<void> {
   const identity = await currentApiTestConnectorCatalogIdentity();
   const db = store.set(writeDb$);


### PR DESCRIPTION
## Summary

- load only the requested built-in connector runtime projections during runner refreshes instead of materializing the full connector catalog
- preserve authoritative full-catalog fallback when a requested projection is unavailable or invalid, while leaving custom connector snapshot loading unchanged
- add sanitized Runner transport diagnostics for immediate and scheduled connector-runtime sync failures
- cover exact projection isolation, full fallback, and diagnostic redaction

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (174 passed)
- `cargo fmt --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --bin runner provider::connector_runtime_sync::tests::` (49 passed)

## Deployment compatibility

No API contract, queue payload, persisted schema, timeout, or retry-policy changes. Old and new API/Runner versions remain wire-compatible during independent rollout.

Closes #29428
