### PR TITLE
test(db): allow later workflow view migrations

### DIFF
--- a/turbo/packages/db/scripts/test-workflow-compatibility-views.ts
+++ b/turbo/packages/db/scripts/test-workflow-compatibility-views.ts
@@ -359,6 +359,27 @@ function expectedCreateViewStatement(definition: {
   )} FROM "${definition.legacy}";`;
 }
 
+function validateMigrationJournalEntries(
+  entries: readonly JournalEntry[],
+): void {
+  const previousPosition = entries.findIndex(({ tag }) => {
+    return tag === previousMigration;
+  });
+  const expansionPosition = entries.findIndex(({ tag }) => {
+    return tag === expansionMigration;
+  });
+  assert.notEqual(previousPosition, -1);
+  assert.equal(expansionPosition, previousPosition + 1);
+
+  const previousEntry = entries[previousPosition];
+  const expansionEntry = entries[expansionPosition];
+  assert.ok(previousEntry);
+  assert.ok(expansionEntry);
+  assert.equal(previousEntry.idx, 1003);
+  assert.equal(expansionEntry.idx, 1004);
+  assert.equal(expansionEntry.idx, previousEntry.idx + 1);
+}
+
 async function validateMigrationArtifacts(): Promise<void> {
   const migrationSql = await fs.readFile(
     path.join(migrationsDirectory, `${expansionMigration}.sql`),
@@ -404,16 +425,12 @@ async function validateMigrationArtifacts(): Promise<void> {
       "utf8",
     ),
   ) as { entries: JournalEntry[] };
-  const previousEntry = journal.entries.find(({ tag }) => {
-    return tag === previousMigration;
-  });
-  const expansionEntry = journal.entries.find(({ tag }) => {
-    return tag === expansionMigration;
-  });
-  assert.ok(previousEntry);
-  assert.ok(expansionEntry);
-  assert.equal(expansionEntry.idx, previousEntry.idx + 1);
-  assert.equal(journal.entries.at(-1)?.tag, expansionMigration);
+  validateMigrationJournalEntries(journal.entries);
+  validateMigrationJournalEntries([
+    { idx: 1003, tag: previousMigration },
+    { idx: 1004, tag: expansionMigration },
+    { idx: 1005, tag: "1005_later_migration" },
+  ]);
 }
 
 async function readPhysicalCatalog(client: Client): Promise<PhysicalCatalog> {


### PR DESCRIPTION
## Summary

- replace the permanent Workflow compatibility validator's journal-tail assumption with fixed `1003` to `1004` adjacency and ordering checks
- assert both migration journal indexes explicitly while preserving their consecutive-index invariant
- add a focused fixture proving that legitimate journal entries after `1004_workflow_compatibility_views` are accepted

## Scope

- validator-only change in `test-workflow-compatibility-views.ts`
- no migration SQL, snapshot, journal, DDL, Drizzle mapping, runtime/API code, or MaskDB policy changes
- no migration work from #29509 or any other PR is included

## Verification

- PostgreSQL 17.11: `DATABASE_URL=postgresql://postgres@127.0.0.1:5433/vm0_test pnpm --filter @okouai/db test:migration-consistency`
- PostgreSQL 17.11 and 18.6: `pnpm --filter @okouai/db exec tsx scripts/test-workflow-compatibility-views.ts`
- `pnpm --filter @okouai/db lint`
- `pnpm --filter @okouai/db check-types`
- `pnpm format`
- `pnpm knip`
- `git diff --check`

## Fallbacks

- None. This changes only a permanent test validator and introduces no runtime or deployment compatibility behavior.

References #29635.

Addresses the post-merge P1 review on #29649: https://github.com/vm0-ai/vm0/pull/29649#pullrequestreview-5030283238
