### PR TITLE
test: stabilize auth v2 playwright session and navigation races

### DIFF
--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -267,10 +267,11 @@ test("existing sessions continue without exposing organization creation", async 
   await page.goto("/_/skeleton", { waitUntil: "domcontentloaded" });
   await page.waitForFunction(() => Boolean(window.Clerk?.loaded));
   await clerk.signIn({ emailAddress: identity.email, page });
+  await waitForSignedInAccount(page, identity.email);
 
   await openAuthV2(page, authUrl("/v2/sign-in", redirect));
   const account = authV2Root(page).getByRole("button", {
-    name: /Auth Browser/i,
+    name: identity.email,
   });
   await expect(account).toBeVisible();
   await expectStepAnnouncement(page);
@@ -493,19 +494,38 @@ async function waitForActivatedSessionOrRedirect(
   page: Page,
   redirect: URL,
 ): Promise<void> {
-  await expect
-    .poll(async () => {
-      if (new URL(page.url()).pathname === redirect.pathname) {
-        return "activated";
-      }
-      return await page.evaluate(() => {
-        return window.Clerk?.client?.signUp.status === "complete" &&
-          window.Clerk.session
-          ? "activated"
-          : "pending";
-      });
-    })
-    .toBe("activated");
+  await page.waitForFunction(
+    (redirectPathname) => {
+      return (
+        window.location.pathname === redirectPathname ||
+        Boolean(
+          window.Clerk?.client?.signUp.status === "complete" &&
+            window.Clerk.session,
+        )
+      );
+    },
+    redirect.pathname,
+    { timeout: 5_000 },
+  );
+}
+
+async function waitForSignedInAccount(
+  page: Page,
+  emailAddress: string,
+): Promise<void> {
+  await page.waitForFunction(
+    (expectedEmailAddress) => {
+      return Boolean(
+        window.Clerk?.client?.signedInSessions.some(
+          (session) =>
+            session.user.primaryEmailAddress?.emailAddress ===
+            expectedEmailAddress,
+        ),
+      );
+    },
+    emailAddress,
+    { timeout: 5_000 },
+  );
 }
 
 function organizationButton(page: Page, organizationName: string): Locator {


### PR DESCRIPTION
## Summary

- Wait for the fixture-created Clerk identity to appear in `signedInSessions` before Auth v2 snapshots existing accounts.
- Locate the continuation account by the fixture's unique email instead of display-name metadata that may still be loading.
- Replace the navigation-sensitive sign-up poll with a rerunnable `waitForFunction` predicate that survives redirect document changes.

## Root cause

The existing-session test crossed the Clerk helper boundary before the session collection and identity metadata consumed by Auth v2 were guaranteed to be observable. Separately, the progressive sign-up test read the page URL and then called `page.evaluate`; a redirect between those operations destroyed the execution context and failed the poll.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (39 passed)
- `cd e2e && pnpm dlx prettier@3.6.2 --check playwright/tests/auth-v2.spec.ts`
- Auth v2 Playwright discovery (19 tests)
- PR `cli-e2e-02-playwright (auth-v2)` (19 passed, including both changed synchronization paths)

The overall Turbo run remains blocked by unrelated `create Clerk user failed with HTTP 403` errors in the features and paid-onboarding global setup. A failed-jobs rerun reproduced those provider-boundary failures; the target Auth v2 lane is green.

Closes #29562
