### PR TITLE
feat(pi): emit canonical api-first content block events

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4228,6 +4228,139 @@ function piResponsesTextSse(text: string, sequence: number): string {
     .join("");
 }
 
+type PiResponsesSemanticBlock =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "toolCall";
+      readonly callId: string;
+      readonly name: string;
+      readonly arguments: Record<string, unknown>;
+    };
+
+function piResponsesContentSse(args: {
+  readonly blocks: readonly PiResponsesSemanticBlock[];
+  readonly sequence: number;
+  readonly includeReasoning?: boolean;
+}): string {
+  const responseId = `resp_pi_content_${args.sequence.toString()}`;
+  const output: Record<string, unknown>[] = [];
+  const events: Record<string, unknown>[] = [
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        usage: null,
+      },
+    },
+  ];
+  if (args.includeReasoning) {
+    const reasoningText = "API-first reasoning preserved for Sandbox resume";
+    const reasoningItem = {
+      type: "reasoning",
+      id: `rs_pi_content_${args.sequence.toString()}`,
+      content: [{ type: "reasoning_text", text: reasoningText }],
+      summary: [],
+    };
+    output.push(reasoningItem);
+    events.push(
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...reasoningItem, content: [] },
+      },
+      {
+        type: "response.reasoning_text.delta",
+        output_index: 0,
+        content_index: 0,
+        delta: reasoningText,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: reasoningItem,
+      },
+    );
+  }
+  const outputIndexOffset = output.length;
+  for (const [blockIndex, block] of args.blocks.entries()) {
+    const outputIndex = outputIndexOffset + blockIndex;
+    if (block.type === "text") {
+      const item = {
+        type: "message",
+        id: `msg_pi_content_${args.sequence.toString()}_${blockIndex.toString()}`,
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: block.text, annotations: [] }],
+      };
+      output.push(item);
+      events.push(
+        {
+          type: "response.output_item.added",
+          output_index: outputIndex,
+          item: { ...item, status: "in_progress", content: [] },
+        },
+        {
+          type: "response.output_text.delta",
+          output_index: outputIndex,
+          content_index: 0,
+          delta: block.text,
+        },
+        { type: "response.output_item.done", output_index: outputIndex, item },
+      );
+      continue;
+    }
+    const functionArguments = JSON.stringify(block.arguments);
+    const itemId = `fc_pi_content_${args.sequence.toString()}_${blockIndex.toString()}`;
+    const item = {
+      type: "function_call",
+      id: itemId,
+      call_id: block.callId,
+      name: block.name,
+      arguments: functionArguments,
+      status: "completed",
+    };
+    output.push(item);
+    events.push(
+      {
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        item: { ...item, arguments: "", status: "in_progress" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: outputIndex,
+        item_id: itemId,
+        delta: functionArguments,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: outputIndex,
+        item_id: itemId,
+        arguments: functionArguments,
+      },
+      { type: "response.output_item.done", output_index: outputIndex, item },
+    );
+  }
+  events.push({
+    type: "response.completed",
+    response: {
+      id: responseId,
+      object: "response",
+      status: "completed",
+      output,
+      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+    },
+  });
+  return events
+    .map((event) => {
+      return `data: ${JSON.stringify(event)}\n\n`;
+    })
+    .join("");
+}
+
 function piResponsesToolSse(args: {
   readonly callId: string;
   readonly name: string;
@@ -4812,6 +4945,123 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
+  it("projects complete API-first text blocks in source order and completes at N", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    const { providerId } = await upsertOrgModelProvider(actor, {
+      type: "deepseek",
+      secret: "pi-content-block-key",
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "deepseek-v4-flash",
+        isDefault: true,
+        defaultProviderType: "deepseek",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    const archive = latestStoredArchive();
+    const consumedAgentEvents: Record<string, unknown>[] = [];
+    server.use(
+      http.get("https://r2.example.com/storage/archive.tar.gz", () => {
+        return new HttpResponse(archive, {
+          headers: { "content-type": "application/gzip" },
+        });
+      }),
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        async ({ request }) => {
+          const events: unknown = await request.json();
+          if (!Array.isArray(events)) {
+            throw new Error("Expected an Axiom event array");
+          }
+          consumedAgentEvents.push(
+            ...events.filter((event): event is Record<string, unknown> => {
+              return (
+                typeof event === "object" &&
+                event !== null &&
+                !Array.isArray(event)
+              );
+            }),
+          );
+          return HttpResponse.json({
+            ingested: events.length,
+            failed: 0,
+            processedBytes: 123,
+          });
+        },
+      ),
+      http.post("https://api.deepseek.com/responses", () => {
+        return new HttpResponse(
+          piResponsesContentSse({
+            blocks: [
+              { type: "text", text: "alpha" },
+              { type: "text", text: "beta" },
+              { type: "text", text: "gamma" },
+              { type: "text", text: "delta" },
+            ],
+            sequence: 1,
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    mockPiCheckpointObjectStore();
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "preserve each complete API-first text block",
+      model: "deepseek-v4-flash",
+    });
+    await waitForRunStatus(actor, run.runId, "completed");
+    await flushWaitUntilForTest();
+
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    expect(
+      consumedAgentEvents
+        .filter((event) => {
+          return event.runId === run.runId;
+        })
+        .map((event) => {
+          return {
+            sequenceNumber: event.sequenceNumber,
+            eventType: event.eventType,
+          };
+        }),
+    ).toStrictEqual([
+      { sequenceNumber: 0, eventType: "assistant" },
+      { sequenceNumber: 1, eventType: "assistant" },
+      { sequenceNumber: 2, eventType: "assistant" },
+      { sequenceNumber: 3, eventType: "assistant" },
+      { sequenceNumber: 4, eventType: "result" },
+    ]);
+    const thread = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      eventBackedContents(thread.events, run.runId).map((message) => {
+        return {
+          content: message.content,
+          sequenceNumber: message.sequenceNumber,
+          runEventId: message.runEventId,
+        };
+      }),
+    ).toStrictEqual([
+      { content: "alpha", sequenceNumber: 0, runEventId: "event:0" },
+      { content: "beta", sequenceNumber: 1, runEventId: "event:1" },
+      { content: "gamma", sequenceNumber: 2, runEventId: "event:2" },
+      { content: "delta", sequenceNumber: 3, runEventId: "event:3" },
+    ]);
+  }, 90_000);
+
   it.each([
     {
       failure: "resource download",
@@ -4995,7 +5245,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(claim.status).toBe(404);
   }, 90_000);
 
-  it("publishes one H1 and hands an explicit Sandbox tool turn to H2", async () => {
+  it("publishes ordered mixed blocks and hands explicit Sandbox tool turns to H2", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
@@ -5031,12 +5281,38 @@ describe("CHAT-02: model-first provider policies", () => {
       http.post("https://api.deepseek.com/responses", () => {
         modelCalls += 1;
         return new HttpResponse(
-          piResponsesToolSse({
-            callId: "call_pi_read",
-            name: "read",
-            arguments: { path: "/home/user/workspace/handoff.txt" },
-            sequence: modelCalls,
-          }),
+          modelCalls === 1
+            ? piResponsesContentSse({
+                blocks: [
+                  { type: "text", text: "before parallel tools" },
+                  {
+                    type: "toolCall",
+                    callId: "call_pi_read",
+                    name: "read",
+                    arguments: {
+                      path: "/home/user/workspace/handoff.txt",
+                    },
+                  },
+                  {
+                    type: "toolCall",
+                    callId: "call_pi_write",
+                    name: "write",
+                    arguments: {
+                      path: "/home/user/workspace/handoff-copy.txt",
+                      content: "copied",
+                    },
+                  },
+                  { type: "text", text: "after parallel tools" },
+                ],
+                sequence: modelCalls,
+                includeReasoning: true,
+              })
+            : piResponsesToolSse({
+                callId: "call_pi_read",
+                name: "read",
+                arguments: { path: "/home/user/workspace/handoff.txt" },
+                sequence: modelCalls,
+              }),
           { headers: { "content-type": "text/event-stream" } },
         );
       }),
@@ -5069,7 +5345,7 @@ describe("CHAT-02: model-first provider policies", () => {
       readonly sandboxEventSequenceStart?: unknown;
     };
     expect(manifest).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       outcome: "handoff",
       baseSession: { sessionId: run.threadId, sha256: null },
       session: {
@@ -5077,8 +5353,26 @@ describe("CHAT-02: model-first provider policies", () => {
         sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
         rawSize: expect.any(Number),
       },
+      sandboxEventSequenceStart: 4,
     });
-    expect(manifest).not.toHaveProperty("sandboxEventSequenceStart");
+    const projected = await waitForThreadMessages(
+      actor,
+      run.threadId,
+      (messages) => {
+        return eventBackedContents(messages, run.runId).length === 2;
+      },
+    );
+    expect(
+      eventBackedContents(projected.events, run.runId).map((message) => {
+        return {
+          content: message.content,
+          sequenceNumber: message.sequenceNumber,
+        };
+      }),
+    ).toStrictEqual([
+      { content: "before parallel tools", sequenceNumber: 0 },
+      { content: "after parallel tools", sequenceNumber: 3 },
+    ]);
     const claimed = await claimChatRun(runnerGroup, run.runId);
     expect(claimed.claim.cliAgentType).toBe("pi");
     expect(claimed.claim.piSessionId).toBe(run.threadId);
@@ -5125,14 +5419,122 @@ describe("CHAT-02: model-first provider policies", () => {
         },
       ],
     });
+    expect(
+      h1Assistant?.role === "assistant"
+        ? h1Assistant.content
+            .filter((content) => {
+              return content.type !== "thinking";
+            })
+            .map((content) => {
+              return content.type === "text"
+                ? { type: content.type, text: content.text }
+                : {
+                    type: content.type,
+                    id: content.id,
+                    name: content.name,
+                  };
+            })
+        : [],
+    ).toStrictEqual([
+      { type: "text", text: "before parallel tools" },
+      {
+        type: "toolCall",
+        id: "call_pi_read|fc_pi_content_1_1",
+        name: "read",
+      },
+      {
+        type: "toolCall",
+        id: "call_pi_write|fc_pi_content_1_2",
+        name: "write",
+      },
+      { type: "text", text: "after parallel tools" },
+    ]);
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 0,
+            message: {
+              content: [{ type: "text", text: "before parallel tools" }],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "call_pi_read|fc_pi_content_1_1",
+                  name: "read",
+                  input: { path: "/home/user/workspace/handoff.txt" },
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 2,
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "call_pi_write|fc_pi_content_1_2",
+                  name: "write",
+                  input: {
+                    path: "/home/user/workspace/handoff-copy.txt",
+                    content: "copied",
+                  },
+                },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            sequenceNumber: 3,
+            message: {
+              content: [{ type: "text", text: "after parallel tools" }],
+            },
+          },
+        ],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ).map((message) => {
+        return {
+          content: message.content,
+          sequenceNumber: message.sequenceNumber,
+        };
+      }),
+    ).toStrictEqual([
+      { content: "before parallel tools", sequenceNumber: 0 },
+      { content: "after parallel tools", sequenceNumber: 3 },
+    ]);
     h2Session.appendMessage({
       role: "toolResult",
-      toolCallId: "call_pi_read|fc_pi_tool_1",
+      toolCallId: "call_pi_read|fc_pi_content_1_1",
       toolName: "read",
       content: [{ type: "text", text: "Sandbox tool output" }],
       details: {},
       isError: false,
       timestamp: 2,
+    });
+    h2Session.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_pi_write|fc_pi_content_1_2",
+      toolName: "write",
+      content: [{ type: "text", text: "Sandbox write output" }],
+      details: {},
+      isError: false,
+      timestamp: 3,
     });
     h2Session.appendMessage({
       role: "assistant",
@@ -5149,7 +5551,7 @@ describe("CHAT-02: model-first provider policies", () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       },
       stopReason: "stop",
-      timestamp: 3,
+      timestamp: 4,
     });
     const h2 = h2Session.toJsonl();
     const h2Hash = createHash("sha256").update(h2).digest("hex");

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -372,7 +372,7 @@ async function canCommitApiTurn(
   );
 }
 
-function projectedAssistantContent(
+function projectedAssistantBlocks(
   assistant: PiApiFirstTurnResult["assistantMessage"],
 ): unknown[] {
   return assistant.content.flatMap((block): unknown[] => {
@@ -406,37 +406,40 @@ function assistantText(
     .join("\n\n");
 }
 
-function assistantEvent(
+function assistantEvents(
   runId: string,
   assistant: PiApiFirstTurnResult["assistantMessage"],
-): AgentEvent {
-  return {
-    type: "assistant",
-    sequenceNumber: 0,
-    message: {
-      id:
-        assistant.responseId ??
-        `${runId}:${assistant.timestamp}:${assistant.model}`,
-      role: "assistant",
-      content: projectedAssistantContent(assistant),
-      model: assistant.model,
-      usage: {
-        input_tokens: assistant.usage.input,
-        output_tokens: assistant.usage.output,
-        cache_read_input_tokens: assistant.usage.cacheRead,
-        cache_creation_input_tokens: assistant.usage.cacheWrite,
+): AgentEvent[] {
+  return projectedAssistantBlocks(assistant).map((block, sequenceNumber) => {
+    return {
+      type: "assistant",
+      sequenceNumber,
+      message: {
+        id:
+          assistant.responseId ??
+          `${runId}:${assistant.timestamp}:${assistant.model}`,
+        role: "assistant",
+        content: [block],
+        model: assistant.model,
+        usage: {
+          input_tokens: assistant.usage.input,
+          output_tokens: assistant.usage.output,
+          cache_read_input_tokens: assistant.usage.cacheRead,
+          cache_creation_input_tokens: assistant.usage.cacheWrite,
+        },
       },
-    },
-  };
+    };
+  });
 }
 
 function resultEvent(
   assistant: PiApiFirstTurnResult["assistantMessage"],
   startedAt: number,
+  sequenceNumber: number,
 ): AgentEvent {
   return {
     type: "result",
-    sequenceNumber: 1,
+    sequenceNumber,
     subtype: "success",
     is_error: false,
     result: assistantText(assistant),
@@ -940,6 +943,7 @@ const finalizeCompleteTurn$ = command(async function finalizeCompleteTurn(
   { set },
   args: ApiFirstTurnContext,
   prepared: PreparedApiFirstTurn,
+  lastEventSequence: number,
   signal: AbortSignal,
 ): Promise<CompleteSideEffectsInput | undefined> {
   const completion = await set(
@@ -949,7 +953,7 @@ const finalizeCompleteTurn$ = command(async function finalizeCompleteTurn(
       body: {
         runId: args.activation.runId,
         exitCode: 0,
-        lastEventSequence: 1,
+        lastEventSequence,
       },
     },
     signal,
@@ -999,16 +1003,25 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
   );
   signal.throwIfAborted();
 
+  const blockEvents = assistantEvents(
+    args.activation.runId,
+    prepared.turn.assistantMessage,
+  );
+  const nextSequenceNumber = blockEvents.length;
   const events = prepared.turn.handoffRequired
-    ? [assistantEvent(args.activation.runId, prepared.turn.assistantMessage)]
+    ? blockEvents
     : [
-        assistantEvent(args.activation.runId, prepared.turn.assistantMessage),
-        resultEvent(prepared.turn.assistantMessage, prepared.startedAt),
+        ...blockEvents,
+        resultEvent(
+          prepared.turn.assistantMessage,
+          prepared.startedAt,
+          nextSequenceNumber,
+        ),
       ];
   await set(publishEvents$, { auth: prepared.auth, events }, signal);
   if (prepared.turn.handoffRequired) {
     const manifest: PiApiFirstTurnManifest = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       outcome: "handoff",
       baseSession: prepared.baseSession,
       session: {
@@ -1016,6 +1029,7 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
         sha256: prepared.sessionHash,
         rawSize: prepared.sessionBytes.length,
       },
+      sandboxEventSequenceStart: nextSequenceNumber,
     };
     await set(
       writeManifest$,
@@ -1026,7 +1040,13 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
   }
 
   await set(persistCompleteTurnCheckpoint$, args, prepared, signal);
-  const sideEffects = await set(finalizeCompleteTurn$, args, prepared, signal);
+  const sideEffects = await set(
+    finalizeCompleteTurn$,
+    args,
+    prepared,
+    nextSequenceNumber,
+    signal,
+  );
   stopPreparedSandbox(args.activation, "completed");
   return sideEffects;
 });

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -551,7 +551,7 @@ describe("sandbox Pi agent loop", () => {
               sessionUrl: `${handoffBaseUrl}/session.jsonl`,
               deadlineAt: Date.now() + 10_000,
               baseSession: { sessionId: SESSION_ID, sha256: null },
-              sandboxEventSequenceStart: 4,
+              sandboxEventSequenceStart: 1,
             },
           },
         }),

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
@@ -174,7 +174,7 @@ describe("Pi API first-turn handoff loader", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("restores H1 with a matching future dynamic boundary", async () => {
+  it("restores H1 with the authoritative future manifest boundary", async () => {
     const sessionDir = await mkdtemp(join(tmpdir(), "pi-handoff-loader-"));
     temporaryDirectories.push(sessionDir);
     const jsonl = HANDOFF_SESSION_JSONL;
@@ -186,7 +186,7 @@ describe("Pi API first-turn handoff loader", () => {
     });
 
     const restored = await resolvePiApiFirstTurnHandoff({
-      config: config(5_000, sandboxEventSequenceStart),
+      config: config(5_000),
       sessionDir,
       sessionId: SESSION_ID,
       runtime: fixedRuntime(fetchMock as typeof fetch),
@@ -196,25 +196,15 @@ describe("Pi API first-turn handoff loader", () => {
     expect(await readFile(restored.sessionFile, "utf8")).toBe(jsonl);
   });
 
-  it.each([
-    {
-      name: "v1 manifest with a dynamic launch boundary",
-      pointer: manifest(HANDOFF_SESSION_JSONL),
-      launchBoundary: 4,
-    },
-    {
-      name: "v2 manifest with a different launch boundary",
-      pointer: manifestV2(HANDOFF_SESSION_JSONL, 4),
-      launchBoundary: 3,
-    },
-  ])("fails closed for $name", async ({ pointer, launchBoundary }) => {
+  it("fails closed for a v1 manifest with a dynamic launch boundary", async () => {
+    const pointer = manifest(HANDOFF_SESSION_JSONL);
     const fetchMock = vi.fn(async () => {
       return Response.json(pointer);
     });
 
     await expect(
       resolvePiApiFirstTurnHandoff({
-        config: config(5_000, launchBoundary),
+        config: config(5_000, 4),
         sessionDir: "/unused",
         sessionId: SESSION_ID,
         runtime: fixedRuntime(fetchMock as typeof fetch),

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -241,17 +241,16 @@ function validatedSandboxEventSequenceStart(args: {
   // and the two-hour runner drain. Remove v1 after #29618 is live on every Pi
   // runner, pre-v2 work has drained, and no retained rollback API emits v1;
   // tracked by #29612.
-  const manifestSequenceStart =
-    args.manifest.schemaVersion === 1
-      ? 1
-      : args.manifest.sandboxEventSequenceStart;
-  if (manifestSequenceStart !== args.config.sandboxEventSequenceStart) {
+  if (args.manifest.schemaVersion === 2) {
+    return args.manifest.sandboxEventSequenceStart;
+  }
+  if (args.config.sandboxEventSequenceStart !== 1) {
     throw new PiApiFirstTurnHandoffError(
       "PI_HANDOFF_SEQUENCE_MISMATCH",
       "Pi API first-turn manifest boundary does not match the launch",
     );
   }
-  return manifestSequenceStart;
+  return 1;
 }
 
 async function restoreSession(args: {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -316,7 +316,7 @@ describe("Pi sandbox execution contract", () => {
     ).toBe(false);
   });
 
-  it("accepts a future manifest and launch config with the same dynamic boundary", () => {
+  it("accepts an authoritative future manifest boundary after launch", () => {
     const sandboxEventSequenceStart = 4;
     const manifest = piApiFirstTurnManifestSchema.parse({
       schemaVersion: 2,
@@ -325,16 +325,15 @@ describe("Pi sandbox execution contract", () => {
       session: handoffSession,
       sandboxEventSequenceStart,
     });
-    const config = piApiFirstTurnConfigSchema.parse({
-      ...piStoredContext.piLaunchConfig.apiFirstTurn,
-      sandboxEventSequenceStart,
-    });
+    const config = piApiFirstTurnConfigSchema.parse(
+      piStoredContext.piLaunchConfig.apiFirstTurn,
+    );
 
     expect(manifest).toMatchObject({
       schemaVersion: 2,
       sandboxEventSequenceStart,
     });
-    expect(config.sandboxEventSequenceStart).toBe(sandboxEventSequenceStart);
+    expect(config.sandboxEventSequenceStart).toBe(1);
   });
 
   it.each([0, -1, 1.5, MAX_EVENT_SEQUENCE_NUMBER + 1])(


### PR DESCRIPTION
## Summary

- emit one canonical Pi API-first `AgentEvent` for each normalized semantic content block in exact source order
- derive both integer event sequences and the v2 handoff `sandboxEventSequenceStart` boundary from the same normalized block list
- place the no-handoff result at `N`, while preserving session-before-events, publish-before-manifest, checkpoint, retry, masking, and terminal lifecycle behavior
- retain manifest v1 compatibility at boundary 1 and treat the post-response v2 manifest boundary as authoritative over the pre-response launch placeholder

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm knip`
- staged package type checks for API, app, CLI, and contracts
- `pnpm --filter api check-types:tests`
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts` (91 passed)
- `pnpm --filter @okouai/cli exec vitest run src/lib/pi-api-first-turn-handoff.test.ts src/lib/pi-agent-loop.test.ts` (26 passed)
- focused `chat-events.bdd.test.ts` API-first no-handoff and mixed-block handoff cases (2 passed)

Closes #29618
