### PR TITLE
perf(runner): bound axiom textual fields before queueing

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -51,15 +51,16 @@ const _: () = assert!(
     FLUSH_DEADLINE.as_nanos() >= HTTP_TIMEOUT.as_nanos(),
     "FLUSH_DEADLINE must be >= HTTP_TIMEOUT; see FLUSH_DEADLINE doc comment",
 );
-/// Max bytes we'll serialize from a single `Debug`-formatted field.
+/// Max content bytes we'll retain from a single textual field.
 ///
-/// Covers typical legit Debug output (errors, configs — nearly all under
-/// ~2 KiB) while flagging accidental huge-struct dumps: `tracing::warn!(v
-/// = ?gigantic, ...)` would otherwise embed megabytes into a single event
-/// and blow past Axiom's per-request body limit. Oversized values are
-/// truncated on a UTF-8 boundary with a `…[truncated]` marker so the
-/// condition is visible in the log.
-const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
+/// Covers typical legitimate strings and formatted values while flagging
+/// accidental huge fields. Oversized values are truncated on a UTF-8
+/// boundary with a visible marker. The marker is appended after this content
+/// cap, matching the existing bounded Debug-field behavior.
+const TEXT_FIELD_MAX_BYTES: usize = 4 * 1024;
+/// Max native error sources retained after the top-level error message.
+const ERROR_SOURCE_MAX_DEPTH: usize = 8;
+const TRUNCATION_MARKER: &str = "…[truncated]";
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
 const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
