### PR TITLE
refactor(python): avoid caching resolved auth base urls

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_rewrite.py
+++ b/crates/runner/mitm-addon/src/auth_base_rewrite.py
@@ -17,6 +17,7 @@ from authority_utils import (
 )
 from host_normalization import normalize_hostname
 from path_security import has_unsafe_path
+from runtime_url_parsing import split_runtime_url
 from url_syntax import (
     has_raw_whitespace,
     has_unsafe_url_codepoint,
@@ -194,7 +195,7 @@ def _validated_rewrite_base(resolved_base: str) -> tuple[urllib.parse.SplitResul
             "Invalid auth.base URL: must not contain control characters or invalid Unicode"
         )
 
-    parsed = urllib.parse.urlsplit(resolved_base)
+    parsed = split_runtime_url(resolved_base)
     if parsed.scheme.lower() != _VALID_AUTH_BASE_SCHEME:
         raise ValueError("Invalid auth.base URL: scheme must be https")
     if not parsed.netloc:

--- a/crates/runner/mitm-addon/tests/test_auth_base_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_rewrite.py
@@ -1,5 +1,6 @@
 """Tests for URL reconstruction and rewrite utilities."""
 
+import urllib.parse
 from collections.abc import Iterator
 
 import pytest
@@ -62,6 +63,25 @@ class TestBuildRewriteUrl:
             "",
         )
         assert url == "https://example.com/hook?token=secret"
+
+    def test_resolved_base_does_not_enter_global_parse_cache(self):
+        urllib.parse.urlsplit.cache_clear()
+        try:
+            urllib.parse.urlsplit("https://stable-config.example.com")
+            stable_cache = urllib.parse.urlsplit.cache_info()
+
+            url = auth_base_rewrite.build_rewrite_url(
+                "https://hooks.example.com/webhook/secret?token=trusted",
+                "/events",
+                "client=visible",
+            )
+
+            assert url == (
+                "https://hooks.example.com/webhook/secret/events?token=trusted&client=visible"
+            )
+            assert urllib.parse.urlsplit.cache_info() == stable_cache
+        finally:
+            urllib.parse.urlsplit.cache_clear()
 
     def test_base_unicode_host_normalized_for_forwarding(self):
         url = auth_base_rewrite.build_rewrite_url(


### PR DESCRIPTION
## Summary

- parse credential-derived auth.base rewrite URLs through the shared uncached runtime URL boundary
- preserve the existing auth.base validation, normalization, query merge, serialization, and forwarding behavior
- add a public-boundary regression that proves resolved bases do not enter urllib's process-wide split cache and existing stable cache entries remain intact

## Scope exclusions

- no auth result, cache, transport, API, schema, persistence, protocol, configuration, or migration changes
- no changes to stable configuration URL parsing or unrelated runtime URL consumers

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_rewrite.py` (127 passed)
- `uv run --no-sync python -m pytest tests/` (6654 passed)
- lefthook pre-commit and commitlint hooks

Closes #29547
