### PR TITLE
test(guest-download): bound tcp fixture shutdown

### DIFF
--- a/crates/guest-download/tests/integration/binary_logging/attribution.rs
+++ b/crates/guest-download/tests/integration/binary_logging/attribution.rs
@@ -1,11 +1,11 @@
 use super::{BinaryLoggingFixture, assert_action_types_present};
-use crate::support::{create_tar_gz, read_http_request_path, write_manifest};
+use crate::support::{TcpTestServer, create_tar_gz, read_http_request_path, write_manifest};
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse};
 use serde_json::{Value, json};
-use std::io::Write as _;
-use std::net::TcpListener;
+use std::io::{self, Write as _};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
@@ -49,11 +49,14 @@ fn start_delayed_archive_server(
     archive: Vec<u8>,
     header_delay: Duration,
     body_delay: Duration,
-) -> std::io::Result<(String, thread::JoinHandle<std::io::Result<()>>)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let url = format!("http://{}/archive.tar.gz", listener.local_addr()?);
-    let handle = thread::spawn(move || {
-        let (mut stream, _) = listener.accept()?;
+) -> io::Result<TcpTestServer<()>> {
+    TcpTestServer::start(move |server| {
+        let mut stream = server.accept()?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Interrupted,
+                "delayed archive server stopped before receiving a request",
+            )
+        })?;
         assert_eq!(read_http_request_path(&mut stream)?, "/archive.tar.gz");
         thread::sleep(header_delay);
         write!(
@@ -65,8 +68,7 @@ fn start_delayed_archive_server(
         thread::sleep(body_delay);
         stream.write_all(&archive)?;
         stream.flush()
-    });
-    Ok((url, handle))
+    })
 }
 
 #[test]
