### PR TITLE
refactor(api): report machine secret alias source at startup

### DIFF
--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -1,8 +1,13 @@
+import { createHash } from "node:crypto";
+
+import { EVENT } from "@axiomhq/logging";
 import {
   apiNamespaceAliasPaths,
   brandedApiNamespace,
 } from "@okouai/api-contracts/contracts/api-namespaces";
+import { billingRedeemCodeContract } from "@okouai/api-contracts/contracts/billing";
 
+import { optionalEnv } from "../lib/env";
 import { ROUTES } from "../signals/route";
 import {
   assertUniqueRouteRegistrations,
@@ -10,9 +15,39 @@ import {
   withApiNamespaceAliases,
   withMigratedBrandedPaths,
 } from "../signals/route-entry";
+import { getApiTestMocks } from "./mocks";
 
 const CANONICAL_PREFIX = "/api/okou";
 const LEGACY_PREFIX = "/api/zero";
+const MACHINE_SECRET_ALIAS_RESOLUTION_EVENT =
+  "billing_machine_secret_alias_resolution";
+const MACHINE_SECRET_LOG_CONTEXT = "api:zero:billing-redeem-code";
+const legacyMachineSecret = optionalEnv("VM0_MACHINE_SECRET_KEY");
+if (!legacyMachineSecret) {
+  throw new Error("Expected the API test machine secret fixture");
+}
+
+const apiTestMocks = getApiTestMocks();
+const machineSecretInitializationInfoCalls =
+  apiTestMocks.axiomLogging.info.mock.calls.filter(([message]) => {
+    return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+  });
+const machineSecretInitializationWarnCalls =
+  apiTestMocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+    return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
+  });
+
+function expectValueFree(diagnostics: string, value: string): void {
+  const forbiddenDerivatives = [
+    value,
+    String(value.length),
+    createHash("sha256").update(value).digest("hex"),
+    JSON.stringify(value),
+  ];
+  for (const derivative of forbiddenDerivatives) {
+    expect(diagnostics).not.toContain(derivative);
+  }
+}
 
 // The six legacy `/api/zero/**` paths this service still owes a caller after
 // #28701, keyed by the canonical `/api/okou/**` path. Restated here rather than
@@ -115,6 +150,35 @@ function brandedRouteSource(): RouteEntry {
 function brandedPath(neutralPath: string): string {
   return `${CANONICAL_PREFIX}${neutralPath.slice("/api".length)}`;
 }
+
+describe("API route bundle initialization", () => {
+  it("reports the machine secret source without changing the redeem route", () => {
+    expect(machineSecretInitializationInfoCalls).toStrictEqual([
+      [
+        MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,
+        {
+          [EVENT]: { source: "api" },
+          source: "legacy-only",
+          context: MACHINE_SECRET_LOG_CONTEXT,
+        },
+      ],
+    ]);
+    expect(machineSecretInitializationWarnCalls).toStrictEqual([]);
+    expectValueFree(
+      JSON.stringify(machineSecretInitializationInfoCalls),
+      legacyMachineSecret,
+    );
+
+    expect(
+      ROUTES.filter(({ route }) => {
+        return (
+          route.method === billingRedeemCodeContract.create.method &&
+          route.path === billingRedeemCodeContract.create.path
+        );
+      }),
+    ).toHaveLength(1);
+  });
+});
 
 // Per-endpoint behaviour is covered through the endpoints themselves. This
 // file asserts the properties no single endpoint can express: over the whole

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -70,7 +70,10 @@ import { billingCreditCheckoutRoutes } from "./routes/billing-credit-checkout";
 import { billingDowngradeRoutes } from "./routes/billing-downgrade";
 import { billingInvoicesRoutes } from "./routes/billing-invoices";
 import { billingPortalRoutes } from "./routes/billing-portal";
-import { billingRedeemCodeRoutes } from "./routes/billing-redeem-code";
+import {
+  billingRedeemCodeRoutes,
+  reportMachineSecretAliasSourceAtProcessInitialization,
+} from "./routes/billing-redeem-code";
 import { billingRedeemRoutes } from "./routes/billing-redeem";
 import { billingRestoreRoutes } from "./routes/billing-restore";
 import { billingStatusRoutes } from "./routes/billing-status";
@@ -194,6 +197,8 @@ import { voiceIoSttRoutes } from "./routes/voice-io-stt";
 import { videoIoGenerateRoutes } from "./routes/video-io-generate";
 import { webDownloadRoutes } from "./routes/web-download";
 import { webFileUrlRoutes } from "./routes/web-file-url";
+
+reportMachineSecretAliasSourceAtProcessInitialization();
 
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
@@ -9,7 +9,10 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { createRouteMocks } from "./helpers/route-test";
-import { billingRedeemCodeRoutes } from "../billing-redeem-code";
+import {
+  billingRedeemCodeRoutes,
+  reportMachineSecretAliasSourceAtProcessInitialization,
+} from "../billing-redeem-code";
 
 const context = testContext();
 const mocks = createRouteMocks(context);
@@ -133,7 +136,7 @@ describe("POST /api/billing/redeem-code", () => {
     });
   });
 
