### PR TITLE
feat(cli): list connector accounts

### DIFF
--- a/turbo/apps/cli/src/commands/connector/account-label.ts
+++ b/turbo/apps/cli/src/commands/connector/account-label.ts
@@ -1,0 +1,44 @@
+import {
+  connectorAccountEffectiveLabel,
+  connectorAccountExternalIdentity,
+  type ConnectorAccountIdentityFields,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+
+interface ConnectorAccountCliLabelInput extends ConnectorAccountIdentityFields {
+  readonly connectionId: string;
+}
+
+function connectorAccountCliExternalIdentity(
+  account: ConnectorAccountIdentityFields,
+): string | null {
+  const identity = connectorAccountExternalIdentity(account);
+  if (
+    identity &&
+    identity === account.externalUsername &&
+    !account.externalEmail
+  ) {
+    return `@${identity}`;
+  }
+  return identity;
+}
+
+export function connectorAccountCliLabel(
+  account: ConnectorAccountCliLabelInput,
+): string {
+  const fallbackLabel = `Account #${account.connectionId.slice(0, 8)}`;
+  if (account.displayName) {
+    return connectorAccountEffectiveLabel(account, fallbackLabel);
+  }
+  return connectorAccountCliExternalIdentity(account) ?? fallbackLabel;
+}
+
+export function connectorAccountCliInventoryLabel(
+  account: ConnectorAccountCliLabelInput,
+): string {
+  const label = connectorAccountCliLabel(account);
+  const identity = connectorAccountCliExternalIdentity(account);
+  if (account.displayName && identity && identity !== account.displayName) {
+    return `${label} (${identity})`;
+  }
+  return label;
+}

--- a/turbo/apps/cli/src/commands/connector/account-label.ts
+++ b/turbo/apps/cli/src/commands/connector/account-label.ts
@@ -36,8 +36,14 @@ export function connectorAccountCliInventoryLabel(
   account: ConnectorAccountCliLabelInput,
 ): string {
   const label = connectorAccountCliLabel(account);
+  const rawIdentity = connectorAccountExternalIdentity(account);
   const identity = connectorAccountCliExternalIdentity(account);
-  if (account.displayName && identity && identity !== account.displayName) {
+  if (
+    account.displayName &&
+    rawIdentity &&
+    rawIdentity !== account.displayName &&
+    identity !== account.displayName
+  ) {
     return `${label} (${identity})`;
   }
   return label;

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -104,6 +104,9 @@ describe("okou connector account list command", () => {
         connectorAccount({
           id: "44444444-4444-4444-8444-444444444444",
           authMethod: "api-token",
+          externalEmail: "",
+          externalId: "",
+          externalUsername: "",
         }),
       ]),
     );

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -18,6 +18,7 @@ import { listConnectorAccountsCommand } from "../list";
 const FIRST_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
 const SECOND_CONNECTION_ID = "22222222-2222-4222-8222-222222222222";
 const CUSTOM_CONNECTOR_ID = "33333333-3333-4333-8333-333333333333";
+const FALLBACK_CONNECTION_ID = "44444444-4444-4444-8444-444444444444";
 
 function connectorAccount(
   overrides: Partial<ConnectorAccountConnection> = {},
@@ -102,7 +103,7 @@ describe("okou connector account list command", () => {
           reconnectReason: "authorization_expired_or_revoked",
         }),
         connectorAccount({
-          id: "44444444-4444-4444-8444-444444444444",
+          id: FALLBACK_CONNECTION_ID,
           authMethod: "api-token",
           externalEmail: "",
           externalId: "",
@@ -128,6 +129,15 @@ describe("okou connector account list command", () => {
     expect(output).toContain("reconnect-required");
     expect(output).toContain(FIRST_CONNECTION_ID);
     expect(output).toContain(SECOND_CONNECTION_ID);
+    const workRow = output.split("\n").find((row) => {
+      return row.includes(FIRST_CONNECTION_ID);
+    });
+    expect(workRow).toContain("yes");
+    expect(workRow).toContain("oauth");
+    const fallbackRow = output.split("\n").find((row) => {
+      return row.includes(FALLBACK_CONNECTION_ID);
+    });
+    expect(fallbackRow).toContain("api-token");
   });
 
   it("resolves a custom connector slug to its connection target", async () => {

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -108,6 +108,11 @@ describe("okou connector account list command", () => {
           externalId: "",
           externalUsername: "",
         }),
+        connectorAccount({
+          id: "55555555-5555-4555-8555-555555555555",
+          displayName: "same-user",
+          externalUsername: "same-user",
+        }),
       ]),
     );
 
@@ -119,6 +124,7 @@ describe("okou connector account list command", () => {
     expect(output).toContain("Work (work@example.com)");
     expect(output).toContain("@octocat");
     expect(output).toContain("Account #44444444");
+    expect(output).not.toContain("same-user (@same-user)");
     expect(output).toContain("reconnect-required");
     expect(output).toContain(FIRST_CONNECTION_ID);
     expect(output).toContain(SECOND_CONNECTION_ID);

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -371,8 +371,22 @@ describe("okou connector account list command", () => {
 
   it("lists available inventory inside a run without changing its meaning", async () => {
     vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+    vi.stubEnv("OKOU_TOKEN", "agent-token");
     server.use(
-      stubAccounts([connectorAccount({ displayName: "Available account" })]),
+      http.get(
+        "http://localhost:3000/api/connector-accounts/connections",
+        ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer agent-token",
+          );
+          return HttpResponse.json({
+            connections: [
+              connectorAccount({ displayName: "Available account" }),
+            ],
+            nextCursor: null,
+          });
+        },
+      ),
     );
 
     await listConnectorAccountsCommand.parseAsync(["node", "okou", "github"]);

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -1,0 +1,376 @@
+import type { ConnectorAccountConnection } from "@okouai/api-contracts/contracts/connector-accounts";
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import {
+  authCodeMethod,
+  catalogStatusItem,
+  stubConnectorCatalogStatus,
+} from "../../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../../__tests__/helpers/custom-connectors";
+import { listConnectorAccountsCommand } from "../list";
+
+const FIRST_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+const SECOND_CONNECTION_ID = "22222222-2222-4222-8222-222222222222";
+const CUSTOM_CONNECTOR_ID = "33333333-3333-4333-8333-333333333333";
+
+function connectorAccount(
+  overrides: Partial<ConnectorAccountConnection> = {},
+): ConnectorAccountConnection {
+  return {
+    id: FIRST_CONNECTION_ID,
+    target: { kind: "builtin", connectorSlug: "github" },
+    authMethod: "oauth",
+    displayName: null,
+    isDefault: false,
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: ["repo"],
+    connectionStatus: "connected",
+    reconnectReason: null,
+    tokenExpiresAt: "2026-09-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function stubCatalog(): ReturnType<typeof http.get> {
+  return stubConnectorCatalogStatus([
+    catalogStatusItem({
+      connectorSlug: "github",
+      label: "GitHub",
+      authMethods: [authCodeMethod("oauth")],
+    }),
+  ]);
+}
+
+function stubAccounts(
+  connections: readonly ConnectorAccountConnection[],
+): ReturnType<typeof http.get> {
+  return http.get(
+    "http://localhost:3000/api/connector-accounts/connections",
+    () => {
+      return HttpResponse.json({ connections, nextCursor: null });
+    },
+  );
+}
+
+describe("okou connector account list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    listConnectorAccountsCommand.setOptionValue("json", false);
+    listConnectorAccountsCommand.setOptionValue("search", undefined);
+    server.use(stubCatalog(), stubCustomConnectors([]));
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders safe account details with shared label fallbacks", async () => {
+    server.use(
+      stubAccounts([
+        connectorAccount({
+          displayName: "Work",
+          externalEmail: "work@example.com",
+          isDefault: true,
+        }),
+        connectorAccount({
+          id: SECOND_CONNECTION_ID,
+          externalUsername: "octocat",
+          connectionStatus: "reconnect-required",
+          reconnectReason: "authorization_expired_or_revoked",
+        }),
+        connectorAccount({
+          id: "44444444-4444-4444-8444-444444444444",
+          authMethod: "api-token",
+        }),
+      ]),
+    );
+
+    await listConnectorAccountsCommand.parseAsync(["node", "okou", "github"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Available accounts for GitHub (github):");
+    expect(output).toContain("ACCOUNT");
+    expect(output).toContain("Work (work@example.com)");
+    expect(output).toContain("@octocat");
+    expect(output).toContain("Account #44444444");
+    expect(output).toContain("reconnect-required");
+    expect(output).toContain(FIRST_CONNECTION_ID);
+    expect(output).toContain(SECOND_CONNECTION_ID);
+  });
+
+  it("resolves a custom connector slug to its connection target", async () => {
+    const custom = customConnector({
+      id: CUSTOM_CONNECTOR_ID,
+      slug: "_acme-search",
+      displayName: "Acme Search",
+    });
+    server.use(
+      stubCustomConnectors([custom]),
+      http.get(
+        "http://localhost:3000/api/connector-accounts/connections",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("kind")).toBe("custom");
+          expect(url.searchParams.get("customConnectorId")).toBe(
+            CUSTOM_CONNECTOR_ID,
+          );
+          expect(url.searchParams.get("limit")).toBe("100");
+          return HttpResponse.json({
+            connections: [
+              connectorAccount({
+                target: {
+                  kind: "custom",
+                  customConnectorId: CUSTOM_CONNECTOR_ID,
+                },
+              }),
+            ],
+            nextCursor: null,
+          });
+        },
+      ),
+    );
+
+    await listConnectorAccountsCommand.parseAsync([
+      "node",
+      "okou",
+      "_acme-search",
+    ]);
+
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      "Available accounts for Acme Search (_acme-search):",
+    );
+  });
+
+  it("fetches all pages sequentially and forwards search", async () => {
+    const cursors: (string | null)[] = [];
+    server.use(
+      http.get(
+        "http://localhost:3000/api/connector-accounts/connections",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const cursor = url.searchParams.get("cursor");
+          cursors.push(cursor);
+          expect(url.searchParams.get("kind")).toBe("builtin");
+          expect(url.searchParams.get("connectorSlug")).toBe("github");
+          expect(url.searchParams.get("limit")).toBe("100");
+          expect(url.searchParams.get("search")).toBe("work");
+          return HttpResponse.json(
+            cursor
+              ? {
+                  connections: [connectorAccount({ id: SECOND_CONNECTION_ID })],
+                  nextCursor: null,
+                }
+              : {
+                  connections: [connectorAccount()],
+                  nextCursor: "page-2",
+                },
+          );
+        },
+      ),
+    );
+
+    await listConnectorAccountsCommand.parseAsync([
+      "node",
+      "okou",
+      "github",
+      "--search",
+      " work ",
+    ]);
+
+    expect(cursors).toStrictEqual([null, "page-2"]);
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(FIRST_CONNECTION_ID);
+    expect(output).toContain(SECOND_CONNECTION_ID);
+  });
+
+  it("emits stable JSON without credentials or operational timestamps", async () => {
+    server.use(
+      stubAccounts([
+        connectorAccount({
+          externalUsername: "octocat",
+          isDefault: true,
+        }),
+      ]),
+    );
+
+    await listConnectorAccountsCommand.parseAsync([
+      "node",
+      "okou",
+      "github",
+      "--json",
+    ]);
+
+    const output = String(mockConsoleLog.mock.calls[0]?.[0]);
+    const parsed: unknown = JSON.parse(output);
+    expect(parsed).toStrictEqual({
+      context: "available",
+      connector: {
+        kind: "builtin",
+        slug: "github",
+        label: "GitHub",
+        target: { kind: "builtin", connectorSlug: "github" },
+      },
+      accounts: [
+        {
+          connectionId: FIRST_CONNECTION_ID,
+          effectiveLabel: "octocat",
+          displayName: null,
+          externalIdentity: "octocat",
+          isDefault: true,
+          authMethod: "oauth",
+          connectionStatus: "connected",
+          reconnectReason: null,
+        },
+      ],
+    });
+    expect(output).not.toContain("oauthScopes");
+    expect(output).not.toContain("tokenExpiresAt");
+    expect(output).not.toContain("createdAt");
+    expect(output).not.toContain("updatedAt");
+  });
+
+  it("distinguishes an empty inventory from an empty search", async () => {
+    server.use(stubAccounts([]));
+
+    await listConnectorAccountsCommand.parseAsync(["node", "okou", "github"]);
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      "Run: okou connector status github",
+    );
+
+    mockConsoleLog.mockClear();
+    await listConnectorAccountsCommand.parseAsync([
+      "node",
+      "okou",
+      "github",
+      "--search",
+      "personal",
+    ]);
+    const filteredOutput = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(filteredOutput).toContain('match "personal"');
+    expect(filteredOutput).not.toContain("Run: okou connector status");
+  });
+
+  it("guides custom connector empty inventories to custom status", async () => {
+    server.use(
+      stubCustomConnectors([
+        customConnector({
+          id: CUSTOM_CONNECTOR_ID,
+          slug: "_acme-search",
+          displayName: "Acme Search",
+        }),
+      ]),
+      stubAccounts([]),
+    );
+
+    await listConnectorAccountsCommand.parseAsync([
+      "node",
+      "okou",
+      "_acme-search",
+    ]);
+
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      `Run: okou connector custom status ${CUSTOM_CONNECTOR_ID}`,
+    );
+  });
+
+  it("rejects an empty search before making API requests", async () => {
+    await expect(
+      listConnectorAccountsCommand.parseAsync([
+        "node",
+        "okou",
+        "github",
+        "--search",
+        "   ",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--search cannot be empty",
+    );
+  });
+
+  it("reports unknown slugs with all available built-in and custom slugs", async () => {
+    server.use(
+      stubCustomConnectors([
+        customConnector({
+          id: CUSTOM_CONNECTOR_ID,
+          slug: "_acme-search",
+        }),
+      ]),
+    );
+
+    await expect(
+      listConnectorAccountsCommand.parseAsync(["node", "okou", "missing"]),
+    ).rejects.toThrow("process.exit called");
+
+    const error = mockConsoleError.mock.calls.flat().join("\n");
+    expect(error).toContain("Unknown or unavailable connector: missing");
+    expect(error).toContain("Available connectors: _acme-search, github");
+  });
+
+  it("discards partial pages when the account inventory becomes unavailable", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/connector-accounts/connections",
+        ({ request }) => {
+          const cursor = new URL(request.url).searchParams.get("cursor");
+          return cursor
+            ? HttpResponse.json(
+                { error: { code: "NOT_FOUND", message: "Not found" } },
+                { status: 404 },
+              )
+            : HttpResponse.json({
+                connections: [connectorAccount()],
+                nextCursor: "page-2",
+              });
+        },
+      ),
+    );
+
+    await expect(
+      listConnectorAccountsCommand.parseAsync(["node", "okou", "github"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Available account inventory is unavailable for github",
+    );
+  });
+
+  it("lists available inventory inside a run without changing its meaning", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+    server.use(
+      stubAccounts([connectorAccount({ displayName: "Available account" })]),
+    );
+
+    await listConnectorAccountsCommand.parseAsync(["node", "okou", "github"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Available accounts for GitHub");
+    expect(output).toContain("Available account");
+    expect(output).not.toContain("ACCOUNT USED BY THIS RUN");
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/account/index.ts
+++ b/turbo/apps/cli/src/commands/connector/account/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+
+import { listConnectorAccountsCommand } from "./list";
+
+export const connectorAccountCommand = new Command()
+  .name("account")
+  .description("Inspect connector accounts")
+  .addCommand(listConnectorAccountsCommand);

--- a/turbo/apps/cli/src/commands/connector/account/list.ts
+++ b/turbo/apps/cli/src/commands/connector/account/list.ts
@@ -1,0 +1,207 @@
+import {
+  connectorAccountEffectiveLabel,
+  connectorAccountExternalIdentity,
+  type ConnectorAccountConnection,
+  type ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import chalk from "chalk";
+import { Command } from "commander";
+
+import {
+  listConnectorAccountConnections,
+  listConnectorCatalogStatus,
+  listCustomConnectors,
+} from "../../../lib/api/domains/connectors";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { connectorAccountCliInventoryLabel } from "../account-label";
+import {
+  connectorDiscoveryItems,
+  type ConnectorDiscoveryItem,
+} from "../discovery";
+
+interface ListConnectorAccountOptions {
+  readonly json?: boolean;
+  readonly search?: string;
+}
+
+function accountFallbackLabel(account: ConnectorAccountConnection): string {
+  return `Account #${account.id.slice(0, 8)}`;
+}
+
+function resolveTarget(
+  connector: ConnectorDiscoveryItem,
+): ConnectorAccountTarget {
+  return connector.kind === "catalog"
+    ? { kind: "builtin", connectorSlug: connector.slug }
+    : {
+        kind: "custom",
+        customConnectorId: connector.customConnector.id,
+      };
+}
+
+function printTable(connections: readonly ConnectorAccountConnection[]): void {
+  const headers = [
+    "ACCOUNT",
+    "DEFAULT",
+    "STATUS",
+    "AUTH METHOD",
+    "CONNECTION ID",
+  ];
+  const rows = connections.map((connection) => {
+    return [
+      connectorAccountCliInventoryLabel({
+        ...connection,
+        connectionId: connection.id,
+      }),
+      connection.isDefault ? "yes" : "-",
+      connection.connectionStatus,
+      connection.authMethod,
+      connection.id,
+    ];
+  });
+  const widths = headers.map((header, columnIndex) => {
+    return Math.max(
+      header.length,
+      ...rows.map((row) => {
+        return row[columnIndex]?.length ?? 0;
+      }),
+    );
+  });
+  console.log(
+    chalk.dim(
+      headers
+        .map((header, columnIndex) => {
+          return header.padEnd(widths[columnIndex] ?? header.length);
+        })
+        .join("  "),
+    ),
+  );
+  for (const row of rows) {
+    console.log(
+      row
+        .map((cell, columnIndex) => {
+          return cell.padEnd(widths[columnIndex] ?? cell.length);
+        })
+        .join("  "),
+    );
+  }
+}
+
+function printEmptyState(
+  connector: ConnectorDiscoveryItem,
+  search: string | undefined,
+): void {
+  if (search) {
+    console.log(
+      `No available accounts for ${connector.label} match "${search}".`,
+    );
+    return;
+  }
+  console.log(`No available accounts for ${connector.label}.`);
+  const statusCommand =
+    connector.kind === "catalog"
+      ? `okou connector status ${connector.slug}`
+      : `okou connector custom status ${connector.customConnector.id}`;
+  console.log(chalk.dim(`Run: ${statusCommand}`));
+}
+
+function jsonOutput(
+  connector: ConnectorDiscoveryItem,
+  target: ConnectorAccountTarget,
+  connections: readonly ConnectorAccountConnection[],
+): object {
+  return {
+    context: "available",
+    connector: {
+      kind: target.kind,
+      slug: connector.slug,
+      label: connector.label,
+      target,
+    },
+    accounts: connections.map((account) => {
+      return {
+        connectionId: account.id,
+        effectiveLabel: connectorAccountEffectiveLabel(
+          account,
+          accountFallbackLabel(account),
+        ),
+        displayName: account.displayName,
+        externalIdentity: connectorAccountExternalIdentity(account),
+        isDefault: account.isDefault,
+        authMethod: account.authMethod,
+        connectionStatus: account.connectionStatus,
+        reconnectReason: account.reconnectReason,
+      };
+    }),
+  };
+}
+
+export const listConnectorAccountsCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List available accounts for one connector")
+  .argument("<slug>", "Connector slug")
+  .option("--search <text>", "Filter accounts by name or provider identity")
+  .option("--json", "Output available accounts as JSON")
+  .action(
+    withErrorHandler(
+      async (slug: string, options: ListConnectorAccountOptions) => {
+        const search = options.search?.trim();
+        if (options.search !== undefined && !search) {
+          throw new Error("--search cannot be empty");
+        }
+
+        const [{ connectors }, customConnectors] = await Promise.all([
+          listConnectorCatalogStatus(),
+          listCustomConnectors(),
+        ]);
+        const discoveredConnectors = connectorDiscoveryItems(
+          connectors,
+          customConnectors,
+        );
+        const connector = discoveredConnectors.find((item) => {
+          return item.slug === slug;
+        });
+        if (!connector) {
+          throw new Error(`Unknown or unavailable connector: ${slug}`, {
+            cause: new Error(
+              `Available connectors: ${discoveredConnectors
+                .map((item) => {
+                  return item.slug;
+                })
+                .sort()
+                .join(", ")}`,
+            ),
+          });
+        }
+
+        const target = resolveTarget(connector);
+        const result = await listConnectorAccountConnections(target, search);
+        if (result.state === "unavailable") {
+          throw new Error(
+            `Available account inventory is unavailable for ${connector.slug}`,
+          );
+        }
+
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              jsonOutput(connector, target, result.connections),
+              null,
+              2,
+            ),
+          );
+          return;
+        }
+
+        console.log(
+          `Available accounts for ${connector.label} (${connector.slug}):`,
+        );
+        if (result.connections.length === 0) {
+          printEmptyState(connector, search);
+          return;
+        }
+        printTable(result.connections);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/connector/discovery.ts
+++ b/turbo/apps/cli/src/commands/connector/discovery.ts
@@ -28,7 +28,7 @@ interface CustomConnectorDiscoveryItem {
   readonly customConnector: CustomConnectorResponse;
 }
 
-type ConnectorDiscoveryItem =
+export type ConnectorDiscoveryItem =
   | CatalogConnectorDiscoveryItem
   | CustomConnectorDiscoveryItem;
 

--- a/turbo/apps/cli/src/commands/connector/index.ts
+++ b/turbo/apps/cli/src/commands/connector/index.ts
@@ -6,10 +6,12 @@ import { searchCommand } from "./search";
 import { statusCommand } from "./status";
 import { customConnectorCommand } from "./custom";
 import { permissionRequestCommand } from "./permission-request";
+import { connectorAccountCommand } from "./account";
 
 export const connectorCommand = new Command()
   .name("connector")
   .description("Manage and diagnose third-party service connections")
+  .addCommand(connectorAccountCommand)
   .addCommand(checkConnectorCommand)
   .addCommand(customConnectorCommand)
   .addCommand(connectCommand)

--- a/turbo/apps/cli/src/commands/connector/run-account-context.ts
+++ b/turbo/apps/cli/src/commands/connector/run-account-context.ts
@@ -20,6 +20,7 @@ import {
   getOkouAgentId,
   getOkouConnectorAccountContextFile,
 } from "../../lib/okou-env";
+import { connectorAccountCliLabel } from "./account-label";
 
 export const RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES = 1024 * 1024;
 
@@ -207,14 +208,6 @@ function metadataKey(
   return `${connectorAccountTargetKey(target)}:${connectionId}`;
 }
 
-function effectiveAccountLabel(metadata: RunConnectorAccountMetadata): string {
-  if (metadata.displayName) return metadata.displayName;
-  if (metadata.externalEmail) return metadata.externalEmail;
-  if (metadata.externalUsername) return `@${metadata.externalUsername}`;
-  if (metadata.externalId) return metadata.externalId;
-  return `Account #${metadata.connectionId.slice(0, 8)}`;
-}
-
 async function enrichTargets(
   targets: readonly RunConnectorAccountTarget[],
 ): Promise<ReadonlyMap<string, RunConnectorAccountMetadata>> {
@@ -315,7 +308,7 @@ export async function resolveRunConnectorAccountView(): Promise<RunConnectorAcco
           ? {
               state: "available" as const,
               connectionId: projected.connectionId,
-              label: effectiveAccountLabel(current),
+              label: connectorAccountCliLabel(current),
               metadata: current,
             }
           : {

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -4,9 +4,12 @@ import type {
   ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import {
+  CONNECTOR_ACCOUNT_LIST_MAX_LIMIT,
   connectorAccountsContract,
+  type ConnectorAccountConnection,
   type ConnectorAccountInspectionResult,
   type ConnectorAccountSelection,
+  type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorManualGrantContract,
@@ -54,6 +57,57 @@ type ZeroConnectorCatalogListResponse = PublicConnectorCatalogListResponse;
 type ZeroConnectorCatalogStatusResponse = PublicConnectorCatalogStatusResponse;
 export type ConnectorCatalogPermissionDetail =
   PublicConnectorCatalogPermissionDetail;
+
+type ConnectorAccountConnectionsResult =
+  | {
+      readonly state: "available";
+      readonly connections: readonly ConnectorAccountConnection[];
+    }
+  | { readonly state: "unavailable" };
+
+export async function listConnectorAccountConnections(
+  target: ConnectorAccountTarget,
+  search?: string,
+): Promise<ConnectorAccountConnectionsResult> {
+  const config = await getClientConfig();
+  const client = initClient(connectorAccountsContract, {
+    ...config,
+    validateResponse: true,
+  });
+  const connections: ConnectorAccountConnection[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const paging = {
+      limit: CONNECTOR_ACCOUNT_LIST_MAX_LIMIT,
+      ...(cursor ? { cursor } : {}),
+      ...(search ? { search } : {}),
+    };
+    const query =
+      target.kind === "builtin"
+        ? {
+            ...paging,
+            kind: "builtin" as const,
+            connectorSlug: target.connectorSlug,
+          }
+        : {
+            ...paging,
+            kind: "custom" as const,
+            customConnectorId: target.customConnectorId,
+          };
+    const result = await client.connections({ headers: {}, query });
+    if (result.status === 404) {
+      return { state: "unavailable" };
+    }
+    if (result.status !== 200) {
+      handleError(result, "Failed to list connector accounts");
+    }
+    connections.push(...result.body.connections);
+    cursor = result.body.nextCursor;
+  } while (cursor);
+
+  return { state: "available", connections };
+}
 
 export async function inspectConnectorAccounts(
   selections: readonly ConnectorAccountSelection[],

--- a/turbo/apps/platform/src/signals/connector-domain.ts
+++ b/turbo/apps/platform/src/signals/connector-domain.ts
@@ -1,8 +1,5 @@
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
-import type {
-  ConnectorAccountConnection,
-  ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
@@ -27,16 +24,3 @@ export type PlatformWorkflowConnectorReadinessResponse =
 export const singleAccountConnectorMutation = {
   intent: "single-account",
 } satisfies ConnectorAccountMutationIntent;
-
-export function connectorAccountEffectiveLabel(
-  account: ConnectorAccountConnection,
-  fallbackLabel: string,
-): string {
-  return (
-    account.displayName ??
-    account.externalEmail ??
-    account.externalUsername ??
-    account.externalId ??
-    fallbackLabel
-  );
-}

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -147,15 +147,13 @@ import {
 } from "@okouai/core/workflow-template-items";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type {
-  ConnectorAccountConnection,
-  ConnectorAccountSelection,
-  ConnectorAccountTarget,
-} from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorAccountEffectiveLabel,
-  type PlatformConnectorCatalogStatusItem,
-} from "../../signals/connector-domain.ts";
+  type ConnectorAccountConnection,
+  type ConnectorAccountSelection,
+  type ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import {
   isIntegrationManagedCustomConnector,
   type CustomConnectorResponse,

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -3,9 +3,11 @@ import { useGet, useLoadable, useSet, type Loadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { EllipsisVertical } from "lucide-react";
-import type {
-  ConnectorAccountConnection,
-  ConnectorAccountTarget,
+import {
+  connectorAccountEffectiveLabel,
+  connectorAccountExternalIdentity,
+  type ConnectorAccountConnection,
+  type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   Button,
@@ -22,7 +24,6 @@ import {
   Input,
 } from "@okouai/ui";
 
-import { connectorAccountEffectiveLabel } from "../../../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   connectorAccountSummaryByTarget$,
@@ -56,15 +57,6 @@ interface ConnectorAccountManagerDialogProps {
   readonly onClose: () => void;
   readonly onAdd: () => void;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
-}
-
-function accountIdentity(account: ConnectorAccountConnection): string | null {
-  return (
-    account.externalEmail ??
-    account.externalUsername ??
-    account.externalId ??
-    null
-  );
 }
 
 function AccountStatus({ account }: { account: ConnectorAccountConnection }) {
@@ -179,7 +171,7 @@ function AccountRow({
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
 }) {
   const { t } = useTranslation();
-  const identity = accountIdentity(account);
+  const identity = connectorAccountExternalIdentity(account);
   const label = connectorAccountEffectiveLabel(
     account,
     t(

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
@@ -12,8 +12,8 @@ import {
   DialogTitle,
   Input,
 } from "@okouai/ui";
+import { connectorAccountEffectiveLabel } from "@okouai/api-contracts/contracts/connector-accounts";
 
-import { connectorAccountEffectiveLabel } from "../../../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { renameConnectorAccount$ } from "../../../../signals/okou-page/settings/connector-accounts.ts";
 import {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -3,11 +3,11 @@ import type { LoadableState } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { CircleCheck, EllipsisVertical, Loader2, Plus } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type { ConnectorAccountSummary } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorAccountEffectiveLabel,
-  type PlatformConnectorCatalogStatusItem,
-} from "../../../../signals/connector-domain.ts";
+  type ConnectorAccountSummary,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
 import {
   Button,
   DropdownMenu,

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -357,7 +357,10 @@ export function connectorAccountExternalIdentity(
   account: Omit<ConnectorAccountIdentityFields, "displayName">,
 ): string | null {
   return (
-    account.externalEmail ?? account.externalUsername ?? account.externalId
+    account.externalEmail ||
+    account.externalUsername ||
+    account.externalId ||
+    null
   );
 }
 export function connectorAccountEffectiveLabel(

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -61,6 +61,7 @@ export const connectorAccountSelectionSchema = z
   .strict();
 
 export const CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS = 256;
+export const CONNECTOR_ACCOUNT_LIST_MAX_LIMIT = 100;
 
 const connectorAccountInspectionAvailableSchema = z
   .object({
@@ -133,7 +134,12 @@ export const connectorAccountTargetQuerySchema = z.discriminatedUnion("kind", [
 
 const connectorAccountListQueryFields = {
   cursor: z.string().min(1).optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(50),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(CONNECTOR_ACCOUNT_LIST_MAX_LIMIT)
+    .default(50),
   search: z.string().trim().min(1).max(255).optional(),
 } as const;
 
@@ -343,6 +349,27 @@ export function connectorAccountTargetKey(
 export type ConnectorAccountConnection = z.infer<
   typeof connectorAccountConnectionSchema
 >;
+export type ConnectorAccountIdentityFields = Pick<
+  ConnectorAccountConnection,
+  "displayName" | "externalEmail" | "externalId" | "externalUsername"
+>;
+export function connectorAccountExternalIdentity(
+  account: Omit<ConnectorAccountIdentityFields, "displayName">,
+): string | null {
+  return (
+    account.externalEmail ?? account.externalUsername ?? account.externalId
+  );
+}
+export function connectorAccountEffectiveLabel(
+  account: ConnectorAccountIdentityFields,
+  fallbackLabel: string,
+): string {
+  return (
+    account.displayName ??
+    connectorAccountExternalIdentity(account) ??
+    fallbackLabel
+  );
+}
 export type ConnectorAccountSelection = z.infer<
   typeof connectorAccountSelectionSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -742,6 +742,9 @@ export {
 
 export {
   CONNECTOR_ACCOUNT_INSPECTION_MAX_SELECTIONS,
+  CONNECTOR_ACCOUNT_LIST_MAX_LIMIT,
+  connectorAccountEffectiveLabel,
+  connectorAccountExternalIdentity,
   connectorAccountDisplayNameSchema,
   connectorAccountTargetSchema,
   connectorAccountConnectionSchema,
@@ -754,6 +757,7 @@ export {
   connectorAccountsContract,
   type ConnectorAccountTarget,
   type ConnectorAccountConnection,
+  type ConnectorAccountIdentityFields,
   type ConnectorAccountSelection,
   type ConnectorAccountInspectionResult,
   type ConnectorAccountMutationIntent,


### PR DESCRIPTION
## Summary

- add `okou connector account list <slug>` for built-in and custom connectors
- support sequential cursor pagination, server-side search, human-readable output, and a stable safe-metadata JSON projection
- make available-account inventory explicit inside and outside Agent Runs without changing the account admitted to a run
- share connector account identity and effective-label precedence between the CLI and platform UI

## Scope

- read-only account discovery only
- no account mutation, thread selection, permission, runner, firewall, database, or API endpoint changes
- continues to use the existing `GET /api/connector-accounts/connections` authorization and availability behavior

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/app lint`
- `pnpm check-types` (pre-commit hook; all 14 tasks passed)
- `pnpm knip`
- `pnpm -F @okouai/api-contracts test` (622 tests)
- `pnpm -F @okouai/cli exec vitest run src/commands/connector` (210 tests)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/personal-providers-tab.test.tsx src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (91 tests)
- `pnpm -F @okouai/cli build`

Closes #29622

Parent context: #22832
