### PR TITLE
fix(agent): preserve original shell commands in tool events

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
 name = "guest-contracts"
 version = "0.11.22"
 dependencies = [
+ "base64 0.23.1",
  "chrono",
  "libc",
  "process-control-ipc",
@@ -1390,7 +1391,6 @@ dependencies = [
  "process-control-ipc",
  "serde",
  "serde_json",
- "shell-quote",
  "tempfile",
 ]
 

--- a/crates/guest-agent/src/cli/provider_event_normalization.rs
+++ b/crates/guest-agent/src/cli/provider_event_normalization.rs
@@ -1,15 +1,63 @@
-//! Provider-owned semantic arrays flattened before canonical sequencing.
+//! Provider normalization before canonical sequencing and secret masking.
 
+use guest_contracts::managed_command::decode_managed_shell_command;
 use serde_json::Value;
 
 use crate::env::Framework;
 
 pub(super) fn normalize_for_sequencing(framework: Framework, event: Value) -> Vec<Value> {
-    match framework {
+    let events = match framework {
         Framework::ClaudeCode => expand_claude_message_content(event),
         Framework::Codex => expand_codex_file_changes(event),
         Framework::Pi => vec![event],
+    };
+    events
+        .into_iter()
+        .filter_map(|mut event| restore_original_command(framework, &mut event).then_some(event))
+        .collect()
+}
+
+fn restore_original_command(framework: Framework, event: &mut Value) -> bool {
+    let command = match framework {
+        Framework::ClaudeCode => claude_bash_command_mut(event),
+        Framework::Codex => codex_command_mut(event),
+        Framework::Pi => None,
+    };
+    let Some(command) = command else {
+        return true;
+    };
+    let Some(provider_command) = command.as_str() else {
+        return true;
+    };
+    match decode_managed_shell_command(provider_command) {
+        Ok(Some(original_command)) => {
+            *command = Value::String(original_command);
+            true
+        }
+        Ok(None) => true,
+        Err(_) => false,
     }
+}
+
+fn claude_bash_command_mut(event: &mut Value) -> Option<&mut Value> {
+    let block = event.pointer_mut("/message/content/0")?.as_object_mut()?;
+    if block.get("type").and_then(Value::as_str) != Some("tool_use")
+        || !block
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| name.eq_ignore_ascii_case("Bash"))
+    {
+        return None;
+    }
+    block.get_mut("input")?.as_object_mut()?.get_mut("command")
+}
+
+fn codex_command_mut(event: &mut Value) -> Option<&mut Value> {
+    let item = event.get_mut("item")?.as_object_mut()?;
+    if item.get("type").and_then(Value::as_str) != Some("command_execution") {
+        return None;
+    }
+    item.get_mut("command")
 }
 
 fn expand_claude_message_content(event: Value) -> Vec<Value> {
@@ -80,4 +128,238 @@ fn expand_codex_file_changes(event: Value) -> Vec<Value> {
             Value::Object(normalized_outer)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use guest_contracts::managed_command::render_managed_shell_command;
+    use serde_json::json;
+
+    use super::*;
+    use crate::events;
+    use crate::masker::SecretMasker;
+
+    fn claude_bash_event(command: &str) -> Value {
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "message-1",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "Bash",
+                    "input": {
+                        "command": command,
+                        "description": "run the command"
+                    }
+                }]
+            }
+        })
+    }
+
+    fn codex_command_event(event_type: &str, command: &str, status: &str) -> Value {
+        json!({
+            "type": event_type,
+            "item": {
+                "id": "command-1",
+                "type": "command_execution",
+                "command": command,
+                "status": status,
+                "aggregated_output": "command output",
+                "exit_code": 0,
+                "duration_ms": 42
+            }
+        })
+    }
+
+    fn normalized_command(framework: Framework, event: Value, path: &str) -> String {
+        let events = normalize_for_sequencing(framework, event);
+        assert_eq!(events.len(), 1);
+        events[0]
+            .pointer(path)
+            .and_then(Value::as_str)
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn both_providers_restore_lossless_original_commands() {
+        let commands = [
+            "printf '%s\\n' one".to_string(),
+            "printf \"%s\\n\" \"$HOME\"".to_string(),
+            "printf '%s' '$LITERAL'".to_string(),
+            "printf '%s' `uname`".to_string(),
+            "printf one | sed 's/one/two/'; printf done".to_string(),
+            "  leading and trailing  ".to_string(),
+            "printf first\nprintf second".to_string(),
+            "printf '你好，世界 🌍'".to_string(),
+            "x".repeat(1024 * 1024),
+        ];
+        for command in commands {
+            let managed = render_managed_shell_command(&command).unwrap();
+            assert_eq!(
+                normalized_command(
+                    Framework::ClaudeCode,
+                    claude_bash_event(&managed),
+                    "/message/content/0/input/command"
+                ),
+                command
+            );
+            let codex_outer = format!("/bin/bash -lc '{managed}'");
+            assert_eq!(
+                normalized_command(
+                    Framework::Codex,
+                    codex_command_event("item.started", &codex_outer, "in_progress"),
+                    "/item/command"
+                ),
+                command
+            );
+        }
+    }
+
+    #[test]
+    fn codex_started_and_terminal_events_keep_execution_fields() {
+        let original = "printf complete";
+        let managed = render_managed_shell_command(original).unwrap();
+        for (event_type, status) in [
+            ("item.started", "in_progress"),
+            ("item.completed", "completed"),
+        ] {
+            let events = normalize_for_sequencing(
+                Framework::Codex,
+                codex_command_event(event_type, &managed, status),
+            );
+            assert_eq!(events.len(), 1);
+            let item = &events[0]["item"];
+            assert_eq!(item["command"], original);
+            assert_eq!(item["status"], status);
+            assert_eq!(item["aggregated_output"], "command output");
+            assert_eq!(item["exit_code"], 0);
+            assert_eq!(item["duration_ms"], 42);
+        }
+    }
+
+    #[test]
+    fn restored_commands_are_masked_in_plain_and_encoded_forms() {
+        let secret = "managed-command-secret";
+        let encoded_secret = base64::engine::general_purpose::STANDARD.encode(secret);
+        let original = format!("printf '%s' '{secret}' '{encoded_secret}'");
+        let managed = render_managed_shell_command(&original).unwrap();
+        let masker = SecretMasker::from_raw(&encoded_secret);
+
+        for (framework, event, path) in [
+            (
+                Framework::ClaudeCode,
+                claude_bash_event(&managed),
+                "/message/content/0/input/command",
+            ),
+            (
+                Framework::Codex,
+                codex_command_event("item.completed", &managed, "completed"),
+                "/item/command",
+            ),
+        ] {
+            let event = normalize_for_sequencing(framework, event).remove(0);
+            let delivered = events::prepare_event_for_delivery(event, 7, &masker);
+            assert_eq!(
+                delivered.pointer(path).and_then(Value::as_str),
+                Some("printf '%s' '***' '***'")
+            );
+            let serialized = serde_json::to_string(&delivered).unwrap();
+            assert!(!serialized.contains(secret));
+            assert!(!serialized.contains(&encoded_secret));
+            assert!(!serialized.contains("guest-tool-exec"));
+            assert!(!serialized.contains("vm0.command"));
+        }
+    }
+
+    #[test]
+    fn invalid_managed_envelopes_fail_closed_for_both_providers() {
+        let managed = render_managed_shell_command("printf safe").unwrap();
+        let envelope_end = managed.find(" --shell ").unwrap();
+        let invalid = [
+            format!(
+                "{}{}",
+                &managed[..envelope_end - 1],
+                &managed[envelope_end..]
+            ),
+            managed.replace(".v1.", ".v2."),
+            managed.replace("vm0.command.v1.", "vm0.command.v1.*"),
+            managed[..envelope_end].to_string(),
+            format!(
+                "exec {} --shell \"$0\"",
+                guest_contracts::process_containment::TOOL_EXEC_PATH
+            ),
+        ];
+        for command in invalid {
+            assert!(
+                normalize_for_sequencing(Framework::ClaudeCode, claude_bash_event(&command))
+                    .is_empty()
+            );
+            assert!(
+                normalize_for_sequencing(
+                    Framework::Codex,
+                    codex_command_event(
+                        "item.completed",
+                        &format!("/bin/bash -lc '{command}'"),
+                        "completed"
+                    )
+                )
+                .is_empty()
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_commands_pass_through_and_one_invalid_claude_block_does_not_hide_siblings() {
+        for (framework, event) in [
+            (Framework::ClaudeCode, claude_bash_event("printf plain")),
+            (
+                Framework::Codex,
+                codex_command_event("item.started", "printf plain", "in_progress"),
+            ),
+        ] {
+            let path = match framework {
+                Framework::ClaudeCode => "/message/content/0/input/command",
+                Framework::Codex | Framework::Pi => "/item/command",
+            };
+            assert_eq!(normalized_command(framework, event, path), "printf plain");
+        }
+
+        let malformed = format!(
+            "exec {} --command-envelope=vm0.command.v1.12.cHJpbnRm --shell \"$0\"",
+            guest_contracts::process_containment::TOOL_EXEC_PATH
+        );
+        let event = json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    { "type": "text", "text": "before" },
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "Bash",
+                        "input": { "command": malformed }
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tool-2",
+                        "name": "Read",
+                        "input": { "file_path": "README.md" }
+                    }
+                ]
+            }
+        });
+        let events = normalize_for_sequencing(Framework::ClaudeCode, event);
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].pointer("/message/content/0/type"),
+            Some(&json!("text"))
+        );
+        assert_eq!(
+            events[1].pointer("/message/content/0/name"),
+            Some(&json!("Read"))
+        );
+    }
 }

