### PR TITLE
fix(connectors): persist custom oauth granted scopes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2445,6 +2445,83 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await bdd.deleteAgent(member, agent.agentId);
   });
 
+  it.each([
+    {
+      name: "reported subset",
+      tokenScope: "read",
+      expectedScopes: ["read"],
+    },
+    {
+      name: "reported supplemental grant",
+      tokenScope: "read write admin",
+      expectedScopes: ["read", "write", "admin"],
+    },
+    {
+      name: "omitted token scope",
+      tokenScope: undefined,
+      expectedScopes: ["read", "write"],
+    },
+  ] as const)(
+    "persists the $name for a standard custom OAuth connection",
+    async ({ tokenScope, expectedScopes }) => {
+      mockEnv("APP_URL", "https://app.vm0.test");
+      const provider =
+        tokenScope === undefined
+          ? mockCustomConnectorOAuth2Provider(context)
+          : mockCustomConnectorOAuth2Provider(context, {
+              initialScope: tokenScope,
+            });
+      const admin = createBddApi(context).user({ orgRole: "org:admin" });
+      await connectorsApi.updateFeatureSwitches(admin, {
+        [FeatureSwitchKey.ConnectorAccounts]: true,
+      });
+      const connector = await connectorsApi.createCustomConnector(admin, {
+        displayName: `BDD OAuth Scope ${randomUUID()}`,
+        prefixTemplates: [
+          `https://${randomUUID()}.oauth-scope.example.test/v1/`,
+        ],
+        fields: [],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{oauth.access_token}}",
+          },
+        ],
+        queryInjections: [],
+        authMode: "oauth",
+        oauthConfig: {
+          providerAdapter: "standard",
+          clientId: "oauth-scope-client-id",
+          clientSecret: "oauth-scope-client-secret",
+          authorizationUrl: provider.authorizationUrl,
+          tokenUrl: provider.tokenUrl,
+          tokenEndpointAuthMethod: "client_secret_post",
+          pkceMethod: "none",
+          scopes: ["read", "write"],
+          authorizationParams: {},
+        },
+      });
+
+      const authorizationUrl = await connectorsApi.startCustomConnectorOAuth2(
+        admin,
+        connector.id,
+      );
+      await connectorsApi.completeCustomConnectorOAuth2Callback({
+        code: "oauth-scope-authorization-code",
+        state: stateFromAuthorizationUrl(authorizationUrl),
+      });
+
+      const accounts = await connectorsApi.listCustomConnectorAccounts(
+        admin,
+        connector.id,
+      );
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]?.oauthScopes).toStrictEqual(expectedScopes);
+
+      await connectorsApi.deleteCustomConnector(admin, connector.id);
+    },
+  );
+
   it("removes OAuth tokens when manual credentials replace the connection", async () => {
     mockEnv("APP_URL", "https://app.vm0.test");
     const provider = mockCustomConnectorOAuth2Provider(context, {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -17,6 +17,7 @@ import type {
 } from "@okouai/api-contracts/contracts/connector-identity";
 import {
   connectorAccountsContract,
+  type ConnectorAccountConnection,
   type ConnectorAccountMutationIntent,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import { connectorsSlugCallbackContract } from "@okouai/api-contracts/contracts/connectors-slug-callback";
@@ -216,6 +217,7 @@ interface CustomConnectorOAuth2ProviderRecorder {
 interface CustomConnectorOAuth2ProviderOptions {
   readonly initialExpiresIn?: number;
   readonly initialRefreshToken?: string | null;
+  readonly initialScope?: string;
   readonly refreshResponse?: (attempt: number) => Response | Promise<Response>;
 }
 
@@ -257,6 +259,9 @@ export function mockCustomConnectorOAuth2Provider(
         id_token: "custom-oauth-id-token",
         token_type: "Bearer",
         expires_in: options.initialExpiresIn ?? 0,
+        ...(options.initialScope === undefined
+          ? {}
+          : { scope: options.initialScope }),
       });
     }),
   );
@@ -1477,6 +1482,27 @@ export function createConnectorBddApi(context: TestContext) {
         }),
         statuses,
       );
