### PR TITLE
refactor(api): observe backend url aliases at startup

### DIFF
--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -19,15 +19,30 @@ import { getApiTestMocks } from "./mocks";
 
 const CANONICAL_PREFIX = "/api/okou";
 const LEGACY_PREFIX = "/api/zero";
+const API_BACKEND_URL_ALIAS_RESOLUTION_EVENT =
+  "api_backend_url_alias_resolution";
+const API_BACKEND_URL_LOG_CONTEXT = "ApiBackendUrl";
 const MACHINE_SECRET_ALIAS_RESOLUTION_EVENT =
   "billing_machine_secret_alias_resolution";
 const MACHINE_SECRET_LOG_CONTEXT = "api:zero:billing-redeem-code";
+const legacyApiBackendUrl = optionalEnv("VM0_API_BACKEND_URL");
+if (!legacyApiBackendUrl) {
+  throw new Error("Expected the API test backend URL fixture");
+}
 const legacyMachineSecret = optionalEnv("VM0_MACHINE_SECRET_KEY");
 if (!legacyMachineSecret) {
   throw new Error("Expected the API test machine secret fixture");
 }
 
 const apiTestMocks = getApiTestMocks();
+const apiBackendUrlInitializationInfoCalls =
+  apiTestMocks.axiomLogging.info.mock.calls.filter(([message]) => {
+    return message === API_BACKEND_URL_ALIAS_RESOLUTION_EVENT;
+  });
+const apiBackendUrlInitializationWarnCalls =
+  apiTestMocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+    return message === API_BACKEND_URL_ALIAS_RESOLUTION_EVENT;
+  });
 const machineSecretInitializationInfoCalls =
   apiTestMocks.axiomLogging.info.mock.calls.filter(([message]) => {
     return message === MACHINE_SECRET_ALIAS_RESOLUTION_EVENT;
@@ -152,7 +167,25 @@ function brandedPath(neutralPath: string): string {
 }
 
 describe("API route bundle initialization", () => {
-  it("reports the machine secret source without changing the redeem route", () => {
+  it("reports fixed alias sources without changing the redeem route", () => {
+    expect(apiBackendUrlInitializationInfoCalls).toStrictEqual([
+      [
+        API_BACKEND_URL_ALIAS_RESOLUTION_EVENT,
+        {
+          [EVENT]: { source: "api" },
+          canonicalKey: "OKOU_API_BACKEND_URL",
+          legacyKey: "VM0_API_BACKEND_URL",
+          state: "legacy-only",
+          context: API_BACKEND_URL_LOG_CONTEXT,
+        },
+      ],
+    ]);
+    expect(apiBackendUrlInitializationWarnCalls).toStrictEqual([]);
+    expectValueFree(
+      JSON.stringify(apiBackendUrlInitializationInfoCalls),
+      legacyApiBackendUrl,
+    );
+
     expect(machineSecretInitializationInfoCalls).toStrictEqual([
       [
         MACHINE_SECRET_ALIAS_RESOLUTION_EVENT,

--- a/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/api-backend-url.test.ts
@@ -4,7 +4,10 @@ import { EVENT } from "@axiomhq/logging";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../__tests__/test-context";
-import { apiBackendUrl } from "../api-backend-url";
+import {
+  apiBackendUrl,
+  reportApiBackendUrlAliasSourceAtProcessInitialization,
+} from "../api-backend-url";
 import { mockEnv } from "../env";
 import { getOAuthApiOrigin } from "../oauth-origin";
 
@@ -24,35 +27,45 @@ type ApiBackendUrlAliasState =
 
 interface ApiBackendUrlAliasFixture {
   readonly state: ApiBackendUrlAliasState;
-  readonly canonical: string | undefined;
-  readonly legacy: string | undefined;
+  readonly initializationCanonical: string | undefined;
+  readonly initializationLegacy: string | undefined;
+  readonly consumerCanonical: string | undefined;
+  readonly consumerLegacy: string | undefined;
   readonly expected: string | undefined;
 }
 
 const API_BACKEND_URL_ALIAS_FIXTURES: readonly ApiBackendUrlAliasFixture[] = [
   {
     state: "absent",
-    canonical: undefined,
-    legacy: undefined,
+    initializationCanonical: undefined,
+    initializationLegacy: undefined,
+    consumerCanonical: undefined,
+    consumerLegacy: undefined,
     expected: undefined,
   },
   {
     state: "canonical-only",
-    canonical: "https://canonical-only.example.test",
-    legacy: undefined,
-    expected: "https://canonical-only.example.test",
+    initializationCanonical: "https://initial-canonical-only.example.test/path",
+    initializationLegacy: undefined,
+    consumerCanonical: "https://consumer-canonical-only.example.test/path",
+    consumerLegacy: undefined,
+    expected: "https://consumer-canonical-only.example.test/path",
   },
   {
     state: "legacy-only",
-    canonical: undefined,
-    legacy: "https://legacy-only.example.test",
-    expected: "https://legacy-only.example.test",
+    initializationCanonical: undefined,
+    initializationLegacy: "https://initial-legacy-only.example.test/path",
+    consumerCanonical: undefined,
+    consumerLegacy: "https://consumer-legacy-only.example.test/path",
+    expected: "https://consumer-legacy-only.example.test/path",
   },
   {
     state: "equal-dual",
-    canonical: "https://equal-dual.example.test",
-    legacy: "https://equal-dual.example.test",
-    expected: "https://equal-dual.example.test",
+    initializationCanonical: "https://initial-equal-dual.example.test/path",
+    initializationLegacy: "https://initial-equal-dual.example.test/path",
+    consumerCanonical: "https://consumer-equal-dual.example.test/path",
+    consumerLegacy: "https://consumer-equal-dual.example.test/path",
+    expected: "https://consumer-equal-dual.example.test/path",
   },
 ];
 
@@ -89,11 +102,22 @@ function expectValueFree(diagnostics: string, values: readonly string[]): void {
 }
 
 describe("API backend URL aliases", () => {
-  it("resolves the non-conflicting matrix with one value-free event per state", () => {
+  it("observes then resolves every non-conflicting state without retaining values", () => {
     for (const fixture of API_BACKEND_URL_ALIAS_FIXTURES) {
-      configureAliases(fixture.canonical, fixture.legacy);
+      configureAliases(
+        fixture.initializationCanonical,
+        fixture.initializationLegacy,
+      );
       const logCount = context.mocks.axiomLogging.info.mock.calls.length;
 
+      expect(
+        reportApiBackendUrlAliasSourceAtProcessInitialization(),
+      ).toBeUndefined();
+      expect(
+        reportApiBackendUrlAliasSourceAtProcessInitialization(),
+      ).toBeUndefined();
+
+      configureAliases(fixture.consumerCanonical, fixture.consumerLegacy);
       expect(apiBackendUrl()).toBe(fixture.expected);
       expect(apiBackendUrl()).toBe(fixture.expected);
 
@@ -103,7 +127,12 @@ describe("API backend URL aliases", () => {
       ]);
       expectValueFree(
         JSON.stringify(calls),
-        [fixture.canonical, fixture.legacy].filter((value): value is string => {
+        [
+          fixture.initializationCanonical,
+          fixture.initializationLegacy,
+          fixture.consumerCanonical,
+          fixture.consumerLegacy,
+        ].filter((value): value is string => {
           return value !== undefined;
         }),
       );
@@ -113,11 +142,26 @@ describe("API backend URL aliases", () => {
   });
 
   it("fails closed on conflicting aliases with bounded value-free diagnostics", () => {
-    const canonical = "https://canonical-url-must-not-leak.example.test";
-    const legacy = "https://legacy-url-must-not-leak.example.test";
+    const initializationCanonical =
+      "https://initial-canonical-conflict-must-not-leak.example.test/path";
+    const initializationLegacy =
+      "https://initial-legacy-conflict-must-not-leak.example.test/path";
+    const consumerCanonical =
+      "https://consumer-canonical-conflict-must-not-leak.example.test/path";
+    const consumerLegacy =
+      "https://consumer-legacy-conflict-must-not-leak.example.test/path";
     const expectedMessage =
       "API backend URL aliases conflict: canonicalKey=OKOU_API_BACKEND_URL legacyKey=VM0_API_BACKEND_URL state=conflicting-dual";
-    configureAliases(canonical, legacy);
+    configureAliases(initializationCanonical, initializationLegacy);
+
+    expect(
+      reportApiBackendUrlAliasSourceAtProcessInitialization(),
+    ).toBeUndefined();
+    expect(
+      reportApiBackendUrlAliasSourceAtProcessInitialization(),
+    ).toBeUndefined();
+
+    configureAliases(consumerCanonical, consumerLegacy);
 
     expect(() => {
       apiBackendUrl();
@@ -136,8 +180,12 @@ describe("API backend URL aliases", () => {
       error: expectedMessage,
       logs: context.mocks.axiomLogging.warn.mock.calls,
     });
-    expect(diagnostics).not.toContain(canonical);
-    expect(diagnostics).not.toContain(legacy);
+    expectValueFree(diagnostics, [
+      initializationCanonical,
+      initializationLegacy,
+      consumerCanonical,
+      consumerLegacy,
+    ]);
     expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalled();
     expect(context.mocks.axiomLogging.info).not.toHaveBeenCalled();
   });

--- a/turbo/apps/api/src/lib/api-backend-url.ts
+++ b/turbo/apps/api/src/lib/api-backend-url.ts
@@ -14,6 +14,11 @@ type ApiBackendUrlAliasState =
   | "equal-dual"
   | "conflicting-dual";
 
+interface ApiBackendUrlResolution {
+  readonly state: ApiBackendUrlAliasState;
+  readonly value: string | undefined;
+}
+
 const log = logger("ApiBackendUrl");
 const reportedStates = singleton(() => {
   return new Set<ApiBackendUrlAliasState>();
@@ -38,6 +43,29 @@ function reportResolution(state: ApiBackendUrlAliasState): void {
   logAliasResolutionInfo(log, API_BACKEND_URL_ALIAS_RESOLUTION_EVENT, fields);
 }
 
+function resolveApiBackendUrl(): ApiBackendUrlResolution {
+  const canonical = env(CANONICAL_API_BACKEND_URL_KEY);
+  const legacy = env(LEGACY_API_BACKEND_URL_KEY);
+
+  if (!canonical) {
+    return {
+      state: legacy ? "legacy-only" : "absent",
+      value: legacy,
+    };
+  }
+  if (!legacy) {
+    return { state: "canonical-only", value: canonical };
+  }
+  if (canonical === legacy) {
+    return { state: "equal-dual", value: canonical };
+  }
+  return { state: "conflicting-dual", value: undefined };
+}
+
+export function reportApiBackendUrlAliasSourceAtProcessInitialization(): void {
+  reportResolution(resolveApiBackendUrl().state);
+}
+
 // This API-process compatibility boundary retains VM0_API_BACKEND_URL while
 // repository, deployment, preview, and local writers remain legacy-only.
 // Under #28914, remove the legacy input only after an exact release containing
@@ -45,24 +73,11 @@ function reportResolution(state: ApiBackendUrlAliasState): void {
 // target can start after writer cutover, and value-free telemetry reports zero
 // legacy-only and equal-dual resolutions through that rollback window.
 export function apiBackendUrl(): string | undefined {
-  const canonical = env(CANONICAL_API_BACKEND_URL_KEY);
-  const legacy = env(LEGACY_API_BACKEND_URL_KEY);
-
-  if (!canonical) {
-    const state = legacy ? "legacy-only" : "absent";
-    reportResolution(state);
-    return legacy;
+  const resolution = resolveApiBackendUrl();
+  reportResolution(resolution.state);
+  if (resolution.state !== "conflicting-dual") {
+    return resolution.value;
   }
-  if (!legacy) {
-    reportResolution("canonical-only");
-    return canonical;
-  }
-  if (canonical === legacy) {
-    reportResolution("equal-dual");
-    return canonical;
-  }
-
-  reportResolution("conflicting-dual");
   throw new Error(
     `API backend URL aliases conflict: canonicalKey=${CANONICAL_API_BACKEND_URL_KEY} legacyKey=${LEGACY_API_BACKEND_URL_KEY} state=conflicting-dual`,
   );

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -1,3 +1,4 @@
+import { reportApiBackendUrlAliasSourceAtProcessInitialization } from "../lib/api-backend-url";
 import { authMeRoutes } from "./routes/auth-me";
 import { cliAuthRoutes } from "./routes/cli-auth";
 import type { RouteEntry } from "./route-entry";
@@ -200,6 +201,7 @@ import { webDownloadRoutes } from "./routes/web-download";
 import { webFileUrlRoutes } from "./routes/web-file-url";
 
 reportMachineSecretAliasSourceAtProcessInitialization();
+reportApiBackendUrlAliasSourceAtProcessInitialization();
 
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,


### PR DESCRIPTION
## Summary

- observe the existing fixed API backend URL alias state when the global API route bundle initializes
- derive the observer and `apiBackendUrl()` result from one shared resolver while returning no URL from observation and retaining no URL-bearing resolution globally
- keep absent, canonical-only, legacy-only, equal-dual, and conflicting-dual consumer behavior unchanged, including the exact conflict error and request-time failure boundary

## Base and head

- issue JIT base: `45865d362f418c629b83e49e17baeaea345d633f`
- refreshed implementation base: `c9ea26b736a743bc810da5482b8dfb99ecae1313`
- live PR base observed at creation: `8f2c58413029090974c908de8595d1fda55af74d`
- head: `f76bbd60ba90213e0a249efda7462991f6abff3b`
- drift from the JIT base through the live PR base was reviewed commit-by-commit and file-by-file; #29634, #29597, #29653, and #29509 are disjoint from the resolver, route bundle, focused tests, writers, aliases, and telemetry contract

## Verification

- locked Prettier 3.8.1 write/check for all four changed TypeScript files
- focused Oxlint and ESLint for all four changed TypeScript files
- `pnpm --filter api lint`
- `pnpm --filter api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/lib/__tests__/api-backend-url.test.ts` — 3 passed
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/__tests__/api-namespace-compatibility.test.ts` — 11 passed
- `git diff --check`
- final caller and semantic searches confirmed that every existing `apiBackendUrl()` consumer is unchanged; global route initialization calls only the new `void` observer
- writer, action, local template, devcontainer, Turbo pass-through, schema, URL consumer, route registration, external configuration, and release surfaces have zero diff

## Open PR audit

- refreshed immediately before commit on `2026-08-26`; fully paginated 20 open PRs and all 291 GitHub-declared changed files, fetched 291 records with zero pagination mismatch
- stale #25722 remains at head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`; its only selected-file overlap is `turbo/apps/api/src/signals/route.ts`, where it still only imports and spreads two unrelated Worker probe/readiness route arrays
- #29442 remains an unrelated CLI website-generation fixture change whose existing `VM0_API_BACKEND_URL` literal does not touch the API resolver, initialization, writer, or telemetry behavior
- #29634 merged during implementation and is included in the refreshed base; its former CLI fixture literal remains unrelated
- new #29656 and #29657 and the refreshed #29640 head have no selected-file, resolver-symbol, event, or alias-semantic overlap
- no other open PR overlaps the four changed files or this observation slice

## Rollout boundaries

- observation only: no writer, alias, schema, pass-through, external configuration, URL, route registration, or telemetry shape changes
- this PR does not perform or approve a release, deployment, production QA, rollback, canonical-only cutover, legacy-reader removal, ownership-guard cleanup, Cloudflare Worker work, or next-wave work
- after merge, the controller owns an exact API release and bounded production acceptance requiring positive `equal-dual` observations with zero canonical-only, legacy-only, conflicting-dual, and absent states in that release window

## Fallbacks

Revert this PR. The revert removes only the additive process-initialization observation and restores API backend URL telemetry to consumer-triggered emission. No writer, external configuration, schema, pass-through, URL, route, or alias rollback is required because this PR changes none of those contracts; the existing consumer remains the behavior-enforcement boundary.

Closes #29654
Part of #28914 (Wave 54)
