### PR TITLE
refactor(api): retain alias source telemetry

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { EVENT } from "@axiomhq/logging";
 import { describe, expect, it } from "vitest";
 
@@ -72,29 +74,41 @@ function aliasEvidence(state: string): Readonly<Record<string, unknown>> {
   };
 }
 
+function expectValueFree(diagnostics: string, values: readonly string[]): void {
+  for (const value of values) {
+    const forbiddenDerivatives = [
+      value,
+      String(value.length),
+      createHash("sha256").update(value).digest("hex"),
+      JSON.stringify(value),
+    ];
+    for (const derivative of forbiddenDerivatives) {
+      expect(diagnostics).not.toContain(derivative);
+    }
+  }
+}
+
 describe("API backend URL aliases", () => {
   it("resolves the non-conflicting matrix with one value-free event per state", () => {
     for (const fixture of API_BACKEND_URL_ALIAS_FIXTURES) {
       configureAliases(fixture.canonical, fixture.legacy);
-      const logCount = context.mocks.axiomLogging.debug.mock.calls.length;
+      const logCount = context.mocks.axiomLogging.info.mock.calls.length;
 
       expect(apiBackendUrl()).toBe(fixture.expected);
       expect(apiBackendUrl()).toBe(fixture.expected);
 
-      const calls = context.mocks.axiomLogging.debug.mock.calls.slice(logCount);
+      const calls = context.mocks.axiomLogging.info.mock.calls.slice(logCount);
       expect(calls).toStrictEqual([
         [API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, aliasEvidence(fixture.state)],
       ]);
-      const evidence = JSON.stringify(calls);
-      const containsConfiguredValue = [fixture.canonical, fixture.legacy]
-        .filter((value): value is string => {
+      expectValueFree(
+        JSON.stringify(calls),
+        [fixture.canonical, fixture.legacy].filter((value): value is string => {
           return value !== undefined;
-        })
-        .some((value) => {
-          return evidence.includes(value);
-        });
-      expect(containsConfiguredValue).toBeFalsy();
+        }),
+      );
     }
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
     expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 
@@ -125,6 +139,7 @@ describe("API backend URL aliases", () => {
     expect(diagnostics).not.toContain(canonical);
     expect(diagnostics).not.toContain(legacy);
     expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalled();
   });
 });
 

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -114,6 +114,20 @@ function debugAliasEvidence(state: string): Readonly<Record<string, unknown>> {
   };
 }
 
+function expectValueFree(diagnostics: string, values: readonly string[]): void {
+  for (const value of values) {
+    const forbiddenDerivatives = [
+      value,
+      String(value.length),
+      createHash("sha256").update(value).digest("hex"),
+      JSON.stringify(value),
+    ];
+    for (const derivative of forbiddenDerivatives) {
+      expect(diagnostics).not.toContain(derivative);
+    }
+  }
+}
+
 beforeEach(() => {
   __resetForTest();
   axiomLogging.flush.mockResolvedValue(undefined);
@@ -124,14 +138,22 @@ describe("debug environment aliases", () => {
     "resolves $description with bounded source evidence",
     ({ canonical, legacy, state, expectedLevel }) => {
       configureDebugAliases(canonical, legacy);
-      const debugLogCount = axiomLogging.debug.mock.calls.length;
+      const infoLogCount = axiomLogging.info.mock.calls.length;
 
       expect(logger("debug-matrix-target").level).toBe(expectedLevel);
       expect(logger("another-logger").level).toBe("info");
 
-      expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+      const calls = axiomLogging.info.mock.calls.slice(infoLogCount);
+      expect(calls).toStrictEqual([
         [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence(state)],
       ]);
+      expectValueFree(
+        JSON.stringify(calls),
+        [canonical, legacy].filter((value): value is string => {
+          return Boolean(value);
+        }),
+      );
+      expect(axiomLogging.debug).not.toHaveBeenCalled();
       expect(axiomLogging.warn).not.toHaveBeenCalled();
     },
   );
@@ -153,24 +175,13 @@ describe("debug environment aliases", () => {
       [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("conflicting-dual")],
     ]);
     expect(axiomLogging.debug).not.toHaveBeenCalled();
+    expect(axiomLogging.info).not.toHaveBeenCalled();
 
     const diagnostics = JSON.stringify({
       error: DEBUG_ALIAS_CONFLICT_ERROR,
       logs: axiomLogging.warn.mock.calls,
     });
-    const forbiddenDerivatives = [
-      canonical,
-      legacy,
-      String(canonical.length),
-      String(legacy.length),
-      createHash("sha256").update(canonical).digest("hex"),
-      createHash("sha256").update(legacy).digest("hex"),
-      JSON.stringify(canonical),
-      JSON.stringify(legacy),
-    ];
-    for (const derivative of forbiddenDerivatives) {
-      expect(diagnostics).not.toContain(derivative);
-    }
+    expectValueFree(diagnostics, [canonical, legacy]);
   });
 
   it.each([
@@ -223,7 +234,7 @@ describe("debug environment aliases", () => {
 
   it("keeps configuration and logger levels cached until the existing reset", () => {
     configureDebugAliases("CachedLogger", undefined);
-    const debugLogCount = axiomLogging.debug.mock.calls.length;
+    const infoLogCount = axiomLogging.info.mock.calls.length;
 
     const cached = logger("CachedLogger");
     expect(cached.level).toBe("debug");
@@ -232,14 +243,14 @@ describe("debug environment aliases", () => {
     expect(logger("CachedLogger")).toBe(cached);
     expect(logger("CachedLogger").level).toBe("debug");
     expect(logger("AfterResetLogger").level).toBe("info");
-    expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+    expect(axiomLogging.info.mock.calls.slice(infoLogCount)).toStrictEqual([
       [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
     ]);
 
     __resetForTest();
 
     expect(logger("AfterResetLogger").level).toBe("debug");
-    expect(axiomLogging.debug.mock.calls.slice(debugLogCount)).toStrictEqual([
+    expect(axiomLogging.info.mock.calls.slice(infoLogCount)).toStrictEqual([
       [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
       [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
     ]);

--- a/turbo/apps/api/src/lib/__tests__/web-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/web-url.test.ts
@@ -126,12 +126,12 @@ describe("web URL aliases", () => {
   it("resolves the non-conflicting matrix with one value-free event per state", () => {
     for (const fixture of WEB_URL_ALIAS_FIXTURES) {
       configureAliases(fixture.canonical, fixture.legacy);
-      const logCount = context.mocks.axiomLogging.debug.mock.calls.length;
+      const logCount = context.mocks.axiomLogging.info.mock.calls.length;
 
       expect(webUrl()).toBe(fixture.expected);
       expect(webUrl()).toBe(fixture.expected);
 
-      const calls = context.mocks.axiomLogging.debug.mock.calls.slice(logCount);
+      const calls = context.mocks.axiomLogging.info.mock.calls.slice(logCount);
       expect(calls).toStrictEqual([
         [WEB_URL_ALIAS_RESOLUTION_EVENT, aliasEvidence(fixture.state)],
       ]);
@@ -142,6 +142,7 @@ describe("web URL aliases", () => {
         }),
       );
     }
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
     expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 
@@ -161,6 +162,7 @@ describe("web URL aliases", () => {
       [WEB_URL_ALIAS_RESOLUTION_EVENT, aliasEvidence("absent")],
     ]);
     expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalled();
   });
 
   it("fails before OAuth origin normalization on byte-unequal aliases", () => {
@@ -182,6 +184,7 @@ describe("web URL aliases", () => {
       [WEB_URL_ALIAS_RESOLUTION_EVENT, aliasEvidence("conflicting-dual")],
     ]);
     expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalled();
     expectValueFree(
       JSON.stringify({
         error: WEB_URL_CONFLICT_ERROR,

--- a/turbo/apps/api/src/lib/api-backend-url.ts
+++ b/turbo/apps/api/src/lib/api-backend-url.ts
@@ -1,5 +1,5 @@
 import { env } from "./env";
-import { logger } from "./log";
+import { logAliasResolutionInfo, logger } from "./log";
 import { singleton } from "./singleton";
 
 const CANONICAL_API_BACKEND_URL_KEY = "OKOU_API_BACKEND_URL";
@@ -35,7 +35,7 @@ function reportResolution(state: ApiBackendUrlAliasState): void {
     log.warn(API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
     return;
   }
-  log.debug(API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
+  logAliasResolutionInfo(log, API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
 }
 
 // This API-process compatibility boundary retains VM0_API_BACKEND_URL while

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -63,6 +63,13 @@ interface Logger {
   level: Level;
 }
 
+type RetainedAliasResolutionEvent =
+  | "api_backend_url_alias_resolution"
+  | "web_url_alias_resolution"
+  | "debug_environment_alias_resolution"
+  | "billing_machine_secret_alias_resolution"
+  | "stripe_preview_job_ref_alias_resolution";
+
 class LoggerRegistry {
   private readonly store = new Map<string, Logger>();
 
@@ -96,7 +103,7 @@ function parseDebugPatterns(value: string | undefined): readonly string[] {
 
 function reportDebugAliasResolution(state: DebugAliasState): void {
   logToAxiom(
-    state === "conflicting-dual" ? Level.Warn : Level.Debug,
+    state === "conflicting-dual" ? Level.Warn : Level.Info,
     DEBUG_ALIAS_LOG_CONTEXT,
     [
       DEBUG_ALIAS_RESOLUTION_EVENT,
@@ -427,6 +434,14 @@ export function logger(name: string): Logger {
   const loggerInstance = createLogger(name);
   registry.set(name, loggerInstance);
   return loggerInstance;
+}
+
+export function logAliasResolutionInfo(
+  loggerInstance: Pick<Logger, "info">,
+  event: RetainedAliasResolutionEvent,
+  fields: Readonly<Record<string, string>>,
+): void {
+  loggerInstance.info(event, fields);
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/turbo/apps/api/src/lib/web-url.ts
+++ b/turbo/apps/api/src/lib/web-url.ts
@@ -1,5 +1,5 @@
 import { env } from "./env";
-import { logger } from "./log";
+import { logAliasResolutionInfo, logger } from "./log";
 import { singleton } from "./singleton";
 
 const CANONICAL_WEB_URL_KEY = "OKOU_WEB_URL";
@@ -38,7 +38,7 @@ function reportResolution(state: WebUrlAliasState): void {
     log.warn(WEB_URL_ALIAS_RESOLUTION_EVENT, fields);
     return;
   }
-  log.debug(WEB_URL_ALIAS_RESOLUTION_EVENT, fields);
+  logAliasResolutionInfo(log, WEB_URL_ALIAS_RESOLUTION_EVENT, fields);
 }
 
 // This API-process compatibility boundary retains VM0_WEB_URL while the

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { EVENT } from "@axiomhq/logging";
 import { billingRedeemCodeContract } from "@okouai/api-contracts/contracts/billing";
@@ -21,10 +21,81 @@ const MACHINE_SECRET_ALIAS_RESOLUTION_EVENT =
   "billing_machine_secret_alias_resolution";
 const MACHINE_SECRET_LOG_CONTEXT = "api:zero:billing-redeem-code";
 
+type MachineSecretAliasState =
+  | "absent"
+  | "canonical-only"
+  | "legacy-only"
+  | "equal-dual"
+  | "conflicting-dual";
+
+interface MachineSecretAliasFixture {
+  readonly source: MachineSecretAliasState;
+  readonly canonical: string | undefined;
+  readonly legacy: string | undefined;
+  readonly expectedStatus: 200 | 503;
+}
+
+const MACHINE_SECRET_ALIAS_FIXTURES: readonly MachineSecretAliasFixture[] = [
+  {
+    source: "absent",
+    canonical: "",
+    legacy: "",
+    expectedStatus: 503,
+  },
+  {
+    source: "canonical-only",
+    canonical: `canonical-machine-secret-${"c".repeat(113)}`,
+    legacy: "",
+    expectedStatus: 200,
+  },
+  {
+    source: "legacy-only",
+    canonical: "",
+    legacy: `legacy-machine-secret-${"l".repeat(127)}`,
+    expectedStatus: 200,
+  },
+  {
+    source: "equal-dual",
+    canonical: `equal-machine-secret-${"e".repeat(131)}`,
+    legacy: `equal-machine-secret-${"e".repeat(131)}`,
+    expectedStatus: 200,
+  },
+  {
+    source: "conflicting-dual",
+    canonical: `conflicting-canonical-secret-${"x".repeat(137)}`,
+    legacy: `conflicting-legacy-secret-${"y".repeat(139)}`,
+    expectedStatus: 503,
+  },
+];
+
 interface SessionFixture {
   readonly userId: string;
   readonly orgId: string;
   readonly email: string;
+}
+
+function aliasEvidence(
+  source: MachineSecretAliasState,
+): Readonly<Record<string, unknown>> {
+  return {
+    [EVENT]: { source: "api" },
+    source,
+    context: MACHINE_SECRET_LOG_CONTEXT,
+  };
+}
+
+function expectValueFree(diagnostics: string, values: readonly string[]): void {
+  for (const value of values) {
+    const forbiddenDerivatives = [
+      value,
+      String(value.length),
+      createHash("sha256").update(value).digest("hex"),
+      JSON.stringify(value),
+    ];
+    for (const derivative of forbiddenDerivatives) {
+      expect(diagnostics).not.toContain(derivative);
+    }
+  }
 }
 
 function setAdminSession(): SessionFixture {
@@ -60,6 +131,76 @@ describe("POST /api/billing/redeem-code", () => {
     context.mocks.clerk.m2m.createToken.mockResolvedValue({
       token: ATOM_M2M_TOKEN,
     });
+  });
+
+  it("reports every machine secret source once per process without exposing values", async () => {
+    server.use(
+      http.post(`${ATOM_URL}/api/redeem-codes/consume`, () => {
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
+      billingRedeemCodeContract,
+    );
+
+    for (const fixture of MACHINE_SECRET_ALIAS_FIXTURES) {
+      mockOptionalEnv("OKOU_MACHINE_SECRET_KEY", fixture.canonical);
+      mockOptionalEnv("VM0_MACHINE_SECRET_KEY", fixture.legacy);
+      setAdminSession();
+      const infoLogCount = context.mocks.axiomLogging.info.mock.calls.filter(
+        ([message]) => {
+          return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+        },
+      ).length;
+      const warnLogCount = context.mocks.axiomLogging.warn.mock.calls.filter(
+        ([message]) => {
+          return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+        },
+      ).length;
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const response = await accept(
+          client.create({
+            body: { code: `YUMA-${fixture.source}-${attempt}` },
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200, 503],
+        );
+        expect(response.status).toBe(fixture.expectedStatus);
+      }
+
+      const infoCalls = context.mocks.axiomLogging.info.mock.calls
+        .filter(([message]) => {
+          return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+        })
+        .slice(infoLogCount);
+      const warnCalls = context.mocks.axiomLogging.warn.mock.calls
+        .filter(([message]) => {
+          return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+        })
+        .slice(warnLogCount);
+      const expectedCall = [
+        MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
+        aliasEvidence(fixture.source),
+      ];
+      const expectedInfoCalls =
+        fixture.source === "conflicting-dual" ? [] : [expectedCall];
+      const expectedWarnCalls =
+        fixture.source === "conflicting-dual" ? [expectedCall] : [];
+      expect(infoCalls).toStrictEqual(expectedInfoCalls);
+      expect(warnCalls).toStrictEqual(expectedWarnCalls);
+      expectValueFree(
+        JSON.stringify({ infoCalls, warnCalls }),
+        [fixture.canonical, fixture.legacy].filter((value): value is string => {
+          return Boolean(value);
+        }),
+      );
+    }
+
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+      MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -166,14 +307,6 @@ describe("POST /api/billing/redeem-code", () => {
       },
     });
     expect(context.mocks.clerk.m2m.createToken).not.toHaveBeenCalled();
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
-      MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
-      MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
-      expect.anything(),
-    );
   });
 
   it("fails closed when Atom Clerk M2M auth aliases conflict", async () => {
@@ -209,20 +342,6 @@ describe("POST /api/billing/redeem-code", () => {
     });
     expect(context.mocks.clerk.m2m.createToken).not.toHaveBeenCalled();
     expect(calledAtom).toBeFalsy();
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(1);
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-      MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
-      {
-        [EVENT]: { source: "api" },
-        source: "conflicting-dual",
-        context: MACHINE_SECRET_LOG_CONTEXT,
-      },
-    );
-    const warningLog = JSON.stringify(
-      context.mocks.axiomLogging.warn.mock.calls,
-    );
-    expect(warningLog).not.toContain(canonicalSecret);
-    expect(warningLog).not.toContain(legacySecret);
   });
 
   it("returns 503 when Atom Clerk M2M auth fails", async () => {
@@ -418,7 +537,7 @@ describe("POST /api/billing/redeem-code", () => {
     },
   ])(
     "redeems a code with $source machine secret configuration",
-    async ({ source, canonical, legacy, expected }) => {
+    async ({ canonical, legacy, expected }) => {
       mockOptionalEnv("OKOU_MACHINE_SECRET_KEY", canonical);
       mockOptionalEnv("VM0_MACHINE_SECRET_KEY", legacy);
       const fixture = setAdminSession();
@@ -459,22 +578,6 @@ describe("POST /api/billing/redeem-code", () => {
         org_id: fixture.orgId,
         user_id: fixture.userId,
       });
-      const expectedAliasLogs =
-        source === "legacy-only"
-          ? [
-              [
-                MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
-                {
-                  [EVENT]: { source: "api" },
-                  source: "legacy-only",
-                  context: MACHINE_SECRET_LOG_CONTEXT,
-                },
-              ],
-            ]
-          : [];
-      expect(context.mocks.axiomLogging.debug.mock.calls).toStrictEqual(
-        expectedAliasLogs,
-      );
     },
   );
 });

--- a/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
@@ -3,7 +3,8 @@ import { billingRedeemCodeContract } from "@okouai/api-contracts/contracts/billi
 
 import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, providerUnavailable } from "../../lib/error";
-import { logger } from "../../lib/log";
+import { logAliasResolutionInfo, logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
@@ -37,6 +38,27 @@ type MachineSecretKeyResolution =
       readonly source: "canonical-only" | "legacy-only" | "equal-dual";
       readonly value: string;
     };
+
+type MachineSecretAliasState = MachineSecretKeyResolution["source"];
+
+const reportedMachineSecretStates = singleton(() => {
+  return new Set<MachineSecretAliasState>();
+});
+
+function reportMachineSecretResolution(source: MachineSecretAliasState): void {
+  const states = reportedMachineSecretStates();
+  if (states.has(source)) {
+    return;
+  }
+  states.add(source);
+
+  const fields = { source };
+  if (source === "conflicting-dual") {
+    log.warn(MACHINE_SECRET_ALIAS_RESOLUTION_EVENT, fields);
+    return;
+  }
+  logAliasResolutionInfo(log, MACHINE_SECRET_ALIAS_RESOLUTION_EVENT, fields);
+}
 
 const ATOM_REDEEM_CODE_ERROR_MESSAGES: Readonly<Record<string, string>> =
   Object.freeze({
@@ -225,15 +247,8 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const machineSecretKeyResolution = resolveMachineSecretKey();
-  if (machineSecretKeyResolution.source === "legacy-only") {
-    log.debug(MACHINE_SECRET_ALIAS_RESOLUTION_EVENT, {
-      source: machineSecretKeyResolution.source,
-    });
-  }
+  reportMachineSecretResolution(machineSecretKeyResolution.source);
   if (machineSecretKeyResolution.source === "conflicting-dual") {
-    log.warn(MACHINE_SECRET_ALIAS_RESOLUTION_EVENT, {
-      source: machineSecretKeyResolution.source,
-    });
     return providerUnavailable("Redeem service not configured");
   }
   if (machineSecretKeyResolution.source === "absent") {

--- a/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/stripe-preview-metadata.service.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { EVENT } from "@axiomhq/logging";
 import { describe, expect, it } from "vitest";
 
@@ -20,7 +22,8 @@ type PreviewJobRefAliasState =
   | "absent"
   | "canonical-only"
   | "legacy-only"
-  | "dual";
+  | "equal-dual"
+  | "conflicting-dual";
 
 interface PreviewJobRefAliasFixture {
   readonly name: string;
@@ -91,7 +94,7 @@ const PREVIEW_JOB_REF_ALIAS_FIXTURES: readonly PreviewJobRefAliasFixture[] = [
     name: "equal dual aliases",
     canonical: "shared-preview-job",
     legacy: "shared-preview-job",
-    state: "dual",
+    state: "equal-dual",
     jobRef: "shared-preview-job",
   },
 ];
@@ -118,11 +121,36 @@ function aliasEvidence(
   };
 }
 
+function expectValueFree(diagnostics: string, values: readonly string[]): void {
+  for (const value of values) {
+    const forbiddenDerivatives = [
+      value,
+      String(value.length),
+      createHash("sha256").update(value).digest("hex"),
+      JSON.stringify(value),
+    ];
+    for (const derivative of forbiddenDerivatives) {
+      expect(diagnostics).not.toContain(derivative);
+    }
+  }
+}
+
 describe("Stripe preview metadata job reference aliases", () => {
-  it.each(PREVIEW_JOB_REF_ALIAS_FIXTURES)(
-    "resolves $name for metadata creation and matching",
-    ({ canonical, legacy, state, jobRef }) => {
+  it("resolves the matrix with one value-free info event per state", () => {
+    const reportedStates = new Set<PreviewJobRefAliasState>();
+
+    for (const {
+      canonical,
+      legacy,
+      state,
+      jobRef,
+    } of PREVIEW_JOB_REF_ALIAS_FIXTURES) {
       configureAliases("preview", canonical, legacy);
+      const logCount = context.mocks.axiomLogging.info.mock.calls.filter(
+        ([message]) => {
+          return message === PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT;
+        },
+      ).length;
       const expectedMetadata: Readonly<Record<string, string>> = jobRef
         ? { vm0_environment: "preview", job_ref: jobRef }
         : {};
@@ -131,38 +159,37 @@ describe("Stripe preview metadata job reference aliases", () => {
       expect(isCurrentStripePreviewMetadata(expectedMetadata)).toBeTruthy();
       expect(isCurrentStripePreviewMetadata(null)).toBe(jobRef === null);
 
-      const aliasResolutionCalls =
-        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+      const aliasResolutionCalls = context.mocks.axiomLogging.info.mock.calls
+        .filter(([message]) => {
           return message === PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT;
-        });
-      expect(aliasResolutionCalls).toHaveLength(3);
-      for (const call of aliasResolutionCalls) {
-        expect(call).toStrictEqual([
-          PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-          aliasEvidence(state),
-        ]);
-      }
-      const evidence = JSON.stringify(aliasResolutionCalls);
+        })
+        .slice(logCount);
+      const expectedCalls = reportedStates.has(state)
+        ? []
+        : [[PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, aliasEvidence(state)]];
+      expect(aliasResolutionCalls).toStrictEqual(expectedCalls);
+      reportedStates.add(state);
       const configuredValues = [canonical, legacy].filter(
         (value): value is string => {
           return Boolean(value);
         },
       );
-      expect(
-        configuredValues.some((value) => {
-          return evidence.includes(value);
-        }),
-      ).toBeFalsy();
-      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
-    },
-  );
+      expectValueFree(JSON.stringify(aliasResolutionCalls), configuredValues);
+    }
+
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
 
   it("fails closed on unequal dual aliases without exposing either value", () => {
     const canonical = "canonical-job-ref-must-not-leak";
     const legacy = "legacy-job-ref-must-not-leak";
     configureAliases("preview", canonical, legacy);
     const expectedMessage =
-      "Preview job reference aliases conflict: canonicalKey=OKOU_PREVIEW_JOB_REF legacyKey=VM0_PREVIEW_JOB_REF state=dual";
+      "Preview job reference aliases conflict: canonicalKey=OKOU_PREVIEW_JOB_REF legacyKey=VM0_PREVIEW_JOB_REF state=conflicting-dual";
 
     expect(() => {
       stripePreviewMetadata();
@@ -174,20 +201,25 @@ describe("Stripe preview metadata job reference aliases", () => {
       });
     }).toThrow(expectedMessage);
 
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(2);
-    for (const call of context.mocks.axiomLogging.warn.mock.calls) {
-      expect(call).toStrictEqual([
+    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([
+      [
         PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
-        aliasEvidence("dual"),
-      ]);
-    }
+        aliasEvidence("conflicting-dual"),
+      ],
+    ]);
     const diagnostics = JSON.stringify({
       error: expectedMessage,
       logs: context.mocks.axiomLogging.warn.mock.calls,
     });
-    expect(diagnostics).not.toContain(canonical);
-    expect(diagnostics).not.toContain(legacy);
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expectValueFree(diagnostics, [canonical, legacy]);
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
+      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
   });
 
   it("ignores preview alias conflicts outside preview deployments", () => {
@@ -199,7 +231,14 @@ describe("Stripe preview metadata job reference aliases", () => {
 
     expect(stripePreviewMetadata()).toStrictEqual({});
     expect(isCurrentStripePreviewMetadata(null)).toBeTruthy();
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
+      PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT,
+      expect.anything(),
+    );
     expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -1,5 +1,6 @@
 import { env, optionalEnv } from "../../lib/env";
-import { logger } from "../../lib/log";
+import { logAliasResolutionInfo, logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
 
 const PREVIEW_ENVIRONMENT_METADATA_KEY = "vm0_environment";
 const PREVIEW_JOB_REF_METADATA_KEY = "job_ref";
@@ -14,13 +15,37 @@ type PreviewJobRefAliasState =
   | "absent"
   | "canonical-only"
   | "legacy-only"
-  | "dual";
+  | "equal-dual"
+  | "conflicting-dual";
+
+const reportedStates = singleton(() => {
+  return new Set<PreviewJobRefAliasState>();
+});
+
+function reportResolution(state: PreviewJobRefAliasState): void {
+  const states = reportedStates();
+  if (states.has(state)) {
+    return;
+  }
+  states.add(state);
+
+  const fields = {
+    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
+    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
+    state,
+  };
+  if (state === "conflicting-dual") {
+    log.warn(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, fields);
+    return;
+  }
+  logAliasResolutionInfo(log, PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, fields);
+}
 
 // The preview deployment action intentionally emits equal-dual aliases so old
 // API rollback targets keep the legacy input while current APIs exercise the
 // canonical reader. Cut the writer to canonical-only only after every eligible
 // API can read the canonical key; remove the legacy reader separately after
-// bounded evidence shows zero legacy-only or dual resolutions through the
+// bounded evidence shows zero legacy-only or equal-dual resolutions through the
 // supported rollback window.
 function resolveStripePreviewJobRef(): string | null {
   if (env("ENV") !== "preview") {
@@ -30,13 +55,9 @@ function resolveStripePreviewJobRef(): string | null {
   const canonical = optionalEnv(CANONICAL_PREVIEW_JOB_REF_ENV_KEY);
   const legacy = optionalEnv(LEGACY_PREVIEW_JOB_REF_ENV_KEY);
   if (canonical && legacy && canonical !== legacy) {
-    log.warn(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, {
-      canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
-      legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
-      state: "dual",
-    });
+    reportResolution("conflicting-dual");
     throw new Error(
-      `Preview job reference aliases conflict: canonicalKey=${CANONICAL_PREVIEW_JOB_REF_ENV_KEY} legacyKey=${LEGACY_PREVIEW_JOB_REF_ENV_KEY} state=dual`,
+      `Preview job reference aliases conflict: canonicalKey=${CANONICAL_PREVIEW_JOB_REF_ENV_KEY} legacyKey=${LEGACY_PREVIEW_JOB_REF_ENV_KEY} state=conflicting-dual`,
     );
   }
 
@@ -44,7 +65,7 @@ function resolveStripePreviewJobRef(): string | null {
   let state: PreviewJobRefAliasState;
   if (canonical && legacy) {
     jobRef = canonical;
-    state = "dual";
+    state = "equal-dual";
   } else if (canonical) {
     jobRef = canonical;
     state = "canonical-only";
@@ -56,11 +77,7 @@ function resolveStripePreviewJobRef(): string | null {
     state = "absent";
   }
 
-  log.debug(PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, {
-    canonicalKey: CANONICAL_PREVIEW_JOB_REF_ENV_KEY,
-    legacyKey: LEGACY_PREVIEW_JOB_REF_ENV_KEY,
-    state,
-  });
+  reportResolution(state);
   return jobRef;
 }
 


### PR DESCRIPTION
## Summary

- retain the five inventoried API environment-alias source events at production-visible levels without logging values or derivatives
- bound each event/state to one emission per process while keeping conflicts and the required missing web URL failure at warning level
- distinguish Stripe preview `equal-dual` from `conflicting-dual` without changing resolver, writer, output, or failure behavior

## Scope boundaries

- no shared Axiom client changes, debug-ingestion changes, environment writer/reader/schema/configuration changes, canonical-only cutover, legacy-reader removal, namespace-guard changes, or #25722 code
- no release or cutover performed

## Verification

- `pnpm -F api lint`
- focused ESLint on all 10 touched files (`--max-warnings 0`)
- `pnpm -F api check-types`
- focused Vitest: 5 files, 88 tests passed
- focused Prettier check and `git diff --check`

## Base and overlap

- dispatched base: `61ec6f4fd459407e88e70ee780efad59e5a475ef`
- refreshed before edits: `fea30c27192abef62cfff0a8978a690e15424760`
- final refreshed base: `f9d9692d06e8f9574d2888397e0ab38ec2adc029`
- final open-PR audit: 28 PRs, 403 declared / 403 fetched changed files, zero mismatch; only stale #25722 overlaps `log.ts` and its test through unrelated Worker/invocation Axiom lifecycle work and was excluded

Closes #29470
Parent: #28914
