### PR TITLE
fix(python): preserve jsonl cleanup after reporter failure

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1997,8 +1997,10 @@ def done():
             finally:
                 auth_base_forwarder.shutdown_forward_request_workers(wait=False)
         finally:
-            model_provider_failure.shutdown()
-            shutdown_log_writer()
+            try:
+                model_provider_failure.shutdown()
+            finally:
+                shutdown_log_writer()
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -374,6 +374,7 @@ class TestDoneHook:
                 (
                     "usage-executor:shutdown:wait=True",
                     "auth-base:shutdown:wait=False",
+                    "model-provider:shutdown",
                     "jsonl:shutdown",
                 ),
                 id="usage-executor-shutdown",
@@ -384,6 +385,7 @@ class TestDoneHook:
                     "usage-executor:shutdown:wait=True",
                     "usage:drain",
                     "auth-base:shutdown:wait=False",
+                    "model-provider:shutdown",
                     "jsonl:shutdown",
                 ),
                 id="post-executor-usage-drain",
@@ -394,9 +396,21 @@ class TestDoneHook:
                     "usage-executor:shutdown:wait=True",
                     "usage:drain",
                     "auth-base:shutdown:wait=False",
+                    "model-provider:shutdown",
                     "jsonl:shutdown",
                 ),
                 id="auth-base-worker-shutdown",
+            ),
+            pytest.param(
+                "model-provider",
+                (
+                    "usage-executor:shutdown:wait=True",
+                    "usage:drain",
+                    "auth-base:shutdown:wait=False",
+                    "model-provider:shutdown",
+                    "jsonl:shutdown",
+                ),
+                id="model-provider-reporter-shutdown",
             ),
         ],
     )
@@ -423,6 +437,11 @@ class TestDoneHook:
             if failure_point == "auth-base":
                 raise failure
 
+        def shutdown_model_provider() -> None:
+            calls.append("model-provider:shutdown")
+            if failure_point == "model-provider":
+                raise failure
+
         def shutdown_jsonl() -> None:
             calls.append("jsonl:shutdown")
 
@@ -441,6 +460,11 @@ class TestDoneHook:
                 mitm_addon.auth_base_forwarder,
                 "shutdown_forward_request_workers",
                 side_effect=shutdown_auth_base,
+            ),
+            patch.object(
+                mitm_addon.model_provider_failure,
+                "shutdown",
+                side_effect=shutdown_model_provider,
             ),
             patch.object(mitm_addon, "shutdown_log_writer", side_effect=shutdown_jsonl),
             pytest.raises(RuntimeError) as exc_info,


### PR DESCRIPTION
## Summary

- guarantee the bounded JSONL writer shutdown runs after model-provider reporter shutdown fails
- preserve the existing reporter-before-writer order and original exception propagation
- extend the `done()` failure matrix to cover the reporter boundary and all final-stage ordering

## Scope

- no API, database, persisted state, runner protocol, configuration, or dependency changes
- simultaneous reporter and JSONL shutdown failures remain governed by Python's existing `finally` exception semantics

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_done_hook.py` (13 passed)
- `uv run --no-sync python -m pytest tests/` (6,662 passed)
- `git diff --check`

Closes #29590
