### PR TITLE
feat(pi): accept dynamic handoff sequence boundaries

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -64,7 +64,7 @@ pub mod runners {
             /// Checkpoint used as the base Pi session.
             pub base_session: PiLaunchConfigApiFirstTurnBaseSession,
             /// First sandbox event sequence number for the resumed session.
-            pub sandbox_event_sequence_start: i64,
+            pub sandbox_event_sequence_start: u64,
         }
 
         /// API-owned launch configuration forwarded to Pi in the sandbox.

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -55,7 +55,7 @@ use crate::paths;
 use crate::session_metadata::{SessionHistoryLaunchSource, SessionMetadataStore};
 use crate::timing;
 use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
-use event_delivery::{EventDeliveryRuntime, EventDeliverySender};
+use event_delivery::{EventDeliveryReport, EventDeliveryRuntime, EventDeliverySender};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
@@ -87,6 +87,7 @@ const CODEX_SERVICE_TIER_LEGACY_ENV: &str = "VM0_CODEX_SERVICE_TIER";
 const CODEX_SERVICE_TIER_RESOLUTION_EVENT: &str = "codex_service_tier_environment_resolution";
 const CLI_PACKAGE_URL_ENV_KEY: &str = "CLI_PKG_URL";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
+const MAX_EVENT_SEQUENCE_NUMBER: u32 = i32::MAX as u32;
 const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
     "analytics.enabled=false",
     "features.plugins=false",
@@ -605,30 +606,6 @@ fn write_claude_append_system_prompt_file(
     Ok(())
 }
 
