### PR TITLE
test(platform): stabilize member usage billing test

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -321,78 +321,122 @@ async function waitForAnimationFrame(): Promise<void> {
   await frame.promise;
 }
 
-describe("organization billing settings", () => {
-  it("configures member usage", async () => {
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Usage Pack Org",
-      role: "admin",
-    });
-    context.mocks.api(billingStatusContract.get, ({ respond }) => {
-      return respond(200, noActiveBillingStatus());
-    });
-    context.mocks.api(billingUsagePackCatalogContract.get, ({ respond }) => {
-      return respond(200, usagePackCatalogResponse());
-    });
-    context.mocks.data.orgMembers({
-      name: "Usage Pack Org",
-      role: "admin",
-      members: [
-        {
-          userId: "user_1",
-          email: "alex@example.com",
-          firstName: "Alex",
-          lastName: "Chen",
-          imageUrl: "",
-          role: "admin",
-          joinedAt: "2026-01-01T00:00:00Z",
-        },
-        {
-          userId: "user_2",
-          email: "sam@example.com",
-          firstName: "Sam",
-          lastName: "Lee",
-          imageUrl: "",
-          role: "member",
-          joinedAt: "2026-01-02T00:00:00Z",
-        },
-      ],
-      pendingInvitations: [
-        {
-          id: "invitation_1",
-          email: "pending@example.com",
-          role: "member",
-          createdAt: "2026-01-03T00:00:00Z",
-        },
-      ],
-      membershipRequests: [],
-      createdAt: "2026-01-01T00:00:00Z",
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/?settings=billing",
-      user: {
-        id: "user_1",
-        fullName: "Alex Chen",
+function mockInitialUsagePackPurchase(): void {
+  context.mocks.data.org({
+    id: "org_1",
+    name: "Usage Pack Org",
+    role: "admin",
+  });
+  context.mocks.api(billingStatusContract.get, ({ respond }) => {
+    return respond(200, noActiveBillingStatus());
+  });
+  context.mocks.api(billingUsagePackCatalogContract.get, ({ respond }) => {
+    return respond(200, usagePackCatalogResponse());
+  });
+  context.mocks.data.orgMembers({
+    name: "Usage Pack Org",
+    role: "admin",
+    members: [
+      {
+        userId: "user_1",
         email: "alex@example.com",
+        firstName: "Alex",
+        lastName: "Chen",
+        imageUrl: "",
+        role: "admin",
+        joinedAt: "2026-01-01T00:00:00Z",
       },
-    });
+      {
+        userId: "user_2",
+        email: "sam@example.com",
+        firstName: "Sam",
+        lastName: "Lee",
+        imageUrl: "",
+        role: "member",
+        joinedAt: "2026-01-02T00:00:00Z",
+      },
+    ],
+    pendingInvitations: [
+      {
+        id: "invitation_1",
+        email: "pending@example.com",
+        role: "member",
+        createdAt: "2026-01-03T00:00:00Z",
+      },
+    ],
+    membershipRequests: [],
+    createdAt: "2026-01-01T00:00:00Z",
+  });
+}
 
-    await waitFor(() => {
-      expect(screen.getByText("No active plan")).toBeInTheDocument();
-    });
-    click(buttonByText("Upgrade"));
+async function openUsagePackPlanSelection(): Promise<{
+  choosePlanHeading: HTMLElement;
+  proPlan: HTMLElement;
+  teamPlan: HTMLElement;
+}> {
+  detachedSetupPage({
+    context,
+    path: "/?settings=billing",
+    user: {
+      id: "user_1",
+      fullName: "Alex Chen",
+      email: "alex@example.com",
+    },
+  });
 
-    const choosePlanHeading = await screen.findByRole("heading", {
-      name: "Choose a plan",
-    });
+  await waitFor(() => {
+    expect(screen.getByText("No active plan")).toBeInTheDocument();
+  });
+  click(buttonByText("Upgrade"));
+
+  const choosePlanHeading = await screen.findByRole("heading", {
+    name: "Choose a plan",
+  });
+  const proPlan = await screen.findByRole("article", { name: "Pro plan" });
+  const teamPlan = screen.getByRole("article", { name: "Team plan" });
+  return { choosePlanHeading, proPlan, teamPlan };
+}
+
+async function openTeamMemberPackages(teamPlan: HTMLElement): Promise<{
+  configurePackagesHeading: HTMLElement;
+  memberUsage: HTMLElement;
+  orderSummary: HTMLElement;
+}> {
+  click(buttonByText("Start with Team", teamPlan));
+  const configurePackagesHeading = await screen.findByRole("heading", {
+    name: "Configure member packages",
+  });
+  const memberUsage = screen.getByRole("group", {
+    name: "Member usage",
+  });
+  const orderSummary = screen.getByRole("region", {
+    name: "Order summary",
+  });
+  return { configurePackagesHeading, memberUsage, orderSummary };
+}
+
+async function selectMemberUsagePack(
+  memberUsage: HTMLElement,
+  memberName: string,
+  optionName: string,
+): Promise<void> {
+  click(
+    within(memberUsage).getByRole("combobox", {
+      name: `Usage for ${memberName}`,
+    }),
+  );
+  click(await screen.findByRole("option", { name: optionName }));
+}
+
+describe("organization billing settings", () => {
+  it("shows usage pack plan pricing and capabilities", async () => {
+    mockInitialUsagePackPurchase();
+    const { choosePlanHeading, proPlan, teamPlan } =
+      await openUsagePackPlanSelection();
     expect(choosePlanHeading).toBeInTheDocument();
     // The plan steps are a dialog over the billing tab, not a page that
     // replaces it, so the plan the workspace is deciding against stays visible.
     expect(screen.getByText("No active plan")).toBeInTheDocument();
-    const proPlan = await screen.findByRole("article", { name: "Pro plan" });
-    const teamPlan = screen.getByRole("article", { name: "Team plan" });
     // The figure is a floor, not a fixed total: a workspace pays the plan plus
     // one package for every member, and packages run $20 to $200.
     expect(proPlan).toHaveTextContent("from $20/month");
@@ -471,20 +515,14 @@ describe("organization billing settings", () => {
     ]) {
       expect(within(teamPlan).queryByText(item)).toBeNull();
     }
+  });
 
-    click(buttonByText("Start with Team", teamPlan));
-
-    const configurePackagesHeading = await screen.findByRole("heading", {
-      name: "Configure member packages",
-    });
+  it("configures member usage and updates package totals", async () => {
+    mockInitialUsagePackPurchase();
+    const { teamPlan } = await openUsagePackPlanSelection();
+    const { configurePackagesHeading, memberUsage, orderSummary } =
+      await openTeamMemberPackages(teamPlan);
     expect(configurePackagesHeading).toBeInTheDocument();
-
-    const memberUsage = screen.getByRole("group", {
-      name: "Member usage",
-    });
-    const orderSummary = screen.getByRole("region", {
-      name: "Order summary",
-    });
     expect(within(memberUsage).getByText("Alex Chen")).toBeInTheDocument();
     expect(
       within(memberUsage).getByText("alex@example.com"),
@@ -557,6 +595,22 @@ describe("organization billing settings", () => {
     expect(alexUsage).not.toBeDisabled();
     expect(samUsage).not.toBeDisabled();
     expect(pendingUsage).not.toBeDisabled();
+  });
+
+  it("navigates back and closes member package configuration", async () => {
+    mockInitialUsagePackPurchase();
+    const { teamPlan } = await openUsagePackPlanSelection();
+    const { memberUsage } = await openTeamMemberPackages(teamPlan);
+    await selectMemberUsagePack(
+      memberUsage,
+      "Alex Chen",
+      "$50 · 54,321 credits · 8% off",
+    );
+    await selectMemberUsagePack(
+      memberUsage,
+      "pending@example.com",
+      "$100 · 109,999 credits · 9% off",
+    );
 
     click(screen.getByLabelText("Back"));
     const returnedChoosePlanHeading = await screen.findByRole("heading", {
@@ -589,6 +643,32 @@ describe("organization billing settings", () => {
     // Closing the flow lands back on the billing overview it was opened from.
     expect(screen.getByText("No active plan")).toBeInTheDocument();
     expect(buttonByText("Upgrade")).toBeInTheDocument();
+  });
+
+  it("discards unsubmitted member usage after reopening settings", async () => {
+    mockInitialUsagePackPurchase();
+    const { teamPlan } = await openUsagePackPlanSelection();
+    const { memberUsage } = await openTeamMemberPackages(teamPlan);
+    await selectMemberUsagePack(
+      memberUsage,
+      "Alex Chen",
+      "$50 · 54,321 credits · 8% off",
+    );
+    await selectMemberUsagePack(
+      memberUsage,
+      "pending@example.com",
+      "$100 · 109,999 credits · 9% off",
+    );
+
+    const packagesDialog = screen.getByRole("dialog", {
+      name: "Configure member packages",
+    });
+    click(within(packagesDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Configure member packages" }),
+      ).not.toBeInTheDocument();
+    });
 
     const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
     click(within(settingsDialog).getByLabelText("Close"));
@@ -627,27 +707,22 @@ describe("organization billing settings", () => {
       }),
     ).toHaveTextContent("21,234 credits · 6% off");
     expect(resetMemberUsage).toHaveTextContent("$220/month");
-    const resetOrderSummary = screen.getByRole("region", {
-      name: "Order summary",
-    });
+  });
 
-    const resetAlexUsage = within(resetMemberUsage).getByRole("combobox", {
-      name: "Usage for Alex Chen",
-    });
-    click(resetAlexUsage);
-    click(
-      await screen.findByRole("option", {
-        name: "$50 · 54,321 credits · 8% off",
-      }),
+  it("submits member usage selections to checkout", async () => {
+    mockInitialUsagePackPurchase();
+    const { teamPlan } = await openUsagePackPlanSelection();
+    const { memberUsage, orderSummary } =
+      await openTeamMemberPackages(teamPlan);
+    await selectMemberUsagePack(
+      memberUsage,
+      "Alex Chen",
+      "$50 · 54,321 credits · 8% off",
     );
-    const resetPendingUsage = within(resetMemberUsage).getByRole("combobox", {
-      name: "Usage for pending@example.com",
-    });
-    click(resetPendingUsage);
-    click(
-      await screen.findByRole("option", {
-        name: "$100 · 109,999 credits · 9% off",
-      }),
+    await selectMemberUsagePack(
+      memberUsage,
+      "pending@example.com",
+      "$100 · 109,999 credits · 9% off",
     );
     context.mocks.api(
       billingUsagePackCheckoutContract.create,
@@ -663,7 +738,7 @@ describe("organization billing settings", () => {
       },
     );
 
-    click(buttonByText("Upgrade to Team", resetOrderSummary));
+    click(buttonByText("Upgrade to Team", orderSummary));
     await waitFor(() => {
       expect(window.location.href).toBe(
         "https://checkout.stripe.com/test-usage-pack",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -645,7 +645,7 @@ describe("organization billing settings", () => {
     expect(buttonByText("Upgrade")).toBeInTheDocument();
   });
 
-  it("discards unsubmitted member usage after reopening settings", async () => {
+  it("discards unsubmitted usage before checkout after reopening settings", async () => {
     mockInitialUsagePackPurchase();
     const { teamPlan } = await openUsagePackPlanSelection();
     const { memberUsage } = await openTeamMemberPackages(teamPlan);
@@ -707,20 +707,16 @@ describe("organization billing settings", () => {
       }),
     ).toHaveTextContent("21,234 credits · 6% off");
     expect(resetMemberUsage).toHaveTextContent("$220/month");
-  });
-
-  it("submits member usage selections to checkout", async () => {
-    mockInitialUsagePackPurchase();
-    const { teamPlan } = await openUsagePackPlanSelection();
-    const { memberUsage, orderSummary } =
-      await openTeamMemberPackages(teamPlan);
+    const resetOrderSummary = screen.getByRole("region", {
+      name: "Order summary",
+    });
     await selectMemberUsagePack(
-      memberUsage,
+      resetMemberUsage,
       "Alex Chen",
       "$50 · 54,321 credits · 8% off",
     );
     await selectMemberUsagePack(
-      memberUsage,
+      resetMemberUsage,
       "pending@example.com",
       "$100 · 109,999 credits · 9% off",
     );
@@ -738,7 +734,7 @@ describe("organization billing settings", () => {
       },
     );
 
-    click(buttonByText("Upgrade to Team", orderSummary));
+    click(buttonByText("Upgrade to Team", resetOrderSummary));
     await waitFor(() => {
       expect(window.location.href).toBe(
         "https://checkout.stripe.com/test-usage-pack",


### PR DESCRIPTION
## Summary

- split the long member usage billing scenario into focused user-flow tests
- reuse local setup and interaction helpers while preserving the original assertions and reopen-to-checkout path
- keep the default 5-second test timeout and avoid sleeps, retries, or skipped coverage

## Scope

- test-only change in the Platform billing view integration tests
- no production behavior, CI configuration, or global timeout changes

## Validation

- `pnpm exec prettier apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx --write`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/org-billing-tab.test.tsx` (1 file, 47 tests)
- `pnpm -F @okouai/app exec vitest run --maxWorkers=4 --silent=passed-only` (163 files, 2088 tests)
- `pnpm vitest run --project=@okouai/app --shard=7/8 --coverage.enabled --coverage.reporter=json` (20 files, 375 tests)
- pre-commit hooks: Prettier, repository Knip, repository TypeScript checks, file-size check, and commitlint

Closes #29633
