### PR TITLE
fix(python): roll back firewall auth task startup state

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -66,6 +66,7 @@ class FirewallAuthStateSnapshotForTests:
     """Copied auth cache state exposed to tests without leaking private storage."""
 
     has_cached_headers: bool
+    has_in_flight_fetch: bool
     headers: dict[str, str] = field(default_factory=dict)
     resolved_secrets: list[str] = field(default_factory=list)
     base: str | None = None
@@ -284,6 +285,7 @@ def auth_state_snapshot_for_tests(
     if cache is None:
         return FirewallAuthStateSnapshotForTests(
             has_cached_headers=False,
+            has_in_flight_fetch=state.in_flight is not None,
             force_refresh_pending=state.force_refresh_pending,
             last_force_refresh_monotonic_at=state.last_force_refresh_monotonic_at,
         )
@@ -291,6 +293,7 @@ def auth_state_snapshot_for_tests(
     payload = cache.payload
     return FirewallAuthStateSnapshotForTests(
         has_cached_headers=True,
+        has_in_flight_fetch=state.in_flight is not None,
         headers=dict(payload.headers),
         resolved_secrets=list(payload.resolved_secrets),
         base=payload.base,
@@ -434,24 +437,32 @@ async def get_firewall_headers(
         fetch_task = state.in_flight
         created_fetch = fetch_task is None
         if fetch_task is None:
+            force_refresh = state.force_refresh_pending
+            force_refresh_started_at = time.monotonic() if force_refresh else None
             _reserve_firewall_auth_fetch()
 
-            # Consume the marker before creating the task so only this shared
-            # operation can trigger the refresh. Recording before the fetch
-            # preserves the intentional failed-refresh cooldown semantics.
-            force_refresh = state.force_refresh_pending
+            fetch_coroutine = _fetch_and_cache_firewall_headers(
+                state,
+                request,
+                force_refresh=force_refresh,
+            )
+            try:
+                fetch_task = asyncio.create_task(fetch_coroutine)
+            except BaseException:
+                fetch_coroutine.close()
+                _release_firewall_auth_fetch()
+                raise
+
+            state.in_flight = fetch_task
+
+            # Task selection and publication contain no await, so consuming
+            # the marker here is still atomic with choosing this shared fetch.
+            # Recording before the task runs preserves the intentional
+            # failed-refresh cooldown once task ownership has transferred.
             state.force_refresh_pending = False
             if force_refresh:
-                state.last_force_refresh_monotonic_at = time.monotonic()
+                state.last_force_refresh_monotonic_at = force_refresh_started_at
 
-            fetch_task = asyncio.create_task(
-                _fetch_and_cache_firewall_headers(
-                    state,
-                    request,
-                    force_refresh=force_refresh,
-                )
-            )
-            state.in_flight = fetch_task
             fetch_task.add_done_callback(_observe_fetch_task_exception)
 
         result = await asyncio.shield(fetch_task)

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -203,8 +203,10 @@ class TestFirewallHeaderCache:
         ):
             await auth_cache.get_firewall_headers(cache_key, auth_request)
 
-        gc.collect()
         assert exc_info.value is task_factory_error
+        task_factory_error.__traceback__ = None
+        del exc_info
+        gc.collect()
         assert not any(
             warning.category is RuntimeWarning and "was never awaited" in str(warning.message)
             for warning in recwarn

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -1,10 +1,13 @@
 """Tests for firewall auth cache behavior."""
 
 import asyncio
+import gc
 import json
 import threading
 import time
 import urllib.error
+from collections.abc import Coroutine
+from typing import Never
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -14,6 +17,7 @@ import registry as registry_cache
 from tests.auth_endpoint_helpers import FakeAuthEndpoint, firewall_auth_success_response
 from tests.auth_state_helpers import (
     auth_cache_key,
+    auth_state_snapshot,
     cached_headers,
     force_refresh_pending,
     has_auth_state,
@@ -183,6 +187,94 @@ class TestFirewallHeaderCache:
         assert retry["headers"] == {"Authorization": "Bearer retry"}
         assert retry["cache_hit"] is False
         assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer retry"}
+
+    async def test_task_startup_failure_rolls_back_admission_and_allows_retry(self, recwarn):
+        cache_key = auth_cache_key()
+        auth_request = firewall_auth_request(auth_headers={"Authorization": "template"})
+        task_factory_error = RuntimeError("task factory failed")
+
+        def reject_task_creation(coroutine: Coroutine[object, object, object]) -> Never:
+            raise task_factory_error
+
+        with (
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache.asyncio, "create_task", new=reject_task_creation),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+        gc.collect()
+        assert exc_info.value is task_factory_error
+        assert not any(
+            warning.category is RuntimeWarning and "was never awaited" in str(warning.message)
+            for warning in recwarn
+        )
+        assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+        failed_state = auth_state_snapshot(cache_key)
+        assert failed_state is not None
+        assert not failed_state.has_in_flight_fetch
+
+        mock_fetch = AsyncMock(
+            return_value=firewall_auth_success(headers={"Authorization": "Bearer recovered"})
+        )
+        with (
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache, "fetch_firewall_headers", mock_fetch),
+        ):
+            result = await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+        assert result["headers"] == {"Authorization": "Bearer recovered"}
+        assert result["cache_hit"] is False
+        assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+        recovered_state = auth_state_snapshot(cache_key)
+        assert recovered_state is not None
+        assert not recovered_state.has_in_flight_fetch
+
+    async def test_force_refresh_task_startup_failure_preserves_refresh_for_retry(self):
+        cache_key = auth_cache_key()
+        auth_request = firewall_auth_request(auth_headers={"Authorization": "template"})
+        set_last_force_refresh_monotonic_at(cache_key, 1000.0)
+        mark_force_refresh(cache_key)
+        task_factory_error = RuntimeError("task factory failed")
+
+        def reject_task_creation(coroutine: Coroutine[object, object, object]) -> Never:
+            raise task_factory_error
+
+        with (
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache.time, "monotonic", return_value=2000.0),
+            patch.object(auth_cache.asyncio, "create_task", new=reject_task_creation),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+        assert exc_info.value is task_factory_error
+        assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+        failed_state = auth_state_snapshot(cache_key)
+        assert failed_state is not None
+        assert not failed_state.has_in_flight_fetch
+        assert failed_state.force_refresh_pending
+        assert failed_state.last_force_refresh_monotonic_at == 1000.0
+
+        mock_fetch = AsyncMock(
+            return_value=firewall_auth_success(headers={"Authorization": "Bearer refreshed"})
+        )
+        with (
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache.time, "monotonic", return_value=3000.0),
+            patch.object(auth_cache, "fetch_firewall_headers", mock_fetch),
+        ):
+            result = await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+        assert result["headers"] == {"Authorization": "Bearer refreshed"}
+        assert result["cache_hit"] is False
+        assert mock_fetch.call_args.kwargs["force_refresh"] is True
+        assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+        recovered_state = auth_state_snapshot(cache_key)
+        assert recovered_state is not None
+        assert not recovered_state.has_in_flight_fetch
+        assert not recovered_state.force_refresh_pending
+        assert recovered_state.last_force_refresh_monotonic_at == 3000.0
 
     async def test_different_keys_fetch_independently(self, mitm_ctx):
         """Different auth cache keys should fetch independently."""


### PR DESCRIPTION
## Summary

- make the firewall-auth fetch reservation and coroutine ownership rollback explicit when `asyncio.create_task()` rejects startup
- commit force-refresh marker and cooldown state only after task ownership transfers successfully
- add deterministic integration coverage for ordinary and forced-refresh startup failures, clean state, warning suppression, and successful retries

## Scope

- keeps existing same-key coalescing, cancellation shielding, admission saturation, and post-start fetch-failure behavior unchanged
- does not change APIs, persisted state, runner protocols, migrations, or deployment compatibility

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_auth_cache.py` (57 passed)
- `uv run --no-sync python -m pytest tests/` (6,663 passed)

Closes #29588