@@ -552,14 +554,15 @@ fn binary_aggregates_remote_attribution_across_retries() {
 fn binary_separates_response_header_and_body_read_wait() {
     let archive = create_tar_gz(&[("delayed.txt", b"delayed")]).unwrap();
     let delay = Duration::from_millis(80);
-    let (url, server) = start_delayed_archive_server(archive, delay, delay).unwrap();
+    let server = start_delayed_archive_server(archive, delay, delay).unwrap();
+    let url = format!("{}/archive.tar.gz", server.base_url());
     let fixture = BinaryLoggingFixture::new("remote-attribution-delays").unwrap();
     let mount = fixture.dir.path().join("storage");
     let manifest =
         write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
     let output = fixture.run_manifest_path(&manifest).unwrap();
-    server.join().unwrap().unwrap();
+    server.finish().unwrap();
 
     assert!(
         output.status.success(),
@@ -579,6 +582,25 @@ fn binary_separates_response_header_and_body_read_wait() {
         "header wait was {header_wait}ms: {ops:?}"
     );
     assert!(body_wait >= 50, "body wait was {body_wait}ms: {ops:?}");
+}
+
+#[test]
+fn delayed_archive_server_without_request_returns_bounded_error() {
+    let server = start_delayed_archive_server(Vec::new(), Duration::ZERO, Duration::ZERO).unwrap();
+    let (finished_tx, finished_rx) = mpsc::channel();
+    let completion = thread::spawn(move || {
+        let result = server.finish();
+        let _ = finished_tx.send(());
+        result
+    });
+
+    finished_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    let error = completion.join().unwrap().unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+    assert_eq!(
+        error.to_string(),
+        "delayed archive server stopped before receiving a request"
+    );
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/binary_logging/attribution.rs
+++ b/crates/guest-download/tests/integration/binary_logging/attribution.rs
@@ -597,10 +597,6 @@ fn delayed_archive_server_without_request_returns_bounded_error() {
     finished_rx.recv_timeout(Duration::from_secs(3)).unwrap();
     let error = completion.join().unwrap().unwrap_err();
     assert_eq!(error.kind(), io::ErrorKind::Interrupted);
-    assert_eq!(
-        error.to_string(),
-        "delayed archive server stopped before receiving a request"
-    );
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -1,21 +1,17 @@
 use super::{BinaryLoggingFixture, assert_download_total_success_present};
 use crate::process;
 use crate::support::{
-    assert_does_not_contain_any, create_tar_gz, read_http_request_path, write_manifest,
+    TcpTestServer, TcpTestServerControl, assert_does_not_contain_any, create_tar_gz,
+    read_http_request_path, write_manifest,
 };
 use httpmock::prelude::*;
 use std::io;
-use std::net::TcpListener;
 use std::sync::mpsc::{self, Receiver, Sender};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const EXPECTED_RETRY_ATTEMPTS: usize = 3;
-const SERVER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const SERVER_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(1);
 const SERVER_START_TIMEOUT: Duration = Duration::from_secs(5);
-const SERVER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
-const SERVER_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 fn validate_attempt_warning(
     log_name: &str,
@@ -68,10 +64,8 @@ enum ConnectionBehavior {
 }
 
 struct ConnectionDropServer {
-    base_url: String,
-    stop_tx: Sender<()>,
+    server: TcpTestServer<usize>,
     request_started_rx: Receiver<()>,
-    handle: Option<thread::JoinHandle<io::Result<usize>>>,
 }
 
 impl ConnectionDropServer {
@@ -84,25 +78,19 @@ impl ConnectionDropServer {
     }
 
     fn start_with_behavior(behavior: ConnectionBehavior) -> io::Result<Self> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        listener.set_nonblocking(true)?;
-        let base_url = format!("http://{}", listener.local_addr()?);
-        let (stop_tx, stop_rx) = mpsc::channel();
         let (request_started_tx, request_started_rx) = mpsc::channel();
-        let handle = thread::spawn(move || {
-            serve_dropped_connections(listener, stop_rx, request_started_tx, behavior)
-        });
+        let server = TcpTestServer::start(move |server| {
+            serve_dropped_connections(server, request_started_tx, behavior)
+        })?;
 
         Ok(Self {
-            base_url,
-            stop_tx,
+            server,
             request_started_rx,
-            handle: Some(handle),
         })
     }
 
     fn base_url(&self) -> &str {
-        &self.base_url
+        self.server.base_url()
     }
 
     fn wait_for_request(&self) -> io::Result<()> {
@@ -120,75 +108,28 @@ impl ConnectionDropServer {
         }
     }
 
-    fn finish(mut self) -> io::Result<usize> {
-        self.shutdown()
-    }
-
-    fn shutdown(&mut self) -> io::Result<usize> {
-        let handle = self
-            .handle
-            .take()
-            .ok_or_else(|| io::Error::other("connection-drop server lost its thread"))?;
-        let _ = self.stop_tx.send(());
-        let deadline = Instant::now() + SERVER_CLEANUP_TIMEOUT;
-        while !handle.is_finished() {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    format!(
-                        "connection-drop server did not stop within {SERVER_CLEANUP_TIMEOUT:?}"
-                    ),
-                ));
-            }
-            thread::sleep(remaining.min(SERVER_JOIN_POLL_INTERVAL));
-        }
-
-        handle
-            .join()
-            .map_err(|_| io::Error::other("connection-drop server panicked"))?
-    }
-}
-
-impl Drop for ConnectionDropServer {
-    fn drop(&mut self) {
-        if self.handle.is_some() {
-            let _ = self.shutdown();
-        }
+    fn finish(self) -> io::Result<usize> {
+        self.server.finish()
     }
 }
 
 fn serve_dropped_connections(
-    listener: TcpListener,
-    stop_rx: Receiver<()>,
+    server: TcpTestServerControl,
     request_started_tx: Sender<()>,
     behavior: ConnectionBehavior,
 ) -> io::Result<usize> {
     let mut accepted = 0;
     loop {
-        match stop_rx.try_recv() {
-            Ok(()) | Err(mpsc::TryRecvError::Disconnected) => return Ok(accepted),
-            Err(mpsc::TryRecvError::Empty) => {}
-        }
-
-        match listener.accept() {
-            Ok((mut stream, _)) => {
-                stream.set_read_timeout(Some(SERVER_STREAM_READ_TIMEOUT))?;
-                read_http_request_path(&mut stream)?;
-                accepted += 1;
-                let _ = request_started_tx.send(());
-                if matches!(behavior, ConnectionBehavior::Hold) {
-                    let _ = stop_rx.recv();
-                    return Ok(accepted);
-                }
-            }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                match stop_rx.recv_timeout(SERVER_POLL_INTERVAL) {
-                    Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(accepted),
-                    Err(mpsc::RecvTimeoutError::Timeout) => {}
-                }
-            }
-            Err(error) => return Err(error),
+        let Some(mut stream) = server.accept()? else {
+            return Ok(accepted);
+        };
+        stream.set_read_timeout(Some(SERVER_STREAM_READ_TIMEOUT))?;
+        read_http_request_path(&mut stream)?;
+        accepted += 1;
+        let _ = request_started_tx.send(());
+        if matches!(behavior, ConnectionBehavior::Hold) {
+            server.wait_for_shutdown();
+            return Ok(accepted);
         }
     }
 }

--- a/crates/guest-download/tests/integration/download.rs
+++ b/crates/guest-download/tests/integration/download.rs
@@ -1,14 +1,13 @@
 use crate::support::{
-    TarEntry, create_tar_gz, create_tar_gz_entries, manifest_json, read_http_request_path,
-    run_guest_download, run_guest_download_manifest_json, write_manifest,
+    TarEntry, TcpTestServer, create_tar_gz, create_tar_gz_entries, manifest_json,
+    read_http_request_path, run_guest_download, run_guest_download_manifest_json, write_manifest,
 };
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
 use std::io::Write;
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
 
 const STORAGE_ARCHIVE_PATH: &str = "/storage.tar.gz";
 const ARTIFACT_ARCHIVE_PATH: &str = "/artifact.tar.gz";
@@ -100,23 +99,18 @@ fn path_to_str(path: &Path) -> std::io::Result<&str> {
     })
 }
 
