### PR TITLE
feat(runner): publish canonical host attribution

### DIFF
--- a/.github/scripts/tests/runner-attribution-ansible-test.sh
+++ b/.github/scripts/tests/runner-attribution-ansible-test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+ansible_config="$repo_root/ansible/ansible.cfg"
+inventory="$script_dir/fixtures/runner-promotion-local.ini"
+build_playbook="$repo_root/ansible/playbooks/build-runner.yml"
+rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
+runner_name=v999.0.0
+
+if ! command -v ansible-playbook >/dev/null; then
+  echo "ansible-playbook is required" >&2
+  exit 1
+fi
+
+assert_line_count() {
+  local file=$1
+  local expected=$2
+  local pattern=$3
+  local actual
+  actual=$(grep -Fxc -- "$pattern" "$file" || true)
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${file} to contain ${expected} exact line(s): ${pattern}; got ${actual}" >&2
+    sed -n '1,40p' "$file" >&2
+    exit 1
+  fi
+}
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+test_home="$tmp/home"
+mkdir -p "$test_home"
+
+prepare_configs() {
+  local hostname
+  for hostname in runner-promotion-a runner-promotion-b; do
+    local runner_dir="$tmp/$hostname/runners/$runner_name"
+    mkdir -p "$runner_dir"
+    printf 'name: %s\nhostname: "stale-host"\n' "$runner_name" \
+      >"$runner_dir/runner.yaml"
+  done
+}
+
+verify_configs() {
+  local hostname
+  for hostname in runner-promotion-a runner-promotion-b; do
+    local config="$tmp/$hostname/runners/$runner_name/runner.yaml"
+    assert_line_count "$config" 1 "name: $runner_name"
+    assert_line_count "$config" 1 "hostname: \"$hostname\""
+  done
+}
+
+run_attribution_tasks() {
+  local playbook=$1
+  HOME="$test_home" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ansible-playbook \
+      -i "$inventory" \
+      --forks 2 \
+      --tags runner-config-attribution \
+      -e "data_dir=$tmp/{{ inventory_hostname }}" \
+      -e "runner_version=999.0.0" \
+      "$playbook" >"$tmp/ansible-output" 2>&1
+}
+
+for playbook in "$build_playbook" "$rollback_playbook"; do
+  HOME="$test_home" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ansible-playbook -i "$inventory" --syntax-check "$playbook" >/dev/null
+
+  prepare_configs
+  if ! run_attribution_tasks "$playbook"; then
+    sed -n '1,200p' "$tmp/ansible-output" >&2
+    exit 1
+  fi
+  verify_configs
+
+  # A repeated deploy must replace the same key rather than append another.
+  if ! run_attribution_tasks "$playbook"; then
+    sed -n '1,200p' "$tmp/ansible-output" >&2
+    exit 1
+  fi
+  verify_configs
+done
+
+if grep -Fq -- "--hostname" "$rollback_playbook"; then
+  echo "rollback must not pass a new hostname flag to retained binaries" >&2
+  exit 1
+fi
+
+echo "runner-attribution-ansible-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -291,6 +291,7 @@ jobs:
             .github/scripts/tests/provision-runner-kvm-test.sh \
             .github/scripts/tests/release-tool-downloads-test.sh \
             .github/scripts/tests/resolve-desktop-version-change-test.sh \
