### PR TITLE
fix(runner): report unavailable best-effort timezones

### DIFF
--- a/crates/guest-reseed/src/lib.rs
+++ b/crates/guest-reseed/src/lib.rs
@@ -323,7 +323,10 @@ where
     };
     match timezone_fn(timezone) {
         Ok(true) => 0,
-        Ok(false) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => 0,
+        Ok(false) if restore.timezone_mode == RestoreTimezoneMode::BestEffort => {
+            let _ = writeln!(stderr, "{TIMEZONE_UNAVAILABLE_MARKER}");
+            0
+        }
         Ok(false) => {
             let _ = writeln!(stderr, "{TIMEZONE_UNAVAILABLE_MARKER}");
             1
@@ -607,7 +610,12 @@ mod tests {
     fn restore_mode_preserves_required_and_best_effort_timezone_failures() {
         let entropy = [5u8; RESTORE_ENTROPY_BYTES];
         for (mode, timezone_result, expected_code, marker) in [
-            ("best-effort", Ok(false), 0, None),
+            (
+                "best-effort",
+                Ok(false),
+                0,
+                Some(TIMEZONE_UNAVAILABLE_MARKER),
+            ),
             (
                 "best-effort",
                 Err(io::Error::other("write denied")),

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -76,7 +76,9 @@ fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {
 }
 
 fn log_embedded_timezone_failure(run_id: RunId, tz: &str, result: &sandbox::ExecResult) {
-    if !stderr_contains_marker(result, TIMEZONE_SYNC_FAILED_MARKER) {
+    if !stderr_contains_marker(result, TIMEZONE_SYNC_FAILED_MARKER)
+        && !stderr_contains_marker(result, TIMEZONE_UNAVAILABLE_MARKER)
+    {
         return;
     }
 

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -181,6 +181,54 @@ async fn restore_guest_state_logs_embedded_timezone_failure_without_failing_rest
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn restore_guest_state_logs_unavailable_best_effort_timezone_without_failing_restore() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        Vec::new(),
+        b"guest timezone unavailable".to_vec(),
+    )));
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("Mars/Olympus".into());
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+
+    restore_guest_state(&sandbox, &ctx).await.unwrap();
+
+    let events = captured.entries();
+    let event = events
+        .iter()
+        .find(|event| {
+            event.level == Level::WARN
+                && event.fields.get("message").map(String::as_str)
+                    == Some("failed to set guest timezone")
+        })
+        .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+    let run_id = RunId::nil().to_string();
+    assert_eq!(
+        event.fields.get("run_id").map(String::as_str),
+        Some(run_id.as_str())
+    );
+    assert_eq!(
+        event.fields.get("tz").map(String::as_str),
+        Some("Mars/Olympus")
+    );
+    assert_eq!(
+        event.fields.get("termination").map(String::as_str),
+        Some("exited")
+    );
+    assert!(
+        event
+            .fields
+            .get("stderr_excerpt")
+            .is_some_and(|value| value.contains("guest timezone unavailable")),
+        "event={event:#?}"
+    );
+}
+
 #[tokio::test]
 async fn restore_guest_state_propagates_exec_error() {
     let sandbox = MockSandbox::new("test");


### PR DESCRIPTION
## Summary

- emit the existing unavailable marker when a best-effort guest timezone is missing while preserving exit code 0
- recognize unavailable and synchronization-failure markers in the runner's successful best-effort restore path
- record the existing warning with run ID, requested timezone, termination, and bounded stderr context
- preserve required-mode unavailable timezone failure behavior

## Compatibility

- no API, database, queue, persisted-state, or wire-format changes
- runner and bundled guest-reseed producer deploy in the same runner artifact
- no feature switch or migration required

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-reseed --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-reseed --all-features --no-deps`
- `cargo test -p guest-reseed` (14 passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner executor::tests::guest_state_tests` (20 passed)
- `cargo test -p runner` (3320 passed, 24 ignored; guest inventory 1 passed)
- pre-commit Rust formatting, rustdoc, Clippy, file-size, and commit-message checks

Closes #29543
