### PR TITLE
feat(pi): materialize chat tool activity

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1139,7 +1139,11 @@ async fn execute_cli_inner(
     let (pi_rpc_response_tx, pi_rpc_response_rx) = tokio::sync::mpsc::unbounded_channel();
     let pi_rpc_cancellation = CancellationToken::new();
     let mut pi_rpc_projection = pi_execution.then(|| {
-        pi_rpc::PiRpcProjection::new(runtime.run_id.as_ref(), runtime.pi_session_id.as_ref())
+        pi_rpc::PiRpcProjection::new(
+            runtime.run_id.as_ref(),
+            runtime.pi_session_id.as_ref(),
+            user_cancellation.clone(),
+        )
     });
     let mut pi_rpc_startup_boundary = pi_execution.then(pi_rpc::PiRpcStartupBoundary::default);
     let mut claude_stdin_write_handle = Some({

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -13,6 +13,7 @@ use crate::error::AgentError;
 
 const PI_RPC_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const PI_API_FIRST_TURN_BOUNDARY_CONTROL_TYPE: &str = "vm0_pi_api_first_turn_boundary";
+const PI_TOOL_RESULT_USER_CANCELLED_FIELD: &str = "vm0_user_cancelled";
 const MAX_EVENT_SEQUENCE_NUMBER: u32 = i32::MAX as u32;
 
 #[derive(Deserialize)]
@@ -159,10 +160,15 @@ pub(super) struct PiRpcProjection {
     emitted_session_init: bool,
     assistant_terminal: Option<PiAssistantTerminal>,
     terminal_error: bool,
+    user_cancellation: CancellationToken,
 }
 
 impl PiRpcProjection {
-    pub(super) fn new(run_id: &str, session_id: &str) -> Self {
+    pub(super) fn new(
+        run_id: &str,
+        session_id: &str,
+        user_cancellation: CancellationToken,
+    ) -> Self {
         Self {
             run_id: run_id.to_string(),
             session_id: session_id.to_string(),
@@ -170,6 +176,7 @@ impl PiRpcProjection {
             emitted_session_init: false,
             assistant_terminal: None,
             terminal_error: false,
+            user_cancellation,
         }
     }
 
@@ -324,17 +331,26 @@ impl PiRpcProjection {
                     "Pi RPC toolResult message omitted its error status".to_string(),
                 )
             })?;
+        let mut result = serde_json::Map::new();
+        result.insert("type".to_string(), Value::String("tool_result".to_string()));
+        result.insert(
+            "tool_use_id".to_string(),
+            Value::String(tool_use_id.to_string()),
+        );
+        result.insert("content".to_string(), Value::Array(content));
+        result.insert("is_error".to_string(), Value::Bool(is_error));
+        if self.user_cancellation.is_cancelled() {
+            result.insert(
+                PI_TOOL_RESULT_USER_CANCELLED_FIELD.to_string(),
+                Value::Bool(true),
+            );
+        }
         Ok(json!({
             "type": "user",
             "session_id": self.session_id,
             "message": {
                 "role": "user",
-                "content": [{
-                    "type": "tool_result",
-                    "tool_use_id": tool_use_id,
-                    "content": content,
-                    "is_error": is_error,
-                }],
+                "content": [Value::Object(result)],
             },
         }))
     }
@@ -680,7 +696,7 @@ mod tests {
     #[test]
     fn projection_uses_agent_settled_as_the_terminal_event() {
         let (responses, _rx) = mpsc::unbounded_channel();
-        let mut projection = PiRpcProjection::new("run", "session");
+        let mut projection = PiRpcProjection::new("run", "session", CancellationToken::new());
         assert!(
             projection
                 .project(
@@ -715,9 +731,50 @@ mod tests {
     }
 
     #[test]
+    fn projection_marks_tool_results_from_positive_user_cancellation_state() {
+        let (responses, _rx) = mpsc::unbounded_channel();
+        let user_cancellation = CancellationToken::new();
+        let mut projection = PiRpcProjection::new("run", "session", user_cancellation.clone());
+        let tool_result = |tool_call_id: &str| {
+            json!({
+                "type": "message_end",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": tool_call_id,
+                    "content": [{ "type": "text", "text": "provider result text" }],
+                    "isError": true,
+                },
+            })
+        };
+
+        let ordinary = projection
+            .project(tool_result("ordinary"), &responses)
+            .expect("ordinary tool result should project")
+            .expect("ordinary tool result should emit an event");
+        assert_eq!(
+            ordinary.pointer("/message/content/0/vm0_user_cancelled"),
+            None
+        );
+
+        user_cancellation.cancel();
+        let cancelled = projection
+            .project(tool_result("cancelled"), &responses)
+            .expect("cancelled tool result should project")
+            .expect("cancelled tool result should emit an event");
+        assert_eq!(
+            cancelled.pointer("/message/content/0/vm0_user_cancelled"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            cancelled.pointer("/message/content/0/is_error"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
     fn projection_validates_get_state_session_identity() {
         let (responses, mut rx) = mpsc::unbounded_channel();
-        let mut projection = PiRpcProjection::new("run", "session");
+        let mut projection = PiRpcProjection::new("run", "session", CancellationToken::new());
         let event = projection
             .project(
                 json!({
@@ -748,7 +805,7 @@ mod tests {
     #[test]
     fn projection_discards_buffered_records_after_extension_failure() {
         let (responses, _rx) = mpsc::unbounded_channel();
-        let mut projection = PiRpcProjection::new("run", "session");
+        let mut projection = PiRpcProjection::new("run", "session", CancellationToken::new());
         let error = projection
             .project(
                 json!({

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts
@@ -69,7 +69,9 @@ function managedCommand(command: string): string {
   return `exec '/usr/local/bin/guest-tool-exec' --shell "$0" -c ${quoteShellArgumentForFixture(command)}`;
 }
 
-async function entitledToolRunActor(): Promise<{
+async function entitledToolRunActor(
+  framework: "claude-code" | "codex" = "claude-code",
+): Promise<{
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly runnerGroup: string;
@@ -83,7 +85,23 @@ async function entitledToolRunActor(): Promise<{
   api.acceptTelemetryIngest();
   const runnerGroup = api.configureRunnerGroup();
   await api.grantProEntitlement(actor);
-  await api.ensureOrgModelProvider(actor);
+  if (framework === "claude-code") {
+    await api.ensureOrgModelProvider(actor);
+  } else {
+    const { providerId } = await api.createOrgModelProvider(actor, {
+      type: "openai-api-key",
+      secret: "tool-materialization-openai-key",
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.6-terra",
+        isDefault: true,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+  }
   const agent = await bdd.createAgent(actor, {
     displayName: `Tool materialization ${randomUUID().slice(0, 8)}`,
     description: "Exercises append-only provider tool materialization.",
@@ -130,6 +148,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
       [FeatureSwitchKey.ChatToolActivity]: true,
     });
     const claim = await claimRun(api, runId, runnerGroup);
+    expect(claim.cliAgentType).toBe("claude-code");
     await webhooks.requestAgentEvents(
       {
         runId,
@@ -237,6 +256,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
       [FeatureSwitchKey.ChatToolActivity]: false,
     });
     const claim = await claimRun(api, runId, runnerGroup);
+    expect(claim.cliAgentType).toBe("claude-code");
     const headers = { authorization: `Bearer ${claim.sandboxToken}` };
     const maskedCommand = managedCommand("printf '%s' '***'");
     const orderedBatch = [
@@ -615,7 +635,8 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
     const chat = createChatFilesBddApi(context);
     const connectors = createConnectorBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
-    const { actor, agentId, runnerGroup, api } = await entitledToolRunActor();
+    const { actor, agentId, runnerGroup, api } =
+      await entitledToolRunActor("codex");
     await connectors.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.ChatToolActivity]: true,
     });
@@ -625,6 +646,7 @@ describe("HOOK-02/CHAT-02: provider tool activity materialization", () => {
       "enabled Codex tool activity",
     );
     const claim = await claimRun(api, runId, runnerGroup);
+    expect(claim.cliAgentType).toBe("codex");
     const headers = { authorization: `Bearer ${claim.sandboxToken}` };
     const wrapped = `/bin/bash -lc ${quoteDoubleShellArgumentForFixture(
       managedCommand("echo ***"),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -978,6 +978,327 @@ function eventBackedContents(
   });
 }
 
+async function verifyPiToolActivityLifecycle(args: {
+  readonly actor: ApiTestUser;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly threadId: string;
+  readonly sandboxHeaders: { readonly authorization: string };
+}): Promise<void> {
+  const sandboxToolEvents = [
+    {
+      type: "user",
+      sequenceNumber: 5,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_pi_write|fc_pi_content_1_2",
+            is_error: true,
+            content: "PI_WRITE_RESULT_SECRET",
+            error: "PI_WRITE_RAW_ERROR_SECRET",
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 4,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_pi_read|fc_pi_content_1_1",
+            is_error: false,
+            content: "PI_READ_RESULT_SECRET",
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 7,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "sandbox-pi-edit",
+            is_error: true,
+            vm0_user_cancelled: true,
+            content: "Operation aborted: PI_CANCELLATION_TEXT_SECRET",
+          },
+        ],
+      },
+    },
+    {
+      type: "assistant",
+      sequenceNumber: 6,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "sandbox-pi-edit",
+            name: "edit",
+            input: {
+              path: "/home/user/workspace/***/handoff-copy.txt",
+              oldText: "PI_EDIT_OLD_TEXT_SECRET",
+              newText: "PI_EDIT_NEW_TEXT_SECRET",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 8,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "orphan-pi-cancellation",
+            is_error: true,
+            vm0_user_cancelled: true,
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 9,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_pi_read|fc_pi_content_1_1",
+            is_error: true,
+            vm0_user_cancelled: true,
+          },
+        ],
+      },
+    },
+    {
+      type: "assistant",
+      sequenceNumber: 10,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "unsupported-pi-case",
+            name: "Read",
+            input: { path: "/home/user/workspace/ignored.txt" },
+          },
+        ],
+      },
+    },
+    {
+      type: "assistant",
+      sequenceNumber: 11,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "malformed-pi-read",
+            name: "read",
+            input: { file_path: "/home/user/workspace/ignored.txt" },
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 12,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "orphan-pi-result",
+            is_error: false,
+          },
+        ],
+      },
+    },
+    {
+      type: "assistant",
+      sequenceNumber: 13,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "sandbox-pi-bash",
+            name: "bash",
+            input: {
+              command: "printf '%s' '***'",
+              description: "PI_BASH_DESCRIPTION_SECRET",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 14,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "sandbox-pi-bash",
+            is_error: false,
+            content: "PI_BASH_RESULT_SECRET",
+          },
+        ],
+      },
+    },
+  ];
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await webhooks.requestAgentEvents(
+      { runId: args.runId, events: sandboxToolEvents },
+      args.sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+  }
+
+  expect(
+    (await chat.listThreadEventRows(args.actor, args.threadId)).filter(
+      (row) => {
+        return row.eventType === "output.tool";
+      },
+    ),
+  ).toHaveLength(0);
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...args.actor, orgId: args.orgId },
+    {
+      [FeatureSwitchKey.PiLoop]: true,
+      [FeatureSwitchKey.ChatToolActivity]: true,
+    },
+  );
+  const piToolRows = (
+    await chat.listThreadEventRows(args.actor, args.threadId)
+  ).filter((row) => {
+    return row.eventType === "output.tool";
+  });
+  expect(
+    piToolRows.map((row) => {
+      return {
+        sequenceNumber: row.runEventSequenceNumber,
+        action: row.payload.action,
+        status: row.payload.status,
+        summary: row.payload.summary,
+      };
+    }),
+  ).toStrictEqual([
+    {
+      sequenceNumber: 1,
+      action: "read",
+      status: "pending",
+      summary: "Reading /home/user/workspace/***/handoff.txt",
+    },
+    {
+      sequenceNumber: 2,
+      action: "write",
+      status: "pending",
+      summary: "Writing /home/user/workspace/***/handoff-copy.txt",
+    },
+    {
+      sequenceNumber: 4,
+      action: "read",
+      status: "success",
+      summary: "Read /home/user/workspace/***/handoff.txt",
+    },
+    {
+      sequenceNumber: 5,
+      action: "write",
+      status: "error",
+      summary: "Wrote /home/user/workspace/***/handoff-copy.txt",
+    },
+    {
+      sequenceNumber: 6,
+      action: "edit",
+      status: "pending",
+      summary: "Editing /home/user/workspace/***/handoff-copy.txt",
+    },
+    {
+      sequenceNumber: 7,
+      action: "edit",
+      status: "cancelled",
+      summary: "Edited /home/user/workspace/***/handoff-copy.txt",
+    },
+    {
+      sequenceNumber: 13,
+      action: "run",
+      status: "pending",
+      summary: "Running printf '%s' '***'",
+    },
+    {
+      sequenceNumber: 14,
+      action: "run",
+      status: "success",
+      summary: "Ran printf '%s' '***'",
+    },
+  ]);
+  expect(piToolRows[0]?.payload.toolUseId).toBe(
+    piToolRows[2]?.payload.toolUseId,
+  );
+  expect(piToolRows[1]?.payload.toolUseId).toBe(
+    piToolRows[3]?.payload.toolUseId,
+  );
+  expect(piToolRows[4]?.payload.toolUseId).toBe(
+    piToolRows[5]?.payload.toolUseId,
+  );
+  expect(piToolRows[6]?.payload.toolUseId).toBe(
+    piToolRows[7]?.payload.toolUseId,
+  );
+  expect(
+    new Set(
+      piToolRows.map((row) => {
+        return row.payload.toolUseId;
+      }),
+    ).size,
+  ).toBe(4);
+  for (const row of piToolRows) {
+    expect(Object.keys(row.payload).sort()).toStrictEqual([
+      "action",
+      "status",
+      "summary",
+      "toolUseId",
+    ]);
+    expect(row.runEventId).toBe(`tool:event:${row.runEventSequenceNumber}`);
+  }
+  const serializedPiToolRows = JSON.stringify(piToolRows);
+  for (const forbidden of [
+    "call_pi_read|fc_pi_content_1_1",
+    "call_pi_write|fc_pi_content_1_2",
+    "sandbox-pi-edit",
+    "sandbox-pi-bash",
+    "orphan-pi-cancellation",
+    "orphan-pi-result",
+    "unsupported-pi-case",
+    "malformed-pi-read",
+    "PI_API_FIRST_WRITE_CONTENT_SECRET",
+    "PI_REPLAY_WRITE_CONTENT_SECRET",
+    "PI_READ_RESULT_SECRET",
+    "PI_WRITE_RESULT_SECRET",
+    "PI_WRITE_RAW_ERROR_SECRET",
+    "PI_EDIT_OLD_TEXT_SECRET",
+    "PI_EDIT_NEW_TEXT_SECRET",
+    "PI_BASH_DESCRIPTION_SECRET",
+    "PI_BASH_RESULT_SECRET",
+    "PI_CANCELLATION_TEXT_SECRET",
+    "Operation aborted",
+    "vm0_user_cancelled",
+    '"framework"',
+  ]) {
+    expect(serializedPiToolRows).not.toContain(forbidden);
+  }
+  const refreshedPiToolRows = (
+    await chat.listThreadEventRows(args.actor, args.threadId)
+  ).filter((row) => {
+    return row.eventType === "output.tool";
+  });
+  expect(refreshedPiToolRows).toStrictEqual(piToolRows);
+}
+
 function recommendedFollowupEvents(
   messages: readonly ChatEvent[],
   runId: string,
@@ -5266,7 +5587,10 @@ describe("CHAT-02: model-first provider policies", () => {
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
+      {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.ChatToolActivity]: true,
+      },
     );
     const archive = latestStoredArchive();
     server.use(
@@ -5290,7 +5614,7 @@ describe("CHAT-02: model-first provider policies", () => {
                     callId: "call_pi_read",
                     name: "read",
                     arguments: {
-                      path: "/home/user/workspace/handoff.txt",
+                      path: "/home/user/workspace/***/handoff.txt",
                     },
                   },
                   {
@@ -5298,8 +5622,8 @@ describe("CHAT-02: model-first provider policies", () => {
                     callId: "call_pi_write",
                     name: "write",
                     arguments: {
-                      path: "/home/user/workspace/handoff-copy.txt",
-                      content: "copied",
+                      path: "/home/user/workspace/***/handoff-copy.txt",
+                      content: "PI_API_FIRST_WRITE_CONTENT_SECRET",
                     },
                   },
                   { type: "text", text: "after parallel tools" },
@@ -5310,7 +5634,7 @@ describe("CHAT-02: model-first provider policies", () => {
             : piResponsesToolSse({
                 callId: "call_pi_read",
                 name: "read",
-                arguments: { path: "/home/user/workspace/handoff.txt" },
+                arguments: { path: "/home/user/workspace/***/handoff.txt" },
                 sequence: modelCalls,
               }),
           { headers: { "content-type": "text/event-stream" } },
@@ -5324,6 +5648,14 @@ describe("CHAT-02: model-first provider policies", () => {
       prompt,
       model: "deepseek-v4-flash",
     });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.ChatToolActivity]: false,
+      },
+    );
     const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
     await expect
       .poll(() => {
@@ -5469,7 +5801,7 @@ describe("CHAT-02: model-first provider policies", () => {
                   type: "tool_use",
                   id: "call_pi_read|fc_pi_content_1_1",
                   name: "read",
-                  input: { path: "/home/user/workspace/handoff.txt" },
+                  input: { path: "/home/user/workspace/***/handoff.txt" },
                 },
               ],
             },
@@ -5484,8 +5816,8 @@ describe("CHAT-02: model-first provider policies", () => {
                   id: "call_pi_write|fc_pi_content_1_2",
                   name: "write",
                   input: {
-                    path: "/home/user/workspace/handoff-copy.txt",
-                    content: "copied",
+                    path: "/home/user/workspace/***/handoff-copy.txt",
+                    content: "PI_REPLAY_WRITE_CONTENT_SECRET",
                   },
                 },
               ],
@@ -5518,6 +5850,13 @@ describe("CHAT-02: model-first provider policies", () => {
       { content: "before parallel tools", sequenceNumber: 0 },
       { content: "after parallel tools", sequenceNumber: 3 },
     ]);
+    await verifyPiToolActivityLifecycle({
+      actor,
+      orgId: actor.orgId,
+      runId: run.runId,
+      threadId: run.threadId,
+      sandboxHeaders: claimed.sandboxHeaders,
+    });
     h2Session.appendMessage({
       role: "toolResult",
       toolCallId: "call_pi_read|fc_pi_content_1_1",

--- a/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-tool-event-normalization.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AgentEvent } from "../../../lib/event-consumer/verify";
-import { normalizeAgentToolEvent } from "../agent-tool-event-normalization";
+import { normalizeAgentToolEvent as normalizeProviderToolEvent } from "../agent-tool-event-normalization";
 import {
   assistantEventIdForRunEvent,
   toolEventIdForRunEvent,
@@ -86,6 +86,14 @@ function codexItem(
   item: Record<string, unknown>,
 ): AgentEvent {
   return agentEvent(1, { type: eventType, item });
+}
+
+function normalizeAgentToolEvent(event: AgentEvent) {
+  const framework =
+    event.type === "item.started" || event.type === "item.completed"
+      ? "codex"
+      : "claude-code";
+  return normalizeProviderToolEvent(event, framework);
 }
 
 describe("agent tool event normalization", () => {
@@ -494,6 +502,183 @@ describe("agent tool event normalization", () => {
       ).toBeNull();
     }
   });
+
+  it("dispatches provider adapters from the durable framework", () => {
+    const piRead = claudeToolUse({
+      name: "read",
+      input: { path: "/workspace/pi.ts" },
+    });
+    const claudeRead = claudeToolUse({
+      name: "Read",
+      input: { file_path: "/workspace/claude.ts" },
+    });
+    const codexRead = codexItem("item.completed", {
+      id: "codex-read",
+      type: "file_read",
+      status: "completed",
+      path: "/workspace/codex.ts",
+    });
+
+    expect(normalizeProviderToolEvent(piRead, "pi")).toMatchObject({
+      provider: "pi",
+      action: "read",
+    });
+    expect(normalizeProviderToolEvent(piRead, "claude-code")).toBeNull();
+    expect(normalizeProviderToolEvent(piRead, "codex")).toBeNull();
+    expect(normalizeProviderToolEvent(piRead, null)).toBeNull();
+
+    expect(normalizeProviderToolEvent(claudeRead, "claude-code")).toMatchObject(
+      { provider: "claude", action: "read" },
+    );
+    expect(normalizeProviderToolEvent(claudeRead, "pi")).toBeNull();
+    expect(normalizeProviderToolEvent(codexRead, "codex")).toMatchObject({
+      action: "read",
+    });
+    expect(normalizeProviderToolEvent(codexRead, "claude-code")).toBeNull();
+
+    const historicalBash = claudeToolUse({
+      name: "bash",
+      input: { command: "printf historical" },
+    });
+    expect(normalizeProviderToolEvent(historicalBash, null)).toMatchObject({
+      provider: "claude",
+      action: "run",
+    });
+  });
+
+  it("maps exact Pi actions and structured terminal states", () => {
+    const cases = [
+      {
+        name: "bash",
+        input: { command: "  printf\tpi\n " },
+        action: "run",
+        summary: "Running printf pi",
+      },
+      {
+        name: "read",
+        input: { path: " /workspace/read.ts " },
+        action: "read",
+        summary: "Reading /workspace/read.ts",
+      },
+      {
+        name: "write",
+        input: { path: "/workspace/write.ts", content: "raw content" },
+        action: "write",
+        summary: "Writing /workspace/write.ts",
+      },
+      {
+        name: "edit",
+        input: { path: "/workspace/edit.ts", diff: "raw diff" },
+        action: "edit",
+        summary: "Editing /workspace/edit.ts",
+      },
+    ] as const;
+    for (const fixture of cases) {
+      expect(
+        normalizeProviderToolEvent(
+          claudeToolUse({ name: fixture.name, input: fixture.input }),
+          "pi",
+        ),
+      ).toStrictEqual({
+        kind: "correlated",
+        provider: "pi",
+        providerOperationId: "claude-operation-1",
+        action: fixture.action,
+        status: "pending",
+        summary: fixture.summary,
+      });
+    }
+
+    const result = (
+      id: string,
+      isError: unknown,
+      cancelled: unknown = undefined,
+    ) => {
+      return agentEvent(2, {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: id,
+              is_error: isError,
+              vm0_user_cancelled: cancelled,
+              content: "raw Pi result must not be projected",
+              error: "raw Pi error must not be projected",
+            },
+          ],
+        },
+      });
+    };
+    expect(
+      normalizeProviderToolEvent(result("success", false), "pi"),
+    ).toStrictEqual({
+      kind: "correlated-terminal",
+      provider: "pi",
+      providerOperationId: "success",
+      status: "success",
+    });
+    expect(
+      normalizeProviderToolEvent(result("error", true), "pi"),
+    ).toStrictEqual({
+      kind: "correlated-terminal",
+      provider: "pi",
+      providerOperationId: "error",
+      status: "error",
+    });
+    expect(
+      normalizeProviderToolEvent(result("cancelled", true, true), "pi"),
+    ).toStrictEqual({
+      kind: "correlated-terminal",
+      provider: "pi",
+      providerOperationId: "cancelled",
+      status: "cancelled",
+      requiresPendingOperation: true,
+    });
+  });
+
+  it("fails closed for unsupported, malformed, and unsafe Pi records", () => {
+    const malformedResults = [
+      { tool_use_id: "missing-error" },
+      { tool_use_id: "string-error", is_error: "false" },
+      { tool_use_id: " ", is_error: false },
+    ];
+    const events = [
+      claudeToolUse({ name: "Bash", input: { command: "pwd" } }),
+      claudeToolUse({ name: "Read", input: { path: "/workspace/a" } }),
+      claudeToolUse({ name: "read", input: { file_path: "/workspace/a" } }),
+      claudeToolUse({ name: "read", input: { path: "   " } }),
+      claudeToolUse({ name: "read", input: { path: "bad\0path" } }),
+      claudeToolUse({
+        name: "bash",
+        input: { command: "/bin/bash -lc 'unterminated" },
+      }),
+      claudeToolUse({ name: "search", input: { query: "needle" } }),
+      ...malformedResults.map((block) => {
+        return agentEvent(2, {
+          type: "user",
+          message: { content: [{ type: "tool_result", ...block }] },
+        });
+      }),
+      agentEvent(3, {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "multi",
+              name: "read",
+              input: { path: "/workspace/a" },
+            },
+            { type: "text", text: "not canonical" },
+          ],
+        },
+      }),
+    ];
+    for (const event of events) {
+      expect(normalizeProviderToolEvent(event, "pi")).toBeNull();
+    }
+  });
 });
 
 describe("tool event identity", () => {
@@ -511,6 +696,11 @@ describe("tool event identity", () => {
       "codex",
       "provider-operation-secret",
     );
+    const piOperationId = toolUseIdForProviderOperation(
+      RUN_ID,
+      "pi",
+      "provider-operation-secret",
+    );
 
     expect(transcriptId).toBe("ae848beb-761a-548f-8929-874f825c4b37");
     expect(pendingRowId).toBe("20054cbd-fac3-585a-8641-99a881e3900e");
@@ -525,6 +715,9 @@ describe("tool event identity", () => {
     expect(pendingRowId).not.toBe(terminalRowId);
     expect(pendingRowId).not.toBe(transcriptId);
     expect(claudeOperationId).not.toBe(codexOperationId);
+    expect(piOperationId).not.toBe(claudeOperationId);
+    expect(piOperationId).not.toBe(codexOperationId);
+    expect(piOperationId).not.toContain("provider-operation-secret");
     expect(claudeOperationId).not.toContain("provider-operation-secret");
     expect(toolUseIdForRunEvent(RUN_ID, "tool:event:4")).not.toBe(
       toolUseIdForRunEvent(RUN_ID, "tool:event:5"),

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -7,6 +7,7 @@ import { and, asc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
+import type { AgentRunLaunchSnapshot } from "@okouai/db/jsonb-contracts/agent-run-session-conversation";
 
 import type {
   AgentEvent,
@@ -248,6 +249,7 @@ function toolRunEventId(sequenceNumber: number): string {
 function assistantEventItems(args: {
   readonly events: readonly AgentEvent[];
   readonly runId: string;
+  readonly framework: AgentRunLaunchSnapshot["framework"] | null;
   readonly toolActivityEnabled: boolean;
   readonly priorToolOperations: ReadonlyMap<string, ToolOperationState>;
 }): InsertAssistantEventsInput["items"] {
@@ -282,7 +284,7 @@ function assistantEventItems(args: {
     if (!args.toolActivityEnabled) {
       continue;
     }
-    const normalized = normalizeAgentToolEvent(event);
+    const normalized = normalizeAgentToolEvent(event, args.framework);
     if (normalized === null) {
       continue;
     }
@@ -314,6 +316,12 @@ function assistantEventItems(args: {
     );
     const prior = toolOperations.get(toolUseId);
     if (normalized.kind === "correlated-terminal") {
+      if (
+        normalized.requiresPendingOperation === true &&
+        prior?.status !== "pending"
+      ) {
+        continue;
+      }
       const sourceOperation =
         prior ??
         (normalized.standaloneOperation === undefined
@@ -408,6 +416,7 @@ async function insertRunOutputChatEvents(
   const [run] = await tx
     .select({
       chatToolActivityEnabled: agentRuns.chatToolActivityEnabled,
+      launchSnapshot: agentRuns.launchSnapshot,
     })
     .from(agentRuns)
     .where(eq(agentRuns.id, payload.runId))
@@ -425,6 +434,7 @@ async function insertRunOutputChatEvents(
   const assistantItems = assistantEventItems({
     events: payload.events,
     runId: payload.runId,
+    framework: run.launchSnapshot?.framework ?? null,
     toolActivityEnabled,
     priorToolOperations,
   });

--- a/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
+++ b/turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts
@@ -1,15 +1,18 @@
 import type { OutputToolPayload } from "@okouai/api-contracts/contracts/chat-events";
+import type { AgentRunLaunchSnapshot } from "@okouai/db/jsonb-contracts/agent-run-session-conversation";
 
 import type { AgentEvent } from "../../lib/event-consumer/verify";
 
 type ToolAction = OutputToolPayload["action"];
 type ToolTerminalStatus = Exclude<OutputToolPayload["status"], "pending">;
 type ToolSummaryLifecycle = "pending" | "terminal";
+type ToolCorrelationProvider = "claude" | "codex" | "pi";
+type ToolEventFramework = AgentRunLaunchSnapshot["framework"] | null;
 
 type NormalizedAgentToolEvent =
   | {
       readonly kind: "correlated";
-      readonly provider: "claude" | "codex";
+      readonly provider: ToolCorrelationProvider;
       readonly providerOperationId: string;
       readonly action: ToolAction;
       readonly status: "pending";
@@ -17,9 +20,10 @@ type NormalizedAgentToolEvent =
     }
   | {
       readonly kind: "correlated-terminal";
-      readonly provider: "claude" | "codex";
+      readonly provider: ToolCorrelationProvider;
       readonly providerOperationId: string;
       readonly status: ToolTerminalStatus;
+      readonly requiresPendingOperation?: true;
       readonly standaloneOperation?: {
         readonly action: ToolAction;
         readonly summary: string;
@@ -262,7 +266,9 @@ function decodedToolCommand(value: unknown): string | null {
   return command;
 }
 
-function claudeContentBlock(event: AgentEvent): Record<string, unknown> | null {
+function singleMessageContentBlock(
+  event: AgentEvent,
+): Record<string, unknown> | null {
   const message = recordOf(event.message);
   const content = message?.content;
   if (!Array.isArray(content) || content.length !== 1) {
@@ -275,7 +281,7 @@ function claudeToolUse(event: AgentEvent): NormalizedAgentToolEvent | null {
   if (event.type !== "assistant") {
     return null;
   }
-  const block = claudeContentBlock(event);
+  const block = singleMessageContentBlock(event);
   if (block?.type !== "tool_use") {
     return null;
   }
@@ -336,7 +342,7 @@ function claudeToolResult(event: AgentEvent): NormalizedAgentToolEvent | null {
   if (event.type !== "user") {
     return null;
   }
-  const block = claudeContentBlock(event);
+  const block = singleMessageContentBlock(event);
   if (block?.type !== "tool_result") {
     return null;
   }
@@ -491,14 +497,118 @@ function codexFile(event: AgentEvent): NormalizedAgentToolEvent | null {
     : { kind: "standalone", action, status, summary };
 }
 
+function piToolUse(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "assistant") {
+    return null;
+  }
+  const block = singleMessageContentBlock(event);
+  if (block?.type !== "tool_use") {
+    return null;
+  }
+  const providerOperationId = nonBlankProviderId(block.id);
+  const input = recordOf(block.input);
+  if (providerOperationId === null || input === null) {
+    return null;
+  }
+
+  let action: ToolAction;
+  let target: unknown;
+  switch (block.name) {
+    case "bash": {
+      action = "run";
+      target = decodedToolCommand(input.command);
+      break;
+    }
+    case "read": {
+      action = "read";
+      target = input.path;
+      break;
+    }
+    case "write": {
+      action = "write";
+      target = input.path;
+      break;
+    }
+    case "edit": {
+      action = "edit";
+      target = input.path;
+      break;
+    }
+    default: {
+      return null;
+    }
+  }
+  const summary = toolSummary(action, "pending", target);
+  if (summary === null) {
+    return null;
+  }
+  return {
+    kind: "correlated",
+    provider: "pi",
+    providerOperationId,
+    action,
+    status: "pending",
+    summary,
+  };
+}
+
+function piToolResult(event: AgentEvent): NormalizedAgentToolEvent | null {
+  if (event.type !== "user") {
+    return null;
+  }
+  const block = singleMessageContentBlock(event);
+  if (block?.type !== "tool_result" || typeof block.is_error !== "boolean") {
+    return null;
+  }
+  const providerOperationId = nonBlankProviderId(block.tool_use_id);
+  if (providerOperationId === null) {
+    return null;
+  }
+  const cancelled = block.vm0_user_cancelled === true;
+  return {
+    kind: "correlated-terminal",
+    provider: "pi",
+    providerOperationId,
+    status: cancelled ? "cancelled" : block.is_error ? "error" : "success",
+    ...(cancelled ? { requiresPendingOperation: true } : {}),
+  };
+}
+
+function normalizeClaudeToolEvent(
+  event: AgentEvent,
+): NormalizedAgentToolEvent | null {
+  return claudeToolUse(event) ?? claudeToolResult(event);
+}
+
+function normalizeCodexToolEvent(
+  event: AgentEvent,
+): NormalizedAgentToolEvent | null {
+  return codexCommand(event) ?? codexFile(event);
+}
+
+function normalizePiToolEvent(
+  event: AgentEvent,
+): NormalizedAgentToolEvent | null {
+  return piToolUse(event) ?? piToolResult(event);
+}
+
 /** Normalize one already-masked, already-sequenced provider event. */
 export function normalizeAgentToolEvent(
   event: AgentEvent,
+  framework: ToolEventFramework,
 ): NormalizedAgentToolEvent | null {
-  return (
-    claudeToolUse(event) ??
-    claudeToolResult(event) ??
-    codexCommand(event) ??
-    codexFile(event)
-  );
+  switch (framework) {
+    case "claude-code": {
+      return normalizeClaudeToolEvent(event);
+    }
+    case "codex": {
+      return normalizeCodexToolEvent(event);
+    }
+    case "pi": {
+      return normalizePiToolEvent(event);
+    }
+    case null: {
+      return normalizeClaudeToolEvent(event) ?? normalizeCodexToolEvent(event);
+    }
+  }
 }

--- a/turbo/apps/api/src/signals/services/assistant-event-id.ts
+++ b/turbo/apps/api/src/signals/services/assistant-event-id.ts
@@ -28,7 +28,7 @@ export function toolEventIdForRunEvent(
 /** Provider IDs are derivation seeds only; the returned correlation is opaque. */
 export function toolUseIdForProviderOperation(
   runId: string,
-  provider: "claude" | "codex",
+  provider: "claude" | "codex" | "pi",
   providerOperationId: string,
 ): string {
   return uuidv5(


### PR DESCRIPTION
## Summary

- dispatch Chat Tool Activity through the durable launch framework with an explicit Pi adapter
- map exact Pi bash/read/write/edit calls and structured results into the existing append-only output.tool lifecycle
- preserve opaque provider-separated correlation and carry explicit user cancellation from guest-agent state
- cover masking, gating, ordering, retries, replay, correlation, malformed input, and Claude/Codex regressions

## Fallbacks

- `agent-tool-event-normalization.ts:normalizeAgentToolEvent` retains the existing Claude/Codex shape-based adapter chain only when a historical Run has no persisted `launchSnapshot`; it never admits Pi. Surface: legitimately nullable persisted Run history predating launch snapshots. Removal condition: no retained Run can have a null snapshot, either through retention expiry or an explicit backfill. #29615 explicitly excludes historical backfill, so removal is not scheduled in this PR.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- affected Turbo/API/platform type checks
- 47 focused Vitest cases across normalization, materialization, masking, snapshots, and UI behavior
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`
- targeted Pi cancellation projection test (1 passed; 614 filtered)
- the exhaustive local guest-agent integration fan-out was attempted twice but exceeded the 16 GiB workspace volume while linking unrelated integration binaries; PR CI owns the full clean-environment result

Closes #29615