### PR TITLE
fix(platform): keep connector row height stable

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -274,13 +274,14 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
-  it("uses permissioned connector content to toggle only access", async () => {
+  it("keeps permissioned connector row height stable while toggling access", async () => {
     const user = userEvent.setup({ delay: null });
     let authorizationWrites = 0;
+    let enabledConnectorSlugs = ["axiom"];
     mockThread();
     mockConnectors([{ connectorSlug: "axiom", authMethod: "api-token" }]);
     context.mocks.api(userConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledConnectorSlugs: ["axiom"] });
+      return respond(200, { enabledConnectorSlugs });
     });
     context.mocks.api(userConnectorsContract.update, ({ body, respond }) => {
       expect(body).toStrictEqual({
@@ -288,7 +289,8 @@ describe("chat composer connector connection", () => {
         operation: "remove",
       });
       authorizationWrites += 1;
-      return respond(200, { enabledConnectorSlugs: [] });
+      enabledConnectorSlugs = [];
+      return respond(200, { enabledConnectorSlugs });
     });
 
     detachedSetupPage({
@@ -305,6 +307,7 @@ describe("chat composer connector connection", () => {
     if (!accessLabel?.control) {
       throw new Error("Expected the Axiom label to target its access switch");
     }
+    expect(accessLabel.parentElement).toHaveClass("h-10");
     expect(
       screen.getByLabelText("Configure Axiom permissions").closest("label"),
     ).toBeNull();
@@ -314,6 +317,13 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(authorizationWrites).toBe(1);
     });
+    const disconnectedAccess = await screen.findByLabelText("Add Axiom");
+    expect(disconnectedAccess.closest("label")?.parentElement).toHaveClass(
+      "h-10",
+    );
+    expect(
+      screen.queryByLabelText("Configure Axiom permissions"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("dialog", { name: /Axiom permissions/u }),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8086,7 +8086,7 @@ function ComposerConnectorAccessRow({
   readonly ariaLabel: string;
 }) {
   return (
-    <div className="flex items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
+    <div className="flex h-10 items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
       {actions ? (
         <span className="order-2 flex shrink-0 items-center gap-2">
           {actions}


### PR DESCRIPTION
## Summary

- keep every chat composer connector row at the existing 40px action-bearing height
- preserve connector label, permission action, account action, and access-switch interaction boundaries
- cover the permission action appearing and disappearing across an access toggle

## Scope

- Platform chat composer connector popover only
- no API, database, runner, persistence, feature-switch, or rollout changes

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx` (17 passed)
- `pnpm knip --workspace @okouai/app`
- pre-commit full Turbo type check, Knip, formatting, and file-size checks
- local browser measurement: Axiom row remained 40px enabled and disabled

Closes #29492
