### PR TITLE
feat(cli): show connector accounts used by current run

### DIFF
--- a/crates/guest-contracts/src/connector_account_context.rs
+++ b/crates/guest-contracts/src/connector_account_context.rs
@@ -1,0 +1,77 @@
+//! Non-secret connector account selection exposed to managed CLI children.
+
+/// Current connector account context schema version.
+pub const SCHEMA_VERSION: u8 = 1;
+
+/// One run's connector account selections.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunConnectorAccountContext {
+    /// Wire schema version.
+    pub schema_version: u8,
+    /// Logical connector targets admitted for the run.
+    pub targets: Vec<RunConnectorAccountTarget>,
+}
+
+/// One logical connector target and its run-pinned account, when available.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum RunConnectorAccountTarget {
+    /// Built-in connector target.
+    #[serde(rename_all = "camelCase")]
+    Builtin {
+        /// Public connector slug.
+        connector_slug: String,
+        /// Exact connector account selected at admission.
+        connection_id: Option<String>,
+    },
+    /// User-managed custom connector target.
+    #[serde(rename_all = "camelCase")]
+    Custom {
+        /// Custom connector definition id.
+        custom_connector_id: String,
+        /// Exact connector account selected at admission.
+        connection_id: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_uses_versioned_camel_case_wire_shape() {
+        let context = RunConnectorAccountContext {
+            schema_version: SCHEMA_VERSION,
+            targets: vec![
+                RunConnectorAccountTarget::Builtin {
+                    connector_slug: "github".to_string(),
+                    connection_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+                },
+                RunConnectorAccountTarget::Custom {
+                    custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
+                    connection_id: None,
+                },
+            ],
+        };
+
+        assert_eq!(
+            serde_json::to_value(context).unwrap(),
+            serde_json::json!({
+                "schemaVersion": 1,
+                "targets": [
+                    {
+                        "kind": "builtin",
+                        "connectorSlug": "github",
+                        "connectionId": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    {
+                        "kind": "custom",
+                        "customConnectorId": "550e8400-e29b-41d4-a716-446655440001",
+                        "connectionId": null
+                    }
+                ]
+            })
+        );
+    }
+}

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -181,6 +181,19 @@ pub const USER_ENV_PRIVATE_DIR_NAME: &str = "user-env";
 /// Private runtime filename used by [`USER_ENV_FILE_ENV`].
 pub const USER_ENV_FILENAME: &str = "env.json";
 
+/// Path to the non-secret connector account context for the current run.
+///
+/// The runner adds this key to the filtered user environment after removing
+/// untrusted runner-owned keys. Managed CLI children may read the referenced
+/// file for self-inspection; authorization does not consume it.
+pub const CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV: &str = "OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE";
+
+/// Private runtime subdirectory used by [`CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV`].
+pub const CONNECTOR_ACCOUNT_CONTEXT_PRIVATE_DIR_NAME: &str = "connector-account-context";
+
+/// Private runtime filename used by [`CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV`].
+pub const CONNECTOR_ACCOUNT_CONTEXT_FILENAME: &str = "context.json";
+
 /// Path to the private runner-owned run payload JSON file.
 ///
 /// Large prompt-like and configuration payloads use this file instead of
@@ -504,6 +517,7 @@ const EXPLICIT_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
     PI_LAUNCH_CONFIG_ENV,
     PI_LAUNCH_PAYLOAD_FILE_ENV,
     PI_MODEL_CONFIG_ENV,
+    CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV,
     CLI_AGENT_TYPE_ENV,
     USE_MOCK_CLAUDE_ENV,
     USE_MOCK_CODEX_ENV,
@@ -622,6 +636,15 @@ mod tests {
         assert_eq!(CANONICAL_USER_ENV_FILE_ENV, "OKOU_USER_ENV_FILE");
         assert_eq!(USER_ENV_PRIVATE_DIR_NAME, "user-env");
         assert_eq!(USER_ENV_FILENAME, "env.json");
+        assert_eq!(
+            CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV,
+            "OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE"
+        );
+        assert_eq!(
+            CONNECTOR_ACCOUNT_CONTEXT_PRIVATE_DIR_NAME,
+            "connector-account-context"
+        );
+        assert_eq!(CONNECTOR_ACCOUNT_CONTEXT_FILENAME, "context.json");
         assert_eq!(RUN_PAYLOAD_FILE_ENV, "VM0_RUN_PAYLOAD_FILE");
         assert_eq!(CANONICAL_RUN_PAYLOAD_FILE_ENV, "OKOU_RUN_PAYLOAD_FILE");
         assert_eq!(RUN_PAYLOAD_PRIVATE_DIR_NAME, "run-payload");
@@ -836,6 +859,7 @@ mod tests {
             PI_LAUNCH_CONFIG_ENV,
             PI_LAUNCH_PAYLOAD_FILE_ENV,
             PI_MODEL_CONFIG_ENV,
+            CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV,
             WORKING_DIR_ENV,
             USER_ENV_FILE_ENV,
             CANONICAL_USER_ENV_FILE_ENV,

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -10,6 +10,7 @@ pub mod active_input_receipts;
 pub mod cli_agent_session_id;
 pub mod codex_session_path;
 pub mod codex_thread_id;
+pub mod connector_account_context;
 pub mod diagnostics;
 pub mod env;
 pub mod epoch_milliseconds;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -39,8 +39,8 @@ use super::diagnostics::{
 };
 use super::effective_cli_framework;
 use super::env::{
-    PreparedRunPayload, build_env_json_for_run, build_user_env_json, write_run_payload_file,
-    write_user_env_file,
+    PreparedRunPayload, build_env_json_for_run, build_user_env_json,
+    write_connector_account_context_file, write_run_payload_file, write_user_env_file,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_cpu::{SessionHistoryCpuJob, SessionHistoryPrefixOutcome};
@@ -2010,8 +2010,38 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // Finalize the prepared private run payload and build the environment used
     // to bootstrap guest-agent. User-provided env is passed through a private
     // guest file and injected into the CLI child after guest-agent has started.
+    let mut user_env_map = build_user_env_json(context);
+    let connector_account_context_started = Instant::now();
+    match write_connector_account_context_file(sandbox, context).await {
+        Ok(path) => {
+            telemetry.record(
+                "runner_connector_account_context_write",
+                connector_account_context_started.elapsed(),
+                true,
+                None,
+            );
+            user_env_map.insert(
+                guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.to_string(),
+                path,
+            );
+        }
+        Err(error) => {
+            let outcome = private_write_timeout_stage(&error);
+            telemetry.record_with_outcome(
+                "runner_connector_account_context_write",
+                connector_account_context_started.elapsed(),
+                false,
+                Some("connector account context unavailable"),
+                outcome,
+            );
+            warn!(
+                run_id = %context.run_id,
+                outcome = outcome.unwrap_or("write_failed"),
+                "connector account context unavailable"
+            );
+        }
+    }
     let user_env_started = Instant::now();
-    let user_env_map = build_user_env_json(context);
     let user_env_file = match write_user_env_file(sandbox, context.run_id, &user_env_map).await {
         Ok(user_env_file) => {
             telemetry.record(

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -6,6 +6,9 @@ use api_contracts::generated::types::runners::runs::{
 };
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::connector_account_context::{
+    RunConnectorAccountContext, RunConnectorAccountTarget,
+};
 use sandbox::Sandbox;
 
 use super::cli_framework::{
@@ -13,7 +16,9 @@ use super::cli_framework::{
 };
 use super::{JOB_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path};
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
+use crate::types::{
+    ConnectorRuntimeTargetRegistration, ExecutionContext, SandboxReuseResult, WorkspaceReuseResult,
+};
 
 pub(super) struct ProtectedModelProviderEnvKey {
     name: &'static str,
@@ -430,6 +435,49 @@ pub(super) fn guest_run_payload_file_path(run_id: RunId) -> RunnerResult<String>
         dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
             .join(guest_contracts::env::RUN_PAYLOAD_FILENAME)
     })
+}
+
+pub(super) fn guest_connector_account_context_file_path(run_id: RunId) -> RunnerResult<String> {
+    guest_runtime_path(run_id, |dir| {
+        dir.join(guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_PRIVATE_DIR_NAME)
+            .join(guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILENAME)
+    })
+}
+
+pub(super) async fn write_connector_account_context_file(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+) -> RunnerResult<String> {
+    let targets = context
+        .connector_runtime_targets
+        .iter()
+        .map(|target| match target {
+            ConnectorRuntimeTargetRegistration::Builtin {
+                connector_slug,
+                source_id,
+                ..
+            } => RunConnectorAccountTarget::Builtin {
+                connector_slug: connector_slug.clone(),
+                connection_id: source_id.clone(),
+            },
+            ConnectorRuntimeTargetRegistration::Custom {
+                custom_connector_id,
+                source_id,
+                ..
+            } => RunConnectorAccountTarget::Custom {
+                custom_connector_id: custom_connector_id.clone(),
+                connection_id: source_id.clone(),
+            },
+        })
+        .collect();
+    let payload = serde_json::to_vec(&RunConnectorAccountContext {
+        schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
+        targets,
+    })
+    .map_err(|e| RunnerError::Internal(format!("serialize connector account context: {e}")))?;
+    let file_path = guest_connector_account_context_file_path(context.run_id)?;
+    sandbox.write_private_file(&file_path, &payload).await?;
+    Ok(file_path)
 }
 
 pub(super) async fn write_user_env_file(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -13,8 +13,9 @@ use super::super::cli_framework::{
 };
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_run_payload_for_run, build_user_env_json,
-    guest_run_payload_file_path, guest_user_env_file_path, is_runner_owned_env_key,
-    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
+    guest_connector_account_context_file_path, guest_run_payload_file_path,
+    guest_user_env_file_path, is_runner_owned_env_key, validate_execution_context_before_sandbox,
+    validate_model_provider_env_placeholders, write_connector_account_context_file,
     write_run_payload_file, write_user_env_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
@@ -30,7 +31,9 @@ use crate::host_env::{
 };
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
-use crate::types::{ExecutionContext, ResumeSession, SandboxReuseResult};
+use crate::types::{
+    ConnectorRuntimeTargetRegistration, ExecutionContext, ResumeSession, SandboxReuseResult,
+};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();
@@ -1261,6 +1264,83 @@ async fn write_user_env_file_returns_private_write_error() {
     assert!(sandbox.write_file_calls().is_empty());
     let writes = sandbox.private_write_file_calls();
     assert_eq!(writes.len(), 1);
+}
+
+#[tokio::test]
+async fn write_connector_account_context_file_projects_only_target_and_source() {
+    let sandbox = MockSandbox::new("test");
+    let mut context = minimal_context();
+    context.connector_runtime_targets = vec![
+        ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "github".to_string(),
+            base_url_vars: Some(HashMap::from([(
+                "API_ORIGIN".to_string(),
+                "https://api.github.com".to_string(),
+            )])),
+            source_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        },
+        ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
+            base_url_vars: HashMap::from([(
+                "CUSTOM_ORIGIN".to_string(),
+                "https://custom.example.test".to_string(),
+            )]),
+            source_id: None,
+        },
+    ];
+
+    let path = write_connector_account_context_file(&sandbox, &context)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        path,
+        guest_connector_account_context_file_path(context.run_id).unwrap()
+    );
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    let decoded: guest_contracts::connector_account_context::RunConnectorAccountContext =
+        serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(
+        decoded,
+        guest_contracts::connector_account_context::RunConnectorAccountContext {
+            schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
+            targets: vec![
+                guest_contracts::connector_account_context::RunConnectorAccountTarget::Builtin {
+                    connector_slug: "github".to_string(),
+                    connection_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string(),),
+                },
+                guest_contracts::connector_account_context::RunConnectorAccountTarget::Custom {
+                    custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
+                    connection_id: None,
+                },
+            ],
+        }
+    );
+}
+
+#[tokio::test]
+async fn write_connector_account_context_file_writes_known_empty_projection() {
+    let sandbox = MockSandbox::new("test");
+    let context = minimal_context();
+
+    let path = write_connector_account_context_file(&sandbox, &context)
+        .await
+        .unwrap();
+
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    let decoded: guest_contracts::connector_account_context::RunConnectorAccountContext =
+        serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(
+        decoded,
+        guest_contracts::connector_account_context::RunConnectorAccountContext {
+            schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
+            targets: Vec::new(),
+        }
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1054,7 +1054,23 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         ("VM0_API_TOKEN".into(), "stolen-token".into()),
         (USER_ENV_FILE_ENV_KEY.into(), "/tmp/evil-env.json".into()),
         ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
+        (
+            guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.into(),
+            "/tmp/evil-connector-account-context.json".into(),
+        ),
     ]));
+    ctx.connector_runtime_targets = vec![
+        ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "github".into(),
+            base_url_vars: None,
+            source_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+        },
+        ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".into(),
+            base_url_vars: HashMap::new(),
+            source_id: None,
+        },
+    ];
 
     let (exit_code, error_msg) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
