### PR TITLE
perf(platform): defer marketing scripts until first content

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -900,14 +900,15 @@
           window.setTimeout(loadMarketingScripts, 0);
         }
 
-        // Keep vendor work outside the first-content critical path, with a
-        // bounded fallback for bootstraps that never reach real app content.
+        // Keep vendor work outside the first-content critical path. The
+        // 30-second guard exceeds the observed mobile P90 startup window and
+        // still bounds bootstraps that never reach real app content.
         window.addEventListener(
           "vm0:app-first-content-visible",
           scheduleMarketingScripts,
           { once: true },
         );
-        window.setTimeout(scheduleMarketingScripts, 5000);
+        window.setTimeout(scheduleMarketingScripts, 30000);
       })();
     </script>
     <script>

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -900,10 +900,10 @@
           window.setTimeout(loadMarketingScripts, 0);
         }
 
-        // Optimize loading performance: attribution scripts can wait until
-        // the app skeleton is visible, with a fallback for failed bootstraps.
+        // Keep vendor work outside the first-content critical path, with a
+        // bounded fallback for bootstraps that never reach real app content.
         window.addEventListener(
-          "vm0:app-skeleton-visible",
+          "vm0:app-first-content-visible",
           scheduleMarketingScripts,
           { once: true },
         );

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+
+import indexHtml from "../../index.html?raw";
+import { testContext } from "../signals/__tests__/test-helpers.ts";
+
+const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
+const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
+const GOOGLE_TAG_SCRIPT_URL =
+  "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+const LINKEDIN_SCRIPT_URL =
+  "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+const MARKETING_FALLBACK_DELAY_MS = 5000;
+
+type LinkedInTracker = ((first: unknown, second: unknown) => void) & {
+  q: [unknown, unknown][];
+};
+
+type MarketingWindow = Window & {
+  dataLayer?: IArguments[];
+  gtag?: (...args: unknown[]) => void;
+  _linkedin_data_partner_ids?: string[];
+  lintrk?: LinkedInTracker;
+};
+
+type MarketingEntrypointScript = (
+  windowObject: Window,
+  documentObject: Document,
+) => void;
+
+interface ScheduledTimeout {
+  readonly callback: () => void;
+  readonly delay: number | undefined;
+}
+
+interface MarketingHarness {
+  readonly fallbackDelay: number | undefined;
+  readonly marketingWindow: MarketingWindow;
+  readonly requestedScriptUrls: string[];
+  readonly flushIdleCallbacks: () => void;
+  readonly runFallback: () => void;
+}
+
+const context = testContext();
+
+function marketingEntrypointSource(): string {
+  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)]
+    .map((match) => {
+      return match[1];
+    })
+    .find((script) => {
+      return script?.includes('window.gtag("config", "AW-18407336975")');
+    });
+  if (source === undefined) {
+    throw new Error("Unable to locate the marketing loader in index.html");
+  }
+  return source;
+}
+
+function executeMarketingEntrypoint(hostname: string): MarketingHarness {
+  const marketingWindow = window as MarketingWindow;
+  context.mocks.browser.url(`https://${hostname}/`);
+  vi.stubGlobal("dataLayer", undefined);
+  vi.stubGlobal("gtag", undefined);
+  vi.stubGlobal("_linkedin_data_partner_ids", undefined);
+  vi.stubGlobal("lintrk", undefined);
+
+  const insertionPoint = document.createElement("script");
+  document.head.appendChild(insertionPoint);
+  context.signal.addEventListener("abort", () => {
+    insertionPoint.remove();
+  });
+  const requestedScriptUrls: string[] = [];
+  vi.spyOn(document.head, "appendChild").mockImplementation(
+    <T extends Node>(node: T): T => {
+      if (node instanceof HTMLScriptElement) {
+        requestedScriptUrls.push(node.src);
+      }
+      return node;
+    },
+  );
+  vi.spyOn(document.head, "insertBefore").mockImplementation(
+    <T extends Node>(node: T, _child: Node | null): T => {
+      if (node instanceof HTMLScriptElement) {
+        requestedScriptUrls.push(node.src);
+      }
+      return node;
+    },
+  );
+
+  const scheduledTimeouts: ScheduledTimeout[] = [];
+  vi.spyOn(window, "setTimeout").mockImplementation((handler, delay) => {
+    if (typeof handler !== "function") {
+      throw new Error("Expected a function timeout handler");
+    }
+    scheduledTimeouts.push({
+      callback: () => {
+        handler();
+      },
+      delay,
+    });
+    return scheduledTimeouts.length;
+  });
+
+  const idleCallbacks: IdleRequestCallback[] = [];
+  vi.stubGlobal(
+    "requestIdleCallback",
+    (callback: IdleRequestCallback): number => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+  );
+
+  const executeEntrypointScript = new Function(
+    "window",
+    "document",
+    `${marketingEntrypointSource()}\n//# sourceURL=platform-marketing-entrypoint-test.js`,
+  ) as MarketingEntrypointScript;
+  executeEntrypointScript(window, document);
+
+  const fallback = scheduledTimeouts.find(({ delay }) => {
+    return delay === MARKETING_FALLBACK_DELAY_MS;
+  });
+
+  return {
+    fallbackDelay: fallback?.delay,
+    flushIdleCallbacks: () => {
+      for (const callback of idleCallbacks.splice(0)) {
+        callback({
+          didTimeout: false,
+          timeRemaining: () => {
+            return 50;
+          },
+        });
+      }
+    },
+    marketingWindow,
+    requestedScriptUrls,
+    runFallback: () => {
+      if (!fallback) {
+        throw new Error("Marketing fallback was not scheduled");
+      }
+      fallback.callback();
+    },
+  };
+}
+
+describe("platform marketing scripts", () => {
+  it("loads Google Ads and LinkedIn after first app content", () => {
+    const harness = executeMarketingEntrypoint("app.vm0.ai");
+
+    expect(
+      harness.marketingWindow.dataLayer?.map((entry) => {
+        return [...entry];
+      }),
+    ).toStrictEqual([
+      ["js", expect.any(Date)],
+      ["config", "AW-18144854014"],
+      ["config", "AW-18407336975"],
+    ]);
+
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+    harness.flushIdleCallbacks();
+
+    expect(harness.requestedScriptUrls).toStrictEqual([
+      GOOGLE_TAG_SCRIPT_URL,
+      LINKEDIN_SCRIPT_URL,
+    ]);
+    expect(harness.marketingWindow._linkedin_data_partner_ids).toStrictEqual([
+      "9378804",
+    ]);
+    expect(typeof harness.marketingWindow.lintrk).toBe("function");
+    expect(harness.marketingWindow.lintrk?.q).toStrictEqual([]);
+  });
+
+  it("uses the bounded fallback when app content never becomes ready", () => {
+    const harness = executeMarketingEntrypoint("app.vm0.ai");
+
+    expect(harness.fallbackDelay).toBe(MARKETING_FALLBACK_DELAY_MS);
+    harness.runFallback();
+    harness.flushIdleCallbacks();
+
+    expect(harness.requestedScriptUrls).toStrictEqual([
+      GOOGLE_TAG_SCRIPT_URL,
+      LINKEDIN_SCRIPT_URL,
+    ]);
+
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+  });
+
+  it("loads each script once across duplicate readiness and fallback signals", () => {
+    const harness = executeMarketingEntrypoint("app.vm0.ai");
+
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+    harness.runFallback();
+    harness.flushIdleCallbacks();
+
+    expect(harness.requestedScriptUrls).toStrictEqual([
+      GOOGLE_TAG_SCRIPT_URL,
+      LINKEDIN_SCRIPT_URL,
+    ]);
+  });
+
+  it("does not request scripts when only the app skeleton is visible", () => {
+    const harness = executeMarketingEntrypoint("app.vm0.ai");
+
+    window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
+    harness.flushIdleCallbacks();
+
+    expect(harness.requestedScriptUrls).toStrictEqual([]);
+
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+    harness.flushIdleCallbacks();
+  });
+
+  it.each(["localhost", "pr-29576-app.vm6.ai", "app.vm0.ai.example.com"])(
+    "does not initialize or request scripts on %s",
+    (hostname) => {
+      const harness = executeMarketingEntrypoint(hostname);
+
+      window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
+      window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
+      harness.flushIdleCallbacks();
+
+      expect(harness.fallbackDelay).toBeUndefined();
+      expect(harness.marketingWindow.dataLayer).toBeUndefined();
+      expect(harness.marketingWindow.gtag).toBeUndefined();
+      expect(
+        harness.marketingWindow._linkedin_data_partner_ids,
+      ).toBeUndefined();
+      expect(harness.marketingWindow.lintrk).toBeUndefined();
+      expect(harness.requestedScriptUrls).toStrictEqual([]);
+    },
+  );
+});

