### PR TITLE
fix(platform): prevent pinned agent drags from opening split view

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -382,11 +382,20 @@ function commandItemByText(container: HTMLElement, text: string): HTMLElement {
  * jsdom does not implement DataTransfer, so drag events need a stub that keeps
  * the payload the pinned grid writes on drag start.
  */
-function createDataTransferStub(): DataTransfer {
-  const values = new Map<string, string>();
+function createDataTransferStub(
+  initialValues: Readonly<Record<string, string>> = {},
+): DataTransfer {
+  let values = new Map<string, string>(Object.entries(initialValues));
   return {
     effectAllowed: "none",
     dropEffect: "none",
+    clearData: (format?: string) => {
+      if (format === undefined) {
+        values = new Map<string, string>();
+        return;
+      }
+      values.delete(format);
+    },
     setData: (format: string, value: string) => {
       values.set(format, value);
     },
@@ -4072,7 +4081,7 @@ describe("zero sidebar", () => {
     expect(screen.queryByTestId("pin-agent-dialog-list")).toBeNull();
   });
 
-  it("reorders pinned agents with drag and drop", async () => {
+  it("reorders pinned agents without retaining the browser link payload", async () => {
     const pinnedAgentIds = prepareOverflowingPinnedAgents();
     context.mocks.data.userPreferences({ pinnedAgentIds });
 
@@ -4097,10 +4106,18 @@ describe("zero sidebar", () => {
       "Billing Agent",
     ]);
 
-    const dataTransfer = createDataTransferStub();
     const dragged = pinnedAgentLink(grid, "Support Agent");
     const target = pinnedAgentLink(grid, "Billing Agent");
+    const dataTransfer = createDataTransferStub({
+      "text/uri-list": dragged.href,
+      "text/plain": dragged.href,
+    });
     fireEvent.dragStart(dragged, { dataTransfer });
+    expect(dataTransfer.getData("text/uri-list")).toBe("");
+    expect(dataTransfer.getData("text/plain")).toBe("");
+    expect(dataTransfer.getData("application/x-okou-pinned-agent")).toBe(
+      SUPPORT_AGENT_ID,
+    );
     fireEvent.dragOver(target, { dataTransfer });
     fireEvent.drop(target, { dataTransfer });
 
@@ -4279,8 +4296,12 @@ describe("zero sidebar", () => {
     fireEvent.dragStart(pinnedAgentLink(grid, "Support Agent"), {
       dataTransfer: leadDragTransfer,
     });
-    fireEvent.dragOver(lead, { dataTransfer: leadDragTransfer });
-    fireEvent.drop(lead, { dataTransfer: leadDragTransfer });
+    expect(
+      fireEvent.dragOver(lead, { dataTransfer: leadDragTransfer }),
+    ).toBeFalsy();
+    expect(
+      fireEvent.drop(lead, { dataTransfer: leadDragTransfer }),
+    ).toBeFalsy();
     fireEvent.dragEnd(pinnedAgentLink(grid, "Support Agent"), {
       dataTransfer: leadDragTransfer,
     });

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -328,18 +328,22 @@ function PinnedAgentGridCard({
       title={displayName}
       draggable={isReorderable}
       onDragStart={(e) => {
+        e.dataTransfer.clearData();
         e.dataTransfer.effectAllowed = "move";
-        e.dataTransfer.setData("text/plain", agent.id);
+        e.dataTransfer.setData("application/x-okou-pinned-agent", agent.id);
         startDrag(agent.id);
       }}
       onDragEnd={() => {
         endDrag();
       }}
       onDragOver={(e) => {
-        if (!acceptsDrop) {
+        if (draggingAgentId === null) {
           return;
         }
         e.preventDefault();
+        if (!acceptsDrop) {
+          return;
+        }
         e.dataTransfer.dropEffect = "move";
         setDropTarget(agent.id);
       }}
@@ -349,10 +353,13 @@ function PinnedAgentGridCard({
         }
       }}
       onDrop={(e) => {
-        if (!acceptsDrop || draggingAgentId === null) {
+        if (draggingAgentId === null) {
           return;
         }
         e.preventDefault();
+        if (!acceptsDrop) {
+          return;
+        }
         detach(
           moveAgent(
             { agentId: draggingAgentId, targetAgentId: agent.id },


### PR DESCRIPTION
## Summary

- clear browser-provided link drag data before pinned-agent reordering starts
- use an app-specific drag payload so Chrome cannot interpret the drag as navigation or split view
- prevent default browser handling for every in-flight pinned-agent drop target while preserving reorder behavior
- cover the sanitized payload, fixed-slot default prevention, and successful reordering in the sidebar integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --maxWorkers=1 -t 'reorders pinned agents without retaining the browser link payload|leaves the lead agent in place when it is dragged'` (2 passed)

## Browser QA

- not run locally because repository instructions prohibit starting the dev server unless explicitly requested
