### PR TITLE
fix(ci): clean stale clerk example.com accounts

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -295,10 +295,10 @@ end
 stale_step = stale_steps.fetch(0)
 expected_roles = "browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude"
 unless stale_step.fetch("run").include?(
-    "cleanup-stale #{expected_roles} --older-than-hours 0.5",
+    "cleanup-stale #{expected_roles} --older-than-hours 0.5 --example-older-than-hours 24",
   ) && stale_step.dig("env", "CLERK_SECRET_KEY") == "${{ secrets.CLERK_SECRET_KEY }}" &&
     stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "stale Clerk cleanup must use every marked role and a 30-minute cutoff"
+  raise "stale Clerk cleanup must use every marked role, a 30-minute CI cutoff, and a 24-hour example.com cutoff"
 end
 
 cleanup_sources = [

--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -295,10 +295,10 @@ end
 stale_step = stale_steps.fetch(0)
 expected_roles = "browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude"
 unless stale_step.fetch("run").include?(
-    "cleanup-stale #{expected_roles} --older-than-hours 0.5 --example-older-than-hours 24",
+    "cleanup-stale #{expected_roles} --ci-older-than-hours 0.5 --staging-browser-older-than-hours 8",
   ) && stale_step.dig("env", "CLERK_SECRET_KEY") == "${{ secrets.CLERK_SECRET_KEY }}" &&
     stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "stale Clerk cleanup must use every marked role, a 30-minute CI cutoff, and a 24-hour example.com cutoff"
+  raise "stale Clerk cleanup must use every marked role, a 30-minute CI cutoff, and an 8-hour staging browser cutoff"
 end
 
 cleanup_sources = [

--- a/.github/workflows/cleanup-clerk-test-resources.yml
+++ b/.github/workflows/cleanup-clerk-test-resources.yml
@@ -40,6 +40,7 @@ jobs:
           cleanup-stale
           browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude
           --older-than-hours 0.5
+          --example-older-than-hours 24
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           DRY_RUN: ${{ env.DRY_RUN }}

--- a/.github/workflows/cleanup-clerk-test-resources.yml
+++ b/.github/workflows/cleanup-clerk-test-resources.yml
@@ -39,8 +39,8 @@ jobs:
           cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
           cleanup-stale
           browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude
-          --older-than-hours 0.5
-          --example-older-than-hours 24
+          --ci-older-than-hours 0.5
+          --staging-browser-older-than-hours 8
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           DRY_RUN: ${{ env.DRY_RUN }}

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
           `cleanup-stale requires <roles> ${STALE_CI_CLEANUP_ARGUMENT} <hours>`,
         );
       }
