### PR TITLE
perf(platform): avoid serialized home agent validation

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -92,7 +92,12 @@ export const currentAgent$ = computed((get) => {
 
 const lastUsedAgentId$ = computed((get) => {
   const value = get(lastUsedAgentIdRaw$);
-  return typeof value === "string" && value.length > 0 ? value : null;
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const parsed = agentsByIdContract.get.pathParams.safeParse({ id: value });
+  return parsed.success ? parsed.data.id : null;
 });
 
 export const rememberLastUsedAgentId$ = command(({ set }, agentId: string) => {
@@ -111,19 +116,14 @@ export const agents$ = computed(async (get) => {
 
 export const homeAgentId$ = computed(async (get) => {
   const lastUsedAgentId = get(lastUsedAgentId$);
-  if (!lastUsedAgentId) {
-    return await get(defaultAgentId$);
-  }
-
-  const agents = await get(agents$);
-  if (
-    agents.some((agent) => {
-      return agent.id === lastUsedAgentId;
-    })
-  ) {
+  if (lastUsedAgentId) {
     return lastUsedAgentId;
   }
 
+  // The agent chat route renders a non-interactive shell, validates the
+  // candidate against the current org's team, and only then activates its
+  // draft and composer. Avoid repeating that validation while the home
+  // route's full-screen skeleton is still visible.
   return await get(defaultAgentId$);
 });
 

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { AgentChatPage } from "../../views/okou-page/agent-chat-page.tsx";
+import { AgentChatValidationPage } from "../../views/okou-page/agent-chat-validation-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import {
@@ -36,33 +37,21 @@ import { i18n } from "../../i18n/index.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(AgentChatPage), "sidebar");
+    const agentId = get(currentAgentId$);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    set(updatePage$, createElement(AgentChatValidationPage));
     set(
       updateDocumentTitle$,
       i18n.t(($) => {
         return $.chat.documentTitle;
       }),
     );
-    set(reloadTagline$);
-
-    set(resetChatPageModelSelection$);
-
-    // Read agent ID from URL immediately (synchronous) and update sidebar
-    // highlight early so the UI responds without waiting for async data.
-    const agentId = get(currentAgentId$);
-    let agentDraft: EnsuredAgentDraft | undefined;
-    if (agentId) {
-      set(setChatAgentId$, agentId);
-      agentDraft = set(ensureAgentDraft$, agentId);
-      set(setAgentComposerContext$, { agentId, agentDraft });
-      set(setTalkDraft$, agentDraft.draft);
-    }
 
     await set(hideAppSkeleton$, signal);
-
-    if (await set(onboardGuard$, signal)) {
-      return;
-    }
 
     if (!agentId) {
       throw new Error("Chat page requires an active agent, but none found");
@@ -87,6 +76,14 @@ export const setupAgentChatPage$ = command(
       });
       return;
     }
+
+    set(setChatAgentId$, agentId);
+    const agentDraft: EnsuredAgentDraft = set(ensureAgentDraft$, agentId);
+    set(setAgentComposerContext$, { agentId, agentDraft });
+    set(setTalkDraft$, agentDraft.draft);
+    set(reloadTagline$);
+    set(resetChatPageModelSelection$);
+    set(updatePage$, createElement(AgentChatPage), "sidebar");
 
     set(rememberLastUsedAgentId$, agentId);
     set(

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-validation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-validation.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { currentAgentId$, reloadAgents$ } from "../agent.ts";
+import { detachedNavigateTo$, searchParams$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+
+export const retryAgentChatValidation$ = command(({ get, set }) => {
+  const agentId = get(currentAgentId$);
+  if (!agentId) {
+    throw new Error("Chat page requires an active agent, but none found");
+  }
+
+  const searchParams = get(searchParams$);
+  set(reloadAgents$);
+  set(detachedNavigateTo$, ROUTES.agentChat, {
+    pathParams: { agentId },
+    searchParams,
+    replace: true,
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2107,10 +2107,14 @@ describe("chat composer models", () => {
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
     await waitFor(() => {
-      expect(billingRequestCount).toBeGreaterThanOrEqual(2);
+      expect(billingRequestCount).toBeGreaterThanOrEqual(1);
       expect(
         context.mocks.ably.hasSubscription("billing:changed"),
       ).toBeTruthy();
+    });
+    context.mocks.ably.trigger("billing:changed");
+    await waitFor(() => {
+      expect(billingRequestCount).toBeGreaterThanOrEqual(2);
     });
     await user.click(await findComposerModel("Claude Fable 5"));
     await expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
@@ -1,0 +1,500 @@
+import { onboardingStatusContract } from "@okouai/api-contracts/contracts/onboarding";
+import { agentDraftContract } from "@okouai/api-contracts/contracts/agent-draft";
+import {
+  teamContract,
+  type TeamComposeItem,
+} from "@okouai/api-contracts/contracts/team";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { pathname } from "../../../signals/location.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
+import { isAbortError } from "../../../signals/utils.ts";
+
+const context = testContext();
+const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
+const TEAM_REQUEST_PATTERN = `*${teamContract.list.path}`;
+const {
+  get$: lastUsedAgentId$,
+  set$: setLastUsedAgentId$,
+  clear$: clearLastUsedAgentId$,
+} = localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const RETURNING_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
+const DELETED_AGENT_ID = "c0000000-0000-4000-a000-000000000003";
+const OTHER_ORG_AGENT_ID = "c0000000-0000-4000-a000-000000000004";
+const CURRENT_ORG_AGENT_ID = "c0000000-0000-4000-a000-000000000005";
+const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000006";
+
+const UNVALIDATED_AGENT_CASES = [
+  {
+    candidateId: STALE_AGENT_ID,
+    label: "stale",
+    recoveryAgentId: DEFAULT_AGENT_ID,
+    recoveryAgentName: "Default agent",
+    switchedOrganization: false,
+  },
+  {
+    candidateId: DELETED_AGENT_ID,
+    label: "deleted",
+    recoveryAgentId: DEFAULT_AGENT_ID,
+    recoveryAgentName: "Default agent",
+    switchedOrganization: false,
+  },
+  {
+    candidateId: OTHER_ORG_AGENT_ID,
+    label: "cross-organization",
+    recoveryAgentId: CURRENT_ORG_AGENT_ID,
+    recoveryAgentName: "Current organization agent",
+    switchedOrganization: true,
+  },
+] as const;
+
+function teamAgent(id: string, displayName: string): TeamComposeItem {
+  return {
+    id,
+    displayName,
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    updatedAt: "2026-08-26T00:00:00.000Z",
+  };
+}
+
+function deferTeamResponse(team: TeamComposeItem[]) {
+  const started = context.mocks.deferred<void>();
+  const release = context.mocks.deferred<void>();
+  context.mocks.api(teamContract.list, async ({ respond }) => {
+    started.resolve(undefined);
+    await release.promise;
+    return respond(200, team);
+  });
+  return { release, started };
+}
+
+function recordAgentDraftLoads(): () => readonly string[] {
+  const agentIds: string[] = [];
+  context.mocks.api(agentDraftContract.get, ({ params, respond }) => {
+    agentIds.push(params.id);
+    return respond(200, {
+      draftUserMessage: null,
+      draftAttachments: null,
+    });
+  });
+  return () => {
+    return agentIds;
+  };
+}
+
+function buttonByText(text: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim() === text;
+  });
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+function setupCandidateHomeRoute(
+  candidate: (typeof UNVALIDATED_AGENT_CASES)[number],
+  path = "/",
+): void {
+  detachedSetupPage({
+    context,
+    path,
+    ...(candidate.switchedOrganization
+      ? {
+          org: {
+            activeOrg: {
+              id: "org_current",
+              name: "Current organization",
+            },
+            memberships: [{ id: "org_current" }, { id: "org_previous" }],
+          },
+        }
+      : {}),
+  });
+}
+
+function blockUnexpectedTeamRequests(): () => number {
+  let requestCount = 0;
+  context.mocks.api(teamContract.list, ({ never }) => {
+    requestCount += 1;
+    return never();
+  });
+  return () => {
+    return requestCount;
+  };
+}
+
+function installBootstrapSkeleton(): HTMLDivElement {
+  const skeleton = document.createElement("div");
+  skeleton.id = "app-bootstrap-skeleton";
+  document.body.append(skeleton);
+  context.signal.addEventListener("abort", () => {
+    skeleton.remove();
+  });
+  return skeleton;
+}
+
+describe("home route", () => {
+  it("routes a first-time user to the default agent before the team list resolves", async () => {
+    context.store.set(clearLastUsedAgentId$);
+    context.mocks.data.onboardingStatus({
+      defaultAgentId: DEFAULT_AGENT_ID,
+    });
+    const team = deferTeamResponse([
+      teamAgent(DEFAULT_AGENT_ID, "Default agent"),
+    ]);
+
+    detachedSetupPage({ context, path: "/" });
+
+    await team.started.promise;
+    expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+    await expect(
+      screen.findByTestId("agent-chat-validation"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+
+    team.release.resolve(undefined);
+    await waitFor(() => {
+      expect(document.title).toContain("Default agent");
+    });
+    await expect(
+      screen.findByRole("textbox", { name: "Message" }),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("shows a returning user's persisted agent route before team validation resolves", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    const bootstrapSkeleton = installBootstrapSkeleton();
+    const team = deferTeamResponse([
+      teamAgent(DEFAULT_AGENT_ID, "Default agent"),
+      teamAgent(RETURNING_AGENT_ID, "Returning agent"),
+    ]);
+
+    detachedSetupPage({ context, path: "/" });
+
+    await team.started.promise;
+    expect(pathname()).toBe(`/agents/${RETURNING_AGENT_ID}/chat`);
+    expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    await expect(
+      screen.findByTestId("agent-chat-validation"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+
+    team.release.resolve(undefined);
+    await waitFor(() => {
+      expect(document.title).toContain("Returning agent");
+    });
+    await expect(
+      screen.findByRole("textbox", { name: "Message" }),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("ignores a malformed stale persisted ID", async () => {
+    context.store.set(setLastUsedAgentId$, "stale-agent-id");
+    context.mocks.data.onboardingStatus({
+      defaultAgentId: DEFAULT_AGENT_ID,
+    });
+    const team = deferTeamResponse([
+      teamAgent(DEFAULT_AGENT_ID, "Default agent"),
+    ]);
+
+    detachedSetupPage({ context, path: "/" });
+
+    await team.started.promise;
+    expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+    team.release.resolve(undefined);
+    await waitFor(() => {
+      expect(document.title).toContain("Default agent");
+    });
+  });
+
+  it.each(UNVALIDATED_AGENT_CASES)(
+    "keeps a $label persisted candidate non-interactive until validation",
+    async (candidate) => {
+      context.store.set(setLastUsedAgentId$, candidate.candidateId);
+      context.mocks.data.onboardingStatus({
+        defaultAgentId: candidate.recoveryAgentId,
+      });
+      const draftLoads = recordAgentDraftLoads();
+      const team = deferTeamResponse([
+        teamAgent(candidate.recoveryAgentId, candidate.recoveryAgentName),
+      ]);
+
+      setupCandidateHomeRoute(candidate);
+
+      await team.started.promise;
+      expect(pathname()).toBe(`/agents/${candidate.candidateId}/chat`);
+      await expect(
+        screen.findByTestId("agent-chat-validation"),
+      ).resolves.toBeInTheDocument();
+      expect(
+        screen.queryByRole("textbox", { name: "Message" }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryAllByRoleFast("button").some((button) => {
+          return button.textContent?.trim() === "Send";
+        }),
+      ).toBeFalsy();
+      expect(draftLoads()).not.toContain(candidate.candidateId);
+
+      team.release.resolve(undefined);
+      await waitFor(() => {
+        expect(pathname()).toBe(`/agents/${candidate.recoveryAgentId}/chat`);
+        expect(document.title).toContain(candidate.recoveryAgentName);
+      });
+      expect(draftLoads()).not.toContain(candidate.candidateId);
+    },
+  );
+
+  it("keeps onboarding ahead of persisted-agent navigation", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    context.mocks.data.onboardingStatus({
+      needsOnboarding: true,
+      onboardingComplete: false,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
+    });
+    const teamRequestCount = blockUnexpectedTeamRequests();
+
+    detachedSetupPage({ context, path: "/" });
+
+    await expect(
+      screen.findByRole("heading", { name: "What do you want to make first" }),
+    ).resolves.toBeInTheDocument();
+    expect(pathname()).toBe(ROUTES.onboarding);
+    expect(teamRequestCount()).toBe(0);
+  });
+
+  it("keeps organization selection ahead of persisted-agent navigation", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    context.mocks.browser.url("https://app.vm0.ai/");
+    const teamRequestCount = blockUnexpectedTeamRequests();
+
+    detachedSetupPage({
+      context,
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_member" }],
+      },
+      path: "/",
+    });
+
+    await waitFor(() => {
+      expect(new URL(window.location.href).pathname).toBe(
+        "/sign-in/tasks/choose-organization",
+      );
+    });
+    expect(teamRequestCount()).toBe(0);
+  });
+
+  it("keeps authentication ahead of persisted-agent navigation", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    context.mocks.browser.url("https://app.vm0.ai/");
+    const teamRequestCount = blockUnexpectedTeamRequests();
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      session: null,
+      user: null,
+    });
+
+    await waitFor(() => {
+      expect(new URL(window.location.href).pathname).toBe("/sign-in");
+    });
+    expect(teamRequestCount()).toBe(0);
+  });
+
+  it("keeps a persisted route non-interactive and retryable when team validation fails", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    const bootstrapSkeleton = installBootstrapSkeleton();
+    const teamRequestStarted = context.mocks.deferred<void>();
+    let teamRequestCount = 0;
+    context.mocks.http.get(TEAM_REQUEST_PATTERN, () => {
+      teamRequestCount += 1;
+      if (teamRequestCount === 1) {
+        teamRequestStarted.resolve(undefined);
+        return HttpResponse.error();
+      }
+      return HttpResponse.json([
+        teamAgent(DEFAULT_AGENT_ID, "Default agent"),
+        teamAgent(RETURNING_AGENT_ID, "Returning agent"),
+      ]);
+    });
+    const draftLoads = recordAgentDraftLoads();
+
+    detachedSetupPage({ context, path: "/?prompt=Recovered%20prompt" });
+
+    await teamRequestStarted.promise;
+    expect(pathname()).toBe(`/agents/${RETURNING_AGENT_ID}/chat`);
+    expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    expect(context.store.get(lastUsedAgentId$)).toBe(RETURNING_AGENT_ID);
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+      "Failed to load agent",
+    );
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+    expect(draftLoads()).not.toContain(RETURNING_AGENT_ID);
+
+    fireEvent.click(buttonByText("Try again"));
+
+    const composer = await screen.findByRole("textbox", { name: "Message" });
+    await waitFor(() => {
+      expect(document.title).toContain("Returning agent");
+      expect(composer).toHaveTextContent("Recovered prompt");
+    });
+    expect(teamRequestCount).toBe(2);
+  });
+
+  it.each(UNVALIDATED_AGENT_CASES)(
+    "recovers a $label candidate safely after team validation fails",
+    async (candidate) => {
+      context.store.set(setLastUsedAgentId$, candidate.candidateId);
+      context.mocks.data.onboardingStatus({
+        defaultAgentId: candidate.recoveryAgentId,
+      });
+      const teamRequestStarted = context.mocks.deferred<void>();
+      let teamRequestCount = 0;
+      context.mocks.http.get(TEAM_REQUEST_PATTERN, () => {
+        teamRequestCount += 1;
+        if (teamRequestCount === 1) {
+          teamRequestStarted.resolve(undefined);
+          return HttpResponse.error();
+        }
+        return HttpResponse.json([
+          teamAgent(candidate.recoveryAgentId, candidate.recoveryAgentName),
+        ]);
+      });
+      const draftLoads = recordAgentDraftLoads();
+
+      setupCandidateHomeRoute(candidate, "/?prompt=Safe%20recovery");
+
+      await teamRequestStarted.promise;
+      expect(pathname()).toBe(`/agents/${candidate.candidateId}/chat`);
+      await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+        "Failed to load agent",
+      );
+      expect(
+        screen.queryByRole("textbox", { name: "Message" }),
+      ).not.toBeInTheDocument();
+      expect(draftLoads()).not.toContain(candidate.candidateId);
+
+      fireEvent.click(buttonByText("Try again"));
+
+      await waitFor(() => {
+        expect(pathname()).toBe(`/agents/${candidate.recoveryAgentId}/chat`);
+      });
+      const composer = await screen.findByRole("textbox", { name: "Message" });
+      await waitFor(() => {
+        expect(composer).toHaveTextContent("Safe recovery");
+      });
+      expect(teamRequestCount).toBe(2);
+      expect(draftLoads()).not.toContain(candidate.candidateId);
+    },
+  );
+
+  it("does not activate an agent after chat validation navigation is aborted", async () => {
+    const draftLoads = recordAgentDraftLoads();
+    const team = deferTeamResponse([
+      teamAgent(RETURNING_AGENT_ID, "Returning agent"),
+    ]);
+    const setupPromise = setupPage({
+      context,
+      path: `/agents/${RETURNING_AGENT_ID}/chat`,
+    });
+    context.track(setupPromise);
+
+    await team.started.promise;
+    await expect(
+      screen.findByTestId("agent-chat-validation"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+
+    context.store.set(detachedNavigateTo$, ROUTES.skeleton, { replace: true });
+    await waitFor(() => {
+      expect(pathname()).toBe(ROUTES.skeleton);
+    });
+    team.release.resolve(undefined);
+
+    let setupError: unknown;
+    try {
+      await setupPromise;
+    } catch (error: unknown) {
+      setupError = error;
+    }
+    expect(isAbortError(setupError)).toBeTruthy();
+    expect(pathname()).toBe(ROUTES.skeleton);
+    expect(draftLoads()).not.toContain(RETURNING_AGENT_ID);
+  });
+
+  it("does not redirect after the home navigation lifecycle is aborted", async () => {
+    context.store.set(setLastUsedAgentId$, RETURNING_AGENT_ID);
+    const onboardingRequestStarted = context.mocks.deferred<void>();
+    const releaseOnboardingRequest = context.mocks.deferred<void>();
+    context.mocks.api(
+      onboardingStatusContract.getStatus,
+      async ({ respond }) => {
+        onboardingRequestStarted.resolve(undefined);
+        await releaseOnboardingRequest.promise;
+        return respond(200, {
+          needsOnboarding: false,
+          onboardingComplete: true,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: DEFAULT_AGENT_ID,
+          defaultAgentMetadata: { displayName: "Default agent" },
+        });
+      },
+    );
+    const teamRequestCount = blockUnexpectedTeamRequests();
+
+    const setupPromise = setupPage({
+      context,
+      path: "/",
+    });
+    context.track(setupPromise);
+    await onboardingRequestStarted.promise;
+    await waitFor(() => {
+      expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
+    });
+
+    context.store.set(detachedNavigateTo$, ROUTES.skeleton, { replace: true });
+    await waitFor(() => {
+      expect(pathname()).toBe(ROUTES.skeleton);
+    });
+
+    releaseOnboardingRequest.resolve(undefined);
+    let setupError: unknown;
+    try {
+      await setupPromise;
+    } catch (error: unknown) {
+      setupError = error;
+    }
+    expect(isAbortError(setupError)).toBeTruthy();
+    expect(pathname()).toBe(ROUTES.skeleton);
+    expect(teamRequestCount()).toBe(0);
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2029,10 +2029,10 @@ describe("zero sidebar", () => {
 
     setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
-    const sidebar = await waitFor(() => {
+    const initialSidebar = await waitFor(() => {
       return screen.getByRole("navigation", { name: "Sidebar" });
     });
-    click(within(sidebar).getByLabelText("Open a conversation"));
+    click(within(initialSidebar).getByLabelText("Open a conversation"));
 
     const dialog = await screen.findByRole("dialog", { name: "Talk to" });
     expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
@@ -2077,7 +2077,9 @@ describe("zero sidebar", () => {
           "Open agent menu",
         ),
       ).toBeInTheDocument();
-      expect(within(sidebar).getByText("Research Agent")).toBeInTheDocument();
+      expect(
+        within(initialSidebar).getByText("Research Agent"),
+      ).toBeInTheDocument();
     });
 
     openAgentRowMenu(dialog, "Research Agent");
@@ -2085,7 +2087,7 @@ describe("zero sidebar", () => {
 
     await waitFor(() => {
       expect(
-        within(sidebar).queryByText("Research Agent"),
+        within(initialSidebar).queryByText("Research Agent"),
       ).not.toBeInTheDocument();
     });
 
@@ -2098,7 +2100,9 @@ describe("zero sidebar", () => {
           "Open agent menu",
         ),
       ).toBeInTheDocument();
-      expect(within(sidebar).getByText("Research Agent")).toBeInTheDocument();
+      expect(
+        within(initialSidebar).getByText("Research Agent"),
+      ).toBeInTheDocument();
     });
 
     click(within(dialog).getByRole("option", { name: /Research Agent/ }));
@@ -2108,10 +2112,12 @@ describe("zero sidebar", () => {
         screen.queryByRole("dialog", { name: "Talk to" }),
       ).not.toBeInTheDocument();
       expect(
-        within(sidebar).getByText("Chats with Research Agent"),
+        within(sidebar()).getByText("Chats with Research Agent"),
       ).toBeInTheDocument();
-      expect(within(sidebar).getByText("Research kickoff")).toBeInTheDocument();
-      expect(within(sidebar).queryByText("New chat")).not.toBeInTheDocument();
+      expect(
+        within(sidebar()).getByText("Research kickoff"),
+      ).toBeInTheDocument();
+      expect(within(sidebar()).queryByText("New chat")).not.toBeInTheDocument();
     });
 
     expect(createRequests).toBe(0);

--- a/turbo/apps/platform/src/views/okou-page/agent-chat-validation-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/agent-chat-validation-page.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@okouai/ui";
+import { useLoadable, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { agents$ } from "../../signals/agent.ts";
+import { retryAgentChatValidation$ } from "../../signals/okou-page/agent-chat-validation.ts";
+
+export function AgentChatValidationPage() {
+  const { t } = useTranslation();
+  const agentsLoadable = useLoadable(agents$);
+  const retry = useSet(retryAgentChatValidation$);
+
+  return (
+    <main
+      className="flex min-h-dvh w-full items-center justify-center bg-background px-6"
+      data-testid="agent-chat-validation"
+    >
+      {agentsLoadable.state === "hasError" ? (
+        <div
+          className="zero-card flex max-w-sm flex-col items-center gap-4 px-6 py-8 text-center"
+          role="alert"
+        >
+          <p className="text-sm text-muted-foreground">
+            {t(($) => {
+              return $.authorization.permission.errors.loadAgent;
+            })}
+          </p>
+          <Button type="button" variant="outline" onClick={retry}>
+            {t(($) => {
+              return $.chat.errors.recovery.tryAgain;
+            })}
+          </Button>
+        </div>
+      ) : (
+        <div
+          className="flex w-full max-w-3xl flex-col items-center"
+          role="status"
+          aria-label={t(($) => {
+            return $.connectors.access.loading;
+          })}
+        >
+          <div className="h-8 w-64 animate-pulse rounded-lg bg-muted" />
+          <div className="mt-8 h-32 w-full animate-pulse rounded-3xl border border-border bg-muted/40" />
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- route a syntactically valid persisted last-used agent from home immediately after the existing authentication, organization-selection, and onboarding guards
- render only an isolated, non-interactive validation shell until `/api/team` proves that the candidate belongs to the current organization; the sidebar, active chat agent, draft, composer context, and send controls are installed only after validation succeeds
- redirect stale, deleted, and cross-organization candidates to the current default agent while preserving deep-link parameters
- keep team transport failures on a safe error surface with an explicit retry that refetches membership and reloads the same parameter-preserving route
- cover first-time and returning users, malformed and valid stale IDs, deleted agents, organization switches, onboarding/authentication guards, valid and invalid transport-failure recovery, navigation aborts, sidebar remount behavior, and billing realtime refresh ordering

No API contract changes.

## Failure behavior

A failed current-organization team request does not infer that the persisted candidate is valid or invalid. It leaves the candidate unactivated on a non-interactive error page. Retrying refetches the team list; a subsequently validated candidate activates normally, while an absent candidate deterministically redirects to the current default agent. Repeated failures remain safe and retryable without creating candidate draft or composer state.

## Testing

- `pnpm exec prettier --check` on the changed files
- file-scoped ESLint, Oxlint, and type-aware Oxlint on the changed implementation and regression files
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/home-route.test.tsx` (15 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t "pins an agent from the conversation picker and opens that agent chat"` (1 passed, 79 skipped)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx -t "restores personal models when billing refreshes after realtime subscribes"` (5 consecutive passes before rebase and one pass on the final rebased head; the original two-request and restored-model assertions remain intact)

Refs #29576