### PR TITLE
perf(api): attribute goal scheduler start latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -80,8 +80,17 @@ const CHAT_CALLBACK_PRE_CREATE_TIMING_PREFIX =
   "api_dispatch_pre_create_zero_chat_callback_";
 const GOAL_DRAIN_PRE_CREATE_TIMING_PREFIX =
   "api_dispatch_pre_create_zero_goal_drain_";
+const GOAL_SCHEDULER_TIMING_ACTION_TYPES = [
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry",
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup",
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run",
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+  "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff",
+] as const;
 const GOAL_DRAIN_SUCCESS_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap",
+  ...GOAL_SCHEDULER_TIMING_ACTION_TYPES,
   "api_dispatch_pre_create_zero_goal_drain_event_queue_age",
   "api_dispatch_pre_create_zero_goal_drain_load_event",
   "api_dispatch_pre_create_zero_goal_drain_load_target",
@@ -854,8 +863,17 @@ function isGoalDrainWaitingTimingAction(actionType: string): boolean {
   );
 }
 
+function isGoalSchedulerTimingAction(actionType: string): boolean {
+  return (
+    actionType ===
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap" ||
+    actionType.startsWith("api_dispatch_pre_create_zero_goal_drain_scheduler_")
+  );
+}
+
 async function expectGoalDrainPreCreateTiming(args: {
   readonly runId: string;
+  readonly schedulerOrigin: "chat_callback" | "terminal_callback_fallback";
   readonly forbiddenValues: readonly string[];
 }): Promise<void> {
   await expect
@@ -896,17 +914,33 @@ async function expectGoalDrainPreCreateTiming(args: {
         goal_drain_timing_role: isGoalDrainWaitingTimingAction(actionType)
           ? "waiting"
           : "phase",
+        ...(isGoalSchedulerTimingAction(actionType)
+          ? { goal_scheduler_origin: args.schedulerOrigin }
+          : {}),
       }),
     );
     expect(event?.duration_ms).toStrictEqual(expect.any(Number));
     expect(Number(event?.duration_ms)).toBeGreaterThanOrEqual(0);
     expect(event.goal_drain_attempt).toBe(
-      actionType ===
-        "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap"
-        ? undefined
-        : "initial",
+      isGoalSchedulerTimingAction(actionType) ? undefined : "initial",
     );
   }
