### PR TITLE
refactor(api): write canonical web url only

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -247,7 +247,6 @@ runs:
           add_env FEISHU_CALLBACK_BASE_URL "$api_backend_url"
           add_env FINICITY_WEBHOOK_BASE_URL "$api_backend_url"
           add_env OKOU_WEB_URL "$web_url"
-          add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
           add_env CLI_PKG_URL "$INPUT_CLI_PKG_URL"
           if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -158,14 +158,12 @@ assert_machine_secret_aliases_equal_dual() {
   assert_env_values_equal "$env_file" OKOU_MACHINE_SECRET_KEY VM0_MACHINE_SECRET_KEY
 }
 
-assert_web_url_aliases_equal_dual() {
+assert_web_url_canonical_only() {
   local env_file="$1"
   local expected="$2"
   assert_env_key_count "$env_file" OKOU_WEB_URL 1
-  assert_env_key_count "$env_file" VM0_WEB_URL 1
   assert_env_value "$env_file" OKOU_WEB_URL "$expected"
-  assert_env_value "$env_file" VM0_WEB_URL "$expected"
-  assert_env_values_equal "$env_file" OKOU_WEB_URL VM0_WEB_URL
+  assert_env_key_absent "$env_file" VM0_WEB_URL
 }
 
 assert_web_url_aliases_absent() {
@@ -526,7 +524,7 @@ assert_env_values_equal "$success_env_file" OKOU_PREVIEW_JOB_REF VM0_PREVIEW_JOB
 assert_api_backend_url_aliases_equal_dual "$success_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
-assert_web_url_aliases_equal_dual "$success_env_file" "https://pr-123-www.vm0.test"
+assert_web_url_canonical_only "$success_env_file" "https://pr-123-www.vm0.test"
 assert_env_value "$success_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"
 assert_env_value "$success_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$success_env_file" "ONBOARDING_URL="
@@ -639,7 +637,7 @@ assert_contains "$production_api_output" "Rendered"
 assert_no_fixture_secret_values "$production_api_output"
 assert_zero_keys_with_live_readers_absent "$production_api_env_file"
 assert_debug_aliases_absent "$production_api_env_file"
-assert_web_url_aliases_equal_dual "$production_api_env_file" "https://pr-123-www.vm0.test"
+assert_web_url_canonical_only "$production_api_env_file" "https://pr-123-www.vm0.test"
 assert_api_backend_url_aliases_equal_dual "$production_api_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -11,7 +11,6 @@ OKOU_API_BACKEND_URL=https://api.vm7.ai:8443
 VM0_API_BACKEND_URL=https://api.vm7.ai:8443
 FEISHU_CALLBACK_BASE_URL=https://api.vm7.ai:8443
 OKOU_WEB_URL=https://www.vm7.ai:8443
-VM0_WEB_URL=https://www.vm7.ai:8443
 APP_URL=https://app.vm7.ai:8443
 
 # CLI_PKG_URL is appended by scripts/sync-env.sh using the local machine identity.

--- a/turbo/apps/api/src/lib/web-url.ts
+++ b/turbo/apps/api/src/lib/web-url.ts
@@ -42,12 +42,12 @@ function reportResolution(state: WebUrlAliasState): void {
 }
 
 // This API-process compatibility boundary retains VM0_WEB_URL while the
-// deployment action, local API template, and Turbo pass-through emit
-// byte-equal aliases. Under #28914, remove the legacy input only after every
-// supported writer is canonical-only, old-only rollback targets are retired,
-// and value-free telemetry reports zero legacy-only and equal-dual resolutions
-// through that rollback window. Refresh stale Worker PR #25722 before that
-// cutover.
+// deployment action and local API template emit only OKOU_WEB_URL and Turbo
+// keeps both aliases in its environment pass-through. Under #28914, remove the
+// legacy input only after every supported writer is canonical-only, old-only
+// rollback targets are retired, and value-free telemetry reports zero
+// legacy-only and equal-dual resolutions through that rollback window. Refresh
+// stale Worker PR #25722 before that cutover.
 export function webUrl(): string {
   const canonical = env(CANONICAL_WEB_URL_KEY);
   const legacy = env(LEGACY_WEB_URL_KEY);


### PR DESCRIPTION
## Summary

- Stop emitting `VM0_WEB_URL` from the repository-owned preview/production API deployment writer while retaining the existing `OKOU_WEB_URL` value source and API-only scope.
- Update the real composite-action contract so preview and production API output contains exactly one canonical key with the exact existing value and no legacy key; preview and production web output still contains neither alias.
- Remove the legacy line from the local API template and update only the stale migration comment around the unchanged deployed dual reader.
- Preserve both schema entries, fail-closed resolver behavior and errors, source telemetry, Turbo pass-through, test-oauth behavior, broad legacy-reader fixtures, and every unrelated environment contract.

## Base, head, and overlap evidence

- Pre-edit refreshed base: `a6f81f719b0307fe9d020d0f19472e1ee058c970`.
- Final refreshed `main` during final-head acceptance: `8c5719c271c6274406c0e93de804c96b5e703ae2`.
- Final implementation head: `2e14a5a938574a097ef58685312d5095809d34b0`.
- The pre-edit audit at `2026-08-26T11:51:04Z` fully paginated all 28 open PRs and reconciled 432 GitHub-declared / 432 fetched changed files with zero mismatch.
- The final-head audit at `2026-08-26T12:11:42Z` fully paginated all 27 open PRs and reconciled 415 GitHub-declared / 415 fetched changed files with zero mismatch.
- #29509 remains open at head `874c750fc76f012a644e1ac9bb9627010df5ac0e`. Its only exact-key overlap is one added `mockEnv("VM0_WEB_URL", ...)` inside a broad connector BDD compatibility case; it touches no selected writer, reader, schema, telemetry, Turbo, action, workflow, or local-template path and has no production-writer semantic overlap.
- Stale #25722 remains open and conflicting at unchanged head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, base `505aae73170efd5b484599eb7d433f404f5c3d2f`, and update time `2026-08-13T15:03:45Z`, with 185/185 changed files across two pages. Its selected shared-file hunks do not change the Web URL action output lines, but its separate Worker shard allowlist and direct Worker fallback remain legacy-only. None of its Worker/Cloudflare scope is imported here; if refreshed or landed, it must carry canonical-only deployment output forward, admit `OKOU_WEB_URL`, and use the repository dual resolver.
- No other selected-path or exact-key overlap was found. The four commits that advanced `main` during verification are disjoint from every selected or preserved Web URL surface, and the final head merges with refreshed `main` without conflict.

## Verification

- `pnpm format` with lockfile-pinned Prettier 3.8.1; no unrelated file changed.
- Focused `pnpm exec prettier --check --ignore-unknown` for all four touched paths.
- Bash syntax for `.github/scripts/tests/web-api-env-action-test.sh` and for the Bash extracted from `.github/actions/web-api-env/action.yml`.
- ShellCheck 0.9.0 for the contract and extracted composite-action script.
- `bash .github/scripts/tests/web-api-env-action-test.sh`: passed the real preview/production and web/API matrix.
- `pnpm turbo run lint --concurrency=1 --log-order grouped`: 13/13 tasks passed; advisory warnings were pre-existing in untouched files.
- `pnpm knip`: passed with existing configuration hints only.
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`: 12/12 tasks passed.
- `pnpm --filter @okouai/app run check-types`: production and test projects passed.
- `pnpm --filter api run check-types`: dependency build, boundary audit, gateways, core, bootstrap, tests, and bootstrap-wiring stages passed.
- Exact semantic assertions proved one action canonical writer / zero legacy writers, two API canonical-only cases, two web dual-absence cases, and one exact local canonical value / zero local legacy values.
- Diff/search assertions proved the action input/value source, API-only scope, dual resolver branches and errors, both schema entries, telemetry, Turbo pass-through, test-oauth resolver, broad legacy-only fixtures, workflows, and unrelated environment contracts unchanged. Final inventory is 23 `OKOU_WEB_URL` lines across 10 files and 74 retained `VM0_WEB_URL` lines across 38 files. `git diff --check` passed.

No full local Vitest suite or local development server was run. Protected PR CI remains authoritative for repository-wide validation.

## Rollout boundaries

- This PR changes repository-owned writers only. It performs no release, production approval, deployment, production QA, external configuration mutation, rollback, reader removal, telemetry cleanup, namespace-guard cleanup, or Production Release thread work.
- Preview and production continue to use the existing `web-url` action input and repository-variable path. API output receives `OKOU_WEB_URL`; web output receives neither alias.

## Fallbacks

- **Code-only equal-dual restore:** Revert this PR to restore the adjacent `VM0_WEB_URL` output beside `OKOU_WEB_URL` in `.github/actions/web-api-env/action.yml` and `turbo/apps/api/.env.local.tpl`. No GitHub secret/variable, Doppler, Vercel, Cloudflare, 1Password, domain, or other external configuration change is required.
- **Retained dual reader:** `turbo/apps/api/src/lib/web-url.ts` continues to accept canonical-only, legacy-only, and byte-equal dual input and to fail closed on absence or conflict. Both typed schema entries, source telemetry, errors, and Turbo pass-through remain available for code rollback and supported artifacts.
- **Expected post-release evidence:** A later authorized release of the containing SHA should produce positive `canonical-only` `web_url_alias_resolution` telemetry from the exact API cutover, with zero `equal-dual`, `legacy-only`, `conflicting-dual`, and `absent` observations. This PR performs no release or production claim.
- **Later reader removal:** Removing `VM0_WEB_URL` from the reader, schema, telemetry, Turbo pass-through, fixtures, or ownership guard remains a separate later child under #28914 after its own rollback-window and zero-use evidence. This PR does none of that work.
- **Stale Worker trigger:** If #25722 refreshes or lands, re-audit its Worker allowlist, runtime fallback, action contract, workflow, and Turbo changes before any further migration step under #28914.

Closes #29641

Parent EPIC: #28914