-  it("reports every machine secret source once per process without exposing values", async () => {
+  it("reports every machine secret source at initialization once per process without exposing values", async () => {
     server.use(
       http.post(`${ATOM_URL}/api/redeem-codes/consume`, () => {
         return HttpResponse.json({ ok: true });
@@ -157,6 +160,9 @@ describe("POST /api/billing/redeem-code", () => {
           return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
         },
       ).length;
+
+      reportMachineSecretAliasSourceAtProcessInitialization();
+      reportMachineSecretAliasSourceAtProcessInitialization();
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const response = await accept(
@@ -536,8 +542,9 @@ describe("POST /api/billing/redeem-code", () => {
       expected: "msk_test_atom_equal_dual",
     },
   ])(
-    "redeems a code with $source machine secret configuration",
+    "redeems a code with $source machine secret configuration after startup observation",
     async ({ canonical, legacy, expected }) => {
+      reportMachineSecretAliasSourceAtProcessInitialization();
       mockOptionalEnv("OKOU_MACHINE_SECRET_KEY", canonical);
       mockOptionalEnv("VM0_MACHINE_SECRET_KEY", legacy);
       const fixture = setAdminSession();

--- a/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
@@ -112,6 +112,10 @@ function resolveMachineSecretKey(): MachineSecretKeyResolution {
   return { source: "conflicting-dual" };
 }
 
+export function reportMachineSecretAliasSourceAtProcessInitialization(): void {
+  reportMachineSecretResolution(resolveMachineSecretKey().source);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }


### PR DESCRIPTION
## Summary

- report the existing machine-secret alias source when the global API route bundle initializes
- resolve only long enough to pass the fixed `source` label to the existing bounded reporter; do not retain, return, or reuse a credential-bearing resolution
- preserve the redeem route's authorization ordering, fail-closed behavior, and request-time resolution immediately before Clerk M2M token creation

## Verification

- focused API tests: 28 passed across `billing-redeem-code.test.ts` and the global `ROUTES` regression in `api-namespace-compatibility.test.ts`
- locked Prettier check for all four changed TypeScript files
- focused Oxlint and ESLint for all four changed TypeScript files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check origin/main...HEAD`
- full caller and semantic searches confirmed that writers, schemas, aliases, event shape, billing flow, and external configuration are unchanged

## Open PR audit

- refreshed at `2026-08-26T08:23:18Z` against `main@f42bc1a5677f412f93c79e4525ffa34897b1c8d4`
- fully paginated 37 open PRs and all 434 GitHub-declared changed files; fetched 434 files with zero pagination mismatch
- stale #25722 remains at head `2aed1f0de2a54db881ca266151c1362ea6c9dd62` on base `505aae73170efd5b484599eb7d433f404f5c3d2f`
- its only exact changed-file overlap remains `turbo/apps/api/src/signals/route.ts`; the hunk still only adds two Worker route imports/spreads
- its `env.ts` and `log.ts` Worker-runtime hunks contain no machine-secret, billing-alias, resolver, or reporter references; no new semantic overlap was found
- the five commits that reached `main` after this branch was created are disjoint from the four changed files and the machine-secret scope

## Fallbacks

Revert this PR. The revert removes only the additive API-process initialization observation. It does not require a writer, configuration, schema, alias, billing, or credential rollback because this PR changes none of those contracts; the existing redeem-time resolver and reporter remain the behavioral source of truth.

Closes #29546
Part of #28914 (Wave 51)
