### PR TITLE
test(e2e): use email-code sign-in for test users

### DIFF
--- a/e2e/playwright/lib/auth.test.ts
+++ b/e2e/playwright/lib/auth.test.ts
@@ -6,6 +6,7 @@ import { chromium } from "@playwright/test";
 
 import {
   getCurrentClerkSessionToken,
+  signInWithLoadedClerkTestingHelper,
   type ClerkSessionTokenCache,
   withLoadedClerkTestingPage,
 } from "./auth";
@@ -14,6 +15,7 @@ type ClerkFixtureMode =
   | "absent"
   | "incomplete"
   | "loaded"
+  | "loaded-email-code"
   | "loaded-without-token"
   | "recover";
 
@@ -216,6 +218,50 @@ test("keeps Clerk session tokens current across repeated observers", async (cont
   }
 });
 
+test("signs testing emails in through Clerk's email-code strategy", async () => {
+  const browser = await chromium.launch();
+  try {
+    await withClerkFixture("loaded-email-code", async (fixture) => {
+      await withLoadedClerkTestingPage(
+        browser,
+        {
+          appUrl: fixture.appUrl,
+          contextOptions: {},
+        },
+        async (page) => {
+          const token = await signInWithLoadedClerkTestingHelper(
+            page,
+            "fixture+clerk_test@example.com",
+            fixture.appUrl,
+            { preserveAppPage: true },
+          );
+          const signInState = await page.evaluate(() => {
+            const fixtureWindow = window as unknown as {
+              __clerkEmailCodeState: {
+                attemptedCode: string | null;
+                identifier: string | null;
+                preparedEmailAddressId: string | null;
+                sessionId: string | null;
+              };
+            };
+            return fixtureWindow.__clerkEmailCodeState;
+          });
+
+          assert.equal(token, "fixture-token-1");
+          assert.deepEqual(signInState, {
+            attemptedCode: "424242",
+            identifier: "fixture+clerk_test@example.com",
+            preparedEmailAddressId: "email_fixture",
+            sessionId: "session_fixture",
+          });
+        },
+      );
+    });
+  } finally {
+    await browser.close();
+  }
+});
+
 async function withClerkFixture<Result>(
   mode: ClerkFixtureMode,
   use: (fixture: ClerkFixture) => Promise<Result>,
@@ -273,18 +319,62 @@ function clerkFixtureDocument(
   mode: ClerkFixtureMode,
   documentRequest: number,
 ): string {
-  if (mode === "loaded" || mode === "loaded-without-token") {
+  if (
+    mode === "loaded" ||
+    mode === "loaded-email-code" ||
+    mode === "loaded-without-token"
+  ) {
     const tokenResult =
       mode === "loaded-without-token"
         ? "null"
         : "`fixture-token-${++tokenRequests}`";
+    const sessionFixture =
+      mode === "loaded-email-code"
+        ? "null"
+        : `{ getToken: async () => ${tokenResult} }`;
+    const emailCodeFixture =
+      mode === "loaded-email-code"
+        ? `
+  window.__clerkEmailCodeState = {
+    attemptedCode: null,
+    identifier: null,
+    preparedEmailAddressId: null,
+    sessionId: null,
+  };
+  const signIn = {
+    create: async ({ identifier }) => {
+      window.__clerkEmailCodeState.identifier = identifier;
+      return {
+        supportedFirstFactors: [
+          { strategy: "email_code", emailAddressId: "email_fixture" },
+        ],
+      };
+    },
+    prepareFirstFactor: async ({ emailAddressId }) => {
+      window.__clerkEmailCodeState.preparedEmailAddressId = emailAddressId;
+    },
+    attemptFirstFactor: async ({ code }) => {
+      window.__clerkEmailCodeState.attemptedCode = code;
+      return { status: "complete", createdSessionId: "session_fixture" };
+    },
+  };
+  const setActive = async ({ session }) => {
+    window.__clerkEmailCodeState.sessionId = session;
+    window.Clerk.session = { getToken: async () => ${tokenResult} };
+    window.Clerk.user = { id: "user_fixture" };
+  };`
+        : "";
     return `<!doctype html>
 <script>
   let tokenRequests = 0;
+  ${emailCodeFixture}
   window.Clerk = {
+    client: ${mode === "loaded-email-code" ? "{ signIn }" : "undefined"},
     loaded: true,
     organization: { id: "org_fixture" },
-    session: { getToken: async () => ${tokenResult} },
+    session: ${sessionFixture},
+    user: null,
+    setActive: ${mode === "loaded-email-code" ? "setActive" : "undefined"},
   };
 </script>`;
   }

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -148,7 +148,12 @@ export async function signInWithLoadedClerkTestingHelper(
     ...clerkStateBefore,
   });
 
-  await clerk.signIn({ page, emailAddress: email });
+  // Generated E2E identities are Clerk testing emails. Keep sign-in on the
+  // testing-token FAPI path instead of adding Backend API lookup/token calls.
+  await clerk.signIn({
+    page,
+    signInParams: { strategy: "email_code", identifier: email },
+  });
   await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
     timeout: 30_000,
   });


### PR DESCRIPTION
## Summary

- sign generated `+clerk_test` identities in with Clerk's `email_code` testing strategy
- remove the helper's dependency on the opaque Backend API user lookup and sign-in-token creation path
- add browser-backed integration coverage for the email identifier, documented `424242` code, activated session, and refreshed session token

## Root cause

Merge-group job [98184739015](https://github.com/vm0-ai/vm0/actions/runs/32970813446/job/98184739015) failed inside `@clerk/testing` before its page ticket evaluation. The package's `emailAddress` overload performs a Backend API user lookup and sign-in-token POST, then wraps the rejected SDK error with an empty message. The same paid-onboarding lane [passed on the next merge-group run](https://github.com/vm0-ai/vm0/actions/runs/32971812286/job/98188328229), isolating the failure to that transient external boundary.

The generated identities are already Clerk testing emails. Using the supported `email_code` strategy keeps authentication on the existing testing-token Frontend API path and preserves the product-level session, active-organization, and token assertions without adding a test retry, sleep, timeout, or skip.

## Scope

This changes E2E test infrastructure only. It does not change production authentication, APIs, onboarding behavior, database state, or test assertions.

## Validation

- `npx --yes prettier@3.8.1 --check e2e/playwright/lib/auth.ts e2e/playwright/lib/auth.test.ts`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm exec tsx --test playwright/lib/auth.test.ts` (9 passed)
- new email-code integration test repeated 5 times (5 passed)
- `cd e2e && pnpm test` (41 passed)
- `git diff --check`

The live Clerk and preview-app Playwright lanes require CI credentials and deployments and are left to the PR pipeline.

Closes #29655
