### PR TITLE
fix(runner): apply parent-death setup to kmsg monitor

### DIFF
--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -72,13 +72,20 @@ impl KmsgHandle {
 /// network log entries. Returns a handle; call [`KmsgHandle::stop`] during
 /// shutdown so the tokio runtime can exit cleanly.
 pub fn spawn(network_log_manager: NetworkLogManager) -> std::io::Result<KmsgHandle> {
-    let child = tokio::process::Command::new("dmesg")
-        .args(["-w"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    let mut command = tokio::process::Command::new("dmesg");
+    configure_command(&mut command);
+    let child = command.spawn()?;
 
     KmsgHandle::from_child(child, network_log_manager)
+}
+
+fn configure_command(command: &mut tokio::process::Command) {
+    command
+        .args(["-w"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    crate::parent_death::configure_parent_death_signal(command);
 }
 
 impl KmsgHandle {
@@ -271,6 +278,31 @@ mod tests {
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainContext;
     use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn command_configures_parent_death_signal() {
+        let mut command = tokio::process::Command::new("/bin/true");
+        configure_command(&mut command);
+
+        // SAFETY: `prctl(PR_GET_PDEATHSIG)` is async-signal-safe. The hook
+        // only reads the configured signal and returns fixed OS errors.
+        unsafe {
+            command.pre_exec(|| {
+                let mut signal = 0;
+                if nix::libc::prctl(nix::libc::PR_GET_PDEATHSIG, &mut signal) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if signal != nix::libc::SIGKILL {
+                    return Err(std::io::Error::from_raw_os_error(nix::libc::EPROTO));
+                }
+                Ok(())
+            });
+        }
+
+        let status = command.status().await.unwrap();
+
+        assert!(status.success());
+    }
 
     #[test]
     fn parse_udp_log_message() {


### PR DESCRIPTION
## Summary

- apply the runner's canonical parent-death contract before spawning the long-lived `dmesg -w` kmsg monitor
- keep the existing command arguments, pipes, cancellation, and `NetworkLogProcess` cleanup behavior unchanged
- add a real-process test that reads `PR_GET_PDEATHSIG` before exec and requires `SIGKILL`

## Scope

- no changes to the shared `parent_death` implementation
- no public API, configuration, persistence, or cross-version protocol changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner kmsg_log::tests::command_configures_parent_death_signal -- --exact`
- mutation check: the focused test fails with `EPROTO` when the kmsg helper call is removed
- `cargo test -p runner parent_death::tests`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3332 passed, 24 ignored; integration test passed)
- pre-commit workspace Rust formatting, Clippy, documentation, and file-size checks

Closes #29589