@@ -71,27 +72,27 @@ const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 #[derive(Default)]
-struct BoundedDebugOutput {
+struct BoundedTextOutput {
     value: String,
     truncated: bool,
 }
 
-impl BoundedDebugOutput {
+impl BoundedTextOutput {
     fn finish(mut self) -> String {
         if self.truncated {
-            self.value.push_str("…[truncated]");
+            self.value.push_str(TRUNCATION_MARKER);
         }
         self.value
     }
 }
 
-impl std::fmt::Write for BoundedDebugOutput {
+impl std::fmt::Write for BoundedTextOutput {
     fn write_str(&mut self, value: &str) -> std::fmt::Result {
         if self.truncated {
             return Err(std::fmt::Error);
         }
 
-        let remaining = DEBUG_FIELD_MAX_BYTES - self.value.len();
+        let remaining = TEXT_FIELD_MAX_BYTES - self.value.len();
         if value.len() <= remaining {
             self.value.push_str(value);
             return Ok(());
@@ -105,6 +106,12 @@ impl std::fmt::Write for BoundedDebugOutput {
         self.truncated = true;
         Err(std::fmt::Error)
     }
+}
+
+fn format_bounded(arguments: std::fmt::Arguments<'_>) -> String {
+    let mut output = BoundedTextOutput::default();
+    let _ = output.write_fmt(arguments);
+    output.finish()
 }
 
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
@@ -328,7 +335,10 @@ fn serialize_event(event: &Event<'_>) -> Value {
     struct V(Map<String, Value>);
     impl Visit for V {
         fn record_str(&mut self, f: &Field, v: &str) {
-            self.0.insert(f.name().into(), Value::String(v.into()));
+            self.0.insert(
+                f.name().into(),
+                Value::String(format_bounded(format_args!("{v}"))),
+            );
         }
         fn record_i64(&mut self, f: &Field, v: i64) {
             self.0.insert(f.name().into(), v.into());
@@ -355,12 +365,21 @@ fn serialize_event(event: &Event<'_>) -> Value {
             // `.source()`, the closest analog to JS `cause`.
             let mut chain: Vec<Value> = Vec::new();
             let mut cur = err.source();
-            while let Some(e) = cur {
-                chain.push(Value::String(e.to_string()));
+            for _ in 0..ERROR_SOURCE_MAX_DEPTH {
+                let Some(e) = cur else {
+                    break;
+                };
+                chain.push(Value::String(format_bounded(format_args!("{e}"))));
                 cur = e.source();
             }
+            if cur.is_some() {
+                chain.push(Value::String(TRUNCATION_MARKER.into()));
+            }
             let mut obj = Map::new();
-            obj.insert("message".into(), Value::String(err.to_string()));
+            obj.insert(
+                "message".into(),
+                Value::String(format_bounded(format_args!("{err}"))),
+            );
             if !chain.is_empty() {
                 obj.insert("chain".into(), Value::Array(chain));
             }
@@ -369,10 +388,10 @@ fn serialize_event(event: &Event<'_>) -> Value {
         fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
             // Cap per-field size so a user who logs a huge struct via `?v`
             // can't blow past Axiom's body limit or starve the dispatcher.
-            let mut output = BoundedDebugOutput::default();
-            let _ = write!(output, "{v:?}");
-            self.0
-                .insert(f.name().into(), Value::String(output.finish()));
+            self.0.insert(
+                f.name().into(),
+                Value::String(format_bounded(format_args!("{v:?}"))),
+            );
         }
     }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -12,8 +12,9 @@ use std::thread;
 use std::time::Duration;
 
 use super::{
-    AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, DEBUG_FIELD_MAX_BYTES, INTERNAL_TARGET,
-    init_from_env_values, init_with_base_url, with_ingest_filter,
+    AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, ERROR_SOURCE_MAX_DEPTH, INTERNAL_TARGET,
+    TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER, init_from_env_values, init_with_base_url,
+    with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -345,6 +346,39 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
 }
 
 #[tokio::test]
+async fn oversized_string_field_is_bounded_before_ingest() {
+    const SENTINEL_PAST_CAP: &str = "STRING_SENTINEL_PAST_CAP";
+
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        let mut oversized = "A".repeat(TEXT_FIELD_MAX_BYTES + 1_000);
+        oversized.push_str(SENTINEL_PAST_CAP);
+        tracing::warn!(oversized = oversized.as_str(), "bounded string");
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    let event = event_with_message(&events, "bounded string");
+    let retained = string_field(event, "oversized");
+    assert_eq!(
+        retained.len(),
+        TEXT_FIELD_MAX_BYTES + TRUNCATION_MARKER.len(),
+    );
+    assert!(retained.ends_with(TRUNCATION_MARKER));
+    assert!(
+        !retained.contains(SENTINEL_PAST_CAP),
+        "far-past-cap string content reached ingest: {retained:?}",
+    );
+}
+
+#[tokio::test]
 async fn axiom_filter_does_not_suppress_sibling_local_layers() {
     let server = MockServer::start_async().await;
 
@@ -433,13 +467,13 @@ fn init_returns_none_when_token_empty() {
 /// `record_error` visitor without pulling in extra deps.
 #[derive(Debug)]
 struct ChainErr {
-    msg: &'static str,
+    msg: String,
     src: Option<Box<ChainErr>>,
 }
 
 impl std::fmt::Display for ChainErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.msg)
+        f.write_str(&self.msg)
     }
 }
 
@@ -461,11 +495,11 @@ async fn error_field_serializes_with_message_and_source_chain() {
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         let err = ChainErr {
-            msg: "top",
+            msg: "top".into(),
             src: Some(Box::new(ChainErr {
-                msg: "middle",
+                msg: "middle".into(),
                 src: Some(Box::new(ChainErr {
-                    msg: "root",
+                    msg: "root".into(),
                     src: None,
                 })),
             })),
@@ -482,6 +516,112 @@ async fn error_field_serializes_with_message_and_source_chain() {
     let event = event_with_message(&events, "explosion");
     assert_eq!(event["error"]["message"], json!("top"));
     assert_eq!(event["error"]["chain"], json!(["middle", "root"]));
+}
+
+#[tokio::test]
+async fn oversized_deep_error_is_bounded_independently_of_input_size() {
+    const SENTINEL_PAST_CAP: &str = "ERROR_SENTINEL_PAST_CAP";
+
+    fn oversized_message(label: &str, input_bytes: usize) -> String {
+        let mut message = format!("{label}:");
+        message.push_str(&"A".repeat(input_bytes));
+        message.push_str(SENTINEL_PAST_CAP);
+        message
+    }
+
+    fn oversized_chain(input_bytes: usize) -> ChainErr {
+        let mut source = None;
+        for index in (0..ERROR_SOURCE_MAX_DEPTH + 2).rev() {
+            source = Some(Box::new(ChainErr {
+                msg: oversized_message(&format!("source-{index}"), input_bytes),
+                src: source,
+            }));
+        }
+        ChainErr {
+            msg: oversized_message("top", input_bytes),
+            src: source,
+        }
+    }
+
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        for input_bytes in [TEXT_FIELD_MAX_BYTES * 2, TEXT_FIELD_MAX_BYTES * 20] {
+            let err = oversized_chain(input_bytes);
+            tracing::error!(
+                error = &err as &(dyn std::error::Error + 'static),
+                "bounded error",
+            );
+        }
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    assert_eq!(events.len(), 2);
+
+    let mut serialized_event_bytes = Vec::new();
+    for event in &events {
+        let error = &event["error"];
+        let message = string_field(error, "message");
+        assert!(message.starts_with("top:"));
+        assert!(message.ends_with(TRUNCATION_MARKER));
+        assert_eq!(
+            message.len(),
+            TEXT_FIELD_MAX_BYTES + TRUNCATION_MARKER.len(),
+        );
+
+        let chain = error["chain"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected bounded error chain: {event:#?}"));
+        assert_eq!(chain.len(), ERROR_SOURCE_MAX_DEPTH + 1);
+        for (index, source) in chain[..ERROR_SOURCE_MAX_DEPTH].iter().enumerate() {
+            let source = source
+                .as_str()
+                .unwrap_or_else(|| panic!("expected string source in chain: {event:#?}"));
+            assert!(source.starts_with(&format!("source-{index}:")));
+            assert!(source.ends_with(TRUNCATION_MARKER));
+            assert_eq!(source.len(), TEXT_FIELD_MAX_BYTES + TRUNCATION_MARKER.len(),);
+        }
+        assert_eq!(
+            chain[ERROR_SOURCE_MAX_DEPTH].as_str(),
+            Some(TRUNCATION_MARKER),
+        );
+        assert!(
+            !json_contains_string(event, SENTINEL_PAST_CAP),
+            "far-past-cap error content reached ingest: {event:#?}",
+        );
+
+        let retained_error_text_bytes = message.len()
+            + chain
+                .iter()
+                .map(|source| {
+                    source
+                        .as_str()
+                        .expect("error chain values are strings")
+                        .len()
+                })
+                .sum::<usize>();
+        assert_eq!(
+            retained_error_text_bytes,
+            (ERROR_SOURCE_MAX_DEPTH + 1) * (TEXT_FIELD_MAX_BYTES + TRUNCATION_MARKER.len())
+                + TRUNCATION_MARKER.len(),
+        );
+        serialized_event_bytes.push(
+            serde_json::to_vec(event)
+                .expect("captured Axiom event should serialize")
+                .len(),
+        );
+    }
+    assert_eq!(
+        serialized_event_bytes[0], serialized_event_bytes[1],
+        "serialized event size should not grow with the original error text",
+    );
 }
 
 #[tokio::test]
@@ -659,7 +799,7 @@ async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
     );
 }
 
-// -- Debug field truncation (DEBUG_FIELD_MAX_BYTES = 4 KiB) ------------------
+// -- Debug field truncation (TEXT_FIELD_MAX_BYTES = 4 KiB) -------------------
 
 #[tokio::test]
 async fn debug_field_formatting_stops_after_reaching_limit() {
@@ -703,7 +843,7 @@ async fn debug_field_formatting_stops_after_reaching_limit() {
     );
     assert_eq!(
         formatted_chunks.load(Ordering::Relaxed),
-        DEBUG_FIELD_MAX_BYTES / CHUNK_BYTES + 1,
+        TEXT_FIELD_MAX_BYTES / CHUNK_BYTES + 1,
         "formatting should stop on the first chunk beyond the byte limit instead of visiting all {TOTAL_CHUNKS} chunks",
     );
 }
@@ -786,7 +926,7 @@ async fn debug_field_at_exact_limit_passes_through_unmodified() {
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // Debug form of a &str is `"<contents>"` — surrounding quotes cost
-        // 2 bytes, so 4094 content bytes yields exactly DEBUG_FIELD_MAX_BYTES.
+        // 2 bytes, so 4094 content bytes yields exactly TEXT_FIELD_MAX_BYTES.
         // The truncation check is `s.len() > MAX`, which is FALSE at equality
         // → value must pass through unmodified. Ending with a sentinel lets
         // the positive mock verify the full body arrived, not just the


### PR DESCRIPTION
## Summary

- bound direct Axiom string fields and native error messages with the existing 4 KiB UTF-8-safe truncation contract before queueing
- retain at most eight native error sources and append an explicit marker when deeper sources are omitted
- cover oversized direct strings, oversized/deep errors, normal error shape, retained text size, and serialized event size through the real layer-to-mocked-ingest path

## Scope

This does not add a whole-event or HTTP request byte budget and does not change channel, batch, retry, API, protocol, storage, or deployment behavior. Normal-sized text and native error chains with at most eight sources remain unchanged.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner axiom_layer` (18 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3319 passed, 24 existing ignored; integration inventory 1 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- repository pre-commit and commit-message hooks

Closes #29517