+    },
+
+    async listCustomConnectorAccounts(
+      actor: ApiTestUser,
+      connectorId: string,
+    ): Promise<readonly ConnectorAccountConnection[]> {
+      const client = setupApp({ context, routes: connectorAccountRoutes })(
+        connectorAccountsContract,
+      );
+      const response = await accept(
+        client.connections({
+          headers: authenticate(actor),
+          query: {
+            kind: "custom",
+            customConnectorId: connectorId,
+            limit: 100,
+          },
+        }),
+        [200],
+      );
+      return response.body.connections;
     },
 
     async requestScopeDiff(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11274,6 +11274,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
               : "custom-oauth-force-rotated-refresh-token",
           token_type: "Bearer",
           expires_in: 3600,
+          ...(attempt === 1 ? { scope: "read refreshed" } : {}),
         });
       },
     });
@@ -11281,6 +11282,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
 
     const custom = await connectors.createCustomConnector(actor, {
       displayName: "BDD OAuth 2.0 Runtime API",
@@ -11468,6 +11472,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       connected: true,
       missingRequiredFields: [],
     });
+    await expect(
+      connectors.listCustomConnectorAccounts(actor, custom.id),
+    ).resolves.toMatchObject([{ oauthScopes: ["read", "refreshed"] }]);
 
     const currentResolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -11539,6 +11546,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectedBasicAuthorization,
       expectedBasicAuthorization,
     ]);
+    await expect(
+      connectors.listCustomConnectorAccounts(actor, custom.id),
+    ).resolves.toMatchObject([{ oauthScopes: ["read", "refreshed"] }]);
 
     const failedRefresh = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },

