### PR TITLE
fix(platform): keep pin dialog open after updates

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Wähle einen Agenten aus, den du an die Seitenleiste anheften möchtest.",
     "pinned": "Angepinnt",
     "pinnedAgents": "Angepinnte Agenten",
+    "pinSuccess": "{{agentName}} angepinnt",
     "resultCount_one": "{{count}} Ergebnis",
     "resultCount_other": "{{count}} Ergebnisse",
     "searchAgents": "Suchagenten...",
@@ -627,7 +628,8 @@
       "others": "Andere"
     },
     "talkTo": "Sprechen mit",
-    "unpin": "Nicht mehr anheften"
+    "unpin": "Nicht mehr anheften",
+    "unpinSuccess": "{{agentName}} nicht mehr angepinnt"
   },
   "status": {
     "unread": "Ungelesen"

--- a/turbo/apps/platform/src/i18n/locales/en-US/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Choose an agent to pin to the sidebar.",
     "pinned": "Pinned",
     "pinnedAgents": "Pinned agents",
+    "pinSuccess": "{{agentName}} pinned",
     "resultCount_one": "{{count}} result",
     "resultCount_other": "{{count}} results",
     "searchAgents": "Search agents...",
@@ -627,7 +628,8 @@
       "others": "Others"
     },
     "talkTo": "Talk to",
-    "unpin": "Unpin"
+    "unpin": "Unpin",
+    "unpinSuccess": "{{agentName}} unpinned"
   },
   "status": {
     "unread": "Unread"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Elige un agente para fijarlo en la barra lateral.",
     "pinned": "Fijados",
     "pinnedAgents": "Agentes fijados",
+    "pinSuccess": "{{agentName}} fijado",
     "resultCount_one": "{{count}} resultado",
     "resultCount_many": "{{count}} resultados",
     "resultCount_other": "{{count}} resultados",
@@ -628,7 +629,8 @@
       "others": "Otros"
     },
     "talkTo": "Hablar con",
-    "unpin": "Desfijar"
+    "unpin": "Desfijar",
+    "unpinSuccess": "{{agentName}} desfijado"
   },
   "status": {
     "unread": "No leído"

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Choisissez un agent à épingler à la barre latérale.",
     "pinned": "Épinglé",
     "pinnedAgents": "Agents épinglés",
+    "pinSuccess": "{{agentName}} épinglé",
     "resultCount_one": "{{count}} résultat",
     "resultCount_many": "{{count}} résultats",
     "resultCount_other": "{{count}} résultats",
@@ -628,7 +629,8 @@
       "others": "Autres"
     },
     "talkTo": "Parler à",
-    "unpin": "Détacher"
+    "unpin": "Détacher",
+    "unpinSuccess": "{{agentName}} détaché"
   },
   "status": {
     "unread": "Non lu"

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "साइडबार पर पिन करने के लिए एक एजेंट चुनें।",
     "pinned": "पिन की गई",
     "pinnedAgents": "पिन किए गए एजेंट",
+    "pinSuccess": "{{agentName}} को पिन किया गया",
     "resultCount_one": "{{count}} परिणाम",
     "resultCount_other": "{{count}} परिणाम",
     "searchAgents": "खोज एजेंट...",
@@ -627,7 +628,8 @@
       "others": "अन्य"
     },
     "talkTo": "से बात",
-    "unpin": "अनपिन"
+    "unpin": "अनपिन",
+    "unpinSuccess": "{{agentName}} को अनपिन किया गया"
   },
   "status": {
     "unread": "अपठित"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Pilih agen untuk disematkan ke sidebar.",
     "pinned": "Disematkan",
     "pinnedAgents": "Agen yang disematkan",
+    "pinSuccess": "{{agentName}} disematkan",
     "resultCount_other": "{{count}} hasil",
     "searchAgents": "Cari agen...",
     "searchAgentsAndChats": "Cari agen dan chat...",
@@ -626,7 +627,8 @@
       "others": "Lainnya"
     },
     "talkTo": "Ngobrol dengan",
-    "unpin": "Lepaskan sematan"
+    "unpin": "Lepaskan sematan",
+    "unpinSuccess": "Sematan {{agentName}} dilepas"
   },
   "status": {
     "unread": "Belum dibaca"

--- a/turbo/apps/platform/src/i18n/locales/it-IT/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Scegli un agente da fissare nella barra laterale.",
     "pinned": "In evidenza",
     "pinnedAgents": "Agenti in evidenza",
+    "pinSuccess": "{{agentName}} fissato",
     "resultCount_one": "{{count}} risultato",
     "resultCount_many": "{{count}} risultati",
     "resultCount_other": "{{count}} risultati",
@@ -628,7 +629,8 @@
       "others": "Altri"
     },
     "talkTo": "Parla con",
