### PR TITLE
fix(auth): align clerk passkey action styling

### DIFF
--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -745,6 +745,28 @@ describe("app auth pages", () => {
     expect(getComputedStyle(checkbox).height).toBe("16px");
   });
 
+  it("presents the Clerk passkey action as a full-width outline control", async () => {
+    setBrowserUrl("https://app.vm0.ai/sign-in");
+
+    detachedSetupPage({ context, path: "/sign-in" });
+
+    const clerkSurface = await screen.findByTestId("clerk-sign-in");
+    const action = document.createElement("div");
+    action.className = "cl-footerAction cl-footerAction__usePasskey";
+    const link = document.createElement("a");
+    link.className = "cl-footerActionLink cl-footerActionLink__usePasskey";
+    link.href = "#";
+    link.textContent = "Use passkey instead";
+    action.append(link);
+    clerkSurface.append(action);
+
+    expect(getComputedStyle(action).width).toBe("100%");
+    expect(getComputedStyle(link).display).toBe("inline-flex");
+    expect(getComputedStyle(link).height).toBe("36px");
+    expect(getComputedStyle(link).width).toBe("100%");
+    expect(getComputedStyle(link).borderStyle).toBe("solid");
+  });
+
   it("routes ad-attributed sign-up visits through onboarding", async () => {
     const path = "/sign-up?gclid=click-123&utm_campaign=summer";
     setBrowserUrl(`https://app.vm0.ai${path}`);

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -258,6 +258,40 @@ button[class*="socialButtonsBlockButton"] img,
   color: hsl(var(--primary) / 0.9) !important;
 }
 
+/* The discoverable passkey action is rendered by Clerk as a footer link even
+   though it is a peer of the other sign-in methods. Match the standard outline
+   button without changing other footer or recovery links. */
+.cl-footerAction__usePasskey {
+  width: 100% !important;
+}
+
+.cl-footerActionLink__usePasskey {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 100% !important;
+  height: 36px !important;
+  border-width: 0.7px !important;
+  border-style: solid !important;
+  border-color: hsl(var(--gray-400)) !important;
+  border-radius: 0.5rem !important;
+  background-color: hsl(var(--background)) !important;
+  color: hsl(var(--foreground)) !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
+  transition: background-color 0.2s !important;
+}
+
+.cl-footerActionLink__usePasskey:hover {
+  background-color: var(--color-state-hover) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.cl-footerActionLink__usePasskey:active {
+  background-color: var(--color-state-pressed) !important;
+}
+
 /* OTP/Verification Code Input Boxes - Match cli-auth style */
 .cl-otpCodeFieldInput {
   height: 36px !important;


### PR DESCRIPTION
## Summary
- style only the Clerk discoverable passkey action as a full-width outline control
- keep other footer and recovery links unchanged
- add page-level coverage for the rendered Clerk class contract

## Verification
- pnpm exec vitest run apps/platform/src/views/auth/__tests__/auth-page.test.tsx
- package-local oxlint, including type-aware lint
- targeted ESLint with zero warnings
- Prettier 3.8.1