### PR TITLE
fix(platform): unify settings surfaces

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4718,7 +4718,7 @@
         },
         "preference": {
           "description": "Personalize how the app looks and behaves.",
-          "title": "Preference"
+          "title": "Preferences"
         },
         "usage": {
           "balanceDescription": "What your team has left to spend.",
@@ -5020,7 +5020,7 @@
     "preferences": {
       "account": {
         "manage": "Manage",
-        "sectionTitle": "Account & Security"
+        "sectionTitle": "Account & security"
       },
       "appearance": {
         "description": "Choose how the interface looks.",
@@ -5126,14 +5126,14 @@
       },
       "tabs": {
         "appearance": "Appearance",
-        "models": "Personal Models",
-        "timezone": "Time Zone"
+        "models": "Personal models",
+        "timezone": "Time zone"
       },
       "timezone": {
         "description": "Times shown to you and used for automation runs.",
         "rowDescription": "Your agents will use this time zone during runs",
         "rowTitle": "Time zone",
-        "sectionTitle": "Time Zone",
+        "sectionTitle": "Time zone",
         "zones": {
           "alaska": "Alaska Time (AKT)",
           "auckland": "New Zealand Time (NZST)",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
@@ -1164,9 +1164,9 @@ describe("settings dialog", () => {
       return button;
     };
 
-    click(dialogButton("Preference"));
+    click(dialogButton("Preferences"));
     await expect(
-      screen.findByRole("heading", { name: "Preference" }),
+      screen.findByRole("heading", { name: "Preferences" }),
     ).resolves.toBeInTheDocument();
     click(dialogButton("Debug"));
     await waitFor(() => {
@@ -1392,9 +1392,9 @@ describe("settings dialog", () => {
       return button;
     };
 
-    click(dialogButton("Preference"));
+    click(dialogButton("Preferences"));
     await expect(
-      screen.findByRole("heading", { name: "Preference" }),
+      screen.findByRole("heading", { name: "Preferences" }),
     ).resolves.toBeInTheDocument();
 
     click(dialogButton("Debug"));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1215,11 +1215,11 @@ describe("zero sidebar account menu", () => {
       const dialog = screen.getByRole("dialog", { name: "Settings" });
       expect(dialog).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Preference" }),
+        screen.getByRole("heading", { name: "Preferences" }),
       ).toBeInTheDocument();
       // Scoped to the dialog: the sidebar account row also carries the name.
       expect(
-        within(dialog).getByText("Account & Security"),
+        within(dialog).getByText("Account & security"),
       ).toBeInTheDocument();
       expect(within(dialog).getByText("Alex Rivera")).toBeInTheDocument();
       expect(
@@ -1329,7 +1329,7 @@ describe("zero sidebar account menu", () => {
 
     const dialog = await screen.findByRole("dialog", { name: "Settings" });
     expect(
-      within(dialog).getByRole("heading", { name: "Preference" }),
+      within(dialog).getByRole("heading", { name: "Preferences" }),
     ).toBeInTheDocument();
     expect(within(dialog).queryByText("Debug")).not.toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/okou-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/billing-dialog.tsx
@@ -25,12 +25,9 @@ import {
 } from "../../signals/okou-page/billing.ts";
 import { UnsavedBar } from "./components/org-manage/unsaved-bar.tsx";
 import { formatUsd } from "../../i18n/format.ts";
+import { SettingsSectionHeading } from "./components/settings/settings-section-heading.tsx";
 
 const CREDITS_PER_DOLLAR = 1000;
-
-const settingsCardBorder = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
 
 export function AutoRechargeSection({
   allowed,
@@ -107,21 +104,18 @@ export function AutoRechargeSection({
     detach(doSave(values, pageSignal), Reason.DomCallback);
   };
 
-  const inputRowClass = "h-9 w-[200px] shrink-0";
+  const inputRowClass = "h-9 w-full shrink-0 sm:w-[200px]";
 
   return (
     <>
       <section className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium text-foreground">
-          {t(($) => {
+        <SettingsSectionHeading
+          title={t(($) => {
             return $.billing.autoRecharge.title;
           })}
-        </h3>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={settingsCardBorder}
-        >
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
+        />
+        <div className="zero-card overflow-hidden">
+          <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             <div className="min-w-0">
               <p className="text-sm font-medium text-foreground">
                 {t(($) => {
@@ -149,7 +143,7 @@ export function AutoRechargeSection({
           {displayEnabled && (
             <>
               <div className="h-0 zero-border-t mx-5" />
-              <div className="flex items-center justify-between gap-4 px-5 py-4">
+              <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-foreground">
                     {t(($) => {
@@ -183,7 +177,7 @@ export function AutoRechargeSection({
                 />
               </div>
               <div className="h-0 zero-border-t mx-5" />
-              <div className="flex items-center justify-between gap-4 px-5 py-4">
+              <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
                 <div className="min-w-0 flex flex-col gap-1">
                   <span className="text-xl font-semibold tabular-nums tracking-tight text-foreground">
                     {dollarAmount}
@@ -194,7 +188,7 @@ export function AutoRechargeSection({
                     })}
                   </p>
                 </div>
-                <div className="relative w-[200px] shrink-0">
+                <div className="relative w-full shrink-0 sm:w-[200px]">
                   <Input
                     type="text"
                     inputMode="numeric"

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/buy-credits-section.tsx
@@ -16,6 +16,7 @@ import {
   type CreditCheckoutSelection,
 } from "../../../../signals/okou-page/billing.ts";
 import { formatLocalizedNumber, formatUsd } from "../../../../i18n/format.ts";
+import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 
 const CREDITS_PER_DOLLAR = 1000;
 const PRESETS = [10, 20, 50] as const;
@@ -24,12 +25,8 @@ const MAX_CUSTOM_USD = 10_000;
 
 type Preset = (typeof PRESETS)[number];
 
-const settingsCardBorder = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
-
 const tileBaseClass =
-  "flex flex-col rounded-xl bg-background px-4 py-3 text-left transition-colors";
+  "flex flex-col rounded-[var(--zero-card-radius)] bg-background px-4 py-3 text-left transition-colors";
 
 function tileBorderClass(selected: boolean): string {
   return selected
@@ -256,15 +253,12 @@ export function BuyCreditsSection() {
 
   return (
     <section className="flex flex-col gap-3">
-      <h3 className="text-sm font-medium text-foreground">
-        {t(($) => {
+      <SettingsSectionHeading
+        title={t(($) => {
           return $.billing.credits.title;
         })}
-      </h3>
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={settingsCardBorder}
-      >
+      />
+      <div className="zero-card overflow-hidden">
         <div className="flex flex-col gap-3 px-5 py-4">
           <div className="min-w-0">
             <p className="text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
@@ -125,10 +125,7 @@ function ConnectionCard({
     return null;
   }
   return (
-    <div
-      className="flex items-center gap-3 rounded-xl bg-card px-4 py-3"
-      style={ZERO_BORDER}
-    >
+    <div className="zero-card flex items-center gap-3 px-4 py-3">
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-foreground">
           {connection.displayName}
@@ -514,7 +511,7 @@ export function ModelProviderConnectionsSection() {
     return null;
   }
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-3">
       <SettingsSectionHeading
         title={t(($) => {
           return $.settings.models.gateways.title;
@@ -525,10 +522,7 @@ export function ModelProviderConnectionsSection() {
         action={<AddConnectionMenu />}
       />
       {connections.length === 0 ? (
-        <p
-          className="rounded-xl bg-card px-4 py-5 text-sm text-muted-foreground"
-          style={ZERO_BORDER}
-        >
+        <p className="zero-card px-4 py-5 text-sm text-muted-foreground">
           {t(($) => {
             return $.settings.models.gateways.empty;
           })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -100,6 +100,7 @@ import {
   UsagePackMigrationPlanSelectionPage,
   UsagePackPricingDialogs,
 } from "./usage-pack-pricing-page.tsx";
+import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 
 const PLANS = [
   {
@@ -628,7 +629,7 @@ function PlanCard({
   });
 
   return (
-    <div className="relative flex flex-col rounded-xl transition-transform duration-200 hover:-translate-y-0.5 zero-border px-6 py-7">
+    <div className="relative flex flex-col rounded-[var(--zero-card-radius)] transition-transform duration-200 hover:-translate-y-0.5 zero-border px-6 py-7">
       {plan.tier === "pro" && (
         <span className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
           <Crown size={12} className="text-amber-500" />
@@ -647,7 +648,7 @@ function PlanCard({
         />
       )}
 
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-[#D27939] font-mono">
+      <h3 className="text-sm font-semibold text-[#D27939] font-mono">
         {planName(plan.tier)}
       </h3>
 
@@ -1249,7 +1250,7 @@ function PlanActionButtons({
   const showRestore = !futureTier && !customLocked && isPaid && canRestorePlan;
 
   return (
-    <div className="flex items-center gap-2 shrink-0">
+    <div className="flex shrink-0 flex-wrap items-center gap-2">
       {showRestore && (
         <Button
           size="sm"
@@ -1612,7 +1613,7 @@ function ConcurrencySubscriptionRow({
   return (
     <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <p className="mb-0.5 text-[12px] font-medium text-muted-foreground first-letter:uppercase">
+        <p className="mb-0.5 text-[12px] font-medium text-muted-foreground">
           {i18n.t(($) => {
             return $.billing.concurrency.paidAddOn;
           })}
@@ -2322,12 +2323,12 @@ function ConcurrencyBillingSection({
 
   return (
     <section className="flex flex-col gap-3">
-      <h3 className="text-sm font-medium text-foreground">
-        {i18n.t(($) => {
+      <SettingsSectionHeading
+        title={i18n.t(($) => {
           return $.billing.concurrency.title;
         })}
-      </h3>
-      <div className="overflow-hidden rounded-xl bg-card zero-border">
+      />
+      <div className="zero-card overflow-hidden">
         <div className="px-5 py-4">
           <p className="text-2xl font-medium tracking-tight text-foreground tabular-nums">
             {i18n.t(
@@ -2444,22 +2445,18 @@ function UsagePackMigrationAvailability({
   const configurable = usagePackMigrationConfigurable(migration);
   return (
     <section className="flex flex-col gap-3">
-      <div>
-        <h3 className="text-sm font-medium text-foreground">
-          {i18n.t(($) => {
-            return $.billing.plans.usagePacks.migration.title;
-          })}
-        </h3>
-        <p className="mt-0.5 text-[13px] text-muted-foreground">
-          {i18n.t(
-            ($) => {
-              return $.billing.plans.usagePacks.migration.description;
-            },
-            { plan: planName(migration.tier) },
-          )}
-        </p>
-      </div>
-      <div className="flex items-center justify-between gap-4 rounded-xl bg-card px-5 py-4 zero-border">
+      <SettingsSectionHeading
+        title={i18n.t(($) => {
+          return $.billing.plans.usagePacks.migration.title;
+        })}
+        description={i18n.t(
+          ($) => {
+            return $.billing.plans.usagePacks.migration.description;
+          },
+          { plan: planName(migration.tier) },
+        )}
+      />
+      <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <p className="text-sm text-muted-foreground">
           {configurable
             ? i18n.t(($) => {
@@ -2905,14 +2902,14 @@ export function OrgBillingTab() {
   return (
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium text-foreground">
-          {t(($) => {
+        <SettingsSectionHeading
+          title={t(($) => {
             return $.billing.plans.sectionTitle;
           })}
-        </h3>
-        <div className="overflow-hidden rounded-xl bg-card zero-border">
+        />
+        <div className="zero-card overflow-hidden">
           {statusLoading && !status ? (
-            <div className="flex items-center justify-between gap-4 px-5 py-4">
+            <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
               <div className="min-w-0">
                 <div className="h-4 w-28 rounded bg-muted/50 animate-pulse" />
                 <div className="h-3 w-48 rounded bg-muted/30 animate-pulse mt-1.5" />
@@ -2940,7 +2937,7 @@ export function OrgBillingTab() {
             </div>
           ) : (
             <>
-              <div className="flex items-center justify-between gap-4 px-5 py-4">
+              <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
                 <div className="min-w-0">
                   <CurrentPlanTitle
                     label={currentPlanLabel}
@@ -2999,7 +2996,7 @@ export function OrgBillingTab() {
               {canManageBilling && (
                 <>
                   <div className="h-0 zero-border-t mx-5" />
-                  <div className="flex items-center justify-between gap-4 px-5 py-4">
+                  <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-foreground">
                         {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
@@ -42,10 +42,7 @@ import {
   WORKSPACE_DELETE_CONFIRMATION,
 } from "../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import { readImageDimensions } from "./read-image-dimensions.ts";
-
-const sectionCardStyle = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
+import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 
 const MIN_LOGO_DIMENSION = 100;
 const MAX_LOGO_DIMENSION = 4096;
@@ -158,17 +155,14 @@ function ProfileSection({
 
   return (
     <section className="flex flex-col gap-3">
-      <h3 className="text-sm font-medium text-foreground">
-        {t(($) => {
+      <SettingsSectionHeading
+        title={t(($) => {
           return $.settings.workspace.profile.sectionTitle;
         })}
-      </h3>
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={sectionCardStyle}
-      >
+      />
+      <div className="zero-card overflow-hidden">
         {/* Logo row */}
-        <div className="flex items-center justify-between gap-4 px-5 py-4">
+        <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <div className="min-w-0">
             <p className="text-sm font-medium text-foreground">
               {t(($) => {
@@ -239,7 +233,7 @@ function ProfileSection({
         </div>
         <div className="h-0 zero-border-t mx-5" />
         {/* Name row */}
-        <div className="flex items-center justify-between gap-4 px-5 py-4">
+        <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <div className="min-w-0">
             <p className="text-sm font-medium text-foreground">
               {t(($) => {
@@ -262,7 +256,7 @@ function ProfileSection({
               placeholder={t(($) => {
                 return $.settings.workspace.profile.name.placeholder;
               })}
-              className="w-[220px] shrink-0"
+              className="w-full shrink-0 sm:w-[220px]"
             />
           ) : (
             <span className="text-sm text-foreground shrink-0">
@@ -339,19 +333,16 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
 
   return (
     <section className="flex flex-col gap-3">
-      <h3 className="text-sm font-medium text-foreground">
-        {t(($) => {
+      <SettingsSectionHeading
+        title={t(($) => {
           return $.settings.workspace.danger.sectionTitle;
         })}
-      </h3>
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={sectionCardStyle}
-      >
+      />
+      <div className="zero-card overflow-hidden">
         {canLeave && (
           <>
             {/* Leave workspace */}
-            <div className="flex items-center justify-between gap-4 px-5 py-4">
+            <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
               <div className="min-w-0">
                 <p className="text-sm font-medium text-foreground">
                   {t(($) => {
@@ -369,7 +360,7 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
                   <Button
                     variant="destructive"
                     size="sm"
-                    className="shrink-0 gap-1.5"
+                    className="w-full shrink-0 gap-1.5 sm:w-auto"
                   >
                     {t(($) => {
                       return $.settings.workspace.danger.leave.title;
@@ -426,7 +417,7 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
           <>
             {canLeave && <div className="h-0 zero-border-t mx-5" />}
             {/* Delete workspace */}
-            <div className="flex items-center justify-between gap-4 px-5 py-4">
+            <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
               <div className="min-w-0">
                 <p className="text-sm font-medium text-foreground">
                   {t(($) => {
@@ -444,7 +435,7 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
                   <Button
                     variant="destructive"
                     size="sm"
-                    className="shrink-0 gap-1.5"
+                    className="w-full shrink-0 gap-1.5 sm:w-auto"
                   >
                     {t(($) => {
                       return $.settings.shared.delete;
@@ -551,12 +542,9 @@ function GeneralTabSkeleton() {
       {/* Profile section skeleton */}
       <section className="flex flex-col gap-3">
         <div className="h-4 w-12 rounded bg-muted/50 animate-pulse" />
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={sectionCardStyle}
-        >
+        <div className="zero-card overflow-hidden">
           {/* Logo row */}
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
+          <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             <div className="min-w-0">
               <div className="h-4 w-8 rounded bg-muted/50 animate-pulse" />
               <div className="h-3 w-48 rounded bg-muted/30 animate-pulse mt-1.5" />
@@ -565,23 +553,20 @@ function GeneralTabSkeleton() {
           </div>
           <div className="h-0 zero-border-t mx-5" />
           {/* Name row */}
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
+          <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             <div className="min-w-0">
               <div className="h-4 w-10 rounded bg-muted/50 animate-pulse" />
               <div className="h-3 w-40 rounded bg-muted/30 animate-pulse mt-1.5" />
             </div>
-            <div className="h-9 w-[220px] shrink-0 rounded-lg bg-muted/30 animate-pulse" />
+            <div className="h-9 w-full shrink-0 rounded-lg bg-muted/30 animate-pulse sm:w-[220px]" />
           </div>
         </div>
       </section>
       {/* Danger zone skeleton */}
       <section className="flex flex-col gap-3">
         <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={sectionCardStyle}
-        >
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
+        <div className="zero-card overflow-hidden">
+          <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             <div className="min-w-0">
               <div className="h-4 w-28 rounded bg-muted/50 animate-pulse" />
               <div className="h-3 w-64 rounded bg-muted/30 animate-pulse mt-1.5" />

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -39,9 +39,8 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 import { currentLocale } from "../../../../i18n/index.ts";
 import { formatUsd } from "../../../../i18n/format.ts";
 
-const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
-
-const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
+const ROW_GRID =
+  "grid min-w-[560px] grid-cols-[1fr_8rem_6rem_3rem] items-center gap-x-6";
 
 function formatDate(unixTimestamp: number): string {
   return new Date(unixTimestamp * 1000).toLocaleDateString(currentLocale());
@@ -308,7 +307,7 @@ export function OrgInvoicesTab() {
 
   if (!loading && invoices.length === 0) {
     return (
-      <div className="flex flex-col gap-4">
+      <div className="zero-card flex flex-col items-center px-6 py-12 text-center">
         <p className="text-sm text-muted-foreground">
           {t(($) => {
             return $.billing.invoices.empty;
@@ -325,10 +324,7 @@ export function OrgInvoicesTab() {
           <DownloadReceiptsDialog months={months} />
         </div>
       )}
-      <div
-        className="overflow-hidden rounded-[10px] bg-card"
-        style={cardBorder}
-      >
+      <div className="zero-card overflow-x-auto">
         <div
           className={cn(
             ROW_GRID,

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -107,8 +107,8 @@ function memberRowGrid(showUsagePack: boolean): string {
   return cn(
     ROW_GRID,
     showUsagePack
-      ? "grid-cols-[minmax(0,1fr)_6rem_13rem_5.5rem_2rem]"
-      : "grid-cols-[minmax(0,1fr)_6rem_5.5rem_2rem]",
+      ? "min-w-[720px] grid-cols-[minmax(0,1fr)_6rem_13rem_5.5rem_2rem]"
+      : "min-w-[480px] grid-cols-[minmax(0,1fr)_6rem_5.5rem_2rem]",
   );
 }
 
@@ -254,7 +254,7 @@ export function OrgMembersTab() {
         )}
       </div>
 
-      <div className="overflow-hidden rounded-xl bg-card zero-border">
+      <div className="zero-card overflow-x-auto">
         <MembersTableHeader showUsagePack={showUsagePack} />
         <div className="h-0 zero-border-t mx-5" />
 
@@ -286,7 +286,7 @@ export function OrgMembersTab() {
         {!isLoading && membershipRequests.length > 0 && (
           <>
             <div className="px-5 pt-3 pb-1">
-              <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                 <UserPlus size={13} />
                 {t(($) => {
                   return $.settings.workspace.members.joinRequests;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -321,8 +321,7 @@ function DefaultModelRow({
   return (
     <div
       data-testid="default-model-row"
-      className="flex flex-col gap-3 overflow-hidden rounded-xl bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+      className="zero-card flex flex-col gap-3 overflow-hidden px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="min-w-0">
         <p className="text-sm font-medium text-foreground">
@@ -361,10 +360,7 @@ function DefaultModelRow({
           }}
           disabled={disabled}
         >
-          <SelectTrigger
-            className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]"
-            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-          >
+          <SelectTrigger className="zero-btn-morandi h-9 w-full shrink-0 sm:w-[280px]">
             <SelectValue
               placeholder={t(($) => {
                 return $.settings.models.policies.selectDefaultModel;
@@ -738,7 +734,7 @@ function RouteChoiceButton({
           : "0.7px solid hsl(var(--gray-400))",
       }}
       className={cn(
-        "flex flex-col gap-0.5 rounded-xl bg-card px-5 py-4 text-left transition-colors",
+        "flex flex-col gap-0.5 rounded-[var(--zero-card-radius)] bg-card px-5 py-4 text-left transition-colors",
         active && "bg-primary/5",
         !active && !disabled && "hover:bg-state-hover",
         disabled && "cursor-not-allowed opacity-50",
@@ -1808,7 +1804,7 @@ export function OrgModelPoliciesSection() {
   };
 
   return (
-    <section className="flex flex-col gap-6">
+    <section className="flex flex-col gap-8">
       <DefaultModelRow
         policies={visiblePolicies}
         workspaceDefaultModel={data.workspaceDefaultModel}
@@ -1833,10 +1829,7 @@ export function OrgModelPoliciesSection() {
             />
           }
         />
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-        >
+        <div className="zero-card overflow-hidden">
           <div className="hidden grid-cols-[minmax(0,1fr)_236px_96px_36px] gap-3 border-b border-border/50 px-5 py-3 text-xs font-medium text-muted-foreground lg:grid">
             <span>
               {t(($) => {
@@ -1891,7 +1884,7 @@ function ModelPoliciesSkeleton() {
   return (
     <section className="flex flex-col gap-3">
       <div className="h-5 w-24 rounded bg-muted/50 animate-pulse" />
-      <div className="overflow-hidden rounded-xl border border-border/50 bg-card">
+      <div className="zero-card overflow-hidden">
         {[0, 1, 2].map((item) => {
           return (
             <div key={item} className="flex h-16 items-center gap-3 px-4">

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -360,7 +360,12 @@ function DefaultModelRow({
           }}
           disabled={disabled}
         >
-          <SelectTrigger className="zero-btn-morandi h-9 w-full shrink-0 sm:w-[280px]">
+          <SelectTrigger
+            className="zero-btn-morandi h-9 w-full shrink-0 sm:w-[280px]"
+            aria-label={t(($) => {
+              return $.settings.models.policies.defaultModel;
+            })}
+          >
             <SelectValue
               placeholder={t(($) => {
                 return $.settings.models.policies.selectDefaultModel;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-providers-tab.tsx
@@ -27,7 +27,7 @@ export function OrgProvidersTab() {
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-8">
       {isAdmin && <OrgModelPoliciesSection />}
       <StaleBannerSection />
       {isAdmin && <ModelProviderConnectionsSection />}
@@ -111,7 +111,7 @@ function StaleProviderBanner({
   })();
   return (
     <section
-      className="flex items-center gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4"
+      className="flex items-center gap-3 rounded-[var(--zero-card-radius)] border border-destructive/40 bg-destructive/5 p-4"
       role="alert"
     >
       <div className="min-w-0 flex-1">

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-usage-tab.tsx
@@ -368,7 +368,7 @@ function UsageAllowanceCard({
   return (
     <div
       data-testid="usage-allowance-section"
-      className="overflow-hidden rounded-xl bg-card px-5 py-4 zero-border"
+      className="zero-card overflow-hidden px-5 py-4"
     >
       <p className="text-sm font-semibold text-foreground">
         {t(($) => {
@@ -906,7 +906,7 @@ export function CreditBalanceCard({
           splitLayout={splitLayout}
         />
       ) : null}
-      <div className="overflow-hidden rounded-xl bg-card zero-border">
+      <div className="zero-card overflow-hidden">
         {billingLoading && !billing ? (
           <div className="px-5 py-4 space-y-2">
             <div className="h-4 w-48 rounded bg-muted/50 animate-pulse" />
@@ -946,7 +946,7 @@ export function MemberUsageTable({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="overflow-hidden rounded-xl bg-card zero-border">
+    <div className="zero-card overflow-hidden">
       {/* Header */}
       <div className="grid grid-cols-[1fr_7rem] gap-x-4 items-center px-5 py-2.5 text-[13px] font-medium text-foreground">
         <span>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -934,7 +934,7 @@ function PlanHighlights({ tier }: { readonly tier: UsagePackPlanTier }) {
 
 function PlanSelectionPanel({ children }: { readonly children: ReactNode }) {
   return (
-    <div className="grid grid-cols-1 overflow-hidden rounded-xl bg-card zero-border sm:grid-cols-2">
+    <div className="zero-card grid grid-cols-1 overflow-hidden sm:grid-cols-2">
       {children}
     </div>
   );
@@ -1811,7 +1811,7 @@ function SubscriptionComparisonTable({
           className={
             tooltip
               ? "text-[13px] font-normal leading-5 text-muted-foreground"
-              : "bg-muted/40 text-sm font-medium uppercase tracking-wide text-muted-foreground"
+              : "bg-muted/40 text-sm font-medium text-muted-foreground"
           }
         >
           <tr>
@@ -2542,7 +2542,7 @@ function MigrationOrderSummary({
       aria-label={i18n.t(($) => {
         return $.billing.plans.usagePacks.orderSummary;
       })}
-      className={inDialog ? undefined : "rounded-xl bg-card p-4 zero-border"}
+      className={inDialog ? undefined : "zero-card p-4"}
     >
       {!inDialog && (
         <>
@@ -2644,7 +2644,7 @@ function MigrationRevisionOrderSummary({
       aria-label={i18n.t(($) => {
         return $.billing.plans.usagePacks.orderSummary;
       })}
-      className={inDialog ? undefined : "rounded-xl bg-card p-4 zero-border"}
+      className={inDialog ? undefined : "zero-card p-4"}
     >
       {!inDialog && (
         <>

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -236,23 +236,25 @@ function OAuthAccountGroup({
 
   return (
     <div className="[&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50">
-      <div className="flex items-center gap-3 px-5 py-4">
-        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ProviderIcon type={type} size={20} />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-foreground">
-            {title}
-          </p>
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
-            {description}
-          </p>
+      <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center">
+        <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+            <ProviderIcon type={type} size={20} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="break-words text-sm font-medium text-foreground sm:truncate">
+              {title}
+            </p>
+            <p className="mt-0.5 break-words text-xs text-muted-foreground sm:truncate">
+              {description}
+            </p>
+          </div>
         </div>
         <Button
           type="button"
           variant="outline"
           size="sm"
-          className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
+          className="zero-btn-morandi h-9 w-full shrink-0 gap-1.5 rounded-lg border sm:w-auto"
           disabled={actionPending || accounts.length >= 10}
           onClick={onAdd}
         >
@@ -1275,30 +1277,32 @@ function OAuthCredentialRow({
       data-testid={testId}
       className="px-5 py-4 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
     >
-      <div className="flex items-center gap-3">
-        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ProviderIcon type={type} size={20} />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p
-            data-testid="connector-card-label"
-            className="truncate text-sm font-medium text-foreground"
-          >
-            {title}
-          </p>
-          <p
-            data-testid="connector-help-text"
-            className="mt-0.5 truncate text-xs text-muted-foreground"
-          >
-            {description}
-          </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+            <ProviderIcon type={type} size={20} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p
+              data-testid="connector-card-label"
+              className="break-words text-sm font-medium text-foreground sm:truncate"
+            >
+              {title}
+            </p>
+            <p
+              data-testid="connector-help-text"
+              className="mt-0.5 break-words text-xs text-muted-foreground sm:truncate"
+            >
+              {description}
+            </p>
+          </div>
         </div>
         {status === "missing" ? (
           <Button
             type="button"
             variant="outline"
             size="sm"
-            className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
+            className="zero-btn-morandi h-9 w-full shrink-0 rounded-lg border sm:w-auto"
             aria-label={t(
               ($) => {
                 return $.settings.models.personal.actionForProvider;
@@ -1314,7 +1318,7 @@ function OAuthCredentialRow({
             {actionLabel}
           </Button>
         ) : (
-          <div className="ml-auto flex items-center justify-end gap-1.5">
+          <div className="flex w-full items-center justify-between gap-1.5 sm:ml-auto sm:w-auto sm:justify-end">
             <OAuthFooterStatus
               status={status}
               detail={status === "connected" ? connectedDetail : null}
@@ -1406,14 +1410,16 @@ function OAuthCredentialRowSkeleton() {
   return (
     <div
       data-testid="oauth-card-skeleton"
-      className="flex animate-pulse items-center gap-3 px-5 py-4 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
+      className="flex animate-pulse flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50"
     >
-      <span className="h-5 w-5 shrink-0 rounded bg-muted/50" />
-      <div className="min-w-0 flex-1">
-        <span className="block h-4 w-32 rounded bg-muted/50" />
-        <span className="mt-1.5 block h-3 w-48 rounded bg-muted/30" />
+      <div className="flex w-full min-w-0 items-center gap-3">
+        <span className="h-5 w-5 shrink-0 rounded bg-muted/50" />
+        <div className="min-w-0 flex-1">
+          <span className="block h-4 w-32 rounded bg-muted/50" />
+          <span className="mt-1.5 block h-3 w-48 max-w-full rounded bg-muted/30" />
+        </div>
       </div>
-      <span className="h-9 w-20 shrink-0 rounded bg-muted/30" />
+      <span className="h-9 w-full shrink-0 rounded bg-muted/30 sm:w-20" />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -135,13 +135,10 @@ function OAuthAccountGroupsSection() {
   };
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-3">
       <PersonalModelsHeading />
       <TooltipProvider delayDuration={100}>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-        >
+        <div className="zero-card overflow-hidden">
           {isLoading ? (
             <>
               <OAuthCredentialRowSkeleton />
@@ -563,12 +560,9 @@ function LegacyOAuthCredentialsSection() {
   };
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-3">
       <PersonalModelsHeading />
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="zero-card overflow-hidden">
         {isLoading ? (
           <>
             <OAuthCredentialRowSkeleton />

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-usage-record.tsx
@@ -54,8 +54,6 @@ import {
   formatLocalizedNumber,
 } from "../../../../i18n/format.ts";
 
-const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
-
 const SOURCE_ICONS = {
   chat: MessageCircle,
   automation: Clock,
@@ -459,10 +457,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
 
 function UsageRecordSkeleton() {
   return (
-    <div
-      className="overflow-hidden rounded-xl bg-card"
-      style={{ border: CARD_BORDER }}
-    >
+    <div className="zero-card overflow-hidden">
       {[0, 1, 2].map((i) => {
         return (
           <div
@@ -504,8 +499,7 @@ function UsageRecordEmpty({
 }) {
   return (
     <div
-      className="flex flex-col items-center rounded-xl bg-card px-6 py-12 text-center"
-      style={{ border: CARD_BORDER }}
+      className="zero-card flex flex-col items-center px-6 py-12 text-center"
       data-testid="usage-records-empty"
     >
       <img
@@ -593,10 +587,7 @@ function UsageRecordList({ data }: { data: UsageRecordResponse }) {
   return (
     <div className="flex flex-col gap-3">
       <TooltipProvider delayDuration={100}>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={{ border: CARD_BORDER }}
-        >
+        <div className="zero-card overflow-hidden">
           <UsageRecordSummary
             count={data.pagination.total}
             totalCredits={data.totalCredits}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
@@ -84,7 +84,7 @@ export function BuildInfoBlock() {
     : formatBuildInfoValue(backendBuildInfo?.backendVersion, unavailable);
 
   return (
-    <div className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border">
+    <div className="zero-card flex items-start gap-4 px-5 py-4">
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
           <GitCommit size={22} className="text-muted-foreground" />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -40,7 +40,7 @@ function CooldownDiagnosticsSummary({
   const { t } = useTranslation();
 
   return (
-    <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
+    <summary className="flex w-full cursor-pointer list-none items-start gap-4 px-5 py-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center">
         <Cpu size={22} className="text-muted-foreground" />
       </span>
@@ -53,7 +53,7 @@ function CooldownDiagnosticsSummary({
             return $.settings.preferences.debug.builtInModelCooldown.title;
           })}
         </span>
-        <span className="text-sm text-muted-foreground">
+        <span className="text-[13px] text-muted-foreground">
           {t(($) => {
             return $.settings.preferences.debug.builtInModelCooldown
               .description;
@@ -375,12 +375,12 @@ export function BuiltInModelCooldownDiagnosticsBlock() {
   return (
     <section
       aria-labelledby="built-in-model-cooldown-diagnostics-title"
-      className="overflow-hidden rounded-xl bg-card zero-border"
+      className="zero-card overflow-hidden"
     >
       {diagnostics ? (
         <details className="group">
           <CooldownDiagnosticsSummary diagnostics={diagnostics} />
-          <div className="border-t border-border/60 p-4">
+          <div className="border-t border-border/60 px-5 py-4">
             <CooldownDiagnosticsContent
               diagnostics={diagnostics}
               loading={loading}
@@ -388,7 +388,7 @@ export function BuiltInModelCooldownDiagnosticsBlock() {
           </div>
         </details>
       ) : (
-        <div className="flex items-start gap-4 p-4">
+        <div className="flex items-start gap-4 px-5 py-4">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
               <Cpu size={22} className="text-muted-foreground" />
@@ -404,7 +404,7 @@ export function BuiltInModelCooldownDiagnosticsBlock() {
               })}
             </div>
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="text-sm text-muted-foreground">
+              <div className="text-[13px] text-muted-foreground">
                 {loading
                   ? t(($) => {
                       return $.settings.preferences.debug.builtInModelCooldown

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
@@ -38,7 +38,7 @@ function ConnectionDiagnosticsSummary({
   const channelState = diagnostics.snapshot.channelState ?? unavailable;
 
   return (
-    <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
+    <summary className="flex w-full cursor-pointer list-none items-start gap-4 px-5 py-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center">
         <RadioTower size={22} className="text-muted-foreground" />
       </span>
@@ -48,7 +48,7 @@ function ConnectionDiagnosticsSummary({
             return $.settings.preferences.debug.connectionDiagnostics.title;
           })}
         </span>
-        <span className="text-sm text-muted-foreground">
+        <span className="text-[13px] text-muted-foreground">
           {t(($) => {
             return $.settings.preferences.debug.connectionDiagnostics
               .description;
@@ -157,7 +157,7 @@ function ConnectionDiagnosticsDetails({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col gap-4 border-t border-border/60 p-4">
+    <div className="flex flex-col gap-4 border-t border-border/60 px-5 py-4">
       <div className="grid gap-2 font-mono text-[11px] sm:grid-cols-2">
         <div className="rounded-md bg-muted/40 px-3 py-2 break-all">
           {t(($) => {
@@ -250,7 +250,7 @@ export function ConnectionDiagnosticsBlock() {
   };
 
   return (
-    <details className="group overflow-hidden rounded-xl bg-card zero-border">
+    <details className="zero-card group overflow-hidden">
       <ConnectionDiagnosticsSummary diagnostics={diagnostics} />
       <ConnectionDiagnosticsDetails
         diagnostics={diagnostics}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -197,7 +197,7 @@ function AccountRow({
             {label}
           </span>
           {account.isDefault ? (
-            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
               {t(($) => {
                 return $.connectors.accounts.default;
               })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -228,7 +228,7 @@ function CatalogDiagnosticsSummary({
   );
 
   return (
-    <summary className="flex w-full cursor-pointer list-none items-start gap-4 p-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
+    <summary className="flex w-full cursor-pointer list-none items-start gap-4 px-5 py-4 text-left transition-colors hover:bg-state-hover [&::-webkit-details-marker]:hidden">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center">
         <Plug size={22} className="text-muted-foreground" />
       </span>
@@ -287,7 +287,7 @@ function RejectedCandidateDiagnostics({
 }) {
   return (
     <div className="border-t border-border/60 pt-4">
-      <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="mb-3 text-xs font-medium text-muted-foreground">
         {i18n.t(($) => {
           return $.connectors.providerSettings.catalogDiagnostics.sections
             .rejectedCandidate;
@@ -437,7 +437,7 @@ function DiagnosticsContent({
       <CatalogSyncDiagnostics diagnostics={diagnostics} />
 
       <div className="border-t border-border/60 pt-4">
-        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <div className="mb-3 text-xs font-medium text-muted-foreground">
           {i18n.t(($) => {
             return $.connectors.providerSettings.catalogDiagnostics.sections
               .compatibility;
@@ -505,7 +505,7 @@ function DiagnosticsContent({
       </div>
 
       <div className="border-t border-border/60 pt-4">
-        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <div className="mb-3 text-xs font-medium text-muted-foreground">
           {i18n.t(($) => {
             return $.connectors.providerSettings.catalogDiagnostics.sections
               .credentialStorage;
@@ -564,17 +564,17 @@ export function ConnectorCatalogDiagnosticsBlock() {
   return (
     <section
       aria-labelledby="connector-catalog-diagnostics-title"
-      className="overflow-hidden rounded-xl bg-card zero-border"
+      className="zero-card overflow-hidden"
     >
       {diagnostics ? (
         <details className="group">
           <CatalogDiagnosticsSummary diagnostics={diagnostics} />
-          <div className="border-t border-border/60 p-4">
+          <div className="border-t border-border/60 px-5 py-4">
             <DiagnosticsContent diagnostics={diagnostics} />
           </div>
         </details>
       ) : (
-        <div className="flex items-start gap-4 p-4">
+        <div className="flex items-start gap-4 px-5 py-4">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
               <Plug size={22} className="text-muted-foreground" />
@@ -589,7 +589,7 @@ export function ConnectorCatalogDiagnosticsBlock() {
                 return $.connectors.providerSettings.catalogDiagnostics.title;
               })}
             </div>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-[13px] text-muted-foreground">
               {loading
                 ? t(($) => {
                     return $.connectors.providerSettings.catalogDiagnostics

--- a/turbo/apps/platform/src/views/okou-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/language-settings.tsx
@@ -153,7 +153,7 @@ export function LanguageSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+      <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4">
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
@@ -166,7 +166,7 @@ export function LanguageSettings() {
                 return $.settings.preferences.language.title;
               })}
             </div>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-[13px] text-muted-foreground">
               {t(
                 ($) => {
                   return $.settings.preferences.language.description;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/morning-brief-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/morning-brief-settings.tsx
@@ -80,11 +80,13 @@ export function MorningBriefSettings() {
   }
 
   if (!preferences) {
-    return <Skeleton className="h-[76px] w-full rounded-xl" />;
+    return (
+      <Skeleton className="h-[76px] w-full rounded-[var(--zero-card-radius)]" />
+    );
   }
 
   return (
-    <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+    <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4">
       <div className="flex flex-1 items-center gap-4 min-w-0">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
@@ -97,7 +99,7 @@ export function MorningBriefSettings() {
               return $.settings.preferences.morningBrief.title;
             })}
           </div>
-          <div className="text-sm text-muted-foreground">
+          <div className="text-[13px] text-muted-foreground">
             {t(($) => {
               return $.settings.preferences.morningBrief.description;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx
@@ -26,24 +26,28 @@ export function AccountSection() {
   const initial = (displayName || email || "U").charAt(0).toUpperCase();
 
   return (
-    <div className="flex items-center gap-4 bg-card rounded-xl zero-border p-5">
-      <UserAvatar
-        imageUrl={user?.imageUrl}
-        name={displayName}
-        initial={initial}
-        size="xl"
-      />
-      <div className="flex-1 min-w-0">
-        {displayName && (
-          <div className="text-sm font-medium text-foreground truncate">
-            {displayName}
-          </div>
-        )}
-        {email && (
-          <div className="text-sm text-muted-foreground truncate">{email}</div>
-        )}
+    <div className="zero-card flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-4">
+        <UserAvatar
+          imageUrl={user?.imageUrl}
+          name={displayName}
+          initial={initial}
+          size="xl"
+        />
+        <div className="min-w-0 flex-1">
+          {displayName && (
+            <div className="truncate text-sm font-medium text-foreground">
+              {displayName}
+            </div>
+          )}
+          {email && (
+            <div className="truncate text-sm text-muted-foreground">
+              {email}
+            </div>
+          )}
+        </div>
       </div>
-      <Button asChild className="shrink-0">
+      <Button asChild className="w-full shrink-0 sm:w-auto">
         <a href={userProfileUrl} target="_blank" rel="noreferrer">
           <ExternalLink size={14} />
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -364,7 +364,7 @@ function UsagePackMemberCard({ row }: { row: UsagePackMemberRow }) {
     <div
       role="listitem"
       data-testid={`usage-pack-member-credit-${member.userId}`}
-      className="overflow-hidden rounded-xl bg-card zero-border"
+      className="zero-card overflow-hidden"
     >
       <div className="px-5 py-4">
         <UsagePackMemberHeader credits={credits} member={member} />
@@ -518,7 +518,7 @@ function UsagePackCreditCard({ isAdmin }: { isAdmin: boolean }) {
   return (
     <div
       data-testid="usage-pack-credit-card"
-      className="overflow-hidden rounded-xl bg-card px-5 py-4 zero-border"
+      className="zero-card overflow-hidden px-5 py-4"
     >
       {creditsLoadable.state === "loading" && !data ? (
         <div className="space-y-2">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/debug-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/debug-section.tsx
@@ -38,7 +38,7 @@ function CaptureNetworkBodiesBlock() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
+      <div className="zero-card flex items-center gap-4 px-5 py-4">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
             <Bug size={22} className="text-muted-foreground" />
@@ -50,7 +50,7 @@ function CaptureNetworkBodiesBlock() {
               return $.settings.preferences.debug.capture.title;
             })}
           </div>
-          <div className="text-sm text-muted-foreground">
+          <div className="text-[13px] text-muted-foreground">
             {enabled
               ? t(
                   ($) => {
@@ -77,7 +77,7 @@ function CaptureNetworkBodiesBlock() {
 
 export function DebugSection() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-4">
       <BuildInfoBlock />
       <ConnectionDiagnosticsBlock />
       <ConnectorCatalogDiagnosticsBlock />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/model-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/model-section.tsx
@@ -9,7 +9,7 @@ export function ModelSection() {
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
 
   return (
-    <div className="flex flex-col gap-10">
+    <div className="flex flex-col gap-8">
       {isAdmin && <OrgProvidersTab />}
       <PersonalProvidersTab />
     </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -41,7 +41,7 @@ function AppearanceBlock() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+      <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4">
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
@@ -54,7 +54,7 @@ function AppearanceBlock() {
                 return $.settings.preferences.appearance.theme.title;
               })}
             </div>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-[13px] text-muted-foreground">
               {t(($) => {
                 return $.settings.preferences.appearance.theme.description;
               })}
@@ -122,7 +122,7 @@ function EnterBlock() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+      <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4">
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
@@ -135,7 +135,7 @@ function EnterBlock() {
                 return $.settings.preferences.send.title;
               })}
             </div>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-[13px] text-muted-foreground">
               {effective === "enter"
                 ? t(($) => {
                     return $.settings.preferences.send.enterDescription;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -87,7 +87,7 @@ function AppearanceBlock() {
                 className={cn(
                   "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isActive
-                    ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                    ? "border-primary/40 bg-primary/10 text-foreground dark:border-primary/50 dark:bg-primary/15"
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
@@ -170,7 +170,7 @@ function EnterBlock() {
                 className={cn(
                   "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isActive
-                    ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                    ? "border-primary/40 bg-primary/10 text-foreground dark:border-primary/50 dark:bg-primary/15"
                     : "zero-chip text-muted-foreground hover:text-foreground",
                   saving !== null && "opacity-60 cursor-not-allowed",
                 )}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/usage-records-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/usage-records-section.tsx
@@ -49,7 +49,7 @@ export function UsageRecordsSection() {
   return (
     <div className="flex flex-col gap-4">
       {/* One compact header row: tabs on the left, range filter on the right. */}
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <Tabs
           value={tab}
           onValueChange={(value) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -273,7 +273,12 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           return $.settings.shared.close;
         })}
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
-        style={{ "--primary-foreground": "220 18% 10%" } as CSSProperties}
+        style={
+          {
+            "--color-primary-foreground": "hsl(220 18% 10%)",
+            "--primary-foreground": "220 18% 10%",
+          } as CSSProperties
+        }
       >
         <DialogTitle className="sr-only">
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -1,5 +1,5 @@
 // oxlint-disable max-lines-per-function
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
@@ -273,6 +273,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           return $.settings.shared.close;
         })}
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
+        style={{ "--primary-foreground": "220 18% 10%" } as CSSProperties}
       >
         <DialogTitle className="sr-only">
           {t(($) => {
@@ -294,7 +295,12 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 handleSectionChange(v as SettingsSection);
               }}
             >
-              <SelectTrigger className="h-9 w-full">
+              <SelectTrigger
+                className="h-9 w-full"
+                aria-label={t(($) => {
+                  return $.settings.dialog.title;
+                })}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -317,7 +317,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
               return (
                 <div key={group.label} className="shrink-0">
                   <div className="h-7 flex items-center pl-2">
-                    <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
+                    <span className="text-[13px] leading-4 text-sidebar-foreground/60 font-medium">
                       {group.label}
                     </span>
                   </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-section-heading.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-section-heading.tsx
@@ -12,14 +12,16 @@ export function SettingsSectionHeading({
   action,
 }: SettingsSectionHeadingProps) {
   return (
-    <div className="flex items-start justify-between gap-3">
-      <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 flex-col gap-1">
         <h3 className="text-base font-semibold text-foreground">{title}</h3>
         {description !== undefined && (
           <p className="text-sm text-muted-foreground">{description}</p>
         )}
       </div>
-      {action !== undefined && <div className="shrink-0">{action}</div>}
+      {action !== undefined && (
+        <div className="shrink-0 self-start">{action}</div>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx
@@ -149,7 +149,12 @@ export function TimezoneSettings() {
             onValueChange={handleChange}
             disabled={loading}
           >
-            <SelectTrigger className="zero-btn-morandi">
+            <SelectTrigger
+              className="zero-btn-morandi"
+              aria-label={t(($) => {
+                return $.settings.preferences.timezone.rowTitle;
+              })}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx
@@ -107,7 +107,9 @@ export function TimezoneSettings() {
   });
 
   if (!preferences) {
-    return <Skeleton className="h-[76px] w-full rounded-xl" />;
+    return (
+      <Skeleton className="h-[76px] w-full rounded-[var(--zero-card-radius)]" />
+    );
   }
 
   const currentTimezone =
@@ -121,7 +123,7 @@ export function TimezoneSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+      <div className="zero-card flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:gap-4">
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
@@ -134,7 +136,7 @@ export function TimezoneSettings() {
                 return $.settings.preferences.timezone.rowTitle;
               })}
             </div>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-[13px] text-muted-foreground">
               {t(($) => {
                 return $.settings.preferences.timezone.rowDescription;
               })}

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -70,7 +70,7 @@ describe("preferences page", () => {
       expect(document.documentElement).toHaveAttribute("data-theme", "dark");
     });
 
-    click(screen.getByText("Time Zone"));
+    click(screen.getByText("Time zone"));
 
     await waitFor(() => {
       expect(screen.getByText("Time zone")).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe("preferences page", () => {
     expect(cmdEnterSegment).toBeInTheDocument();
     click(cmdEnterSegment as HTMLElement);
 
-    click(screen.getByText("Time Zone"));
+    click(screen.getByText("Time zone"));
 
     await waitFor(() => {
       expect(screen.getByText("Time zone")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- apply the canonical Zero card surface across all unified Settings sections
- standardize section headings, spacing, responsive rows, and table overflow behavior
- normalize Settings navigation labels to sentence case

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, platform, and API type checks
- 10 targeted Settings test files (170 tests)
- post-rebase platform type check and Settings dialog test (35 tests)