### PR TITLE
refactor(api): dual-write api backend url aliases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 
     "CARGO_HOME": "/home/vscode/.cache/cargo",
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
+    "OKOU_API_BACKEND_URL": "https://api.vm7.ai:8443",
     "VM0_API_BACKEND_URL": "https://api.vm7.ai:8443",
     "AGENT_BROWSER_HEADED": "1",
     "DISPLAY": ":99",

--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -236,6 +236,7 @@ runs:
         fi
 
         if [[ -n "$api_backend_url" ]]; then
+          add_env OKOU_API_BACKEND_URL "$api_backend_url"
           add_env VM0_API_BACKEND_URL "$api_backend_url"
         fi
         if [[ "$INPUT_APP" == "api" ]]; then

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -138,6 +138,16 @@ assert_debug_aliases_absent() {
   assert_env_key_absent "$env_file" VM0_DEBUG
 }
 
+assert_api_backend_url_aliases_equal_dual() {
+  local env_file="$1"
+  local expected="$2"
+  assert_env_key_count "$env_file" OKOU_API_BACKEND_URL 1
+  assert_env_key_count "$env_file" VM0_API_BACKEND_URL 1
+  assert_env_value "$env_file" OKOU_API_BACKEND_URL "$expected"
+  assert_env_value "$env_file" VM0_API_BACKEND_URL "$expected"
+  assert_env_values_equal "$env_file" OKOU_API_BACKEND_URL VM0_API_BACKEND_URL
+}
+
 assert_web_url_aliases_equal_dual() {
   local env_file="$1"
   local expected="$2"
@@ -503,7 +513,7 @@ assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
 assert_env_value "$success_env_file" OKOU_PREVIEW_JOB_REF "pr-123"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_values_equal "$success_env_file" OKOU_PREVIEW_JOB_REF VM0_PREVIEW_JOB_REF
-assert_env_value "$success_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_aliases_equal_dual "$success_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_web_url_aliases_equal_dual "$success_env_file" "https://pr-123-www.vm0.test"
@@ -549,6 +559,7 @@ preview_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${
 assert_contains "$preview_web_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$preview_web_env_file"
 assert_debug_aliases_equal_dual "$preview_web_env_file"
+assert_api_backend_url_aliases_equal_dual "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_web_url_aliases_absent "$preview_web_env_file"
 
 empty_job_ref_dir="$(mktemp -d)"
@@ -558,6 +569,7 @@ empty_job_ref_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "
 assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
 assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
+assert_api_backend_url_aliases_equal_dual "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -567,6 +579,7 @@ assert_contains "$empty_output" "Rendered"
 assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_debug_aliases_equal_dual "$empty_env_file"
+assert_api_backend_url_aliases_equal_dual "$empty_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -583,6 +596,7 @@ assert_contains "$production_web_output" "Rendered"
 assert_no_fixture_secret_values "$production_web_output"
 assert_zero_keys_with_live_readers_absent "$production_web_env_file"
 assert_debug_aliases_absent "$production_web_env_file"
+assert_api_backend_url_aliases_equal_dual "$production_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_web_url_aliases_absent "$production_web_env_file"
 assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
@@ -611,7 +625,7 @@ assert_no_fixture_secret_values "$production_api_output"
 assert_zero_keys_with_live_readers_absent "$production_api_env_file"
 assert_debug_aliases_absent "$production_api_env_file"
 assert_web_url_aliases_equal_dual "$production_api_env_file" "https://pr-123-www.vm0.test"
-assert_env_value "$production_api_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_aliases_equal_dual "$production_api_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -7,6 +7,7 @@ CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 CLERK_WEBHOOK_SIGNING_SECRET=op://Development/clerk/CLERK_WEBHOOK_SIGNING_SECRET
 
 # Required: API, web, and app URLs
+OKOU_API_BACKEND_URL=https://api.vm7.ai:8443
 VM0_API_BACKEND_URL=https://api.vm7.ai:8443
 FEISHU_CALLBACK_BASE_URL=https://api.vm7.ai:8443
 OKOU_WEB_URL=https://www.vm7.ai:8443


### PR DESCRIPTION
## Summary

- Emit adjacent, byte-equal `OKOU_API_BACKEND_URL` and retained `VM0_API_BACKEND_URL` values from the existing `api_backend_url` bytes under the unchanged non-empty condition, before the later API-only branch.
- Extend the real composite-action contract with one backend-alias helper and require exact counts, exact values, and byte equality for every existing successful preview/production web/API rendering.
- Add adjacent equal aliases to the local API template and development container while leaving Turbo's existing equal pass-through and every resolver, reader, workflow, runtime, and external configuration boundary unchanged.

## Base and overlap evidence

- Dispatched and pre-edit refreshed base: `e2f149caa16ccca33896688d4fcce8f4edcb7b57`.
- Pre-edit stable tree: `e2f149caa16ccca33896688d4fcce8f4edcb7b57`; the audit covered 24 open PRs and 302 GitHub-declared / 302 fetched changed files with zero pagination mismatch.
- While focused checks ran, `main` advanced through five disjoint Runner, Guest Agent, Python documentation, and database commits. Their changed files and semantic diff had no API-backend writer overlap.
- Final refreshed/rebased base: `403a2a5a93ff7ecfce40b202389d092759921d0b`.
- Final stable PR head: `39a927f2a1fd6065834408e6f5a57a78aa773871`.
- The final fully paginated audit covered all 27 open PRs and 324 GitHub-declared / 324 fetched changed files with zero pagination mismatch.
- Stale #25722 remains open and `DIRTY` / `CONFLICTING` at unchanged head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, base `505aae73170efd5b484599eb7d433f404f5c3d2f`, last updated `2026-08-13T15:03:45Z`, with 185 declared / 185 fetched files. It overlaps the action, action contract, API schema, Turbo pass-through, several E2E readers, and proposed Cloudflare Worker/runtime API URL reads. Those Worker/runtime files are not active on current `main`, #25722 does not provide a complete canonical migration, and none of its scope or code was imported here.
- Draft #29442 remains `DIRTY` / `CONFLICTING` at head `70e0f6d925a415003daf69a8ffc3e16a74704354`. Its only textual overlap is deletion context for `VM0_API_BACKEND_URL` in a CLI website-generation test; it touches no selected writer file and has no semantic overlap with this API-process writer expansion.
- A tracked-file inventory matched the issue's base evidence exactly: 31 canonical occurrences and 271 legacy occurrences across a 176-file union. The final patch has 37 canonical and 272 retained legacy occurrences across the same 176-file union.

## Verification

- Pinned Prettier 3.8.1 write/check on all touched supported formats.
- `pnpm turbo run lint --concurrency=1 --log-order grouped`: 13/13 tasks passed; existing advisory Oxlint warnings were on untouched files.
- `pnpm knip`: passed with existing configuration hints only.
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`: 12/12 tasks passed.
- `pnpm --filter @okouai/app run check-types`: passed.
- `pnpm --filter api run check-types`: all dependency, boundary, gateway, core, bootstrap, test, and bootstrap-wiring stages passed.
- Bash syntax checks for the action contract and extracted composite-action script.
- ShellCheck 0.9.0 for the action contract and extracted composite-action script.
- `bash .github/scripts/tests/web-api-env-action-test.sh`: passed the real preview/production and web/API matrix.
- `jq empty .devcontainer/devcontainer.json` and `jq empty turbo/turbo.json`.
- Exact local-template and devcontainer exactly-once, adjacency, exact-value, and byte-equality assertions.
- Exact action assertions proved lines 238-240 remain one non-empty block with canonical and legacy output from the same shell variable, immediately before the API-only branch at line 242.
- Turbo exactly-once/adjacency assertions proved both aliases remain present without modifying `turbo/turbo.json`.
- Hash/diff assertions proved `release-please.yml`, `rollback-production.yml`, `turbo.yml`, Turbo, the API resolver/schema, consumers, CLI, connectors, E2E, Runner, Guest, and Worker scope unchanged.
- Semantic searches found zero new canonical repository-variable/secret reads, zero new URL logging, zero forbidden paths, and a clean `git diff --check`.
- After rebasing onto `403a2a5a93ff7ecfce40b202389d092759921d0b`, reran focused Prettier, Bash, ShellCheck, the real action contract, JSON, equality, adjacency, excluded-surface, semantic, and diff checks on exact head `39a927f2a1fd6065834408e6f5a57a78aa773871`.

No full local Vitest suite or local development server was run. Protected PR CI remains authoritative for repository-wide validation.

## Rollout boundaries

- This PR expands repository-owned writers only. It does not rename or mutate the production repository variable, secrets, Doppler values, live environment, workflow inputs, or any external configuration.
- The current production release `76543ae27ffb59adb22f11f084e5aa999ceed80e` / API `v1.494.1` and retained rollback release `6c290d952c6d628c2698ffa27c2b25b9a9285176` / API `v1.494.0` both contain the dual reader. Production currently proves `legacy-only`, so retaining the old output is mandatory.
- A later controller-owned release must deploy the exact containing API SHA. Acceptance must query `api_backend_url_alias_resolution` for that exact deployment window and prove `equal-dual` with zero `legacy-only`, `canonical-only`, and `conflicting-dual` observations at the API-process boundary.
- No release, environment approval, deployment, production QA, rollback, canonical-only cutover, reader removal, or namespace-guard cleanup is performed or authorized here.

## Fallbacks

- `.github/actions/web-api-env/action.yml`'s non-empty API-backend output block, `turbo/apps/api/.env.local.tpl`, and `.devcontainer/devcontainer.json` retain `VM0_API_BACKEND_URL` beside byte-equal `OKOU_API_BACKEND_URL`; `turbo/turbo.json` already passes the same pair and remains unchanged. This protects old-only API rollback artifacts while current API processes accept the canonical twin. Surface: repository-owned deployment/local-development writer -> supported old API target. Window: the full supported API rollback window. Reverting this PR restores the previous legacy-only writer state without changing the deployed dual reader.
- Removal gate: first deploy the exact containing SHA and prove bounded production `equal-dual` plus zero `legacy-only`, `canonical-only`, and `conflicting-dual` evidence. Then a separate just-in-time canonical-only writer issue under #28914 must refresh every production, preview, local, rerun, and stale #25722 Worker/configuration source and prove the old-reader rollback target is retired before removing any retained legacy writer.
- Reader-removal gate: after that later canonical-only cutover, retain the dual reader until bounded value-free telemetry records zero `legacy-only` and zero `equal-dual` throughout the supported rollback window. Legacy-reader removal and the final `VM0_*` ownership-guard cleanup remain separate later children of #28914.

Closes #29495

Parent EPIC: #28914
