### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.143.0"
+version = "1.144.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ade5433c9561daac7c0c6bc910f1240b4f8ec0d6148b0b463aac0691d747c9"
+checksum = "30dc8bf6baaf7d46336a0ca2c69f223d9b90d7a801fb3e28f7ea17b00dc6b1de"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -843,9 +843,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -1455,20 +1455,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -1845,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -1979,11 +1973,11 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update `aws-sdk-s3` from 1.143.0 to 1.144.0
- update `combine` from 4.6.7 to 4.6.8
- update `lru` from 0.16.4 to 0.18.2
- consolidate `hashbrown` on 0.17.1 by removing the older 0.16.1 lockfile entry
- keep Cargo manifests unchanged; no dependency constraints were adjusted manually

## Blocked dependencies

- `generic-array` remains at 0.14.7 (`0.14.9` is available) because `crypto-common` 0.1.7 requires exactly `generic-array = 0.14.7` through `digest` 0.10.7 -> `crc-fast` 1.10.0 -> `aws-smithy-checksums` 0.65.0 -> `aws-sdk-s3` 1.144.0 -> `runner` 0.173.8

## Validation

- `cargo test --workspace --exclude runner --no-fail-fast` (passed, including doctests)
- `cargo check -p runner` (passed against the latest `main`)
- `cargo check -p runner --tests` (passed against the latest `main`)
- `cargo test -p runner --no-fail-fast` compiled the updated dependencies, including `aws-sdk-s3` 1.144.0 and `lru` 0.18.2, but the memory cgroup killed `rustc` during full runner test-target code generation at approximately 3.74 GB RSS (exit 137; this host has 3.8 GB RAM and no swap)
- final `cargo update --verbose` resolved zero additional packages
