### PR TITLE
fix(platform): preview effective connector account names

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2417,8 +2417,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} erfordern Aufmerksamkeit",
       "summaryWithAttention_one": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Arbeitskonto"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Anwenden",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2409,8 +2409,7 @@
       "summaryMany": "{{value}} accounts",
       "summaryOne": "{{value}} account",
       "summaryWithAttention": "{{summary}} · {{value}} need attention",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Work account"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Apply",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2465,8 +2465,7 @@
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Cuenta de trabajo"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Aplicar",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2465,8 +2465,7 @@
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Compte professionnel"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Appliquer",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2417,8 +2417,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} पर ध्यान देना आवश्यक है",
       "summaryWithAttention_one": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "कार्य खाता"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "आवेदन करना",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2409,8 +2409,7 @@
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} memerlukan perhatian",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Akun kerja"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Terapkan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2465,8 +2465,7 @@
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Account di lavoro"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Applicare",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2409,8 +2409,7 @@
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} 件に対応が必要",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "仕事用アカウント"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "申し込む",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2409,8 +2409,7 @@
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}}개에 주의 필요",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "업무용 계정"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "적용",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2465,8 +2465,7 @@
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}",
-      "workPlaceholder": "Conta de trabalho"
+      "summaryWithDefault": "{{summary}} · {{account}}"
     },
     "actions": {
       "apply": "Aplicar",

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -10,6 +10,7 @@ import type { PlatformConnectorCatalogStatusItem } from "../../connector-domain.
 import { reloadConnectorAccountSummaries$ } from "../connector-accounts.ts";
 import {
   connectorAccountDeletionImpact$,
+  readConnectorAccount$,
   settingsConnectorAccounts,
 } from "./connector-accounts.ts";
 
@@ -146,7 +147,7 @@ export const closeCustomAccountConnectDialog$ = command(({ set }) => {
 
 interface ConnectorAccountNamePrompt {
   readonly target: ConnectorAccountTarget;
-  readonly connectionId: string;
+  readonly account: ConnectorAccountConnection;
   readonly connectorLabel: string;
 }
 
@@ -181,21 +182,30 @@ export const closeConnectorAccountNamePrompt$ = command(({ set }) => {
 });
 
 export const finishConnectorAccountConnection$ = command(
-  (
+  async (
     { set },
-    args: Omit<ConnectorAccountNamePrompt, "connectionId"> & {
+    args: {
+      readonly target: ConnectorAccountTarget;
       readonly connectionId: string | null;
+      readonly connectorLabel: string;
       readonly mode: ConnectorAccountConnectMode;
     },
-  ) => {
+    signal: AbortSignal,
+  ): Promise<void> => {
     set(reloadConnectorAccountSummaries$);
     if (args.mode.kind !== "add" || !args.connectionId) {
       return;
     }
+    const account = await set(
+      readConnectorAccount$,
+      { target: args.target, connectionId: args.connectionId },
+      signal,
+    );
+    signal.throwIfAborted();
     set(internalConnectorAccountNamePromptValue$, "");
     set(internalConnectorAccountNamePrompt$, {
       target: args.target,
-      connectionId: args.connectionId,
+      account,
       connectorLabel: args.connectorLabel,
     });
   },

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import {
   connectorAccountsContract,
+  type ConnectorAccountConnection,
   type ConnectorAccountMutationIntent,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
@@ -91,6 +92,28 @@ const invalidateConnectorAccounts$ = command(({ set }, signal: AbortSignal) => {
   set(reloadConnectorAccountSummaries$);
   set(settingsConnectorAccounts.reload$, signal);
 });
+
+export const readConnectorAccount$ = command(
+  async (
+    { get },
+    args: {
+      readonly target: ConnectorAccountTarget;
+      readonly connectionId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ConnectorAccountConnection> => {
+    const result = await accept(
+      get(apiClient$)(connectorAccountsContract).connection({
+        params: { connectionId: args.connectionId },
+        query: args.target,
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return result.body;
+  },
+);
 
 export const renameConnectorAccount$ = command(
   async (

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1472,13 +1472,13 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         submittedAccount = body.account;
         submittedAuthorizeAgent = body.authorizeAgent;
-        const connector = {
+        const connector: ConnectorResponse = {
           id: connectionId,
           slug: params.connectorSlug,
           authMethod: body.authMethod,
-          externalId: null,
-          externalUsername: null,
-          externalEmail: null,
+          externalId: "provider-account-id",
+          externalUsername: "provider-user",
+          externalEmail: "owner@example.com",
           oauthScopes: null,
           connectionStatus: "connected" as const,
           reconnectReason: null,
@@ -1532,8 +1532,10 @@ describe("connectors page", () => {
     const nameDialog = await screen.findByRole("dialog", {
       name: "Name your Ahrefs account",
     });
-    expect(within(nameDialog).getByLabelText("Account name")).toHaveValue("");
-    await fill(within(nameDialog).getByLabelText("Account name"), "Work");
+    const nameInput = within(nameDialog).getByLabelText("Account name");
+    expect(nameInput).toHaveValue("");
+    expect(nameInput).toHaveAttribute("placeholder", "owner@example.com");
+    await fill(nameInput, "Work");
     click(buttonByText("Save", nameDialog));
     await waitFor(() => {
       expect(renamedConnectionId).toBe(connectionId);
@@ -3565,7 +3567,7 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         submittedAccount = body.account;
         submittedAuthorizeAgent = body.authorizeAgent;
-        return respond(200, {
+        const connector: ConnectorResponse = {
           id: connectionId,
           slug: params.connectorSlug,
           authMethod: body.authMethod,
@@ -3578,7 +3580,9 @@ describe("connectors page", () => {
           tokenExpiresAt: null,
           createdAt: "2026-01-01T00:00:00.000Z",
           updatedAt: "2026-01-01T00:00:00.000Z",
-        });
+        };
+        context.mocks.data.connectors([connector]);
+        return respond(200, connector);
       },
     );
     detachedSetupPage({
@@ -3592,6 +3596,10 @@ describe("connectors page", () => {
     const nameDialog = await screen.findByRole("dialog", {
       name: "Name your Public Stripe account",
     });
+    expect(within(nameDialog).getByLabelText("Account name")).toHaveAttribute(
+      "placeholder",
+      `Account #${connectionId.slice(0, 8)}`,
+    );
     click(buttonByText("Skip", nameDialog));
     expect(submittedAccount).toStrictEqual({ intent: "add" });
     expect(submittedAuthorizeAgent).toBeUndefined();
@@ -6375,6 +6383,7 @@ describe("connectors page", () => {
     async ({ connector: initialConnector }) => {
       let connector: CustomConnectorResponse = initialConnector;
       let account: ConnectorAccountConnection | null = null;
+      const connectionId = crypto.randomUUID();
       let submittedAccount: unknown;
       let grantMutationCount = 0;
       context.mocks.api(customConnectorsContract.list, ({ respond }) => {
@@ -6394,6 +6403,16 @@ describe("connectors page", () => {
             : [],
         });
       });
+      context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+        return account
+          ? respond(200, account)
+          : respond(404, {
+              error: {
+                message: "Connector account not found",
+                code: "NOT_FOUND",
+              },
+            });
+      });
       context.mocks.api(
         customConnectorValuesContract.set,
         ({ body, respond }) => {
@@ -6405,7 +6424,7 @@ describe("connectors page", () => {
             configuredFieldKeys: ["secret"],
           };
           account = {
-            id: crypto.randomUUID(),
+            id: connectionId,
             target: {
               kind: "custom",
               customConnectorId: connector.id,
@@ -6456,6 +6475,10 @@ describe("connectors page", () => {
       const nameDialog = await screen.findByRole("dialog", {
         name: `Name your ${connector.displayName} account`,
       });
+      expect(within(nameDialog).getByLabelText("Account name")).toHaveAttribute(
+        "placeholder",
+        `Account #${connectionId.slice(0, 8)}`,
+      );
       click(buttonByText("Skip", nameDialog));
       await waitFor(() => {
         expect(

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
@@ -13,6 +13,7 @@ import {
   Input,
 } from "@okouai/ui";
 
+import { connectorAccountEffectiveLabel } from "../../../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { renameConnectorAccount$ } from "../../../../signals/okou-page/settings/connector-accounts.ts";
 import {
@@ -47,7 +48,7 @@ export function ConnectorAccountNameDialog() {
         await rename(
           {
             target: prompt.target,
-            connectionId: prompt.connectionId,
+            connectionId: prompt.account.id,
             displayName,
           },
           signal,
@@ -98,9 +99,15 @@ export function ConnectorAccountNameDialog() {
               onChange={(event) => {
                 return setValue(event.target.value);
               }}
-              placeholder={t(($) => {
-                return $.connectors.accounts.workPlaceholder;
-              })}
+              placeholder={connectorAccountEffectiveLabel(
+                prompt.account,
+                t(
+                  ($) => {
+                    return $.connectors.accounts.fallbackName;
+                  },
+                  { id: prompt.account.id.slice(0, 8) },
+                ),
+              )}
               maxLength={255}
             />
           </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -570,16 +570,19 @@ function CustomConnectorGrid({
     detach(disconnect(connector.id, signal), Reason.DomCallback);
   };
 
-  const finishExplicitAccountAdd = (
+  const finishExplicitAccountAdd = async (
     connector: CustomConnectorResponse,
     connectionId: string | null,
-  ) => {
-    finishAccountConnection({
-      target: { kind: "custom", customConnectorId: connector.id },
-      connectionId,
-      connectorLabel: connector.displayName,
-      mode: { kind: "add" },
-    });
+  ): Promise<void> => {
+    await finishAccountConnection(
+      {
+        target: { kind: "custom", customConnectorId: connector.id },
+        connectionId,
+        connectorLabel: connector.displayName,
+        mode: { kind: "add" },
+      },
+      signal,
+    );
   };
   const handleConnect = (connector: CustomConnectorResponse) => {
     if (connectorAccountsEnabled) {
@@ -591,7 +594,7 @@ function CustomConnectorGrid({
               signal,
             );
             if (result.connected) {
-              finishExplicitAccountAdd(connector, result.connectionId);
+              await finishExplicitAccountAdd(connector, result.connectionId);
             }
           })(),
           Reason.DomCallback,
@@ -668,16 +671,19 @@ function CustomAccountDialogs({
           connector={accountConnect.connector}
           accountMode={accountConnect.mode}
           onClose={closeAccountConnect}
-          onSuccess={(connectionId) => {
-            finishAccountConnection({
-              target: {
-                kind: "custom",
-                customConnectorId: accountConnect.connector.id,
+          onSuccess={async (connectionId) => {
+            await finishAccountConnection(
+              {
+                target: {
+                  kind: "custom",
+                  customConnectorId: accountConnect.connector.id,
+                },
+                connectionId,
+                connectorLabel: accountConnect.connector.displayName,
+                mode: accountConnect.mode,
               },
-              connectionId,
-              connectorLabel: accountConnect.connector.displayName,
-              mode: accountConnect.mode,
-            });
+              signal,
+            );
           }}
         />
       ) : null}
@@ -706,15 +712,18 @@ function CustomAccountDialogs({
                     signal,
                   );
                   if (result.connected) {
-                    finishAccountConnection({
-                      target: {
-                        kind: "custom",
-                        customConnectorId: managedAccounts.id,
+                    await finishAccountConnection(
+                      {
+                        target: {
+                          kind: "custom",
+                          customConnectorId: managedAccounts.id,
+                        },
+                        connectionId: result.connectionId,
+                        connectorLabel: managedAccounts.displayName,
+                        mode: { kind: "add" },
                       },
-                      connectionId: result.connectionId,
-                      connectorLabel: managedAccounts.displayName,
-                      mode: { kind: "add" },
-                    });
+                      signal,
+                    );
                   }
                 })(),
                 Reason.DomCallback,

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -1106,16 +1106,19 @@ export function ConnectorsPage() {
     };
   };
 
-  const finishExplicitAccountAdd = (
+  const finishExplicitAccountAdd = async (
     connector: PlatformConnectorCatalogStatusItem,
     connectionId: string | null,
-  ) => {
-    finishAccountConnection({
-      target: { kind: "builtin", connectorSlug: connector.slug },
-      connectionId,
-      connectorLabel: connector.label,
-      mode: { kind: "add" },
-    });
+  ): Promise<void> => {
+    await finishAccountConnection(
+      {
+        target: { kind: "builtin", connectorSlug: connector.slug },
+        connectionId,
+        connectorLabel: connector.label,
+        mode: { kind: "add" },
+      },
+      signal,
+    );
   };
 
   const accountConnectHandlers = (
@@ -1137,7 +1140,7 @@ export function ConnectorsPage() {
           signal,
         );
         if (result) {
-          finishExplicitAccountAdd(connector, result.connectionId);
+          await finishExplicitAccountAdd(connector, result.connectionId);
         }
         return result;
       },
@@ -1154,7 +1157,7 @@ export function ConnectorsPage() {
           signal,
         );
         if (result) {
-          finishExplicitAccountAdd(connector, result.connectionId);
+          await finishExplicitAccountAdd(connector, result.connectionId);
         }
         return result;
       },
@@ -1320,16 +1323,19 @@ export function ConnectorsPage() {
           onClose={() => {
             closeAccountConnect();
           }}
-          onSuccess={(connectionId) => {
-            finishAccountConnection({
-              target: {
-                kind: "builtin",
-                connectorSlug: accountConnect.connector.slug,
+          onSuccess={async (connectionId) => {
+            await finishAccountConnection(
+              {
+                target: {
+                  kind: "builtin",
+                  connectorSlug: accountConnect.connector.slug,
+                },
+                connectionId,
+                connectorLabel: accountConnect.connector.label,
+                mode: accountConnect.mode,
               },
-              connectionId,
-              connectorLabel: accountConnect.connector.label,
-              mode: accountConnect.mode,
-            });
+              signal,
+            );
           }}
         />
       )}


### PR DESCRIPTION
## Summary

- read the newly connected account before opening the optional naming prompt
- preview the same effective account label used by connector account consumers
- keep the preview separate from `displayName` so Skip preserves the provider-derived fallback
- remove the obsolete localized `Work account` placeholder

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=4 --silent=passed-only`
- `pnpm -F @okouai/app exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace @okouai/app`
- pre-commit formatting, repository Knip, repository type checks, and commitlint

## Compatibility

The connector-account feature is still disabled. This change does not alter API contracts, database state, or persisted naming semantics, so no transitional compatibility path is included.

Closes #29433

Parent: #28571
