### PR TITLE
refactor(api): dual-write machine secret environment aliases

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -262,6 +262,7 @@ runs:
             add_env ATOM_URL "$atom_url"
           fi
           if [[ -n "$machine_secret_key" ]]; then
+            add_env OKOU_MACHINE_SECRET_KEY "$machine_secret_key"
             add_env VM0_MACHINE_SECRET_KEY "$machine_secret_key"
           fi
         fi

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -148,6 +148,16 @@ assert_api_backend_url_aliases_equal_dual() {
   assert_env_values_equal "$env_file" OKOU_API_BACKEND_URL VM0_API_BACKEND_URL
 }
 
+assert_machine_secret_aliases_equal_dual() {
+  local env_file="$1"
+  local expected="$2"
+  assert_env_key_count "$env_file" OKOU_MACHINE_SECRET_KEY 1
+  assert_env_key_count "$env_file" VM0_MACHINE_SECRET_KEY 1
+  assert_env_value "$env_file" OKOU_MACHINE_SECRET_KEY "$expected"
+  assert_env_value "$env_file" VM0_MACHINE_SECRET_KEY "$expected"
+  assert_env_values_equal "$env_file" OKOU_MACHINE_SECRET_KEY VM0_MACHINE_SECRET_KEY
+}
+
 assert_web_url_aliases_equal_dual() {
   local env_file="$1"
   local expected="$2"
@@ -506,7 +516,7 @@ assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-se
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
 assert_env_value "$success_env_file" UNSPLASH_ACCESS_KEY "github-unsplash-access-key"
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
-assert_env_value "$success_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
+assert_machine_secret_aliases_equal_dual "$success_env_file" "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
 assert_env_key_count "$success_env_file" OKOU_PREVIEW_JOB_REF 1
 assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
@@ -560,6 +570,8 @@ assert_contains "$preview_web_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$preview_web_env_file"
 assert_debug_aliases_equal_dual "$preview_web_env_file"
 assert_api_backend_url_aliases_equal_dual "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
+assert_env_key_absent "$preview_web_env_file" OKOU_MACHINE_SECRET_KEY
+assert_env_key_absent "$preview_web_env_file" VM0_MACHINE_SECRET_KEY
 assert_web_url_aliases_absent "$preview_web_env_file"
 
 empty_job_ref_dir="$(mktemp -d)"
@@ -570,6 +582,7 @@ assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
 assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
 assert_api_backend_url_aliases_equal_dual "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
+assert_machine_secret_aliases_equal_dual "$empty_job_ref_env_file" "github-atom-machine-secret"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -580,6 +593,7 @@ assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_debug_aliases_equal_dual "$empty_env_file"
 assert_api_backend_url_aliases_equal_dual "$empty_env_file" "https://pr-123-api-backend.vm0.test"
+assert_machine_secret_aliases_equal_dual "$empty_env_file" "github-atom-machine-secret"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -602,7 +616,8 @@ assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
 assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$production_web_env_file" "ATOM_URL="
-assert_env_absent_value "$production_web_env_file" "VM0_MACHINE_SECRET_KEY="
+assert_env_key_absent "$production_web_env_file" OKOU_MACHINE_SECRET_KEY
+assert_env_key_absent "$production_web_env_file" VM0_MACHINE_SECRET_KEY
 assert_env_absent_value "$production_web_env_file" "CLI_PKG_URL="
 assert_env_absent_value "$production_web_env_file" "JOGGAI_WEBHOOK_SECRET="
 assert_env_value "$production_web_env_file" OKOU_WEATHER_GOOGLE_WEATHER_TOKEN "github-google-weather-token"
@@ -630,7 +645,7 @@ assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"
 assert_env_value "$production_api_env_file" ATOM_URL "https://atom.github.test"
-assert_env_value "$production_api_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
+assert_machine_secret_aliases_equal_dual "$production_api_env_file" "github-atom-machine-secret"
 assert_env_value "$production_api_env_file" JOGGAI_WEBHOOK_SECRET "github-joggai-webhook-secret"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_ID "github-teams-bot-app-id"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_PASSWORD "github-teams-bot-app-password"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -18,6 +18,7 @@ APP_URL=https://app.vm7.ai:8443
 
 # Optional: Atom redeem service for onboarding codes
 ATOM_URL=https://atom-api.vm7.ai:8442
+OKOU_MACHINE_SECRET_KEY=op://Development/clerk/OKOU_MACHINE_SECRET_KEY
 VM0_MACHINE_SECRET_KEY=op://Development/clerk/OKOU_MACHINE_SECRET_KEY
 
 # Required: API deploy stage tag


### PR DESCRIPTION
## Summary

- Emit adjacent, byte-equal `OKOU_MACHINE_SECRET_KEY` and retained `VM0_MACHINE_SECRET_KEY` values from the same existing `machine_secret_key` bytes inside the unchanged API-only, non-empty action branch. Preview and production still read the existing legacy-named `VM0_MACHINE_SECRET_KEY` repository secret once; no canonical external secret lookup was added.
- Extend the real composite-action contract with one machine-secret alias helper that requires exact key counts, exact expected fixture values, and byte equality for every successful preview API case and production API. Preview and production web outputs require both aliases to be absent, while the existing no-secret-output diagnostics remain intact.
- Add adjacent local API aliases backed by the exact same existing `op://Development/clerk/OKOU_MACHINE_SECRET_KEY` item. Turbo pass-through, the environment schema, dual resolver, startup observer, logger/event shape, billing request-time resolution, test environment stub, workflows, and external configuration remain unchanged.

## Base and overlap evidence

- Pre-edit refreshed base: `bac7e5573d2b0ee4a43d00a0c43c8ce9c84baf44`. Its fully paginated audit covered 37 open PRs and 578 GitHub-declared / 578 fetched changed files with zero mismatch.
- `main` advanced during verification through disjoint workflow, UI, Runner, Python, Sandbox, and Guest Agent changes. The branch was refreshed twice; the workflow-catalog change added an unrelated route registration while preserving `reportMachineSecretAliasSourceAtProcessInitialization()` unchanged.
- Final refreshed/rebased base: `083edf48f49ae80fc055b89030858373052f2209`.
- Final stable PR head: `8cc7c50c65386505ff19965bf0b2e1f2f07e24bc`.
- Final exact-key inventory: 16 `OKOU_MACHINE_SECRET_KEY` occurrences and 20 retained `VM0_MACHINE_SECRET_KEY` occurrences across the same 9-file union. The base inventory was 8 canonical occurrences across 4 files and 18 legacy occurrences across 9 files.
- The final fully paginated audit at `2026-08-26T10:41:15Z` covered all 32 open PRs and all 452 GitHub-declared / 452 fetched changed files with zero pagination mismatch.
- Stale #25722 remains open and `DIRTY` at unchanged head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, base `505aae73170efd5b484599eb7d433f404f5c3d2f`, and update time `2026-08-13T15:03:45Z`, with 185 declared / 185 fetched files. It overlaps the action and action contract while retaining legacy-only machine-secret output; its proposed Worker allowlist also admits only `VM0_MACHINE_SECRET_KEY`. None of its Worker/runtime scope was imported or modified here. If it refreshes or lands, it must preserve this equal-dual output and admit both aliases before the Worker unknown-key guard can safely consume the rendered environment.

## Verification

- Pinned Prettier 3.8.1 write/check on touched supported formats; `pnpm format` completed with no unrelated changes.
- Bash syntax checks for the action contract and the extracted composite-action script.
- ShellCheck 0.9.0 for the action contract and the extracted composite-action script.
- `bash .github/scripts/tests/web-api-env-action-test.sh`: passed the real preview/production and web/API matrix after each final base refresh.
- `pnpm turbo run lint --concurrency=1 --log-order grouped`: 13/13 tasks passed; advisory Oxlint warnings were pre-existing on untouched files.
- `pnpm knip`: passed with existing configuration hints only.
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`: 12/12 tasks passed.
- `pnpm --filter @okouai/app run check-types`: passed.
- `pnpm --filter api run check-types`: dependency, boundary, gateway, core, bootstrap, test, and bootstrap-wiring stages passed.
- Exact semantic assertions proved the external lookup remains legacy-only, the action writes both aliases exactly once from one variable inside the API/non-empty branch, and the local aliases are adjacent, exactly once, and backed by one unchanged 1Password reference without resolving or printing it.
- Diff/hash assertions proved the API backend URL, Turbo pass-through, schema, resolver, startup observer, logger, billing route/tests, test env stub, release/rollback workflows, devcontainer, and unrelated configuration unchanged. `git diff --check` passed.

No full local Vitest suite or local development server was run. Protected PR CI remains authoritative for repository-wide validation.

## Rollout boundaries

- This PR expands repository-owned writers only. It does not create, copy, rename, read, print, rotate, or mutate a GitHub secret or variable, Vercel/Doppler/1Password configuration, workflow input, live environment, deployment, or release approval.
- Every retained rollback API already contains the dual reader. The retained legacy output remains mandatory for old-API rollback while current API processes consume the byte-equal canonical twin.
- A later controller-owned release must deploy the exact containing API SHA. Production acceptance must query `billing_machine_secret_alias_resolution` from the exact API cutover and prove positive `equal-dual` observations with zero `legacy-only`, `canonical-only`, `conflicting-dual`, and `absent` states.
- Canonical-only output, external secret migration, legacy-reader removal, telemetry cleanup, Worker sequencing, and the final `VM0_*` ownership-guard cleanup remain separate just-in-time work under #28914.

## Fallbacks

- `.github/actions/web-api-env/action.yml` and `turbo/apps/api/.env.local.tpl` retain `VM0_MACHINE_SECRET_KEY` immediately beside byte-equal `OKOU_MACHINE_SECRET_KEY` from the same existing source. This preserves old-reader API rollback for the full supported rollback window; current dual readers accept either alias and fail closed on conflict.
- Revert this PR to restore the previous legacy-only repository-owned runtime and local writer state. The revert requires no GitHub secret, Vercel, Doppler, 1Password, resolver, billing, release-workflow, or external-configuration change.
- Removal gate: first deploy the exact containing SHA and prove bounded production `equal-dual` observations with zero `legacy-only`, `canonical-only`, `conflicting-dual`, and `absent` states. A later canonical-only writer issue under #28914 must then refresh all active and stale writer/Worker boundaries and prove the old-reader rollback target retired before removing the retained legacy writer.
- Reader-removal and telemetry/`VM0_*` guard cleanup remain later independent children of #28914 after their own rollback-window and zero-use evidence.

Closes #29619

Parent EPIC: #28914
