### PR TITLE
fix(auth): preserve checkbox primitive styles

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -1,0 +1,61 @@
+import { compile } from "tailwindcss";
+
+interface CheckboxPresentation {
+  readonly backgroundColor: string;
+  readonly borderColor: string;
+  readonly borderRadius: string;
+  readonly borderStyle: string;
+  readonly borderWidth: string;
+  readonly flexShrink: string;
+  readonly height: string;
+  readonly width: string;
+}
+
+const checkboxTheme = `
+  @theme {
+    --spacing: 0.25rem;
+    --radius-md: 0.375rem;
+    --color-border: rgb(10 20 30);
+    --color-input: rgb(40 50 60);
+    --color-primary: rgb(70 80 90);
+    --color-foreground: rgb(100 110 120);
+  }
+  @tailwind utilities;
+`;
+
+export async function renderedCheckboxPresentation(
+  checkbox: HTMLElement,
+  signal: AbortSignal,
+): Promise<CheckboxPresentation> {
+  const compiler = await compile(checkboxTheme);
+  const styleElement = document.createElement("style");
+  styleElement.textContent = compiler
+    .build([...checkbox.classList])
+    .replaceAll("var(--spacing)", "4px")
+    .replaceAll("var(--radius-md)", "6px")
+    .replaceAll("var(--color-border)", "rgb(10 20 30)")
+    .replaceAll("var(--color-input)", "rgb(40 50 60)")
+    .replaceAll("var(--color-primary)", "rgb(70 80 90)")
+    .replaceAll("var(--color-foreground)", "rgb(100 110 120)")
+    .replaceAll("var(--tw-border-style)", "solid");
+  document.head.append(styleElement);
+  signal.addEventListener(
+    "abort",
+    () => {
+      styleElement.remove();
+    },
+    { once: true },
+  );
+
+  const style = getComputedStyle(checkbox);
+  return {
+    backgroundColor: style.backgroundColor,
+    borderColor: style.borderColor,
+    borderRadius: style.borderRadius,
+    borderStyle: style.borderStyle,
+    borderWidth: style.borderWidth,
+    flexShrink: style.flexShrink,
+    height: style.height,
+    width: style.width,
+  };
+}

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -25,6 +25,7 @@ import {
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
 import { mockNow } from "../../../../lib/time.ts";
+import { renderedCheckboxPresentation } from "../../__tests__/auth-v2-style-assertions.ts";
 
 const context = testContext();
 
@@ -1572,17 +1573,18 @@ describe("auth v2 sign-in flow", () => {
       name: "Sign out of all other devices",
     });
     expect(signOutOtherDevices).toBeChecked();
-    expect(signOutOtherDevices).toHaveClass(
-      "h-4",
-      "w-4",
-      "rounded-md",
-      "border-border",
-      "bg-input",
-    );
-    expect(signOutOtherDevices).not.toHaveClass(
-      "rounded-[3px]",
-      "border-foreground/50",
-    );
+    await expect(
+      renderedCheckboxPresentation(signOutOtherDevices, context.signal),
+    ).resolves.toStrictEqual({
+      backgroundColor: "rgb(70 80 90)",
+      borderColor: "rgb(70 80 90)",
+      borderRadius: "6px",
+      borderStyle: "solid",
+      borderWidth: "1px",
+      flexShrink: "0",
+      height: "calc(4px * 4)",
+      width: "calc(4px * 4)",
+    });
     expect(
       screen.getByRole("region", { name: "Set new password" }),
     ).not.toHaveAttribute("aria-describedby");

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -1572,6 +1572,17 @@ describe("auth v2 sign-in flow", () => {
       name: "Sign out of all other devices",
     });
     expect(signOutOtherDevices).toBeChecked();
+    expect(signOutOtherDevices).toHaveClass(
+      "h-4",
+      "w-4",
+      "rounded-md",
+      "border-border",
+      "bg-input",
+    );
+    expect(signOutOtherDevices).not.toHaveClass(
+      "rounded-[3px]",
+      "border-foreground/50",
+    );
     expect(
       screen.getByRole("region", { name: "Set new password" }),
     ).not.toHaveAttribute("aria-describedby");

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -1033,7 +1033,7 @@ function NewPasswordStep({ copy, signals }: SignInStepProps) {
           <label className="flex cursor-pointer items-start gap-1.5 text-sm leading-5 font-medium text-foreground">
             <Checkbox
               checked={signOutOfOtherSessions}
-              className="mt-0.5 size-4 shrink-0 rounded-[3px] border-foreground/50"
+              className="mt-0.5"
               onCheckedChange={(checked) => {
                 setSignOutOfOtherSessions(checked === true);
               }}

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
+import { renderedCheckboxPresentation } from "../../__tests__/auth-v2-style-assertions.ts";
 
 const context = testContext();
 
@@ -198,17 +199,18 @@ describe("auth v2 sign-up flow", () => {
     expect(roleElement("link", "Use current sign-up")).toBeDefined();
     const legalConsent = screen.getByRole("checkbox");
     expect(legalConsent).toBeVisible();
-    expect(legalConsent).toHaveClass(
-      "h-4",
-      "w-4",
-      "rounded-md",
-      "border-border",
-      "bg-input",
-    );
-    expect(legalConsent).not.toHaveClass(
-      "rounded-[3px]",
-      "border-foreground/50",
-    );
+    await expect(
+      renderedCheckboxPresentation(legalConsent, context.signal),
+    ).resolves.toStrictEqual({
+      backgroundColor: "rgb(40 50 60)",
+      borderColor: "rgb(10 20 30)",
+      borderRadius: "6px",
+      borderStyle: "solid",
+      borderWidth: "1px",
+      flexShrink: "0",
+      height: "calc(4px * 4)",
+      width: "calc(4px * 4)",
+    });
     expect(roleElement("link", "Terms of Service")).toHaveAttribute(
       "href",
       "https://vm0.ai/legal/terms",

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -196,7 +196,19 @@ describe("auth v2 sign-up flow", () => {
       screen.getByRole("region", { name: "Create your account" }),
     ).toContainElement(signIn);
     expect(roleElement("link", "Use current sign-up")).toBeDefined();
-    expect(screen.getByRole("checkbox")).toBeVisible();
+    const legalConsent = screen.getByRole("checkbox");
+    expect(legalConsent).toBeVisible();
+    expect(legalConsent).toHaveClass(
+      "h-4",
+      "w-4",
+      "rounded-md",
+      "border-border",
+      "bg-input",
+    );
+    expect(legalConsent).not.toHaveClass(
+      "rounded-[3px]",
+      "border-foreground/50",
+    );
     expect(roleElement("link", "Terms of Service")).toHaveAttribute(
       "href",
       "https://vm0.ai/legal/terms",

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/sign-up-content.tsx
@@ -487,7 +487,7 @@ function DetailsStep({
                   }
                   aria-invalid={error?.field === "legal" ? true : undefined}
                   checked={legalAccepted}
-                  className="mt-0.5 size-4 shrink-0 rounded-[3px] border-foreground/50"
+                  className="mt-0.5"
                   onCheckedChange={(checked) => {
                     setLegalAccepted(checked === true);
                   }}


### PR DESCRIPTION
## Summary
- remove Auth v2 checkbox size, radius, and border overrides
- preserve only layout spacing for legal consent and session reset controls
- cover both controls against the shared Checkbox primitive classes

## Verification
- pnpm exec vitest run apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
- package-local oxlint, including type-aware lint
- targeted ESLint with zero warnings
- Prettier 3.8.1