+
+  const schedulerStartGap = timingEventsForAction(
+    goalDrainEvents,
+    "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap",
+  )[0];
+  if (!schedulerStartGap) {
+    throw new Error("Expected goal scheduler start gap timing");
+  }
+  const schedulerPhaseDuration = GOAL_SCHEDULER_TIMING_ACTION_TYPES.reduce(
+    (total, actionType) => {
+      const event = timingEventsForAction(goalDrainEvents, actionType)[0];
+      return total + Number(event?.duration_ms);
+    },
+    0,
+  );
+  expect(schedulerPhaseDuration).toBe(Number(schedulerStartGap.duration_ms));
 
   const entrypointGapEvents = timingEventsForAction(
     allEvents,
@@ -1860,6 +1894,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     expect(kms.generateDataKeyCalls).toBe(1);
     await expectGoalDrainPreCreateTiming({
       runId: goalContinuation.runId,
+      schedulerOrigin: "chat_callback",
       forbiddenValues: [
         goalBrief,
         goalObjective,
@@ -1948,6 +1983,18 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await expect(goalRunIds(first.threadId)).resolves.toStrictEqual([
       continuation.runId,
     ]);
+    await expectGoalDrainPreCreateTiming({
+      runId: continuation.runId,
+      schedulerOrigin: "terminal_callback_fallback",
+      forbiddenValues: [
+        goalBrief,
+        actor.userId,
+        ...(actor.orgId ? [actor.orgId] : []),
+        agentId,
+        first.threadId,
+        continuation.id,
+      ],
+    });
 
     await api.requestCancelRun(actor, continuation.runId, [200]);
     await waitForRunStatus(actor, continuation.runId, "cancelled");

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -143,6 +143,7 @@ const dispatchInternalCallback$ = command(
                 {
                   chatThreadId,
                   dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+                  goalSchedulerOrigin: "chat_callback",
                   timing,
                 },
                 inputSignal,

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -545,6 +545,7 @@ const dispatchTerminalCompleteSideEffects$ = command(
             runId: input.runId,
             dispatchFailedCallbacks: dispatchFailedRunCallbacks,
             apiStartTime: input.apiStartTime,
+            goalSchedulerOrigin: "terminal_callback_fallback",
           },
           signal,
         ),

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -338,6 +338,7 @@ export class ApiDispatchPhaseCollector {
   }
 }
 
+/** Hold shared scheduler phases until a created goal run owns their flush. */
 export class GoalSchedulerTimingCollector {
   private readonly records: GoalSchedulerTimingRecord[] = [];
   private previousBoundaryAt: number;

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -136,6 +136,12 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_teams_entrypoint_gap"
   | "api_dispatch_pre_create_zero_teams_create_run"
   | "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff"
   | "api_dispatch_pre_create_zero_goal_drain_event_queue_age"
   | "api_dispatch_pre_create_zero_goal_drain_load_event"
   | "api_dispatch_pre_create_zero_goal_drain_load_target"
@@ -278,6 +284,27 @@ interface ApiDispatchPhaseRecord {
   readonly finishedAt: number;
 }
 
+export type GoalSchedulerTimingOrigin =
+  | "chat_callback"
+  | "terminal_callback_fallback"
+  | "run_recovery"
+  | "direct"
+  | "stale_sweep";
+
+type GoalSchedulerTimingActionType =
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain"
+  | "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff";
+
+interface GoalSchedulerTimingRecord {
+  readonly actionType: GoalSchedulerTimingActionType;
+  readonly startedAt: number;
+  readonly finishedAt: number;
+}
+
 export class ApiDispatchPhaseCollector {
   private readonly records: ApiDispatchPhaseRecord[] = [];
   private previousBoundaryAt: number;
@@ -306,6 +333,48 @@ export class ApiDispatchPhaseCollector {
         "top_level",
         record.startedAt,
         record.finishedAt,
+      );
+    }
+  }
+}
+
+export class GoalSchedulerTimingCollector {
+  private readonly records: GoalSchedulerTimingRecord[] = [];
+  private previousBoundaryAt: number;
+  readonly origin: GoalSchedulerTimingOrigin;
+
+  constructor(startedAt: number, origin: GoalSchedulerTimingOrigin) {
+    this.previousBoundaryAt = startedAt;
+    this.origin = origin;
+  }
+
+  checkpoint(
+    actionType: GoalSchedulerTimingActionType,
+    finishedAt: number = now(),
+  ): void {
+    const boundedFinishedAt = Math.max(this.previousBoundaryAt, finishedAt);
+    this.records.push({
+      actionType,
+      startedAt: this.previousBoundaryAt,
+      finishedAt: boundedFinishedAt,
+    });
+    this.previousBoundaryAt = boundedFinishedAt;
+  }
+
+  appendTo(
+    timing: ApiDispatchTimingCollector,
+    dimensions: ApiDispatchTimingDimensions,
+  ): void {
+    for (const record of this.records.splice(0)) {
+      timing.recordElapsed(
+        record.actionType,
+        "nested",
+        record.startedAt,
+        record.finishedAt,
+        {
+          ...dimensions,
+          goal_scheduler_origin: this.origin,
+        },
       );
     }
   }

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -212,15 +212,14 @@ export const drainChatThreadQueueForRun$ = command(
     input: {
       readonly runId: string;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
-      readonly apiStartTime?: number;
+      readonly apiStartTime: number;
       readonly goalSchedulerOrigin?: GoalSchedulerTimingOrigin;
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const apiStartTime = input.apiStartTime ?? now();
     const lookupStartedAt = now();
     const goalSchedulerTiming = new GoalSchedulerTimingCollector(
-      apiStartTime,
+      input.apiStartTime,
       input.goalSchedulerOrigin ?? "run_recovery",
     );
     goalSchedulerTiming.checkpoint(
@@ -243,7 +242,7 @@ export const drainChatThreadQueueForRun$ = command(
       drainChatThreadQueueForThread$,
       {
         chatThreadId: run.chatThreadId,
-        apiStartTime,
+        apiStartTime: input.apiStartTime,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,
         goalSchedulerTiming,
       },

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -142,6 +142,9 @@ export const drainChatThreadQueueForThread$ = command(
         schedulerEnteredAt,
       );
     }
+    // Run-based drains close their database lookup at this common entry, so
+    // that phase also includes the command handoff. Direct drains emit the
+    // same action with zero duration to keep one fixed per-run action set.
     goalSchedulerTiming.checkpoint(
       "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup",
       schedulerEnteredAt,

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -24,7 +24,11 @@ import {
 } from "./workflow-queue-drain.service";
 import { expiredCancellationRecoveryThreads } from "./chat-active-run.service";
 import { drainGoalQueueForThread$ } from "./goal-queue-drain.service";
-import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
+import {
+  GoalSchedulerTimingCollector,
+  type ApiDispatchTimingCollector,
+  type GoalSchedulerTimingOrigin,
+} from "./api-dispatch-timing.service";
 import { pendingActiveInputCondition } from "./chat-event-queue.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
@@ -47,6 +51,8 @@ interface DrainChatThreadQueueInput {
   readonly apiStartTime?: number;
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly goalSchedulerOrigin?: GoalSchedulerTimingOrigin;
+  readonly goalSchedulerTiming?: GoalSchedulerTimingCollector;
   readonly queueItemCreatedBefore?: Date;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
   readonly automationEventLaunch?: {
@@ -122,13 +128,36 @@ export const drainChatThreadQueueForThread$ = command(
     input: DrainChatThreadQueueInput,
     signal: AbortSignal,
   ): Promise<WorkflowQueueDrainResult | null> => {
-    const apiStartTime = input.apiStartTime ?? now();
+    const schedulerEnteredAt = now();
+    const apiStartTime = input.apiStartTime ?? schedulerEnteredAt;
+    const goalSchedulerTiming =
+      input.goalSchedulerTiming ??
+      new GoalSchedulerTimingCollector(
+        apiStartTime,
+        input.goalSchedulerOrigin ?? "direct",
+      );
+    if (!input.goalSchedulerTiming) {
+      goalSchedulerTiming.checkpoint(
+        "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry",
+        schedulerEnteredAt,
+      );
+    }
+    goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_run_thread_lookup",
+      schedulerEnteredAt,
+    );
     const db = set(writeDb$);
-    if (await notifyRunningChatRunOfPendingInput(db, input.chatThreadId)) {
-      signal.throwIfAborted();
+    const notifiedRunningRun = await notifyRunningChatRunOfPendingInput(
+      db,
+      input.chatThreadId,
+    );
+    signal.throwIfAborted();
+    goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_notify_running_run",
+    );
+    if (notifiedRunningRun) {
       return null;
     }
-    signal.throwIfAborted();
     await set(
       drainQueuedUserMessagesForThread$,
       {
@@ -140,6 +169,9 @@ export const drainChatThreadQueueForThread$ = command(
       signal,
     );
     signal.throwIfAborted();
+    goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_user_message_drain",
+    );
     const workflowResult = await set(
       drainWorkflowQueueForThread$,
       {
@@ -154,12 +186,16 @@ export const drainChatThreadQueueForThread$ = command(
       signal,
     );
     signal.throwIfAborted();
+    goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_workflow_drain",
+    );
     await set(
       drainGoalQueueForThread$,
       {
         chatThreadId: input.chatThreadId,
         apiStartTime,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        goalSchedulerTiming,
         queueItemCreatedBefore: input.queueItemCreatedBefore,
       },
       signal,
@@ -177,9 +213,20 @@ export const drainChatThreadQueueForRun$ = command(
       readonly runId: string;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
       readonly apiStartTime?: number;
+      readonly goalSchedulerOrigin?: GoalSchedulerTimingOrigin;
     },
     signal: AbortSignal,
   ): Promise<void> => {
+    const apiStartTime = input.apiStartTime ?? now();
+    const lookupStartedAt = now();
+    const goalSchedulerTiming = new GoalSchedulerTimingCollector(
+      apiStartTime,
+      input.goalSchedulerOrigin ?? "run_recovery",
+    );
+    goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_pre_entry",
+      lookupStartedAt,
+    );
     const db = set(writeDb$);
     const [run] = await db
       .select({ chatThreadId: agentRuns.chatThreadId })
@@ -196,8 +243,9 @@ export const drainChatThreadQueueForRun$ = command(
       drainChatThreadQueueForThread$,
       {
         chatThreadId: run.chatThreadId,
-        apiStartTime: input.apiStartTime,
+        apiStartTime,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        goalSchedulerTiming,
       },
       signal,
     );
@@ -276,6 +324,7 @@ export const drainStaleChatThreadQueues$ = command(
           {
             chatThreadId: candidate.chatThreadId,
             dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+            goalSchedulerOrigin: "stale_sweep",
             queueItemCreatedBefore:
               candidate.reason === "queue-item-stale"
                 ? candidate.queueItemCreatedBefore

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   ApiDispatchTimingCollector,
   type ApiDispatchTimingDimensions,
+  type GoalSchedulerTimingCollector,
 } from "./api-dispatch-timing.service";
 import {
   loadGoalQueueTarget,
@@ -480,6 +481,7 @@ export const drainGoalQueueForThread$ = command(
       readonly chatThreadId: string;
       readonly apiStartTime: number;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+      readonly goalSchedulerTiming: GoalSchedulerTimingCollector;
       readonly queueItemCreatedBefore?: Date;
     },
     signal: AbortSignal,
@@ -487,12 +489,23 @@ export const drainGoalQueueForThread$ = command(
     const drainStartedAt = now();
     const apiStartTime = args.apiStartTime;
     const timing = new ApiDispatchTimingCollector();
+    args.goalSchedulerTiming.checkpoint(
+      "api_dispatch_pre_create_zero_goal_drain_scheduler_goal_handoff",
+      drainStartedAt,
+    );
+    args.goalSchedulerTiming.appendTo(
+      timing,
+      goalDrainTimingDimensions({ role: "phase" }),
+    );
     timing.recordElapsed(
       "api_dispatch_pre_create_zero_goal_drain_scheduler_start_gap",
       "nested",
       apiStartTime,
       drainStartedAt,
-      goalDrainTimingDimensions({ role: "waiting" }),
+      {
+        ...goalDrainTimingDimensions({ role: "waiting" }),
+        goal_scheduler_origin: args.goalSchedulerTiming.origin,
+      },
     );
     const db = set(writeDb$);
 


### PR DESCRIPTION
## Summary

- add a deferred goal scheduler timing collector that emits six sequential predecessor phases on the created goal run
- distinguish canonical chat callback, terminal fallback, run recovery, direct, and stale-sweep scheduler origins with a fixed low-cardinality dimension
- verify canonical and fallback terminal routes emit one complete phase set whose durations reconcile exactly with the existing scheduler-start aggregate

## Scope

This PR is additive observability only. It preserves the existing scheduler-start aggregate and does not change queue priority, callback ownership, locking, scheduling, cancellation, retries, persistence, API contracts, queue payloads, or Runner protocols.

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` (52 passed)
- `cd turbo && pnpm knip --workspace api`
- pre-commit hook: repository Knip, repository type checks, formatting, and file-size checks passed

Closes #29623
Parent context: #24203
