### PR TITLE
refactor(api): make workflow dedupe writes view-safe

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/immutable-dedupe-insert.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/immutable-dedupe-insert.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveImmutableDedupeInsert } from "../immutable-dedupe-insert";
+
+function postgresError(code: string): Error {
+  return new Error(`PostgreSQL error ${code}`, { cause: { code } });
+}
+
+describe("resolveImmutableDedupeInsert", () => {
+  it("returns the row created by a successful insert", () => {
+    const row = { id: "created-row" };
+
+    expect(resolveImmutableDedupeInsert({ ok: true, value: [row] })).toBe(row);
+  });
+
+  it("maps an exact PostgreSQL 23505 to the duplicate result", () => {
+    expect(
+      resolveImmutableDedupeInsert({
+        ok: false,
+        error: postgresError("23505"),
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["foreign-key violation", postgresError("23503")],
+    ["check violation", postgresError("23514")],
+    ["connection failure", postgresError("ECONNRESET")],
+    ["abort", new DOMException("aborted", "AbortError")],
+    ["arbitrary error", new Error("arbitrary failure")],
+  ])("rethrows a %s unchanged", (_label, error) => {
+    expect(() => {
+      resolveImmutableDedupeInsert({ ok: false, error });
+    }).toThrow(error);
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/immutable-dedupe-insert.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/immutable-dedupe-insert.test.ts
@@ -6,11 +6,20 @@ function postgresError(code: string): Error {
   return new Error(`PostgreSQL error ${code}`, { cause: { code } });
 }
 
+// Public webhook APIs cannot construct arbitrary database-driver failures.
+// Keep this direct coverage for the issue-mandated exact SQLSTATE boundary;
+// route tests cover sequential, concurrent, and cleanup behavior end to end.
 describe("resolveImmutableDedupeInsert", () => {
   it("returns the row created by a successful insert", () => {
     const row = { id: "created-row" };
 
     expect(resolveImmutableDedupeInsert({ ok: true, value: [row] })).toBe(row);
+  });
+
+  it("fails fast when a successful insert returns no row", () => {
+    expect(() => {
+      resolveImmutableDedupeInsert({ ok: true, value: [] });
+    }).toThrow("Immutable dedupe INSERT ... RETURNING returned no row");
   });
 
   it("maps an exact PostgreSQL 23505 to the duplicate result", () => {

--- a/turbo/apps/api/src/lib/immutable-dedupe-insert.ts
+++ b/turbo/apps/api/src/lib/immutable-dedupe-insert.ts
@@ -15,7 +15,11 @@ export function resolveImmutableDedupeInsert<T>(
     | { readonly ok: false; readonly error: unknown },
 ): T | null {
   if (insert.ok) {
-    return insert.value[0] ?? null;
+    const row = insert.value[0];
+    if (row === undefined) {
+      throw new Error("Immutable dedupe INSERT ... RETURNING returned no row");
+    }
+    return row;
   }
   if (isUniqueViolation(insert.error)) {
     return null;

--- a/turbo/apps/api/src/lib/immutable-dedupe-insert.ts
+++ b/turbo/apps/api/src/lib/immutable-dedupe-insert.ts
@@ -1,0 +1,24 @@
+import { isUniqueViolation } from "./pg-errors";
+
+/**
+ * Resolve one settled immutable-dedupe `INSERT ... RETURNING` while leaving
+ * the physical unique index as the race arbiter. Only an exact PostgreSQL
+ * 23505 maps to the duplicate result.
+ *
+ * Callers must settle a standalone statement issued through the top-level Db.
+ * Classifying the statement error here does not make an ambient PostgreSQL
+ * transaction usable again after that transaction enters the aborted state.
+ */
+export function resolveImmutableDedupeInsert<T>(
+  insert:
+    | { readonly ok: true; readonly value: readonly T[] }
+    | { readonly ok: false; readonly error: unknown },
+): T | null {
+  if (insert.ok) {
+    return insert.value[0] ?? null;
+  }
+  if (isUniqueViolation(insert.error)) {
+    return null;
+  }
+  throw insert.error;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -1164,6 +1164,31 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     expect(secondMerged).toStrictEqual({ status: 200, text: "OK" });
     await flushWaitUntilForTest();
 
+    const concurrentDeliveryId = `delivery-${randomUUID()}`;
+    const concurrentPayload = githubPullRequestPayload({
+      action: "closed",
+      merged: true,
+      number: 45,
+      installationId: installed.remoteInstallationId,
+    });
+    const concurrent = await Promise.all([
+      postGithubWebhook({
+        event: "pull_request",
+        deliveryId: concurrentDeliveryId,
+        rawBody: concurrentPayload,
+      }),
+      postGithubWebhook({
+        event: "pull_request",
+        deliveryId: concurrentDeliveryId,
+        rawBody: concurrentPayload,
+      }),
+    ]);
+    expect(concurrent).toStrictEqual([
+      { status: 200, text: "OK" },
+      { status: 200, text: "OK" },
+    ]);
+    await flushWaitUntilForTest();
+
     const closedWithoutMerge = await postGithubWebhook({
       event: "pull_request",
       deliveryId: `delivery-${randomUUID()}`,
@@ -1178,11 +1203,11 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     await flushWaitUntilForTest();
     await flushWaitUntilForTest();
 
-    // Two merged deliveries matched two automations each; the duplicate
-    // redelivery was recorded as processed and added nothing, and the
+    // Three accepted merged deliveries matched two automations each. The
+    // sequential and concurrent duplicate attempts added nothing, and the
     // closed-without-merge delivery never matched. Under the per-thread
     // workflow queue, the first matched event creates the only admitted run
-    // and the remaining three wait as pending workflow queue events.
+    // and the remaining five wait as pending workflow queue events.
     await runsApi.heartbeatRunner();
     const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
     const admittedRunId = listedRuns.runs[0]?.id;
@@ -1199,7 +1224,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     }
     await expect(
       pendingAutomationEventCount(created.body.chatThreadId),
-    ).resolves.toBe(3);
+    ).resolves.toBe(5);
 
     for (const runId of [admittedRunId]) {
       const timingEvents = sandboxOperationEventsForRun(runId);
@@ -1290,18 +1315,34 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     await flushWaitUntilForTest();
 
     const deliveryId = `delivery-${randomUUID()}`;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const matching = await postGithubWebhook({
+    const matchingPayload = githubWorkflowRunPayload({
+      conclusion: "failure",
+      installationId: installed.remoteInstallationId,
+    });
+    const concurrent = await Promise.all([
+      postGithubWebhook({
         event: "workflow_run",
         deliveryId,
-        rawBody: githubWorkflowRunPayload({
-          conclusion: "failure",
-          installationId: installed.remoteInstallationId,
-        }),
-      });
+        rawBody: matchingPayload,
+      }),
+      postGithubWebhook({
+        event: "workflow_run",
+        deliveryId,
+        rawBody: matchingPayload,
+      }),
+    ]);
+    for (const matching of concurrent) {
       expect(matching).toStrictEqual({ status: 200, text: "OK" });
-      await flushWaitUntilForTest();
     }
+    await flushWaitUntilForTest();
+
+    const sequentialDuplicate = await postGithubWebhook({
+      event: "workflow_run",
+      deliveryId,
+      rawBody: matchingPayload,
+    });
+    expect(sequentialDuplicate).toStrictEqual({ status: 200, text: "OK" });
+    await flushWaitUntilForTest();
 
     await runsApi.heartbeatRunner();
     const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -1,4 +1,5 @@
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
+import { modelProvidersByTypeContract } from "@okouai/api-contracts/contracts/model-provider-routes";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -12,6 +13,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createRouteMocks } from "./helpers/route-test";
 import { workflowAutomationsRoutes } from "../workflow-automations";
+import { modelProvidersRoutes } from "../model-providers";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
@@ -32,6 +34,12 @@ function authHeaders() {
 function automationsClient() {
   return setupApp({ context, routes: workflowAutomationsRoutes })(
     workflowAutomationsContract,
+  );
+}
+
+function modelProvidersByTypeClient() {
+  return setupApp({ context, routes: modelProvidersRoutes })(
+    modelProvidersByTypeContract,
   );
 }
 
@@ -90,6 +98,40 @@ async function setupFixture(): Promise<{
   };
 }
 
+async function createWebhookAutomation(workflowId: string): Promise<{
+  readonly id: string;
+  readonly token: string;
+  readonly webhookUrl: string;
+  readonly secret: string;
+}> {
+  const created = await accept(
+    automationsClient().create({
+      headers: authHeaders(),
+      params: { workflowId },
+      body: { kind: "event", eventType: "webhook-received" },
+    }),
+    [201],
+  );
+  if (
+    created.body.kind !== "event" ||
+    created.body.eventType !== "webhook-received" ||
+    !created.body.webhookUrl ||
+    !created.body.webhookSecret
+  ) {
+    throw new Error("Expected a webhook automation with a one-time secret");
+  }
+  const token = new URL(created.body.webhookUrl).pathname.split("/").at(-1);
+  if (!token) {
+    throw new Error("Expected webhook URL token");
+  }
+  return {
+    id: created.body.id,
+    token,
+    webhookUrl: created.body.webhookUrl,
+    secret: created.body.webhookSecret,
+  };
+}
+
 async function postWorkflowWebhook(args: {
   readonly token: string;
   readonly rawBody: string;
@@ -123,30 +165,9 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
     const { workflowId } = await setupFixture();
     const runsApi = createRunsApi(context);
     const runnerGroup = runsApi.configureRunnerGroup();
-
-    const created = await accept(
-      automationsClient().create({
-        headers: authHeaders(),
-        params: { workflowId },
-        body: { kind: "event", eventType: "webhook-received" },
-      }),
-      [201],
-    );
-    if (
-      created.body.kind !== "event" ||
-      created.body.eventType !== "webhook-received" ||
-      !created.body.webhookUrl ||
-      !created.body.webhookSecret
-    ) {
-      throw new Error("Expected a webhook automation with a one-time secret");
-    }
-
-    const token = new URL(created.body.webhookUrl).pathname.split("/").at(-1);
-    if (!token) {
-      throw new Error("Expected webhook URL token");
-    }
-    expect(new URL(created.body.webhookUrl).pathname).toBe(
-      `/api/webhooks/workflow-automations/${token}`,
+    const webhook = await createWebhookAutomation(workflowId);
+    expect(new URL(webhook.webhookUrl).pathname).toBe(
+      `/api/webhooks/workflow-automations/${webhook.token}`,
     );
 
     const rawBody = JSON.stringify({
@@ -155,9 +176,9 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
     });
     const timestamp = Math.floor(now() / 1000);
     const first = await postWorkflowWebhook({
-      token,
+      token: webhook.token,
       rawBody,
-      secret: created.body.webhookSecret,
+      secret: webhook.secret,
       timestamp,
     });
 
@@ -215,15 +236,15 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
     const serializedTiming = JSON.stringify(timingEvents);
     expect(serializedTiming).not.toContain("vm0-timing-sensitive-ping");
     expect(serializedTiming).not.toContain("vm0-timing-secret-value");
-    expect(serializedTiming).not.toContain(created.body.id);
+    expect(serializedTiming).not.toContain(webhook.id);
     expect(serializedTiming).not.toContain(WORKFLOW_NAME);
-    expect(serializedTiming).not.toContain(token);
-    expect(serializedTiming).not.toContain(created.body.webhookSecret);
+    expect(serializedTiming).not.toContain(webhook.token);
+    expect(serializedTiming).not.toContain(webhook.secret);
 
     const second = await postWorkflowWebhook({
-      token,
+      token: webhook.token,
       rawBody,
-      secret: created.body.webhookSecret,
+      secret: webhook.secret,
       timestamp,
     });
 
@@ -235,6 +256,92 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
     // The duplicate retry does not enqueue a second runner job.
     const idleAfterDuplicate = await runsApi.pollRunner(runnerGroup);
     expect(idleAfterDuplicate.body.job).toBeNull();
+
+    const concurrentRawBody = JSON.stringify({
+      event: "concurrent-dedupe",
+      value: "same-delivery",
+    });
+    const concurrent = await Promise.all([
+      postWorkflowWebhook({
+        token: webhook.token,
+        rawBody: concurrentRawBody,
+        secret: webhook.secret,
+        timestamp,
+      }),
+      postWorkflowWebhook({
+        token: webhook.token,
+        rawBody: concurrentRawBody,
+        secret: webhook.secret,
+        timestamp,
+      }),
+    ]);
+    expect(concurrent).toStrictEqual(
+      expect.arrayContaining([
+        {
+          status: 200,
+          body: { success: true, duplicate: false },
+        },
+        {
+          status: 200,
+          body: { success: true, duplicate: true },
+        },
+      ]),
+    );
+    expect(concurrent).toHaveLength(2);
+  });
+
+  it("deletes a failed delivery so an identical request can retry", async () => {
+    const { actor, fixture, workflowId } = await setupFixture();
+    const runsApi = createRunsApi(context);
+    const webhook = await createWebhookAutomation(workflowId);
+    const rawBody = JSON.stringify({ event: "retry-after-dispatch-failure" });
+    const timestamp = Math.floor(now() / 1000);
+
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await accept(
+      modelProvidersByTypeClient().delete({
+        headers: authHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+    const failed = await postWorkflowWebhook({
+      token: webhook.token,
+      rawBody,
+      secret: webhook.secret,
+      timestamp,
+    });
+    expect(failed).toStrictEqual({
+      status: 500,
+      body: { error: "Failed to start webhook workflow run" },
+    });
+
+    await runsApi.ensureOrgModelProvider(actor);
+    const retried = await postWorkflowWebhook({
+      token: webhook.token,
+      rawBody,
+      secret: webhook.secret,
+      timestamp,
+    });
+    expect(retried).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        duplicate: false,
+        runId: expect.any(String),
+      },
+    });
+
+    const duplicate = await postWorkflowWebhook({
+      token: webhook.token,
+      rawBody,
+      secret: webhook.secret,
+      timestamp,
+    });
+    expect(duplicate).toStrictEqual({
+      status: 200,
+      body: { success: true, duplicate: true },
+    });
   });
 
   it("auto-disables only enabled webhooks after an effective Stripe downgrade", async () => {

--- a/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
@@ -27,9 +27,11 @@ import {
   workflowGithubProcessedEvents,
   workflows,
 } from "@okouai/db/schema/workflow";
+import { resolveImmutableDedupeInsert } from "../../lib/immutable-dedupe-insert";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
+import { settle } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
@@ -702,20 +704,23 @@ async function recordProcessedDelivery(args: {
   readonly event: GithubWebhookAutomationEvent;
 }): Promise<string | null> {
   const subject = eventSubject(args.event);
-  const [row] = await args.db
-    .insert(workflowGithubProcessedEvents)
-    .values({
-      automationId: args.automation.automation.id,
-      githubDeliveryId: args.deliveryId,
-      repo: eventRepository(args.event).full_name,
-      subjectType: subject.type,
-      subjectNumber: subject.number,
-      action: eventAction(args.event),
-      labelNameNormalized: null,
-      createdAt: nowDate(),
-    })
-    .onConflictDoNothing()
-    .returning({ id: workflowGithubProcessedEvents.id });
+  const row = resolveImmutableDedupeInsert(
+    await settle(
+      args.db
+        .insert(workflowGithubProcessedEvents)
+        .values({
+          automationId: args.automation.automation.id,
+          githubDeliveryId: args.deliveryId,
+          repo: eventRepository(args.event).full_name,
+          subjectType: subject.type,
+          subjectNumber: subject.number,
+          action: eventAction(args.event),
+          labelNameNormalized: null,
+          createdAt: nowDate(),
+        })
+        .returning({ id: workflowGithubProcessedEvents.id }),
+    ),
+  );
   return row?.id ?? null;
 }
 

--- a/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
@@ -13,9 +13,11 @@ import {
   workflowGithubProcessedEvents,
   workflows,
 } from "@okouai/db/schema/workflow";
+import { resolveImmutableDedupeInsert } from "../../lib/immutable-dedupe-insert";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
+import { settle } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
@@ -273,20 +275,23 @@ async function recordProcessedDelivery(args: {
   readonly deliveryId: string;
   readonly payload: GithubWorkflowRunEventPayload;
 }): Promise<string | null> {
-  const [row] = await args.db
-    .insert(workflowGithubProcessedEvents)
-    .values({
-      automationId: args.automation.automation.id,
-      githubDeliveryId: args.deliveryId,
-      repo: args.payload.repository.full_name,
-      subjectType: null,
-      subjectNumber: null,
-      action: args.payload.action,
-      labelNameNormalized: null,
-      createdAt: nowDate(),
-    })
-    .onConflictDoNothing()
-    .returning({ id: workflowGithubProcessedEvents.id });
+  const row = resolveImmutableDedupeInsert(
+    await settle(
+      args.db
+        .insert(workflowGithubProcessedEvents)
+        .values({
+          automationId: args.automation.automation.id,
+          githubDeliveryId: args.deliveryId,
+          repo: args.payload.repository.full_name,
+          subjectType: null,
+          subjectNumber: null,
+          action: args.payload.action,
+          labelNameNormalized: null,
+          createdAt: nowDate(),
+        })
+        .returning({ id: workflowGithubProcessedEvents.id }),
+    ),
+  );
   return row?.id ?? null;
 }
 

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
@@ -13,11 +13,12 @@ import {
   workflows,
 } from "@okouai/db/schema/workflow";
 import { verifyCallbackRequest } from "../../lib/event-consumer/verify-signature";
+import { resolveImmutableDedupeInsert } from "../../lib/immutable-dedupe-insert";
 import { testOverride } from "../../lib/singleton";
 import { webUrl } from "../../lib/web-url";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { safeJsonParse } from "../utils";
+import { safeJsonParse, settle } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import {
@@ -490,19 +491,21 @@ async function insertWebhookDelivery(
     readonly currentTime: Date;
   },
 ): Promise<{ readonly id: string } | null> {
-  const [delivery] = await db
-    .insert(workflowWebhookDeliveries)
-    .values({
-      automationId: args.automationId,
-      deliveryKey: args.deliveryKey,
-      bodySha256: args.bodySha256,
-      status: "accepted",
-      receivedAt: args.currentTime,
-      createdAt: args.currentTime,
-    })
-    .onConflictDoNothing()
-    .returning({ id: workflowWebhookDeliveries.id });
-  return delivery ?? null;
+  return resolveImmutableDedupeInsert(
+    await settle(
+      db
+        .insert(workflowWebhookDeliveries)
+        .values({
+          automationId: args.automationId,
+          deliveryKey: args.deliveryKey,
+          bodySha256: args.bodySha256,
+          status: "accepted",
+          receivedAt: args.currentTime,
+          createdAt: args.currentTime,
+        })
+        .returning({ id: workflowWebhookDeliveries.id }),
+    ),
+  );
 }
 
 async function deleteWebhookDelivery(


### PR DESCRIPTION
## Summary

- replace the three issue-scoped workflow dedupe `INSERT ... ON CONFLICT` statements with plain `INSERT ... RETURNING`
- classify only exact PostgreSQL `23505` failures as duplicates while preserving first-insert-wins semantics and the physical unique indexes as the race arbiters
- cover sequential and true concurrent duplicates for both dedupe relations, exact error classification, non-unique error propagation, and signed-webhook cleanup/retry behavior

## Safety and scope

- all three writes remain standalone statements through the top-level `Db`; the helper documents that classifying a settled statement cannot recover an already-aborted ambient transaction
- foreign-key, check, connection, abort, and arbitrary errors continue to propagate unchanged
- final implementation head is based directly on `e2f149caa16ccca33896688d4fcce8f4edcb7b57`
- a fresh scan of 27 open PRs and 310 changed-file entries found no overlap with the seven changed files
- no migration, schema, snapshot, journal, table/view/index/FK/check mapping, MaskDB policy, or unrelated conflict handler changed

## Validation

- `pnpm exec prettier --check <seven changed files>`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/lib/__tests__/immutable-dedupe-insert.test.ts` (8 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-github-workflow.test.ts` (16 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-workflow-automations.test.ts` (4 passed)
- `git diff --check origin/main...HEAD`

References #29481