### PR TITLE
fix(platform): stabilize connector row alignment

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -307,7 +307,7 @@ describe("chat composer connector connection", () => {
     if (!accessLabel?.control) {
       throw new Error("Expected the Axiom label to target its access switch");
     }
-    expect(accessLabel.parentElement).toHaveClass("h-10");
+    expect(accessLabel.parentElement).toHaveClass("h-10", "shrink-0");
     expect(
       screen.getByLabelText("Configure Axiom permissions").closest("label"),
     ).toBeNull();
@@ -320,6 +320,7 @@ describe("chat composer connector connection", () => {
     const disconnectedAccess = await screen.findByLabelText("Add Axiom");
     expect(disconnectedAccess.closest("label")?.parentElement).toHaveClass(
       "h-10",
+      "shrink-0",
     );
     expect(
       screen.queryByLabelText("Configure Axiom permissions"),

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8142,7 +8142,7 @@ function ComposerConnectorAccessRow({
   readonly ariaLabel: string;
 }) {
   return (
-    <div className="flex h-10 items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
+    <div className="flex h-10 shrink-0 items-center gap-2 px-3 py-2 hover:bg-state-hover transition-colors">
       {actions ? (
         <span className="order-2 flex shrink-0 items-center gap-2">
           {actions}

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -18,7 +18,8 @@ const SIZES = {
   },
   sm: {
     root: "h-4 w-7",
-    thumb: "h-3 w-3 data-checked:translate-x-3 data-unchecked:translate-x-0",
+    thumb:
+      "h-3 w-3 shadow-none data-checked:translate-x-3 data-unchecked:translate-x-0",
   },
 } as const;
 

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -18,8 +18,7 @@ const SIZES = {
   },
   sm: {
     root: "h-4 w-7",
-    thumb:
-      "h-3 w-3 shadow-none data-checked:translate-x-3 data-unchecked:translate-x-0",
+    thumb: "h-3 w-3 data-checked:translate-x-3 data-unchecked:translate-x-0",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- keep connector access rows at a stable 40px height when the scrollable list is crowded
- cover both enabled and disabled connector row states in the existing page-level test

## Scope

This changes only connector row layout. It does not change switch styling, connector authorization, account selection, permissions, or API behavior.

## Validation

- `pnpm exec prettier --check apps/platform/src/views/okou-page/chat-composer.tsx apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx --silent=passed-only`
- pre-commit hooks, including full Turbo Knip and type checks
- browser verification: enabled and disabled connector rows both measured 40px