--- a/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
@@ -18,6 +18,7 @@ import {
 } from "../services/connector-oauth-state.service";
 import { validateConnectorAuthorizationTarget$ } from "../services/connected-connector-authorization.service";
 import {
+  customConnectorOAuth2EffectiveInitialToken as effectiveInitialToken,
   customConnectorOAuthStateMatchesDefinition,
   decryptCustomConnectorOAuth2Credentials,
   exchangeCustomConnectorOAuth2Code,
@@ -374,7 +375,7 @@ const completeOAuth2Callback$ = command(
             userId: claimed.state.userId,
             connectorId: connector.id,
             storageVersion: connector.storageVersion,
-            token,
+            token: effectiveInitialToken(token, claimed.state.authorizationUrl),
             featureContext,
             account: claimed.state.accountMutation,
             insertConnectionId:

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -44,6 +44,7 @@ type ConnectorConnectionTarget =
   | {
       readonly kind: "custom";
       readonly customConnectorId: string;
+      readonly oauthScopes: readonly string[] | null;
     };
 
 interface ConnectorCredentialWriteContext {
@@ -266,19 +267,29 @@ export async function writeConnectorConnectionMetadata(
   },
 ): Promise<StoredConnectorConnectionRow> {
   const identityValues =
-    args.target.kind === "builtin" && args.target.identity.kind === "external"
+    args.target.kind === "custom"
       ? {
-          externalId: args.target.identity.externalId,
-          externalUsername: args.target.identity.externalUsername,
-          externalEmail: args.target.identity.externalEmail,
-          oauthScopes: JSON.stringify(args.target.identity.oauthScopes),
-        }
-      : {
           externalId: null,
           externalUsername: null,
           externalEmail: null,
-          oauthScopes: null,
-        };
+          oauthScopes:
+            args.target.oauthScopes === null
+              ? null
+              : JSON.stringify(args.target.oauthScopes),
+        }
+      : args.target.identity.kind === "external"
+        ? {
+            externalId: args.target.identity.externalId,
+            externalUsername: args.target.identity.externalUsername,
+            externalEmail: args.target.identity.externalEmail,
+            oauthScopes: JSON.stringify(args.target.identity.oauthScopes),
+          }
+        : {
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            oauthScopes: null,
+          };
   const targetValues =
     args.target.kind === "builtin"
       ? {

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -97,6 +97,7 @@ const oauthTokenResponseSchema = z.object({
   id_token: z.string().min(1).nullable().optional(),
   token_type: z.string().min(1).optional(),
   expires_in: z.union([z.number(), z.string()]).optional(),
+  scope: z.string().trim().min(1).optional(),
 });
 
 const oauthTokenErrorResponseSchema = z.object({
@@ -109,6 +110,7 @@ export interface OAuthTokenResult {
   readonly refreshToken: string | null;
   readonly idToken: string | null;
   readonly expiresAt: Date | null;
+  readonly scopes: readonly string[] | null;
 }
 
 interface OAuthClientCredentials {
@@ -262,6 +264,32 @@ function hasHttpHeaderControlCharacter(value: string): boolean {
   return false;
 }
 
+function oauthScopeTokens(scope: string): readonly string[] {
+  return scope.split(/\s+/u);
+}
+
+function customConnectorOAuth2AuthorizationScopes(
+  authorizationUrl: string | null,
+): readonly string[] {
+  if (!authorizationUrl) {
+    throw new Error("Custom connector OAuth state has no authorization URL");
+  }
+  const scope = new URL(authorizationUrl).searchParams.get("scope");
+  return scope ? oauthScopeTokens(scope) : [];
+}
+
+export function customConnectorOAuth2EffectiveInitialToken(
+  token: OAuthTokenResult,
+  authorizationUrl: string | null,
+): OAuthTokenResult {
+  return token.scopes === null
+    ? {
+        ...token,
+        scopes: customConnectorOAuth2AuthorizationScopes(authorizationUrl),
+      }
+    : token;
+}
+
 function tokenResult(response: PublicHttpsResponse): OAuthTokenResult {
   if (response.status < 200 || response.status >= 300) {
     const parsed = oauthTokenErrorResponseSchema.safeParse(
@@ -292,6 +320,10 @@ function tokenResult(response: PublicHttpsResponse): OAuthTokenResult {
       expiresIn === null
         ? null
         : new Date(nowDate().getTime() + expiresIn * 1000),
+    scopes:
+      parsed.data.scope === undefined
+        ? null
+        : oauthScopeTokens(parsed.data.scope),
   };
 }
 
@@ -346,6 +378,7 @@ function feishuOAuthTokenResult(token: {
     refreshToken: token.refreshToken,
     idToken: null,
     expiresAt: new Date(nowDate().getTime() + token.expiresInSeconds * 1000),
+    scopes: null,
   };
 }
 
@@ -761,6 +794,9 @@ async function replaceConnectionTokens(args: {
       tokenExpiresAt: args.token.expiresAt,
       needsReconnect: false,
       reconnectReason: null,
+      ...(args.token.scopes === null
+        ? {}
+        : { oauthScopes: JSON.stringify(args.token.scopes) }),
       updatedAt: nowDate(),
     })
     .where(
@@ -876,6 +912,7 @@ export async function storeCustomConnectorOAuth2Connection(
         target: {
           kind: "custom",
           customConnectorId: args.connectorId,
+          oauthScopes: args.token.scopes,
         },
         resolution: resolution.mutation,
         insertConnectionId: args.insertConnectionId,

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -2823,6 +2823,7 @@ async function persistCustomConnectorValues(
     target: {
       kind: "custom",
       customConnectorId: args.request.connectorId,
+      oauthScopes: null,
     },
   };
   let connectedAccountId: string;


### PR DESCRIPTION
## Summary

- parse the optional OAuth token response `scope` field for standard custom connectors
- persist the effective granted scopes from the initial exchange and reported refresh responses
- preserve the previous effective grant when a refresh response omits `scope`
- cover reported subsets, supplemental grants, initial omission, refresh replacement, and refresh omission through API integration tests

## Scope

- standard organization-defined custom OAuth connectors only
- no database migration or public API contract change
- built-in and integration-managed provider adapters remain outside this PR

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/routes/custom-connectors-oauth2.ts apps/api/src/signals/services/connector-connection-write.service.ts apps/api/src/signals/services/custom-connector-oauth2.service.ts apps/api/src/signals/services/custom-connector.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip --workspace api`
- pre-commit repository Knip and full Turbo type checks

Closes #29464

Parent: #29462