-    "unpin": "Rimuovi dalla barra laterale"
+    "unpin": "Rimuovi dalla barra laterale",
+    "unpinSuccess": "{{agentName}} rimosso dalla barra laterale"
   },
   "status": {
     "unread": "Non letto"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "サイドバーにピン留めするエージェントを選択してください。",
     "pinned": "ピン留め済み",
     "pinnedAgents": "ピン留めしたエージェント",
+    "pinSuccess": "{{agentName}}をピン留めしました",
     "resultCount_other": "{{count}} 件の結果",
     "searchAgents": "エージェントを検索...",
     "searchAgentsAndChats": "エージェントとチャットを検索...",
@@ -626,7 +627,8 @@
       "others": "その他"
     },
     "talkTo": "話しかける",
-    "unpin": "固定を解除する"
+    "unpin": "固定を解除する",
+    "unpinSuccess": "{{agentName}}のピン留めを解除しました"
   },
   "status": {
     "unread": "未読"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "사이드바에 고정할 에이전트를 선택하세요.",
     "pinned": "고정됨",
     "pinnedAgents": "고정된 에이전트",
+    "pinSuccess": "{{agentName}}을(를) 고정했습니다",
     "resultCount_other": "결과 {{count}}개",
     "searchAgents": "에이전트 검색...",
     "searchAgentsAndChats": "에이전트 및 채팅 검색...",
@@ -626,7 +627,8 @@
       "others": "기타"
     },
     "talkTo": "대화하기",
-    "unpin": "고정 해제"
+    "unpin": "고정 해제",
+    "unpinSuccess": "{{agentName}} 고정을 해제했습니다"
   },
   "status": {
     "unread": "읽지 않음"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
@@ -614,6 +614,7 @@
     "pinAgentDescription": "Escolha um agente para fixar na barra lateral.",
     "pinned": "Fixados",
     "pinnedAgents": "Agentes fixados",
+    "pinSuccess": "{{agentName}} fixado",
     "resultCount_one": "{{count}} resultado",
     "resultCount_many": "{{count}} resultados",
     "resultCount_other": "{{count}} resultados",
@@ -628,7 +629,8 @@
       "others": "Outros"
     },
     "talkTo": "Conversar com",
