### PR TITLE
docs(python): document firewall rule specificity ordering

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -78,6 +78,24 @@ _RESERVED_DECLARED_FIREWALL_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _VALID_AUTH_BASE_SCHEME = "https"
 _AUTH_TEMPLATE_START = "${{"
 _AUTH_TEMPLATE_URL_PLACEHOLDER = "placeholder"
+
+# Path-rule specificity is a Python tuple compared lexicographically from left to right. Keep
+# these coordinates aligned with the labeled TypeScript ``PathSpecificity`` tuple in
+# ``turbo/packages/connectors/src/firewall-rule-matcher.ts``:
+#
+# 1. ``literal_segments`` (``literalSegments``): number of fully literal path segments.
+# 2. ``mixed_param_segments`` (``mixedParamSegments``): number of parameter segments with a
+#    literal prefix or suffix.
+# 3. ``plain_param_segments`` (``plainParamSegments``): number of non-greedy parameter segments
+#    without a literal prefix or suffix.
+# 4. ``plus_greedy_segments`` (``plusGreedySegments``): number of ``+`` greedy parameter segments.
+# 5. ``negative_star_greedy_segments`` (``negativeStarGreedySegments``): the negated number of
+#    ``*`` greedy parameter segments, so fewer ``*`` segments are more specific after earlier
+#    coordinates tie.
+# 6. ``literal_chars`` (``literalChars``): number of Unicode code points in literal text, including
+#    mixed-segment prefixes and suffixes. Python ``len()`` has the same code-point meaning as the
+#    TypeScript matcher’s ``codePointLength()`` for this contract.
+# 7. ``segment_count`` (``segmentCount``): total number of path segments.
 _PathSpecificity = tuple[int, int, int, int, int, int, int]
 
 
@@ -836,6 +854,15 @@ def declared_firewall_permission_name_invalid_reason(
 # no allow/deny resolved, malformed network policy resolves before malformed
 # firewall config; malformed unknownPolicy only affects unknown-endpoint
 # resolution.
+#
+# Path-rule specificity is applied after the best matching base specificity has selected the API
+# tier. The tuple documented above is compared lexicographically, and only rules with the highest
+# matching tuple are evaluated. APIs and rules tied at that tuple remain candidates for the later
+# connector-owner and network-policy reduction; equal-specificity candidates are not discarded
+# during specificity selection. The focused contract is covered by
+# ``tests/test_compiled_firewall_rule_specificity_precedence.py``,
+# ``tests/test_compiled_firewall_cross_firewall_precedence.py``, and the parity cases in
+# ``turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts``.
 def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
     """Compile one firewall into reusable matcher data.
 


### PR DESCRIPTION
## Summary

- Document the seven-coordinate Python firewall path-specificity tuple and its lexicographic ordering.
- Explain the negated `*` greedy coordinate, Unicode code-point counting, and equal-specificity policy reduction.
- Link the focused Python precedence tests and the labeled TypeScript parity tuple.

## Scope

This is a documentation-only change in `crates/runner/mitm-addon/src/matching.py`. It does not
change runtime behavior, tuple representation, tests, TypeScript source, API contracts, or
deployment behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_rule_specificity_precedence.py tests/test_compiled_firewall_cross_firewall_precedence.py`

Closes #29536