+            .github/scripts/tests/runner-attribution-ansible-test.sh \
             .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/reconcile-runner-binary-groups-test.sh \
             .github/scripts/tests/report-cgroup-memory-peak-test.sh \

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -119,3 +119,15 @@
         --runner-dirname {{ runner_name }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
+
+    # Keep deployment identity separate from the version-shaped runner name.
+    # JSON strings are valid YAML scalars and preserve inventory_hostname
+    # without relying on manual quote escaping.
+    - name: Persist canonical runner hostname
+      lineinfile:
+        path: "{{ runner_dir }}/runner.yaml"
+        regexp: "^hostname:"
+        insertafter: "^name:"
+        line: "hostname: {{ inventory_hostname | to_json }}"
+      tags:
+        - runner-config-attribution

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -403,6 +403,19 @@
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
 
+    # Write the additive YAML field after invoking the retained target binary.
+    # Older Serde readers ignore this field, while an older CLI would reject a
+    # new command-line option.
+    - name: Persist canonical runner hostname
+      when: not (skip_install | default(false))
+      lineinfile:
+        path: "{{ runner_dir }}/runner.yaml"
+        regexp: "^hostname:"
+        insertafter: "^name:"
+        line: "hostname: {{ inventory_hostname | to_json }}"
+      tags:
+        - runner-config-attribution
+
     # Both the readiness wait and the later non-target drain/stop operations
     # shell out to the target runner binary. On the skip_install path, Phase 5
     # was skipped, so assert the binary exists before entering the rescue-wrapped

--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -131,6 +131,10 @@ pub mod runners {
     /// The API stale barrier remains longer than this runner-owned deadline so delivery latency cannot release a healthy recovery early.
     pub const RUNNER_CANCELLATION_RECOVERY_GRACE_MS: u64 = 90000;
 
+    /// Maximum configured runner hostname length accepted by the runner-facing API.
+    /// Rust runners use JavaScript UTF-16 string length semantics when enforcing this shared boundary.
+    pub const RUNNER_HOSTNAME_MAX_LENGTH: u64 = 255;
+
     /// Maximum runner-local claim cooldown exclusions accepted by the poll endpoint.
     /// Rust runners use this shared contract value to bound local cooldown state and poll request size.
     pub const RUNNER_POLL_EXCLUDED_RUN_IDS_MAX: u64 = 128;

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -147,11 +147,12 @@ impl AxiomGuard {
 /// Initialize the Axiom layer. Returns `None` when required env is missing —
 /// caller should install a `None` layer in that case (no-op). Production
 /// entry point; always targets `DEFAULT_AXIOM_URL`.
-pub(crate) fn init() -> Option<(AxiomLayer, AxiomGuard)> {
+pub(crate) fn init(runner_hostname: Option<String>) -> Option<(AxiomLayer, AxiomGuard)> {
     init_from_env_values(
         DEFAULT_AXIOM_URL,
         std::env::var(AXIOM_TOKEN_ENV).ok(),
         std::env::var(AXIOM_SUFFIX_ENV).ok(),
+        runner_hostname,
     )
 }
 
@@ -159,20 +160,31 @@ fn init_from_env_values(
     base_url: &str,
     token: Option<String>,
     suffix: Option<String>,
+    runner_hostname: Option<String>,
 ) -> Option<(AxiomLayer, AxiomGuard)> {
     let token = token.filter(|s| !s.is_empty())?;
     let suffix = suffix.filter(|s| !s.is_empty())?;
-    init_with_base_url(base_url, &token, &suffix)
+    init_with_base_url_and_hostname(base_url, &token, &suffix, runner_hostname)
 }
 
 /// Core init with an explicit base URL. Exists so module tests can point
 /// at an `httpmock` server without leaking an `AXIOM_URL` override into the
 /// runner's production env surface — production code should always call
 /// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
+#[cfg(test)]
 fn init_with_base_url(
     base_url: &str,
     token: &str,
     suffix: &str,
+) -> Option<(AxiomLayer, AxiomGuard)> {
+    init_with_base_url_and_hostname(base_url, token, suffix, None)
+}
+
+fn init_with_base_url_and_hostname(
+    base_url: &str,
+    token: &str,
+    suffix: &str,
+    runner_hostname: Option<String>,
 ) -> Option<(AxiomLayer, AxiomGuard)> {
     // Shared dataset with TS: turbo/apps/web/src/lib/shared/axiom/datasets.ts
     // DATASETS.WEB_LOGS. APL queries filter by `service == "runner"`.
@@ -198,6 +210,7 @@ fn init_with_base_url(
         AxiomLayer {
             tx: tx.clone(),
             dropped: AtomicU64::new(0),
+            runner_hostname,
         },
         AxiomGuard {
             tx,
@@ -209,6 +222,7 @@ fn init_with_base_url(
 pub(crate) struct AxiomLayer {
     tx: mpsc::Sender<Msg>,
     dropped: AtomicU64,
+    runner_hostname: Option<String>,
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
@@ -252,7 +266,10 @@ where
             return;
         };
 
-        permit.send(Msg::Event(serialize_event(event)));
+        permit.send(Msg::Event(serialize_event(
+            event,
+            self.runner_hostname.as_deref(),
+        )));
     }
 }
 
@@ -331,7 +348,7 @@ async fn flush(client: &Client, ingest_url: &str, token: &str, batch: &mut Vec<V
 /// `turbo/apps/web/src/lib/shared/logger.ts`: flat top-level `_time`, `level`
 /// (lowercase), `message`, `context`, plus any user-supplied fields —
 /// augmented with a Rust-only `service` discriminator.
-fn serialize_event(event: &Event<'_>) -> Value {
+fn serialize_event(event: &Event<'_>, runner_hostname: Option<&str>) -> Value {
     struct V(Map<String, Value>);
     impl Visit for V {
         fn record_str(&mut self, f: &Field, v: &str) {
@@ -410,6 +427,16 @@ fn serialize_event(event: &Event<'_>) -> Value {
     );
     out.insert("context".into(), Value::String(meta.target().into()));
     out.insert("service".into(), Value::String(SERVICE_NAME.into()));
+    if let Some(runner_hostname) = runner_hostname {
+        out.insert(
+            "runner_hostname".into(),
+            Value::String(runner_hostname.to_string()),
+        );
+    }
+    out.insert(
+        "runner_version".into(),
+        Value::String(env!("CARGO_PKG_VERSION").into()),
+    );
     Value::Object(out)
 }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use super::{
     AxiomLayer, BATCH_INTERVAL, BATCH_SIZE, CHANNEL_CAP, ERROR_SOURCE_MAX_DEPTH, INTERNAL_TARGET,
     TEXT_FIELD_MAX_BYTES, TRUNCATION_MARKER, init_from_env_values, init_with_base_url,
-    with_ingest_filter,
+    init_with_base_url_and_hostname, with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -328,6 +328,8 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     let events = captured.events();
     let warning = event_with_message(&events, "a warning");
     assert_eq!(warning["service"], json!("runner"));
+    assert_eq!(warning["runner_version"], json!(env!("CARGO_PKG_VERSION")));
+    assert!(warning.get("runner_hostname").is_none());
     assert_eq!(warning["level"], json!("warn"));
     assert_eq!(warning["foo"], json!("bar"));
     assert!(
@@ -343,6 +345,36 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         !has_event_with_message(&events, "info is below threshold, should not be ingested"),
         "INFO event should not be ingested: {events:#?}",
     );
+}
+
+#[tokio::test]
+async fn configured_hostname_and_version_are_common_axiom_dimensions() {
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+    let (layer, guard) = init_with_base_url_and_hostname(
+        &server.base_url(),
+        "test-token",
+        "test",
+        Some("prod-1.aws.vm3.ai".to_string()),
+    )
+    .expect("init must succeed");
+
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::warn!(
+            runner_hostname = "event-local-host",
+            runner_version = "event-local-version",
+            "attributed warning"
+        );
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    let warning = event_with_message(&events, "attributed warning");
+    assert_eq!(warning["runner_hostname"], json!("prod-1.aws.vm3.ai"));
+    assert_eq!(warning["runner_version"], json!(env!("CARGO_PKG_VERSION")));
 }
 
 #[tokio::test]
@@ -449,7 +481,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
 
 #[test]
 fn init_returns_none_when_env_missing() {
-    let result = init_from_env_values("https://example.invalid", None, None);
+    let result = init_from_env_values("https://example.invalid", None, None, None);
     assert!(result.is_none());
 }
 
@@ -459,6 +491,7 @@ fn init_returns_none_when_token_empty() {
         "https://example.invalid",
         Some(String::new()),
         Some("dev".to_string()),
+        None,
     );
     assert!(result.is_none());
 }
@@ -693,6 +726,7 @@ fn burst_past_channel_cap_drops_without_blocking() {
     let layer = AxiomLayer {
         tx,
         dropped: AtomicU64::new(0),
+        runner_hostname: None,
     };
     let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     let dispatch = tracing::Dispatch::new(subscriber);
@@ -732,6 +766,7 @@ fn rejected_events_are_not_serialized() {
     let layer = AxiomLayer {
         tx,
         dropped: AtomicU64::new(0),
+        runner_hostname: None,
     };
     let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     let formatting_count = AtomicUsize::new(0);

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -27,6 +27,9 @@ pub struct ConfigArgs {
     /// Runner logical name
     #[arg(long)]
     name: String,
+    /// Canonical physical hostname used for diagnostic attribution
+    #[arg(long)]
+    hostname: Option<String>,
     /// Runner group in `vm0/<name>` format (e.g. "vm0/production")
     #[arg(long)]
     group: String,
@@ -75,6 +78,9 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
 
 async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResult<()> {
     // Pure-CPU validation first — fail fast before any filesystem I/O.
+    if let Some(hostname) = args.hostname.as_deref() {
+        config::validate_runner_hostname(hostname)?;
+    }
     crate::group::validate_or_err(&args.group)?;
     crate::runner_dirname::validate_or_err(&args.runner_dirname)?;
     validate_concurrency_factor(args.concurrency_factor)?;
@@ -133,6 +139,7 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);
     let runner_config = RunnerConfig {
         name: args.name,
+        hostname: args.hostname,
         group: args.group,
         base_dir: runner_dir.clone(),
         ca_dir: paths.ca_dir(),
@@ -176,6 +183,7 @@ mod tests {
             rootfs_hash: vec!["dummy".into()],
             snapshot_hash: vec!["dummy".into()],
             name: "test".into(),
+            hostname: None,
             group: "vm0/test".into(),
             runner_dirname: dirname.into(),
             max_concurrent: 0,
@@ -281,6 +289,26 @@ mod tests {
             !msg.contains(&dirname),
             "overlong dirname should be previewed, not echoed in full: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_invalid_hostname_before_filesystem_setup() {
+        let max_length = usize::try_from(
+            api_contracts::generated::constants::runners::RUNNER_HOSTNAME_MAX_LENGTH,
+        )
+        .unwrap();
+        for hostname in [String::new(), "a".repeat(max_length + 1)] {
+            let mut args = args_with_valid_image_hashes();
+            args.hostname = Some(hostname);
+
+            let err = run_config(args).await.unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("hostname"), "got: {msg}");
+            assert!(
+                !msg.contains("rootfs not found"),
+                "hostname validation should happen before image checks: {msg}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -393,7 +421,8 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
-        let args = args_with_valid_image_hashes();
+        let mut args = args_with_valid_image_hashes();
+        args.hostname = Some("prod-1.aws.vm3.ai".to_string());
         let config_path = home
             .runners_dir()
             .join(&args.runner_dirname)
@@ -434,6 +463,7 @@ mod tests {
         assert_eq!(profile.snapshot_hash, snapshot_hash);
         assert_eq!(profile.rootfs_disk_mb, 12288);
         assert_eq!(profile.workspace_disk_mb, 16384);
+        assert_eq!(runner_config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
     }
 
     fn args_with_concurrency_factor(factor: f64) -> ConfigArgs {
@@ -442,6 +472,7 @@ mod tests {
             rootfs_hash: vec!["dummy".into()],
             snapshot_hash: vec!["dummy".into()],
             name: "test".into(),
+            hostname: None,
             group: "vm0/test".into(),
             runner_dirname: "runner-01".into(),
             max_concurrent: 0,

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -800,6 +800,7 @@ async fn complete_claimed_without_sandbox(
             context.run_id,
             context.sandbox_token.clone(),
             ctx.exec_config.runner_name.clone(),
+            ctx.exec_config.runner_hostname.clone(),
         );
         outcome.record(&mut telemetry);
         telemetry

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -216,6 +216,7 @@ impl ExecutorInvocation {
                     run_id,
                     sandbox_token,
                     exec_config_for_panic.runner_name.clone(),
+                    exec_config_for_panic.runner_hostname.clone(),
                 );
                 let failure =
                     executor::ExecutionFailure::from_error(format!("executor task panicked: {e}"));
@@ -1050,6 +1051,7 @@ mod tests {
                 run_id,
                 "sandbox-token".into(),
                 "test-runner".into(),
+                None,
             ),
         }
     }
@@ -1075,6 +1077,7 @@ mod tests {
                 run_id,
                 "sandbox-token".into(),
                 "test-runner".into(),
+                None,
             ),
         }
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -519,6 +519,7 @@ async fn run_start_with_home(
     })?;
     let background_fill = crate::storage_cache::StorageCacheBackgroundFillCoordinator::new()?;
     let name = runner_config.name;
+    let hostname = runner_config.hostname;
     let group = runner_config.group;
     let cancel_tokens = RunCancellationRegistry::new();
     let local_group_dir = if args.local {
@@ -789,6 +790,7 @@ async fn run_start_with_home(
             server.token,
             ApiProviderConfig {
                 runner_identity,
+                runner_hostname: hostname.clone(),
                 group,
                 supported_profiles: profiles,
             },
@@ -806,6 +808,7 @@ async fn run_start_with_home(
     let exec_config = Arc::new(ExecutorConfig {
         api_url: server.url,
         runner_name: name.clone(),
+        runner_hostname: hostname,
         registry: registry_handle,
         http,
         log_paths,

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -258,6 +258,7 @@ fn build_mock_run_config_with_runtime(
         exec_config: Arc::new(executor::ExecutorConfig {
             api_url: api_url.to_string(),
             runner_name: "test-runner".to_string(),
+            runner_hostname: None,
             registry,
             http: crate::http::HttpClient::new(crate::http::HttpClientConfig {
                 api_url: api_url.to_string(),

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -47,6 +47,7 @@ use std::path::{Path, PathBuf};
 use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 
+use api_contracts::generated::constants::runners::RUNNER_HOSTNAME_MAX_LENGTH;
 use guest_contracts::process_containment::{
     MIN_PROFILE_MEMORY_MB, MIN_PROFILE_VCPU, WorkloadResourcePolicy,
 };
@@ -74,6 +75,11 @@ pub struct RunnerConfig {
     /// Human-readable identifier for this runner instance, surfaced in logs
     /// and reported to the control plane alongside `group`.
     pub name: String,
+    /// Canonical physical host identity used only for diagnostic attribution.
+    /// The raw configured value is preserved and never used for scheduling,
+    /// authorization, targeting, or ownership.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
     /// Runner group in `org/name` format (e.g. `vm0/prod`). Used to scope
     /// runners on the server and to build on-disk paths; validated by
     /// [`crate::group::validate_or_err`].
@@ -266,6 +272,21 @@ pub(crate) fn validate_concurrency_factor(value: f64) -> RunnerResult<()> {
         return Err(RunnerError::Config(
             "concurrency_factor must be a positive finite number".into(),
         ));
+    }
+    Ok(())
+}
+
+/// Validate a configured hostname against the runner-facing API boundary.
+///
+/// Zod measures JavaScript string length in UTF-16 code units, so the Runner
+/// uses the same rule before publishing this value.
+pub(crate) fn validate_runner_hostname(value: &str) -> RunnerResult<()> {
+    let within_bound = u64::try_from(value.encode_utf16().count())
+        .is_ok_and(|length| length <= RUNNER_HOSTNAME_MAX_LENGTH);
+    if value.is_empty() || !within_bound {
+        return Err(RunnerError::Config(format!(
+            "hostname must be a non-empty string of at most {RUNNER_HOSTNAME_MAX_LENGTH} UTF-16 code units"
+        )));
     }
     Ok(())
 }
@@ -527,6 +548,9 @@ async fn validate(
     validate_image_artifacts: bool,
 ) -> RunnerResult<()> {
     // Pure-CPU checks first — fail fast before any filesystem I/O.
+    if let Some(hostname) = config.hostname.as_deref() {
+        validate_runner_hostname(hostname)?;
+    }
     crate::group::validate_or_err(&config.group)?;
     if config.profiles.is_empty() {
         return Err(RunnerError::Config("profiles must not be empty".into()));

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -332,6 +332,7 @@ server:
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
     assert_eq!(config.name, "test-runner");
+    assert_eq!(config.hostname, None);
     assert_eq!(config.profiles.len(), 1);
     let default = &config.profiles["vm0/default"];
     assert_eq!(default.vcpu, 2);
@@ -343,6 +344,37 @@ server:
     let server = config.server.unwrap();
     assert_eq!(server.url, "https://api.example.com");
     assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
+async fn load_preserves_optional_hostname() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml_with_default_profile("hostname: prod-1.aws.vm3.ai\n");
+
+    let config = fixture.load_config(&yaml, true).await.unwrap();
+
+    assert_eq!(config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
+}
+
+#[tokio::test]
+async fn load_enforces_api_hostname_length_semantics() {
+    let fixture = ConfigFixture::new().await;
+    let accepted = format!("{}a", "😀".repeat(127));
+    let accepted_yaml = fixture.yaml_with_default_profile(&format!(
+        "hostname: {}\n",
+        serde_yaml_ng::to_string(&accepted).unwrap().trim()
+    ));
+    let config = fixture.load_config(&accepted_yaml, true).await.unwrap();
+    assert_eq!(config.hostname.as_deref(), Some(accepted.as_str()));
+
+    for rejected in [String::new(), "😀".repeat(128)] {
+        let rejected_yaml = fixture.yaml_with_default_profile(&format!(
+            "hostname: {}\n",
+            serde_yaml_ng::to_string(&rejected).unwrap().trim()
+        ));
+        let err = fixture.load_config(&rejected_yaml, true).await.unwrap_err();
+        assert!(err.to_string().contains("hostname"), "got: {err}");
+    }
 }
 
 #[tokio::test]
@@ -1108,6 +1140,7 @@ async fn generate_then_load_round_trip() {
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
         name: "test-runner".into(),
+        hostname: Some("prod-1.aws.vm3.ai".into()),
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
         ca_dir: fixture.path().to_path_buf(),
@@ -1167,6 +1200,7 @@ async fn generate_tightens_existing_runner_dir_and_config_file() {
 
     let config = RunnerConfig {
         name: "test-runner".into(),
+        hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
         ca_dir: fixture.path().to_path_buf(),
@@ -1245,6 +1279,7 @@ fn factory_config_resolves_paths() {
 
     let config = RunnerConfig {
         name: "test".into(),
+        hostname: None,
         group: "test/group".into(),
         base_dir: dir.path().join("runner"),
         ca_dir: dir.path().join("ca"),
@@ -1277,6 +1312,7 @@ async fn idle_pool_config_round_trip() {
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
         name: "test-runner".into(),
+        hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
         ca_dir: fixture.path().to_path_buf(),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -188,6 +188,7 @@ fn guest_runtime_path(
 pub struct ExecutorConfig {
     pub api_url: String,
     pub runner_name: String,
+    pub runner_hostname: Option<String>,
     pub registry: ProxyRegistryHandle,
     pub http: HttpClient,
     pub log_paths: LogPaths,
@@ -606,6 +607,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
         run_id,
         context.sandbox_token.clone(),
         config.runner_name.clone(),
+        config.runner_hostname.clone(),
     );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
@@ -714,6 +716,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         run_id,
         context.sandbox_token.clone(),
         config.runner_name.clone(),
+        config.runner_hostname.clone(),
     );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -26,6 +26,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
     ExecutorConfig {
         api_url: "http://localhost:9999".into(),
         runner_name: "test-runner".into(),
+        runner_hostname: None,
         registry: proxy::ProxyRegistryHandle::new(registry_path, lock_path),
         http: crate::http::HttpClient::new(HttpClientConfig {
             api_url: "http://localhost:9999".into(),
@@ -119,6 +120,7 @@ pub(in crate::executor::tests) fn test_telemetry(
         ctx.run_id,
         ctx.sandbox_token.clone(),
         config.runner_name.clone(),
+        config.runner_hostname.clone(),
     )
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -111,6 +111,7 @@ fn new_telemetry() -> JobTelemetry {
         RunId::nil(),
         "tok".to_string(),
         "test-runner".to_string(),
+        None,
     )
 }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -197,6 +197,25 @@ fn runner_name_from_config(path: &Path) -> String {
     sanitize_name(&raw)
 }
 
+/// Read the optional canonical hostname before tracing starts.
+///
+/// Normal config loading remains responsible for reporting read, parse, and
+/// validation failures. This early read only supplies trusted common Axiom
+/// dimensions when the same Runner config boundary already accepts the value.
+fn runner_hostname_from_config(path: &Path) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        hostname: Option<String>,
+    }
+
+    let content = std::fs::read_to_string(path).ok()?;
+    let hostname = serde_yaml_ng::from_str::<Partial>(&content)
+        .ok()?
+        .hostname?;
+    config::validate_runner_hostname(&hostname).ok()?;
+    Some(hostname)
+}
+
 /// Replace non-`[a-zA-Z0-9_-]` characters with `-`.
 /// Returns `"default"` if the result is empty.
 fn sanitize_name(raw: &str) -> String {
@@ -293,9 +312,14 @@ async fn main() -> ExitCode {
 
     let cli = Cli::parse_with_environment_aliases();
 
+    let runner_hostname = match &cli.command {
+        Command::Start(args) => runner_hostname_from_config(&args.config),
+        _ => None,
+    };
+
     // Axiom layer (dual-write with fmt). Returns None — zero overhead — when
     // AXIOM_TOKEN_TELEMETRY / AXIOM_DATASET_SUFFIX are unset.
-    let (axiom_layer, axiom_guard) = match axiom_layer::init() {
+    let (axiom_layer, axiom_guard) = match axiom_layer::init(runner_hostname) {
         Some((layer, guard)) => (Some(layer), Some(guard)),
         None => (None, None),
     };
@@ -599,6 +623,33 @@ mod tests {
             runner_name_from_config(Path::new("/nonexistent.yaml")),
             "default"
         );
+    }
+
+    #[test]
+    fn runner_hostname_partial_read_preserves_valid_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("runner.yaml");
+        std::fs::write(
+            &config_path,
+            "name: v0.174.0\nhostname: prod-1.aws.vm3.ai\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            runner_hostname_from_config(&config_path).as_deref(),
+            Some("prod-1.aws.vm3.ai")
+        );
+    }
+
+    #[test]
+    fn runner_hostname_partial_read_omits_missing_or_invalid_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("runner.yaml");
+        std::fs::write(&config_path, "name: v0.174.0\n").unwrap();
+        assert_eq!(runner_hostname_from_config(&config_path), None);
+
+        std::fs::write(&config_path, "name: v0.174.0\nhostname: ''\n").unwrap();
+        assert_eq!(runner_hostname_from_config(&config_path), None);
     }
 
     #[test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -61,6 +61,8 @@ fn supports_thread_active_input(reuse_key: Option<&str>) -> bool {
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestBody<'a> {
     runner_identity: &'a RunnerProcessIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_hostname: Option<&'a str>,
     telemetry: ClaimRequestTelemetry,
 }
 
@@ -241,6 +243,7 @@ enum DiscoveryWakeup {
 pub struct ApiProvider {
     api: ApiClient,
     runner_identity: RunnerProcessIdentity,
+    runner_hostname: Option<String>,
     group: String,
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
@@ -268,6 +271,7 @@ pub struct BuiltinFirewallCatalogCachePaths {
 
 pub struct ApiProviderConfig {
     pub(crate) runner_identity: RunnerProcessIdentity,
+    pub(crate) runner_hostname: Option<String>,
     pub group: String,
     pub supported_profiles: Vec<String>,
 }
@@ -284,6 +288,7 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let ApiProviderConfig {
             runner_identity,
+            runner_hostname,
             group,
             supported_profiles,
         } = config;
@@ -304,6 +309,7 @@ impl ApiProvider {
         Arc::new(Self {
             api,
             runner_identity,
+            runner_hostname,
             group,
             supported_profiles,
             poll_wakeups,
@@ -640,7 +646,14 @@ impl JobProvider for ApiProvider {
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
         let claim_request_started_at = Instant::now();
-        let claim_result = self.api.claim(&candidate, &self.runner_identity).await;
+        let claim_result = self
+            .api
+            .claim(
+                &candidate,
+                &self.runner_identity,
+                self.runner_hostname.as_deref(),
+            )
+            .await;
         let claim_request_elapsed = claim_request_started_at.elapsed();
         match claim_result {
             Ok(Some(SuccessfulClaimResponse {
@@ -1054,9 +1067,10 @@ impl ApiClient {
         &self,
         candidate: &JobCandidate,
         runner_identity: &RunnerProcessIdentity,
+        runner_hostname: Option<&str>,
     ) -> Result<Option<SuccessfulClaimResponse>, ClaimApiError> {
         let run_id = candidate.run_id();
-        let body = claim_request_body(candidate, runner_identity);
+        let body = claim_request_body(candidate, runner_identity, runner_hostname);
         let run_id = run_id.to_string();
         let resp = send_api(
             self.http
@@ -1103,7 +1117,7 @@ impl ApiClient {
         let runner_identity =
             RunnerProcessIdentity::new("550e8400-e29b-41d4-a716-446655440000".parse().unwrap(), 7)
                 .unwrap();
-        self.claim(candidate, &runner_identity).await
+        self.claim(candidate, &runner_identity, None).await
     }
     /// Report job completion. Uses the per-job **sandbox token** for auth.
     async fn complete(&self, sandbox_token: &str, request: &CompleteRequest) -> RunnerResult<()> {
@@ -1259,6 +1273,7 @@ impl ApiClient {
 fn claim_request_body<'a>(
     candidate: &JobCandidate,
     runner_identity: &'a RunnerProcessIdentity,
+    runner_hostname: Option<&'a str>,
 ) -> ClaimRequestBody<'a> {
     let runner_preference_telemetry = candidate.runner_preference_claim_telemetry();
     let is_ably_candidate = candidate.discovery_source() == Some(JobDiscoverySource::Ably);
@@ -1288,6 +1303,7 @@ fn claim_request_body<'a>(
 
     ClaimRequestBody {
         runner_identity,
+        runner_hostname,
         telemetry: ClaimRequestTelemetry {
             discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
             job_discovered_to_claim_request_ms: claim_telemetry_duration_ms(
@@ -1606,7 +1622,7 @@ mod tests {
 
     fn claim_request_body_for_test(candidate: &JobCandidate) -> serde_json::Value {
         let runner_identity = test_runner_identity();
-        serde_json::to_value(claim_request_body(candidate, &runner_identity)).unwrap()
+        serde_json::to_value(claim_request_body(candidate, &runner_identity, None)).unwrap()
     }
 
     #[test]
@@ -1928,6 +1944,7 @@ mod tests {
             builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController::disabled(),
             api,
             runner_identity: test_runner_identity(),
+            runner_hostname: None,
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
@@ -2191,6 +2208,7 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert!(body.get("runnerHostname").is_none());
         assert!(body["telemetry"].get("runnerPreference").is_none());
         assert!(
             body["telemetry"]
@@ -2203,6 +2221,15 @@ mod tests {
         assert!(!body.to_string().contains("cacheKey"));
         assert!(!body.to_string().contains("path"));
         assert!(body.get("capabilities").is_none());
+
+        let runner_identity = test_runner_identity();
+        let attributed = serde_json::to_value(claim_request_body(
+            &candidate,
+            &runner_identity,
+            Some("prod-1.aws.vm3.ai"),
+        ))
+        .unwrap();
+        assert_eq!(attributed["runnerHostname"], "prod-1.aws.vm3.ai");
     }
 
     #[test]
@@ -4182,7 +4209,8 @@ mod tests {
                             "runnerIdentity": {
                                 "runnerId": TEST_RUNNER_ID,
                                 "heartbeatGeneration": TEST_HEARTBEAT_GENERATION,
-                            }
+                            },
+                            "runnerHostname": "prod-1.aws.vm3.ai",
                         })
                         .to_string(),
                     );
@@ -4195,11 +4223,14 @@ mod tests {
                 }));
             })
             .await;
-        let provider = api_provider_for_test(
+        let mut provider = api_provider_for_test(
             server.base_url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
+        Arc::get_mut(&mut provider)
+            .expect("fresh test provider should not be shared")
+            .runner_hostname = Some("prod-1.aws.vm3.ai".to_string());
 
         let claimed = provider
             .claim(JobCandidate::new(

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3400,6 +3400,7 @@ mod tests {
             RunId::nil(),
             "test-token".to_string(),
             "test-runner".to_string(),
+            None,
         )
     }
 

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -28,6 +28,7 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 
 /// Timeout for telemetry HTTP requests (shorter than default API timeout).
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
+const RUNNER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Effective resource path once the guest process has spawned.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -87,6 +88,7 @@ pub struct JobTelemetry {
     run_id: RunId,
     sandbox_token: String,
     runner_name: String,
+    runner_hostname: Option<String>,
     runner_pre_spawn_attribution: Option<RunnerPreSpawnAttribution>,
     pending_ops: Vec<SandboxOp>,
     oldest_pending: Option<Instant>,
@@ -120,6 +122,9 @@ struct SandboxOp {
 struct TelemetryPayload {
     run_id: String,
     runner_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_hostname: Option<String>,
+    runner_version: &'static str,
     sandbox_operations: Vec<SandboxOp>,
 }
 
@@ -132,12 +137,14 @@ impl JobTelemetry {
         run_id: RunId,
         sandbox_token: String,
         runner_name: String,
+        runner_hostname: Option<String>,
     ) -> Self {
         Self {
             http,
             run_id,
             sandbox_token,
             runner_name,
+            runner_hostname,
             runner_pre_spawn_attribution: None,
             pending_ops: Vec::new(),
             oldest_pending: None,
@@ -249,6 +256,7 @@ impl JobTelemetry {
             run_id: self.run_id,
             sandbox_token: self.sandbox_token.clone(),
             runner_name: self.runner_name.clone(),
+            runner_hostname: self.runner_hostname.clone(),
         }
     }
 
@@ -298,9 +306,17 @@ impl JobTelemetry {
         let in_flight_flushes = std::mem::take(&mut self.in_flight_flushes);
         let run_id = self.run_id;
         let runner_name = self.runner_name.clone();
+        let runner_hostname = self.runner_hostname.clone();
 
         tokio::join!(
-            send_telemetry(&self.http, run_id, &self.sandbox_token, runner_name, ops,),
+            send_telemetry(
+                &self.http,
+                run_id,
+                &self.sandbox_token,
+                runner_name,
+                runner_hostname,
+                ops,
+            ),
             drain_in_flight_flushes(run_id, in_flight_flushes),
         );
     }
@@ -400,9 +416,18 @@ impl JobTelemetry {
         let run_id = self.run_id;
         let sandbox_token = self.sandbox_token.clone();
         let runner_name = self.runner_name.clone();
+        let runner_hostname = self.runner_hostname.clone();
 
         let handle = tokio::spawn(async move {
-            send_telemetry(&http, run_id, &sandbox_token, runner_name, ops).await;
+            send_telemetry(
+                &http,
+                run_id,
+                &sandbox_token,
+                runner_name,
+                runner_hostname,
+                ops,
+            )
+            .await;
         });
         self.in_flight_flushes.push(handle);
     }
@@ -414,6 +439,7 @@ pub(crate) struct SandboxOpReporter {
     run_id: RunId,
     sandbox_token: String,
     runner_name: String,
+    runner_hostname: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -460,6 +486,7 @@ impl SandboxOpReporter {
             self.run_id,
             &self.sandbox_token,
             self.runner_name.clone(),
+            self.runner_hostname.clone(),
             ops,
         )
         .await;
@@ -540,6 +567,7 @@ async fn send_telemetry(
     run_id: RunId,
     sandbox_token: &str,
     runner_name: String,
+    runner_hostname: Option<String>,
     ops: Vec<SandboxOp>,
 ) {
     if ops.is_empty() {
@@ -549,6 +577,8 @@ async fn send_telemetry(
     let payload = TelemetryPayload {
         run_id: run_id.to_string(),
         runner_name,
+        runner_hostname,
+        runner_version: RUNNER_VERSION,
         sandbox_operations: ops,
     };
 
@@ -637,6 +667,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         telemetry.record_bounded_outcome(
             "storage_cache_fresh_delivery_scan_groups",
@@ -681,6 +712,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         telemetry.record_with_outcome(
             "runner_host_physical_park_balloon_settle",
@@ -701,6 +733,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         telemetry.start_runner_pre_spawn_attribution(RunnerPreSpawnAttribution::new(
             RunnerPreSpawnConcurrencyBucket::ThreeToFour,
@@ -737,6 +770,8 @@ mod tests {
         let payload = TelemetryPayload {
             run_id: "abc-123".to_string(),
             runner_name: "test-runner".to_string(),
+            runner_hostname: None,
+            runner_version: RUNNER_VERSION,
             sandbox_operations: vec![SandboxOp {
                 ts: "2026-01-15T10:00:00+00:00".to_string(),
                 action_type: "test".to_string(),
@@ -757,6 +792,7 @@ mod tests {
             serde_json::json!({
                 "runId": "abc-123",
                 "runnerName": "test-runner",
+                "runnerVersion": RUNNER_VERSION,
                 "sandboxOperations": [{
                     "ts": "2026-01-15T10:00:00+00:00",
                     "action_type": "test",
@@ -778,10 +814,12 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_payload_includes_required_runner_name() {
+    fn telemetry_payload_includes_canonical_attribution_and_legacy_name() {
         let payload = TelemetryPayload {
             run_id: "abc-123".to_string(),
             runner_name: "v0.168.14".to_string(),
+            runner_hostname: Some("prod-1.aws.vm3.ai".to_string()),
+            runner_version: RUNNER_VERSION,
             sandbox_operations: vec![],
         };
 
@@ -790,6 +828,8 @@ mod tests {
             serde_json::json!({
                 "runId": "abc-123",
                 "runnerName": "v0.168.14",
+                "runnerHostname": "prod-1.aws.vm3.ai",
+                "runnerVersion": RUNNER_VERSION,
                 "sandboxOperations": [],
             })
         );
@@ -803,6 +843,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         assert!(telemetry.pending_ops.is_empty());
         assert!(telemetry.oldest_pending.is_none());
@@ -817,6 +858,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
 
         telemetry.record("sandbox_create", Duration::from_millis(500), true, None);
@@ -846,6 +888,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         let metadata = session_history_metadata()
             .with_cache_probe(SessionHistoryCacheProbeMetadata::new(false, true))
@@ -882,6 +925,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
 
         telemetry.record("huge_op", Duration::MAX, true, None);
@@ -898,6 +942,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
@@ -918,7 +963,9 @@ mod tests {
                     .path("/api/webhooks/agent/telemetry")
                     .body_includes(r#""ts":"2026-08-11T10:20:30.456Z""#)
                     .body_includes(r#""action_type":"concurrent_operation""#)
-                    .body_includes(r#""runnerName":"v0.168.14""#);
+                    .body_includes(r#""runnerName":"v0.168.14""#)
+                    .body_includes(r#""runnerHostname":"prod-1.aws.vm3.ai""#)
+                    .body_includes(format!(r#""runnerVersion":"{RUNNER_VERSION}""#));
                 then.status(200)
                     .header("content-type", "application/json")
                     .body(r#"{"success":true,"id":"ok"}"#);
@@ -929,6 +976,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "v0.168.14".to_string(),
+            Some("prod-1.aws.vm3.ai".to_string()),
         );
         let completed_at = DateTime::parse_from_rfc3339("2026-08-11T10:20:30.456Z")
             .unwrap()
@@ -954,6 +1002,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
@@ -995,6 +1044,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "v0.168.14".to_string(),
+            Some("prod-1.aws.vm3.ai".to_string()),
         );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
@@ -1014,6 +1064,8 @@ mod tests {
         assert!(request.contains(r#""action_type":"op1""#));
         assert!(request.contains(r#""action_type":"op2""#));
         assert!(request.contains(r#""runnerName":"v0.168.14""#));
+        assert!(request.contains(r#""runnerHostname":"prod-1.aws.vm3.ai""#));
+        assert!(request.contains(&format!(r#""runnerVersion":"{RUNNER_VERSION}""#)));
 
         let mut flush = Box::pin(telemetry.flush());
         assert!(
@@ -1042,6 +1094,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
+            None,
         );
         let reporter = telemetry.reporter();
 
@@ -1082,6 +1135,7 @@ mod tests {
             RunId::nil(),
             "tok".to_string(),
             "v0.168.14".to_string(),
+            Some("prod-1.aws.vm3.ai".to_string()),
         );
         telemetry
             .reporter()
@@ -1096,5 +1150,7 @@ mod tests {
         let requests = server.assert_finished_with_requests().await;
         let request = &requests[0];
         assert!(request.contains(r#""runnerName":"v0.168.14"#));
+        assert!(request.contains(r#""runnerHostname":"prod-1.aws.vm3.ai""#));
+        assert!(request.contains(&format!(r#""runnerVersion":"{RUNNER_VERSION}""#)));
     }
 }

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -1,5 +1,32 @@
 # Runner Host Configuration
 
+## Diagnostic Host Attribution
+
+`runner.yaml` may contain an optional `hostname` used only to identify the
+physical runner in claims, sandbox telemetry, and Runner Axiom warning/error
+events. Production automation writes the exact Ansible `inventory_hostname`;
+it does not derive the value from DNS or the operating system at runtime.
+
+The value must be non-empty and no longer than 255 JavaScript string units
+(UTF-16 code units). `runner config --hostname <value>` validates and preserves
+the raw value. Existing configuration files without `hostname` continue to
+load and omit the canonical hostname fields.
+
+Hostname does not select a service, directory, release, or rollback target.
+Those lifecycle identities continue to use the version-shaped `name`, such as
+`v0.174.0`. During the compatibility window, sandbox telemetry sends all of:
+
+- legacy `runnerName`, retaining its version-shaped value;
+- optional canonical `runnerHostname` from configuration; and
+- canonical `runnerVersion` compiled into the Runner binary.
+
+Runner Axiom warning/error events similarly include optional
+`runner_hostname` and required `runner_version`. Deploy the compatible API
+receiver before deploying a Runner that produces these fields. Canary the
+Runner and verify claim snapshots, telemetry/Axiom dimensions, distinct
+hostnames on two hosts running one version, and retained-version rollback
+before relying on canonical attribution in presentation code.
+
 The runner reads host-local overrides from `/etc/vm0-runner/host.env` once
 during startup. A missing file is equivalent to an empty file: the runner uses
 `runner.yaml` for its concurrency factor and leaves I/O limiters disabled.

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -40,6 +40,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
+  RUNNER_HOSTNAME_MAX_LENGTH,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
   SESSION_HISTORY_DOWNLOAD_SOURCE_DEFAULT_R2_ENDPOINT,
@@ -128,6 +129,11 @@ const connectorRuntimeSyncRunTerminalErrorCodeDoc = [
 const runnerPollExcludedRunIdsMaxDoc = [
   "Maximum runner-local claim cooldown exclusions accepted by the poll endpoint.",
   "Rust runners use this shared contract value to bound local cooldown state and poll request size.",
+] as const;
+
+const runnerHostnameMaxLengthDoc = [
+  "Maximum configured runner hostname length accepted by the runner-facing API.",
+  "Rust runners use JavaScript UTF-16 string length semantics when enforcing this shared boundary.",
 ] as const;
 const sessionHistoryEncodingGzipDoc = [
   "Wire and blob metadata value for gzip-compressed resume session history.",
@@ -293,6 +299,12 @@ const expectedBindings = [
     rustConstName: "CANCELLATION_RECOVERY_STALE_AFTER_MS",
     value: rustU64(CANCELLATION_RECOVERY_STALE_AFTER_MS),
     rustDoc: cancellationRecoveryStaleAfterMsDoc,
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "RUNNER_HOSTNAME_MAX_LENGTH",
+    value: rustU64(RUNNER_HOSTNAME_MAX_LENGTH),
+    rustDoc: runnerHostnameMaxLengthDoc,
   },
   {
     rustModulePath: ["runners"],
@@ -578,6 +590,9 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const CANCELLATION_RECOVERY_STALE_AFTER_MS: u64 = ${CANCELLATION_RECOVERY_STALE_AFTER_MS};`,
+    );
+    expect(firstRender).toContain(
+      `pub const RUNNER_HOSTNAME_MAX_LENGTH: u64 = ${RUNNER_HOSTNAME_MAX_LENGTH};`,
     );
     expect(firstRender).toContain(
       `pub const RUNNER_POLL_EXCLUDED_RUN_IDS_MAX: u64 = ${RUNNER_POLL_EXCLUDED_RUN_IDS_MAX};`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -29,6 +29,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
+  RUNNER_HOSTNAME_MAX_LENGTH,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
   SESSION_HISTORY_DOWNLOAD_SOURCE_DEFAULT_R2_ENDPOINT,
@@ -350,6 +351,15 @@ export const rustConstantBindings = [
     rustDoc: [
       "Maximum API admission hold after public user cancellation when recovery completion is lost.",
       "The stale queue sweep reconsiders expired recovery barriers independently of the generic queue-item age.",
+    ],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "RUNNER_HOSTNAME_MAX_LENGTH",
+    value: rustU64(RUNNER_HOSTNAME_MAX_LENGTH),
+    rustDoc: [
+      "Maximum configured runner hostname length accepted by the runner-facing API.",
+      "Rust runners use JavaScript UTF-16 string length semantics when enforcing this shared boundary.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

- add an optional, shared-bound Runner hostname configuration and publish it on claims
- dual-write canonical hostname/version on sandbox telemetry while preserving legacy `runnerName`
- add canonical hostname/version dimensions to Runner Axiom warning and error events
- persist `inventory_hostname` through production build and retained-binary rollback automation
- document diagnostic attribution and its rollout gate

## Compatibility and scope

- Existing configs may omit `hostname`.
- Production service names, directories, promotion, rollback, readiness, doctor, and GC remain version-based.
- Rollback invokes retained binaries without the new CLI flag, then writes the additive YAML key that older Serde readers ignore.
- This PR does not render Activity fields, remove legacy `runnerName`, or change live-state ownership.
- Deploy the compatible API receiver from #29527 before deploying this Runner producer; canary two-host attribution and retained-target rollback before the presentation slice.

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts generate:rust`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test` (622 tests)
- `pnpm knip --workspace @okouai/api-contracts`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner` (3,338 tests passed; 24 ignored)
- `.github/scripts/tests/runner-attribution-ansible-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`
- `bash -n .github/scripts/tests/runner-attribution-ansible-test.sh .github/scripts/tests/runner-promotion-ansible-test.sh`
- pre-commit repository Knip, TypeScript type checks, Rust fmt/Clippy/docs, file-size check, and commitlint

Closes #29528

Parent context: #29497
