### PR TITLE
docs(guest-agent): clarify has_api capability semantics

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -252,6 +252,14 @@ impl HttpClient {
         )
     }
 
+    /// Returns whether backend API/webhook configuration is present.
+    ///
+    /// This reports API capability, not generic HTTP transport availability.
+    /// [`Self::new`] returns `false` here while still providing a transport for
+    /// presigned uploads. [`Self::for_config`] also returns `false` when its API
+    /// token is empty, but that API-disabled client has no transport. Presigned
+    /// uploads require only the transport, while backend API operations require
+    /// API configuration.
     pub fn has_api(&self) -> bool {
         self.api.is_some()
     }


### PR DESCRIPTION
## Summary

- Clarify that `HttpClient::has_api()` reports backend API/webhook configuration, not generic HTTP transport availability.
- Document the distinction between `HttpClient::new()` and API-disabled `HttpClient::for_config()` clients, including their presigned upload capabilities.

## Explicit Exclusions

- No runtime behavior, caller, API name, or transport capability changes.
- No new fallback or compatibility behavior.
- No tests, generated files, migrations, or deployment configuration changes.

## Validation

- `cargo fmt --all -- --check` (from `crates/`) — passed.
- `cargo clippy --all-targets --all-features` (from `crates/`) — passed.
- `cargo doc --workspace --all-features --no-deps` (from `crates/`) — passed.
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib` — passed: 615 tests.
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent` — attempted, but the linker failed with `No space left on device` while building an integration-test binary before tests ran. The local `crates/target` cache was then cleaned and the 615-test library suite passed.

Closes #29479