@@ -1068,6 +1084,8 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
     let expected_user_env_file = guest_user_env_file_path(ctx.run_id).unwrap();
     let expected_run_payload_file = guest_run_payload_file_path(ctx.run_id).unwrap();
+    let expected_connector_account_context_file =
+        guest_connector_account_context_file_path(ctx.run_id).unwrap();
     assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
     assert_eq!(
@@ -1128,7 +1146,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "user env file should not be written through shell exec"
     );
     let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 2);
+    assert_eq!(private_writes.len(), 3);
     let user_env_write = private_writes
         .iter()
         .find(|write| write.path == expected_user_env_file)
@@ -1136,6 +1154,10 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let run_payload_write = private_writes
         .iter()
         .find(|write| write.path == expected_run_payload_file)
+        .unwrap();
+    let connector_account_context_write = private_writes
+        .iter()
+        .find(|write| write.path == expected_connector_account_context_file)
         .unwrap();
     let user_env: HashMap<String, String> =
         serde_json::from_slice(&user_env_write.content).unwrap();
@@ -1158,9 +1180,67 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
     assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
     assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    assert_eq!(
+        user_env
+            .get(guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV)
+            .map(String::as_str),
+        Some(expected_connector_account_context_file.as_str())
+    );
+    let connector_account_context: guest_contracts::connector_account_context::RunConnectorAccountContext =
+        serde_json::from_slice(&connector_account_context_write.content).unwrap();
+    assert_eq!(
+        connector_account_context,
+        guest_contracts::connector_account_context::RunConnectorAccountContext {
+            schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
+            targets: vec![
+                guest_contracts::connector_account_context::RunConnectorAccountTarget::Builtin {
+                    connector_slug: "github".into(),
+                    connection_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+                },
+                guest_contracts::connector_account_context::RunConnectorAccountTarget::Custom {
+                    custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".into(),
+                    connection_id: None,
+                },
+            ],
+        }
+    );
     let run_payload: guest_contracts::env::RunPayload =
         serde_json::from_slice(&run_payload_write.content).unwrap();
     assert_eq!(run_payload.prompt, ctx.prompt);
+}
+
+#[tokio::test]
+async fn execute_inner_continues_when_connector_account_context_write_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(sandbox_write_file_error(
+        "connector account context write failed",
+    )));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let context = minimal_context();
+
+    let (exit_code, error_msg) =
+        run_new_sandbox_status(&factory, &context, &config, &default_params())
+            .await
+            .unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(error_msg.is_none());
+    let private_writes = overrides.private_write_file_calls();
+    assert_eq!(private_writes.len(), 2);
+    assert_eq!(
+        private_writes[0].path,
+        guest_connector_account_context_file_path(context.run_id).unwrap()
+    );
+    assert_eq!(
+        private_writes[1].path,
+        guest_run_payload_file_path(context.run_id).unwrap()
+    );
+    let start_calls = overrides.start_process_calls();
+    assert_eq!(start_calls.len(), 1);
+    let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
+    assert!(!start_env.contains_key(USER_ENV_FILE_ENV_KEY));
 }
 
 #[tokio::test]
@@ -1168,6 +1248,8 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Ok(()));
+    overrides.push_private_write_file_result(Ok(()));
     overrides.push_private_write_file_result(Err(sandbox_write_file_error(
         "No space left on device (os error 28)",
     )));
@@ -1199,13 +1281,13 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
         Some(ResourceFailureKind::GuestRootFilesystemFull)
     );
     let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
