### PR TITLE
fix(runner): reject stale host oom evidence

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
-rustix = { workspace = true, features = ["process"] }
+rustix = { workspace = true, features = ["process", "time"] }
 hex = { workspace = true }
 idna = { workspace = true }
 libc = { workspace = true }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -31,8 +31,9 @@ use super::diagnostics::{
     StdoutDrainReport, build_agent_env_diagnostics, build_agent_env_key_diagnostics,
     check_host_oom, collect_agent_abnormal_exit_diagnostics, dmesg_indicates_oom,
     drain_stdout_to_file, explicit_enospc_evidence, failure_diagnostic_reports_workload_memory_oom,
-    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
-    log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
+    host_oom_evidence_since_now, log_agent_abnormal_exit_env_diagnostics,
+    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
+    read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
     should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
@@ -1299,6 +1300,7 @@ impl RunControls {
 struct PreparedAgentProcess {
     handle: GuestProcessHandle,
     agent_started_at: Instant,
+    host_oom_evidence_since: super::diagnostics::HostOomEvidenceSince,
     deferred_background_fill: Option<crate::storage_cache::DeferredBackgroundFill>,
     session_restore_diagnostics: Option<SessionRestoreDiagnostics>,
     pre_run_restored_session_identity: Option<RestoredSessionIdentity>,
@@ -2130,6 +2132,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // Guest-agent receives JOB_TIMEOUT as the user execution budget. The
     // sandbox supervisor remains a later hard fallback so guest-agent can
     // terminate the CLI and create a recovery checkpoint first.
+    let host_oom_evidence_since = host_oom_evidence_since_now();
     let t = Instant::now();
     let handle = sandbox
         .start_process(&StartProcessRequest {
@@ -2177,6 +2180,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             RunnerResult::Ok(PreparedAgentProcess {
                 handle,
                 agent_started_at: t,
+                host_oom_evidence_since,
                 deferred_background_fill,
                 session_restore_diagnostics,
                 pre_run_restored_session_identity,
@@ -2214,6 +2218,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let PreparedAgentProcess {
         mut handle,
         agent_started_at: t,
+        host_oom_evidence_since,
         deferred_background_fill,
         session_restore_diagnostics,
         mut pre_run_restored_session_identity,
@@ -2348,7 +2353,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             // Sandbox crashed — check host dmesg for OOM evidence naming the
             // firecracker process before propagating a generic error.
             if let Some(host_process_pid) = sandbox.host_process_pid()
-                && check_host_oom(host_process_pid).await
+                && check_host_oom(host_process_pid, host_oom_evidence_since).await
             {
                 warn!(
                     run_id = %context.run_id,

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -51,7 +51,9 @@ pub(super) use guest_logs::copy_guest_logs;
 pub(super) use guest_logs::{GuestLogCopyFailureKind, guest_log_copy_failure_kind};
 #[cfg(test)]
 pub(super) use oom::host_dmesg_indicates_oom;
-pub(super) use oom::{check_host_oom, dmesg_indicates_oom};
+pub(super) use oom::{
+    HostOomEvidenceSince, check_host_oom, dmesg_indicates_oom, host_oom_evidence_since_now,
+};
 pub(super) use resource::collect_agent_abnormal_exit_diagnostics;
 #[cfg(test)]
 pub(super) use resource::parse_agent_abnormal_exit_resource_diagnostics;

--- a/crates/runner/src/executor/diagnostics/oom.rs
+++ b/crates/runner/src/executor/diagnostics/oom.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use rustix::time::{ClockId, clock_gettime};
 use tokio::process::Command;
 use tracing::warn;
 
@@ -8,6 +9,17 @@ use crate::bounded_command::{
 };
 
 const HOST_OOM_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+const MICROSECONDS_PER_SECOND: i128 = 1_000_000;
+
+/// Boot-relative monotonic timestamp used as the lower bound for host OOM evidence.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(in crate::executor) struct HostOomEvidenceSince(i128);
+
+impl HostOomEvidenceSince {
+    pub(in crate::executor) const fn from_micros(micros: i128) -> Self {
+        Self(micros)
+    }
+}
 
 /// Returns true if dmesg output indicates an OOM kill.
 pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
@@ -17,15 +29,23 @@ pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
 
 /// Checks host `dmesg` output for OOM evidence naming a specific Firecracker process.
 ///
-/// Invokes `dmesg` directly under the runner's current privileges. After a
-/// five-second execution deadline, the child is terminated and reaped before
-/// returning. Returns `false` when the command exits unsuccessfully, execution
-/// fails, or the operation times out.
-pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
-    check_host_oom_command(pid, Command::new("dmesg"), HOST_OOM_CHECK_TIMEOUT).await
+/// Invokes `dmesg` directly under the runner's current privileges and accepts
+/// only raw-timestamped records at or after `since`. After a five-second
+/// execution deadline, the child is terminated and reaped before returning.
+/// Returns `false` when the command exits unsuccessfully, execution fails, the
+/// operation times out, or record freshness cannot be established.
+pub(in crate::executor) async fn check_host_oom(pid: u32, since: HostOomEvidenceSince) -> bool {
+    let mut command = Command::new("dmesg");
+    command.arg("--time-format=raw");
+    check_host_oom_command(pid, since, command, HOST_OOM_CHECK_TIMEOUT).await
 }
 
-async fn check_host_oom_command(pid: u32, command: Command, timeout: Duration) -> bool {
+async fn check_host_oom_command(
+    pid: u32,
+    since: HostOomEvidenceSince,
+    command: Command,
+    timeout: Duration,
+) -> bool {
     match run_output_bounded(
         command,
         "dmesg",
@@ -35,7 +55,7 @@ async fn check_host_oom_command(pid: u32, command: Command, timeout: Duration) -
     .await
     {
         Ok(BoundedCommandOutcome::Exited(output)) if output.status.success() => {
-            host_dmesg_indicates_oom(&String::from_utf8_lossy(&output.stdout), pid)
+            host_dmesg_indicates_oom(&String::from_utf8_lossy(&output.stdout), pid, since)
         }
         Ok(BoundedCommandOutcome::Exited(output)) => {
             warn!(pid, exit_code = output.status.code(), "dmesg failed");
@@ -60,31 +80,67 @@ async fn check_host_oom_command(pid: u32, command: Command, timeout: Duration) -
     }
 }
 
-/// Returns `true` when host `dmesg` output contains the case-sensitive
-/// `oom-kill` marker and the `task=firecracker,pid=<pid>` substring.
-///
-/// The two substrings are searched independently across the full output and
-/// need not occur in the same log record. The predicate does not require a
-/// memory-cgroup constraint marker. The character after the PID must not be a
-/// digit, avoiding prefix matches such as `pid=1234` matching `pid=12345`.
-pub(in crate::executor) fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
-    if !dmesg.contains("oom-kill") {
-        return false;
+/// Capture the host monotonic clock used by raw kernel-log timestamps.
+pub(in crate::executor) fn host_oom_evidence_since_now() -> HostOomEvidenceSince {
+    let timestamp = clock_gettime(ClockId::Monotonic);
+    HostOomEvidenceSince::from_micros(
+        i128::from(timestamp.tv_sec) * MICROSECONDS_PER_SECOND
+            + i128::from(timestamp.tv_nsec) / 1_000,
+    )
+}
+
+fn parse_raw_dmesg_record(line: &str) -> Option<(HostOomEvidenceSince, &str)> {
+    let (timestamp, message) = line.trim_start().strip_prefix('[')?.split_once(']')?;
+    let (seconds, micros) = timestamp.trim().split_once('.')?;
+    if seconds.is_empty()
+        || !seconds.bytes().all(|byte| byte.is_ascii_digit())
+        || micros.len() != 6
+        || !micros.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
     }
+    let micros = seconds
+        .parse::<i128>()
+        .ok()?
+        .checked_mul(MICROSECONDS_PER_SECOND)?
+        .checked_add(micros.parse::<i128>().ok()?)?;
+    Some((HostOomEvidenceSince::from_micros(micros), message))
+}
+
+fn record_has_firecracker_pid(record: &str, pid: u32) -> bool {
     let needle = format!("task=firecracker,pid={pid}");
     let mut start = 0;
-    while let Some(pos) = dmesg[start..].find(&needle) {
+    while let Some(pos) = record[start..].find(&needle) {
         let abs = start + pos + needle.len();
-        // Accept if needle is at end of string or next char is not a digit.
-        match dmesg.as_bytes().get(abs) {
+        match record.as_bytes().get(abs) {
             Some(c) if c.is_ascii_digit() => {
-                // Prefix match (e.g. pid=1234 inside pid=12345) — keep searching.
                 start = abs;
             }
             _ => return true,
         }
     }
     false
+}
+
+/// Returns `true` when one fresh host `dmesg` record contains both the
+/// case-sensitive `oom-kill` marker and the exact
+/// `task=firecracker,pid=<pid>` substring.
+///
+/// Records without the raw boot-relative timestamp are rejected. The
+/// predicate does not require a memory-cgroup constraint marker. The character
+/// after the PID must not be a digit, avoiding prefix matches such as
+/// `pid=1234` matching `pid=12345`.
+pub(in crate::executor) fn host_dmesg_indicates_oom(
+    dmesg: &str,
+    pid: u32,
+    since: HostOomEvidenceSince,
+) -> bool {
+    dmesg.lines().any(|line| {
+        let Some((timestamp, record)) = parse_raw_dmesg_record(line) else {
+            return false;
+        };
+        timestamp >= since && record.contains("oom-kill") && record_has_firecracker_pid(record, pid)
+    })
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -96,21 +152,45 @@ mod tests {
         let mut command = Command::new("sleep");
         command.arg("60");
 
-        assert!(!check_host_oom_command(42, command, Duration::ZERO).await);
+        assert!(
+            !check_host_oom_command(
+                42,
+                HostOomEvidenceSince::from_micros(0),
+                command,
+                Duration::ZERO,
+            )
+            .await
+        );
     }
 
     #[tokio::test]
     async fn unsuccessful_command_is_not_oom_evidence() {
         let command = Command::new("false");
 
-        assert!(!check_host_oom_command(42, command, Duration::from_secs(2)).await);
+        assert!(
+            !check_host_oom_command(
+                42,
+                HostOomEvidenceSince::from_micros(0),
+                command,
+                Duration::from_secs(2),
+            )
+            .await
+        );
     }
 
     #[tokio::test]
     async fn successful_command_captures_stdout_for_oom_detection() {
         let mut command = Command::new("printf");
-        command.arg("oom-kill:task=firecracker,pid=42");
+        command.arg("[42.000000] oom-kill:task=firecracker,pid=42");
 
-        assert!(check_host_oom_command(42, command, Duration::from_secs(2)).await);
+        assert!(
+            check_host_oom_command(
+                42,
+                HostOomEvidenceSince::from_micros(42_000_000),
+                command,
+                Duration::from_secs(2),
+            )
+            .await
+        );
     }
 }

--- a/crates/runner/src/executor/tests/diagnostics_tests/oom.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/oom.rs
@@ -1,4 +1,10 @@
-use super::super::super::diagnostics::{dmesg_indicates_oom, host_dmesg_indicates_oom};
+use super::super::super::diagnostics::{
+    HostOomEvidenceSince, dmesg_indicates_oom, host_dmesg_indicates_oom,
+};
+
+fn since_micros(micros: i128) -> HostOomEvidenceSince {
+    HostOomEvidenceSince::from_micros(micros)
+}
 
 #[test]
 fn dmesg_oom_positive() {
@@ -35,12 +41,29 @@ const PROD3_OOM_GREP: &str = "\
 
 #[test]
 fn host_oom_matches_real_prod3_output() {
-    assert!(host_dmesg_indicates_oom(PROD3_OOM_GREP, 586629));
+    assert!(host_dmesg_indicates_oom(
+        PROD3_OOM_GREP,
+        586629,
+        since_micros(1_718_300_651_117),
+    ));
+}
+
+#[test]
+fn host_oom_rejects_stale_same_pid_record() {
+    assert!(!host_dmesg_indicates_oom(
+        PROD3_OOM_GREP,
+        586629,
+        since_micros(1_718_300_651_118),
+    ));
 }
 
 #[test]
 fn host_oom_no_match_different_pid() {
-    assert!(!host_dmesg_indicates_oom(PROD3_OOM_GREP, 12345));
+    assert!(!host_dmesg_indicates_oom(
+        PROD3_OOM_GREP,
+        12345,
+        since_micros(0),
+    ));
 }
 
 #[test]
@@ -48,31 +71,51 @@ fn host_oom_no_match_different_process() {
     // Same structure as prod-3 but task=node instead of task=firecracker
     let dmesg = "[1718300.651117] oom-kill:constraint=CONSTRAINT_MEMCG,\
             task=node,pid=586629,uid=1000";
-    assert!(!host_dmesg_indicates_oom(dmesg, 586629));
+    assert!(!host_dmesg_indicates_oom(dmesg, 586629, since_micros(0),));
 }
 
 #[test]
 fn host_oom_no_match_empty() {
-    assert!(!host_dmesg_indicates_oom("", 12345));
+    assert!(!host_dmesg_indicates_oom("", 12345, since_micros(0),));
 }
 
 #[test]
 fn host_oom_no_match_without_oom_kill() {
     // Has the PID pattern but no oom-kill keyword
     let dmesg = "[1718300.651117] task=firecracker,pid=12345,uid=1000 started";
-    assert!(!host_dmesg_indicates_oom(dmesg, 12345));
+    assert!(!host_dmesg_indicates_oom(dmesg, 12345, since_micros(0),));
 }
 
 #[test]
 fn host_oom_no_prefix_match() {
     // pid=58662 must NOT match pid=586629
-    assert!(!host_dmesg_indicates_oom(PROD3_OOM_GREP, 58662));
+    assert!(!host_dmesg_indicates_oom(
+        PROD3_OOM_GREP,
+        58662,
+        since_micros(0),
+    ));
 }
 
 #[test]
 fn host_oom_pid_at_end_of_line() {
     // PID at end of string (no trailing comma) — edge case
-    let dmesg = "[0.0] oom-kill:constraint=CONSTRAINT_MEMCG,task=firecracker,pid=42";
-    assert!(host_dmesg_indicates_oom(dmesg, 42));
-    assert!(!host_dmesg_indicates_oom(dmesg, 4));
+    let dmesg = "[0.000000] oom-kill:constraint=CONSTRAINT_MEMCG,task=firecracker,pid=42";
+    assert!(host_dmesg_indicates_oom(dmesg, 42, since_micros(0)));
+    assert!(!host_dmesg_indicates_oom(dmesg, 4, since_micros(0)));
+}
+
+#[test]
+fn host_oom_requires_marker_and_pid_in_same_record() {
+    let dmesg = "[1.000000] oom-kill:constraint=CONSTRAINT_MEMCG,task=node,pid=7\n\
+                 [2.000000] task=firecracker,pid=42,uid=1000";
+    assert!(!host_dmesg_indicates_oom(dmesg, 42, since_micros(0),));
+}
+
+#[test]
+fn host_oom_rejects_missing_or_malformed_timestamp() {
+    let missing = "oom-kill:constraint=CONSTRAINT_MEMCG,task=firecracker,pid=42";
+    let malformed = "[1.00000x] oom-kill:constraint=CONSTRAINT_MEMCG,task=firecracker,pid=42";
+
+    assert!(!host_dmesg_indicates_oom(missing, 42, since_micros(0),));
+    assert!(!host_dmesg_indicates_oom(malformed, 42, since_micros(0),));
 }


### PR DESCRIPTION
## Summary

- capture a host monotonic cutoff before guest process creation and retain it through the wait-error path
- parse explicit raw-timestamped `dmesg` records and require fresh, same-line host OOM evidence for the exact Firecracker PID
- reject stale same-PID, mixed-record, and malformed-timestamp evidence while preserving the existing bounded diagnostic fallback

## Scope

This fixes post-start Firecracker crashes classified by the existing guest wait-error path. It does not change Firecracker startup-failure diagnosis, guest OOM detection, host memory policy, or sandbox retry policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --all-targets --all-features` (`3316 passed`, `24 ignored`; guest inventory `1 passed`)
- staged pre-commit hooks: cargo fmt, rustdoc, Clippy, file-size check, and commitlint

Closes #29488
