### PR TITLE
docs(python): document buffered response capture decode policy

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -467,7 +467,13 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     ``response_streaming.configure_response_stream()`` because that path keeps a
     bounded raw wire-byte buffer and records whether it was truncated. Bounded
     ``flow.response.raw_content`` decoding is used only when no stream
-    buffer metadata exists.
+    buffer metadata exists. These sources intentionally use different decode
+    policies: retained stream buffers use best-effort ``decompress_body()``,
+    which can preserve original wire bytes or partial decoded output after a
+    decode problem, while buffered ``raw_content`` uses the strict
+    ``decode_response_body_for_network_log_capture()`` helper. A strict
+    ``None`` result omits a non-empty buffered body and marks it ``binary``;
+    ``b""`` remains a successful empty result with no body field.
     """
     # Request headers (always available)
     request_inspection = _inspect_headers_for_capture(flow.request.headers)

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -386,7 +386,31 @@ def decode_response_body_for_network_log_capture(
     *,
     max_output: int = DEFAULT_BODY_DECODE_LIMIT,
 ) -> bytes | None:
-    """Decode a buffered response body with bounded mitmproxy compatibility."""
+    """Decode a buffered response body with bounded mitmproxy-compatible semantics.
+
+    Missing or ``identity`` encoding returns ``data`` unchanged. A supported
+    encoding returns decoded bytes on success, including ``b""`` for a
+    successful empty result. ``None`` means that the encoding is unsupported or
+    that decoding failed. For supported encodings, decoded output is bounded by
+    ``max_output``; reaching that bound returns the successful decoded prefix,
+    even when the compressed input has not reached a complete frame where the
+    codec policy permits that result.
+
+    The supported codec compatibility is intentionally aligned with mitmproxy:
+
+    - ``gzip`` accepts gzip and zlib wrappers and may return output from an
+      incomplete stream.
+    - ``deflate`` tries the zlib wrapper and then the raw-deflate wrapper, and
+      requires a complete stream unless the decoded-output bound is reached.
+    - ``br`` rejects invalid or incomplete input, except that reaching the
+      decoded-output bound returns the bounded prefix.
+    - ``zstd`` reads concatenated frames up to ``max_output`` bytes and returns
+      ``None`` when the reader reports malformed or invalid trailing input.
+
+    This is stricter than the best-effort ``decompress_body()`` path used for
+    retained streaming buffers, which can preserve original wire bytes or
+    partial decoded output after a decode problem.
+    """
     encoding = headers.get("content-encoding", "").strip().lower()
     if not encoding or encoding == "identity":
         return data


### PR DESCRIPTION
## Summary

- Document the buffered response decoder's return values, output bound, and codec completeness policy.
- Explain why retained response stream buffers use best-effort decoding while buffered
  `flow.response.raw_content` uses the strict helper, including the `None` and `b""` capture outcomes.

## Scope

This is a documentation-only change in the mitmproxy addon. Runtime decoding, network-log behavior,
tests, dependencies, and schemas are unchanged.

## Validation

- `uv lock --check`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_capture_fields.py tests/test_body_capture_decompression.py tests/test_body_decoding.py` (178 passed)

Closes #29587
