### PR TITLE
docs(python): document network-log capture sanitization contract

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -429,6 +429,35 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     #         response_headers_truncated, response_body, response_body_encoding,
     #         response_body_truncated
 
+    Capture is an opt-in persistent-log boundary. Header values are redacted by
+    default; only constrained protocol metadata is preserved: normalized
+    allowlisted ``content-type`` media types (with parameters removed), valid
+    ``accept-encoding`` and ``content-encoding`` codings, decimal
+    ``content-length``, and valid IMF-fixdate ``date`` values. Unsafe,
+    malformed, or overlong values are represented as ``***``. Header names
+    must be HTTP field-name-shaped and at most 256 characters; invalid or
+    overlong names are represented as ``[redacted-header-name]``. Only the
+    first case-insensitive occurrence of each captured name is retained.
+
+    Each serialized header map is a prefix bounded to 512 fields and 32 KiB of
+    raw name/value bytes. ``*_headers_truncated`` means that this serialized
+    prefix did not contain every header field; it does not describe body
+    capture. Body dependency headers are inspected separately with the same
+    field and byte budgets, so unrelated header overflow cannot hide a later
+    ``content-type`` or ``content-encoding`` field. Duplicate, malformed,
+    unsafe, or over-budget dependency metadata fails body capture closed.
+
+    Bodies are bounded by ``BODY_CAPTURE_LIMIT`` (currently 64 KiB) after
+    decoding. Empty bodies have no body or encoding field. Text-like bodies are
+    emitted as UTF-8 when valid, or as base64 when invalid bytes must be
+    preserved. Non-text bodies, failed decoding, and invalid body dependencies
+    omit the body and use ``binary`` when a non-empty body was observed.
+    ``*_body_truncated`` records incomplete, suppressed, stream-truncated, or
+    body-size-limited capture and is independent of whether a body string is
+    emitted. A terminal incomplete UTF-8 sequence caused by the size limit is
+    removed so the bounded prefix can remain UTF-8; other invalid prefixes use
+    base64.
+
     Request bodies prefer request streaming metadata when requestheaders()
     installed a safe capped stream before mitmproxy buffered the body.
 

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -444,8 +444,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     prefix did not contain every header field; it does not describe body
     capture. Body dependency headers are inspected separately with the same
     field and byte budgets, so unrelated header overflow cannot hide a later
-    ``content-type`` or ``content-encoding`` field. Duplicate, malformed,
-    unsafe, or over-budget dependency metadata fails body capture closed.
+    ``content-type`` or ``content-encoding`` field. Multiple ``content-type``
+    values are ambiguous, while repeated ``content-encoding`` fields are folded
+    and validated. Malformed, unsafe, or over-budget dependency metadata fails
+    body capture closed.
 
     Bodies are bounded by ``BODY_CAPTURE_LIMIT`` (currently 64 KiB) after
     decoding. Empty bodies have no body or encoding field. Text-like bodies are

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -645,7 +645,13 @@ const networkLogEntrySchema = z.object({
   auth_cache_hit: z.boolean().optional(),
   auth_url_rewrite: z.boolean().optional(),
   error: z.string().optional(),
-  // Capture-only fields (opt-in via captureNetworkBodies)
+  // Capture-only fields (opt-in via captureNetworkBodies). Header maps are
+  // default-redacted, sanitized, and independently bounded to 512 fields / 32
+  // KiB; see crates/runner/mitm-addon/src/body_capture.py for the contract.
+  // *_headers_truncated describes only an incomplete serialized header map.
+  // Body strings are bounded capture results; *_body_encoding distinguishes
+  // UTF-8, base64, and binary outcomes, while *_body_truncated describes an
+  // incomplete or suppressed capture. Empty bodies have no body or encoding.
   request_headers: z.record(z.string(), z.string()).optional(),
   request_headers_truncated: z.boolean().optional(),
   request_body: z.string().optional(),


### PR DESCRIPTION
## Summary

- Document the persistent network-log capture contract at the Python capture boundary, including
  header redaction, normalization, duplicate handling, budgets, independent body-dependency
  inspection, fail-closed behavior, and body encoding/truncation outcomes.
- Keep the shared network-log schema comments consistent with those semantics.

## Scope

This PR changes documentation comments only. It does not change executable code, schema types,
tests, generated files, dependencies, migrations, or runtime behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6636 passed
- `git diff --check`

Closes #29514
