### PR TITLE
fix(platform): preview the real shape while drawing and widen the keyboard

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -6,7 +6,6 @@ import {
   HIGHLIGHT_FILL,
   REDACT_FILL,
   STROKE_HALO_INNER,
-  STROKE_HALO_OUTER,
 } from "./image-annotation.ts";
 import { createDeferredPromise } from "../utils.ts";
 
@@ -95,9 +94,9 @@ function roundedRectPath(
 }
 
 /**
- * Draws the same shape three times — dark, light, then ink — so the stroke ends
- * up with a halo on both of its edges. This is what lets any swatch stay legible
- * over a photo, a white page, or a dark IDE screenshot.
+ * Draws the shape twice — a light halo, then the ink over it — matching what
+ * the editor shows. The dark outer pass is gone: it read as a grey outline
+ * around every mark.
  */
 function strokeWithHalo(
   context: CanvasRenderingContext2D,
@@ -111,18 +110,13 @@ function strokeWithHalo(
   context.lineCap = "round";
   context.lineJoin = "round";
 
-  context.strokeStyle = STROKE_HALO_OUTER;
+  context.strokeStyle = STROKE_HALO_INNER;
   context.lineWidth = stroke + halo * 2;
   path();
   context.stroke();
 
-  context.strokeStyle = STROKE_HALO_INNER;
-  context.lineWidth = stroke;
-  path();
-  context.stroke();
-
   context.strokeStyle = ink;
-  context.lineWidth = Math.max(1, stroke - halo);
+  context.lineWidth = stroke;
   path();
   context.stroke();
 }

--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -37,11 +37,11 @@ export const HIGHLIGHT_FILL = "rgba(237, 196, 62, 0.32)";
 export const REDACT_FILL = "#525B68";
 
 /**
- * Strokes carry a halo on both sides — dark outside, light inside — so a mark
- * keeps an edge on white, on near-black, and on the busy mid-tones of a photo.
- * Without it the ink swatch would be a contrast gamble rather than a preference.
+ * A mark is drawn in ink alone. An earlier version carried a dark outer halo
+ * for contrast on busy imagery, but it read as a grey outline around every
+ * shape, which is worse than the problem it solved. The light halo stays: it is
+ * invisible on a white screenshot and does the separating work on a dark one.
  */
-export const STROKE_HALO_OUTER = "rgba(20, 23, 29, 0.30)";
 export const STROKE_HALO_INNER = "rgba(255, 255, 255, 0.90)";
 
 /**

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -293,6 +293,31 @@ describe("composer image annotation", () => {
     });
   });
 
+  it("removes the selected mark with the Delete key", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    mockAgentChatPage();
+    mockDraftWithImage([boxMark()]);
+
+    setup(true);
+
+    const chip = await screen.findByLabelText(
+      "Open image preview for billing-page.png",
+    );
+    await user.click(chip);
+    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
+    await screen.findByTestId("image-annotation-editor");
+    await user.click(screen.getByTestId("annotation-mark-1"));
+
+    // The note must not hold focus for a non-text mark, or Delete lands in the
+    // field instead of removing the mark.
+    fireEvent.keyDown(document, { key: "Delete" });
+
+    await waitFor(() => {
+      expect(screen.getByText("0 marks")).toBeInTheDocument();
+    });
+  });
+
   it("keeps an opened-but-untouched image unannotated", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -3,6 +3,7 @@ import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
   ArrowUpRight,
+  EyeOff,
   Minus,
   Pencil,
   Plus,
@@ -68,7 +69,7 @@ const TOOLS: readonly { tool: AnnotationTool; icon: typeof Square }[] = [
   { tool: "arrow", icon: ArrowUpRight },
   { tool: "pen", icon: Pencil },
   { tool: "text", icon: Type },
-  { tool: "redact", icon: Trash2 },
+  { tool: "redact", icon: EyeOff },
 ];
 
 /**
@@ -77,6 +78,15 @@ const TOOLS: readonly { tool: AnnotationTool; icon: typeof Square }[] = [
  * is impossible to see and impossible to select in order to delete.
  */
 const MIN_DRAG = 0.005;
+
+/** One letter per tool, matching the first letter of each label. */
+const TOOL_SHORTCUTS: Readonly<Record<string, AnnotationTool | undefined>> = {
+  b: "box",
+  a: "arrow",
+  d: "pen",
+  t: "text",
+  r: "redact",
+};
 
 function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value));