-      const createdBefore = staleCutoff(requiredArgument(5, "stale CI age"));
+      const ciCreatedBefore = staleCutoff(requiredArgument(5, "stale CI age"));
       if (process.argv[6] !== STALE_STAGING_BROWSER_CLEANUP_ARGUMENT) {
         throw new Error(
           `cleanup-stale requires <roles> ${STALE_CI_CLEANUP_ARGUMENT} <hours> ${STALE_STAGING_BROWSER_CLEANUP_ARGUMENT} <hours>`,
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
         requiredArgument(7, "stale staging browser age"),
       );
       assertNoExtraArguments(8);
-      result = await cleanupStaleClerkTestResources(roles, createdBefore, {
+      result = await cleanupStaleClerkTestResources(roles, ciCreatedBefore, {
         dryRun,
         stagingBrowserCreatedBefore,
       });

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -8,8 +8,9 @@ import {
   type ClerkTestRole,
 } from "./lib/clerk-api";
 
-const STALE_CLEANUP_ARGUMENT = "--older-than-hours";
-const STALE_EXAMPLE_CLEANUP_ARGUMENT = "--example-older-than-hours";
+const STALE_CI_CLEANUP_ARGUMENT = "--ci-older-than-hours";
+const STALE_STAGING_BROWSER_CLEANUP_ARGUMENT =
+  "--staging-browser-older-than-hours";
 
 async function main(): Promise<void> {
   const command = process.argv[2];
@@ -31,30 +32,30 @@ async function main(): Promise<void> {
       break;
     case "cleanup-stale": {
       const roles = parseRoles(requiredArgument(3, "role list"));
-      if (process.argv[4] !== STALE_CLEANUP_ARGUMENT) {
+      if (process.argv[4] !== STALE_CI_CLEANUP_ARGUMENT) {
         throw new Error(
-          `cleanup-stale requires <roles> ${STALE_CLEANUP_ARGUMENT} <hours>`,
+          `cleanup-stale requires <roles> ${STALE_CI_CLEANUP_ARGUMENT} <hours>`,
         );
       }
-      const createdBefore = staleCutoff(requiredArgument(5, "stale age"));
-      if (process.argv[6] !== STALE_EXAMPLE_CLEANUP_ARGUMENT) {
+      const createdBefore = staleCutoff(requiredArgument(5, "stale CI age"));
+      if (process.argv[6] !== STALE_STAGING_BROWSER_CLEANUP_ARGUMENT) {
         throw new Error(
-          `cleanup-stale requires <roles> ${STALE_CLEANUP_ARGUMENT} <hours> ${STALE_EXAMPLE_CLEANUP_ARGUMENT} <hours>`,
+          `cleanup-stale requires <roles> ${STALE_CI_CLEANUP_ARGUMENT} <hours> ${STALE_STAGING_BROWSER_CLEANUP_ARGUMENT} <hours>`,
         );
       }
-      const exampleCreatedBefore = staleCutoff(
-        requiredArgument(7, "stale example.com age"),
+      const stagingBrowserCreatedBefore = staleCutoff(
+        requiredArgument(7, "stale staging browser age"),
       );
       assertNoExtraArguments(8);
       result = await cleanupStaleClerkTestResources(roles, createdBefore, {
         dryRun,
-        exampleCreatedBefore,
+        stagingBrowserCreatedBefore,
       });
       break;
     }
     default:
       throw new Error(
-        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --older-than-hours <hours> --example-older-than-hours <hours>",
+        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --ci-older-than-hours <hours> --staging-browser-older-than-hours <hours>",
       );
   }
 

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -9,6 +9,7 @@ import {
 } from "./lib/clerk-api";
 
 const STALE_CLEANUP_ARGUMENT = "--older-than-hours";
+const STALE_EXAMPLE_CLEANUP_ARGUMENT = "--example-older-than-hours";
 
 async function main(): Promise<void> {
   const command = process.argv[2];
@@ -36,15 +37,24 @@ async function main(): Promise<void> {
         );
       }
       const createdBefore = staleCutoff(requiredArgument(5, "stale age"));
-      assertNoExtraArguments(6);
+      if (process.argv[6] !== STALE_EXAMPLE_CLEANUP_ARGUMENT) {
+        throw new Error(
+          `cleanup-stale requires <roles> ${STALE_CLEANUP_ARGUMENT} <hours> ${STALE_EXAMPLE_CLEANUP_ARGUMENT} <hours>`,
+        );
+      }
+      const exampleCreatedBefore = staleCutoff(
+        requiredArgument(7, "stale example.com age"),
+      );
+      assertNoExtraArguments(8);
       result = await cleanupStaleClerkTestResources(roles, createdBefore, {
         dryRun,
+        exampleCreatedBefore,
       });
       break;
     }
     default:
       throw new Error(
-        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --older-than-hours <hours>",
+        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --older-than-hours <hours> --example-older-than-hours <hours>",
       );
   }
 

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -596,6 +596,128 @@ test("stale cleanup isolates roles, requires strict markers, and supports dry-ru
   );
 });
 
+test("stale cleanup removes example.com browser QA resources without shared organizations", async () => {
+  const cutoff = new Date(10_000);
+  await withClerkServer(
+    (request, response) => {
+      const url = new URL(request.url, "http://clerk.test");
+      if (request.method === "GET" && url.pathname === "/v1/users") {
+        sendJson(response, 200, [
+          clerkUser("user_example", "qa+clerk_test@example.com", 1_000),
+          clerkUser("user_fallback", "fallback@example.com", 1_000),
+          clerkUser(
+            "user_without_org",
+            "walkthrough+clerk_test@example.com",
+            1_000,
+          ),
+          clerkUser(
+            "user_shared_creator",
+            "shared+clerk_test@example.com",
+            1_000,
+          ),
+          clerkUser(
+            "user_recent_org_creator",
+            "recent-org+clerk_test@example.com",
+            1_000,
+          ),
+          clerkUser("user_recent", "active+clerk_test@example.com", 20_000),
+          clerkUser("user_team", "member@vm0.ai", 1_000),
+          {
+            id: "user_multiple_emails",
+            created_at: 1_000,
+            email_addresses: [
+              { email_address: "multiple+clerk_test@example.com" },
+              { email_address: "member@vm0.ai" },
+            ],
+          },
+        ]);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/v1/organizations") {
+        sendJson(response, 200, {
+          data: [
+            clerkOwnedOrganization("org_example", "user_example", 1_000),
+            clerkOwnedOrganization("org_stale_members", "user_fallback", 1_000),
+            clerkOwnedOrganization(
+              "org_shared_member",
+              "user_shared_creator",
+              1_000,
+            ),
+            clerkOwnedOrganization(
+              "org_recent",
+              "user_recent_org_creator",
+              20_000,
+            ),
+            clerkOwnedOrganization("org_unrelated", "user_team", 1_000),
+          ],
+          total_count: 5,
+        });
+        return;
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/v1/organizations/org_example/memberships"
+      ) {
+        sendJson(response, 200, clerkMemberships("user_example"));
+        return;
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/v1/organizations/org_stale_members/memberships"
+      ) {
+        sendJson(
+          response,
+          200,
+          clerkMemberships("user_example", "user_fallback"),
+        );
+        return;
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/v1/organizations/org_shared_member/memberships"
+      ) {
+        sendJson(
+          response,
+          200,
+          clerkMemberships("user_shared_creator", "user_team"),
+        );
+        return;
+      }
+      if (request.method === "DELETE") {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      sendJson(response, 500, { unexpected: request.url });
+    },
+    async (requests) => {
+      const result = await cleanupStaleClerkTestResources(["browser"], cutoff, {
+        exampleCreatedBefore: cutoff,
+      });
+      assert.equal(result.selectedOrganizations, 2);
+      assert.equal(result.selectedUsers, 3);
+      assert.deepEqual(
+        requests
+          .filter((request) => request.method === "DELETE")
+          .map((request) => request.url),
+        [
+          "/v1/organizations/org_example",
+          "/v1/organizations/org_stale_members",
+          "/v1/users/user_example",
+          "/v1/users/user_fallback",
+          "/v1/users/user_without_org",
+        ],
+      );
+      assert.equal(
+        requests.some((request) =>
+          request.url.startsWith("/v1/organizations/org_recent/memberships?"),
+        ),
+        false,
+      );
+    },
+  );
+});
+
 test("retries exact deletion and surfaces permanent HTTP failures", async () => {
   const email = "cleanup@example.com";
   await withClerkServer(
@@ -722,6 +844,25 @@ function clerkOrganization(
     ...(privateMetadata === undefined
       ? {}
       : { private_metadata: privateMetadata }),
+  };
+}
+
+function clerkOwnedOrganization(
+  id: string,
+  createdBy: string,
+  createdAt: number,
+): object {
+  return {
+    id,
+    created_by: createdBy,
+    created_at: createdAt,
+  };
+}
+
+function clerkMemberships(...userIds: readonly string[]): object {
+  return {
+    data: userIds.map((userId) => ({ public_user_data: { user_id: userId } })),
+    total_count: userIds.length,
   };
 }
 

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -692,7 +692,7 @@ test("stale cleanup removes example.com browser QA resources without shared orga
     },
     async (requests) => {
       const result = await cleanupStaleClerkTestResources(["browser"], cutoff, {
-        exampleCreatedBefore: cutoff,
+        stagingBrowserCreatedBefore: cutoff,
       });
       assert.equal(result.selectedOrganizations, 2);
       assert.equal(result.selectedUsers, 3);

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -4,9 +4,10 @@ const DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1";
 const CLERK_PAGE_LIMIT = 500;
 const CLERK_RETRY_DELAYS_MS = [500, 1_500, 3_500] as const;
 const CLERK_MAX_RETRY_AFTER_MS = 30_000;
-const CLERK_DELETE_PACE_MS = 110;
+const CLERK_BULK_REQUEST_PACE_MS = 110;
 const CLERK_TEST_DOMAIN = "vm0-e2e.ai";
 const CLERK_TEST_MARKER = "clerk_test";
+const CLERK_STAGING_BROWSER_TEST_DOMAIN = "example.com";
 const LOCAL_JOB_REF = "local";
 const LOCAL_GENERATION = "local-1";
 
@@ -39,6 +40,10 @@ export interface ClerkCleanupOptions {
   readonly dryRun?: boolean;
 }
 
+export interface ClerkStaleCleanupOptions extends ClerkCleanupOptions {
+  readonly exampleCreatedBefore?: Date;
+}
+
 export interface ClerkCleanupResult {
   readonly scannedOrganizations: number;
   readonly selectedOrganizations: number;
@@ -65,12 +70,29 @@ interface ClerkUserSummary {
 interface ClerkOrganizationSummary {
   readonly id: string;
   readonly created_at?: number;
+  readonly created_by?: string | null;
   readonly private_metadata?: unknown;
 }
 
 interface ClerkOrganizationList {
   readonly data: readonly ClerkOrganizationSummary[];
   readonly total_count: number;
+}
+
+interface ClerkOrganizationMembershipSummary {
+  readonly public_user_data: {
+    readonly user_id: string;
+  };
+}
+
+interface ClerkOrganizationMembershipList {
+  readonly data: readonly ClerkOrganizationMembershipSummary[];
+  readonly total_count: number;
+}
+
+interface ClerkCleanupResources {
+  readonly organizations: readonly ClerkOrganizationSummary[];
+  readonly users: readonly ClerkUserSummary[];
 }
 
 interface RetryableClerkRequestInit extends RequestInit {
@@ -94,6 +116,7 @@ type ClerkCleanupSelection =
   | {
       readonly kind: "stale";
       readonly createdBeforeMs: number;
+      readonly exampleCreatedBeforeMs?: number;
       readonly roles: readonly ClerkTestRole[];
     };
 
@@ -354,15 +377,29 @@ export async function cleanupClerkTestJobRef(
 export async function cleanupStaleClerkTestResources(
   roles: readonly ClerkTestRole[],
   createdBefore: Date,
-  options: ClerkCleanupOptions = {},
+  options: ClerkStaleCleanupOptions = {},
 ): Promise<ClerkCleanupResult> {
   assertCleanupRoles(roles);
   const createdBeforeMs = createdBefore.getTime();
   if (!Number.isFinite(createdBeforeMs)) {
     throw new Error("Stale Clerk cleanup cutoff must be a valid date");
   }
+  const exampleCreatedBeforeMs = options.exampleCreatedBefore?.getTime();
+  if (
+    exampleCreatedBeforeMs !== undefined &&
+    !Number.isFinite(exampleCreatedBeforeMs)
+  ) {
+    throw new Error("Stale example.com cleanup cutoff must be a valid date");
+  }
   return await cleanupClerkTestResources(
-    { kind: "stale", createdBeforeMs, roles },
+    {
+      kind: "stale",
+      createdBeforeMs,
+      ...(exampleCreatedBeforeMs === undefined
+        ? {}
+        : { exampleCreatedBeforeMs }),
+      roles,
+    },
     options,
   );
 }
@@ -373,12 +410,17 @@ async function cleanupClerkTestResources(
 ): Promise<ClerkCleanupResult> {
   const users = await listClerkUsers();
   const organizations = await listClerkOrganizations();
+  const exampleResources = await selectStaleExampleResources(
+    selection,
+    users,
+    organizations,
+  );
 
   const organizationsWithOwners = organizations.map((organization) => ({
     organization,
     owner: parseClerkTestOrganizationMetadata(organization.private_metadata),
   }));
-  const selectedOrganizations = organizationsWithOwners
+  const selectedMarkedOrganizations = organizationsWithOwners
     .filter(({ organization, owner }) => {
       return (
         owner !== null &&
@@ -386,6 +428,10 @@ async function cleanupClerkTestResources(
       );
     })
     .map(({ organization }) => organization);
+  const selectedOrganizations = [
+    ...selectedMarkedOrganizations,
+    ...exampleResources.organizations,
+  ];
   const retainedOrganizationOwners = new Set<string>();
   if (selection.kind === "stale") {
     // Keep an owner user until every marked organization in its scope is old
@@ -399,7 +445,7 @@ async function cleanupClerkTestResources(
       }
     }
   }
-  const selectedUsers = users.filter((user) => {
+  const selectedMarkedUsers = users.filter((user) => {
     const emailAddress = user.email_addresses[0];
     if (user.email_addresses.length !== 1 || !emailAddress) {
       return false;
@@ -411,6 +457,7 @@ async function cleanupClerkTestResources(
       !retainedOrganizationOwners.has(clerkTestOwnerKey(owner))
     );
   });
+  const selectedUsers = [...selectedMarkedUsers, ...exampleResources.users];
 
   let deletedOrganizations = 0;
   let alreadyAbsentOrganizations = 0;
@@ -426,7 +473,7 @@ async function cleanupClerkTestResources(
         alreadyAbsentOrganizations += 1;
       }
       deletionIndex += 1;
-      await paceClerkDeletion(deletionIndex, deletionCount);
+      await paceClerkBulkRequest(deletionIndex, deletionCount);
     }
     for (const user of selectedUsers) {
       if (await deleteUserById(user.id)) {
@@ -435,7 +482,7 @@ async function cleanupClerkTestResources(
         alreadyAbsentUsers += 1;
       }
       deletionIndex += 1;
-      await paceClerkDeletion(deletionIndex, deletionCount);
+      await paceClerkBulkRequest(deletionIndex, deletionCount);
     }
   }
 
@@ -450,6 +497,66 @@ async function cleanupClerkTestResources(
     deletedUsers,
     alreadyAbsentUsers,
     skippedUsers: users.length - selectedUsers.length,
+  };
+}
+
+async function selectStaleExampleResources(
+  selection: ClerkCleanupSelection,
+  users: readonly ClerkUserSummary[],
+  organizations: readonly ClerkOrganizationSummary[],
+): Promise<ClerkCleanupResources> {
+  if (
+    selection.kind !== "stale" ||
+    selection.exampleCreatedBeforeMs === undefined
+  ) {
+    return { organizations: [], users: [] };
+  }
+  const exampleCreatedBeforeMs = selection.exampleCreatedBeforeMs;
+
+  const staleUsers = users.filter((user) => {
+    const emailAddress = user.email_addresses[0];
+    return (
+      user.email_addresses.length === 1 &&
+      emailAddress !== undefined &&
+      isStagingBrowserTestEmail(emailAddress.email_address) &&
+      user.created_at !== undefined &&
+      user.created_at < exampleCreatedBeforeMs
+    );
+  });
+  const staleUserIds = new Set(staleUsers.map((user) => user.id));
+  const retainedUserIds = new Set<string>();
+  const selectedOrganizations: ClerkOrganizationSummary[] = [];
+  const ownedOrganizations = organizations.flatMap((organization) => {
+    const createdBy = organization.created_by;
+    return typeof createdBy === "string" && staleUserIds.has(createdBy)
+      ? [{ organization, createdBy }]
+      : [];
+  });
+
+  for (const [index, ownedOrganization] of ownedOrganizations.entries()) {
+    const { organization, createdBy } = ownedOrganization;
+    if (
+      organization.created_at === undefined ||
+      organization.created_at >= exampleCreatedBeforeMs
+    ) {
+      retainedUserIds.add(createdBy);
+      continue;
+    }
+
+    const memberUserIds = await listClerkOrganizationMemberUserIds(
+      organization.id,
+    );
+    if (memberUserIds.every((userId) => staleUserIds.has(userId))) {
+      selectedOrganizations.push(organization);
+    } else {
+      retainedUserIds.add(createdBy);
+    }
+    await paceClerkBulkRequest(index + 1, ownedOrganizations.length);
+  }
+
+  return {
+    organizations: selectedOrganizations,
+    users: staleUsers.filter((user) => !retainedUserIds.has(user.id)),
   };
 }
 
@@ -552,6 +659,35 @@ async function listClerkOrganizations(): Promise<
   }
 }
 
+async function listClerkOrganizationMemberUserIds(
+  organizationId: string,
+): Promise<readonly string[]> {
+  const userIds: string[] = [];
+  let offset = 0;
+  while (true) {
+    const parameters = new URLSearchParams({
+      limit: String(CLERK_PAGE_LIMIT),
+      offset: String(offset),
+    });
+    const response = await requestClerkWithRetry(
+      "list Clerk test organization memberships",
+      `/organizations/${organizationId}/memberships?${parameters.toString()}`,
+      { method: "GET", headers: getClerkHeaders() },
+    );
+    const page = await readClerkOrganizationMemberships(
+      response,
+      "list Clerk test organization memberships",
+    );
+    userIds.push(
+      ...page.data.map((membership) => membership.public_user_data.user_id),
+    );
+    if (page.data.length === 0 || userIds.length >= page.total_count) {
+      return userIds;
+    }
+    offset += page.data.length;
+  }
+}
+
 export async function deleteOrganizationById(
   organizationId: string,
 ): Promise<boolean> {
@@ -611,14 +747,14 @@ async function deleteUserById(userId: string): Promise<boolean> {
   return response.status !== 404;
 }
 
-async function paceClerkDeletion(
-  deletionIndex: number,
-  deletionCount: number,
+async function paceClerkBulkRequest(
+  requestIndex: number,
+  requestCount: number,
 ): Promise<void> {
-  if (deletionIndex >= deletionCount || process.env.CLERK_API_TEST_BASE_URL) {
+  if (requestIndex >= requestCount || process.env.CLERK_API_TEST_BASE_URL) {
     return;
   }
-  await wait(CLERK_DELETE_PACE_MS);
+  await wait(CLERK_BULK_REQUEST_PACE_MS);
 }
 
 async function requestClerk(
@@ -751,6 +887,19 @@ async function readClerkOrganizations(
   return data;
 }
 
+async function readClerkOrganizationMemberships(
+  response: Response,
+  operation: string,
+): Promise<ClerkOrganizationMembershipList> {
+  const data = await readClerkJson(response, operation);
+  if (!isClerkOrganizationMembershipList(data)) {
+    throw new Error(
+      `${operation} returned an unexpected response: ${formatClerkResponseSummary(response)}`,
+    );
+  }
+  return data;
+}
+
 function isClerkUserList(value: unknown): value is readonly ClerkUserSummary[] {
   return Array.isArray(value) && value.every(isClerkUserSummary);
 }
@@ -790,13 +939,48 @@ function isClerkOrganizationSummary(
   return (
     isRecord(value) &&
     typeof value.id === "string" &&
-    (!("created_at" in value) || typeof value.created_at === "number")
+    (!("created_at" in value) || typeof value.created_at === "number") &&
+    (!("created_by" in value) ||
+      value.created_by === null ||
+      typeof value.created_by === "string")
+  );
+}
+
+function isClerkOrganizationMembershipList(
+  value: unknown,
+): value is ClerkOrganizationMembershipList {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.data) &&
+    value.data.every(isClerkOrganizationMembershipSummary) &&
+    typeof value.total_count === "number" &&
+    Number.isInteger(value.total_count) &&
+    value.total_count >= 0
+  );
+}
+
+function isClerkOrganizationMembershipSummary(
+  value: unknown,
+): value is ClerkOrganizationMembershipSummary {
+  return (
+    isRecord(value) &&
+    isRecord(value.public_user_data) &&
+    typeof value.public_user_data.user_id === "string"
   );
 }
 
 function formatClerkTestEmail(owner: ClerkTestOwner, nonce?: string): string {
   const role = nonce ? `${owner.role}-${nonce}` : owner.role;
   return `${owner.jobRef}+${CLERK_TEST_MARKER}+${owner.generation}+${role}@${CLERK_TEST_DOMAIN}`;
+}
+
+function isStagingBrowserTestEmail(email: string): boolean {
+  const addressParts = email.split("@");
+  return (
+    addressParts.length === 2 &&
+    addressParts[0] !== "" &&
+    addressParts[1] === CLERK_STAGING_BROWSER_TEST_DOMAIN
+  );
 }
 
 function parseRolePart(rolePart: string): ClerkTestRole | null {

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -41,7 +41,7 @@ export interface ClerkCleanupOptions {
 }
 
 export interface ClerkStaleCleanupOptions extends ClerkCleanupOptions {
-  readonly exampleCreatedBefore?: Date;
+  readonly stagingBrowserCreatedBefore?: Date;
 }
 
 export interface ClerkCleanupResult {
@@ -116,7 +116,7 @@ type ClerkCleanupSelection =
   | {
       readonly kind: "stale";
       readonly createdBeforeMs: number;
-      readonly exampleCreatedBeforeMs?: number;
+      readonly stagingBrowserCreatedBeforeMs?: number;
       readonly roles: readonly ClerkTestRole[];
     };
 
@@ -384,20 +384,23 @@ export async function cleanupStaleClerkTestResources(
   if (!Number.isFinite(createdBeforeMs)) {
     throw new Error("Stale Clerk cleanup cutoff must be a valid date");
   }
-  const exampleCreatedBeforeMs = options.exampleCreatedBefore?.getTime();
+  const stagingBrowserCreatedBeforeMs =
+    options.stagingBrowserCreatedBefore?.getTime();
   if (
-    exampleCreatedBeforeMs !== undefined &&
-    !Number.isFinite(exampleCreatedBeforeMs)
+    stagingBrowserCreatedBeforeMs !== undefined &&
+    !Number.isFinite(stagingBrowserCreatedBeforeMs)
   ) {
-    throw new Error("Stale example.com cleanup cutoff must be a valid date");
+    throw new Error(
+      "Stale staging browser cleanup cutoff must be a valid date",
+    );
   }
   return await cleanupClerkTestResources(
     {
       kind: "stale",
       createdBeforeMs,
-      ...(exampleCreatedBeforeMs === undefined
+      ...(stagingBrowserCreatedBeforeMs === undefined
         ? {}
-        : { exampleCreatedBeforeMs }),
+        : { stagingBrowserCreatedBeforeMs }),
       roles,
     },
     options,
@@ -410,7 +413,7 @@ async function cleanupClerkTestResources(
 ): Promise<ClerkCleanupResult> {
   const users = await listClerkUsers();
   const organizations = await listClerkOrganizations();
-  const exampleResources = await selectStaleExampleResources(
+  const stagingBrowserResources = await selectStaleStagingBrowserResources(
     selection,
     users,
     organizations,
@@ -430,7 +433,7 @@ async function cleanupClerkTestResources(
     .map(({ organization }) => organization);
   const selectedOrganizations = [
     ...selectedMarkedOrganizations,
-    ...exampleResources.organizations,
+    ...stagingBrowserResources.organizations,
   ];
   const retainedOrganizationOwners = new Set<string>();
   if (selection.kind === "stale") {
@@ -457,7 +460,10 @@ async function cleanupClerkTestResources(
       !retainedOrganizationOwners.has(clerkTestOwnerKey(owner))
     );
   });
-  const selectedUsers = [...selectedMarkedUsers, ...exampleResources.users];
+  const selectedUsers = [
+    ...selectedMarkedUsers,
+    ...stagingBrowserResources.users,
+  ];
 
   let deletedOrganizations = 0;
   let alreadyAbsentOrganizations = 0;
@@ -500,18 +506,18 @@ async function cleanupClerkTestResources(
   };
 }
 
-async function selectStaleExampleResources(
+async function selectStaleStagingBrowserResources(
   selection: ClerkCleanupSelection,
   users: readonly ClerkUserSummary[],
   organizations: readonly ClerkOrganizationSummary[],
 ): Promise<ClerkCleanupResources> {
   if (
     selection.kind !== "stale" ||
-    selection.exampleCreatedBeforeMs === undefined
+    selection.stagingBrowserCreatedBeforeMs === undefined
   ) {
     return { organizations: [], users: [] };
   }
-  const exampleCreatedBeforeMs = selection.exampleCreatedBeforeMs;
+  const stagingBrowserCreatedBeforeMs = selection.stagingBrowserCreatedBeforeMs;
 
   const staleUsers = users.filter((user) => {
     const emailAddress = user.email_addresses[0];
@@ -520,7 +526,7 @@ async function selectStaleExampleResources(
       emailAddress !== undefined &&
       isStagingBrowserTestEmail(emailAddress.email_address) &&
       user.created_at !== undefined &&
-      user.created_at < exampleCreatedBeforeMs
+      user.created_at < stagingBrowserCreatedBeforeMs
     );
   });
   const staleUserIds = new Set(staleUsers.map((user) => user.id));
@@ -537,7 +543,7 @@ async function selectStaleExampleResources(
     const { organization, createdBy } = ownedOrganization;
     if (
       organization.created_at === undefined ||
-      organization.created_at >= exampleCreatedBeforeMs
+      organization.created_at >= stagingBrowserCreatedBeforeMs
     ) {
       retainedUserIds.add(createdBy);
       continue;

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -115,7 +115,7 @@ type ClerkCleanupSelection =
   | { readonly kind: "job-ref"; readonly jobRef: string }
   | {
       readonly kind: "stale";
-      readonly createdBeforeMs: number;
+      readonly ciCreatedBeforeMs: number;
       readonly stagingBrowserCreatedBeforeMs?: number;
       readonly roles: readonly ClerkTestRole[];
     };
@@ -376,13 +376,13 @@ export async function cleanupClerkTestJobRef(
 
 export async function cleanupStaleClerkTestResources(
   roles: readonly ClerkTestRole[],
-  createdBefore: Date,
+  ciCreatedBefore: Date,
   options: ClerkStaleCleanupOptions = {},
 ): Promise<ClerkCleanupResult> {
   assertCleanupRoles(roles);
-  const createdBeforeMs = createdBefore.getTime();
-  if (!Number.isFinite(createdBeforeMs)) {
-    throw new Error("Stale Clerk cleanup cutoff must be a valid date");
+  const ciCreatedBeforeMs = ciCreatedBefore.getTime();
+  if (!Number.isFinite(ciCreatedBeforeMs)) {
+    throw new Error("Stale CI cleanup cutoff must be a valid date");
   }
   const stagingBrowserCreatedBeforeMs =
     options.stagingBrowserCreatedBefore?.getTime();
@@ -397,7 +397,7 @@ export async function cleanupStaleClerkTestResources(
   return await cleanupClerkTestResources(
     {
       kind: "stale",
-      createdBeforeMs,
+      ciCreatedBeforeMs,
       ...(stagingBrowserCreatedBeforeMs === undefined
         ? {}
         : { stagingBrowserCreatedBeforeMs }),
@@ -590,7 +590,7 @@ function cleanupSelectionMatches(
       return (
         selection.roles.includes(owner.role) &&
         createdAt !== undefined &&
-        createdAt < selection.createdBeforeMs
+        createdAt < selection.ciCreatedBeforeMs
       );
   }
 }

--- a/e2e/playwright/lib/clerk-test-resources.test.ts
+++ b/e2e/playwright/lib/clerk-test-resources.test.ts
@@ -40,6 +40,8 @@ test("runs generation and stale cleanup through the command entry point", async 
         "browser,playwright,paid-onboarding",
         "--older-than-hours",
         "6",
+        "--example-older-than-hours",
+        "24",
       ],
       { ...environment, DRY_RUN: "true" },
     );
@@ -70,10 +72,25 @@ test("runs generation and stale cleanup through the command entry point", async 
     );
     await assert.rejects(
       runClerkCommand(
-        ["cleanup-stale", "runner", "--older-than-hours", "30", "unexpected"],
+        [
+          "cleanup-stale",
+          "runner",
+          "--older-than-hours",
+          "30",
+          "--example-older-than-hours",
+          "24",
+          "unexpected",
+        ],
         environment,
       ),
       /Unexpected argument: unexpected/,
+    );
+    await assert.rejects(
+      runClerkCommand(
+        ["cleanup-stale", "runner", "--older-than-hours", "30"],
+        environment,
+      ),
+      /cleanup-stale requires/,
     );
     assert.equal(requestCount, requestCountBeforeInvalidArguments);
   } finally {

--- a/e2e/playwright/lib/clerk-test-resources.test.ts
+++ b/e2e/playwright/lib/clerk-test-resources.test.ts
@@ -38,10 +38,10 @@ test("runs generation and stale cleanup through the command entry point", async 
       [
         "cleanup-stale",
         "browser,playwright,paid-onboarding",
-        "--older-than-hours",
+        "--ci-older-than-hours",
         "6",
-        "--example-older-than-hours",
-        "24",
+        "--staging-browser-older-than-hours",
+        "8",
       ],
       { ...environment, DRY_RUN: "true" },
     );
@@ -56,7 +56,7 @@ test("runs generation and stale cleanup through the command entry point", async 
     );
     await assert.rejects(
       runClerkCommand(
-        ["cleanup-stale", "runner,unknown", "--older-than-hours", "30"],
+        ["cleanup-stale", "runner,unknown", "--ci-older-than-hours", "30"],
         environment,
       ),
       /Unknown Clerk test role: unknown/,
@@ -75,10 +75,10 @@ test("runs generation and stale cleanup through the command entry point", async 
         [
           "cleanup-stale",
           "runner",
-          "--older-than-hours",
+          "--ci-older-than-hours",
           "30",
-          "--example-older-than-hours",
-          "24",
+          "--staging-browser-older-than-hours",
+          "8",
           "unexpected",
         ],
         environment,
@@ -87,7 +87,7 @@ test("runs generation and stale cleanup through the command entry point", async 
     );
     await assert.rejects(
       runClerkCommand(
-        ["cleanup-stale", "runner", "--older-than-hours", "30"],
+        ["cleanup-stale", "runner", "--ci-older-than-hours", "30"],
         environment,
       ),
       /cleanup-stale requires/,


### PR DESCRIPTION
## Summary

- include stale `@example.com` staging-browser identities in the scheduled Clerk cleanup with an 8-hour cutoff
- expose explicit `--ci-older-than-hours` and `--staging-browser-older-than-hours` cleanup thresholds
- delete target-created organizations only when they are also stale and every member is a stale `@example.com` user
- preserve the existing 30-minute cleanup behavior for marked `@vm0-e2e.ai` CI resources

## Testing

- `npx --yes prettier@3.8.1 --check ...`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm exec tsx --test playwright/lib/clerk-api.test.ts playwright/lib/clerk-test-resources.test.ts` (12 passed)
- `bash -n .github/scripts/tests/clerk-test-resource-workflow-test.sh`