-    "unpin": "Desafixar"
+    "unpin": "Desafixar",
+    "unpinSuccess": "{{agentName}} desafixado"
   },
   "status": {
     "unread": "Não lido"

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3981,7 +3981,7 @@ describe("zero sidebar", () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it("pins an agent from the grid pin entry", async () => {
+  it("keeps the pin dialog open and confirms a row pin", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({ pinnedAgentIds: [RESEARCH_AGENT_ID] });
 
@@ -4006,13 +4006,28 @@ describe("zero sidebar", () => {
 
     click(commandItemByText(dialogList, "Support Agent"));
 
+    await expect(
+      screen.findByText("Support Agent pinned"),
+    ).resolves.toBeInTheDocument();
     await waitFor(() => {
-      expect(pinnedAgentLink(grid, "Support Agent")).toBeInTheDocument();
+      expect(pinnedAgentNames(grid)).toStrictEqual([
+        "Zero",
+        "Research Agent",
+        "Support Agent",
+      ]);
     });
-    expect(screen.queryByTestId("pin-agent-dialog-list")).toBeNull();
+    expect(dialogList).toBeInTheDocument();
+    expect(
+      buttonByText("Unpin", commandItemByText(dialogList, "Support Agent")),
+    ).toBeInTheDocument();
+    click(screen.getByLabelText("Close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("pin-agent-dialog-list")).toBeNull();
+    });
+    expect(pinnedAgentLink(grid, "Support Agent")).toBeInTheDocument();
   });
 
-  it("unpins an agent from the grid pin entry", async () => {
+  it("keeps the pin dialog open and confirms an unpin", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({
       pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID],
@@ -4040,10 +4055,16 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(pinnedAgentNames(grid)).toStrictEqual(["Zero", "Research Agent"]);
     });
-    expect(screen.queryByTestId("pin-agent-dialog-list")).toBeNull();
+    expect(dialogList).toBeInTheDocument();
+    expect(
+      buttonByText("Pin", commandItemByText(dialogList, "Support Agent")),
+    ).toBeInTheDocument();
+    await expect(
+      screen.findByText("Support Agent unpinned"),
+    ).resolves.toBeInTheDocument();
   });
 
-  it("pins an agent from the pin dialog row action", async () => {
+  it("keeps the pin dialog open after its row action pins an agent", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({ pinnedAgentIds: [] });
 
@@ -4069,7 +4090,13 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(pinnedAgentNames(grid)).toStrictEqual(["Zero", "Support Agent"]);
     });
-    expect(screen.queryByTestId("pin-agent-dialog-list")).toBeNull();
+    expect(dialogList).toBeInTheDocument();
+    expect(
+      buttonByText("Unpin", commandItemByText(dialogList, "Support Agent")),
+    ).toBeInTheDocument();
+    await expect(
+      screen.findByText("Support Agent pinned"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("reorders pinned agents with drag and drop", async () => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -18,6 +18,7 @@ import {
   Input,
   RunningIndicator,
 } from "@okouai/ui";
+import { toast } from "@okouai/ui/components/ui/sonner";
 import { useTranslation } from "react-i18next";
 import { formatRelativeTimestamp } from "../../i18n/format.ts";
 import { emptySearchImg } from "./platform-assets.ts";
@@ -282,16 +283,19 @@ function AgentCommandPinToggle({
   label,
   icon,
   onToggle,
+  disabled,
 }: {
   readonly label: string;
   readonly icon: ReactNode;
   readonly onToggle: () => void;
+  readonly disabled: boolean;
 }) {
   return (
     <Button
       type="button"
       variant="quiet"
       size="xs"
+      disabled={disabled}
       className="ml-auto shrink-0 gap-1.5 opacity-0 transition-opacity duration-150 group-data-[selected=true]:opacity-100 focus-visible:opacity-100"
       onClick={(e) => {
         e.stopPropagation();
@@ -1694,12 +1698,14 @@ export function PinAgentDialog({
   open,
   onOpenChange,
   subagents,
+  saving,
   onSetAgentPinned,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   subagents: SubagentInfo[];
-  onSetAgentPinned: (agentId: string, pinned: boolean) => void;
+  saving: boolean;
+  onSetAgentPinned: (agentId: string, pinned: boolean) => Promise<void>;
 }) {
   const { t } = useTranslation("agents");
   const query = useGet(pinAgentDialogQuery$);
@@ -1725,9 +1731,26 @@ export function PinAgentDialog({
     return matchedIds.has(agent.id);
   });
 
-  const setAgentPinned = (agentId: string, pinned: boolean) => {
-    onOpenChange(false);
-    onSetAgentPinned(agentId, pinned);
+  const saveAgentPinned = async (agent: SubagentInfo, pinned: boolean) => {
+    await onSetAgentPinned(agent.id, pinned);
+    toast.success(
+      pinned
+        ? t(
+            ($) => {
+              return $.sidebar.pinSuccess;
+            },
+            { agentName: agentDialogLabel(agent) },
+          )
+        : t(
+            ($) => {
+              return $.sidebar.unpinSuccess;
+            },
+            { agentName: agentDialogLabel(agent) },
+          ),
+    );
+  };
+  const setAgentPinned = (agent: SubagentInfo, pinned: boolean) => {
+    detach(saveAgentPinned(agent, pinned), Reason.DomCallback);
   };
   const pinLabel = t(($) => {
     return $.sidebar.addPin;
@@ -1791,8 +1814,9 @@ export function PinAgentDialog({
                 <CommandItem
                   key={agent.id}
                   value={agent.id}
+                  disabled={saving}
                   onSelect={() => {
-                    return setAgentPinned(agent.id, true);
+                    return setAgentPinned(agent, true);
                   }}
                   className="group w-full gap-2 px-1 py-2"
                 >
@@ -1800,8 +1824,9 @@ export function PinAgentDialog({
                   <AgentCommandPinToggle
                     label={pinLabel}
                     icon={<Pin size={16} />}
+                    disabled={saving}
                     onToggle={() => {
-                      return setAgentPinned(agent.id, true);
+                      return setAgentPinned(agent, true);
                     }}
                   />
                 </CommandItem>
@@ -1821,8 +1846,9 @@ export function PinAgentDialog({
                 <CommandItem
                   key={agent.id}
                   value={agent.id}
+                  disabled={saving}
                   onSelect={() => {
-                    return setAgentPinned(agent.id, false);
+                    return setAgentPinned(agent, false);
                   }}
                   className="group w-full gap-2 px-1 py-2"
                 >
@@ -1830,8 +1856,9 @@ export function PinAgentDialog({
                   <AgentCommandPinToggle
                     label={unpinLabel}
                     icon={<PinOff size={16} />}
+                    disabled={saving}
                     onToggle={() => {
-                      return setAgentPinned(agent.id, false);
+                      return setAgentPinned(agent, false);
                     }}
                   />
                 </CommandItem>

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -445,7 +445,7 @@ function PinAgentDialogContainer() {
   const onOpenChange = useSet(setPinAgentDialogOpen$);
   const subagents = useLastResolved(subagents$) ?? [];
   const pageSignal = useGet(pageSignal$);
-  const [, saveAgentPinned] = useLoadableSet(setAgentPinned$);
+  const [pinLoadable, saveAgentPinned] = useLoadableSet(setAgentPinned$);
 
   if (!open) {
     return null;
@@ -456,11 +456,9 @@ function PinAgentDialogContainer() {
       open
       onOpenChange={onOpenChange}
       subagents={subagents}
+      saving={pinLoadable.state === "loading"}
       onSetAgentPinned={(agentId, pinned) => {
-        detach(
-          saveAgentPinned({ agentId, pinned }, pageSignal),
-          Reason.DomCallback,
-        );
+        return saveAgentPinned({ agentId, pinned }, pageSignal);
       }}
     />
   );


### PR DESCRIPTION
## Summary

- keep the three-column pin agent dialog open after pin and unpin actions
- show localized success toasts and update the Pinned/Others sections in place
- preserve and verify persisted drag-and-drop ordering for pinned agents

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t "pin dialog|grid pin entry|reorders pinned agents"` (4 passed)

Full local Vitest was not run per repository guidance.
