### PR TITLE
perf(platform): add bootstrap phase telemetry

### DIFF
--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -43,6 +43,8 @@ declare global {
      * the first time the app skeleton is dismissed.
      */
     __appBootstrapStart?: number;
+    /** Set when the entry module graph has finished evaluating. */
+    __appBootstrapModuleReady?: number;
   }
 }
 

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -1,5 +1,6 @@
 import { command, state } from "ccstate";
 import { posthog, type CaptureResult } from "posthog-js";
+import { isStandalonePwa } from "./keyboard-dismiss-gesture.ts";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 
 const RUNTIME_CONFIG = resolvePlatformRuntimeConfig();
@@ -364,6 +365,234 @@ export function capturePageView(): void {
     posthog.capture("$pageview");
   });
 }
+
+export const BOOTSTRAP_PHASE_TIMING_EVENT = "app_bootstrap_phase_timing";
+
+export type BootstrapThreadMetadataSource =
+  | "local"
+  | "memory"
+  | "not_found"
+  | "remote";
+
+interface BootstrapPhaseTimingState {
+  readonly finalRoute?: string;
+  readonly initialRoute?: string;
+  readonly initialVisibilityState: DocumentVisibilityState;
+  readonly localeInitDurationMs?: number;
+  readonly localeInitStartedAt?: number;
+  readonly localThreadMetadataDurationMs?: number;
+  readonly remoteThreadMetadataDurationMs?: number;
+  readonly routeSetupStartedAt?: number;
+  readonly threadMetadataSource?: BootstrapThreadMetadataSource;
+  readonly wasHidden: boolean;
+}
+
+const bootstrapPhaseTimingState$ = state<BootstrapPhaseTimingState | null>(
+  null,
+);
+const bootstrapPhaseTimingReported$ = state(false);
+
+const BOOTSTRAP_CLERK_LOAD_STARTED_MARK = "vm0:bootstrap:clerk-load-started";
+const BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK =
+  "vm0:bootstrap:clerk-load-completed";
+
+export const initBootstrapPhaseTiming$ = command(
+  ({ set }, signal: AbortSignal) => {
+    performance.clearMarks(BOOTSTRAP_CLERK_LOAD_STARTED_MARK);
+    performance.clearMarks(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK);
+    set(bootstrapPhaseTimingState$, {
+      initialVisibilityState: document.visibilityState,
+      wasHidden: document.visibilityState !== "visible",
+    });
+    document.addEventListener(
+      "visibilitychange",
+      () => {
+        if (document.visibilityState !== "visible") {
+          set(bootstrapPhaseTimingState$, (current) => {
+            return current ? { ...current, wasHidden: true } : current;
+          });
+        }
+      },
+      { signal },
+    );
+  },
+);
+
+export const markBootstrapLocaleInitStarted$ = command(({ get, set }) => {
+  const current = get(bootstrapPhaseTimingState$);
+  if (!current || current.localeInitStartedAt !== undefined) {
+    return;
+  }
+  set(bootstrapPhaseTimingState$, {
+    ...current,
+    localeInitStartedAt: performance.now(),
+  });
+});
+
+export const markBootstrapLocaleInitCompleted$ = command(({ get, set }) => {
+  const current = get(bootstrapPhaseTimingState$);
+  if (
+    !current ||
+    current.localeInitStartedAt === undefined ||
+    current.localeInitDurationMs !== undefined
+  ) {
+    return;
+  }
+  set(bootstrapPhaseTimingState$, {
+    ...current,
+    localeInitDurationMs: Math.round(
+      performance.now() - current.localeInitStartedAt,
+    ),
+  });
+});
+
+export function markBootstrapClerkLoadStarted(): void {
+  if (
+    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_STARTED_MARK, "mark")
+      .length === 0
+  ) {
+    performance.mark(BOOTSTRAP_CLERK_LOAD_STARTED_MARK);
+  }
+}
+
+export function markBootstrapClerkLoadCompleted(): void {
+  if (
+    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_STARTED_MARK, "mark")
+      .length === 0 ||
+    performance.getEntriesByName(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK, "mark")
+      .length > 0
+  ) {
+    return;
+  }
+  performance.mark(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK);
+}
+
+export const markBootstrapRouteSetup$ = command(
+  ({ get, set }, route: string) => {
+    const current = get(bootstrapPhaseTimingState$);
+    if (!current) {
+      return;
+    }
+    set(bootstrapPhaseTimingState$, {
+      ...current,
+      finalRoute: route,
+      initialRoute: current.initialRoute ?? route,
+      localThreadMetadataDurationMs: undefined,
+      remoteThreadMetadataDurationMs: undefined,
+      routeSetupStartedAt: current.routeSetupStartedAt ?? performance.now(),
+      threadMetadataSource: undefined,
+    });
+  },
+);
+
+export const recordBootstrapThreadMetadataTiming$ = command(
+  (
+    { get, set },
+    timing: {
+      readonly localDurationMs?: number;
+      readonly remoteDurationMs?: number;
+      readonly source: BootstrapThreadMetadataSource;
+    },
+  ) => {
+    const current = get(bootstrapPhaseTimingState$);
+    if (!current) {
+      return;
+    }
+    set(bootstrapPhaseTimingState$, {
+      ...current,
+      localThreadMetadataDurationMs: timing.localDurationMs,
+      remoteThreadMetadataDurationMs: timing.remoteDurationMs,
+      threadMetadataSource: timing.source,
+    });
+  },
+);
+
+function elapsedDuration(
+  startedAt: number | undefined,
+  completedAt: number | undefined,
+): number | undefined {
+  if (
+    startedAt === undefined ||
+    completedAt === undefined ||
+    completedAt < startedAt
+  ) {
+    return undefined;
+  }
+  return Math.round(completedAt - startedAt);
+}
+
+function markStartTime(markName: string): number | undefined {
+  return performance.getEntriesByName(markName, "mark").at(-1)?.startTime;
+}
+
+function setDurationProperty(
+  properties: Record<string, string | number | boolean>,
+  name: string,
+  durationMs: number | undefined,
+): void {
+  if (durationMs !== undefined) {
+    properties[name] = durationMs;
+  }
+}
+
+export const captureBootstrapPhaseTiming$ = command(({ get, set }) => {
+  if (get(bootstrapPhaseTimingReported$)) {
+    return;
+  }
+  set(bootstrapPhaseTimingReported$, true);
+
+  runPostHog(() => {
+    const capturedAt = performance.now();
+    const current = get(bootstrapPhaseTimingState$);
+    const entryModuleReadyDurationMs = elapsedDuration(
+      window.__appBootstrapStart,
+      window.__appBootstrapModuleReady,
+    );
+    const clerkLoadDurationMs = elapsedDuration(
+      markStartTime(BOOTSTRAP_CLERK_LOAD_STARTED_MARK),
+      markStartTime(BOOTSTRAP_CLERK_LOAD_COMPLETED_MARK),
+    );
+    const routeSetupDurationMs = elapsedDuration(
+      current?.routeSetupStartedAt,
+      capturedAt,
+    );
+    const properties: Record<string, string | number | boolean> = {
+      final_route: current?.finalRoute ?? "unknown",
+      initial_route: current?.initialRoute ?? "unknown",
+      initial_visibility_state:
+        current?.initialVisibilityState ?? document.visibilityState,
+      standalone_pwa: isStandalonePwa(),
+      visibility_state: document.visibilityState,
+      was_hidden: current?.wasHidden ?? document.visibilityState !== "visible",
+    };
+    setDurationProperty(
+      properties,
+      "entry_module_ready_ms",
+      entryModuleReadyDurationMs,
+    );
+    setDurationProperty(
+      properties,
+      "locale_init_ms",
+      current?.localeInitDurationMs,
+    );
+    setDurationProperty(properties, "clerk_load_ms", clerkLoadDurationMs);
+    setDurationProperty(properties, "route_setup_ms", routeSetupDurationMs);
+    setDurationProperty(
+      properties,
+      "local_thread_metadata_ms",
+      current?.localThreadMetadataDurationMs,
+    );
+    setDurationProperty(
+      properties,
+      "remote_thread_metadata_ms",
+      current?.remoteThreadMetadataDurationMs,
+    );
+    if (current?.threadMetadataSource !== undefined) {
+      properties.thread_metadata_source = current.threadMetadataSource;
+    }
+    posthog.capture(BOOTSTRAP_PHASE_TIMING_EVENT, properties);
+  });
+});
 
 const firstSkeletonHideReported$ = state(false);
 

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -10,6 +10,8 @@ import { bootstrap$ } from "./signals/bootstrap.ts";
 import { detach, Reason, resetSignal } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
