### PR TITLE
fix(platform): keep cold start on one skeleton

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -229,3 +229,9 @@ export const hideAppSkeleton$ = command(({ set }, _signal: AbortSignal) => {
   set(captureFirstSkeletonHide$);
   set(captureBootstrapPhaseTiming$);
 });
+
+export const hideAppSkeletonOnContentReadyRef$ = onRef(
+  command(({ set }, _element: HTMLSpanElement, signal: AbortSignal) => {
+    set(hideAppSkeleton$, signal);
+  }),
+);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -78,7 +78,7 @@ export const unloadRightThread$ = command(({ get, set }) => {
 interface PaneSpec {
   setPane$: Command<void, [ChatThreadPaneState]>;
   resetSetupSignal$: ReturnType<typeof resetSignal>;
-  onReady$?: Command<void, [AbortSignal]>;
+  onNotFoundReady$?: Command<void, [AbortSignal]>;
 }
 
 interface RestoredDraftState {
@@ -231,9 +231,6 @@ const setupPaneThread$ = command(
       signal,
     );
     set(spec.setPane$, { kind: "thread", thread });
-    if (spec.onReady$) {
-      set(spec.onReady$, signal);
-    }
 
     await set(
       resolvePaneThread$,
@@ -255,8 +252,8 @@ const setupPaneNotFound$ = command(
   ): void => {
     const signal = set(beginPaneSetup$, spec, parentSignal);
     set(spec.setPane$, { kind: "not-found", threadId });
-    if (spec.onReady$) {
-      set(spec.onReady$, signal);
+    if (spec.onNotFoundReady$) {
+      set(spec.onNotFoundReady$, signal);
     }
   },
 );
@@ -274,7 +271,6 @@ export const setupLeftThread$ = command(
         {
           setPane$: setCurrentLeftPane$,
           resetSetupSignal$: resetLeftSetupSignal$,
-          onReady$: hideAppSkeleton$,
         },
         meta,
         parentSignal,
@@ -295,7 +291,7 @@ export const setupLeftThreadNotFound$ = command(
       {
         setPane$: setCurrentLeftPane$,
         resetSetupSignal$: resetLeftSetupSignal$,
-        onReady$: hideAppSkeleton$,
+        onNotFoundReady$: hideAppSkeleton$,
       },
       threadId,
       parentSignal,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx
@@ -395,7 +395,7 @@ describe("okou chat thread IndexedDB fallback", () => {
     expect(snapshotRequests).toBeGreaterThan(completedSnapshotRequests);
   });
 
-  it("renders from cached thread metadata without waiting for remote sync", async () => {
+  it("keeps cached thread shell behind the app skeleton during initial event sync", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     let metadataRequests = 0;
@@ -430,9 +430,8 @@ describe("okou chat thread IndexedDB fallback", () => {
     await expect(
       screen.findByPlaceholderText(PLACEHOLDER),
     ).resolves.toBeInTheDocument();
-    expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+    expect(screen.getByTestId("app-skeleton")).not.toHaveAttribute(
       "aria-hidden",
-      "true",
     );
     expect(releaseRemoteEvents.settled()).toBeFalsy();
     expect(metadataRequests).toBe(0);
@@ -695,6 +694,8 @@ describe("okou chat thread IndexedDB fallback", () => {
     setupChatPage();
     await snapshotBodyRequested.promise;
 
+    const appSkeleton = await screen.findByTestId("app-skeleton");
+    expect(appSkeleton).not.toHaveAttribute("aria-hidden");
     await waitFor(() => {
       expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
     });
@@ -708,6 +709,7 @@ describe("okou chat thread IndexedDB fallback", () => {
       screen.findByText(ASSISTANT_MESSAGE),
     ).resolves.toBeInTheDocument();
     expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+    expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
     expect(screen.queryByText(EMPTY_THREAD_MESSAGE)).not.toBeInTheDocument();
     expect(emptyThread.wasShown()).toBeFalsy();
     expect(uncoveredLoadingGap).toBeFalsy();

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -18,6 +18,7 @@ import { equalArrays } from "../../lib/equality.ts";
 import { useTranslation } from "react-i18next";
 import { formatChatTimestamp } from "../../i18n/format.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { hideAppSkeletonOnContentReadyRef$ } from "../../signals/app-skeleton.ts";
 import {
   runUsagePopoverOpenRunId$,
   setRunUsagePopoverOpenRunId$,
@@ -2829,6 +2830,21 @@ function HeaderAutomationSidebar({
 // SessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
+function ChatThreadAppSkeletonHandoff({
+  thread,
+}: {
+  thread: ChatPanelSignals;
+}) {
+  const initialEventsReady = useGet(thread.initialEventsReady$);
+  const hideAppSkeletonOnContentReadyRef = useSet(
+    hideAppSkeletonOnContentReadyRef$,
+  );
+  if (!initialEventsReady) {
+    return null;
+  }
+  return <span ref={hideAppSkeletonOnContentReadyRef} hidden />;
+}
+
 function ChatThread({
   isMain,
   thread,
@@ -2852,6 +2868,7 @@ function ChatThread({
       tabIndex={-1}
     >
       <ChatThreadContent thread={thread} />
+      {isMain ? <ChatThreadAppSkeletonHandoff thread={thread} /> : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- keep the branded app skeleton visible until the primary chat's initial events are ready to render
- hand off after the chat DOM commit so the wireframe chat skeleton never becomes the visible cold-start state
- preserve the chat skeleton for in-app thread changes and keep not-found startup handling unchanged

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/app-skeleton.ts apps/platform/src/signals/chat-page/chat-thread-panes.ts apps/platform/src/views/okou-page/chat-thread-page.tsx apps/platform/src/views/okou-page/__tests__/chat-thread-idb.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-idb.test.tsx --silent=passed-only --maxWorkers=1` (7 tests passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx --silent=passed-only --maxWorkers=1` (8 tests passed as part of the targeted two-file run)

## Browser QA

PASS on the deployed PR preview.

- PR head: `1bd366bc2293f84ec5f993322c1dfd3e294a464d`
- Deployed merge candidate: `1055c81d1bbb3e8781b5a879ff30d480847e1eb6`
- App origin: https://pr-29661-app.omby.ai
- API origin: https://pr-29661-api.vm6.ai
- Cold-start route: https://pr-29661-app.omby.ai/chats/9512fd9b-5d68-4e7f-9faa-2ca71385baf8
- Desktop: Chromium 151, `1280x633`
- Mobile: Android 15 / Pixel 9 / Chrome 151, `390x844`
- Feature-switch overrides: none
- Fresh account: `pr29661-1bd366bc+clerk_test@vm0.ai` in `My Organization`
- Fixture: existing chat with one completed user/assistant exchange; onboarding completed through the normal flow with no onboarding bypass

The cold start shows the branded skeleton, then fades directly into the ready chat. The wireframe chat skeleton never becomes the visible page state. The 7.1-second mobile recording was also inspected at every captured frame (10 fps).

[Mobile cold-start recording](https://cdn.vm0.io/artifacts/wl8p7kwh5d.mp4)

Branded skeleton:

![Branded app skeleton](https://cdn.vm0.io/artifacts/qkh60xr35f.png)

Ready chat:

![Ready mobile chat](https://cdn.vm0.io/artifacts/m9gqhmd50n.png)
