### PR TITLE
test(ably-subscriber): assert exact handshake error

### DIFF
--- a/crates/ably-subscriber/tests/integration/connection_messages.rs
+++ b/crates/ably-subscriber/tests/integration/connection_messages.rs
@@ -462,7 +462,7 @@ async fn server_error_during_handshake() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_raw().await.unwrap();
         let error_msg = ProtocolMessage {
             action: action::ERROR,
@@ -481,8 +481,15 @@ async fn server_error_during_handshake() {
     });
 
     let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
+    join_server_task(server_task, "pre-CONNECTED ERROR server")
+        .await
+        .unwrap();
+
     match result {
-        Err(ably_subscriber::Error::Protocol { .. }) => {}
+        Err(ably_subscriber::Error::Protocol { code, message }) => {
+            assert_eq!(code, error_code::FAILED);
+            assert_eq!(message, "Unauthorized");
+        }
         Err(other) => panic!("expected Protocol error, got {other:?}"),
         Ok(_) => panic!("expected error, got Ok"),
     }


### PR DESCRIPTION
## Summary

- retain and bounded-join the mock WebSocket server task in the pre-CONNECTED ERROR integration test
- assert the exact protocol error code and `Unauthorized` message delivered through `subscribe`
- prevent early socket closure or mock-task failure from satisfying the test

## Scope

- test-only change in `ably-subscriber`
- no production behavior, API, data, migration, rollout, or compatibility change

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ably-subscriber --test integration server_error_during_handshake`
- `cargo test -p ably-subscriber --test integration connection_messages::`
- `cargo test -p ably-subscriber`
- `cargo clippy -p ably-subscriber --all-targets --all-features`
- `cargo doc -p ably-subscriber --all-features --no-deps`
- pre-commit workspace Rust formatting, Clippy, documentation, file-size, and commit-message checks

Closes #29480
