### PR TITLE
fix(platform): keep thread account selection in a menu

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1929,13 +1929,13 @@
       "yourComputer": "Ihr Computer"
     },
     "connectors": {
+      "accountForThread": "Konto für diesen Thread",
       "add": "{{connectorName}} hinzufügen",
       "addConnectors": "Integrationen hinzufügen",
       "authorizationFailed": "{{connectorName}} verbunden, konnte aber nicht für {{agentName}} autorisiert werden",
       "authorized": "{{connectorName}} verbunden und autorisiert für {{agentName}}",
       "available_one": "Verfügbare Integration ({{count}})",
       "available_other": "Verfügbare Integrationen ({{count}})",
-      "back": "Zurück",
       "configurePermissions": "Konfigurieren Sie {{connectorName}}-Berechtigungen",
       "customAuthorizeDescription": "Prüfen und verbinden Sie diese benutzerdefinierte Integration und autorisieren Sie sie für den Agenten.",
       "defaultAccountFor": "{{connector}} · Standardkonto wird verwendet: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1929,13 +1929,13 @@
       "yourComputer": "Your computer"
     },
     "connectors": {
+      "accountForThread": "Account for this thread",
       "add": "Add {{connectorName}}",
       "addConnectors": "Add connectors",
       "authorizationFailed": "{{connectorName}} connected but could not be authorized for {{agentName}}",
       "authorized": "{{connectorName}} connected and authorized for {{agentName}}",
       "available_one": "Available connectors to connect ({{count}})",
       "available_other": "Available connectors to connect ({{count}})",
-      "back": "Back",
       "configurePermissions": "Configure {{connectorName}} permissions",
       "customAuthorizeDescription": "Review, connect, and authorize this custom connector for the agent.",
       "defaultAccountFor": "{{connector}} · Using default account: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1959,6 +1959,7 @@
       "yourComputer": "Tu ordenador"
     },
     "connectors": {
+      "accountForThread": "Cuenta para este hilo",
       "add": "Añadir {{connectorName}}",
       "addConnectors": "Añadir conectores",
       "authorizationFailed": "{{connectorName}} está conectado, pero no se pudo autorizar para {{agentName}}",
@@ -1966,7 +1967,6 @@
       "available_one": "Conectores disponibles para conectar ({{count}})",
       "available_many": "Conectores disponibles para conectar ({{count}})",
       "available_other": "Conectores disponibles para conectar ({{count}})",
-      "back": "Atrás",
       "configurePermissions": "Configurar permisos de {{connectorName}}",
       "customAuthorizeDescription": "Revisa, conecta y autoriza este conector personalizado para el agente.",
       "defaultAccountFor": "{{connector}} · Usando la cuenta predeterminada: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1959,6 +1959,7 @@
       "yourComputer": "Votre ordinateur"
     },
     "connectors": {
+      "accountForThread": "Compte pour ce fil",
       "add": "Ajouter {{connectorName}}",
       "addConnectors": "Ajouter des connecteurs",
       "authorizationFailed": "{{connectorName}} connecté mais n'a pas pu être autorisé pour {{agentName}}",
@@ -1966,7 +1967,6 @@
       "available_one": "Connecteurs disponibles à connecter ({{count}})",
       "available_many": "Connecteurs disponibles à connecter ({{count}})",
       "available_other": "Connecteurs disponibles à connecter ({{count}})",
-      "back": "Retour",
       "configurePermissions": "Configurer les autorisations de {{connectorName}}",
       "customAuthorizeDescription": "Examiner, connecter et autoriser ce connecteur personnalisé pour l'agent.",
       "defaultAccountFor": "{{connector}} · Compte par défaut utilisé : {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1929,13 +1929,13 @@
       "yourComputer": "आपका कंप्यूटर"
     },
     "connectors": {
+      "accountForThread": "इस थ्रेड के लिए खाता",
       "add": "{{connectorName}} जोड़ें",
       "addConnectors": "कनेक्टर्स जोड़ें",
       "authorizationFailed": "{{connectorName}} कनेक्ट हुआ लेकिन {{agentName}} के लिए अधिकृत नहीं किया जा सका",
       "authorized": "{{connectorName}} जुड़ा हुआ है और {{agentName}} के लिए अधिकृत है",
       "available_one": "कनेक्ट करने के लिए उपलब्ध कनेक्टर ({{count}})",
       "available_other": "कनेक्ट करने के लिए उपलब्ध कनेक्टर ({{count}})",
-      "back": "वापस",
       "configurePermissions": "{{connectorName}} अनुमतियाँ कॉन्फ़िगर करें",
       "customAuthorizeDescription": "एजेंट के लिए इस कस्टम कनेक्टर की समीक्षा करें, कनेक्ट करें और अधिकृत करें।",
       "defaultAccountFor": "{{connector}} · डिफ़ॉल्ट खाता उपयोग हो रहा है: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1926,13 +1926,13 @@
       "yourComputer": "Komputer Anda"
     },
     "connectors": {
+      "accountForThread": "Akun untuk utas ini",
       "add": "Tambahkan {{connectorName}}",
       "addConnectors": "Tambahkan konektor",
       "authorizationFailed": "{{connectorName}} terhubung tetapi tidak dapat diotorisasi untuk {{agentName}}",
       "authorized": "{{connectorName}} terhubung dan diotorisasi untuk {{agentName}}",
       "available_one": "Konektor yang tersedia untuk dihubungkan ({{count}})",
       "available_other": "Konektor yang tersedia untuk dihubungkan ({{count}})",
-      "back": "Kembali",
       "configurePermissions": "Konfigurasikan izin {{connectorName}}",
       "customAuthorizeDescription": "Tinjau, hubungkan, dan otorisasi konektor kustom ini untuk agen.",
       "defaultAccountFor": "{{connector}} · Menggunakan akun default: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1959,6 +1959,7 @@
       "yourComputer": "Il tuo computer"
     },
     "connectors": {
+      "accountForThread": "Account per questo thread",
       "add": "Aggiungi {{connectorName}}",
       "addConnectors": "Aggiungi connettori",
       "authorizationFailed": "{{connectorName}} connesso ma non è stato possibile autorizzarlo per {{agentName}}",
@@ -1966,7 +1967,6 @@
       "available_one": "Connettori disponibili per la connessione ({{count}})",
       "available_many": "Connettori disponibili per la connessione ({{count}})",
       "available_other": "Connettori disponibili per la connessione ({{count}})",
-      "back": "Indietro",
       "configurePermissions": "Configura le autorizzazioni {{connectorName}}",
       "customAuthorizeDescription": "Esamina, connetti e autorizza questo connettore personalizzato per l'agente.",
       "defaultAccountFor": "{{connector}} · Account predefinito in uso: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1926,13 +1926,13 @@
       "yourComputer": "あなたのコンピュータ"
     },
     "connectors": {
+      "accountForThread": "このスレッドのアカウント",
       "add": "{{connectorName}} を追加",
       "addConnectors": "コネクタの追加",
       "authorizationFailed": "{{connectorName}} は接続されましたが、{{agentName}} に対して認証できませんでした",
       "authorized": "{{connectorName}} が接続され、{{agentName}} に対して承認されました",
       "available_one": "接続可能なコネクタ ({{count}})",
       "available_other": "接続可能なコネクタ ({{count}})",
-      "back": "戻る",
       "configurePermissions": "{{connectorName}} 権限を構成する",
       "customAuthorizeDescription": "エージェント用のこのカスタム コネクタを確認、接続、承認します。",
       "defaultAccountFor": "{{connector}} · デフォルトアカウントを使用中: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1926,13 +1926,13 @@
       "yourComputer": "내 컴퓨터"
     },
     "connectors": {
+      "accountForThread": "이 스레드의 계정",
       "add": "{{connectorName}} 추가",
       "addConnectors": "커넥터 추가",
       "authorizationFailed": "{{connectorName}}는 연결되었으나 {{agentName}}에 대한 권한 부여에 실패했습니다",
       "authorized": "{{connectorName}}가 연결되고 {{agentName}}에 권한이 부여되었습니다",
       "available_one": "연결 가능한 커넥터 ({{count}})",
       "available_other": "연결 가능한 커넥터 ({{count}})",
-      "back": "뒤로",
       "configurePermissions": "{{connectorName}} 권한 구성",
       "customAuthorizeDescription": "이 맞춤 커넥터를 검토하고 연결한 후 에이전트에 권한을 부여하세요.",
       "defaultAccountFor": "{{connector}} · 기본 계정 사용 중: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1959,6 +1959,7 @@
       "yourComputer": "Seu computador"
     },
     "connectors": {
+      "accountForThread": "Conta para esta conversa",
       "add": "Adicionar {{connectorName}}",
       "addConnectors": "Adicionar conectores",
       "authorizationFailed": "{{connectorName}} foi conectado, mas não pôde ser autorizado para {{agentName}}",
@@ -1966,7 +1967,6 @@
       "available_one": "Conectores disponíveis para conectar ({{count}})",
       "available_many": "Conectores disponíveis para conectar ({{count}})",
       "available_other": "Conectores disponíveis para conectar ({{count}})",
-      "back": "Voltar",
       "configurePermissions": "Configurar permissões de {{connectorName}}",
       "customAuthorizeDescription": "Revise, conecte e autorize este conector personalizado para o agente.",
       "defaultAccountFor": "{{connector}} · Usando a conta padrão: {{account}}",

--- a/turbo/apps/platform/src/signals/okou-page/composer-connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-connector-accounts.ts
@@ -39,14 +39,14 @@ export interface ComposerConnectorAccountSignals {
   readonly summaryByTarget$: Computed<
     Promise<ReadonlyMap<string, ConnectorAccountSummary>>
   >;
-  readonly panelTarget$: Computed<ConnectorAccountTarget | null>;
-  readonly panelOpen$: Computed<boolean>;
+  readonly menuTarget$: Computed<ConnectorAccountTarget | null>;
+  readonly menuOpen$: Computed<boolean>;
   readonly search$: Computed<string>;
   readonly accounts$: ReturnType<
     typeof createConnectorAccountListSignals
   >["accounts$"];
   readonly openTarget$: Command<void, [ConnectorAccountTarget, AbortSignal]>;
-  readonly closePanel$: Command<void, []>;
+  readonly closeMenu$: Command<void, []>;
   readonly setSearch$: ReturnType<
     typeof createConnectorAccountListSignals
   >["setSearch$"];
@@ -182,8 +182,8 @@ export function createComposerConnectorAccountSignals(
   threadId?: string,
 ): ComposerConnectorAccountSignals {
   const list = createConnectorAccountListSignals();
-  const panelTarget$ = state<ConnectorAccountTarget | null>(null);
-  const panelOpen$ = state(false);
+  const menuTarget$ = state<ConnectorAccountTarget | null>(null);
+  const menuOpen$ = state(false);
   const reloadVersion$ = state(0);
   const pendingState$ = state<ComposerConnectorAccountPreferenceState>(
     emptyPreferenceState(),
@@ -229,8 +229,8 @@ export function createComposerConnectorAccountSignals(
       target: ConnectorAccountTarget,
       signal: AbortSignal,
     ): void => {
-      const currentTarget = get(panelTarget$);
-      set(panelTarget$, target);
+      const currentTarget = get(menuTarget$);
+      set(menuTarget$, target);
       if (
         currentTarget &&
         connectorAccountTargetKey(currentTarget) ===
@@ -240,11 +240,11 @@ export function createComposerConnectorAccountSignals(
       } else {
         set(list.setTarget$, target, signal);
       }
-      set(panelOpen$, true);
+      set(menuOpen$, true);
     },
   );
-  const closePanel$ = command(({ set }): void => {
-    set(panelOpen$, false);
+  const closeMenu$ = command(({ set }): void => {
+    set(menuOpen$, false);
     set(list.resetSearch$);
   });
 
@@ -267,16 +267,16 @@ export function createComposerConnectorAccountSignals(
     enabled$,
     preferenceState$,
     summaryByTarget$: connectorAccountSummaryByTarget$,
-    panelTarget$: computed((get) => {
-      return get(panelTarget$);
+    menuTarget$: computed((get) => {
+      return get(menuTarget$);
     }),
-    panelOpen$: computed((get) => {
-      return get(panelOpen$);
+    menuOpen$: computed((get) => {
+      return get(menuOpen$);
     }),
     search$: list.search$,
     accounts$: list.accounts$,
     openTarget$,
-    closePanel$,
+    closeMenu$,
     setSearch$: list.setSearch$,
     loadMore$: list.loadMore$,
     selectAccount$,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -471,10 +471,13 @@ describe("chat composer connector connection", () => {
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
-    await user.click(within(composer).getByLabelText("Connectors"));
+    const connectorsButton = within(composer).getByLabelText("Connectors");
+    await user.click(connectorsButton);
     const defaultMode = await screen.findByLabelText(
       "GitHub · Using default account: Work",
     );
+    expect(defaultMode).toHaveClass("text-muted-foreground");
+    expect(defaultMode).not.toHaveClass("border");
     const connectorName = screen.getByText("GitHub");
     const accessLabel = connectorName.closest("label");
     if (!accessLabel?.control) {
@@ -493,6 +496,16 @@ describe("chat composer connector connection", () => {
 
     const summaryReadsBeforeSelection = summaryReads;
     await user.click(defaultMode);
+    await expect(
+      screen.findByText("Account for this thread"),
+    ).resolves.toBeVisible();
+    expect(screen.queryByLabelText("Back")).not.toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeVisible();
+    expect(
+      queryAllByRoleFast("button").find((button) => {
+        return button.textContent?.trim() === "Add connectors";
+      }),
+    ).toBeVisible();
     await expect(screen.findByText("Use default")).resolves.toBeInTheDocument();
     const defaultRadio = screen.getByRole("radio", {
       name: /Use default/u,
@@ -502,19 +515,39 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(selectionWrites).toBe(1);
     });
-    await user.click(screen.getByLabelText("Back"));
+    const selectedWorkMode = await screen.findByLabelText(
+      "GitHub · Selected account: Work",
+    );
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(selectedWorkMode).toHaveClass("text-muted-foreground");
+    expect(selectedWorkMode).not.toHaveClass("border");
+
+    await user.click(selectedWorkMode);
     await expect(
-      screen.findByLabelText("GitHub · Selected account: Work"),
-    ).resolves.toBeInTheDocument();
-    await user.click(screen.getByLabelText("GitHub · Selected account: Work"));
+      screen.findByText("Account for this thread"),
+    ).resolves.toBeVisible();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+    expect(selectedWorkMode).toHaveFocus();
+
+    await user.click(selectedWorkMode);
     await user.click(screen.getByRole("radio", { name: /Personal/u }));
     await waitFor(() => {
       expect(selectionWrites).toBe(2);
     });
-    await user.click(screen.getByLabelText("Back"));
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     await expect(
       screen.findByLabelText("GitHub · Selected account: Personal"),
-    ).resolves.toBeInTheDocument();
+    ).resolves.toHaveClass("text-muted-foreground");
 
     await user.click(
       screen.getByLabelText("GitHub · Selected account: Personal"),
@@ -523,6 +556,13 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(selectionClears).toBe(1);
     });
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    await expect(
+      screen.findByLabelText("GitHub · Using default account: Work"),
+    ).resolves.toBeInTheDocument();
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     expect(authorizationWrites).toBe(1);
     expect(summaryReads).toBe(summaryReadsBeforeSelection);
   });
@@ -600,7 +640,10 @@ describe("chat composer connector connection", () => {
     ).toBeInTheDocument();
     expect(requestedSearches).toStrictEqual(["", "missing"]);
 
-    await user.click(screen.getByLabelText("Back"));
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
     expect(requestedSearches).toStrictEqual(["", "missing"]);
   });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -35,7 +35,6 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import {
   AlertTriangle,
-  ArrowLeft,
   ArrowUp,
   Bolt,
   Check,
@@ -8113,20 +8112,32 @@ function ComposerConnectorAccessRow({
   );
 }
 
-function ComposerConnectorAccountModeButton({
+function ComposerConnectorAccountMenu({
+  signals,
+  target,
   connectorLabel,
   selectedConnection,
   defaultConnection,
   explicit,
-  onOpen,
 }: {
+  readonly signals: ComposerSignals;
+  readonly target: ConnectorAccountTarget;
   readonly connectorLabel: string;
   readonly selectedConnection: ConnectorAccountConnection | undefined;
   readonly defaultConnection: ConnectorAccountConnection | null;
   readonly explicit: boolean;
-  readonly onOpen: () => void;
 }) {
   const { t } = useTranslation();
+  const signal = useGet(pageSignal$);
+  const menuTarget = useGet(signals.connector.accounts.menuTarget$);
+  const menuOpen = useGet(signals.connector.accounts.menuOpen$);
+  const openTarget = useSet(signals.connector.accounts.openTarget$);
+  const closeMenu = useSet(signals.connector.accounts.closeMenu$);
+  const open = Boolean(
+    menuOpen &&
+    menuTarget &&
+    connectorAccountTargetKey(menuTarget) === connectorAccountTargetKey(target),
+  );
   const effectiveConnection = explicit ? selectedConnection : defaultConnection;
   const accountLabel = effectiveConnection
     ? connectorAccountEffectiveLabel(
@@ -8155,28 +8166,49 @@ function ComposerConnectorAccountModeButton({
         { connector: connectorLabel, account: accountLabel },
       );
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-2xs"
-          className={cn(
-            "shrink-0 border border-border/60",
-            explicit ? "text-foreground" : "text-muted-foreground",
-          )}
-          aria-label={accessibleLabel}
-          onClick={() => {
-            onOpen();
-          }}
-        >
-          {explicit ? <UserCheck size={14} /> : <User size={14} />}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="text-xs">
-        {accessibleLabel}
-      </TooltipContent>
-    </Tooltip>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          openTarget(target, signal);
+        } else {
+          closeMenu();
+        }
+      }}
+    >
+      <Tooltip>
+        <PopoverTrigger asChild>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="quiet"
+              size="icon-2xs"
+              className="shrink-0"
+              aria-label={accessibleLabel}
+            >
+              {explicit ? <UserCheck size={14} /> : <User size={14} />}
+            </Button>
+          </TooltipTrigger>
+        </PopoverTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {accessibleLabel}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        side="right"
+        align="start"
+        className="w-72 p-0"
+        aria-label={t(($) => {
+          return $.chat.connectors.accountForThread;
+        })}
+      >
+        <ComposerConnectorAccountMenuContent
+          signals={signals}
+          target={target}
+          connectorLabel={connectorLabel}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -8400,16 +8432,14 @@ function ComposerConnectorAccountChoices({
   );
 }
 
-function ComposerConnectorAccountPanel({
+function ComposerConnectorAccountMenuContent({
   signals,
   target,
   connectorLabel,
-  icon,
 }: {
   readonly signals: ComposerSignals;
   readonly target: ConnectorAccountTarget;
   readonly connectorLabel: string;
-  readonly icon: ReactNode;
 }) {
   const { t } = useTranslation();
   const preferenceLoadable = useLastLoadable(
@@ -8421,7 +8451,7 @@ function ComposerConnectorAccountPanel({
   const accountsLoadable = useLoadable(signals.connector.accounts.accounts$);
   const search = useGet(signals.connector.accounts.search$);
   const savingTargetKey = useGet(signals.connector.accounts.savingTargetKey$);
-  const closePanel = useSet(signals.connector.accounts.closePanel$);
+  const closeMenu = useSet(signals.connector.accounts.closeMenu$);
   const setSearch = useSet(signals.connector.accounts.setSearch$);
   const selectAccount = useSet(signals.connector.accounts.selectAccount$);
   const clearAccountSelection = useSet(signals.connector.accounts.useDefault$);
@@ -8464,30 +8494,31 @@ function ComposerConnectorAccountPanel({
     (summary?.accountCount ?? 0) > CONNECTOR_ACCOUNT_SEARCH_THRESHOLD ||
     accountList.nextCursor !== null;
   const saving = savingTargetKey === targetKey;
+  const selectAndClose = (connection: ConnectorAccountConnection): void => {
+    detach(
+      (async () => {
+        await selectAccount(connection, signal);
+        closeMenu();
+      })(),
+      Reason.DomCallback,
+    );
+  };
+  const selectDefaultAndClose = (): void => {
+    detach(
+      (async () => {
+        await clearAccountSelection(target, signal);
+        closeMenu();
+      })(),
+      Reason.DomCallback,
+    );
+  };
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-2 py-2">
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-2xs"
-          className="shrink-0 text-muted-foreground"
-          aria-label={t(($) => {
-            return $.chat.connectors.back;
-          })}
-          onClick={() => {
-            closePanel();
-          }}
-        >
-          <ArrowLeft size={15} />
-        </Button>
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-          {icon}
-        </span>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-          {connectorLabel}
-        </span>
+    <div className="flex max-h-[min(25rem,var(--available-height))] min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-border/60 px-3 py-2 text-sm font-medium text-foreground">
+        {t(($) => {
+          return $.chat.connectors.accountForThread;
+        })}
       </div>
       {showSearch ? (
         <div className="shrink-0 border-b border-border/50 px-3 py-2">
@@ -8521,10 +8552,10 @@ function ComposerConnectorAccountPanel({
         })}
         loadingAccountCount={summary?.accountCount ?? 0}
         onSelect={(connection) => {
-          detach(selectAccount(connection, signal), Reason.DomCallback);
+          selectAndClose(connection);
         }}
         onUseDefault={() => {
-          detach(clearAccountSelection(target, signal), Reason.DomCallback);
+          selectDefaultAndClose();
         }}
       />
       {accountList.nextCursor ? (
@@ -8574,7 +8605,6 @@ function deriveComposerConnectorPopoverState(args: {
   readonly showSearch: boolean;
   readonly permissionConnectorSlug: ConnectorSlug | null;
   readonly agentConnectors: readonly ComposerConnectorItem[];
-  readonly accountPanelTarget: ConnectorAccountTarget | null;
 }) {
   const sorted = args.sortOrder
     ? [...args.connectorItems].sort((a, b) => {
@@ -8603,60 +8633,7 @@ function deriveComposerConnectorPopoverState(args: {
         return connector.slug === args.permissionConnectorSlug;
       })
     : undefined;
-  const accountPanelTargetKey = args.accountPanelTarget
-    ? connectorAccountTargetKey(args.accountPanelTarget)
-    : null;
-  const accountPanelItem = accountPanelTargetKey
-    ? args.connectorItems.find((item) => {
-        return (
-          connectorAccountTargetKey(composerPopoverConnectorTarget(item)) ===
-          accountPanelTargetKey
-        );
-      })
-    : undefined;
-  return { visibleConnectors, permissionConnector, accountPanelItem };
-}
-
-function composerConnectorPopoverPanelClass(visible: boolean): string {
-  return cn(
-    "grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
-    visible
-      ? "grid-rows-[1fr]"
-      : "invisible grid-rows-[0fr] pointer-events-none",
-  );
-}
-
-function composerConnectorPopoverContentClass(
-  hasAccountPicker: boolean,
-): string {
-  return cn(
-    "w-72 p-0",
-    hasAccountPicker
-      ? "pointer-events-none relative h-[min(25rem,var(--available-height))] overflow-visible border-0 bg-transparent"
-      : "max-h-[var(--available-height)] overflow-hidden rounded-lg",
-  );
-}
-
-function composerConnectorPopoverSurfaceClass(
-  hasAccountPicker: boolean,
-): string {
-  return hasAccountPicker
-    ? "pointer-events-auto absolute inset-x-0 bottom-0 max-h-full overflow-hidden rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card shadow-lg"
-    : "contents";
-}
-
-function composerConnectorPopoverContentStyle(
-  hasAccountPicker: boolean,
-): CSSProperties | undefined {
-  return hasAccountPicker ? { boxShadow: "none" } : undefined;
-}
-
-function composerConnectorAccountPanelVisible(
-  open: boolean,
-  target: ConnectorAccountTarget | null,
-  item: ComposerPopoverConnectorItem | undefined,
-): boolean {
-  return Boolean(open && target && item);
+  return { visibleConnectors, permissionConnector };
 }
 
 function ConnectorsPopoverButton({
@@ -8693,7 +8670,6 @@ function ConnectorsPopoverButton({
   ) => void | Promise<void>;
 }) {
   const { t } = useTranslation();
-  const signal = useGet(pageSignal$);
   const connectorUi = useGet(signals.connector.connectorUiState$);
   const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
   const connectorAccountsEnabled = useGet(signals.connector.accounts.enabled$);
@@ -8703,10 +8679,7 @@ function ConnectorsPopoverButton({
   const accountSummariesLoadable = useLastLoadable(
     signals.connector.accounts.summaryByTarget$,
   );
-  const accountPanelTarget = useGet(signals.connector.accounts.panelTarget$);
-  const accountPanelOpen = useGet(signals.connector.accounts.panelOpen$);
-  const openAccountTarget = useSet(signals.connector.accounts.openTarget$);
-  const closeAccountPanel = useSet(signals.connector.accounts.closePanel$);
+  const closeAccountMenu = useSet(signals.connector.accounts.closeMenu$);
   const openAccountsPopover = useSet(signals.connector.accounts.openPopover$);
   const search = connectorUi.popoverSearch;
   const sortOrder = connectorUi.popoverSortOrder;
@@ -8744,7 +8717,7 @@ function ConnectorsPopoverButton({
       return [connection.id, connection];
     }),
   );
-  const { visibleConnectors, permissionConnector, accountPanelItem } =
+  const { visibleConnectors, permissionConnector } =
     deriveComposerConnectorPopoverState({
       connectorItems,
       sortOrder,
@@ -8752,7 +8725,6 @@ function ConnectorsPopoverButton({
       showSearch,
       permissionConnectorSlug,
       agentConnectors,
-      accountPanelTarget,
     });
   const accountSummaryForItem = (item: ComposerPopoverConnectorItem) => {
     if (
@@ -8780,7 +8752,9 @@ function ConnectorsPopoverButton({
     const targetKey = connectorAccountTargetKey(target);
     const selection = selectionByTarget.get(targetKey);
     return (
-      <ComposerConnectorAccountModeButton
+      <ComposerConnectorAccountMenu
+        signals={signals}
+        target={target}
         connectorLabel={
           item.kind === "builtin"
             ? item.connector.label
@@ -8793,20 +8767,9 @@ function ConnectorsPopoverButton({
             : undefined
         }
         defaultConnection={summary.defaultConnection}
-        onOpen={() => {
-          openAccountTarget(target, signal);
-        }}
       />
     );
   };
-  const hasAccountPicker = connectorItems.some((item) => {
-    return accountSummaryForItem(item) !== undefined;
-  });
-  const accountPanelVisible = composerConnectorAccountPanelVisible(
-    accountPanelOpen,
-    accountPanelTarget,
-    accountPanelItem,
-  );
   const handleOpenChange = (open: boolean) => {
     if (open) {
       // Snapshot the sort order when popover opens
@@ -8815,7 +8778,7 @@ function ConnectorsPopoverButton({
       openAccountsPopover();
     } else {
       updateConnectorUi({ popoverSortOrder: null, popoverSearch: "" });
-      closeAccountPanel();
+      closeAccountMenu();
     }
   };
 
@@ -8854,238 +8817,188 @@ function ConnectorsPopoverButton({
       <PopoverContent
         side="top"
         align="start"
-        className={composerConnectorPopoverContentClass(hasAccountPicker)}
-        style={composerConnectorPopoverContentStyle(hasAccountPicker)}
+        className="w-72 max-h-[var(--available-height)] overflow-hidden rounded-lg p-0"
       >
-        <div className={composerConnectorPopoverSurfaceClass(hasAccountPicker)}>
-          <div
-            className={composerConnectorPopoverPanelClass(!accountPanelVisible)}
-            aria-hidden={accountPanelVisible}
-          >
-            <div className="min-h-0 overflow-hidden">
-              <div className="flex min-h-0 flex-col">
-                {(connectorItems.length > 0 || connectorsLoading) && (
-                  <div className="flex min-h-0 flex-col py-1">
-                    {showSearch && (
-                      <div className="px-3 py-1 border-b border-border/50">
-                        <input
-                          type="text"
-                          placeholder={t(($) => {
-                            return $.chat.connectors.find;
-                          })}
-                          value={search}
-                          onChange={(e) => {
-                            return updateConnectorUi({
-                              popoverSearch: e.target.value,
-                            });
-                          }}
-                          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
-                        />
-                      </div>
-                    )}
-                    {connectorsLoading ? (
-                      <div className="flex flex-col animate-pulse">
-                        {Array.from({ length: 3 }, (_, i) => {
-                          return (
-                            <div
-                              key={i}
-                              className="flex items-center gap-2 px-3 py-2"
-                            >
-                              <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
-                              <span className="h-3.5 w-20 rounded bg-muted/50 flex-1" />
-                              <span className="h-3 w-6 rounded-full bg-muted/50" />
-                            </div>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <div className="flex max-h-64 min-h-0 flex-col overflow-y-auto">
-                        {visibleConnectors.map((item) => {
-                          if (item.kind === "custom") {
-                            const connector = item.connector;
-                            return (
-                              <ComposerConnectorAccessRow
-                                key={connector.id}
-                                icon={
-                                  <CustomConnectorIcon
-                                    id={connector.id}
-                                    displayName={connector.displayName}
-                                    size={16}
-                                  />
-                                }
-                                connectorLabel={connector.displayName}
-                                actions={accountModeButton(item)}
-                                checked={connector.authorized}
-                                onCheckedChange={onDomEventFn(
-                                  async (checked) => {
-                                    await onToggleCustom(connector.id, checked);
-                                  },
-                                )}
-                                loading={
-                                  savingCustomConnectorId === connector.id
-                                }
-                                ariaLabel={
-                                  connector.authorized
-                                    ? t(
-                                        ($) => {
-                                          return $.chat.connectors.remove;
-                                        },
-                                        {
-                                          connectorName: connector.displayName,
-                                        },
-                                      )
-                                    : t(
-                                        ($) => {
-                                          return $.chat.connectors.add;
-                                        },
-                                        {
-                                          connectorName: connector.displayName,
-                                        },
-                                      )
-                                }
-                              />
-                            );
-                          }
-                          const connector = item.connector;
-                          const accountAction = accountModeButton(item);
-                          const showPermissionAction =
-                            Boolean(agentId) &&
-                            connector.authorized &&
-                            connector.permissionSummary.hasPermissions;
-                          return (
-                            <ComposerConnectorAccessRow
-                              key={connector.slug}
-                              icon={
-                                <ConnectorIcon
-                                  icon={connector.icon}
-                                  size={16}
-                                />
-                              }
-                              connectorLabel={connector.label}
-                              actions={
-                                showPermissionAction || accountAction ? (
-                                  <>
-                                    {showPermissionAction ? (
-                                      <Button
-                                        type="button"
-                                        onClick={() => {
-                                          updateConnectorUi({
-                                            permissionConnectorSlug:
-                                              connector.slug,
-                                          });
-                                        }}
-                                        aria-label={t(
-                                          ($) => {
-                                            return $.chat.connectors
-                                              .configurePermissions;
-                                          },
-                                          { connectorName: connector.label },
-                                        )}
-                                        variant="quiet"
-                                        size="icon-2xs"
-                                        className="shrink-0"
-                                      >
-                                        <SlidersHorizontal size={15} />
-                                      </Button>
-                                    ) : null}
-                                    {accountAction}
-                                  </>
-                                ) : null
-                              }
-                              checked={connector.authorized}
-                              onCheckedChange={onDomEventFn(async (checked) => {
-                                await onToggle(connector.slug, checked);
-                              })}
-                              loading={savingConnectorSlug === connector.slug}
-                              ariaLabel={
-                                connector.authorized
-                                  ? t(
-                                      ($) => {
-                                        return $.chat.connectors.remove;
-                                      },
-                                      {
-                                        connectorName: connector.label,
-                                      },
-                                    )
-                                  : t(
-                                      ($) => {
-                                        return $.chat.connectors.add;
-                                      },
-                                      {
-                                        connectorName: connector.label,
-                                      },
-                                    )
-                              }
-                            />
-                          );
-                        })}
-                      </div>
-                    )}
+        <div className="min-h-0 overflow-hidden">
+          <div className="flex min-h-0 flex-col">
+            {(connectorItems.length > 0 || connectorsLoading) && (
+              <div className="flex min-h-0 flex-col py-1">
+                {showSearch && (
+                  <div className="px-3 py-1 border-b border-border/50">
+                    <input
+                      type="text"
+                      placeholder={t(($) => {
+                        return $.chat.connectors.find;
+                      })}
+                      value={search}
+                      onChange={(e) => {
+                        return updateConnectorUi({
+                          popoverSearch: e.target.value,
+                        });
+                      }}
+                      className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+                    />
                   </div>
                 )}
-                <div className="flex shrink-0 flex-col p-1">
-                  {(connectorItems.length > 0 || connectorsLoading) && (
-                    <div className="mx-2 mb-1 border-t border-border/50" />
-                  )}
-                  <button
-                    type="button"
-                    className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-state-hover transition-colors"
-                    onClick={() => {
-                      return onOpenAddDialog();
-                    }}
-                  >
-                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
-                      <Plus size={13} />
-                    </span>
-                    {t(($) => {
-                      return $.chat.connectors.addConnectors;
+                {connectorsLoading ? (
+                  <div className="flex flex-col animate-pulse">
+                    {Array.from({ length: 3 }, (_, i) => {
+                      return (
+                        <div
+                          key={i}
+                          className="flex items-center gap-2 px-3 py-2"
+                        >
+                          <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
+                          <span className="h-3.5 w-20 rounded bg-muted/50 flex-1" />
+                          <span className="h-3 w-6 rounded-full bg-muted/50" />
+                        </div>
+                      );
                     })}
-                  </button>
-                </div>
-                {computerUse && (
-                  <ComputerUseConnectorMenuSection
-                    computerUse={computerUse}
-                    onOpenDownloadDialog={() => {
-                      setDownloadDialogOpen(true);
-                    }}
-                  />
+                  </div>
+                ) : (
+                  <div className="flex max-h-64 min-h-0 flex-col overflow-y-auto">
+                    {visibleConnectors.map((item) => {
+                      if (item.kind === "custom") {
+                        const connector = item.connector;
+                        return (
+                          <ComposerConnectorAccessRow
+                            key={connector.id}
+                            icon={
+                              <CustomConnectorIcon
+                                id={connector.id}
+                                displayName={connector.displayName}
+                                size={16}
+                              />
+                            }
+                            connectorLabel={connector.displayName}
+                            actions={accountModeButton(item)}
+                            checked={connector.authorized}
+                            onCheckedChange={onDomEventFn(async (checked) => {
+                              await onToggleCustom(connector.id, checked);
+                            })}
+                            loading={savingCustomConnectorId === connector.id}
+                            ariaLabel={
+                              connector.authorized
+                                ? t(
+                                    ($) => {
+                                      return $.chat.connectors.remove;
+                                    },
+                                    {
+                                      connectorName: connector.displayName,
+                                    },
+                                  )
+                                : t(
+                                    ($) => {
+                                      return $.chat.connectors.add;
+                                    },
+                                    {
+                                      connectorName: connector.displayName,
+                                    },
+                                  )
+                            }
+                          />
+                        );
+                      }
+                      const connector = item.connector;
+                      const accountAction = accountModeButton(item);
+                      const showPermissionAction =
+                        Boolean(agentId) &&
+                        connector.authorized &&
+                        connector.permissionSummary.hasPermissions;
+                      return (
+                        <ComposerConnectorAccessRow
+                          key={connector.slug}
+                          icon={
+                            <ConnectorIcon icon={connector.icon} size={16} />
+                          }
+                          connectorLabel={connector.label}
+                          actions={
+                            showPermissionAction || accountAction ? (
+                              <>
+                                {showPermissionAction ? (
+                                  <Button
+                                    type="button"
+                                    onClick={() => {
+                                      updateConnectorUi({
+                                        permissionConnectorSlug: connector.slug,
+                                      });
+                                    }}
+                                    aria-label={t(
+                                      ($) => {
+                                        return $.chat.connectors
+                                          .configurePermissions;
+                                      },
+                                      { connectorName: connector.label },
+                                    )}
+                                    variant="quiet"
+                                    size="icon-2xs"
+                                    className="shrink-0"
+                                  >
+                                    <SlidersHorizontal size={15} />
+                                  </Button>
+                                ) : null}
+                                {accountAction}
+                              </>
+                            ) : null
+                          }
+                          checked={connector.authorized}
+                          onCheckedChange={onDomEventFn(async (checked) => {
+                            await onToggle(connector.slug, checked);
+                          })}
+                          loading={savingConnectorSlug === connector.slug}
+                          ariaLabel={
+                            connector.authorized
+                              ? t(
+                                  ($) => {
+                                    return $.chat.connectors.remove;
+                                  },
+                                  {
+                                    connectorName: connector.label,
+                                  },
+                                )
+                              : t(
+                                  ($) => {
+                                    return $.chat.connectors.add;
+                                  },
+                                  {
+                                    connectorName: connector.label,
+                                  },
+                                )
+                          }
+                        />
+                      );
+                    })}
+                  </div>
                 )}
               </div>
+            )}
+            <div className="flex shrink-0 flex-col p-1">
+              {(connectorItems.length > 0 || connectorsLoading) && (
+                <div className="mx-2 mb-1 border-t border-border/50" />
+              )}
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-state-hover transition-colors"
+                onClick={() => {
+                  return onOpenAddDialog();
+                }}
+              >
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
+                  <Plus size={13} />
+                </span>
+                {t(($) => {
+                  return $.chat.connectors.addConnectors;
+                })}
+              </button>
             </div>
-          </div>
-          <div
-            className={composerConnectorPopoverPanelClass(accountPanelVisible)}
-            aria-hidden={!accountPanelVisible}
-          >
-            <div className="min-h-0 overflow-hidden">
-              <div className="flex max-h-[min(25rem,var(--available-height))] min-h-[min(15rem,var(--available-height))] flex-col">
-                {accountPanelTarget && accountPanelItem ? (
-                  <ComposerConnectorAccountPanel
-                    signals={signals}
-                    target={accountPanelTarget}
-                    connectorLabel={
-                      accountPanelItem.kind === "builtin"
-                        ? accountPanelItem.connector.label
-                        : accountPanelItem.connector.displayName
-                    }
-                    icon={
-                      accountPanelItem.kind === "builtin" ? (
-                        <ConnectorIcon
-                          icon={accountPanelItem.connector.icon}
-                          size={16}
-                        />
-                      ) : (
-                        <CustomConnectorIcon
-                          id={accountPanelItem.connector.id}
-                          displayName={accountPanelItem.connector.displayName}
-                          size={16}
-                        />
-                      )
-                    }
-                  />
-                ) : null}
-              </div>
-            </div>
+            {computerUse && (
+              <ComputerUseConnectorMenuSection
+                computerUse={computerUse}
+                onOpenDownloadDialog={() => {
+                  setDownloadDialogOpen(true);
+                }}
+              />
+            )}
           </div>
         </div>
       </PopoverContent>


### PR DESCRIPTION
## Summary

- keep the Connector popover intact while account selection opens in an anchored menu
- label account selection as thread-specific and close only the account menu after a selection
- keep `User`, `UserCheck`, and Permission actions borderless with the same quiet default color
- preserve account loading, search, pagination, empty, and unavailable states

## Scope

- no API, database, connector runtime, or account resolution changes
- zero-account and single-account Connector rows remain unchanged

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx --maxWorkers=1` (17 tests)
- pre-commit full-repository Knip and TypeScript checks
- local browser verification with two Test app accounts

Closes #29510