-fn start_truncated_then_valid_server(
-    archive: Vec<u8>,
-) -> std::io::Result<(String, thread::JoinHandle<std::io::Result<usize>>)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let base_url = format!("http://{}", listener.local_addr()?);
+fn start_truncated_then_valid_server(archive: Vec<u8>) -> std::io::Result<TcpTestServer<usize>> {
     let partial_len = (archive.len() / 2).max(1);
     let partial_archive: Vec<u8> = archive.iter().copied().take(partial_len).collect();
 
-    let handle = thread::spawn(move || -> std::io::Result<usize> {
+    TcpTestServer::start(move |server| {
         let mut storage_requests = 0;
         loop {
-            let (mut stream, _) = listener.accept()?;
+            let Some(mut stream) = server.accept()? else {
+                return Ok(storage_requests);
+            };
             let path = read_http_request_path(&mut stream)?;
-            if path == "/__unblock" {
-                write_response(&mut stream, &[], 0)?;
-                break;
-            } else if path == STORAGE_ARCHIVE_PATH {
+            if path == STORAGE_ARCHIVE_PATH {
                 if storage_requests == 0 {
                     write_response(&mut stream, &partial_archive, archive.len())?;
                 } else {
@@ -131,9 +125,7 @@ fn start_truncated_then_valid_server(
             }
         }
         Ok(storage_requests)
-    });
-
-    Ok((base_url, handle))
+    })
 }
 
 fn write_response(
@@ -147,14 +139,6 @@ fn write_response(
     stream.write_all(headers.as_bytes())?;
     stream.write_all(body)?;
     stream.flush()
-}
-
-fn unblock_server(base_url: &str) -> std::io::Result<()> {
-    let Some(address) = base_url.strip_prefix("http://") else {
-        return Ok(());
-    };
-    let mut stream = TcpStream::connect(address)?;
-    stream.write_all(b"GET /__unblock HTTP/1.1\r\nhost: localhost\r\nconnection: close\r\n\r\n")
 }
 
 #[test]
@@ -405,14 +389,14 @@ fn invalid_tar_gz_non_retriable() {
 #[test]
 fn http_body_read_error_retries_then_succeeds() {
     let tar_gz = create_tar_gz(&[("recovered.txt", b"recovered")]).unwrap();
-    let (base_url, server) = start_truncated_then_valid_server(tar_gz).unwrap();
+    let server = start_truncated_then_valid_server(tar_gz).unwrap();
+    let base_url = server.base_url().to_owned();
 
     let dir = tempfile::tempdir().unwrap();
     let mount = dir.path().join("mount");
     let url = format!("{base_url}{STORAGE_ARCHIVE_PATH}");
     let result = run_storage_download(&dir, &mount, Some(&url)).unwrap();
-    let _ = unblock_server(&base_url);
-    let storage_requests = server.join().unwrap().unwrap();
+    let storage_requests = server.finish().unwrap();
 
     assert!(result);
     assert_eq!(storage_requests, 2);

--- a/crates/guest-download/tests/integration/support.rs
+++ b/crates/guest-download/tests/integration/support.rs
@@ -1,13 +1,113 @@
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use serde_json::{Map, Value, json};
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+const TCP_SERVER_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const TCP_SERVER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const TCP_SERVER_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+pub(crate) struct TcpTestServerControl {
+    listener: TcpListener,
+    stop_rx: Receiver<()>,
+}
+
+impl TcpTestServerControl {
+    pub(crate) fn accept(&self) -> io::Result<Option<TcpStream>> {
+        loop {
+            match self.stop_rx.try_recv() {
+                Ok(()) | Err(mpsc::TryRecvError::Disconnected) => return Ok(None),
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+
+            match self.listener.accept() {
+                Ok((stream, _)) => return Ok(Some(stream)),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    match self.stop_rx.recv_timeout(TCP_SERVER_ACCEPT_POLL_INTERVAL) {
+                        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(None),
+                        Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    pub(crate) fn wait_for_shutdown(&self) {
+        let _ = self.stop_rx.recv();
+    }
+}
+
+pub(crate) struct TcpTestServer<T: Send + 'static> {
+    base_url: String,
+    stop_tx: Sender<()>,
+    handle: Option<JoinHandle<io::Result<T>>>,
+}
+
+impl<T: Send + 'static> TcpTestServer<T> {
+    pub(crate) fn start(
+        serve: impl FnOnce(TcpTestServerControl) -> io::Result<T> + Send + 'static,
+    ) -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let base_url = format!("http://{}", listener.local_addr()?);
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let handle = thread::spawn(move || serve(TcpTestServerControl { listener, stop_rx }));
+
+        Ok(Self {
+            base_url,
+            stop_tx,
+            handle: Some(handle),
+        })
+    }
+
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub(crate) fn finish(mut self) -> io::Result<T> {
+        self.shutdown()
+    }
+
+    fn shutdown(&mut self) -> io::Result<T> {
+        let handle = self
+            .handle
+            .take()
+            .ok_or_else(|| io::Error::other("TCP test server lost its thread"))?;
+        let _ = self.stop_tx.send(());
+        let deadline = Instant::now() + TCP_SERVER_CLEANUP_TIMEOUT;
+        while !handle.is_finished() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("TCP test server did not stop within {TCP_SERVER_CLEANUP_TIMEOUT:?}"),
+                ));
+            }
+            thread::sleep(remaining.min(TCP_SERVER_JOIN_POLL_INTERVAL));
+        }
+
+        handle
+            .join()
+            .map_err(|_| io::Error::other("TCP test server panicked"))?
+    }
+}
+
+impl<T: Send + 'static> Drop for TcpTestServer<T> {
+    fn drop(&mut self) {
+        if self.handle.is_some() {
+            let _ = self.shutdown();
+        }
+    }
+}
 
 pub(crate) fn read_http_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
     let mut request = Vec::new();


### PR DESCRIPTION
## Summary

- centralize guest-download raw TCP fixture ownership in a shared RAII test server
- migrate delayed-response, connection-drop/hold, and truncated-response fixtures to cooperative bounded shutdown
- remove protocol-level `/__unblock` cleanup and add a bounded no-request regression

## Scope

This changes integration-test infrastructure only. Production guest-download behavior, dependencies, APIs, and deployment contracts are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-download --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`

Closes #29537
