### PR TITLE
test(python): cover uncompressed websocket after deflate negotiation

### DIFF
--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
@@ -1063,6 +1063,73 @@ async def test_compressed_fragmented_message_limits_are_cumulative(
         )
 
 
+@pytest.mark.parametrize("from_client", [True, False])
+async def test_uncompressed_message_after_deflate_negotiation_clears_state(
+    tmp_path: Path,
+    from_client: bool,
+) -> None:
+    contents = [b"uncompressed", b"compressed"]
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        running = await _start_websocket(
+            addon_context,
+            permessage_deflate=_PERMESSAGE_DEFLATE,
+        )
+        source = _bounded_source_websocket(running, from_client=from_client)
+        assert len(source._vm0_bounded_deflates) == 1
+        bounded_deflate = source._vm0_bounded_deflates[0]
+
+        uncompressed_frame = _peer(from_client=from_client).send(_message_event(contents[0]))
+        assert uncompressed_frame[0] & 0x40 == 0
+        uncompressed = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                _source_connection(running, from_client=from_client),
+                uncompressed_frame,
+            ),
+        )
+
+        assert len(_message_hooks(uncompressed)) == 1
+        assert len(_data_sends(uncompressed)) == 1
+        assert running.flow.websocket is not None
+        assert running.flow.websocket.timestamp_end is None
+        assert [message.content for message in running.flow.websocket.messages] == contents[:1]
+        assert sum(len(fragment) for fragment in source.frame_buf) == 0
+        assert bounded_deflate._decompressor is None
+        assert bounded_deflate._inbound_compressed is None
+        assert source._vm0_message_limit._budget.decoded_bytes == 0
+        assert source._vm0_message_limit._budget.data_frames == 0
+
+        compressed_frame = _peer(
+            from_client=from_client,
+            permessage_deflate=_PERMESSAGE_DEFLATE,
+        ).send(_message_event(contents[1]))
+        assert compressed_frame[0] & 0x40 == 0x40
+        compressed = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                _source_connection(running, from_client=from_client),
+                compressed_frame,
+            ),
+        )
+
+    assert len(_message_hooks(compressed)) == 1
+    assert len(_data_sends(compressed)) == 1
+    assert running.flow.websocket is not None
+    assert running.flow.websocket.timestamp_end is None
+    assert [message.content for message in running.flow.websocket.messages] == contents
+    assert sum(len(fragment) for fragment in source.frame_buf) == 0
+    assert bounded_deflate._decompressor is not None
+    assert bounded_deflate._inbound_compressed is None
+    assert source._vm0_message_limit._budget.decoded_bytes == 0
+    assert source._vm0_message_limit._budget.data_frames == 0
+
+
 async def test_compression_preserves_context_takeover_and_is_connection_local(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- cover uncompressed WebSocket data after `permessage-deflate` negotiation through the real mitmproxy/wsproto pipeline
- exercise client-to-server and server-to-client traffic, then send a compressed message on the same flow
- assert RSV1 framing, exact delivery, hooks, forwarding, and released per-message accounting/state

## Scope

- test-only change; no production behavior, dependency, protocol, or deployment compatibility changes
- includes mutation verification for both the uncompressed payload bypass and completion marker reset

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_mitmproxy_websocket_framing.py::test_uncompressed_message_after_deflate_negotiation_clears_state`
- `uv run --no-sync python -m pytest -q tests/test_mitmproxy_websocket_framing.py`
- `uv run --no-sync python -m pytest -q tests/`

Closes #29544
