### PR TITLE
refactor(connectors): standardize effective oauth scope reporting

### DIFF
--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -68,6 +68,7 @@ type CallbackIdentity = {
 
 type CompleteOAuthCallbackInput = {
   readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly authorizationUrl: string | null;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -118,6 +119,7 @@ type ResolvedCallbackState =
       readonly authorizeAgent: boolean;
       readonly codeVerifier: string | undefined;
       readonly oauthContext: string | undefined;
+      readonly authorizationUrl: string | null;
       readonly redirectUri: string;
       readonly resolvedMethod: ResolvedConnectorActionMethod;
       readonly account: ConnectorAccountMutationIntent;
@@ -227,6 +229,7 @@ function callbackOriginForStoredState(
 
 async function exchangeTokenForConnector(args: {
   readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly authorizationUrl: string | null;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string | undefined;
@@ -254,6 +257,7 @@ async function exchangeTokenForConnector(args: {
     authMethodId: args.resolvedMethod.authMethodId,
     method: args.resolvedMethod.method,
     authClient,
+    authorizationUrl: args.authorizationUrl,
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
@@ -554,6 +558,7 @@ const completeOAuthCallback$ = command(
   ): Promise<Response> => {
     const token = await exchangeTokenForConnector({
       resolvedMethod: args.resolvedMethod,
+      authorizationUrl: args.authorizationUrl,
       code: args.code,
       redirectUri: args.redirectUri,
       state: args.state,
@@ -731,6 +736,7 @@ async function resolveCallbackState(
     resolvedMethod: authMethodResult.resolvedMethod,
     codeVerifier: args.storedState.codeVerifier ?? undefined,
     oauthContext: args.storedState.oauthContext ?? undefined,
+    authorizationUrl: args.storedState.authorizationUrl,
     redirectUri: args.storedState.redirectUri,
     account: args.storedState.accountMutation,
     insertConnectionId:
@@ -1090,6 +1096,7 @@ const handleAuthCodeConnectorCallback$ = command(
         completeOAuthCallback$,
         {
           resolvedMethod: resolvedState.resolvedMethod,
+          authorizationUrl: resolvedState.authorizationUrl,
           code,
           redirectUri: resolvedState.redirectUri,
           state,

--- a/turbo/packages/connectors/src/auth-providers/__tests__/effective-oauth-scopes.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/__tests__/effective-oauth-scopes.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import type { ConnectorAuthMethodRuntimeConfig } from "../../connector-config";
+import { exchangeConnectorAuthCodeWithMethod } from "../connector-auth";
+import { server } from "./test-server";
+
+const AUTH_CLIENT = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "test-oauth-client",
+  clientSecret: "test-oauth-secret",
+} as const;
+
+function authMethod(
+  scopes: readonly string[],
+): ConnectorAuthMethodRuntimeConfig {
+  return {
+    client: AUTH_CLIENT,
+    storage: {
+      version: 1,
+      secrets: ["TEST_ACCESS_TOKEN", "TEST_REFRESH_TOKEN"],
+      variables: ["TEST_TENANT_ID"],
+    },
+    grant: {
+      kind: "auth-code",
+      callbackOrigin: "api",
+      scopes: [...scopes],
+      outputs: {
+        accessToken: "$secrets.TEST_ACCESS_TOKEN",
+        refreshToken: "$secrets.TEST_REFRESH_TOKEN",
+        tenantId: "$vars.TEST_TENANT_ID",
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      inputs: { refreshToken: "$secrets.TEST_REFRESH_TOKEN" },
+      outputs: {
+        accessToken: "$secrets.TEST_ACCESS_TOKEN",
+        refreshToken: "$secrets.TEST_REFRESH_TOKEN",
+      },
+      refreshableSecrets: ["TEST_ACCESS_TOKEN"],
+      envBindings: {},
+    },
+    revoke: { kind: "none" },
+  };
+}
+
+function mockTestOAuthProvider(scope?: string): void {
+  server.use(
+    http.post("https://provider.example/api/test/oauth-provider/token", () => {
+      return HttpResponse.json({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        ...(scope === undefined ? {} : { scope }),
+      });
+    }),
+    http.get(
+      "https://provider.example/api/test/oauth-provider/userinfo",
+      () => {
+        return HttpResponse.json({
+          id: "user-id",
+          username: "Test User",
+          email: "test@example.com",
+        });
+      },
+    ),
+  );
+}
+
+async function exchangeWithAuthorizationUrl(
+  authorizationUrl: string | null,
+  reportedScope?: string,
+) {
+  vi.stubEnv("VM0_API_BACKEND_URL", "https://provider.example");
+  mockTestOAuthProvider(reportedScope);
+  return await exchangeConnectorAuthCodeWithMethod({
+    connectorSlug: "test-oauth",
+    authMethodId: "oauth",
+    method: authMethod(["catalog-changed"]),
+    authClient: AUTH_CLIENT,
+    authorizationUrl,
+    code: "authorization-code",
+    redirectUri: "https://app.example/callback",
+    state: "state",
+    codeVerifier: undefined,
+    oauthContext: undefined,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("effective OAuth scopes", () => {
+  it("uses the original authorization request when the token omits scope", async () => {
+    const result = await exchangeWithAuthorizationUrl(
+      "https://provider.example/authorize?scope=started+supplemental",
+    );
+
+    expect(result.scopes).toEqual(["started", "supplemental"]);
+  });
+
+  it("uses a reported partial and supplemental grant exactly", async () => {
+    const result = await exchangeWithAuthorizationUrl(
+      "https://provider.example/authorize?scope=started+second",
+      "started provider-added",
+    );
+
+    expect(result.scopes).toEqual(["started", "provider-added"]);
+  });
+
+  it("preserves an explicitly reported empty grant", async () => {
+    const result = await exchangeWithAuthorizationUrl(
+      "https://provider.example/authorize?scope=started",
+      "",
+    );
+
+    expect(result.scopes).toEqual([]);
+  });
+
+  it("parses Slack-style user_scope requests", async () => {
+    const result = await exchangeWithAuthorizationUrl(
+      "https://provider.example/authorize?user_scope=users%3Aread%2Cchat%3Awrite",
+    );
+
+    expect(result.scopes).toEqual(["users:read", "chat:write"]);
+  });
+
+  it("keeps catalog scopes for legacy state without an authorization URL", async () => {
+    const result = await exchangeWithAuthorizationUrl(null);
+
+    expect(result.scopes).toEqual(["catalog-changed"]);
+  });
+
+  it("keeps provider-registered scopes when the URL has no scope parameter", async () => {
+    const result = await exchangeWithAuthorizationUrl(
+      "https://provider.example/authorize?state=state",
+    );
+
+    expect(result.scopes).toEqual(["catalog-changed"]);
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -38,6 +38,7 @@ import {
   type OAuthDeviceAuthStartResult,
 } from "./provider-flow-types";
 import { providerEnvFromObject, type ProviderEnv } from "./provider-env";
+import { authorizationScopesFromUrl } from "./oauth/scope";
 import {
   CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS,
   type ConnectorAuthProviderAuthMethodId,
@@ -1286,6 +1287,7 @@ export async function buildConnectorOpenIdAuthAuthorizationUrlWithMethod(
 export async function exchangeConnectorAuthCodeWithMethod(
   args: ConnectorAuthProviderMethodSelection & {
     readonly authClient: ConnectorAuthClient;
+    readonly authorizationUrl: string | null;
     readonly code: string;
     readonly redirectUri: string;
     readonly state: string | undefined;
@@ -1308,7 +1310,14 @@ export async function exchangeConnectorAuthCodeWithMethod(
     Promise<ConnectorAuthProviderGrantResult>
   >(provider.exchangeCode, {
     authClient: args.authClient,
-    authCodeGrant: args.method.grant,
+    authCodeGrant: {
+      ...args.method.grant,
+      scopes: [
+        ...((args.authorizationUrl
+          ? authorizationScopesFromUrl(args.authorizationUrl)
+          : undefined) ?? args.method.grant.scopes),
+      ],
+    },
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/gmail.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/gmail.test.ts
@@ -64,4 +64,40 @@ describe("connector/providers/gmail", () => {
       name: "Test User",
     });
   });
+
+  it("uses all requested scopes when Google omits scope", async () => {
+    server.use(
+      http.post("https://oauth2.googleapis.com/token", () => {
+        return HttpResponse.json({ access_token: "gmail-test-token" });
+      }),
+      http.get("https://openidconnect.googleapis.com/v1/userinfo", () => {
+        return HttpResponse.json({ sub: "google-user-123" });
+      }),
+    );
+    const authorizationUrl = new URL(
+      buildGmailAuthorizationUrl(
+        authCodeGrant(),
+        "client-id",
+        "https://example.com/callback",
+        "test-state",
+      ),
+    );
+    const authorizationScopes =
+      authorizationUrl.searchParams.get("scope")?.split(" ") ?? [];
+
+    const result = await exchangeGmailCode(
+      authCodeGrantFixture(authorizationScopes),
+      "client-id",
+      "client-secret",
+      "test-code",
+      "https://example.com/callback",
+    );
+
+    expect(result.scopes).toEqual([
+      "https://www.googleapis.com/auth/gmail.modify",
+      "openid",
+      "email",
+      "profile",
+    ]);
+  });
 });

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/google-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/google-ads.test.ts
@@ -71,7 +71,7 @@ describe("connector/providers/google-ads", () => {
           refresh_token: "google-ads-refresh-token",
           expires_in: 3600,
           scope:
-            "https://www.googleapis.com/auth/adwords https://www.googleapis.com/auth/datamanager https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/adwords provider-supplemental",
         });
       });
       const userInfoHandler = http.get(USER_INFO_URL, () => {
@@ -102,8 +102,7 @@ describe("connector/providers/google-ads", () => {
         expiresIn: 3600,
         scopes: [
           "https://www.googleapis.com/auth/adwords",
-          "https://www.googleapis.com/auth/datamanager",
-          "https://www.googleapis.com/auth/userinfo.email",
+          "provider-supplemental",
         ],
         userInfo: {
           id: "google-user-123",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/strava.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/strava.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import { server } from "../../__tests__/test-server";
+import { exchangeStravaCode } from "../strava/oauth";
+import { authCodeGrantFixture } from "./auth-code-grant-fixture";
+
+describe("connector/providers/strava", () => {
+  it("returns the granted scopes reported by Strava", async () => {
+    server.use(
+      http.post("https://www.strava.com/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "strava-access-token",
+          refresh_token: "strava-refresh-token",
+          scope: "read,activity:read",
+          athlete: { id: 42 },
+        });
+      }),
+      http.get("https://www.strava.com/api/v3/athlete", () => {
+        return HttpResponse.json({ id: 42, firstname: "Ada" });
+      }),
+    );
+
+    const result = await exchangeStravaCode(
+      authCodeGrantFixture(["read", "activity:read_all"]),
+      "client-id",
+      "client-secret",
+      "authorization-code",
+    );
+
+    expect(result.scopes).toEqual(["read", "activity:read"]);
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/ahrefs/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/ahrefs/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const AHREFS_TOKEN_URL = "https://app.ahrefs.com/api/token";
 
@@ -104,7 +105,7 @@ export async function exchangeAhrefsCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const AIRTABLE_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
 
@@ -144,7 +145,7 @@ export async function exchangeAirtableCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const BOX_TOKEN_URL = "https://api.box.com/oauth2/token";
 
@@ -98,7 +99,7 @@ export async function exchangeBoxCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : authCodeGrant.scopes,
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/cal-com/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/cal-com/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const AUTHORIZATION_URL = "https://app.cal.com/auth/oauth2/authorize";
 const TOKEN_URL = "https://api.cal.com/v2/auth/oauth2/token";
@@ -86,7 +87,7 @@ export async function exchangeCalComCode(args: {
     accessToken: token.access_token,
     refreshToken: token.refresh_token ?? null,
     expiresIn: token.expires_in,
-    scopes: token.scope ? token.scope.split(/[ ,]+/) : args.grant.scopes,
+    scopes: effectiveOAuthScopes(token.scope, args.grant.scopes, /[ ,]+/),
     userInfo: {
       id: String(user.id),
       username: user.username ?? user.name ?? null,

--- a/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const CANVA_TOKEN_URL = "https://api.canva.com/rest/v1/oauth/token";
 
@@ -205,7 +206,7 @@ export async function exchangeCanvaCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const CLOSE_TOKEN_URL = "https://api.close.com/oauth2/token/";
 
@@ -100,7 +101,7 @@ export async function exchangeCloseCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : authCodeGrant.scopes,
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo: {
       id: userInfo.id,
       email: userInfo.email,

--- a/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth";
 const CLOUDFLARE_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
@@ -35,15 +36,6 @@ function basicAuthHeader(clientId: string, clientSecret: string): string {
   return `Basic ${credentials}`;
 }
 
-function parseScopes(scope: string | undefined): readonly string[] {
-  if (!scope) {
-    return [];
-  }
-  return scope.split(" ").filter((value) => {
-    return value.length > 0;
-  });
-}
-
 function cloudflareTokenRequestHeaders(
   clientId: string,
   clientSecret: string,
@@ -74,7 +66,7 @@ export function buildCloudflareAuthorizationUrl(
 }
 
 export async function exchangeCloudflareCode(
-  _authCodeGrant: ConnectorAuthCodeGrantConfig,
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
   clientId: string,
   clientSecret: string,
   code: string,
@@ -119,7 +111,7 @@ export async function exchangeCloudflareCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token,
     expiresIn: data.expires_in,
-    scopes: parseScopes(data.scope),
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo: await fetchCloudflareUserInfo(data.access_token),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/copper/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/copper/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const AUTHORIZATION_URL = "https://app.copper.com/oauth/authorize";
 const TOKEN_URL = "https://app.copper.com/oauth/token";
@@ -60,7 +61,7 @@ export async function exchangeCopperCode(args: {
     .parse(await accountResponse.json());
   return {
     accessToken: token.access_token,
-    scopes: token.scope ? token.scope.split(" ") : args.grant.scopes,
+    scopes: effectiveOAuthScopes(token.scope, args.grant.scopes, " "),
     userInfo: {
       id: String(account.id),
       username: account.name ?? null,

--- a/turbo/packages/connectors/src/auth-providers/connectors/datadog/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/datadog/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const AUTHORIZATION_URL = "https://app.datadoghq.com/oauth2/v1/authorize";
 const DATADOG_DOMAINS = new Set([
@@ -138,7 +139,7 @@ export async function exchangeDatadogCode(args: {
     accessToken: token.access_token,
     refreshToken: token.refresh_token ?? null,
     expiresIn: token.expires_in,
-    scopes: token.scope ? token.scope.split(" ") : args.grant.scopes,
+    scopes: effectiveOAuthScopes(token.scope, args.grant.scopes, " "),
     domain,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const DEEL_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
 
@@ -223,7 +224,7 @@ export async function exchangeDeelCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const DOCUSIGN_TOKEN_URL = "https://account-d.docusign.com/oauth/token";
 
@@ -148,7 +149,7 @@ export async function exchangeDocuSignCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const DROPBOX_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
 
@@ -107,7 +108,7 @@ export async function exchangeDropboxCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
@@ -105,7 +105,7 @@ export async function exchangeFigmaCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: ["file_content:read"],
+    scopes: authCodeGrant.scopes,
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/github/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/github/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 
@@ -85,7 +86,7 @@ export async function exchangeGitHubCode(
 
   return {
     accessToken: data.access_token,
-    scopes: data.scope ? data.scope.split(",") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, ","),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/gmail/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/gmail/oauth.ts
@@ -4,6 +4,7 @@ import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { buildGoogleAuthorizationUrl } from "../../oauth/google";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
@@ -103,7 +104,7 @@ export async function exchangeGmailCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const GUMROAD_TOKEN_URL = "https://gumroad.com/oauth/token";
 
@@ -97,7 +98,7 @@ export async function exchangeGumroadCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in ?? undefined,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
 
@@ -107,7 +108,7 @@ export async function exchangeLinearCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(",") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, ","),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const MERCURY_ENDPOINTS = {
   production: {
@@ -156,7 +157,7 @@ export async function exchangeMercuryCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/monday/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/monday/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const MONDAY_TOKEN_URL = "https://auth.monday.com/oauth2/token";
 
@@ -103,7 +104,7 @@ export async function exchangeMondayCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/neon/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/neon/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const NEON_TOKEN_URL = "https://oauth2.neon.tech/oauth2/token";
 
@@ -99,7 +100,7 @@ export async function exchangeNeonCode(
   }
 
   const userInfo = await fetchNeonUserInfo(data.access_token);
-  const scopes = data.scope ? data.scope.split(" ") : [];
+  const scopes = effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " ");
 
   return {
     accessToken: data.access_token,

--- a/turbo/packages/connectors/src/auth-providers/connectors/posthog/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/posthog/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const POSTHOG_TOKEN_URL = "https://us.posthog.com/oauth/token";
 
@@ -102,7 +103,7 @@ export async function exchangePosthogCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const QUICKBOOKS_TOKEN_URL =
   "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
@@ -129,7 +130,7 @@ export async function exchangeQuickBooksCode(
     refreshToken: data.refresh_token ?? null,
     realmId: parseQuickBooksRealmId(oauthContext),
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : authCodeGrant.scopes,
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/reddit/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/reddit/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const REDDIT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token";
 
@@ -103,7 +104,7 @@ export async function exchangeRedditCode(
   }
 
   const userInfo = await fetchRedditUserInfo(data.access_token);
-  const scopes = data.scope ? data.scope.split(" ") : [];
+  const scopes = effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " ");
 
   return {
     accessToken: data.access_token,

--- a/turbo/packages/connectors/src/auth-providers/connectors/sentry/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/sentry/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const SENTRY_TOKEN_URL = "https://sentry.io/oauth/token/";
 
@@ -111,7 +112,7 @@ export async function exchangeSentryCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo: {
       id: data.user.id,
       name: data.user.name ?? null,

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
 
@@ -94,7 +95,11 @@ export async function exchangeSlackCode(
 
   return {
     accessToken: data.authed_user.access_token,
-    scopes: data.authed_user.scope?.split(",") ?? [],
+    scopes: effectiveOAuthScopes(
+      data.authed_user.scope,
+      authCodeGrant.scopes,
+      ",",
+    ),
     userId: data.authed_user.id,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
@@ -106,7 +107,7 @@ export async function exchangeSpotifyCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/strava/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/strava/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 
@@ -83,6 +84,7 @@ export async function exchangeStravaCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       athlete: z
         .object({
           id: z.number().optional(),
@@ -121,7 +123,7 @@ export async function exchangeStravaCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, /[ ,]+/),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const STRIPE_TOKEN_URL = "https://connect.stripe.com/oauth/token";
 
@@ -108,7 +109,7 @@ export async function exchangeStripeCode(
     accessToken: data.access_token,
     livemode: data.livemode,
     refreshToken: data.refresh_token ?? null,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const SUPABASE_TOKEN_URL = "https://api.supabase.com/v1/oauth/token";
 
@@ -201,7 +202,7 @@ export async function exchangeSupabaseCode(
   }
 
   const userInfo = await fetchSupabaseUserInfo(data.access_token);
-  const scopes = data.scope ? data.scope.split(" ") : [];
+  const scopes = effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " ");
 
   return {
     accessToken: data.access_token,

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const TEST_OAUTH_AUTHORIZATION_URL = "/api/test/oauth-provider/authorize";
 const TEST_OAUTH_TOKEN_URL = "/api/test/oauth-provider/token";
@@ -184,6 +185,7 @@ const tokenResponseSchema = z.object({
 async function postToken(
   body: URLSearchParams,
   operation: "exchange" | "refresh",
+  authorizationScopes: readonly string[],
   signal: AbortSignal | undefined,
 ): Promise<TokenResponse> {
   const response = await fetch(getTestOAuthTokenUrl(), {
@@ -206,11 +208,12 @@ async function postToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope?.split(" ") ?? [],
+    scopes: effectiveOAuthScopes(data.scope, authorizationScopes, " "),
   };
 }
 
 export async function exchangeTestOAuthCode(
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
   clientId: string,
   clientSecret: string,
   code: string,
@@ -225,6 +228,7 @@ export async function exchangeTestOAuthCode(
       redirect_uri: redirectUri,
     }),
     "exchange",
+    authCodeGrant.scopes,
     undefined,
   );
 }
@@ -243,6 +247,7 @@ export async function refreshTestOAuthToken(
       refresh_token: refreshToken,
     }),
     "refresh",
+    [],
     signal,
   );
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -3,6 +3,7 @@ import type {
   AuthCodeGrantProvider,
   RefreshTokenAccessProvider,
 } from "../../types";
+import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import {
   buildTestOAuthAuthorizationUrl,
   exchangeTestOAuthCode,
@@ -52,12 +53,14 @@ interface TestOAuthTokenExchange {
 }
 
 async function exchangeTestOauthToken(args: {
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   readonly clientId: string;
   readonly clientSecret: string;
   readonly code: string;
   readonly redirectUri: string;
 }): Promise<TestOAuthTokenExchange> {
   const token = await exchangeTestOAuthCode(
+    args.authCodeGrant,
     args.clientId,
     args.clientSecret,
     args.code,
@@ -74,6 +77,7 @@ async function exchangeTestOauthToken(args: {
 }
 
 async function exchangeTestOauthGrant(args: {
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   readonly clientId: string;
   readonly clientSecret: string;
   readonly code: string;
@@ -93,6 +97,7 @@ async function exchangeTestOauthGrant(args: {
 }
 
 async function exchangeTestOauthApiGrant(args: {
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
   readonly clientId: string;
   readonly clientSecret: string;
   readonly code: string;
@@ -126,6 +131,7 @@ function createTestOauthGrant(): AuthCodeGrantProvider<"test-oauth", "oauth"> {
     exchangeCode: async (exchangeArgs) => {
       const { clientId, clientSecret } = exchangeArgs.authClient;
       return await exchangeTestOauthGrant({
+        authCodeGrant: exchangeArgs.authCodeGrant,
         clientId,
         clientSecret,
         code: exchangeArgs.code,
@@ -150,6 +156,7 @@ function createTestOauthApiGrant(): AuthCodeGrantProvider<"test-oauth", "api"> {
     exchangeCode: async (exchangeArgs) => {
       const { clientId, clientSecret } = exchangeArgs.authClient;
       return await exchangeTestOauthApiGrant({
+        authCodeGrant: exchangeArgs.authCodeGrant,
         clientId,
         clientSecret,
         code: exchangeArgs.code,

--- a/turbo/packages/connectors/src/auth-providers/connectors/x/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/x/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const X_TOKEN_URL = "https://api.x.com/2/oauth2/token";
 
@@ -204,7 +205,7 @@ export async function exchangeXCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
 
@@ -106,7 +107,7 @@ export async function exchangeXeroCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 
 const ZOOM_TOKEN_URL = "https://zoom.us/oauth/token";
 
@@ -108,7 +109,7 @@ export async function exchangeZoomCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -31,6 +31,11 @@ export interface ConnectorAuthProviderGrantResult<
   readonly outputs: Outputs;
   /** Seconds until the granted credentials expire. */
   readonly expiresIn?: number;
+  /**
+   * Effective scopes granted for these credentials. Provider-reported scopes
+   * take precedence; an omitted response uses the effective authorization
+   * request.
+   */
   readonly scopes: readonly string[];
   readonly userInfo: ConnectorAuthProviderGrantUserInfo;
   readonly extraConnectorSecrets?: Readonly<Record<string, string>>;

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "./error";
+import { effectiveOAuthScopes } from "./scope";
 
 type GoogleOAuthConnectorSlug =
   | "gmail"
@@ -127,7 +128,7 @@ export async function exchangeGoogleOAuthCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -2,6 +2,7 @@ import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-
 import { z } from "zod";
 
 import { throwOAuthError } from "./error";
+import { effectiveOAuthScopes } from "./scope";
 
 const MICROSOFT_TOKEN_URL =
   "https://login.microsoftonline.com/common/oauth2/v2.0/token";
@@ -114,7 +115,7 @@ export async function exchangeMicrosoftOAuthCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: data.scope ? data.scope.split(" ") : [],
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
     userInfo,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/scope.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/scope.ts
@@ -1,0 +1,20 @@
+export function authorizationScopesFromUrl(
+  authorizationUrl: string,
+): readonly string[] | undefined {
+  const searchParams = new URL(authorizationUrl).searchParams;
+  const serializedScopes =
+    searchParams.get("scope") ?? searchParams.get("user_scope");
+  return serializedScopes === null
+    ? undefined
+    : serializedScopes.split(/[ ,]+/).filter(Boolean);
+}
+
+export function effectiveOAuthScopes(
+  reportedScopes: string | null | undefined,
+  authorizationScopes: readonly string[],
+  separator: string | RegExp,
+): string[] {
+  return reportedScopes === null || reportedScopes === undefined
+    ? [...authorizationScopes]
+    : reportedScopes.split(separator).filter(Boolean);
+}


### PR DESCRIPTION
## Summary

- define `ConnectorAuthProviderGrantResult.scopes` as the effective granted scope set
- carry the stored authorization URL into built-in auth-code exchange and use its original `scope` or Slack `user_scope` request when token responses omit scope
- standardize optional scope handling across auth-code providers, including Gmail identity scopes and Strava's reported grant

## Compatibility and scope

- reported partial, supplemental, and explicitly empty grants remain authoritative
- legacy OAuth state without an authorization URL and providers with registered/default scopes retain the catalog fallback
- no connector persistence, readiness validation, database schema, public API, device-auth, external-code, or OpenID behavior changes

## Validation

- `pnpm -F @okouai/connectors lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F @okouai/connectors test` (44 files, 1077 tests)
- `pnpm knip --workspace @okouai/connectors`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit repository Prettier, Knip, and workspace type checks

Closes #29463

Parent: #29462