+    assert_eq!(private_writes.len(), 3);
     assert!(
-        private_writes[0]
+        private_writes[2]
             .path
             .ends_with("/run-payload/payload.json"),
         "got: {}",
-        private_writes[0].path
+        private_writes[2].path
     );
     assert!(
         overrides.start_process_calls().is_empty(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -19,7 +19,8 @@ use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
 
 use super::super::agent_run::{PreparedRunInputs, ProcessCancelTimeouts, RunControls, RunStart};
 use super::super::env::{
-    guest_run_payload_file_path, guest_user_env_file_path, prepare_run_payload_for_run,
+    guest_connector_account_context_file_path, guest_run_payload_file_path,
+    guest_user_env_file_path, prepare_run_payload_for_run,
 };
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -11,13 +11,16 @@ use tokio_util::sync::CancellationToken;
 async fn execute_job_reuse_succeeds() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let factory = MockSandboxFactory::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut first_context = minimal_context();
+    first_context.run_id = RunId::new_v4();
 
     // First: create a sandbox via normal execute_job
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, _telemetry) = execute_job(
         &factory,
-        minimal_context(),
+        first_context,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
             reuse_result: SandboxReuseResult::NoReuseKey,
@@ -34,9 +37,13 @@ async fn execute_job_reuse_succeeds() {
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
     let cancel = tokio_util::sync::CancellationToken::new();
+    let mut reused_context = minimal_context();
+    reused_context.run_id = RunId::new_v4();
+    let reused_context_path =
+        guest_connector_account_context_file_path(reused_context.run_id).unwrap();
     let (reuse_outcome, _telemetry) = execute_job_reuse(
         idle_sandbox,
-        minimal_context(),
+        reused_context,
         &config,
         &default_params(),
         cancel,
@@ -45,6 +52,20 @@ async fn execute_job_reuse_succeeds() {
     assert_eq!(reuse_outcome.exit_code(), 0);
     assert!(reuse_outcome.error().is_none());
     assert!(reuse_outcome.sandbox.is_some());
+    let connector_account_context_writes = overrides
+        .private_write_file_calls()
+        .into_iter()
+        .filter(|write| {
+            write
+                .path
+                .ends_with("/connector-account-context/context.json")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(connector_account_context_writes.len(), 2);
+    assert_eq!(
+        connector_account_context_writes[1].path,
+        reused_context_path
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1266,6 +1266,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 async fn assert_reused_private_write_timeout_telemetry(
     context: crate::types::ExecutionContext,
     expected_action: &str,
+    successful_writes_before: usize,
     stage: SandboxOperationTimeoutStage,
     expected_outcome: &str,
 ) {
@@ -1279,6 +1280,9 @@ async fn assert_reused_private_write_timeout_telemetry(
     let source_ip = sandbox.source_ip().to_string();
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+    for _ in 0..successful_writes_before {
+        overrides.push_private_write_file_result(Ok(()));
+    }
     overrides.push_private_write_file_result(Err(SandboxError::OperationTimeout {
         operation: SandboxOperation::WriteFile,
         stage,
@@ -1310,7 +1314,65 @@ async fn assert_reused_private_write_timeout_telemetry(
     assert_action_bounded_outcome(&telemetry, expected_action, expected_outcome);
     assert_lacks_action(&telemetry, "runner_agent_start_process");
     assert!(overrides.start_process_calls().is_empty());
-    assert_eq!(overrides.private_write_file_calls().len(), 1);
+    assert_eq!(
+        overrides.private_write_file_calls().len(),
+        successful_writes_before + 1
+    );
+}
+
+#[tokio::test]
+async fn reused_connector_account_context_timeout_records_failure_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(SandboxError::OperationTimeout {
+        operation: SandboxOperation::WriteFile,
+        stage: SandboxOperationTimeoutStage::FrameWrite,
+        timeout_ms: 60_000,
+    }));
+    let sandbox = Box::new(MockSandbox::with_overrides(
+        "connector-account-context-timeout",
+        Arc::clone(&overrides),
+    ));
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (outcome, telemetry) = execute_job_reuse_with_hooks(
+        idle_sandbox,
+        minimal_context(),
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+
+    assert!(outcome.failure.is_none());
+    let operations = telemetry.pending_ops_with_outcome_snapshot();
+    let matching: Vec<_> = operations
+        .iter()
+        .filter(|operation| operation.0 == "runner_connector_account_context_write")
+        .collect();
+    assert_eq!(matching.len(), 1);
+    assert!(!matching[0].1);
+    assert_eq!(matching[0].2.as_deref(), Some("frame_write"));
+    assert_eq!(matching[0].3, None);
+    assert_action_outcome(
+        &telemetry,
+        "runner_connector_account_context_write",
+        false,
+        Some("connector account context unavailable"),
+    );
+    assert_has_action(&telemetry, "runner_agent_start_process");
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.private_write_file_calls().len(), 2);
 }
 
 #[tokio::test]
@@ -1323,6 +1385,7 @@ async fn reused_user_env_write_timeout_records_bounded_stage_before_agent_start(
     assert_reused_private_write_timeout_telemetry(
         context,
         "runner_user_env_write",
+        1,
         SandboxOperationTimeoutStage::FrameWrite,
         "frame_write",
     )
@@ -1334,6 +1397,7 @@ async fn reused_run_payload_write_timeout_records_bounded_stage_before_agent_sta
     assert_reused_private_write_timeout_telemetry(
         minimal_context(),
         "runner_run_payload_write",
+        2,
         SandboxOperationTimeoutStage::AwaitingTerminalResponse,
         "await_terminal_response",
     )

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
+import {
+  CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
+  connectorAccountsContract,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import {
   connectorManualGrantContract,
   connectorsBySlugContract,
@@ -16,6 +20,8 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
 import { connectorAccountRoutes } from "../connector-accounts";
 import { connectorsRoutes } from "../connectors";
 import { customConnectorsRoutes } from "../custom-connectors";
@@ -23,6 +29,7 @@ import { customConnectorsDeleteRoutes } from "../custom-connectors-delete";
 import { customConnectorsValuesSetRoutes } from "../custom-connectors-values-set";
 import { featureSwitchesRoutes } from "../feature-switches";
 import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
+import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
 
 const context = testContext();
@@ -43,6 +50,22 @@ interface Fixture {
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
+}
+
+function sandboxToken(
+  fixture: Fixture,
+  capabilities: readonly Capability[],
+): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "okou",
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    runId: `run_${randomUUID()}`,
+    capabilities: [...capabilities],
+    iat: seconds,
+    exp: seconds + 600,
+  });
 }
 
 function accountClient() {
@@ -165,11 +188,13 @@ async function cleanupFixture(fixture: Fixture): Promise<void> {
 describe("connector account lifecycle routes", () => {
   const track = createFixtureTracker<Fixture>(cleanupFixture);
 
-  async function seedFixture(): Promise<Fixture> {
+  async function seedFixture(
+    overrides: Partial<Fixture> = {},
+  ): Promise<Fixture> {
     const fixture = await track(
       Promise.resolve({
-        orgId: `org_${randomUUID()}`,
-        userId: `user_${randomUUID()}`,
+        orgId: overrides.orgId ?? `org_${randomUUID()}`,
+        userId: overrides.userId ?? `user_${randomUUID()}`,
       }),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -193,6 +218,165 @@ describe("connector account lifecycle routes", () => {
       [404],
     );
     expect(exact.body.error.message).toBe("Resource not found");
+    const inspection = await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: { selections: [] },
+      }),
+      [404],
+    );
+    expect(inspection.body.error.message).toBe("Resource not found");
+  });
+
+  it("inspects only exact owned accounts without leaking credentials", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+    const connected = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add", displayName: "Work" },
+          values: { apiKey: "sk-inspection" },
+        },
+      }),
+      [200],
+    );
+    const missingId = randomUUID();
+
+    const inspected = await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: {
+          selections: [
+            {
+              connectionId: missingId,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+            {
+              connectionId: connected.body.id,
+              target: { kind: "builtin", connectorSlug: "github" },
+            },
+            {
+              connectionId: connected.body.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [200],
+    );
+
+    expect(inspected.body.results).toStrictEqual([
+      {
+        kind: "unavailable",
+        connectionId: missingId,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+      {
+        kind: "unavailable",
+        connectionId: connected.body.id,
+        target: { kind: "builtin", connectorSlug: "github" },
+      },
+      {
+        kind: "available",
+        connectionId: connected.body.id,
+        target: { kind: "builtin", connectorSlug: "openai" },
+        authMethod: "api-token",
+        displayName: "Work",
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        connectionStatus: "connected",
+        reconnectReason: null,
+      },
+    ]);
+  });
+
+  it("requires connector read capability for account inspection", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+    mockClerkMembership(
+      context,
+      {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "org:admin",
+        email: "connector-account-inspection@example.test",
+      },
+      "org:admin",
+    );
+
+    const allowed = await accept(
+      accountClient().inspect({
+        headers: {
+          authorization: `Bearer ${sandboxToken(fixture, ["connector:read"])}`,
+        },
+        body: { selections: [] },
+      }),
+      [200],
+    );
+    expect(allowed.body).toStrictEqual({ results: [] });
+
+    const denied = await accept(
+      accountClient().inspect({
+        headers: {
+          authorization: `Bearer ${sandboxToken(fixture, [])}`,
+        },
+        body: { selections: [] },
+      }),
+      [403],
+    );
+    expect(denied.body.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
+  });
+
+  it("accepts one bounded inspection batch and rejects a larger one", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+    const selection = {
+      connectionId: randomUUID(),
+      target: { kind: "builtin" as const, connectorSlug: "openai" },
+    };
+
+    const maximum = await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: {
+          selections: Array.from(
+            { length: CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS },
+            () => {
+              return selection;
+            },
+          ),
+        },
+      }),
+      [200],
+    );
+    expect(maximum.body.results).toHaveLength(
+      CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
+    );
+    expect(maximum.body.results[0]).toStrictEqual({
+      kind: "unavailable",
+      ...selection,
+    });
+
+    await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: {
+          selections: Array.from(
+            { length: CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS + 1 },
+            () => {
+              return selection;
+            },
+          ),
+        },
+      }),
+      [400],
+    );
   });
 
   it("adds siblings and manages exact default and deletion lifecycle", async () => {
@@ -758,7 +942,7 @@ describe("connector account lifecycle routes", () => {
       }),
       [200],
     );
-    const other = await seedFixture();
+    const other = await seedFixture({ orgId: owner.orgId });
     await setConnectorAccountsEnabled(other, true);
     mocks.clerk.session(other.userId, other.orgId);
 
@@ -783,6 +967,27 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
+    const inspected = await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: {
+          selections: [
+            {
+              connectionId: account.body.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [200],
+    );
+    expect(inspected.body.results).toStrictEqual([
+      {
+        kind: "unavailable",
+        connectionId: account.body.id,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+    ]);
     await accept(
       accountClient().rename({
         headers: authHeaders(),
@@ -794,6 +999,24 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
+
+    const outsider = await seedFixture();
+    await setConnectorAccountsEnabled(outsider, true);
+    const crossOrganization = await accept(
+      accountClient().inspect({
+        headers: authHeaders(),
+        body: {
+          selections: [
+            {
+              connectionId: account.body.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [200],
+    );
+    expect(crossOrganization.body.results[0]?.kind).toBe("unavailable");
   });
 
   it("treats a removed built-in catalog target as absent", async () => {
@@ -994,6 +1217,41 @@ describe("connector account lifecycle routes", () => {
         kind: "custom",
         customConnectorId: definition.body.id,
       });
+
+      const inspected = await accept(
+        accountClient().inspect({
+          headers: authHeaders(),
+          body: {
+            selections: [
+              {
+                connectionId: exact.body.id,
+                target: {
+                  kind: "custom",
+                  customConnectorId: definition.body.id,
+                },
+              },
+            ],
+          },
+        }),
+        [200],
+      );
+      expect(inspected.body.results).toStrictEqual([
+        {
+          kind: "available",
+          connectionId: exact.body.id,
+          target: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+          },
+          authMethod: "manual",
+          displayName: exact.body.displayName,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+        },
+      ]);
 
       const safeDisconnect = await accept(
         accountClient().disconnectSingleAccount({

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -1,5 +1,6 @@
 import { command, computed } from "ccstate";
 import {
+  connectorAccountTargetKey,
   connectorAccountsContract,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
@@ -16,6 +17,7 @@ import type { RouteEntry } from "../route-entry";
 import {
   connectorAccountDeletionImpact,
   getConnectorAccount,
+  listConnectorAccountsByIds,
   listConnectorAccountsForTarget,
   listConnectorAccountSummaries,
   renameConnectorAccount,
@@ -45,6 +47,56 @@ function targetFromQuery(
     ? { kind: "builtin", connectorSlug: query.connectorSlug }
     : { kind: "custom", customConnectorId: query.customConnectorId };
 }
+
+const inspectInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(connectorAccountsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  const body = await get(bodyResultOf(connectorAccountsContract.inspect));
+  if (!body.ok) {
+    return body.response;
+  }
+  const accounts = await listConnectorAccountsByIds(get(db$), {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    connectionIds: body.data.selections.map((selection) => {
+      return selection.connectionId;
+    }),
+  });
+  const accountsById = new Map(
+    accounts.map((account) => {
+      return [account.id, account];
+    }),
+  );
+  return {
+    status: 200 as const,
+    body: {
+      results: body.data.selections.map((selection) => {
+        const account = accountsById.get(selection.connectionId);
+        if (
+          !account ||
+          connectorAccountTargetKey(account.target) !==
+            connectorAccountTargetKey(selection.target)
+        ) {
+          return { kind: "unavailable" as const, ...selection };
+        }
+        return {
+          kind: "available" as const,
+          connectionId: account.id,
+          target: account.target,
+          authMethod: account.authMethod,
+          displayName: account.displayName,
+          externalId: account.externalId,
+          externalUsername: account.externalUsername,
+          externalEmail: account.externalEmail,
+          connectionStatus: account.connectionStatus,
+          reconnectReason: account.reconnectReason,
+        };
+      }),
+    },
+  };
+});
 
 const summariesInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -423,6 +475,10 @@ const writeAuth = {
 } as const;
 
 export const connectorAccountRoutes: readonly RouteEntry[] = [
+  {
+    route: connectorAccountsContract.inspect,
+    handler: authRoute(readAuth, inspectInner$),
+  },
   {
     route: connectorAccountsContract.summaries,
     handler: authRoute(readAuth, summariesInner$),

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -128,6 +128,8 @@ describe("okou connector list command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    listCommand.setOptionValue("agent", undefined);
+    listCommand.setOptionValue("json", false);
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -207,6 +209,28 @@ describe("okou connector list command", () => {
       expect(connectedRow).toContain("connected");
       expect(missingRow).toContain("missing apiKey");
     });
+
+    it("emits parseable current-context JSON without ANSI", async () => {
+      server.use(stubConnectors([connectedGithub]));
+
+      await listCommand.parseAsync(["node", "cli", "--json"]);
+
+      const output = String(mockConsoleLog.mock.calls[0]?.[0]);
+      const json: unknown = JSON.parse(output);
+      expect(json).toStrictEqual(
+        expect.objectContaining({
+          context: "current",
+          connectors: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "builtin",
+              slug: "github",
+              connectionStatus: "connected",
+            }),
+          ]),
+        }),
+      );
+      expect(output).not.toContain("\u001b[");
+    });
   });
 
   describe("with agent context", () => {
@@ -245,39 +269,25 @@ describe("okou connector list command", () => {
       expect(logCalls).toContain("✓");
     });
 
-    it("renders AUTHORIZED FOR column when $OKOU_AGENT_ID is set", async () => {
+    it("fails closed when a legacy run has no account context", async () => {
       vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
-      server.use(
-        stubConnectors([connectedGithub]),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, ["github"]),
-      );
 
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("AUTHORIZED FOR maya");
-      expect(logCalls).toContain("✓");
+      expect(logCalls).toContain("Account used by this run is unavailable");
+      expect(logCalls).toContain("start a new run");
+      expect(logCalls).not.toContain("CONNECTED AS");
     });
 
-    it("--agent overrides $OKOU_AGENT_ID", async () => {
+    it("does not let --agent bypass unavailable run context", async () => {
       vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
-      server.use(
-        stubConnectors([connectedGithub]),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, ["github"]),
-        http.get(`http://localhost:3000/api/agents/${ALT_AGENT_UUID}`, () => {
-          return HttpResponse.json(
-            { error: { message: "should not be called", code: "ERR" } },
-            { status: 500 },
-          );
-        }),
-      );
 
       await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("AUTHORIZED FOR maya");
+      expect(logCalls).toContain("Account used by this run is unavailable");
+      expect(logCalls).not.toContain("AUTHORIZED FOR");
     });
 
     it("falls back to agent UUID when displayName is null", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -229,6 +229,30 @@ describe("run connector account inspection", () => {
     expect(output).not.toContain("default");
   });
 
+  it("treats an empty run projection as known empty without enrichment", async () => {
+    let inspectionRequests = 0;
+    writeContext([]);
+    server.use(
+      stubConnectorCatalog([]),
+      stubCustomConnectors([]),
+      http.post("http://localhost:3000/api/connector-accounts/inspect", () => {
+        inspectionRequests += 1;
+        return HttpResponse.json({ results: [] });
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        context: "run",
+        state: "available",
+        connectors: [],
+      },
+    );
+    expect(inspectionRequests).toBe(0);
+  });
+
   it("uses one exact representation for custom HTTP and MCP targets", async () => {
     const httpConnector = customConnector();
     const mcpConnector = customMcpConnector();

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -1,0 +1,425 @@
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
+import type { CustomConnectorMcpResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  catalogItem,
+  stubConnectorCatalog,
+} from "../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
+import { server } from "../../../mocks/server";
+import { listCommand } from "../list";
+import { RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES } from "../run-account-context";
+import { statusCommand } from "../status";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const PINNED_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+const DELETED_CONNECTION_ID = "22222222-2222-4222-8222-222222222222";
+
+function accountMetadata(
+  connectionId: string,
+  target: {
+    readonly kind: "builtin";
+    readonly connectorSlug: string;
+  },
+) {
+  return {
+    kind: "available" as const,
+    connectionId,
+    target,
+    authMethod: "oauth" as const,
+    displayName: "Thread-selected work account",
+    externalId: "provider-account-7",
+    externalUsername: "work-user",
+    externalEmail: "work@example.test",
+    connectionStatus: "connected" as const,
+    reconnectReason: null,
+  };
+}
+
+function customMcpConnector(): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    slug: "_acme-mcp",
+    displayName: "Acme MCP",
+    endpoint: "https://mcp.example.test/server",
+    transport: "streamable-http",
+    prefixTemplates: [],
+    fields: [],
+    headerInjections: [],
+    queryInjections: [],
+    authMode: "manual",
+    storageVersion: 1,
+    connected: true,
+    missingRequiredFields: [],
+    configuredFieldKeys: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("run connector account inspection", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  let directory = "";
+  let contextPath = "";
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "okou-run-account-"));
+    contextPath = join(directory, "context.json");
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
+    listCommand.setOptionValue("agent", undefined);
+    listCommand.setOptionValue("json", false);
+    statusCommand.setOptionValue("agent", undefined);
+    statusCommand.setOptionValue("json", false);
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  function writeContext(targets: readonly object[]): void {
+    writeFileSync(
+      contextPath,
+      JSON.stringify({ schemaVersion: 1, targets }),
+      "utf8",
+    );
+  }
+
+  it("shows the exact built-in account selected for this run in list, status, and JSON", async () => {
+    const inspectedBodies: unknown[] = [];
+    writeContext([
+      {
+        kind: "builtin",
+        connectorSlug: "github",
+        connectionId: PINNED_CONNECTION_ID,
+      },
+    ]);
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "github", label: "GitHub" }),
+      ]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const raw = await request.json();
+          inspectedBodies.push(raw);
+          const body = connectorAccountsContract.inspect.body.parse(raw);
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              if (selection.target.kind !== "builtin") {
+                throw new Error("Expected a built-in selection");
+              }
+              return accountMetadata(selection.connectionId, selection.target);
+            }),
+          });
+        },
+      ),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+    let output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("ACCOUNT USED BY THIS RUN");
+    expect(output).toContain("Thread-selected work account");
+    expect(output).toContain(PINNED_CONNECTION_ID);
+    expect(output).not.toContain("CONNECTED AS");
+
+    mockConsoleLog.mockClear();
+    await statusCommand.parseAsync(["node", "cli", "github"]);
+    output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Account Used:");
+    expect(output).toContain("Thread-selected work account");
+    expect(output).toContain(PINNED_CONNECTION_ID);
+    expect(output).toContain("Current Status:");
+
+    mockConsoleLog.mockClear();
+    await statusCommand.parseAsync(["node", "cli", "github", "--json"]);
+    const json: unknown = JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]));
+    expect(json).toStrictEqual(
+      expect.objectContaining({
+        context: "run",
+        state: "available",
+        connector: expect.objectContaining({
+          target: { kind: "builtin", connectorSlug: "github" },
+          account: expect.objectContaining({
+            state: "available",
+            connectionId: PINNED_CONNECTION_ID,
+            label: "Thread-selected work account",
+          }),
+        }),
+      }),
+    );
+    expect(JSON.stringify(json)).not.toContain("sk-");
+    expect(inspectedBodies).toHaveLength(3);
+    expect(inspectedBodies[0]).toStrictEqual({
+      selections: [
+        {
+          connectionId: PINNED_CONNECTION_ID,
+          target: { kind: "builtin", connectorSlug: "github" },
+        },
+      ],
+    });
+  });
+
+  it("retains deleted IDs and source-less targets without choosing a sibling", async () => {
+    writeContext([
+      {
+        kind: "builtin",
+        connectorSlug: "github",
+        connectionId: DELETED_CONNECTION_ID,
+      },
+      {
+        kind: "builtin",
+        connectorSlug: "slack",
+        connectionId: null,
+      },
+    ]);
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "github" }),
+        catalogItem({ connectorSlug: "slack" }),
+      ]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          expect(body.selections).toHaveLength(1);
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return { kind: "unavailable" as const, ...selection };
+            }),
+          });
+        },
+      ),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(DELETED_CONNECTION_ID);
+    expect(output).toContain("metadata unavailable or deleted");
+    expect(output).toContain("unavailable for this run");
+    expect(output).not.toContain("default");
+  });
+
+  it("uses one exact representation for custom HTTP and MCP targets", async () => {
+    const httpConnector = customConnector();
+    const mcpConnector = customMcpConnector();
+    const httpConnectionId = "33333333-3333-4333-8333-333333333334";
+    const mcpConnectionId = "44444444-4444-4444-8444-444444444445";
+    writeContext([
+      {
+        kind: "custom",
+        customConnectorId: httpConnector.id,
+        connectionId: httpConnectionId,
+      },
+      {
+        kind: "custom",
+        customConnectorId: mcpConnector.id,
+        connectionId: mcpConnectionId,
+      },
+    ]);
+    server.use(
+      stubConnectorCatalog([]),
+      stubCustomConnectors([httpConnector, mcpConnector]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return { kind: "unavailable" as const, ...selection };
+            }),
+          });
+        },
+      ),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+    let output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(httpConnector.slug);
+    expect(output).toContain(httpConnectionId);
+    expect(output).toContain(mcpConnector.slug);
+    expect(output).toContain(mcpConnectionId);
+
+    mockConsoleLog.mockClear();
+    await statusCommand.parseAsync(["node", "cli", mcpConnector.slug]);
+    output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(mcpConnectionId);
+    expect(output).toContain("Current Status:");
+  });
+
+  it("retains exact IDs when the enrichment route is unavailable", async () => {
+    writeContext([
+      {
+        kind: "builtin",
+        connectorSlug: "github",
+        connectionId: PINNED_CONNECTION_ID,
+      },
+    ]);
+    server.use(
+      stubConnectorCatalog([catalogItem({ connectorSlug: "github" })]),
+      stubCustomConnectors([]),
+      http.post("http://localhost:3000/api/connector-accounts/inspect", () => {
+        return HttpResponse.json(
+          { error: { code: "NOT_FOUND", message: "Resource not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(PINNED_CONNECTION_ID);
+    expect(output).toContain("metadata unavailable");
+  });
+
+  it("chunks more than one bounded API batch in stable order", async () => {
+    const targets = Array.from({ length: 257 }, (_, index) => {
+      const serial = index + 1;
+      return {
+        kind: "builtin" as const,
+        connectorSlug: `connector-${serial}`,
+        connectionId: `00000000-0000-4000-8000-${serial
+          .toString(16)
+          .padStart(12, "0")}`,
+      };
+    });
+    const batchSizes: number[] = [];
+    writeContext(targets);
+    server.use(
+      stubConnectorCatalog([]),
+      stubCustomConnectors([]),
+      http.post(
+        "http://localhost:3000/api/connector-accounts/inspect",
+        async ({ request }) => {
+          const body = connectorAccountsContract.inspect.body.parse(
+            await request.json(),
+          );
+          batchSizes.push(body.selections.length);
+          return HttpResponse.json({
+            results: body.selections.map((selection) => {
+              return { kind: "unavailable" as const, ...selection };
+            }),
+          });
+        },
+      ),
+    );
+
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+    const json = z
+      .object({
+        connectors: z.array(
+          z
+            .object({
+              slug: z.string(),
+              account: z.object({ connectionId: z.string() }).passthrough(),
+            })
+            .passthrough(),
+        ),
+      })
+      .passthrough()
+      .parse(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])));
+    expect(batchSizes).toStrictEqual([256, 1]);
+    expect(json.connectors).toHaveLength(257);
+    expect(json.connectors[0]?.slug).toBe("connector-1");
+    expect(json.connectors[256]?.slug).toBe("connector-257");
+    expect(json.connectors[256]?.account.connectionId).toBe(
+      targets[256]?.connectionId,
+    );
+  });
+
+  it.each([
+    ["malformed", "{"],
+    ["unsupported-version", JSON.stringify({ schemaVersion: 2, targets: [] })],
+    [
+      "duplicate-target",
+      JSON.stringify({
+        schemaVersion: 1,
+        targets: [
+          {
+            kind: "builtin",
+            connectorSlug: "github",
+            connectionId: PINNED_CONNECTION_ID,
+          },
+          {
+            kind: "builtin",
+            connectorSlug: "github",
+            connectionId: DELETED_CONNECTION_ID,
+          },
+        ],
+      }),
+    ],
+    [
+      "malformed",
+      JSON.stringify({
+        schemaVersion: 1,
+        targets: [],
+        credential: "must-not-be-rendered",
+      }),
+    ],
+  ])("fails closed for %s context files", async (reason, contents) => {
+    writeFileSync(contextPath, contents, "utf8");
+
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+    const output = String(mockConsoleLog.mock.calls[0]?.[0]);
+    const json = z
+      .object({ state: z.string(), reason: z.string() })
+      .passthrough()
+      .parse(JSON.parse(output));
+    expect(json).toMatchObject({ state: "unavailable", reason });
+    expect(output).not.toContain("must-not-be-rendered");
+  });
+
+  it("fails closed for oversized and unreadable context paths", async () => {
+    writeFileSync(contextPath, "", "utf8");
+    truncateSync(contextPath, RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES + 1);
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toMatchObject(
+      {
+        state: "unavailable",
+        reason: "oversized",
+      },
+    );
+
+    mockConsoleLog.mockClear();
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", directory);
+    listCommand.setOptionValue("json", false);
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toMatchObject(
+      {
+        state: "unavailable",
+        reason: "unreadable",
+      },
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -126,6 +126,8 @@ describe("okou connector status command", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", "");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
+    statusCommand.setOptionValue("agent", undefined);
+    statusCommand.setOptionValue("json", false);
   });
 
   afterEach(() => {
@@ -199,6 +201,26 @@ describe("okou connector status command", () => {
       expect(logCalls).toContain("/connectors");
       expect(logCalls).not.toContain("okou connector check");
     });
+
+    it("emits parseable current-context JSON without ANSI", async () => {
+      server.use(stubConnector(connectedGithub));
+
+      await statusCommand.parseAsync(["node", "cli", "github", "--json"]);
+
+      const output = String(mockConsoleLog.mock.calls[0]?.[0]);
+      const json: unknown = JSON.parse(output);
+      expect(json).toStrictEqual(
+        expect.objectContaining({
+          context: "current",
+          connector: expect.objectContaining({
+            slug: "github",
+            connectionStatus: "connected",
+          }),
+          authorization: null,
+        }),
+      );
+      expect(output).not.toContain("\u001b[");
+    });
   });
 
   describe("with agent context", () => {
@@ -256,9 +278,8 @@ describe("okou connector status command", () => {
       expect(logCalls).not.toContain("callbackPrompt=");
     });
 
-    it("prints a callback URL example in the current web chat", async () => {
+    it("does not attach run callback context to a standalone agent lookup", async () => {
       vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
-      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),
@@ -277,33 +298,19 @@ describe("okou connector status command", () => {
       expect(logCalls).toContain(
         `/connectors/github/authorize?agentId=${AGENT_UUID}`,
       );
-      expect(logCalls).toContain("threadId=thread-abc-123");
-      expect(logCalls).toContain(
-        "callbackPrompt=SOMETHING_AGENT_WANT_TO_BE_CALLBACK",
-      );
-      expect(logCalls).toContain("automatically start the next round");
+      expect(logCalls).not.toContain("threadId=thread-abc-123");
+      expect(logCalls).not.toContain("callbackPrompt=");
     });
 
-    it("prefers OKOU runtime context over legacy Zero values", async () => {
-      const appOrigin = "https://okou-app.example.test";
-      vi.stubEnv("OKOU_APP_URL", appOrigin);
+    it("fails closed for canonical run context without a projection", async () => {
       vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
-      vi.stubEnv("OKOU_CHAT_THREAD_ID", "okou-thread-123");
       vi.stubEnv("ZERO_CHAT_THREAD_ID", "zero-thread-456");
-      server.use(
-        stubConnector(connectedGithub),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, []),
-      );
 
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        `${appOrigin}/connectors/github/authorize?agentId=${AGENT_UUID}`,
-      );
-      expect(logCalls).toContain("threadId=okou-thread-123");
+      expect(logCalls).toContain("Account used by this run is unavailable");
       expect(logCalls).not.toContain(ALT_AGENT_UUID);
       expect(logCalls).not.toContain("zero-thread-456");
     });
@@ -466,35 +473,17 @@ describe("okou connector status command", () => {
       expect(logCalls).not.toContain("okou connector check");
     });
 
-    it("uses $OKOU_AGENT_ID when --agent flag is not provided", async () => {
+    it("uses $OKOU_AGENT_ID to detect legacy run context", async () => {
       vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
-      server.use(
-        stubConnector(connectedGithub),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, ["github"]),
-      );
 
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        `The github connector is authorized for agent maya (${AGENT_UUID}).`,
-      );
+      expect(logCalls).toContain("Account used by this run is unavailable");
     });
 
-    it("--agent overrides $OKOU_AGENT_ID", async () => {
+    it("does not let --agent bypass canonical run context", async () => {
       vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
-      server.use(
-        stubConnector(connectedGithub),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, ["github"]),
-        http.get(`http://localhost:3000/api/agents/${ALT_AGENT_UUID}`, () => {
-          return HttpResponse.json(
-            { error: { message: "should not be called", code: "ERR" } },
-            { status: 500 },
-          );
-        }),
-      );
 
       await statusCommand.parseAsync([
         "node",
@@ -505,9 +494,8 @@ describe("okou connector status command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        `The github connector is authorized for agent maya (${AGENT_UUID}).`,
-      );
+      expect(logCalls).toContain("Account used by this run is unavailable");
+      expect(logCalls).not.toContain("authorized for agent");
     });
 
     it("falls back to UUID-only label when displayName is null", async () => {

--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -12,14 +12,63 @@ import {
   isConnectorDiscoveryAuthorized,
   renderConnectorDiscoveryConnectedAsCell,
 } from "./discovery";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountView,
+  runConnectorAccountUnavailableMessage,
+  type RunConnectorAccountEntry,
+} from "./run-account-context";
+
+function runAccountCell(connector: RunConnectorAccountEntry): string {
+  if (connector.account.state === "available") {
+    return `${connector.account.label} (${connector.account.connectionId})`;
+  }
+  if (connector.account.state === "metadata-unavailable") {
+    return `${connector.account.connectionId} (metadata unavailable or deleted)`;
+  }
+  return "(unavailable for this run)";
+}
+
+async function printRunConnectorList(json: boolean): Promise<void> {
+  const view = await resolveRunConnectorAccountView();
+  if (json) {
+    console.log(JSON.stringify(view, null, 2));
+    return;
+  }
+  if (view.state === "unavailable") {
+    console.log(runConnectorAccountUnavailableMessage(view.reason));
+    return;
+  }
+  const slugWidth = Math.max(
+    4,
+    ...view.connectors.map((connector) => {
+      return connector.slug.length;
+    }),
+  );
+  console.log(
+    chalk.dim(
+      ["SLUG".padEnd(slugWidth), "ACCOUNT USED BY THIS RUN"].join("  "),
+    ),
+  );
+  for (const connector of view.connectors) {
+    console.log(
+      [connector.slug.padEnd(slugWidth), runAccountCell(connector)].join("  "),
+    );
+  }
+}
 
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all connectors and their status")
   .option("--agent <id>", "Show per-agent authorization column")
+  .option("--json", "Output connector status as JSON")
   .action(
-    withErrorHandler(async (options: { agent?: string }) => {
+    withErrorHandler(async (options: { agent?: string; json?: boolean }) => {
+      if (isRunBoundConnectorContext()) {
+        await printRunConnectorList(options.json ?? false);
+        return;
+      }
       const [{ connectors }, customConnectors, agentCtx] = await Promise.all([
         listConnectorCatalogStatus(),
         listCustomConnectors(),
@@ -29,6 +78,45 @@ export const listCommand = new Command()
         connectors,
         customConnectors,
       );
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              context: "current",
+              connectors: discoveredConnectors.map((connector) => {
+                return connector.kind === "catalog"
+                  ? {
+                      kind: "builtin",
+                      slug: connector.slug,
+                      label: connector.label,
+                      connectionStatus:
+                        connector.catalogConnector.connectionStatus,
+                      connection: connector.catalogConnector.connection,
+                      authorized: agentCtx
+                        ? isConnectorDiscoveryAuthorized(connector, agentCtx)
+                        : null,
+                    }
+                  : {
+                      kind: "custom",
+                      id: connector.customConnector.id,
+                      slug: connector.slug,
+                      label: connector.label,
+                      connected: connector.customConnector.connected,
+                      missingRequiredFields:
+                        connector.customConnector.missingRequiredFields,
+                      authorized: agentCtx
+                        ? isConnectorDiscoveryAuthorized(connector, agentCtx)
+                        : null,
+                    };
+              }),
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
 
       const connectorSlugs = discoveredConnectors.map((connector) => {
         return connector.slug;

--- a/turbo/apps/cli/src/commands/connector/run-account-context.ts
+++ b/turbo/apps/cli/src/commands/connector/run-account-context.ts
@@ -1,0 +1,338 @@
+import { open } from "node:fs/promises";
+
+import {
+  CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
+  connectorAccountTargetKey,
+  type ConnectorAccountInspectionResult,
+  type ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectorSlugSchema } from "@okouai/api-contracts/contracts/connector-identity";
+import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import { z } from "zod";
+
+import {
+  inspectConnectorAccounts,
+  listConnectorCatalog,
+  listCustomConnectors,
+  type ConnectorCatalogItem,
+} from "../../lib/api/domains/connectors";
+import {
+  getOkouAgentId,
+  getOkouConnectorAccountContextFile,
+} from "../../lib/okou-env";
+
+export const RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES = 1024 * 1024;
+
+const runConnectorAccountTargetSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("builtin"),
+      connectorSlug: connectorSlugSchema,
+      connectionId: z.uuid().nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("custom"),
+      customConnectorId: z.uuid(),
+      connectionId: z.uuid().nullable(),
+    })
+    .strict(),
+]);
+
+const runConnectorAccountContextSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    targets: z.array(runConnectorAccountTargetSchema),
+  })
+  .strict();
+
+type RunConnectorAccountTarget = z.infer<
+  typeof runConnectorAccountTargetSchema
+>;
+
+type RunConnectorAccountContextUnavailableReason =
+  | "legacy-or-missing"
+  | "unreadable"
+  | "malformed"
+  | "unsupported-version"
+  | "oversized"
+  | "duplicate-target";
+
+type RunConnectorAccountMetadata = Extract<
+  ConnectorAccountInspectionResult,
+  { kind: "available" }
+>;
+
+export type RunConnectorAccountState =
+  | {
+      readonly state: "available";
+      readonly connectionId: string;
+      readonly label: string;
+      readonly metadata: RunConnectorAccountMetadata;
+    }
+  | {
+      readonly state: "metadata-unavailable";
+      readonly connectionId: string;
+    }
+  | {
+      readonly state: "not-admitted";
+      readonly connectionId: null;
+    };
+
+export interface RunConnectorAccountEntry {
+  readonly target: ConnectorAccountTarget;
+  readonly slug: string;
+  readonly connectorLabel: string;
+  readonly account: RunConnectorAccountState;
+}
+
+type RunConnectorAccountView =
+  | {
+      readonly context: "run";
+      readonly state: "unavailable";
+      readonly reason: RunConnectorAccountContextUnavailableReason;
+      readonly connectors: readonly [];
+    }
+  | {
+      readonly context: "run";
+      readonly state: "available";
+      readonly connectors: readonly RunConnectorAccountEntry[];
+    };
+
+type ProjectionReadResult =
+  | {
+      readonly state: "available";
+      readonly targets: readonly RunConnectorAccountTarget[];
+    }
+  | {
+      readonly state: "unavailable";
+      readonly reason: RunConnectorAccountContextUnavailableReason;
+    };
+
+type BoundedFileReadResult =
+  | { readonly state: "available"; readonly contents: string }
+  | {
+      readonly state: "unavailable";
+      readonly reason: "unreadable" | "oversized";
+    };
+
+function projectionTarget(
+  target: RunConnectorAccountTarget,
+): ConnectorAccountTarget {
+  return target.kind === "builtin"
+    ? { kind: "builtin", connectorSlug: target.connectorSlug }
+    : { kind: "custom", customConnectorId: target.customConnectorId };
+}
+
+async function readBoundedFile(path: string): Promise<BoundedFileReadResult> {
+  try {
+    const handle = await open(path, "r");
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) {
+        return { state: "unavailable", reason: "unreadable" };
+      }
+      if (stats.size > RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES) {
+        return { state: "unavailable", reason: "oversized" };
+      }
+      const buffer = Buffer.alloc(RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES + 1);
+      let totalBytesRead = 0;
+      while (totalBytesRead < buffer.length) {
+        const { bytesRead } = await handle.read(
+          buffer,
+          totalBytesRead,
+          buffer.length - totalBytesRead,
+          totalBytesRead,
+        );
+        if (bytesRead === 0) break;
+        totalBytesRead += bytesRead;
+      }
+      if (totalBytesRead > RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES) {
+        return { state: "unavailable", reason: "oversized" };
+      }
+      return {
+        state: "available",
+        contents: buffer.toString("utf8", 0, totalBytesRead),
+      };
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return { state: "unavailable", reason: "unreadable" };
+  }
+}
+
+async function readProjection(): Promise<ProjectionReadResult> {
+  const path = getOkouConnectorAccountContextFile();
+  if (!path) {
+    return { state: "unavailable", reason: "legacy-or-missing" };
+  }
+  const file = await readBoundedFile(path);
+  if (file.state === "unavailable") {
+    return file;
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(file.contents);
+  } catch {
+    return { state: "unavailable", reason: "malformed" };
+  }
+  const version = z
+    .object({ schemaVersion: z.unknown() })
+    .passthrough()
+    .safeParse(raw);
+  if (version.success && version.data.schemaVersion !== 1) {
+    return { state: "unavailable", reason: "unsupported-version" };
+  }
+  const parsed = runConnectorAccountContextSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { state: "unavailable", reason: "malformed" };
+  }
+  const targetKeys = new Set<string>();
+  for (const target of parsed.data.targets) {
+    const key = connectorAccountTargetKey(projectionTarget(target));
+    if (targetKeys.has(key)) {
+      return { state: "unavailable", reason: "duplicate-target" };
+    }
+    targetKeys.add(key);
+  }
+  return { state: "available", targets: parsed.data.targets };
+}
+
+function metadataKey(
+  target: ConnectorAccountTarget,
+  connectionId: string,
+): string {
+  return `${connectorAccountTargetKey(target)}:${connectionId}`;
+}
+
+function effectiveAccountLabel(metadata: RunConnectorAccountMetadata): string {
+  if (metadata.displayName) return metadata.displayName;
+  if (metadata.externalEmail) return metadata.externalEmail;
+  if (metadata.externalUsername) return `@${metadata.externalUsername}`;
+  if (metadata.externalId) return metadata.externalId;
+  return `Account #${metadata.connectionId.slice(0, 8)}`;
+}
+
+async function enrichTargets(
+  targets: readonly RunConnectorAccountTarget[],
+): Promise<ReadonlyMap<string, RunConnectorAccountMetadata>> {
+  const selections = targets.flatMap((target) => {
+    return target.connectionId
+      ? [
+          {
+            target: projectionTarget(target),
+            connectionId: target.connectionId,
+          },
+        ]
+      : [];
+  });
+  const metadata = new Map<string, RunConnectorAccountMetadata>();
+  for (
+    let offset = 0;
+    offset < selections.length;
+    offset += CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS
+  ) {
+    const chunk = selections.slice(
+      offset,
+      offset + CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
+    );
+    const results = await inspectConnectorAccounts(chunk);
+    if (!results) break;
+    for (const result of results) {
+      if (result.kind === "available") {
+        metadata.set(metadataKey(result.target, result.connectionId), result);
+      }
+    }
+  }
+  return metadata;
+}
+
+function connectorIdentity(
+  target: ConnectorAccountTarget,
+  catalog: readonly ConnectorCatalogItem[],
+  customConnectors: readonly CustomConnectorResponse[],
+): { readonly slug: string; readonly label: string } {
+  if (target.kind === "builtin") {
+    const definition = catalog.find((connector) => {
+      return connector.slug === target.connectorSlug;
+    });
+    return {
+      slug: target.connectorSlug,
+      label: definition?.label ?? target.connectorSlug,
+    };
+  }
+  const definition = customConnectors.find((connector) => {
+    return connector.id === target.customConnectorId;
+  });
+  return {
+    slug: definition?.slug ?? `custom:${target.customConnectorId}`,
+    label: definition?.displayName ?? target.customConnectorId,
+  };
+}
+
+export function isRunBoundConnectorContext(): boolean {
+  return getOkouAgentId() !== undefined;
+}
+
+export async function resolveRunConnectorAccountView(): Promise<RunConnectorAccountView> {
+  const projection = await readProjection();
+  if (projection.state === "unavailable") {
+    return {
+      context: "run",
+      state: "unavailable",
+      reason: projection.reason,
+      connectors: [],
+    };
+  }
+  const [{ connectors: catalog }, customConnectors, metadata] =
+    await Promise.all([
+      listConnectorCatalog(),
+      listCustomConnectors(),
+      enrichTargets(projection.targets),
+    ]);
+  return {
+    context: "run",
+    state: "available",
+    connectors: projection.targets.map((projected) => {
+      const target = projectionTarget(projected);
+      const identity = connectorIdentity(target, catalog, customConnectors);
+      if (!projected.connectionId) {
+        return {
+          target,
+          slug: identity.slug,
+          connectorLabel: identity.label,
+          account: { state: "not-admitted" as const, connectionId: null },
+        };
+      }
+      const current = metadata.get(metadataKey(target, projected.connectionId));
+      return {
+        target,
+        slug: identity.slug,
+        connectorLabel: identity.label,
+        account: current
+          ? {
+              state: "available" as const,
+              connectionId: projected.connectionId,
+              label: effectiveAccountLabel(current),
+              metadata: current,
+            }
+          : {
+              state: "metadata-unavailable" as const,
+              connectionId: projected.connectionId,
+            },
+      };
+    }),
+  };
+}
+
+export function runConnectorAccountUnavailableMessage(
+  reason: RunConnectorAccountContextUnavailableReason,
+): string {
+  const detail =
+    reason === "legacy-or-missing"
+      ? "this run was started without connector account context"
+      : `the connector account context is ${reason.replaceAll("-", " ")}`;
+  return `Account used by this run is unavailable because ${detail}. Reconnect or change the thread selection, then start a new run.`;
+}

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -13,6 +13,12 @@ import {
   connectorActionUrl,
   printCallbackActionUrlExample,
 } from "./action-url";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountView,
+  runConnectorAccountUnavailableMessage,
+  type RunConnectorAccountEntry,
+} from "./run-account-context";
 
 const LABEL_WIDTH = 16;
 
@@ -157,14 +163,118 @@ async function printStandaloneAction(
   }
 }
 
+function printRunConnectorDetails(connector: RunConnectorAccountEntry): void {
+  console.log(`Connector: ${chalk.cyan(connector.slug)}`);
+  console.log();
+  if (connector.account.state === "not-admitted") {
+    console.log(
+      `${"Account Used:".padEnd(LABEL_WIDTH)}${chalk.dim("unavailable for this run")}`,
+    );
+    console.log();
+    console.log(
+      "Reconnect or change the thread selection, then start a new run.",
+    );
+    return;
+  }
+  console.log(
+    `${"Account Used:".padEnd(LABEL_WIDTH)}${
+      connector.account.state === "available"
+        ? connector.account.label
+        : chalk.dim("metadata unavailable or deleted")
+    }`,
+  );
+  console.log(
+    `${"Connection ID:".padEnd(LABEL_WIDTH)}${connector.account.connectionId}`,
+  );
+  if (connector.account.state === "metadata-unavailable") {
+    console.log(
+      `${"Current Status:".padEnd(LABEL_WIDTH)}${chalk.dim("unavailable")}`,
+    );
+    return;
+  }
+  console.log(
+    `${"Current Status:".padEnd(LABEL_WIDTH)}${connector.account.metadata.connectionStatus}`,
+  );
+  console.log(
+    `${"Auth Method:".padEnd(LABEL_WIDTH)}${connector.account.metadata.authMethod}`,
+  );
+  if (connector.account.metadata.reconnectReason) {
+    console.log(
+      `${"Reconnect Reason:".padEnd(LABEL_WIDTH)}${connector.account.metadata.reconnectReason}`,
+    );
+  }
+}
+
+async function printRunConnectorStatus(
+  connectorSlug: string,
+  json: boolean,
+): Promise<void> {
+  const view = await resolveRunConnectorAccountView();
+  if (view.state === "unavailable") {
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            context: "run",
+            state: "unavailable",
+            reason: view.reason,
+            connector: null,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log(runConnectorAccountUnavailableMessage(view.reason));
+    }
+    return;
+  }
+  const connector = view.connectors.find((candidate) => {
+    return candidate.slug === connectorSlug;
+  });
+  if (!connector) {
+    throw new Error(
+      `Connector is not available in this run: ${connectorSlug}`,
+      {
+        cause: new Error(
+          `Available connectors: ${view.connectors
+            .map((candidate) => {
+              return candidate.slug;
+            })
+            .join(", ")}`,
+        ),
+      },
+    );
+  }
+  if (json) {
+    console.log(
+      JSON.stringify(
+        { context: "run", state: "available", connector },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  printRunConnectorDetails(connector);
+}
+
 export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a connector")
   .argument("<slug>", "Connector slug (e.g., github)")
   .option("--agent <id>", "Show authorization state for the given agent")
+  .option("--json", "Output connector status as JSON")
   .action(
     withErrorHandler(
-      async (connectorSlug: string, options: { agent?: string }) => {
+      async (
+        connectorSlug: string,
+        options: { agent?: string; json?: boolean },
+      ) => {
+        if (isRunBoundConnectorContext()) {
+          await printRunConnectorStatus(connectorSlug, options.json ?? false);
+          return;
+        }
         const [catalog, agentCtx] = await Promise.all([
           listConnectorCatalogStatus(),
           resolveAgentContext(options.agent),
@@ -182,6 +292,29 @@ export const statusCommand = new Command()
               ),
             },
           );
+        }
+
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                context: "current",
+                connector,
+                authorization: agentCtx
+                  ? {
+                      agentId: agentCtx.agentId,
+                      displayName: agentCtx.displayName,
+                      authorized: agentCtx.authorizedConnectorSlugs.has(
+                        connector.slug,
+                      ),
+                    }
+                  : null,
+              },
+              null,
+              2,
+            ),
+          );
+          return;
         }
 
         console.log(`Connector: ${chalk.cyan(connector.slug)}`);

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -4,6 +4,11 @@ import type {
   ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import {
+  connectorAccountsContract,
+  type ConnectorAccountInspectionResult,
+  type ConnectorAccountSelection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import {
   connectorManualGrantContract,
   connectorsBySlugContract,
   connectorsMainContract,
@@ -49,6 +54,27 @@ type ZeroConnectorCatalogListResponse = PublicConnectorCatalogListResponse;
 type ZeroConnectorCatalogStatusResponse = PublicConnectorCatalogStatusResponse;
 export type ConnectorCatalogPermissionDetail =
   PublicConnectorCatalogPermissionDetail;
+
+export async function inspectConnectorAccounts(
+  selections: readonly ConnectorAccountSelection[],
+): Promise<readonly ConnectorAccountInspectionResult[] | null> {
+  const config = await getClientConfig();
+  const client = initClient(connectorAccountsContract, {
+    ...config,
+    validateResponse: true,
+  });
+  const result = await client.inspect({
+    headers: {},
+    body: { selections: [...selections] },
+  });
+  if (result.status === 200) {
+    return result.body.results;
+  }
+  if (result.status === 404) {
+    return null;
+  }
+  handleError(result, "Failed to inspect connector accounts for this run");
+}
 
 /**
  * List all connectors for the authenticated user (zero proxy)

--- a/turbo/apps/cli/src/lib/okou-env.ts
+++ b/turbo/apps/cli/src/lib/okou-env.ts
@@ -21,3 +21,7 @@ export function getOkouChatThreadId(): string | undefined {
 export function getOkouAppUrl(): string | undefined {
   return okouEnvironmentValue("APP_URL");
 }
+
+export function getOkouConnectorAccountContextFile(): string | undefined {
+  return okouEnvironmentValue("CONNECTOR_ACCOUNT_CONTEXT_FILE");
+}

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
   connectorAccountsContract,
   connectorAccountDisplayNameSchema,
   connectorAccountListQuerySchema,
@@ -144,6 +145,33 @@ describe("connector account contracts", () => {
       connectionId,
       target: { kind: "custom", customConnectorId },
     });
+  });
+
+  it("bounds exact account inspection batches", () => {
+    const selection = {
+      connectionId,
+      target: { kind: "builtin" as const, connectorSlug: "github" },
+    };
+    expect(
+      connectorAccountsContract.inspect.body.safeParse({
+        selections: Array.from(
+          { length: CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS },
+          () => {
+            return selection;
+          },
+        ),
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorAccountsContract.inspect.body.safeParse({
+        selections: Array.from(
+          { length: CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS + 1 },
+          () => {
+            return selection;
+          },
+        ),
+      }).success,
+    ).toBe(false);
   });
 
   it("requires batched selected account details on thread selection reads", () => {

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -60,6 +60,39 @@ export const connectorAccountSelectionSchema = z
   })
   .strict();
 
+export const CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS = 256;
+
+const connectorAccountInspectionAvailableSchema = z
+  .object({
+    kind: z.literal("available"),
+    connectionId: z.uuid(),
+    target: connectorAccountTargetSchema,
+    authMethod: connectorAuthMethodIdSchema,
+    displayName: z.string().min(1).max(255).nullable(),
+    externalId: z.string().nullable(),
+    externalUsername: z.string().nullable(),
+    externalEmail: z.string().nullable(),
+    connectionStatus: connectorResponseConnectionStatusSchema,
+    reconnectReason: connectorReconnectReasonSchema.nullable(),
+  })
+  .strict();
+
+const connectorAccountInspectionUnavailableSchema = z
+  .object({
+    kind: z.literal("unavailable"),
+    connectionId: z.uuid(),
+    target: connectorAccountTargetSchema,
+  })
+  .strict();
+
+export const connectorAccountInspectionResultSchema = z.discriminatedUnion(
+  "kind",
+  [
+    connectorAccountInspectionAvailableSchema,
+    connectorAccountInspectionUnavailableSchema,
+  ],
+);
+
 export const connectorAccountMutationIntentSchema = z.discriminatedUnion(
   "intent",
   [
@@ -139,6 +172,30 @@ const connectorAccountExactTargetBodySchema = z
   .strict();
 
 export const connectorAccountsContract = c.router({
+  inspect: {
+    method: "POST",
+    path: "/api/connector-accounts/inspect",
+    headers: authHeadersSchema,
+    body: z
+      .object({
+        selections: z
+          .array(connectorAccountSelectionSchema)
+          .max(CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS),
+      })
+      .strict(),
+    responses: {
+      200: z
+        .object({
+          results: z.array(connectorAccountInspectionResultSchema),
+        })
+        .strict(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Inspect exact connector accounts",
+  },
   summaries: {
     method: "GET",
     path: "/api/connector-accounts",
@@ -288,6 +345,9 @@ export type ConnectorAccountConnection = z.infer<
 >;
 export type ConnectorAccountSelection = z.infer<
   typeof connectorAccountSelectionSchema
+>;
+export type ConnectorAccountInspectionResult = z.infer<
+  typeof connectorAccountInspectionResultSchema
 >;
 export type ConnectorAccountMutationIntent = z.infer<
   typeof connectorAccountMutationIntentSchema

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -741,10 +741,12 @@ export {
 } from "./logs";
 
 export {
+  CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
   connectorAccountDisplayNameSchema,
   connectorAccountTargetSchema,
   connectorAccountConnectionSchema,
   connectorAccountSelectionSchema,
+  connectorAccountInspectionResultSchema,
   connectorAccountMutationIntentSchema,
   connectorAccountTargetQuerySchema,
   connectorAccountListQuerySchema,
@@ -753,6 +755,7 @@ export {
   type ConnectorAccountTarget,
   type ConnectorAccountConnection,
   type ConnectorAccountSelection,
+  type ConnectorAccountInspectionResult,
   type ConnectorAccountMutationIntent,
   type ConnectorAccountSummary,
 } from "./connector-accounts";


### PR DESCRIPTION
## Summary

- project each run's exact connector account IDs from the Runner into a versioned private guest file without exposing credentials
- add a bounded exact-account inspection API that enforces owner, organization, target, and `connector:read` boundaries
- make `okou connector list` and `okou connector status` show the accounts used by the current run, including stable JSON and fail-closed compatibility behavior

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-contracts -p runner --all-features --no-deps`
- `cargo test -p guest-contracts --all-features`
- `cargo test -p runner --bin runner --all-features`
- `pnpm format`
- affected API contracts, API, and CLI lint/type checks
- API contracts full test suite (620 tests)
- API full test suite on a clean temporary database (3,534 tests)
- CLI full test suite (1,018 passed, 1 skipped)
- `pnpm knip`

Closes #29436
Relates to #22832