+window.__appBootstrapModuleReady = performance.now();
+
 // (no-op Platform release marker refreshed again on 2026-07-31)
 
 const resetRootSignal$ = resetSignal();

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -1,0 +1,210 @@
+import { waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
+import {
+  BOOTSTRAP_PHASE_TIMING_EVENT,
+  type BootstrapThreadMetadataSource,
+} from "../../lib/posthog.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { testContext } from "./test-helpers.ts";
+
+type Capture = (
+  eventName: string,
+  properties?: Record<string, unknown>,
+) => void;
+type Identify = (
+  distinctId: string,
+  properties?: Record<string, unknown>,
+) => void;
+type Init = (key: string, config?: Record<string, unknown>) => void;
+type Register = (properties: Record<string, unknown>) => void;
+type Reset = () => void;
+type Unregister = (property: string) => void;
+
+const { apiOriginMarker, posthog } = vi.hoisted(() => {
+  vi.stubEnv("VITE_POSTHOG_KEY", "phc_bootstrap_phase_telemetry_test");
+  window.location.href = "https://app.vm0.ai/";
+  const apiOriginMarker = document.createElement("meta");
+  apiOriginMarker.name = "vm0-api-origin";
+  apiOriginMarker.content = "https://api.vm0.ai";
+  document.head.append(apiOriginMarker);
+  return {
+    apiOriginMarker,
+    posthog: {
+      capture: vi.fn<Capture>(),
+      identify: vi.fn<Identify>(),
+      init: vi.fn<Init>(),
+      register: vi.fn<Register>(),
+      reset: vi.fn<Reset>(),
+      unregister: vi.fn<Unregister>(),
+    },
+  };
+});
+
+vi.mock("posthog-js", () => {
+  return { posthog };
+});
+
+const context = testContext();
+const THREAD_ID = "b0000000-0000-4000-a000-000000000901";
+
+function disabledSharedDatabase(): Partial<Record<FeatureSwitchKey, boolean>> {
+  return { [FeatureSwitchKey.SharedChatDatabase]: false };
+}
+
+beforeEach(() => {
+  posthog.capture.mockClear();
+  posthog.identify.mockClear();
+  posthog.init.mockClear();
+  posthog.register.mockClear();
+  posthog.reset.mockClear();
+  posthog.unregister.mockClear();
+  context.mocks.browser.standaloneDisplayMode(false);
+  context.mocks.browser.visibilityState("visible");
+
+  const moduleReadyAt = performance.now();
+  window.__appBootstrapStart = moduleReadyAt - 20;
+  window.__appBootstrapModuleReady = moduleReadyAt - 10;
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      delete window.__appBootstrapStart;
+      delete window.__appBootstrapModuleReady;
+    },
+    { once: true },
+  );
+});
+
+afterAll(() => {
+  apiOriginMarker.remove();
+});
+
+function timingEvents(): Record<string, unknown>[] {
+  return posthog.capture.mock.calls.flatMap(([eventName, properties]) => {
+    return eventName === BOOTSTRAP_PHASE_TIMING_EVENT ? [properties ?? {}] : [];
+  });
+}
+
+function mockEmptyThreadMetadata(): void {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [],
+      latestEventId: null,
+      latestSeqId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
+}
+
+describe("bootstrap phase telemetry", () => {
+  it("captures bounded bootstrap and cold thread metadata phases", async () => {
+    mockEmptyThreadMetadata();
+
+    await setupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      cachedFeatureSwitches: disabledSharedDatabase(),
+      featureSwitches: disabledSharedDatabase(),
+      withoutRender: true,
+    });
+
+    expect(timingEvents()).toHaveLength(1);
+    const properties = timingEvents()[0];
+    expect(properties).toStrictEqual(
+      expect.objectContaining({
+        clerk_load_ms: expect.any(Number),
+        entry_module_ready_ms: 10,
+        final_route: ROUTES.chat,
+        initial_route: ROUTES.chat,
+        initial_visibility_state: "visible",
+        locale_init_ms: expect.any(Number),
+        local_thread_metadata_ms: expect.any(Number),
+        remote_thread_metadata_ms: expect.any(Number),
+        route_setup_ms: expect.any(Number),
+        standalone_pwa: false,
+        thread_metadata_source:
+          "not_found" satisfies BootstrapThreadMetadataSource,
+        visibility_state: "visible",
+        was_hidden: false,
+      }),
+    );
+    expect(JSON.stringify(properties)).not.toContain(THREAD_ID);
+  });
+
+  it("reports the bootstrap event only once", async () => {
+    await setupPage({ context, path: ROUTES.error, withoutRender: true });
+
+    context.store.set(hideAppSkeleton$, context.signal);
+    context.store.set(hideAppSkeleton$, context.signal);
+
+    expect(timingEvents()).toHaveLength(1);
+  });
+
+  it("discards thread timing from an aborted navigation", async () => {
+    const snapshotRequested = context.mocks.deferred<void>();
+    const releaseSnapshot = context.mocks.deferred<void>();
+    context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+      snapshotRequested.resolve();
+      await releaseSnapshot.promise;
+      return respond(200, {
+        chatThreads: [],
+        latestEventId: null,
+        latestSeqId: null,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      cachedFeatureSwitches: disabledSharedDatabase(),
+      featureSwitches: disabledSharedDatabase(),
+      withoutRender: true,
+    });
+    await snapshotRequested.promise;
+
+    context.store.set(detachedNavigateTo$, ROUTES.error, { replace: true });
+
+    await waitFor(() => {
+      expect(timingEvents()).toHaveLength(1);
+    });
+    expect(timingEvents()[0]).toStrictEqual(
+      expect.objectContaining({
+        final_route: ROUTES.error,
+        initial_route: ROUTES.chat,
+      }),
+    );
+    expect(timingEvents()[0]).not.toHaveProperty("thread_metadata_source");
+    expect(timingEvents()[0]).not.toHaveProperty("local_thread_metadata_ms");
+    expect(timingEvents()[0]).not.toHaveProperty("remote_thread_metadata_ms");
+
+    releaseSnapshot.resolve();
+  });
+
+  it("omits an unavailable entry timing mark", async () => {
+    delete window.__appBootstrapStart;
+    delete window.__appBootstrapModuleReady;
+
+    await setupPage({ context, path: ROUTES.error, withoutRender: true });
+
+    expect(timingEvents()).toHaveLength(1);
+    expect(timingEvents()[0]).not.toHaveProperty("entry_module_ready_ms");
+    expect(timingEvents()[0]).toStrictEqual(
+      expect.objectContaining({
+        final_route: ROUTES.error,
+        initial_route: ROUTES.error,
+        locale_init_ms: expect.any(Number),
+        route_setup_ms: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,7 +1,10 @@
 import { command, computed, state } from "ccstate";
 import { completeOnLocalAbort, onRef, resetSignal, setLoop } from "./utils.ts";
 import { getAvatarPresets } from "../views/okou-page/avatars.ts";
-import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
+import {
+  captureBootstrapPhaseTiming$,
+  captureFirstSkeletonHide$,
+} from "../lib/posthog.ts";
 import { i18n } from "../i18n/index.ts";
 import { locale$ } from "./locale.ts";
 
@@ -205,4 +208,5 @@ export const hideAppSkeleton$ = command(({ set }, _signal: AbortSignal) => {
   set(internalVisible$, false);
   hideBootstrapSkeleton();
   set(captureFirstSkeletonHide$);
+  set(captureBootstrapPhaseTiming$);
 });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -4,6 +4,8 @@ import { command, computed, state } from "ccstate";
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 import {
   clearPostHogUser,
+  markBootstrapClerkLoadCompleted,
+  markBootstrapClerkLoadStarted,
   setPostHogOrganization,
   setPostHogUser,
 } from "../lib/posthog.ts";
@@ -407,6 +409,7 @@ export const clerkInstance$ = computed(() => {
 export const clerk$ = computed(async (get) => {
   const clerkInstance = get(clerkInstance$);
   const satelliteConfig = resolveClerkSatelliteConfig();
+  markBootstrapClerkLoadStarted();
   await clerkInstance.load({
     ui,
     ...(satelliteConfig
@@ -419,6 +422,7 @@ export const clerk$ = computed(async (get) => {
     signUpUrl: resolveAppAuthUrl("/sign-up"),
     afterSignOutUrl: resolveAppAuthUrl("/sign-in"),
   });
+  markBootstrapClerkLoadCompleted();
 
   return clerkInstance;
 });

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -98,6 +98,11 @@ import {
 } from "./connection-diagnostics.ts";
 import { checkUnifiedSettingsParam$ } from "./okou-page/settings/settings-dialog.ts";
 import { captureInvitationRedirect$ } from "./invitation-redirect.ts";
+import {
+  initBootstrapPhaseTiming$,
+  markBootstrapLocaleInitCompleted$,
+  markBootstrapLocaleInitStarted$,
+} from "../lib/posthog.ts";
 
 const setupNotFoundPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(NotFoundPage));
@@ -479,9 +484,12 @@ const setupNotificationListener$ = command(({ set }, signal: AbortSignal) => {
 
 export const bootstrap$ = command(
   async ({ get, set }, render: () => void, signal: AbortSignal) => {
+    set(initBootstrapPhaseTiming$, signal);
     set(captureInvitationRedirect$);
+    set(markBootstrapLocaleInitStarted$);
     await set(initLocale$, signal);
     signal.throwIfAborted();
+    set(markBootstrapLocaleInitCompleted$);
     set(initTheme$);
     set(setRootSignal$, signal);
     set(initBootstrapSkeleton$);

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -17,6 +17,7 @@ import { resolvedThreadMeta } from "./chat-thread-event-sourcing.ts";
 import {
   captureNavigationTiming$,
   markRouteSetupBegin$,
+  recordBootstrapThreadMetadataTiming$,
 } from "../../lib/posthog.ts";
 
 const setupResolvedLeftThread$ = command(
@@ -25,8 +26,14 @@ const setupResolvedLeftThread$ = command(
     threadId: string,
     signal: AbortSignal,
   ): Promise<void> => {
-    const meta = await get(resolvedThreadMeta(threadId));
+    const resolution = await get(resolvedThreadMeta(threadId));
     signal.throwIfAborted();
+    set(recordBootstrapThreadMetadataTiming$, {
+      localDurationMs: resolution.localDurationMs,
+      remoteDurationMs: resolution.remoteDurationMs,
+      source: resolution.source,
+    });
+    const { meta } = resolution;
     if (meta) {
       await set(setupLeftThread$, meta, signal);
       return;
@@ -41,7 +48,7 @@ const setupResolvedRightThread$ = command(
     threadId: string,
     signal: AbortSignal,
   ): Promise<void> => {
-    const meta = await get(resolvedThreadMeta(threadId));
+    const { meta } = await get(resolvedThreadMeta(threadId));
     signal.throwIfAborted();
     if (meta) {
       await set(setupRightThread$, meta, signal);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -93,6 +93,13 @@ export interface ThreadMeta {
   readonly selectedImageModel: string | null;
 }
 
+interface ThreadMetaResolution {
+  readonly localDurationMs?: number;
+  readonly meta: ThreadMeta | null;
+  readonly remoteDurationMs?: number;
+  readonly source: "local" | "memory" | "not_found" | "remote";
+}
+
 const optimisticChatThreadEventsState$ = state<
   readonly OptimisticChatThreadEvent[]
 >([]);
@@ -667,12 +674,13 @@ export function threadMeta(threadId: string) {
 
 export function resolvedThreadMeta(threadId: string) {
   const meta$ = threadMeta(threadId);
-  return computed(async (get): Promise<ThreadMeta | null> => {
+  return computed(async (get): Promise<ThreadMetaResolution> => {
     let meta = get(meta$);
     if (meta) {
-      return meta;
+      return { meta, source: "memory" };
     }
 
+    const localStartedAt = performance.now();
     const foregroundReady = get(foregroundReady$);
     const syncBarrier = get(chatThreadEventSyncBarrier$);
     const foregroundSync =
@@ -681,22 +689,35 @@ export function resolvedThreadMeta(threadId: string) {
         : null;
 
     await get(initialLocalChatThreadEventsLoaded$);
+    const localDurationMs = Math.round(performance.now() - localStartedAt);
     meta = get(meta$);
     if (meta) {
-      return meta;
+      return { localDurationMs, meta, source: "local" };
     }
 
+    const remoteStartedAt = performance.now();
     if (foregroundSync) {
       await foregroundReady.promise;
       await foregroundSync;
       meta = get(meta$);
       if (meta) {
-        return meta;
+        return {
+          localDurationMs,
+          meta,
+          remoteDurationMs: Math.round(performance.now() - remoteStartedAt),
+          source: "remote",
+        };
       }
     }
 
     await get(initialRemoteChatThreadEventsSynced$);
-    return get(meta$);
+    meta = get(meta$);
+    return {
+      localDurationMs,
+      meta,
+      remoteDurationMs: Math.round(performance.now() - remoteStartedAt),
+      source: meta ? "remote" : "not_found",
+    };
   });
 }
 

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -7,7 +7,11 @@ import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { detach, onDomEventFn, Reason, resetSignal, settle } from "./utils.ts";
 import { logger } from "./log.ts";
-import { capturePageView, markNavigationPushState$ } from "../lib/posthog.ts";
+import {
+  capturePageView,
+  markBootstrapRouteSetup$,
+  markNavigationPushState$,
+} from "../lib/posthog.ts";
 import { recordAdAttribution$ } from "./bootstrap/ad-attribution.ts";
 import { recordSignupAttribution$ } from "./bootstrap/signup-attribution.ts";
 import { bootstrapGoogleAdsConversionMilestones$ } from "./bootstrap/google-ads-conversion-milestones.ts";
@@ -112,6 +116,7 @@ const loadRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!currentRoute) {
     throw new Error("No route matches, pathname: " + get(pathname$));
   }
+  set(markBootstrapRouteSetup$, currentRoute.path);
   L.debug("loading route", currentRoute.path);
   if (currentRoute.analytics !== false) {
     set(recordAdAttribution$, get(searchParams$));


### PR DESCRIPTION
## Summary

- add a once-only `app_bootstrap_phase_timing` event alongside the unchanged `app_first_skeleton_hide` event
- measure entry/module readiness, locale initialization, Clerk load, route setup, and local/remote chat-thread metadata blocking time
- attach only bounded context: route templates, visibility state, standalone/PWA state, hidden-during-bootstrap state, and thread metadata source (`memory`, `local`, `remote`, or `not_found`)
- discard route-specific metadata timing when navigation is superseded before the route becomes ready

No API contracts or startup control flow are changed.

## Tests

- event shape and low-cardinality route values
- once-only capture behavior
- aborted chat navigation without stale metadata fields
- missing entry/module marks without invalid timing values

## Local verification

- lockfile-pinned Prettier 3.8.1 on touched files
- scoped Oxlint, type-aware Oxlint, and ESLint on touched files
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/bootstrap-phase-telemetry.test.ts`

The coordinating parent thread owns validation against the actual `deploy-app` preview.

Refs #29576
