### PR TITLE
refactor(api): cut over backend url writers to canonical alias

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
     "CARGO_HOME": "/home/vscode/.cache/cargo",
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "OKOU_API_BACKEND_URL": "https://api.vm7.ai:8443",
-    "VM0_API_BACKEND_URL": "https://api.vm7.ai:8443",
     "AGENT_BROWSER_HEADED": "1",
     "DISPLAY": ":99",
     "OP_SERVICE_ACCOUNT_TOKEN": "${localEnv:VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN}"

--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -237,7 +237,6 @@ runs:
 
         if [[ -n "$api_backend_url" ]]; then
           add_env OKOU_API_BACKEND_URL "$api_backend_url"
-          add_env VM0_API_BACKEND_URL "$api_backend_url"
         fi
         if [[ "$INPUT_APP" == "api" ]]; then
           if [[ -z "$INPUT_CLI_PKG_URL" ]]; then

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -138,14 +138,12 @@ assert_debug_aliases_absent() {
   assert_env_key_absent "$env_file" VM0_DEBUG
 }
 
-assert_api_backend_url_aliases_equal_dual() {
+assert_api_backend_url_canonical_only() {
   local env_file="$1"
   local expected="$2"
   assert_env_key_count "$env_file" OKOU_API_BACKEND_URL 1
-  assert_env_key_count "$env_file" VM0_API_BACKEND_URL 1
   assert_env_value "$env_file" OKOU_API_BACKEND_URL "$expected"
-  assert_env_value "$env_file" VM0_API_BACKEND_URL "$expected"
-  assert_env_values_equal "$env_file" OKOU_API_BACKEND_URL VM0_API_BACKEND_URL
+  assert_env_key_count "$env_file" VM0_API_BACKEND_URL 0
 }
 
 assert_machine_secret_aliases_equal_dual() {
@@ -521,7 +519,7 @@ assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
 assert_env_value "$success_env_file" OKOU_PREVIEW_JOB_REF "pr-123"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_values_equal "$success_env_file" OKOU_PREVIEW_JOB_REF VM0_PREVIEW_JOB_REF
-assert_api_backend_url_aliases_equal_dual "$success_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$success_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_web_url_canonical_only "$success_env_file" "https://pr-123-www.vm0.test"
@@ -567,7 +565,7 @@ preview_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${
 assert_contains "$preview_web_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$preview_web_env_file"
 assert_debug_aliases_equal_dual "$preview_web_env_file"
-assert_api_backend_url_aliases_equal_dual "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_key_absent "$preview_web_env_file" OKOU_MACHINE_SECRET_KEY
 assert_env_key_absent "$preview_web_env_file" VM0_MACHINE_SECRET_KEY
 assert_web_url_aliases_absent "$preview_web_env_file"
@@ -579,7 +577,7 @@ empty_job_ref_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "
 assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
 assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
-assert_api_backend_url_aliases_equal_dual "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
 assert_machine_secret_aliases_equal_dual "$empty_job_ref_env_file" "github-atom-machine-secret"
 
 empty_dir="$(mktemp -d)"
@@ -590,7 +588,7 @@ assert_contains "$empty_output" "Rendered"
 assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_debug_aliases_equal_dual "$empty_env_file"
-assert_api_backend_url_aliases_equal_dual "$empty_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$empty_env_file" "https://pr-123-api-backend.vm0.test"
 assert_machine_secret_aliases_equal_dual "$empty_env_file" "github-atom-machine-secret"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
@@ -608,7 +606,7 @@ assert_contains "$production_web_output" "Rendered"
 assert_no_fixture_secret_values "$production_web_output"
 assert_zero_keys_with_live_readers_absent "$production_web_env_file"
 assert_debug_aliases_absent "$production_web_env_file"
-assert_api_backend_url_aliases_equal_dual "$production_web_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$production_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_web_url_aliases_absent "$production_web_env_file"
 assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
@@ -638,7 +636,7 @@ assert_no_fixture_secret_values "$production_api_output"
 assert_zero_keys_with_live_readers_absent "$production_api_env_file"
 assert_debug_aliases_absent "$production_api_env_file"
 assert_web_url_canonical_only "$production_api_env_file" "https://pr-123-www.vm0.test"
-assert_api_backend_url_aliases_equal_dual "$production_api_env_file" "https://pr-123-api-backend.vm0.test"
+assert_api_backend_url_canonical_only "$production_api_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -8,7 +8,6 @@ CLERK_WEBHOOK_SIGNING_SECRET=op://Development/clerk/CLERK_WEBHOOK_SIGNING_SECRET
 
 # Required: API, web, and app URLs
 OKOU_API_BACKEND_URL=https://api.vm7.ai:8443
-VM0_API_BACKEND_URL=https://api.vm7.ai:8443
 FEISHU_CALLBACK_BASE_URL=https://api.vm7.ai:8443
 OKOU_WEB_URL=https://www.vm7.ai:8443
 APP_URL=https://app.vm7.ai:8443

--- a/turbo/apps/api/src/lib/api-backend-url.ts
+++ b/turbo/apps/api/src/lib/api-backend-url.ts
@@ -67,11 +67,11 @@ export function reportApiBackendUrlAliasSourceAtProcessInitialization(): void {
 }
 
 // This API-process compatibility boundary retains VM0_API_BACKEND_URL while
-// repository, deployment, preview, and local writers remain legacy-only.
+// repository-owned deployment, preview, and local writers emit canonical-only.
 // Under #28914, remove the legacy input only after an exact release containing
-// this reader reached every supported API runtime, the supported rollback
-// target can start after writer cutover, and value-free telemetry reports zero
-// legacy-only and equal-dual resolutions through that rollback window.
+// this writer cutover reached every supported API runtime, value-free telemetry
+// reports zero legacy-only and equal-dual resolutions through the supported
+// window, and refreshed rollback evidence supports that later contraction.
 export function apiBackendUrl(): string | undefined {
   const resolution = resolveApiBackendUrl();
   reportResolution(resolution.state);


### PR DESCRIPTION
## Summary

- Contract the repository-owned shared Web/API action, local API template, and development container to emit only `OKOU_API_BACKEND_URL`.
- Update the existing action contract matrix to require exactly one canonical key with the existing value and zero `VM0_API_BACKEND_URL` keys.
- Refresh only the narrowly stale migration comment while retaining the deployed dual reader, observer, schema, telemetry, Turbo pass-through, consumers, and compatibility tests.

Closes #29662

Parent rollout: #28914

## Reviewed base and head

- Reviewed base: `main@1ebefb7a593274dd00ec49f8bd29f17bb5a0a787`
- Reviewed head: `6af8346ca9a4ec952d29416cfa42d4dbba1e025d`
- The JIT main refreshes added #29640 and #29663 only; neither overlaps the selected writers, resolver contract, event, schema, or tests.

## Scope boundaries

- Preserves preview and production inputs, the production `vars.VM0_API_BACKEND_URL` source, Web/API output scope, absence behavior, callbacks, webhooks, and unrelated rendered entries.
- Leaves `api-backend-url.ts` behavior, both schema entries, all five resolver states, conflict timing, value-free telemetry, `turbo.json`, consumers, and legacy-only tests intact.
- Does not change `release-please.yml`, `rollback-production.yml`, `turbo.yml`, or any independent CLI, Runner, Guest, E2E, operator, Worker, or runtime contract.
- Does not rename or mutate any repository variable, secret, Doppler, Vercel, Cloudflare, or other external configuration.

## Open-PR overlap audit

- Pre-edit audit: 20 open PRs, 300 GitHub-declared changed files, 300 fetched records, and zero pagination mismatch.
- Final-head audit: 19 open PRs, 297 GitHub-declared changed files, 297 fetched records, and zero pagination mismatch.
- #29661 remained at `1bd366bc2293f84ec5f993322c1dfd3e294a464d`; its timestamp refreshed but its four platform files and no-overlap classification did not change.
- #29660 remained at `22a000fc18cd98ccc332390d3e4204c3bb00f8db`; its 31 official-workflow files have no selected-file, exact-key, resolver-symbol, event, or semantic overlap.
- Draft #29442 remained at `70e0f6d925a415003daf69a8ffc3e16a74704354`; the legacy key appears only as unchanged context in an unrelated CLI website fixture, with zero changed key lines and no semantic overlap.
- Stale #25722 remained at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, last updated `2026-08-13T15:03:45Z`. Its selected action/test edits remain unrelated naming/comment/Cloudflare Access work, and its `env.ts`/`turbo.json` edits remain independent Worker runtime configuration. Its separate legacy-only Worker work is not absorbed here.
- #29663 changed only release metadata and merged into the reviewed base during implementation; it introduced no overlap.
- No other open PR has a selected-file, exact-key patch, resolver-symbol, event, or semantic overlap, and no new overlap was absorbed.

## Verification

- `bash -n` for the contract test and the extracted composite-action script.
- ShellCheck 0.9.0 for the contract test and the extracted composite-action script.
- `bash .github/scripts/tests/web-api-env-action-test.sh` — passed across the existing preview/production, Web/API, and fallback matrices, including callback/webhook assertions.
- Static action/template/devcontainer proofs — canonical writer count `1`, exact value preserved, legacy writer count `0`; devcontainer JSON parsed successfully.
- Prettier 3.8.1 (the lockfile-pinned version) on all five changed files — passed.
- Focused Oxlint, type-aware Oxlint, and ESLint on `api-backend-url.ts` — passed.
- API type-check stages `deps`, `boundaries`, `gateways`, and `core` — passed.
- `pnpm --filter api exec vitest run src/lib/__tests__/api-backend-url.test.ts` — 3 tests passed against a migrated local PostgreSQL 18 test database.
- Protected workflow/schema/Turbo/reader-test diff proof and `git diff --check` — passed.
- The repository-wide local Vitest suite was not run, and no local development server was started.

## Rollout boundaries

- This PR contracts writers only. It does not perform or approve a release, production deployment, QA, rollback, external-variable cutover, reader removal, schema/Turbo contraction, telemetry cleanup, stale Worker cutover, or guard cleanup.
- A controller-owned later release must deploy the containing API SHA and perform exact-deployment acceptance separately.

## Fallbacks

- Revert this code change to restore the adjacent `VM0_API_BACKEND_URL` equal-dual output in the shared action, local API template, and development container. No external configuration or secret mutation is required.
- The retained dual reader continues to accept canonical-only, legacy-only, and equal-dual input and to fail closed on conflicts.
- Expected post-release telemetry is positive `canonical-only` with zero `equal-dual`, `legacy-only`, `conflicting-dual`, and `absent` observations on the exact API deployment.
- Legacy reader removal remains a later JIT contraction after measured zero use and refreshed rollback evidence under #28914.