--- a/crates/guest-agent/tests/claude_provider_event_normalization.rs
+++ b/crates/guest-agent/tests/claude_provider_event_normalization.rs
@@ -5,6 +5,7 @@ mod common;
 
 use base64::Engine as _;
 use guest_agent::masker::SecretMasker;
+use guest_contracts::managed_command::render_managed_shell_command;
 use serde_json::{Value, json};
 use std::time::Duration;
 
@@ -17,6 +18,9 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(SECRET);
+    let original_command = format!("printf '%s' '{SECRET}' '{encoded_secret}'");
+    let managed_command = render_managed_shell_command(&original_command)?;
     let source_events = [
         json!({
             "type": "system",
@@ -38,9 +42,7 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
                         "id": "tool-use-a",
                         "name": "Bash",
                         "input": {
-                            "command": format!(
-                                "exec '/usr/local/bin/guest-tool-exec' --shell \"$0\" -c 'printf {SECRET}'"
-                            )
+                            "command": managed_command
                         }
                     },
                     {
@@ -99,7 +101,6 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
         Duration::ZERO,
     )?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
-    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(SECRET);
     let masker = SecretMasker::from_raw(&encoded_secret);
 
     let result = tokio::time::timeout(
@@ -194,7 +195,7 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
         delivered[2]
             .pointer("/message/content/0/input/command")
             .and_then(Value::as_str),
-        Some("exec '/usr/local/bin/guest-tool-exec' --shell \"$0\" -c 'printf ***'")
+        Some("printf '%s' '***' '***'")
     );
     assert_eq!(
         delivered[3]
@@ -216,6 +217,9 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
     );
     let delivered_json = serde_json::to_string(&delivered)?;
     assert!(!delivered_json.contains(SECRET));
+    assert!(!delivered_json.contains(&encoded_secret));
+    assert!(!delivered_json.contains("guest-tool-exec"));
+    assert!(!delivered_json.contains("vm0.command"));
     assert!(delivered_json.contains("***"));
 
     let local_events = read_jsonl(runtime.paths.agent_log_file())?;

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -152,11 +152,16 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
     assert_eq!(command["item"]["type"], "command_execution");
     assert_eq!(command["item"]["status"], "completed");
     assert_eq!(command["item"]["exit_code"], 0);
-    assert!(command["item"]["command"].as_str().is_some_and(
-        |text| text.starts_with("command-head-")
+    assert!(command["item"]["command"].as_str().is_some_and(|text| {
+        text.starts_with("command-head-***-")
             && text.ends_with("-command-tail")
             && text.contains(DELIVERY_MARKER)
-    ));
+    }));
+    assert!(
+        !command["item"]["command"]
+            .as_str()
+            .is_some_and(|text| text.contains("guest-tool-exec") || text.contains("vm0.command"))
+    );
     assert!(
         command["item"]["aggregated_output"]
             .as_str()

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
+base64.workspace = true
 chrono = { workspace = true, features = ["alloc"] }
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -16,6 +16,7 @@ pub mod epoch_milliseconds;
 pub mod exec_limits;
 pub mod exec_terminal;
 pub mod file_write;
+pub mod managed_command;
 pub mod process_containment;
 pub mod reuse_preparation;
 pub mod runtime_paths;

--- a/crates/guest-contracts/src/managed_command.rs
+++ b/crates/guest-contracts/src/managed_command.rs
@@ -1,0 +1,323 @@
+//! Versioned transport for commands rewritten by the managed shell hook.
+//!
+//! The hook replaces a Bash command with one deterministic executor invocation.
+//! Its envelope uses only shell-safe ASCII, so provider event normalization can
+//! recover the original command without parsing or evaluating shell quoting.
+
+use std::error::Error;
+use std::fmt;
+
+use base64::Engine as _;
+
+use crate::process_containment::TOOL_EXEC_PATH;
+
+/// Prefix of the executor argument carrying one managed command envelope.
+pub const COMMAND_ENVELOPE_ARGUMENT_PREFIX: &str = "--command-envelope=";
+
+const COMMAND_ENVELOPE_PREFIX: &str = "vm0.command.";
+const COMMAND_ENVELOPE_VERSION: &str = "v1";
+const MANAGED_SHELL_SEPARATOR: &str = " --shell ";
+const OUTER_SHELL_PREFIXES: [&str; 2] = ["/bin/bash -c ", "/bin/bash -lc "];
+
+/// Failure to encode or decode the managed command transport.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedCommandError {
+    /// The command contains a NUL byte that cannot cross the process boundary.
+    ContainsNul,
+    /// The managed executor invocation does not match the deterministic contract.
+    InvalidInvocation,
+    /// The command envelope is malformed or truncated.
+    InvalidEnvelope,
+    /// The command envelope names an unsupported protocol version.
+    UnsupportedVersion,
+    /// The decoded command length differs from the envelope's declared length.
+    LengthMismatch,
+    /// The decoded command is not valid UTF-8.
+    InvalidUtf8,
+}
+
+impl fmt::Display for ManagedCommandError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::ContainsNul => "managed command contains a null byte",
+            Self::InvalidInvocation => "managed command invocation is invalid",
+            Self::InvalidEnvelope => "managed command envelope is invalid",
+            Self::UnsupportedVersion => "managed command envelope version is unsupported",
+            Self::LengthMismatch => "managed command envelope length does not match its payload",
+            Self::InvalidUtf8 => "managed command envelope payload is not valid UTF-8",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl Error for ManagedCommandError {}
+
+/// Encode one original command as the current deterministic envelope version.
+///
+/// The encoded value contains only ASCII letters, digits, dots, hyphens, and
+/// underscores. Its declared byte length makes truncated payloads detectable.
+///
+/// # Errors
+///
+/// Returns [`ManagedCommandError::ContainsNul`] when `command` contains NUL.
+pub fn encode_command_envelope(command: &str) -> Result<String, ManagedCommandError> {
+    if command.contains('\0') {
+        return Err(ManagedCommandError::ContainsNul);
+    }
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(command.as_bytes());
+    Ok(format!(
+        "{COMMAND_ENVELOPE_PREFIX}{COMMAND_ENVELOPE_VERSION}.{}.{payload}",
+        command.len()
+    ))
+}
+
+/// Decode one exact managed command envelope without evaluating its contents.
+///
+/// # Errors
+///
+/// Returns an error for malformed, truncated, non-canonical, unknown-version,
+/// non-UTF-8, length-mismatched, or NUL-containing envelopes.
+pub fn decode_command_envelope(envelope: &str) -> Result<String, ManagedCommandError> {
+    let version_and_payload = envelope
+        .strip_prefix(COMMAND_ENVELOPE_PREFIX)
+        .ok_or(ManagedCommandError::InvalidEnvelope)?;
+    let (version, length_and_payload) = version_and_payload
+        .split_once('.')
+        .ok_or(ManagedCommandError::InvalidEnvelope)?;
+    if version != COMMAND_ENVELOPE_VERSION {
+        return Err(ManagedCommandError::UnsupportedVersion);
+    }
+    let (declared_length, payload) = length_and_payload
+        .split_once('.')
+        .ok_or(ManagedCommandError::InvalidEnvelope)?;
+    if declared_length.is_empty()
+        || payload.contains('.')
+        || (declared_length.len() > 1 && declared_length.starts_with('0'))
+        || !payload
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(ManagedCommandError::InvalidEnvelope);
+    }
+    let declared_length = declared_length
+        .parse::<usize>()
+        .map_err(|_| ManagedCommandError::InvalidEnvelope)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| ManagedCommandError::InvalidEnvelope)?;
+    if base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&decoded) != payload {
+        return Err(ManagedCommandError::InvalidEnvelope);
+    }
+    if decoded.len() != declared_length {
+        return Err(ManagedCommandError::LengthMismatch);
+    }
+    let command = String::from_utf8(decoded).map_err(|_| ManagedCommandError::InvalidUtf8)?;
+    if command.contains('\0') {
+        return Err(ManagedCommandError::ContainsNul);
+    }
+    Ok(command)
+}
+
+/// Render the deterministic shell command installed by the managed Bash hook.
+///
+/// # Errors
+///
+/// Returns [`ManagedCommandError::ContainsNul`] when `command` contains NUL.
+pub fn render_managed_shell_command(command: &str) -> Result<String, ManagedCommandError> {
+    let envelope = encode_command_envelope(command)?;
+    Ok(format!(
+        "exec {TOOL_EXEC_PATH} {COMMAND_ENVELOPE_ARGUMENT_PREFIX}{envelope} --shell \"$0\""
+    ))
+}
+
+/// Recover an original command from a managed provider command representation.
+///
+/// Direct Claude Code hook output and Codex's outer `/bin/bash -c` or
+/// `/bin/bash -lc` display form use the same embedded envelope. Commands that
+/// do not begin with a managed executor invocation return `Ok(None)` unchanged.
+/// No shell syntax is parsed or evaluated.
+///
+/// # Errors
+///
+/// Returns an error when a recognized managed invocation has a malformed,
+/// truncated, ambiguous, or unsupported envelope.
+pub fn decode_managed_shell_command(
+    provider_command: &str,
+) -> Result<Option<String>, ManagedCommandError> {
+    let executable = format!("exec {TOOL_EXEC_PATH}");
+    let legacy_executable = format!("exec '{TOOL_EXEC_PATH}'");
+    let candidate = provider_command_candidate(provider_command);
+    let Some(after_executable) = candidate.strip_prefix(&executable) else {
+        if candidate.starts_with(&legacy_executable)
+            || (candidate.starts_with("exec ")
+                && (candidate.contains(COMMAND_ENVELOPE_ARGUMENT_PREFIX)
+                    || candidate.contains(COMMAND_ENVELOPE_PREFIX)))
+        {
+            return Err(ManagedCommandError::InvalidInvocation);
+        }
+        return Ok(None);
+    };
+    let envelope_prefix = format!(" {COMMAND_ENVELOPE_ARGUMENT_PREFIX}");
+    let after_envelope_prefix = after_executable
+        .strip_prefix(&envelope_prefix)
+        .ok_or(ManagedCommandError::InvalidInvocation)?;
+    let envelope_end = after_envelope_prefix
+        .find(MANAGED_SHELL_SEPARATOR)
+        .ok_or(ManagedCommandError::InvalidInvocation)?;
+    let envelope = &after_envelope_prefix[..envelope_end];
+    let shell = &after_envelope_prefix[envelope_end + MANAGED_SHELL_SEPARATOR.len()..];
+    if shell.is_empty()
+        || shell.contains(&executable)
+        || shell.contains(COMMAND_ENVELOPE_ARGUMENT_PREFIX)
+        || shell.contains(COMMAND_ENVELOPE_PREFIX)
+    {
+        return Err(ManagedCommandError::InvalidInvocation);
+    }
+    decode_command_envelope(envelope).map(Some)
+}
+
+fn provider_command_candidate(provider_command: &str) -> &str {
+    for outer_prefix in OUTER_SHELL_PREFIXES {
+        let Some(outer_command) = provider_command.strip_prefix(outer_prefix) else {
+            continue;
+        };
+        if matches!(outer_command.as_bytes().first(), Some(b'\'' | b'"')) {
+            return &outer_command[1..];
+        }
+        return outer_command;
+    }
+    provider_command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip_commands() -> Vec<String> {
+        vec![
+            String::new(),
+            "printf '%s\\n' one".to_string(),
+            "printf \"%s\\n\" \"$HOME\"".to_string(),
+            "printf '%s' '$LITERAL'".to_string(),
+            "printf '%s' `uname`".to_string(),
+            "printf one | sed 's/one/two/'; printf done".to_string(),
+            "  leading and trailing  ".to_string(),
+            "printf first\\nprintf second".replace("\\n", "\n"),
+            "printf '你好，世界 🌍'".to_string(),
+            "x".repeat(1024 * 1024),
+        ]
+    }
+
+    #[test]
+    fn envelope_round_trips_losslessly_and_deterministically() {
+        for command in round_trip_commands() {
+            let first = encode_command_envelope(&command).unwrap();
+            let second = encode_command_envelope(&command).unwrap();
+            assert_eq!(first, second, "envelope must be deterministic");
+            assert!(first.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_')
+            }));
+            assert_eq!(decode_command_envelope(&first).unwrap(), command);
+        }
+    }
+
+    #[test]
+    fn provider_command_decoder_accepts_direct_and_codex_outer_forms() {
+        let original = "  printf '%s\\n' \"$HOME\" | sed 's/x/y/'; echo `date`\n你好  ";
+        let managed = render_managed_shell_command(original).unwrap();
+        for provider_command in [
+            managed.clone(),
+            format!("/bin/bash -c {managed}"),
+            format!("/bin/bash -lc '{managed}'"),
+            format!("/bin/bash -lc \"{managed}\""),
+        ] {
+            assert_eq!(
+                decode_managed_shell_command(&provider_command).unwrap(),
+                Some(original.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_commands_remain_unwrapped() {
+        for command in [
+            "printf plain",
+            "echo /usr/local/bin/guest-tool-exec",
+            "printf '%s' 'exec /usr/local/bin/guest-tool-exec'",
+            "/bin/bash -lc 'printf plain'",
+            "printf '%s' '--command-envelope=vm0.command.v1.4.c2FmZQ'",
+        ] {
+            assert_eq!(decode_managed_shell_command(command).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn malformed_truncated_and_unknown_envelopes_are_rejected() {
+        let envelope = encode_command_envelope("printf safe").unwrap();
+        let truncated = &envelope[..envelope.len() - 1];
+        assert!(decode_command_envelope(truncated).is_err());
+        assert_eq!(
+            decode_command_envelope(&envelope.replace(".v1.", ".v2.")),
+            Err(ManagedCommandError::UnsupportedVersion)
+        );
+        assert_eq!(
+            decode_command_envelope("vm0.command.v1.4.***"),
+            Err(ManagedCommandError::InvalidEnvelope)
+        );
+        assert_eq!(
+            decode_command_envelope("vm0.command.v1.1.Zg=="),
+            Err(ManagedCommandError::InvalidEnvelope)
+        );
+        assert_eq!(
+            decode_command_envelope("vm0.command.v1.1.Zh"),
+            Err(ManagedCommandError::InvalidEnvelope)
+        );
+        assert_eq!(
+            decode_command_envelope("vm0.command.v1.04.c2FmZQ"),
+            Err(ManagedCommandError::InvalidEnvelope)
+        );
+
+        let executable = format!("exec {TOOL_EXEC_PATH}");
+        assert!(
+            decode_managed_shell_command(&format!(
+                "{executable} {COMMAND_ENVELOPE_ARGUMENT_PREFIX}{truncated} --shell \"$0\""
+            ))
+            .is_err()
+        );
+        assert_eq!(
+            decode_managed_shell_command(&format!(
+                "{executable} {COMMAND_ENVELOPE_ARGUMENT_PREFIX}{envelope}"
+            )),
+            Err(ManagedCommandError::InvalidInvocation)
+        );
+        assert_eq!(
+            decode_managed_shell_command(&format!("{executable} --shell \"$0\"")),
+            Err(ManagedCommandError::InvalidInvocation)
+        );
+        assert_eq!(
+            decode_managed_shell_command(&format!(
+                "/bin/bash -lc \"exec /tmp/not-managed {COMMAND_ENVELOPE_ARGUMENT_PREFIX}{envelope}\""
+            )),
+            Err(ManagedCommandError::InvalidInvocation)
+        );
+        assert_eq!(
+            decode_managed_shell_command(&format!(
+                "/bin/bash -lc \"exec '{TOOL_EXEC_PATH}' --shell \\\"\"'$0\" -c \"'\"'printf legacy'\""
+            )),
+            Err(ManagedCommandError::InvalidInvocation)
+        );
+    }
+
+    #[test]
+    fn nul_is_rejected_on_both_sides_of_the_codec() {
+        assert_eq!(
+            encode_command_envelope("before\0after"),
+            Err(ManagedCommandError::ContainsNul)
+        );
+        let encoded_nul = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"before\0after");
+        assert_eq!(
+            decode_command_envelope(&format!("vm0.command.v1.12.{encoded_nul}")),
+            Err(ManagedCommandError::ContainsNul)
+        );
+    }
+}

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -1,4 +1,5 @@
 use crate::session;
+use guest_contracts::managed_command::render_managed_shell_command;
 use serde_json::{Value, json};
 use std::io::{self, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -152,6 +153,10 @@ pub(super) fn write_oversized_delivery_notifications<W: Write>(
     let large = "α".repeat(2_150_000);
     let secret = "delivery-secret-value";
     let completed_at_ms = 2;
+    let original_command = format!("command-head-{secret}-{large}-command-tail");
+    let managed_command =
+        render_managed_shell_command(&original_command).map_err(io::Error::other)?;
+    let codex_command = format!("/bin/bash -lc '{managed_command}'");
     write_json_line(
         output,
         &json!({
@@ -212,7 +217,7 @@ pub(super) fn write_oversized_delivery_notifications<W: Write>(
                 "item": {
                     "id": "oversized-command",
                     "type": "commandExecution",
-                    "command": format!("command-head-{large}-command-tail"),
+                    "command": codex_command,
                     "cwd": "/workspace",
                     "status": "completed",
                     "aggregatedOutput": format!("output-head-{secret}-{large}-output-tail"),

--- a/crates/guest-tool-exec/Cargo.toml
+++ b/crates/guest-tool-exec/Cargo.toml
@@ -10,7 +10,6 @@ libc.workspace = true
 process-control-ipc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-shell-quote.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/guest-tool-exec/src/lib.rs
+++ b/crates/guest-tool-exec/src/lib.rs
@@ -9,13 +9,15 @@ use std::path::{Component, Path};
 use std::process::{Command, ExitCode};
 use std::time::Duration;
 
+use guest_contracts::managed_command::{
+    COMMAND_ENVELOPE_ARGUMENT_PREFIX, decode_command_envelope, render_managed_shell_command,
+};
 use guest_contracts::process_containment::{
     CANONICAL_TOOL_CGROUP_PROCS_ENV, EXEC_CGROUP_NAME_PREFIX, RUNTIME_CGROUP_NAME,
-    TOOL_CGROUP_PROCS_ENDPOINT_ENV, TOOL_EXEC_PATH, WORKLOAD_CGROUP_NAME,
+    TOOL_CGROUP_PROCS_ENDPOINT_ENV, WORKLOAD_CGROUP_NAME,
 };
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use shell_quote::quote_shell_arg;
 
 const BASH_PATH: &str = "/bin/bash";
 const HOOK_MODE: &str = "hook";
@@ -81,12 +83,8 @@ fn rewrite_pre_tool_use_hook(input: &mut impl Read, output: &mut impl Write) -> 
             "Bash command contains a null byte",
         ));
     }
-    let wrapped = format!(
-        "exec {} {} \"$0\" -c {}",
-        quote_shell_arg(TOOL_EXEC_PATH),
-        SHELL_OPTION,
-        quote_shell_arg(command)
-    );
+    let wrapped = render_managed_shell_command(command)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     input
         .tool_input
         .insert("command".to_string(), Value::String(wrapped));
@@ -253,28 +251,61 @@ fn write_self_to_cgroup(placement: &OwnedFd) -> io::Result<()> {
 }
 
 fn exec_shell() -> io::Error {
-    let mut arguments = env::args_os().skip(1).collect::<Vec<_>>();
-    let shell = if arguments
+    let arguments = env::args_os().skip(1).collect::<Vec<_>>();
+    let (shell, arguments) = match shell_invocation(arguments) {
+        Ok(invocation) => invocation,
+        Err(error) => return error,
+    };
+    let mut command = Command::new(shell);
+    command.args(arguments);
+    command.exec()
+}
+
+fn shell_invocation(mut arguments: Vec<OsString>) -> io::Result<(OsString, Vec<OsString>)> {
+    let envelope = arguments
         .first()
-        .is_some_and(|arg| arg == OsStr::new(SHELL_OPTION))
-    {
+        .and_then(|argument| argument.to_str())
+        .and_then(|argument| argument.strip_prefix(COMMAND_ENVELOPE_ARGUMENT_PREFIX))
+        .map(str::to_string);
+    if envelope.is_some() {
+        let _ = arguments.remove(0);
+    }
+
+    let explicit_shell = arguments
+        .first()
+        .is_some_and(|argument| argument == OsStr::new(SHELL_OPTION));
+    let shell = if explicit_shell {
         let _ = arguments.remove(0);
         if arguments.is_empty() {
-            return io::Error::new(
+            return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("{SHELL_OPTION} requires a shell executable"),
-            );
+            ));
         }
         arguments.remove(0)
     } else {
         OsString::from(BASH_PATH)
     };
     if shell.is_empty() {
-        return io::Error::new(io::ErrorKind::InvalidInput, "shell executable is empty");
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "shell executable is empty",
+        ));
     }
-    let mut command = Command::new(shell);
-    command.args(arguments);
-    command.exec()
+
+    if let Some(envelope) = envelope {
+        if !explicit_shell || !arguments.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "managed command invocation is invalid",
+            ));
+        }
+        let command = decode_command_envelope(&envelope)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+        arguments = vec![OsString::from("-c"), OsString::from(command)];
+    }
+
+    Ok((shell, arguments))
 }
 
 #[cfg(test)]
@@ -418,35 +449,111 @@ mod tests {
     }
 
     #[test]
-    fn hook_wraps_command_and_preserves_other_bash_fields() {
-        let mut output = Vec::new();
-        rewrite_pre_tool_use_hook(
-            &mut br#"{
-                "hook_event_name":"PreToolUse",
-                "tool_name":"Bash",
-                "tool_input":{
-                    "command":"printf '%s\\n' \"$HOME\"",
-                    "description":"print home",
-                    "timeout":120000,
-                    "run_in_background":false
+    fn hook_wraps_commands_losslessly_and_preserves_other_bash_fields() {
+        let commands = [
+            "printf '%s\\n' \"$HOME\"",
+            "printf '$LITERAL' `date`; echo one | sed 's/one/two/'",
+            "  leading and trailing  ",
+            "printf first\nprintf second",
+            "printf '你好，世界 🌍'",
+            &"x".repeat(1024 * 1024),
+        ];
+        for command in commands {
+            let payload = json!({
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": command,
+                    "description": "run command",
+                    "timeout": 120000,
+                    "run_in_background": false
                 }
-            }"#
-            .as_slice(),
-            &mut output,
-        )
-        .unwrap();
+            });
+            let mut output = Vec::new();
+            rewrite_pre_tool_use_hook(
+                &mut serde_json::to_vec(&payload).unwrap().as_slice(),
+                &mut output,
+            )
+            .unwrap();
 
-        let output: Value = serde_json::from_slice(&output).unwrap();
-        assert_eq!(
-            output["hookSpecificOutput"]["updatedInput"],
-            json!({
-                "command": "exec '/usr/local/bin/guest-tool-exec' --shell \"$0\" -c 'printf '\\''%s\\n'\\'' \"$HOME\"'",
-                "description": "print home",
-                "timeout": 120000,
-                "run_in_background": false,
-            })
-        );
-        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+            let output: Value = serde_json::from_slice(&output).unwrap();
+            let updated = &output["hookSpecificOutput"]["updatedInput"];
+            let wrapped = updated["command"].as_str().unwrap();
+            assert_eq!(
+                guest_contracts::managed_command::decode_managed_shell_command(wrapped).unwrap(),
+                Some(command.to_string())
+            );
+            assert_eq!(updated["description"], "run command");
+            assert_eq!(updated["timeout"], 120000);
+            assert_eq!(updated["run_in_background"], false);
+            assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+        }
+    }
+
+    #[test]
+    fn managed_invocation_restores_shell_argv_without_changing_legacy_execution() {
+        let command = "  printf '%s\\n' \"$HOME\"; echo `date` | cat\n你好  ";
+        let envelope = guest_contracts::managed_command::encode_command_envelope(command).unwrap();
+        let (shell, arguments) = shell_invocation(vec![
+            OsString::from(format!("{COMMAND_ENVELOPE_ARGUMENT_PREFIX}{envelope}")),
+            OsString::from(SHELL_OPTION),
+            OsString::from("/bin/custom-bash"),
+        ])
+        .unwrap();
+        assert_eq!(shell, "/bin/custom-bash");
+        assert_eq!(arguments, [OsString::from("-c"), OsString::from(command)]);
+
+        let legacy_arguments = vec![
+            OsString::from(SHELL_OPTION),
+            OsString::from("/bin/custom-bash"),
+            OsString::from("-c"),
+            OsString::from("printf legacy"),
+        ];
+        let (shell, arguments) = shell_invocation(legacy_arguments.clone()).unwrap();
+        assert_eq!(shell, "/bin/custom-bash");
+        assert_eq!(arguments, legacy_arguments[2..]);
+    }
+
+    #[test]
+    fn malformed_managed_invocations_fail_before_shell_execution() {
+        for arguments in [
+            vec![OsString::from(format!(
+                "{COMMAND_ENVELOPE_ARGUMENT_PREFIX}vm0.command.v2.4.c2FmZQ"
+            ))],
+            vec![
+                OsString::from(format!(
+                    "{COMMAND_ENVELOPE_ARGUMENT_PREFIX}vm0.command.v1.4.c2Fm"
+                )),
+                OsString::from(SHELL_OPTION),
+                OsString::from(BASH_PATH),
+            ],
+            vec![
+                OsString::from(format!(
+                    "{COMMAND_ENVELOPE_ARGUMENT_PREFIX}vm0.command.v1.4.c2FmZQ"
+                )),
+                OsString::from(SHELL_OPTION),
+                OsString::from(BASH_PATH),
+                OsString::from("unexpected"),
+            ],
+        ] {
+            assert_eq!(
+                shell_invocation(arguments).unwrap_err().kind(),
+                io::ErrorKind::InvalidInput
+            );
+        }
+    }
+
+    #[test]
+    fn hook_rejects_nul_with_existing_denial_behavior() {
+        let payload = br#"{
+            "hook_event_name":"PreToolUse",
+            "tool_name":"Bash",
+            "tool_input":{"command":"before\u0000after"}
+        }"#;
+        let error =
+            rewrite_pre_tool_use_hook(&mut payload.as_slice(), &mut Vec::new()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(error.to_string(), "Bash command contains a null byte");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add one shared, versioned managed-command envelope (`vm0.command.v1.<utf8-byte-length>.<base64url-no-pad>`) for the Bash pre-hook and executor
- restore the original command at the guest-agent provider-normalization boundary for both Codex `item.command` and Claude Code Bash `input.command`, before the existing `SecretMasker` and delivery path
- fail closed on malformed, truncated, ambiguous, or unknown-version managed envelopes without exposing the wrapper or encoded payload
- preserve the existing `guest-tool-exec` cgroup placement and shell execution behavior; leave Chat/API/UI/schema/materialization unchanged

## Compatibility and rollout

- runner images ship `guest-tool-exec` and guest-agent from the same source revision, so the envelope writer, executor reader, and provider reader roll out together
- the current API accepts the new plain normalized command while retaining its legacy wrapper decoder for old runners and reusable sandboxes during the drain and rollback window
- the legacy API decoder cleanup remains a separate post-drain change, as required by #29447
- #29434 was merged before the final rebase; this PR does not modify any of its API, materializer, or UI files

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo clippy --manifest-path crates/Cargo.toml --no-deps -p guest-contracts -p guest-tool-exec -p guest-agent -p guest-mock-codex --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --no-deps -p guest-contracts -p guest-tool-exec -p guest-agent -p guest-mock-codex`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts managed_command`
- `cargo test --manifest-path crates/Cargo.toml -p guest-tool-exec`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib provider_event_normalization`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test claude_provider_event_normalization`
- `cargo test --manifest-path crates/Cargo.toml -q -p guest-agent --test codex_app_server_oversized_event_delivery`

The targeted runner rootfs wiring test was attempted twice, but linking the full runner test binary was terminated by the local 3.8 GiB container OOM killer (`exit 137`) before any assertion ran. The rootfs hook scripts are unchanged, their Claude Code and Codex hook entries were statically rechecked, and the PR pipeline remains responsible for the full runner build.

Test coverage includes single and double quotes, literal `$`, backticks, pipes, semicolons, leading/trailing whitespace, embedded newlines, Unicode, long commands, NUL rejection, malformed/truncated/unknown-version envelopes, plain and Base64 secret masking, provider lifecycle fields, output, status, and exit-code preservation.

Context: #29244

Fixes #29447