--- a/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
+++ b/turbo/apps/platform/src/__tests__/marketing-scripts.test.ts
@@ -9,7 +9,7 @@ const GOOGLE_TAG_SCRIPT_URL =
   "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
 const LINKEDIN_SCRIPT_URL =
   "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-const MARKETING_FALLBACK_DELAY_MS = 5000;
+const MARKETING_FALLBACK_DELAY_MS = 30_000;
 
 type LinkedInTracker = ((first: unknown, second: unknown) => void) & {
   q: [unknown, unknown][];
@@ -172,10 +172,11 @@ describe("platform marketing scripts", () => {
     expect(harness.marketingWindow.lintrk?.q).toStrictEqual([]);
   });
 
-  it("uses the bounded fallback when app content never becomes ready", () => {
+  it("waits 30 seconds before falling back when content never becomes ready", () => {
     const harness = executeMarketingEntrypoint("app.vm0.ai");
 
     expect(harness.fallbackDelay).toBe(MARKETING_FALLBACK_DELAY_MS);
+    expect(harness.requestedScriptUrls).toStrictEqual([]);
     harness.runFallback();
     harness.flushIdleCallbacks();
 

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -15,6 +15,9 @@ const internalOverlayMounted$ = state(true);
 const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
 const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
   "vm0AppSkeletonVisibleEventQueued";
+const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
+const APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY =
+  "vm0AppFirstContentVisibleEventDispatched";
 const APP_BOOTSTRAP_SKELETON_ID = "app-bootstrap-skeleton";
 const APP_BOOTSTRAP_SKELETON_HIDDEN_CLASS = "app-bootstrap-skeleton--hidden";
 
@@ -50,6 +53,22 @@ function queueAppSkeletonVisibleEvent(): void {
 export const appSkeletonVisibleEventRef$ = onRef(
   command((_visitor, _element: HTMLDivElement, _signal: AbortSignal) => {
     queueAppSkeletonVisibleEvent();
+  }),
+);
+
+export const firstAppContentVisibleEventRef$ = onRef(
+  command((_visitor, _element: HTMLSpanElement, _signal: AbortSignal) => {
+    if (
+      document.documentElement.dataset[
+        APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
+      ] === "true"
+    ) {
+      return;
+    }
+    document.documentElement.dataset[
+      APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
+    ] = "true";
+    window.dispatchEvent(new Event(APP_FIRST_CONTENT_VISIBLE_EVENT));
   }),
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx
@@ -7,6 +7,9 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
 const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
   "vm0AppSkeletonVisibleEventQueued";
+const APP_FIRST_CONTENT_VISIBLE_EVENT = "vm0:app-first-content-visible";
+const APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY =
+  "vm0AppFirstContentVisibleEventDispatched";
 
 const context = testContext();
 
@@ -40,6 +43,42 @@ describe("app skeleton", () => {
       expect(eventCount).toBe(1);
     });
     expect(skeletonMountedAtDispatch).toBeTruthy();
+  });
+
+  it("dispatches one first-content event after the ready page commits", async () => {
+    delete document.documentElement.dataset[
+      APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
+    ];
+    context.signal.addEventListener("abort", () => {
+      delete document.documentElement.dataset[
+        APP_FIRST_CONTENT_VISIBLE_EVENT_DISPATCHED_KEY
+      ];
+    });
+
+    let eventCount = 0;
+    let contentMountedAtDispatch = false;
+    let skeletonHiddenAtDispatch = false;
+    window.addEventListener(
+      APP_FIRST_CONTENT_VISIBLE_EVENT,
+      () => {
+        eventCount += 1;
+        contentMountedAtDispatch =
+          document.querySelector('a[href^="mailto:"]') !== null;
+        skeletonHiddenAtDispatch =
+          document
+            .querySelector('[data-testid="app-skeleton"]')
+            ?.getAttribute("aria-hidden") === "true";
+      },
+      { signal: context.signal },
+    );
+
+    detachedSetupPage({ context, path: "/_/error" });
+
+    await waitFor(() => {
+      expect(eventCount).toBe(1);
+    });
+    expect(contentMountedAtDispatch).toBeTruthy();
+    expect(skeletonHiddenAtDispatch).toBeTruthy();
   });
 
   it("removes the inline loading surface after the page is ready", async () => {

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -5,6 +5,7 @@ import {
   appSkeletonOverlayMounted$,
   appSkeletonVisible$,
   bootstrapSkeletonActive$,
+  firstAppContentVisibleEventRef$,
   unmountAppSkeletonOverlay$,
 } from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./okou-page/app-skeleton.tsx";
@@ -13,7 +14,17 @@ import { MinimalSidebarLayout } from "./okou-page/directed-shared.tsx";
 
 function PageSlot() {
   const page = useGet(page$);
-  return page ?? null;
+  const skeletonVisible = useGet(appSkeletonVisible$);
+  const firstContentVisibleEventRef = useSet(firstAppContentVisibleEventRef$);
+
+  return (
+    <>
+      {page ?? null}
+      {page !== undefined && !skeletonVisible ? (
+        <span ref={firstContentVisibleEventRef} hidden />
+      ) : null}
+    </>
+  );
 }
 
 function LayoutHost({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

- defer external Google Ads and LinkedIn requests until the first route content has committed with the app skeleton hidden
- preserve parse-time `dataLayer`/`gtag` initialization, production-host gating, LinkedIn initialization, and idle scheduling
- use a 30-second failed-bootstrap guard, about 1.9 times the highest observed mobile route P90 of 16.08 seconds, so normal measured slow starts do not contend with vendor requests
- add focused coverage for readiness, the exact fallback bound, duplicate signals, skeleton-only startup, attribution queue order, and non-production hosts

## Verification

- `./node_modules/.bin/prettier --check apps/platform/index.html apps/platform/src/signals/app-skeleton.ts apps/platform/src/views/router.tsx apps/platform/src/views/okou-page/__tests__/app-skeleton.test.tsx apps/platform/src/__tests__/marketing-scripts.test.ts`
- `pnpm -F @okouai/app exec oxlint src/signals/app-skeleton.ts src/views/router.tsx src/views/okou-page/__tests__/app-skeleton.test.tsx src/__tests__/marketing-scripts.test.ts`
- `pnpm -F @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/app-skeleton.ts src/views/router.tsx src/views/okou-page/__tests__/app-skeleton.test.tsx src/__tests__/marketing-scripts.test.ts`
- `pnpm -F @okouai/app exec eslint src/signals/app-skeleton.ts src/views/router.tsx src/views/okou-page/__tests__/app-skeleton.test.tsx --max-warnings 0`
- `pnpm --filter @okouai/app run check-types`
- `pnpm -F @okouai/app exec vitest run src/__tests__/marketing-scripts.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose` (7 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/app-skeleton.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose` (5 passed)
- `git diff --check`

## Residual risk

- An extreme bootstrap lasting more than 30 seconds can still overlap the bounded fallback. The guard is 13.92 seconds beyond the highest measured route P90 while retaining a deterministic path for bootstraps that never reach real content.
- The coordinating parent thread owns staging-browser validation against the actual `deploy-app` preview.

Refs #29576