@@ -98,8 +108,9 @@ function percent(value: number): string {
 function buildMark(
   stroke: AnnotationStroke,
   ink: AnnotationInk,
+  previewId?: string,
 ): ImageAnnotationMark | null {
-  const id = crypto.randomUUID();
+  const id = previewId ?? crypto.randomUUID();
   const rect = rectFrom(stroke.from, stroke.to);
   const dragged = rect.width > MIN_DRAG || rect.height > MIN_DRAG;
 
@@ -214,14 +225,21 @@ function InkSwatches() {
                   onClick={() => {
                     setInk(candidate);
                   }}
+                  className={cn(active && "bg-state-selected")}
                 >
                   <span
-                    style={{ background: candidate }}
+                    style={{
+                      background: candidate,
+                      // The ring is the ink itself, held off the swatch by the
+                      // toolbar colour, so the selected colour is announced by
+                      // the colour rather than by two pixels of extra diameter.
+                      boxShadow: active
+                        ? `0 0 0 2px hsl(var(--background)), 0 0 0 4px ${candidate}`
+                        : "none",
+                    }}
                     className={cn(
                       "rounded-full transition-all",
-                      active
-                        ? "h-[18px] w-[18px] ring-2 ring-card ring-offset-2"
-                        : "h-4 w-4",
+                      active ? "h-3.5 w-3.5" : "h-4 w-4",
                     )}
                   />
                 </Button>
@@ -330,6 +348,7 @@ function MarkNotePopover({ mark }: { mark: ImageAnnotationMark }) {
   const { t } = useTranslation();
   const setNote = useSet(setAnnotationMarkNote$);
   const removeMark = useSet(removeAnnotationMark$);
+  const deselect = useSet(selectAnnotationMark$);
   const anchor = markAnchor(mark);
 
   return (
@@ -353,10 +372,24 @@ function MarkNotePopover({ mark }: { mark: ImageAnnotationMark }) {
           className="h-2.5 w-2.5 shrink-0 rounded-full"
         />
         <Input
-          autoFocus
+          // Only text marks take the caret. Focusing the field for every mark
+          // is what made Delete land in the input instead of removing the mark.
+          autoFocus={mark.shape === "text"}
           value={noteOf(mark)}
           onChange={(event) => {
             setNote(mark.id, event.target.value);
+          }}
+          onKeyDown={(event) => {
+            // Backspace edits the text. Once the field is empty the next press
+            // dismisses the note — deleting the mark from here would be a
+            // surprise, so that stays on the bin button alone.
+            if (
+              (event.key === "Backspace" || event.key === "Delete") &&
+              noteOf(mark).length === 0
+            ) {
+              event.preventDefault();
+              deselect(null);
+            }
           }}
           placeholder={
             mark.shape === "text"
@@ -497,9 +530,19 @@ function EditorFooter() {
   );
 }
 
-/** Delete and Backspace remove the selected mark, unless a field has focus. */
-function DeleteKeyBinding() {
+/**
+ * The editor's keyboard surface. Every binding steps aside while a field has
+ * focus, so typing a note never triggers a shortcut.
+ */
+function KeyboardShortcuts() {
   const removeSelected = useSet(removeSelectedAnnotationMark$);
+  const selectMark = useSet(selectAnnotationMark$);
+  const setTool = useSet(setAnnotationTool$);
+  const undo = useSet(undoAnnotation$);
+  const redo = useSet(redoAnnotation$);
+  const close = useSet(closeAnnotationEditor$);
+  const commit = useSet(commitAnnotation$);
+  const selectedId = useGet(annotationSelectedMarkId$);
   let cleanup: (() => void) | null = null;
 
   return (
@@ -511,19 +554,53 @@ function DeleteKeyBinding() {
           return;
         }
         const onKeyDown = (event: KeyboardEvent) => {
-          if (event.key !== "Delete" && event.key !== "Backspace") {
-            return;
-          }
           const active = document.activeElement;
-          if (
+          const typing =
             active instanceof HTMLInputElement ||
             active instanceof HTMLTextAreaElement ||
-            (active instanceof HTMLElement && active.isContentEditable)
+            (active instanceof HTMLElement && active.isContentEditable);
+
+          if (
+            (event.metaKey || event.ctrlKey) &&
+            event.key.toLowerCase() === "z"
           ) {
+            event.preventDefault();
+            if (event.shiftKey) {
+              redo();
+            } else {
+              undo();
+            }
             return;
           }
-          event.preventDefault();
-          removeSelected();
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            event.preventDefault();
+            commit();
+            return;
+          }
+          if (event.key === "Escape") {
+            event.preventDefault();
+            // Escape backs out one layer at a time: the selection first, the
+            // editor only once nothing is selected.
+            if (selectedId) {
+              selectMark(null);
+            } else {
+              close();
+            }
+            return;
+          }
+          if (typing) {
+            return;
+          }
+          if (event.key === "Delete" || event.key === "Backspace") {
+            event.preventDefault();
+            removeSelected();
+            return;
+          }
+          const shortcut = TOOL_SHORTCUTS[event.key.toLowerCase()];
+          if (shortcut) {
+            event.preventDefault();
+            setTool(shortcut);
+          }
         };
         document.addEventListener("keydown", onKeyDown, true);
         cleanup = () => {
@@ -732,8 +809,10 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
 
   const box = surface?.getBoundingClientRect();
   const aspect = box && box.height > 0 ? box.width / box.height : 1;
-  const preview =
-    stroke && stroke.tool !== "pen" ? rectFrom(stroke.from, stroke.to) : null;
+  // Previewing through the same renderer is what makes a drag show the arrow or
+  // the freehand line it is about to become, rather than a dashed rectangle
+  // standing in for every tool.
+  const preview = stroke ? buildMark(stroke, ink, "annotation-preview") : null;
   const selectedMark = annotation.marks.find((mark) => {
     return mark.id === selectedId;
   });
@@ -830,15 +909,10 @@ function EditorStage({ filename, url }: { filename: string; url: string }) {
           <MarkNotePopover mark={selectedMark} />
         )}
         {preview && (
-          <div
-            style={{
-              left: percent(preview.x),
-              top: percent(preview.y),
-              width: percent(preview.width),
-              height: percent(preview.height),
-              border: `2.5px dashed ${ink}`,
-            }}
-            className="pointer-events-none absolute rounded"
+          <MarkShape
+            mark={preview}
+            ordinal={annotation.marks.length + 1}
+            aspect={aspect}
           />
         )}
       </div>
@@ -876,7 +950,7 @@ function AnnotationSurface({ target }: { target: AnnotationTarget }) {
         className="zero-app fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
         data-testid="image-annotation-editor"
       >
-        <DeleteKeyBinding />
+        <KeyboardShortcuts />
         <div
           className="flex h-[min(700px,90vh)] w-[min(980px,94vw)] min-h-0 flex-col overflow-hidden rounded-xl bg-background text-foreground shadow-[0_24px_70px_hsl(var(--overlay)/0.30)]"
           data-testid="image-annotation-panel"

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -7,7 +7,6 @@ import {
   HIGHLIGHT_FILL,
   REDACT_FILL,
   STROKE_HALO_INNER,
-  STROKE_HALO_OUTER,
 } from "../../signals/okou-page/image-annotation.ts";
 
 /**
@@ -52,7 +51,7 @@ function StrokeMark({
         <polyline
           points={points}
           fill="none"
-          stroke={STROKE_HALO_OUTER}
+          stroke={STROKE_HALO_INNER}
           vectorEffect="non-scaling-stroke"
           style={{ strokeWidth: 5 }}
         />
@@ -103,7 +102,7 @@ function StrokeMark({
       <path
         d={`${shaft} ${arrowHead}`}
         fill="none"
-        stroke={STROKE_HALO_OUTER}
+        stroke={STROKE_HALO_INNER}
         strokeLinecap="round"
         strokeLinejoin="round"
         vectorEffect="non-scaling-stroke"
@@ -134,7 +133,7 @@ function boxedFill(
   return {
     border: `2.5px solid ${mark.ink}`,
     background: `${mark.ink}1A`,
-    boxShadow: `0 0 0 1px ${STROKE_HALO_OUTER}, inset 0 0 0 1px ${STROKE_HALO_INNER}`,
+    boxShadow: `inset 0 0 0 1px ${STROKE_HALO_INNER}`,
   };
 }
 


### PR DESCRIPTION
## 1 & 5. Drawing shows the shape it will become

Dragging rendered a dashed rectangle whatever the tool was, so an arrow only appeared on mouse-up and a freehand line appeared not at all until it was finished. The in-progress mark now goes through **the same renderer as a finished one** — one change fixes both.

## 2. Keyboard

Delete *was* already bound and never fired: the note field autofocused for every mark, and the binding steps aside while a field has focus. Now only text marks take the caret.

| key | |
|---|---|
| `Delete` / `Backspace` | remove the selected mark |
| `Backspace` in a note | edit the text; once empty, dismiss the note |
| `Esc` | drop the selection, then close the editor |
| `Cmd/Ctrl+Z` / `+Shift` | undo / redo |
| `Cmd/Ctrl+Enter` | attach marks |
| `B` `A` `D` `T` `R` | box, arrow, draw, text, redact |

Deleting the mark stays on the bin button in the note — reachable, but it cannot happen by accident while editing text.

## 3. No grey stroke

The dark outer halo is gone from the editor, the viewer and the flattened copy. It was there for contrast on busy imagery, but it read as a grey outline around every shape. The light halo alone stays: invisible on a white screenshot, doing the separating work on a dark one.

## Also, from the same round

- The **redact** tool wore a bin icon, so it read as "delete" and then drew a solid block. It is an eye-off now.
- The **selected ink swatch** was `ring-card` — a white ring on a white toolbar — plus two pixels of diameter. The ring is now the ink itself, held off the swatch by the toolbar colour, over `bg-state-selected`.

## Verification

`lint`, both `tsc` configs, `i18next-cli extract --ci` clean. `vitest`: `image-annotation` 8 tests (new one covers the Delete key specifically), `attachment-chips` 48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)