### PR TITLE
fix(platform): label three-column works nav as channels

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -453,7 +453,7 @@
       "rail": {
         "new": "New",
         "workflows": "Workflows",
-        "works": "Channel"
+        "works": "Channels"
       },
       "searchConversations": "Search conversations",
       "showChatList": "Show chat list",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -453,7 +453,7 @@
       "rail": {
         "new": "New",
         "workflows": "Workflows",
-        "works": "Works"
+        "works": "Channel"
       },
       "searchConversations": "Search conversations",
       "showChatList": "Show chat list",


### PR DESCRIPTION
## Summary
- rename the three-column navigation rail caption from `Works` to `Channels`
- keep the expanded and mobile sidebar label unchanged

## Verification
- `npx prettier@3.8.1 --check turbo/apps/platform/src/i18n/locales/en-US/common.json`
- `git diff --check`
- prior full branch verification: `pnpm format`, lint, knip, and package type checks
- no targeted Vitest added or run for this copy-only change, per the repository guidance against testing UI text content