### PR TITLE
fix(auth): reuse alert for field errors

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-field-error.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-field-error.tsx
@@ -1,3 +1,5 @@
+import { AuthV2ErrorAlert } from "./auth-v2-error-alert.tsx";
+
 export function AuthV2FieldError({
   focusKey,
   id,
@@ -7,29 +9,5 @@ export function AuthV2FieldError({
   readonly id: string;
   readonly message: string;
 }) {
-  return (
-    <p
-      aria-atomic="true"
-      className="rounded-sm text-xs leading-4 text-red-600 outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 dark:text-red-400"
-      id={id}
-      ref={(element) => {
-        if (!element || element.dataset.authV2ErrorFocusKey === focusKey) {
-          return;
-        }
-        element.dataset.authV2ErrorFocusKey = focusKey;
-        queueMicrotask(() => {
-          if (
-            element.isConnected &&
-            element.dataset.authV2ErrorFocusKey === focusKey
-          ) {
-            element.focus({ preventScroll: true });
-          }
-        });
-      }}
-      role="alert"
-      tabIndex={-1}
-    >
-      {message}
-    </p>
-  );
+  return <AuthV2ErrorAlert focusKey={focusKey} id={id} message={message} />;
 }

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -888,6 +888,7 @@ describe("auth v2 sign-up flow", () => {
     expect(legalError).toHaveTextContent(
       "Please read and accept the terms to continue",
     );
+    expect(legalError).toHaveClass("border-red-200", "bg-red-50");
     expect(document.activeElement).toBe(legalError);
     expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
 

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { compile } from "tailwindcss";
 import { describe, expect, it } from "vitest";
 
 import { mockNow, now } from "../../../../lib/time.ts";
@@ -888,7 +889,26 @@ describe("auth v2 sign-up flow", () => {
     expect(legalError).toHaveTextContent(
       "Please read and accept the terms to continue",
     );
-    expect(legalError).toHaveClass("border-red-200", "bg-red-50");
+    const styleElement = document.createElement("style");
+    const tailwindCompiler = await compile("@tailwind utilities;");
+    styleElement.textContent = tailwindCompiler.build([
+      ...legalError.classList,
+    ]);
+    document.head.append(styleElement);
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        styleElement.remove();
+      },
+      { once: true },
+    );
+    const legalErrorStyle = getComputedStyle(legalError);
+    expect([
+      legalErrorStyle.borderTopWidth,
+      legalErrorStyle.borderRightWidth,
+      legalErrorStyle.borderBottomWidth,
+      legalErrorStyle.borderLeftWidth,
+    ]).toStrictEqual(["1px", "1px", "1px", "1px"]);
     expect(document.activeElement).toBe(legalError);
     expect(mockedClerk.clientSignUpCreate).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- render Auth v2 field errors through the existing destructive Alert primitive
- preserve programmatic focus and field aria-describedby associations
- cover the shared alert presentation in the sign-up page test

## Verification
- pnpm exec vitest run apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
- package-local oxlint, including type-aware lint
- targeted ESLint with zero warnings
- Prettier 3.8.1