-fn pi_sandbox_event_sequence_start(runtime: &CliRuntimeConfig<'_>) -> Result<u32, AgentError> {
-    let launch_config: serde_json::Value = serde_json::from_str(runtime.pi_launch_config.as_ref())
-        .map_err(|error| AgentError::Execution(format!("parse Pi launch config: {error}")))?;
-    let sequence = launch_config
-        .pointer("/apiFirstTurn/sandboxEventSequenceStart")
-        .and_then(serde_json::Value::as_u64)
-        .ok_or_else(|| {
-            AgentError::Execution(
-                "Pi launch config requires apiFirstTurn.sandboxEventSequenceStart".to_string(),
-            )
-        })?;
-    let sequence = u32::try_from(sequence).map_err(|_| {
-        AgentError::Execution(
-            "Pi launch config apiFirstTurn.sandboxEventSequenceStart exceeds u32".to_string(),
-        )
-    })?;
-    if sequence != 1 {
-        return Err(AgentError::Execution(
-            "Pi Sandbox event sequence must start at 1".to_string(),
-        ));
-    }
-    Ok(sequence)
-}
-
 fn pi_child_env_values(runtime: &CliRuntimeConfig<'_>) -> [(String, String); 4] {
     [
         (
@@ -839,7 +816,16 @@ impl<'a> CliEventIngestor<'a> {
     ) -> Result<(), AgentError> {
         for event in provider_event_normalization::normalize_for_sequencing(self.framework, event) {
             let sequence = self.seq;
-            self.seq += 1;
+            if sequence > MAX_EVENT_SEQUENCE_NUMBER {
+                return Err(AgentError::Execution(
+                    "CLI event sequence exceeds the supported maximum".to_string(),
+                ));
+            }
+            self.seq = sequence.checked_add(1).ok_or_else(|| {
+                AgentError::Execution(
+                    "CLI event sequence exceeds the supported maximum".to_string(),
+                )
+            })?;
             if should_send_events {
                 let event = events::prepare_event_for_delivery(event, sequence, masker);
                 if self.framework == env::Framework::Codex {
@@ -875,6 +861,30 @@ impl<'a> CliEventIngestor<'a> {
 
     fn failure_diagnostic(&self) -> Option<CliFailureDiagnostic> {
         self.failure_diagnostic.clone()
+    }
+}
+
+struct CliEventPipeline<'a> {
+    ingestor: CliEventIngestor<'a>,
+    delivery: EventDeliveryRuntime,
+}
+
+impl<'a> CliEventPipeline<'a> {
+    fn start(
+        runtime: &CliRuntimeConfig<'_>,
+        session_metadata: SessionMetadataStore,
+        http: &HttpClient,
+        initial_sequence: u32,
+    ) -> Result<Self, AgentError> {
+        let delivery =
+            EventDeliveryRuntime::start(http.clone(), &runtime.run_id, initial_sequence)?;
+        let ingestor = CliEventIngestor::new_with_session_metadata(
+            runtime,
+            None,
+            session_metadata,
+            initial_sequence,
+        );
+        Ok(Self { ingestor, delivery })
     }
 }
 
@@ -1001,12 +1011,6 @@ async fn execute_cli_inner(
         )
         .await;
     }
-
-    let initial_event_sequence = if matches!(runtime.framework, env::Framework::Pi) {
-        pi_sandbox_event_sequence_start(runtime)?
-    } else {
-        0
-    };
 
     let CliExecutionControls {
         active_input,
@@ -1137,6 +1141,7 @@ async fn execute_cli_inner(
     let mut pi_rpc_projection = pi_execution.then(|| {
         pi_rpc::PiRpcProjection::new(runtime.run_id.as_ref(), runtime.pi_session_id.as_ref())
     });
+    let mut pi_rpc_startup_boundary = pi_execution.then(pi_rpc::PiRpcStartupBoundary::default);
     let mut claude_stdin_write_handle = Some({
         let run_id = runtime.run_id.to_string();
         let prompt = runtime.prompt.to_string();
@@ -1228,8 +1233,16 @@ async fn execute_cli_inner(
     // no collection delay or concurrent POST path. Overload enters controlled
     // CLI termination rather than blocking stdout.
     let mut should_send_events = http.has_api();
-    let event_delivery =
-        EventDeliveryRuntime::start(http.clone(), &runtime.run_id, initial_event_sequence)?;
+    let mut event_pipeline = if pi_execution {
+        None
+    } else {
+        Some(CliEventPipeline::start(
+            runtime,
+            session_metadata.clone(),
+            &http,
+            0,
+        )?)
+    };
 
     let mut heartbeat_done = false;
     let mut user_cancellation_handled = false;
@@ -1237,12 +1250,6 @@ async fn execute_cli_inner(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
-    let mut event_ingestor = CliEventIngestor::new_with_session_metadata(
-        runtime,
-        None,
-        session_metadata,
-        initial_event_sequence,
-    );
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             () = user_cancellation.cancelled(), if !user_cancellation_handled && cli_status.is_none() => {
@@ -1386,6 +1393,82 @@ async fn execute_cli_inner(
                         }
 
                         if let Ok(mut event) = serde_json::from_str::<serde_json::Value>(stripped) {
+                            if let Some(startup_boundary) = pi_rpc_startup_boundary.as_mut() {
+                                match startup_boundary.admit(&event) {
+                                    Ok(pi_rpc::PiRpcRecordAdmission::InstallBoundary(sequence)) => {
+                                        match CliEventPipeline::start(
+                                            runtime,
+                                            session_metadata.clone(),
+                                            &http,
+                                            sequence,
+                                        ) {
+                                            Ok(pipeline) => {
+                                                event_pipeline = Some(pipeline);
+                                            }
+                                            Err(error) => {
+                                                startup_boundary.discard_remaining();
+                                                active_input_controller.close_terminal();
+                                                if cli_status.is_some() {
+                                                    break Err(error);
+                                                }
+                                                let error_log = error.to_string();
+                                                termination_runtime.begin_control_failure(
+                                                    TerminationReason::StdoutIngestion,
+                                                    error,
+                                                    ControlTerminationLog::StdoutIngestionFailed {
+                                                        error: error_log,
+                                                    },
+                                                    termination_deadline.as_mut(),
+                                                );
+                                            }
+                                        }
+                                        // The startup control is private CLI/guest state. It is
+                                        // consumed before official RPC projection and is never
+                                        // written to the agent transcript or public delivery.
+                                        continue;
+                                    }
+                                    Ok(pi_rpc::PiRpcRecordAdmission::Project) => {
+                                        if event_pipeline.is_none() {
+                                            startup_boundary.discard_remaining();
+                                            let error = AgentError::Execution(
+                                                "CLI event pipeline was not initialized before Pi RPC projection"
+                                                    .to_string(),
+                                            );
+                                            active_input_controller.close_terminal();
+                                            if cli_status.is_some() {
+                                                break Err(error);
+                                            }
+                                            let error_log = error.to_string();
+                                            termination_runtime.begin_control_failure(
+                                                TerminationReason::StdoutIngestion,
+                                                error,
+                                                ControlTerminationLog::StdoutIngestionFailed {
+                                                    error: error_log,
+                                                },
+                                                termination_deadline.as_mut(),
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                    Ok(pi_rpc::PiRpcRecordAdmission::Discard) => continue,
+                                    Err(error) => {
+                                        active_input_controller.close_terminal();
+                                        if cli_status.is_some() {
+                                            break Err(error);
+                                        }
+                                        let error_log = error.to_string();
+                                        termination_runtime.begin_control_failure(
+                                            TerminationReason::StdoutIngestion,
+                                            error,
+                                            ControlTerminationLog::StdoutIngestionFailed {
+                                                error: error_log,
+                                            },
+                                            termination_deadline.as_mut(),
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
                             if let Some(projection) = pi_rpc_projection.as_mut() {
                                 match projection.project(event, &pi_rpc_response_tx) {
                                     Ok(Some(projected)) => event = projected,
@@ -1439,9 +1522,31 @@ async fn execute_cli_inner(
                                 continue;
                             }
 
+                            let Some(event_pipeline) = event_pipeline.as_mut() else {
+                                let error = AgentError::Execution(
+                                    "CLI event pipeline was not initialized before projection"
+                                        .to_string(),
+                                );
+                                active_input_controller.close_terminal();
+                                if cli_status.is_some() {
+                                    break Err(error);
+                                }
+                                let error_log = error.to_string();
+                                termination_runtime.begin_control_failure(
+                                    TerminationReason::StdoutIngestion,
+                                    error,
+                                    ControlTerminationLog::StdoutIngestionFailed {
+                                        error: error_log,
+                                    },
+                                    termination_deadline.as_mut(),
+                                );
+                                continue;
+                            };
+
                             let post_result_cleanup_was_armed =
                                 termination_runtime.has_post_result_cleanup();
-                            let event_action = event_ingestor
+                            let event_action = event_pipeline
+                                .ingestor
                                 .begin_event(
                                     &mut agent_log,
                                     line.as_bytes(),
@@ -1493,10 +1598,12 @@ async fn execute_cli_inner(
                                     log_warn!(
                                         LOG_TAG,
                                         "Claude JSONL failure result seq={} subtype={subtype}: {}",
-                                        event_ingestor.current_sequence(),
+                                        event_pipeline.ingestor.current_sequence(),
                                         candidate.message
                                     );
-                                    event_ingestor.replace_failure_diagnostic(candidate);
+                                    event_pipeline
+                                        .ingestor
+                                        .replace_failure_diagnostic(candidate);
                                 }
                                 if let Some(result) = event.get("result").and_then(|v| v.as_str())
                                 {
@@ -1534,11 +1641,11 @@ async fn execute_cli_inner(
                             );
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
-                            if let Err(error) = event_ingestor.enqueue_event(
+                            if let Err(error) = event_pipeline.ingestor.enqueue_event(
                                 event,
                                 masker,
                                 should_send_events,
-                                event_delivery.sender(),
+                                event_pipeline.delivery.sender(),
                             ) {
                                 should_send_events = false;
                                 if cli_status.is_some() {
@@ -1552,6 +1659,30 @@ async fn execute_cli_inner(
                                     termination_deadline.as_mut(),
                                 );
                             }
+                        } else if pi_rpc_startup_boundary
+                            .as_ref()
+                            .is_some_and(|boundary| {
+                                boundary.requires_boundary()
+                                    || pi_rpc::PiRpcStartupBoundary::looks_like_control(stripped)
+                            })
+                        {
+                            if let Some(boundary) = pi_rpc_startup_boundary.as_mut() {
+                                boundary.discard_remaining();
+                            }
+                            let error = pi_rpc::PiRpcStartupBoundary::malformed_record_error();
+                            active_input_controller.close_terminal();
+                            if cli_status.is_some() {
+                                break Err(error);
+                            }
+                            let error_log = error.to_string();
+                            termination_runtime.begin_control_failure(
+                                TerminationReason::StdoutIngestion,
+                                error,
+                                ControlTerminationLog::StdoutIngestionFailed {
+                                    error: error_log,
+                                },
+                                termination_deadline.as_mut(),
+                            );
                         } else {
                             agent_log.write_raw_line(line.as_bytes()).await;
                         }
@@ -1559,6 +1690,28 @@ async fn execute_cli_inner(
                     Ok(None) => {
                         stdout_closed = true;
                         active_input_controller.close_terminal();
+                        if pi_rpc_startup_boundary
+                            .as_ref()
+                            .is_some_and(pi_rpc::PiRpcStartupBoundary::requires_boundary)
+                        {
+                            if let Some(boundary) = pi_rpc_startup_boundary.as_mut() {
+                                boundary.discard_remaining();
+                            }
+                            let error = pi_rpc::PiRpcStartupBoundary::missing_error();
+                            if cli_status.is_some() {
+                                break Err(error);
+                            }
+                            let error_log = error.to_string();
+                            termination_runtime.begin_control_failure(
+                                TerminationReason::StdoutIngestion,
+                                error,
+                                ControlTerminationLog::StdoutIngestionFailed {
+                                    error: error_log,
+                                },
+                                termination_deadline.as_mut(),
+                            );
+                            continue;
+                        }
                         if cli_status.is_some() {
                             break Ok(());
                         }
@@ -1839,14 +1992,25 @@ async fn execute_cli_inner(
     } else {
         event_result.err()
     };
+    let last_read_event_at = event_pipeline
+        .as_ref()
+        .and_then(|pipeline| pipeline.ingestor.last_read_event_at());
+    let failure_diagnostic = event_pipeline
+        .as_ref()
+        .and_then(|pipeline| pipeline.ingestor.failure_diagnostic());
 
     // On success, boundedly drain accepted events. On any execution or
     // control error, abort unsent delivery rather than stalling on retries.
-    let delivery_report = if event_error.is_none() && !has_control_error {
-        event_delivery.finish().await
-    } else {
-        Ok(event_delivery.abort().await)
-    }?;
+    let delivery_report = match event_pipeline {
+        Some(pipeline) if event_error.is_none() && !has_control_error => {
+            pipeline.delivery.finish().await?
+        }
+        Some(pipeline) => pipeline.delivery.abort().await,
+        None => EventDeliveryReport {
+            last_acknowledged_sequence: None,
+            diagnostic: None,
+        },
+    };
     let status = match cli_status {
         Some(s) => s,
         None => {
@@ -1855,9 +2019,7 @@ async fn execute_cli_inner(
             status
         }
     };
-    if let (Some(last_read_event_at), Some(cli_exit_at)) =
-        (event_ingestor.last_read_event_at(), cli_exit_at)
-    {
+    if let (Some(last_read_event_at), Some(cli_exit_at)) = (last_read_event_at, cli_exit_at) {
         record_sandbox_op(
             "last_read_event_to_cli_exit",
             cli_exit_at
@@ -1919,7 +2081,7 @@ async fn execute_cli_inner(
         event_delivery: delivery_report.diagnostic,
         claude_result,
         post_result_cleanup_result,
-        failure_diagnostic: event_ingestor.failure_diagnostic(),
+        failure_diagnostic,
         control_error,
         cli_termination,
         active_input_delivery_ids,
@@ -2081,9 +2243,8 @@ mod tests {
     use super::{
         CliExitObservation, CliFailureDiagnostic, CliRuntimeConfig, child_env,
         claude_initial_prompt_frame, cli_exit_summary_from_status, command, exec_boundary,
-        pi_child_env_values, pi_sandbox_event_sequence_start, record_cli_exit,
-        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
-        write_pi_launch_payload_file,
+        pi_child_env_values, record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
+        with_carried_failure_reason, write_pi_launch_payload_file,
     };
     use crate::active_input::ActiveInputRuntime;
     use crate::paths;
@@ -2362,30 +2523,6 @@ mod tests {
         let raw = std::fs::read(paths.pi_launch_payload_file()).unwrap();
         let payload: serde_json::Value = serde_json::from_slice(&raw).unwrap();
         assert!(payload["appendSystemPrompt"].is_null());
-    }
-
-    #[test]
-    fn pi_event_sequence_continues_after_the_api_first_turn() {
-        let user_env = HashMap::new();
-        let mut runtime = runtime_for_command_test(env::Framework::Pi, "prompt", "", &user_env);
-        runtime.pi_launch_config =
-            Cow::Borrowed(r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#);
-
-        assert_eq!(pi_sandbox_event_sequence_start(&runtime).unwrap(), 1);
-    }
-
-    #[test]
-    fn pi_event_sequence_rejects_a_missing_handoff_boundary() {
-        let user_env = HashMap::new();
-        let mut runtime = runtime_for_command_test(env::Framework::Pi, "prompt", "", &user_env);
-        runtime.pi_launch_config = Cow::Borrowed(r#"{"schemaVersion":2}"#);
-
-        assert_eq!(
-            pi_sandbox_event_sequence_start(&runtime)
-                .unwrap_err()
-                .to_string(),
-            "execution: Pi launch config requires apiFirstTurn.sandboxEventSequenceStart"
-        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -2,6 +2,7 @@
 
 use std::time::Instant;
 
+use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
@@ -11,6 +12,122 @@ use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use crate::error::AgentError;
 
 const PI_RPC_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE: &str = "vm0_pi_api_first_turn_boundary";
+const MAX_EVENT_SEQUENCE_NUMBER: u32 = i32::MAX as u32;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PiApiFirstTurnBoundaryControl {
+    #[serde(rename = "type")]
+    record_type: String,
+    schema_version: u32,
+    sandbox_event_sequence_start: u64,
+}
+
+pub(super) enum PiRpcRecordAdmission {
+    InstallBoundary(u32),
+    Project,
+    Discard,
+}
+
+#[derive(Default)]
+pub(super) struct PiRpcStartupBoundary {
+    installed: Option<u32>,
+    official_record_seen: bool,
+    terminal_error: bool,
+}
+
+impl PiRpcStartupBoundary {
+    pub(super) fn admit(&mut self, record: &Value) -> Result<PiRpcRecordAdmission, AgentError> {
+        if self.terminal_error {
+            return Ok(PiRpcRecordAdmission::Discard);
+        }
+        let is_control = record.get("type").and_then(Value::as_str)
+            == Some(PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE);
+        if !is_control {
+            if self.installed.is_none() {
+                return self.reject(Self::missing_error());
+            }
+            self.official_record_seen = true;
+            return Ok(PiRpcRecordAdmission::Project);
+        }
+
+        let candidate = match parse_boundary_control(record) {
+            Ok(candidate) => candidate,
+            Err(error) => return self.reject(error),
+        };
+        let Some(installed) = self.installed else {
+            self.installed = Some(candidate);
+            return Ok(PiRpcRecordAdmission::InstallBoundary(candidate));
+        };
+        if candidate != installed {
+            return self.reject(boundary_error(
+                "PI_HANDOFF_BOUNDARY_CONFLICT",
+                "Pi API first-turn handoff boundary conflicts with the installed boundary",
+            ));
+        }
+        if self.official_record_seen {
+            return self.reject(boundary_error(
+                "PI_HANDOFF_BOUNDARY_LATE",
+                "Pi API first-turn handoff boundary arrived after RPC startup",
+            ));
+        }
+        self.reject(boundary_error(
+            "PI_HANDOFF_BOUNDARY_INVALID",
+            "Pi API first-turn handoff boundary was duplicated",
+        ))
+    }
+
+    pub(super) fn requires_boundary(&self) -> bool {
+        self.installed.is_none() && !self.terminal_error
+    }
+
+    pub(super) fn missing_error() -> AgentError {
+        boundary_error(
+            "PI_HANDOFF_BOUNDARY_MISSING",
+            "Pi API first-turn handoff boundary is required before RPC startup",
+        )
+    }
+
+    pub(super) fn malformed_record_error() -> AgentError {
+        boundary_error(
+            "PI_HANDOFF_BOUNDARY_INVALID",
+            "Pi API first-turn handoff boundary is malformed",
+        )
+    }
+
+    pub(super) fn looks_like_control(raw: &str) -> bool {
+        raw.contains(PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE)
+    }
+
+    pub(super) fn discard_remaining(&mut self) {
+        self.terminal_error = true;
+    }
+
+    fn reject(&mut self, error: AgentError) -> Result<PiRpcRecordAdmission, AgentError> {
+        self.terminal_error = true;
+        Err(error)
+    }
+}
+
+fn parse_boundary_control(record: &Value) -> Result<u32, AgentError> {
+    let control: PiApiFirstTurnBoundaryControl = serde_json::from_value(record.clone())
+        .map_err(|_| PiRpcStartupBoundary::malformed_record_error())?;
+    if control.record_type != PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE || control.schema_version != 1
+    {
+        return Err(PiRpcStartupBoundary::malformed_record_error());
+    }
+    let sequence = u32::try_from(control.sandbox_event_sequence_start)
+        .map_err(|_| PiRpcStartupBoundary::malformed_record_error())?;
+    if sequence == 0 || sequence > MAX_EVENT_SEQUENCE_NUMBER {
+        return Err(PiRpcStartupBoundary::malformed_record_error());
+    }
+    Ok(sequence)
+}
+
+fn boundary_error(code: &str, message: &str) -> AgentError {
+    AgentError::Execution(format!("[{code}] {message}"))
+}
 
 #[derive(Default)]
 struct PiAssistantTerminal {

--- a/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
+++ b/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
@@ -1,0 +1,164 @@
+//! Pi API-first startup boundaries must be installed privately before any
+//! official RPC record enters the public event pipeline.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::CliTerminationReason;
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+struct BoundaryCase {
+    name: &'static str,
+    script: &'static str,
+    expected_code: &'static str,
+}
+
+#[tokio::test]
+async fn guest_fails_closed_for_invalid_missing_conflicting_and_late_pi_boundaries()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        BoundaryCase {
+            name: "missing",
+            script: r#"printf '%s\n' '{"type":"response"}'"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_MISSING",
+        },
+        BoundaryCase {
+            name: "malformed",
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1}'"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
+        },
+        BoundaryCase {
+            name: "zero",
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":0}'"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
+        },
+        BoundaryCase {
+            name: "overflowing",
+            script: r#"printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":2147483648}'"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_INVALID",
+        },
+        BoundaryCase {
+            name: "conflicting",
+            script: r#"
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":5}'
+"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_CONFLICT",
+        },
+        BoundaryCase {
+            name: "late",
+            script: r#"
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+IFS= read -r state_command
+case "$state_command" in
+  *'"type":"get_state"'*) ;;
+  *) exit 21 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:get-state\",\"type\":\"response\",\"command\":\"get_state\",\"success\":true,\"data\":{\"sessionId\":\"11111111-1111-4111-8111-111111111111\",\"sessionFile\":\"/home/user/.pi/agent/sessions/--home-user-workspace--/session.jsonl\"}}"
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
+"#,
+            expected_code: "PI_HANDOFF_BOUNDARY_LATE",
+        },
+    ];
+    let original_directory = std::env::current_dir()?;
+    let base_path = std::env::var_os("PATH").unwrap_or_default();
+
+    for (index, case) in cases.iter().enumerate() {
+        let tmp = tempfile::tempdir()?;
+        let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir)?;
+        let npx = bin_dir.join("npx");
+        std::fs::write(
+            &npx,
+            format!(
+                "#!/bin/sh\nset -eu\n{}\nwhile :; do sleep 1; done\n",
+                case.script
+            ),
+        )?;
+        let mut permissions = std::fs::metadata(&npx)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&npx, permissions)?;
+
+        let run_id = format!("00000000-0000-4000-8000-{:012}", index + 200);
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), &run_id)?;
+        unsafe {
+            common::clear_guest_agent_bootstrap_env_for_test();
+            std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
+            std::env::set_var(guest_contracts::env::RUN_ID_ENV, &run_id);
+            std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+            std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+            std::env::set_var(
+                guest_contracts::env::SANDBOX_ID_ENV,
+                "00000000-0000-4000-8000-000000000abc",
+            );
+            std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+            std::env::set_var("HOME", tmp.path());
+            let mut paths = vec![bin_dir];
+            paths.extend(std::env::split_paths(&base_path));
+            std::env::set_var("PATH", std::env::join_paths(paths)?);
+            common::set_run_payload_file_env_for_test(
+                &runtime_dir,
+                &guest_contracts::env::RunPayload {
+                    prompt: format!("reject {} Pi handoff boundary", case.name),
+                    pi_launch_config:
+                        r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":4}}"#
+                            .to_string(),
+                    pi_model_config: "{}".to_string(),
+                    pi_session_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                    ..guest_contracts::env::RunPayload::default()
+                },
+            )?;
+            common::set_user_env_file_env_for_test(
+                &runtime_dir,
+                &HashMap::from([(
+                    "CLI_PKG_URL".to_string(),
+                    "https://example.invalid/current-okou-cli.tgz".to_string(),
+                )]),
+            )?;
+        }
+        common::ensure_canonical_workspace_for_test()?;
+        std::env::set_current_dir(tmp.path())?;
+
+        let runtime = common::guest_runtime_from_process_env()?;
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            common::execute_cli_for_runtime(
+                &runtime,
+                &SecretMasker::from_raw(""),
+                common::spawn_dummy_heartbeat(),
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("{} boundary case timed out", case.name))?;
+        std::env::set_current_dir(&original_directory)?;
+
+        let control_error = result
+            .control_error
+            .unwrap_or_else(|| panic!("{} boundary case must fail", case.name))
+            .to_string();
+        assert!(
+            control_error.contains(case.expected_code),
+            "{} boundary case produced unexpected error: {control_error}",
+            case.name
+        );
+        assert!(!control_error.contains("2147483648"));
+        assert_eq!(
+            result.cli_termination.map(|termination| termination.reason),
+            Some(CliTerminationReason::StdoutIngestion)
+        );
+
+        let agent_log =
+            std::fs::read_to_string(guest_contracts::runtime_paths::agent_log_file(&runtime_dir))?;
+        assert!(!agent_log.contains("vm0_pi_api_first_turn_boundary"));
+        assert!(!agent_log.contains("sandboxEventSequenceStart"));
+        for request in server.requests()? {
+            assert!(!request.body.contains("vm0_pi_api_first_turn_boundary"));
+            assert!(!request.body.contains("sandboxEventSequenceStart"));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -21,6 +21,7 @@ async fn missing_pi_tool_result_error_status_terminates_projection()
         &npx,
         r#"#!/bin/sh
 set -eu
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -62,6 +62,7 @@ test -n "${OKOU_PI_LAUNCH_PAYLOAD_FILE:-}"
 test -n "${PI_FINAL_ASSISTANT_EVENT_PATH:-}"
 printf '%s' "$OKOU_RUN_ID" > "$RUN_ID_CAPTURE_PATH"
 printf '%s' "$OKOU_PI_LAUNCH_PAYLOAD_FILE" > "$PI_PAYLOAD_CAPTURE_PATH"
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":4}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;
@@ -119,7 +120,7 @@ fi
                 prompt: "verify canonical Pi run identity".to_string(),
                 append_system_prompt: "Your name is Okou.".to_string(),
                 pi_launch_config:
-                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#
+                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":4}}"#
                         .to_string(),
                 pi_model_config: "{}".to_string(),
                 pi_session_id: "11111111-1111-4111-8111-111111111111".to_string(),
@@ -164,7 +165,7 @@ fi
     .expect("canonical Pi CLI process should finish")?;
 
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
-    assert_eq!(result.last_event_sequence, Some(12));
+    assert_eq!(result.last_event_sequence, Some(15));
     assert_eq!(
         result.claude_result.map(|summary| summary.status),
         Some(guest_agent::cli::ClaudeResultStatus::Success)
@@ -173,6 +174,8 @@ fi
     for request in server.requests()? {
         assert_eq!(request.path, "/api/webhooks/agent/events");
         assert_eq!(request.authorization.as_deref(), Some("Bearer test-token"));
+        assert!(!request.body.contains("vm0_pi_api_first_turn_boundary"));
+        assert!(!request.body.contains("sandboxEventSequenceStart"));
         let body: Value = serde_json::from_str(&request.body)?;
         delivered_events.extend(
             body.get("events")
@@ -194,7 +197,7 @@ fi
             .iter()
             .map(|event| event["sequenceNumber"].as_u64())
             .collect::<Vec<_>>(),
-        (1..13).map(Some).collect::<Vec<_>>()
+        (4..16).map(Some).collect::<Vec<_>>()
     );
     assert!(
         delivered_events
@@ -375,6 +378,10 @@ fi
     assert_eq!(payload["schemaVersion"], 1);
     assert_eq!(payload["appendSystemPrompt"], "Your name is Okou.");
     assert_eq!(payload["launchConfig"]["schemaVersion"], 2);
+    let agent_log =
+        std::fs::read_to_string(guest_contracts::runtime_paths::agent_log_file(&runtime_dir))?;
+    assert!(!agent_log.contains("vm0_pi_api_first_turn_boundary"));
+    assert!(!agent_log.contains("sandboxEventSequenceStart"));
     assert_eq!(
         std::fs::metadata(&payload_path)?.permissions().mode() & 0o777,
         0o600

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -39,6 +39,7 @@ async fn run_settlement_case(
         &npx,
         r#"#!/bin/sh
 set -eu
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
 IFS= read -r state_command
 case "$state_command" in
   *'"type":"get_state"'*) ;;

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -185,8 +185,8 @@ fn validate_pi_launch_config(value: &serde_json::Value, session_id: &str) -> Res
     if slot.deadline_at <= 0 {
         return Err("Pi API first-turn deadlineAt must be positive".to_string());
     }
-    if slot.sandbox_event_sequence_start != 1 {
-        return Err("Pi Sandbox event sequence must start at 1".to_string());
+    if !(1..=i32::MAX as u64).contains(&slot.sandbox_event_sequence_start) {
+        return Err("Pi Sandbox event sequence start must be between 1 and 2147483647".to_string());
     }
     if slot.base_session.session_id != session_id {
         return Err("Pi H0 session id does not match pi_session_id".to_string());

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1541,6 +1541,7 @@ fn pi_execution_context_preserves_additive_fields_in_run_payload() {
     ctx.pi_launch_config.as_mut().unwrap()["futureLaunchField"] = json!("launch-root");
     ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["futureFirstTurnField"] =
         json!("first-turn");
+    ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["sandboxEventSequenceStart"] = json!(4);
     ctx.pi_model_config.as_mut().unwrap()["futureModelField"] = json!("model-root");
     let sandbox_id = SandboxId::new_v4().to_string();
     let payload = validate_execution_context_before_sandbox(
@@ -1561,6 +1562,7 @@ fn pi_execution_context_preserves_additive_fields_in_run_payload() {
     assert_eq!(launch["schemaVersion"], 2);
     assert_eq!(launch["futureLaunchField"], "launch-root");
     assert_eq!(launch["apiFirstTurn"]["futureFirstTurnField"], "first-turn");
+    assert_eq!(launch["apiFirstTurn"]["sandboxEventSequenceStart"], 4);
     let model: serde_json::Value = serde_json::from_str(&payload.pi_model_config).unwrap();
     assert_eq!(model["provider"], "deepseek");
     assert_eq!(model["apiKeyEnv"], "OPENAI_API_KEY");
@@ -1642,8 +1644,13 @@ fn pi_execution_context_rejects_invalid_launch_fields_before_sandbox() {
         ),
         (
             "/apiFirstTurn/sandboxEventSequenceStart",
-            json!(2),
-            "event sequence must start at 1",
+            json!(0),
+            "event sequence start must be between 1 and 2147483647",
+        ),
+        (
+            "/apiFirstTurn/sandboxEventSequenceStart",
+            json!(i64::from(i32::MAX) + 1),
+            "event sequence start must be between 1 and 2147483647",
         ),
         (
             "/apiFirstTurn/baseSession/sha256",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5058,6 +5058,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const manifest = JSON.parse(
       checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}",
     ) as {
+      readonly schemaVersion?: unknown;
       readonly outcome?: unknown;
       readonly baseSession?: unknown;
       readonly session?: {
@@ -5065,8 +5066,10 @@ describe("CHAT-02: model-first provider policies", () => {
         readonly sha256?: unknown;
         readonly rawSize?: unknown;
       };
+      readonly sandboxEventSequenceStart?: unknown;
     };
     expect(manifest).toMatchObject({
+      schemaVersion: 1,
       outcome: "handoff",
       baseSession: { sessionId: run.threadId, sha256: null },
       session: {
@@ -5075,6 +5078,7 @@ describe("CHAT-02: model-first provider policies", () => {
         rawSize: expect.any(Number),
       },
     });
+    expect(manifest).not.toHaveProperty("sandboxEventSequenceStart");
     const claimed = await claimChatRun(runnerGroup, run.runId);
     expect(claimed.claim.cliAgentType).toBe("pi");
     expect(claimed.claim.piSessionId).toBe(run.threadId);

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -492,7 +492,7 @@ describe("sandbox Pi agent loop", () => {
     });
     const h1 = memory.toJsonl();
     const manifest = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       outcome: "handoff",
       baseSession: { sessionId: SESSION_ID, sha256: null },
       session: {
@@ -500,6 +500,7 @@ describe("sandbox Pi agent loop", () => {
         sha256: createHash("sha256").update(h1).digest("hex"),
         rawSize: Buffer.byteLength(h1),
       },
+      sandboxEventSequenceStart: 4,
     };
     const handoffServer = createServer((request, response) => {
       if (request.url === "/manifest.json") {
@@ -550,7 +551,7 @@ describe("sandbox Pi agent loop", () => {
               sessionUrl: `${handoffBaseUrl}/session.jsonl`,
               deadlineAt: Date.now() + 10_000,
               baseSession: { sessionId: SESSION_ID, sha256: null },
-              sandboxEventSequenceStart: 1,
+              sandboxEventSequenceStart: 4,
             },
           },
         }),
@@ -573,6 +574,11 @@ describe("sandbox Pi agent loop", () => {
 
       host = new RpcHost({ cwd: root, agentDir, sessionDir, env });
       const state = await host.state("handoff-state");
+      expect(host.records[0]).toStrictEqual({
+        type: "vm0_pi_api_first_turn_boundary",
+        schemaVersion: 1,
+        sandboxEventSequenceStart: 4,
+      });
       expect(state).toMatchObject({
         sessionId: SESSION_ID,
         messageCount: 2,

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -18,6 +18,8 @@ const RUN_ID_ENV = "OKOU_RUN_ID";
 const PI_SESSION_ID_ENV = "OKOU_PI_SESSION_ID";
 const PI_LAUNCH_PAYLOAD_FILE_ENV = "OKOU_PI_LAUNCH_PAYLOAD_FILE";
 const PI_MODEL_CONFIG_ENV = "OKOU_PI_MODEL_CONFIG";
+const PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE =
+  "vm0_pi_api_first_turn_boundary";
 
 export interface PiSandboxAgentConfig {
   readonly runId: string;
@@ -49,6 +51,29 @@ async function readLaunchPayload(
   const path = requiredEnv(env, PI_LAUNCH_PAYLOAD_FILE_ENV);
   const raw = await readFile(path, "utf8");
   return piLaunchPayloadSchema.parse(JSON.parse(raw) as unknown);
+}
+
+async function writePiApiFirstTurnBoundaryControl(
+  sandboxEventSequenceStart: number,
+): Promise<void> {
+  const line = `${JSON.stringify({
+    type: PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE,
+    schemaVersion: 1,
+    sandboxEventSequenceStart,
+  })}\n`;
+  await new Promise<void>((resolve, reject) => {
+    process.stdout.write(line, (error) => {
+      if (error) {
+        reject(
+          new Error("Pi API first-turn boundary control could not be written", {
+            cause: error,
+          }),
+        );
+      } else {
+        resolve();
+      }
+    });
+  });
 }
 
 /**
@@ -91,6 +116,7 @@ export async function runPiSandboxAgentLoop(args: {
     sessionDir,
     sessionId: args.config.sessionId,
   });
+  await writePiApiFirstTurnBoundaryControl(handoff.sandboxEventSequenceStart);
   return await runPiOfficialRpcMode({
     sessionId: args.config.sessionId,
     sessionDir,

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
@@ -8,6 +8,7 @@ import {
   type PiApiFirstTurnConfig,
   type PiApiFirstTurnManifest,
 } from "@okouai/api-contracts/contracts/runners";
+import { MAX_EVENT_SEQUENCE_NUMBER } from "@okouai/api-contracts/contracts/runs";
 import { MemoryPiSession } from "@okouai/pi-agent-runtime/node";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -61,11 +62,15 @@ function sessionJsonl(sessionId = SESSION_ID, pendingTool = true): string {
 
 const HANDOFF_SESSION_JSONL = sessionJsonl();
 const SETTLED_SESSION_JSONL = sessionJsonl(SESSION_ID, false);
+type PiApiFirstTurnManifestV1 = Extract<
+  PiApiFirstTurnManifest,
+  { readonly schemaVersion: 1 }
+>;
 
 function manifest(
   jsonl: string,
-  overrides: Partial<PiApiFirstTurnManifest> = {},
-): PiApiFirstTurnManifest {
+  overrides: Partial<PiApiFirstTurnManifestV1> = {},
+): PiApiFirstTurnManifestV1 {
   const bytes = Buffer.from(jsonl);
   return {
     schemaVersion: 1,
@@ -80,7 +85,21 @@ function manifest(
   };
 }
 
-function config(deadlineAt: number): PiApiFirstTurnConfig {
+function manifestV2(
+  jsonl: string,
+  sandboxEventSequenceStart: number,
+): PiApiFirstTurnManifest {
+  return {
+    ...manifest(jsonl),
+    schemaVersion: 2,
+    sandboxEventSequenceStart,
+  };
+}
+
+function config(
+  deadlineAt: number,
+  sandboxEventSequenceStart = 1,
+): PiApiFirstTurnConfig {
   return {
     schemaVersion: 1,
     resourceSnapshotDigest: "a".repeat(64),
@@ -88,7 +107,7 @@ function config(deadlineAt: number): PiApiFirstTurnConfig {
     sessionUrl: "https://handoff.example/session.jsonl",
     deadlineAt,
     baseSession: { sessionId: SESSION_ID, sha256: H0_HASH },
-    sandboxEventSequenceStart: 1,
+    sandboxEventSequenceStart,
   };
 }
 
@@ -151,7 +170,88 @@ describe("Pi API first-turn handoff loader", () => {
       `api-first-turn-${SESSION_ID}.jsonl`,
     );
     expect(await readFile(restored.sessionFile, "utf8")).toBe(jsonl);
+    expect(restored.sandboxEventSequenceStart).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("restores H1 with a matching future dynamic boundary", async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), "pi-handoff-loader-"));
+    temporaryDirectories.push(sessionDir);
+    const jsonl = HANDOFF_SESSION_JSONL;
+    const sandboxEventSequenceStart = 4;
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      return String(input).endsWith("manifest.json")
+        ? Response.json(manifestV2(jsonl, sandboxEventSequenceStart))
+        : new Response(jsonl);
+    });
+
+    const restored = await resolvePiApiFirstTurnHandoff({
+      config: config(5_000, sandboxEventSequenceStart),
+      sessionDir,
+      sessionId: SESSION_ID,
+      runtime: fixedRuntime(fetchMock as typeof fetch),
+    });
+
+    expect(restored.sandboxEventSequenceStart).toBe(sandboxEventSequenceStart);
+    expect(await readFile(restored.sessionFile, "utf8")).toBe(jsonl);
+  });
+
+  it.each([
+    {
+      name: "v1 manifest with a dynamic launch boundary",
+      pointer: manifest(HANDOFF_SESSION_JSONL),
+      launchBoundary: 4,
+    },
+    {
+      name: "v2 manifest with a different launch boundary",
+      pointer: manifestV2(HANDOFF_SESSION_JSONL, 4),
+      launchBoundary: 3,
+    },
+  ])("fails closed for $name", async ({ pointer, launchBoundary }) => {
+    const fetchMock = vi.fn(async () => {
+      return Response.json(pointer);
+    });
+
+    await expect(
+      resolvePiApiFirstTurnHandoff({
+        config: config(5_000, launchBoundary),
+        sessionDir: "/unused",
+        sessionId: SESSION_ID,
+        runtime: fixedRuntime(fetchMock as typeof fetch),
+      }),
+    ).rejects.toMatchObject({ code: "PI_HANDOFF_SEQUENCE_MISMATCH" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "missing future boundary",
+      pointer: {
+        ...manifest(HANDOFF_SESSION_JSONL),
+        schemaVersion: 2,
+      },
+    },
+    {
+      name: "zero future boundary",
+      pointer: manifestV2(HANDOFF_SESSION_JSONL, 0),
+    },
+    {
+      name: "overflowing future boundary",
+      pointer: manifestV2(HANDOFF_SESSION_JSONL, MAX_EVENT_SEQUENCE_NUMBER + 1),
+    },
+  ])("rejects a $name as an invalid manifest", async ({ pointer }) => {
+    const fetchMock = vi.fn(async () => {
+      return Response.json(pointer);
+    });
+
+    await expect(
+      resolvePiApiFirstTurnHandoff({
+        config: config(5_000),
+        sessionDir: "/unused",
+        sessionId: SESSION_ID,
+        runtime: fixedRuntime(fetchMock as typeof fetch),
+      }),
+    ).rejects.toMatchObject({ code: "PI_HANDOFF_MANIFEST_INVALID" });
   });
 
   it("fails with the one deadline when the manifest never appears", async () => {

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -24,6 +24,7 @@ type PiApiFirstTurnHandoffErrorCode =
   | "PI_HANDOFF_H1_WRITE_FAILED"
   | "PI_HANDOFF_MANIFEST_INVALID"
   | "PI_HANDOFF_MANIFEST_TIMEOUT"
+  | "PI_HANDOFF_SEQUENCE_MISMATCH"
   | "PI_HANDOFF_SESSION_MISMATCH";
 
 class PiApiFirstTurnHandoffError extends Error {
@@ -42,6 +43,7 @@ class PiApiFirstTurnHandoffError extends Error {
 
 interface PiApiFirstTurnHandoff {
   readonly sessionFile: string;
+  readonly sandboxEventSequenceStart: number;
 }
 
 export interface HandoffRuntime {
@@ -231,6 +233,23 @@ function validateManifestIdentity(args: {
   }
 }
 
+function validatedSandboxEventSequenceStart(args: {
+  readonly config: PiApiFirstTurnConfig;
+  readonly manifest: PiApiFirstTurnManifest;
+}): number {
+  const manifestSequenceStart =
+    args.manifest.schemaVersion === 1
+      ? 1
+      : args.manifest.sandboxEventSequenceStart;
+  if (manifestSequenceStart !== args.config.sandboxEventSequenceStart) {
+    throw new PiApiFirstTurnHandoffError(
+      "PI_HANDOFF_SEQUENCE_MISMATCH",
+      "Pi API first-turn manifest boundary does not match the launch",
+    );
+  }
+  return manifestSequenceStart;
+}
+
 async function restoreSession(args: {
   readonly config: PiApiFirstTurnConfig;
   readonly manifest: PiApiFirstTurnManifest;
@@ -339,6 +358,10 @@ export async function resolvePiApiFirstTurnHandoff(args: {
 }): Promise<PiApiFirstTurnHandoff> {
   const runtime = args.runtime ?? defaultRuntime;
   const manifest = await pollManifest(args.config, runtime);
+  const sandboxEventSequenceStart = validatedSandboxEventSequenceStart({
+    config: args.config,
+    manifest,
+  });
   return {
     sessionFile: await restoreSession({
       config: args.config,
@@ -347,5 +370,6 @@ export async function resolvePiApiFirstTurnHandoff(args: {
       sessionDir: args.sessionDir,
       sessionId: args.sessionId,
     }),
+    sandboxEventSequenceStart,
   };
 }

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -237,6 +237,10 @@ function validatedSandboxEventSequenceStart(args: {
   readonly config: PiApiFirstTurnConfig;
   readonly manifest: PiApiFirstTurnManifest;
 }): number {
+  // API-written manifests and commit-addressed CLIs overlap across queued runs
+  // and the two-hour runner drain. Remove v1 after #29618 is live on every Pi
+  // runner, pre-v2 work has drained, and no retained rollback API emits v1;
+  // tracked by #29612.
   const manifestSequenceStart =
     args.manifest.schemaVersion === 1
       ? 1

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -15,6 +15,8 @@ import {
   heldSandboxStateSchema,
   heldWorkspaceStateSchema,
   jobSchema,
+  piApiFirstTurnConfigSchema,
+  piApiFirstTurnManifestSchema,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
@@ -32,6 +34,7 @@ import {
   storedResumeSessionSchema,
 } from "../runners";
 import { runRunnerContract } from "../run-routes";
+import { MAX_EVENT_SEQUENCE_NUMBER } from "../runs";
 
 describe("active-input reservation contract", () => {
   const deliveryId = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
@@ -237,6 +240,7 @@ describe("runner claim response contract", () => {
 });
 
 describe("Pi sandbox execution contract", () => {
+  const piSessionId = "22222222-2222-4222-8222-222222222222";
   const storedContext = {
     storageMounts: [],
     connectorRuntimeTargets: [],
@@ -247,7 +251,7 @@ describe("Pi sandbox execution contract", () => {
     cliAgentType: "pi",
   };
   const piStoredContext = {
-    piSessionId: "22222222-2222-4222-8222-222222222222",
+    piSessionId,
     piLaunchConfig: {
       schemaVersion: 2 as const,
       apiFirstTurn: {
@@ -257,7 +261,7 @@ describe("Pi sandbox execution contract", () => {
         sessionUrl: "https://storage.example/session.jsonl",
         deadlineAt: 2_000_000_000_000,
         baseSession: {
-          sessionId: "22222222-2222-4222-8222-222222222222",
+          sessionId: piSessionId,
           sha256: null,
         },
         sandboxEventSequenceStart: 1 as const,
@@ -287,6 +291,83 @@ describe("Pi sandbox execution contract", () => {
       reason: "noReuseKey" as const,
     },
   };
+
+  const handoffSession = {
+    sessionId: piSessionId,
+    sha256: "b".repeat(64),
+    rawSize: 1024,
+  };
+
+  it("accepts manifest v1 as the implicit start-at-1 contract", () => {
+    const manifest = piApiFirstTurnManifestSchema.parse({
+      schemaVersion: 1,
+      outcome: "handoff",
+      baseSession: { sessionId: piSessionId, sha256: null },
+      session: handoffSession,
+    });
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest).not.toHaveProperty("sandboxEventSequenceStart");
+    expect(
+      piApiFirstTurnManifestSchema.safeParse({
+        ...manifest,
+        sandboxEventSequenceStart: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts a future manifest and launch config with the same dynamic boundary", () => {
+    const sandboxEventSequenceStart = 4;
+    const manifest = piApiFirstTurnManifestSchema.parse({
+      schemaVersion: 2,
+      outcome: "handoff",
+      baseSession: { sessionId: piSessionId, sha256: null },
+      session: handoffSession,
+      sandboxEventSequenceStart,
+    });
+    const config = piApiFirstTurnConfigSchema.parse({
+      ...piStoredContext.piLaunchConfig.apiFirstTurn,
+      sandboxEventSequenceStart,
+    });
+
+    expect(manifest).toMatchObject({
+      schemaVersion: 2,
+      sandboxEventSequenceStart,
+    });
+    expect(config.sandboxEventSequenceStart).toBe(sandboxEventSequenceStart);
+  });
+
+  it.each([0, -1, 1.5, MAX_EVENT_SEQUENCE_NUMBER + 1])(
+    "rejects invalid dynamic boundary %s in both manifest and launch config",
+    (sandboxEventSequenceStart) => {
+      expect(
+        piApiFirstTurnManifestSchema.safeParse({
+          schemaVersion: 2,
+          outcome: "handoff",
+          baseSession: { sessionId: piSessionId, sha256: null },
+          session: handoffSession,
+          sandboxEventSequenceStart,
+        }).success,
+      ).toBe(false);
+      expect(
+        piApiFirstTurnConfigSchema.safeParse({
+          ...piStoredContext.piLaunchConfig.apiFirstTurn,
+          sandboxEventSequenceStart,
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("rejects a future manifest without its dynamic boundary", () => {
+    expect(
+      piApiFirstTurnManifestSchema.safeParse({
+        schemaVersion: 2,
+        outcome: "handoff",
+        baseSession: { sessionId: piSessionId, sha256: null },
+        session: handoffSession,
+      }).success,
+    ).toBe(false);
+  });
 
   it("preserves the Chat Thread session across stored and Runner-facing contexts", () => {
     const stored = storedExecutionContextSchema.parse({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -13,6 +13,7 @@ import { CONNECTOR_CATALOG_MAX_RAW_BYTES } from "./connector-catalog";
 import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import { modelProviderCodexRuntimeConfigSchema } from "./model-providers";
+import { eventSequenceNumberSchema } from "./runs";
 
 const c = initContract();
 
@@ -780,26 +781,46 @@ export const piResourceSnapshotSchema = z
   .strict()
   .readonly();
 
-export const piApiFirstTurnManifestSchema = z
+const piApiFirstTurnSessionSchema = z
+  .object({
+    sessionId: z.uuid(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    rawSize: z
+      .number()
+      .int()
+      .positive()
+      .max(PI_API_FIRST_TURN_SESSION_MAX_BYTES),
+  })
+  .strict()
+  .readonly();
+
+const piSandboxEventSequenceStartSchema = eventSequenceNumberSchema.min(1);
+
+export const piApiFirstTurnManifestV1Schema = z
   .object({
     schemaVersion: z.literal(1),
     outcome: z.literal("handoff"),
     baseSession: piSessionCheckpointSchema,
-    session: z
-      .object({
-        sessionId: z.uuid(),
-        sha256: z.string().regex(/^[a-f0-9]{64}$/),
-        rawSize: z
-          .number()
-          .int()
-          .positive()
-          .max(PI_API_FIRST_TURN_SESSION_MAX_BYTES),
-      })
-      .strict()
-      .readonly(),
+    session: piApiFirstTurnSessionSchema,
   })
   .strict()
   .readonly();
+
+export const piApiFirstTurnManifestV2Schema = z
+  .object({
+    schemaVersion: z.literal(2),
+    outcome: z.literal("handoff"),
+    baseSession: piSessionCheckpointSchema,
+    session: piApiFirstTurnSessionSchema,
+    sandboxEventSequenceStart: piSandboxEventSequenceStartSchema,
+  })
+  .strict()
+  .readonly();
+
+export const piApiFirstTurnManifestSchema = z.discriminatedUnion(
+  "schemaVersion",
+  [piApiFirstTurnManifestV1Schema, piApiFirstTurnManifestV2Schema],
+);
 
 export const piApiFirstTurnConfigSchema = z
   .object({
@@ -809,7 +830,7 @@ export const piApiFirstTurnConfigSchema = z
     sessionUrl: z.url(),
     deadlineAt: z.number().int().positive(),
     baseSession: piSessionCheckpointSchema,
-    sandboxEventSequenceStart: z.literal(1),
+    sandboxEventSequenceStart: piSandboxEventSequenceStartSchema,
   })
   .strict()
   .readonly();

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -11,6 +11,7 @@ import {
   rustTypeBindings,
 } from "../types";
 import { modelProviderCodexRuntimeConfigSchema } from "../../contracts/model-providers";
+import { MAX_EVENT_SEQUENCE_NUMBER } from "../../contracts/runs";
 import {
   piLaunchConfigSchema,
   piModelConfigSchema,
@@ -397,7 +398,11 @@ describe("Rust type bindings", () => {
           ],
           properties: {
             schemaVersion: { const: 1 },
-            sandboxEventSequenceStart: { const: 1 },
+            sandboxEventSequenceStart: {
+              type: "integer",
+              minimum: 1,
+              maximum: MAX_EVENT_SEQUENCE_NUMBER,
+            },
             baseSession: {
               required: ["sessionId", "sha256"],
             },


### PR DESCRIPTION
## Summary

- accept manifest v1 as implicit sequence 1 and future manifest v2 with a validated positive dynamic handoff boundary
- carry the validated boundary through a private CLI/guest startup record and initialize sequencing plus delivery atomically before Pi RPC projection
- fail closed on missing, malformed, zero, overflowing, conflicting, late, or mismatched boundaries without exposing the private record
- keep the production API manifest writer on v1; this consumer compatibility is a prerequisite for #29618

## Fallbacks

- `pi-api-first-turn-handoff.ts:validatedSandboxEventSequenceStart` accepts the production manifest v1 shape as implicit sequence 1 while new consumers also understand the future v2 explicit boundary. Surface: API-written handoff manifest -> commit-addressed CLI/runner, including queued contexts and retained API rollback targets. Remove the v1 branch only after #29618 has deployed the v2 writer, every Pi-eligible runner path has the compatible consumer, pre-v2 queued/claimed runs have exceeded their queue plus two-hour guest/finalization drain, and no retained rollback API can emit v1; tracked by #29612.

## Testing

- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F api check-types`
- api-contracts and CLI lint; targeted API BDD lint
- targeted api-contracts Vitest: 124 passed
- targeted CLI Vitest: 27 passed
- `cargo test -p api-contracts`: 34 passed
- targeted guest-agent integrations for dynamic sequencing, redaction, and boundary rejection
- `cargo check -p api-contracts -p guest-agent -p runner --tests`
- `cargo clippy -p guest-agent -p runner --tests -- -D warnings`
- `cargo doc -p guest-agent -p runner --no-deps`
- targeted API writer BDD requires PostgreSQL locally and is left to PR CI (`ECONNREFUSED :5432`)
- runner test binary linking exceeded the local 4 GB environment twice; runner tests compile under `cargo check --tests` and are left to PR CI

Closes #29616