### PR TITLE
feat(chat): expose unread threads to workflows

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-thread-unreads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-thread-unreads.test.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from "node:crypto";
+
+import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
+import {
+  type ChatEvent,
+  chatThreadsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { seedOrgMembership$ } from "./helpers/org-membership";
+import { chatThreadRoutes } from "../chat-threads";
+
+const context = testContext();
+const store = createStore();
+const bdd = createBddApi(context);
+const api = createRunsApi(context);
+const chat = createChatFilesBddApi(context);
+const chatCallbacks = createChatCallbacksApi(context);
+
+interface SeededThread {
+  readonly threadId: string;
+  readonly unreadAt: string;
+}
+
+function orgIdOf(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped actor");
+  }
+  return actor.orgId;
+}
+
+async function seedMembership(actor: ApiTestUser): Promise<void> {
+  await store.set(
+    seedOrgMembership$,
+    { orgId: orgIdOf(actor), userId: actor.userId },
+    context.signal,
+  );
+}
+
+function prepareChatRuntime(): void {
+  api.configureRunnerGroup();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  chatCallbacks.acceptChatObjectStorage();
+  chatCallbacks.disableVapid();
+  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+}
+
+async function createEntitledAgent(
+  actor: ApiTestUser,
+  displayName: string,
+): Promise<string> {
+  await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName,
+    visibility: "private",
+  });
+  return agent.agentId;
+}
+
+function terminalEvent(
+  events: readonly ChatEvent[],
+  runId: string,
+): Extract<ChatEvent, { readonly eventType: "run.cancelled" }> | undefined {
+  return events.find(
+    (
+      event,
+    ): event is Extract<ChatEvent, { readonly eventType: "run.cancelled" }> => {
+      return event.runId === runId && event.eventType === "run.cancelled";
+    },
+  );
+}
+
+async function createCancelledThread(args: {
+  readonly actor: ApiTestUser;
+  readonly agentId: string;
+  readonly prompt: string;
+}): Promise<SeededThread> {
+  const sent = await chat.requestSendEvent(
+    args.actor,
+    { agentId: args.agentId, prompt: args.prompt },
+    [201],
+  );
+  if (sent.status !== 201 || sent.body.runId === null) {
+    throw new Error("Expected the entitled Chat send to create a Run");
+  }
+  await api.requestCancelRun(args.actor, sent.body.runId, [200]);
+  await flushWaitUntilForTest();
+
+  let finished: ReturnType<typeof terminalEvent>;
+  await expect
+    .poll(async () => {
+      const page = await chat.listThreadEvents(args.actor, sent.body.threadId);
+      finished = terminalEvent(page.events, sent.body.runId ?? "");
+      return finished?.createdAt ?? null;
+    })
+    .not.toBeNull();
+  if (!finished) {
+    throw new Error("Expected the cancelled Run to append a terminal event");
+  }
+  return { threadId: sent.body.threadId, unreadAt: finished.createdAt };
+}
+
+function okouToken(args: {
+  readonly actor: ApiTestUser;
+  readonly capabilities: readonly Capability[];
+}): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "okou",
+    userId: args.actor.userId,
+    orgId: orgIdOf(args.actor),
+    runId: randomUUID(),
+    capabilities: [...args.capabilities],
+    iat: seconds,
+    exp: seconds + 600,
+  });
+}
+
+function client() {
+  return setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract);
+}
+
+describe("GET /api/chat-thread-unreads", () => {
+  it("lists canonical unread rows for an Okou token without changing read state", async () => {
+    prepareChatRuntime();
+    const actor = bdd.user();
+    const agentId = await createEntitledAgent(actor, "Unread route agent");
+    const emptyAgent = await bdd.createAgent(actor, {
+      displayName: "Empty unread route agent",
+      visibility: "private",
+    });
+    const unread = await createCancelledThread({
+      actor,
+      agentId,
+      prompt: "Unread route thread",
+    });
+    const read = await createCancelledThread({
+      actor,
+      agentId,
+      prompt: "Read route thread",
+    });
+    await chat.markThreadRead(actor, read.threadId);
+    await seedMembership(actor);
+    const headers = {
+      authorization: `Bearer ${okouToken({
+        actor,
+        capabilities: ["chat-thread:read"],
+      })}`,
+    };
+    const before = {
+      unread: (await chat.readThread(actor, unread.threadId)).lastReadAt,
+      read: (await chat.readThread(actor, read.threadId)).lastReadAt,
+    };
+
+    await expect(chat.listThreadUnreads(actor, agentId)).resolves.toStrictEqual(
+      [unread],
+    );
+    const first = await accept(
+      client().unreads({ headers, query: { agentId } }),
+      [200],
+    );
+    expect(first.body.unreads).toStrictEqual([unread]);
+    const repeated = await accept(
+      client().unreads({ headers, query: { agentId } }),
+      [200],
+    );
+    expect(repeated.body).toStrictEqual(first.body);
+    const empty = await accept(
+      client().unreads({
+        headers,
+        query: { agentId: emptyAgent.agentId },
+      }),
+      [200],
+    );
+    expect(empty.body.unreads).toStrictEqual([]);
+    await expect(
+      chat.readThread(actor, unread.threadId),
+    ).resolves.toMatchObject({ lastReadAt: before.unread });
+    await expect(chat.readThread(actor, read.threadId)).resolves.toMatchObject({
+      lastReadAt: before.read,
+    });
+  });
+
+  it("returns the standard capability error for an Okou token without chat-thread:read", async () => {
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Unread capability agent",
+      visibility: "private",
+    });
+    await seedMembership(actor);
+    const token = okouToken({ actor, capabilities: ["chat-event:read"] });
+
+    const response = await accept(
+      client().unreads({
+        headers: { authorization: `Bearer ${token}` },
+        query: { agentId: agent.agentId },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: chat-thread:read",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("scopes caller-supplied Agent IDs to the token user and organization", async () => {
+    prepareChatRuntime();
+    const owner = bdd.user();
+    const peer = bdd.user({ orgId: orgIdOf(owner) });
+    const otherOrg = bdd.user({ userId: owner.userId });
+    const ownerAgentId = await createEntitledAgent(owner, "Unread owner agent");
+    const peerAgentId = await createEntitledAgent(peer, "Unread peer agent");
+    const otherOrgAgentId = await createEntitledAgent(
+      otherOrg,
+      "Unread other organization agent",
+    );
+    const ownerUnread = await createCancelledThread({
+      actor: owner,
+      agentId: ownerAgentId,
+      prompt: "Owner unread thread",
+    });
+    await createCancelledThread({
+      actor: peer,
+      agentId: peerAgentId,
+      prompt: "Peer unread thread",
+    });
+    await createCancelledThread({
+      actor: otherOrg,
+      agentId: otherOrgAgentId,
+      prompt: "Other organization unread thread",
+    });
+    await seedMembership(owner);
+    await seedMembership(peer);
+    await seedMembership(otherOrg);
+    const headers = {
+      authorization: `Bearer ${okouToken({
+        actor: owner,
+        capabilities: ["chat-thread:read"],
+      })}`,
+    };
+
+    const own = await accept(
+      client().unreads({ headers, query: { agentId: ownerAgentId } }),
+      [200],
+    );
+    expect(own.body.unreads).toStrictEqual([ownerUnread]);
+    for (const agentId of [peerAgentId, otherOrgAgentId, randomUUID()]) {
+      const isolated = await accept(
+        client().unreads({ headers, query: { agentId } }),
+        [200],
+      );
+      expect(isolated.body.unreads).toStrictEqual([]);
+    }
+  });
+});

--- a/turbo/apps/api/src/signals/routes/chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-mark-read.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { and, eq, gt, isNotNull, isNull, or } from "drizzle-orm";
 import { chatThreadMarkReadContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { agents } from "@okouai/db/schema/agent";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -23,16 +24,18 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const [thread] = await writeDb
     .select({
       lastReadAt: chatThreads.lastReadAt,
-      agentId: chatThreads.agentId,
+      agentId: agents.id,
+      orgId: agents.orgId,
     })
     .from(chatThreads)
+    .innerJoin(agents, eq(agents.id, chatThreads.agentId))
     .where(
       and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
     )
     .limit(1);
   signal.throwIfAborted();
 
-  if (!thread?.agentId) {
+  if (!thread) {
     return notFound("Chat thread not found");
   }
   const agentId = thread.agentId;
@@ -41,6 +44,7 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     const unreads = await get(
       chatThreadUnreads({
         userId: auth.userId,
+        orgId: thread.orgId,
         agentId: agentId,
       }),
     );

--- a/turbo/apps/api/src/signals/routes/chat-threads-mark-unread.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-mark-unread.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { chatThreadMarkUnreadContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { agents } from "@okouai/db/schema/agent";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -21,17 +22,19 @@ const markUnreadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const [thread] = await writeDb
     .update(chatThreads)
     .set({ lastReadAt: null })
+    .from(agents)
     .where(
       and(
         eq(chatThreads.id, params.id),
         eq(chatThreads.userId, auth.userId),
+        eq(agents.id, chatThreads.agentId),
         isNotNull(chatThreads.agentId),
       ),
     )
-    .returning({ agentId: chatThreads.agentId });
+    .returning({ agentId: agents.id, orgId: agents.orgId });
   signal.throwIfAborted();
 
-  if (!thread?.agentId) {
+  if (!thread) {
     return notFound("Chat thread not found");
   }
 
@@ -45,6 +48,7 @@ const markUnreadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const unreads = await get(
     chatThreadUnreads({
       userId: auth.userId,
+      orgId: thread.orgId,
       agentId: thread.agentId,
     }),
   );

--- a/turbo/apps/api/src/signals/routes/chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads.ts
@@ -314,12 +314,13 @@ const listChatThreadDraftsInner$ = computed(async (get) => {
 });
 
 const listChatThreadUnreadsInner$ = computed(async (get) => {
-  const auth = get(authContext$);
+  const auth = get(organizationAuthContext$);
   const query = get(queryOf(chatThreadsContract.unreads));
 
   const unreads = await get(
     chatThreadUnreads({
       userId: auth.userId,
+      orgId: auth.orgId,
       agentId: query.agentId,
     }),
   );
@@ -417,7 +418,14 @@ export const chatThreadRoutes: readonly RouteEntry[] = [
   },
   {
     route: chatThreadsContract.unreads,
-    handler: authRoute({}, listChatThreadUnreadsInner$),
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "chat-thread:read",
+      },
+      listChatThreadUnreadsInner$,
+    ),
   },
   {
     route: chatThreadByIdContract.get,

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -319,6 +319,7 @@ export function chatThreadDetail(args: {
  */
 export function chatThreadUnreads(args: {
   readonly userId: string;
+  readonly orgId: string;
   readonly agentId: string;
 }): Computed<Promise<readonly { threadId: string; unreadAt: string }[]>> {
   return computed(async (get) => {
@@ -330,10 +331,12 @@ export function chatThreadUnreads(args: {
         unreadAt: lastRunFinish.createdAt,
       })
       .from(chatThreads)
+      .innerJoin(agents, eq(agents.id, chatThreads.agentId))
       .crossJoinLateral(lastRunFinish)
       .where(
         and(
           eq(chatThreads.userId, args.userId),
+          eq(agents.orgId, args.orgId),
           eq(chatThreads.agentId, args.agentId),
           or(
             isNull(chatThreads.lastReadAt),

--- a/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
@@ -14,6 +14,7 @@ const OTHER_AGENT_ID = "00000000-0000-4000-8000-000000000102";
 const THREAD_ID = "00000000-0000-4000-8000-000000000201";
 const SECOND_THREAD_ID = "00000000-0000-4000-8000-000000000202";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000203";
+const THIRD_THREAD_ID = "00000000-0000-4000-8000-000000000204";
 const INITIAL_EVENT_ID = "00000000-0000-4000-8000-000000000301";
 const RENAME_EVENT_ID = "00000000-0000-4000-8000-000000000302";
 const SORT_EVENT_ID = "00000000-0000-4000-8000-000000000303";
@@ -24,6 +25,7 @@ const SORT_SEQ_ID = 3;
 const REFRESH_SEQ_ID = 4;
 const SNAPSHOT_URL = "http://localhost:3000/api/chat-threads/snapshot";
 const EVENTS_URL = "http://localhost:3000/api/chat-threads/events";
+const UNREADS_URL = "http://localhost:3000/api/chat-thread-unreads";
 
 function okouToken(): string {
   const payload = Buffer.from(
@@ -69,6 +71,23 @@ function event(options: {
     ...options,
     selectedModel: null,
   };
+}
+
+function mockStableThreadSnapshot(
+  threads: readonly ReturnType<typeof snapshotThread>[],
+): void {
+  server.use(
+    http.get(SNAPSHOT_URL, () => {
+      return HttpResponse.json({
+        chatThreads: threads,
+        latestEventId: INITIAL_EVENT_ID,
+        latestSeqId: INITIAL_SEQ_ID,
+      });
+    }),
+    http.get(EVENTS_URL, () => {
+      return HttpResponse.json({ events: [], hasMore: false });
+    }),
+  );
 }
 
 describe("okou chat list command", () => {
@@ -313,6 +332,237 @@ describe("okou chat list command", () => {
         ],
       },
     );
+  });
+
+  it("filters unread threads before the limit and orders equal timestamps deterministically", async () => {
+    const unreadAt = "2026-07-24T06:00:00.000Z";
+    mockStableThreadSnapshot([
+      snapshotThread({
+        id: THIRD_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Newest but read",
+        sortAt: "2026-07-24T07:00:00.000Z",
+      }),
+      snapshotThread({
+        id: THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Unread one",
+        sortAt: "2026-07-24T03:00:00.000Z",
+      }),
+      snapshotThread({
+        id: SECOND_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Unread two",
+        sortAt: "2026-07-24T02:00:00.000Z",
+      }),
+      snapshotThread({
+        id: OTHER_THREAD_ID,
+        agentId: OTHER_AGENT_ID,
+        title: "Other agent unread",
+        sortAt: "2026-07-24T08:00:00.000Z",
+      }),
+    ]);
+    let unreadRequests = 0;
+    server.use(
+      http.get(UNREADS_URL, ({ request }) => {
+        unreadRequests++;
+        expect(new URL(request.url).searchParams.get("agentId")).toBe(AGENT_ID);
+        return HttpResponse.json({
+          unreads: [
+            { threadId: THREAD_ID, unreadAt },
+            { threadId: SECOND_THREAD_ID, unreadAt },
+            {
+              threadId: OTHER_THREAD_ID,
+              unreadAt: "2026-07-24T09:00:00.000Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await chatCommand.parseAsync([
+      "node",
+      "cli",
+      "list",
+      "--unread",
+      "--limit",
+      "1",
+      "--json",
+    ]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        agentId: AGENT_ID,
+        total: 2,
+        threads: [
+          expect.objectContaining({
+            id: SECOND_THREAD_ID,
+            agentId: AGENT_ID,
+            unreadAt,
+          }),
+        ],
+      },
+    );
+
+    mockConsoleLog.mockClear();
+    await chatCommand.parseAsync([
+      "node",
+      "cli",
+      "list",
+      "--agent",
+      AGENT_ID,
+      "--unread",
+      "--limit",
+      "2",
+    ]);
+    const humanOutput = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(humanOutput).toContain("UNREAD AT");
+    expect(humanOutput).toContain("2026-07-24T06:00:00Z");
+    expect(humanOutput.indexOf(SECOND_THREAD_ID)).toBeLessThan(
+      humanOutput.indexOf(THREAD_ID),
+    );
+    expect(unreadRequests).toBe(2);
+  });
+
+  it("fans unread requests across snapshot agents with bounded concurrency", async () => {
+    const agentIds = Array.from({ length: 6 }, (_, index) => {
+      return `00000000-0000-4000-8000-${String(110 + index).padStart(12, "0")}`;
+    });
+    const threads = agentIds.map((agentId, index) => {
+      return snapshotThread({
+        id: `00000000-0000-4000-8000-${String(210 + index).padStart(12, "0")}`,
+        agentId,
+        title: `Agent ${index}`,
+        sortAt: new Date(
+          Date.parse("2026-07-24T01:00:00.000Z") + index * 1000,
+        ).toISOString(),
+      });
+    });
+    mockStableThreadSnapshot(threads);
+    const threadByAgent = new Map(
+      threads.map((thread) => {
+        return [thread.agentId, thread] as const;
+      }),
+    );
+    const requestedAgentIds = new Set<string>();
+    let requestCount = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    let releaseRequests: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    server.use(
+      http.get(UNREADS_URL, async ({ request }) => {
+        const url = new URL(request.url);
+        expect([...url.searchParams.keys()]).toStrictEqual(["agentId"]);
+        const agentId = url.searchParams.get("agentId");
+        if (!agentId) {
+          throw new Error("Expected an unread request agentId");
+        }
+        const thread = threadByAgent.get(agentId);
+        if (!thread) {
+          throw new Error(`Unexpected unread request for ${agentId}`);
+        }
+        requestedAgentIds.add(agentId);
+        requestCount += 1;
+        activeRequests += 1;
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+        if (requestCount <= 4) {
+          await requestGate;
+        }
+        activeRequests -= 1;
+        return HttpResponse.json({
+          unreads: [{ threadId: thread.id, unreadAt: thread.sortAt }],
+        });
+      }),
+    );
+
+    const parsing = chatCommand.parseAsync([
+      "node",
+      "cli",
+      "list",
+      "--unread",
+      "--all-agents",
+      "--json",
+    ]);
+    await expect
+      .poll(() => {
+        return requestCount;
+      })
+      .toBeGreaterThanOrEqual(4);
+    const firstWaveRequests = requestCount;
+    if (!releaseRequests) {
+      throw new Error("Expected the unread request gate to be initialized");
+    }
+    releaseRequests();
+    await parsing;
+
+    expect(firstWaveRequests).toBe(4);
+    expect(maxActiveRequests).toBe(4);
+    expect(requestedAgentIds).toStrictEqual(new Set(agentIds));
+    const output = JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])) as {
+      readonly allAgents: boolean;
+      readonly total: number;
+      readonly threads: readonly {
+        readonly id: string;
+        readonly agentId: string;
+        readonly unreadAt: string;
+      }[];
+    };
+    expect(output.allAgents).toBe(true);
+    expect(output.total).toBe(6);
+    expect(output.threads).toHaveLength(6);
+    expect(output.threads[0]).toMatchObject({
+      id: threads.at(-1)?.id,
+      agentId: threads.at(-1)?.agentId,
+      unreadAt: threads.at(-1)?.sortAt,
+    });
+  });
+
+  it("rejects --all-agents with --agent", async () => {
+    await expect(async () => {
+      await chatCommand.parseAsync([
+        "node",
+        "cli",
+        "list",
+        "--all-agents",
+        "--agent",
+        AGENT_ID,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("--all-agents and --agent are mutually exclusive");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps human output unchanged without new flags and reports empty unread results", async () => {
+    mockStableThreadSnapshot([
+      snapshotThread({
+        id: THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Existing human row",
+        sortAt: "2026-07-24T03:00:00.000Z",
+      }),
+    ]);
+    server.use(
+      http.get(UNREADS_URL, () => {
+        return HttpResponse.json({ unreads: [] });
+      }),
+    );
+
+    await chatCommand.parseAsync(["node", "cli", "list"]);
+    const existingOutput = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(existingOutput).toContain("THREAD ID");
+    expect(existingOutput).toContain("SORTED");
+    expect(existingOutput).toContain("PINNED");
+    expect(existingOutput).not.toContain("UNREAD AT");
+    expect(existingOutput).not.toContain("AGENT ID");
+
+    mockConsoleLog.mockClear();
+    await chatCommand.parseAsync(["node", "cli", "list", "--unread"]);
+    expect(mockConsoleLog).toHaveBeenCalledWith("No unread chat threads found");
   });
 
   it("requires an agent id from --agent or OKOU_AGENT_ID", async () => {

--- a/turbo/apps/cli/src/commands/chat/list.ts
+++ b/turbo/apps/cli/src/commands/chat/list.ts
@@ -1,7 +1,9 @@
 import chalk from "chalk";
 import { Command } from "commander";
+import type { EventDrivenChatThread } from "@okouai/core/chat-thread-event-replay";
 
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { listChatThreadUnreads } from "../../lib/api/domains/chat";
 import { formatIsoTimestamp } from "../../lib/utils/time-format";
 import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
 import { isUuid } from "../../lib/utils/uuid";
@@ -10,12 +12,19 @@ import { syncCachedChatThreads } from "./chat-thread-cache";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
+const MAX_UNREAD_REQUEST_CONCURRENCY = 4;
 
 interface ListOptions {
   readonly agent?: string;
+  readonly allAgents?: boolean;
   readonly json?: boolean;
   readonly limit?: string;
+  readonly unread?: boolean;
 }
+
+type UnreadChatThread = EventDrivenChatThread & {
+  readonly unreadAt: string;
+};
 
 function printUsageError(message: string, hint: string): never {
   console.error(chalk.red(`✗ ${message}`));
@@ -44,11 +53,57 @@ function titleForDisplay(title: string | null): string {
   return (title ?? "(untitled)").replace(/\s+/g, " ");
 }
 
+async function unreadTimestampsByThread(
+  agentIds: readonly string[],
+): Promise<ReadonlyMap<string, string>> {
+  const unreadTimestamps = new Map<string, string>();
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < agentIds.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const agentId = agentIds[index];
+      if (agentId === undefined) {
+        throw new Error(`Unread agent ${index} is missing`);
+      }
+      const unreads = await listChatThreadUnreads({ agentId });
+      for (const unread of unreads) {
+        unreadTimestamps.set(unread.threadId, unread.unreadAt);
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(MAX_UNREAD_REQUEST_CONCURRENCY, agentIds.length),
+      },
+      async () => {
+        await worker();
+      },
+    ),
+  );
+  return unreadTimestamps;
+}
+
+function compareUnreadThreads(
+  left: UnreadChatThread,
+  right: UnreadChatThread,
+): number {
+  return (
+    right.unreadAt.localeCompare(left.unreadAt) ||
+    right.id.localeCompare(left.id)
+  );
+}
+
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List web chat threads for an agent")
+  .description("List web chat threads")
   .option("--agent <id>", "Filter by agent ID (defaults to OKOU_AGENT_ID)")
+  .option("--all-agents", "List threads across all agents in the current org")
+  .option("--unread", "List only canonical unread threads")
   .option(
     "--limit <n>",
     `Maximum number of threads to print (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})`,
@@ -60,31 +115,72 @@ export const listCommand = new Command()
 Examples:
   List this agent's chats:  okou chat list
   List another agent:       okou chat list --agent <agent-id>
+  List unread chats:        okou chat list --unread
+  Unread across all agents: okou chat list --unread --all-agents
   Limit the output:         okou chat list --limit 10
   Print JSON:               okou chat list --json
 
 Notes:
   - Defaults --agent to OKOU_AGENT_ID
-  - Authenticates via OKOU_TOKEN (requires chat-thread:read capability)
+  - --all-agents and --agent are mutually exclusive
+  - Listing and --unread require chat-thread:read
+  - Reading a selected thread with okou chat messages requires chat-event:read
+  - Authenticates via OKOU_TOKEN
   - Replays cached snapshot and incremental chat thread events`,
   )
   .action(
     withErrorHandler(async (options: ListOptions) => {
-      const agentId = resolveAgentId(options.agent);
+      if (options.allAgents && options.agent !== undefined) {
+        printUsageError(
+          "--all-agents and --agent are mutually exclusive",
+          "Choose one agent with --agent, or omit it to list all agents.",
+        );
+      }
+      const agentId = options.allAgents
+        ? undefined
+        : resolveAgentId(options.agent);
       const limit =
         options.limit === undefined
           ? DEFAULT_LIMIT
           : parseBoundedLogCount(options.limit, "--limit", 1, MAX_LIMIT);
       const allThreads = await syncCachedChatThreads();
-      const matchingThreads = allThreads.filter((thread) => {
-        return thread.agentId === agentId;
-      });
+      const agentThreads =
+        agentId === undefined
+          ? allThreads
+          : allThreads.filter((thread) => {
+              return thread.agentId === agentId;
+            });
+      let matchingThreads: readonly (
+        | EventDrivenChatThread
+        | UnreadChatThread
+      )[];
+      if (options.unread) {
+        const unreadTimestamps = await unreadTimestampsByThread(
+          agentId === undefined
+            ? [
+                ...new Set(
+                  agentThreads.map((thread) => {
+                    return thread.agentId;
+                  }),
+                ),
+              ]
+            : [agentId],
+        );
+        matchingThreads = agentThreads
+          .flatMap((thread): UnreadChatThread[] => {
+            const unreadAt = unreadTimestamps.get(thread.id);
+            return unreadAt === undefined ? [] : [{ ...thread, unreadAt }];
+          })
+          .sort(compareUnreadThreads);
+      } else {
+        matchingThreads = agentThreads;
+      }
       const threads = matchingThreads.slice(0, limit);
 
       if (options.json) {
         console.log(
           JSON.stringify({
-            agentId,
+            ...(agentId === undefined ? { allAgents: true } : { agentId }),
             total: matchingThreads.length,
             threads,
           }),
@@ -93,12 +189,20 @@ Notes:
       }
 
       if (threads.length === 0) {
-        console.log(chalk.dim("No chat threads found"));
+        console.log(
+          chalk.dim(
+            options.unread
+              ? "No unread chat threads found"
+              : "No chat threads found",
+          ),
+        );
         return;
       }
 
       const header = [
         "THREAD ID".padEnd(38),
+        ...(options.allAgents ? ["AGENT ID".padEnd(38)] : []),
+        ...(options.unread ? ["UNREAD AT".padEnd(20)] : []),
         "SORTED".padEnd(20),
         "PINNED".padEnd(6),
         "TITLE",
@@ -108,6 +212,10 @@ Notes:
         console.log(
           [
             thread.id.padEnd(38),
+            ...(options.allAgents ? [thread.agentId.padEnd(38)] : []),
+            ...("unreadAt" in thread
+              ? [formatIsoTimestamp(thread.unreadAt).padEnd(20)]
+              : []),
             formatIsoTimestamp(thread.sortAt).padEnd(20),
             (thread.pinnedAt === null ? "-" : "yes").padEnd(6),
             titleForDisplay(thread.title),

--- a/turbo/apps/cli/src/lib/api/domains/chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/chat.ts
@@ -30,6 +30,11 @@ export interface ChatThreadSnapshot {
   readonly latestSeqId: number | null;
 }
 
+interface ChatThreadUnread {
+  readonly threadId: string;
+  readonly unreadAt: string;
+}
+
 export type ChatThreadEvent = ApiChatThreadEvent;
 
 interface ZeroChatEventSnapshotDownload {
@@ -149,6 +154,20 @@ export async function listChatThreadEvents(options: {
     return { kind: "expired" };
   }
   handleError(result, "Failed to list chat thread events");
+}
+
+export async function listChatThreadUnreads(options: {
+  agentId: string;
+}): Promise<readonly ChatThreadUnread[]> {
+  const config = await getClientConfig();
+  const client = initClient(chatThreadsContract, config);
+  const result = await client.unreads({
+    query: { agentId: options.agentId },
+  });
+  if (result.status === 200) {
+    return result.body.unreads;
+  }
+  handleError(result, "Failed to list unread chat threads");
 }
 
 export async function createChatThread(options: {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1219,6 +1219,7 @@ export const chatThreadsContract = c.router({
     responses: {
       200: chatThreadUnreadsSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary:
       "List the caller's unread chat threads under an agent, each with the timestamp of the message that made it unread.",


### PR DESCRIPTION
## Summary

- authorize the existing per-Agent unread route with `chat-thread:read` and scope results by authenticated user, organization, and Agent
- add `okou chat list --unread` and `--all-agents` using bounded fan-out to the backward-compatible unread endpoint
- preserve existing list output without the new flags and cover capability, isolation, no-mutation, filtering, ordering, and output behavior

## Compatibility

- preserves the required `agentId` request and `{ unreads: [{ threadId, unreadAt }] }` success response
- keeps existing App/PAT behavior for organization-scoped callers and keeps new CLI requests compatible with an older API
- adds no schema, migration, feature switch, capability, message content, or read-state mutation

## Verification

- `pnpm exec prettier --check` on all touched files
- `pnpm turbo run lint --filter=api --filter=@okouai/cli --filter=@okouai/api-contracts --concurrency=1 --log-order=grouped`
- `pnpm knip`
- `pnpm turbo run check-types --filter=api --filter=@okouai/cli --filter=@okouai/api-contracts --concurrency=1 --log-order=grouped`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-thread-unreads.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-files.bdd.test.ts -t 'creates, mutates, searches, and deletes a thread through visible APIs'`
- `pnpm --filter @okouai/cli exec vitest run src/commands/chat/__tests__/list.test.ts`

Closes #29521
