### PR TITLE
fix(platform): preserve connector list when dismissing account picker

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1945,6 +1945,7 @@
       "authorized": "{{connectorName}} verbunden und autorisiert für {{agentName}}",
       "available_one": "Verfügbare Integration ({{count}})",
       "available_other": "Verfügbare Integrationen ({{count}})",
+      "back": "Zurück",
       "configurePermissions": "Konfigurieren Sie {{connectorName}}-Berechtigungen",
       "customAuthorizeDescription": "Prüfen und verbinden Sie diese benutzerdefinierte Integration und autorisieren Sie sie für den Agenten.",
       "defaultAccountFor": "{{connector}} · Standardkonto wird verwendet: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1945,6 +1945,7 @@
       "authorized": "{{connectorName}} connected and authorized for {{agentName}}",
       "available_one": "Available connectors to connect ({{count}})",
       "available_other": "Available connectors to connect ({{count}})",
+      "back": "Back",
       "configurePermissions": "Configure {{connectorName}} permissions",
       "customAuthorizeDescription": "Review, connect, and authorize this custom connector for the agent.",
       "defaultAccountFor": "{{connector}} · Using default account: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1976,6 +1976,7 @@
       "available_one": "Conectores disponibles para conectar ({{count}})",
       "available_many": "Conectores disponibles para conectar ({{count}})",
       "available_other": "Conectores disponibles para conectar ({{count}})",
+      "back": "Volver",
       "configurePermissions": "Configurar permisos de {{connectorName}}",
       "customAuthorizeDescription": "Revisa, conecta y autoriza este conector personalizado para el agente.",
       "defaultAccountFor": "{{connector}} · Usando la cuenta predeterminada: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1976,6 +1976,7 @@
       "available_one": "Connecteurs disponibles à connecter ({{count}})",
       "available_many": "Connecteurs disponibles à connecter ({{count}})",
       "available_other": "Connecteurs disponibles à connecter ({{count}})",
+      "back": "Retour",
       "configurePermissions": "Configurer les autorisations de {{connectorName}}",
       "customAuthorizeDescription": "Examiner, connecter et autoriser ce connecteur personnalisé pour l'agent.",
       "defaultAccountFor": "{{connector}} · Compte par défaut utilisé : {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1945,6 +1945,7 @@
       "authorized": "{{connectorName}} जुड़ा हुआ है और {{agentName}} के लिए अधिकृत है",
       "available_one": "कनेक्ट करने के लिए उपलब्ध कनेक्टर ({{count}})",
       "available_other": "कनेक्ट करने के लिए उपलब्ध कनेक्टर ({{count}})",
+      "back": "पीछे",
       "configurePermissions": "{{connectorName}} अनुमतियाँ कॉन्फ़िगर करें",
       "customAuthorizeDescription": "एजेंट के लिए इस कस्टम कनेक्टर की समीक्षा करें, कनेक्ट करें और अधिकृत करें।",
       "defaultAccountFor": "{{connector}} · डिफ़ॉल्ट खाता उपयोग हो रहा है: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1942,6 +1942,7 @@
       "authorized": "{{connectorName}} terhubung dan diotorisasi untuk {{agentName}}",
       "available_one": "Konektor yang tersedia untuk dihubungkan ({{count}})",
       "available_other": "Konektor yang tersedia untuk dihubungkan ({{count}})",
+      "back": "Kembali",
       "configurePermissions": "Konfigurasikan izin {{connectorName}}",
       "customAuthorizeDescription": "Tinjau, hubungkan, dan otorisasi konektor kustom ini untuk agen.",
       "defaultAccountFor": "{{connector}} · Menggunakan akun default: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1976,6 +1976,7 @@
       "available_one": "Connettori disponibili per la connessione ({{count}})",
       "available_many": "Connettori disponibili per la connessione ({{count}})",
       "available_other": "Connettori disponibili per la connessione ({{count}})",
+      "back": "Indietro",
       "configurePermissions": "Configura le autorizzazioni {{connectorName}}",
       "customAuthorizeDescription": "Esamina, connetti e autorizza questo connettore personalizzato per l'agente.",
       "defaultAccountFor": "{{connector}} · Account predefinito in uso: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1942,6 +1942,7 @@
       "authorized": "{{connectorName}} が接続され、{{agentName}} に対して承認されました",
       "available_one": "接続可能なコネクタ ({{count}})",
       "available_other": "接続可能なコネクタ ({{count}})",
+      "back": "戻る",
       "configurePermissions": "{{connectorName}} 権限を構成する",
       "customAuthorizeDescription": "エージェント用のこのカスタム コネクタを確認、接続、承認します。",
       "defaultAccountFor": "{{connector}} · デフォルトアカウントを使用中: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1942,6 +1942,7 @@
       "authorized": "{{connectorName}}가 연결되고 {{agentName}}에 권한이 부여되었습니다",
       "available_one": "연결 가능한 커넥터 ({{count}})",
       "available_other": "연결 가능한 커넥터 ({{count}})",
+      "back": "뒤로",
       "configurePermissions": "{{connectorName}} 권한 구성",
       "customAuthorizeDescription": "이 맞춤 커넥터를 검토하고 연결한 후 에이전트에 권한을 부여하세요.",
       "defaultAccountFor": "{{connector}} · 기본 계정 사용 중: {{account}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1976,6 +1976,7 @@
       "available_one": "Conectores disponíveis para conectar ({{count}})",
       "available_many": "Conectores disponíveis para conectar ({{count}})",
       "available_other": "Conectores disponíveis para conectar ({{count}})",
+      "back": "Voltar",
       "configurePermissions": "Configurar permissões de {{connectorName}}",
       "customAuthorizeDescription": "Revise, conecte e autorize este conector personalizado para o agente.",
       "defaultAccountFor": "{{connector}} · Usando a conta padrão: {{account}}",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -505,12 +505,31 @@ describe("chat composer connector connection", () => {
     });
     expect(screen.queryByText("Use default")).not.toBeInTheDocument();
 
-    const summaryReadsBeforeSelection = summaryReads;
     await user.click(defaultMode);
     await expect(
       screen.findByText("Account for this thread"),
     ).resolves.toBeVisible();
-    expect(screen.queryByLabelText("Back")).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Back"));
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(defaultMode);
+    await expect(
+      screen.findByText("Account for this thread"),
+    ).resolves.toBeVisible();
+    await user.click(document.body);
+    await waitFor(() => {
+      expect(screen.queryByText("Account for this thread")).toBeNull();
+    });
+    expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(defaultMode);
+    await expect(
+      screen.findByText("Account for this thread"),
+    ).resolves.toBeVisible();
+    const summaryReadsBeforeSelection = summaryReads;
     expect(screen.getByText("GitHub")).toBeVisible();
     expect(
       queryAllByRoleFast("button").find((button) => {
@@ -576,6 +595,11 @@ describe("chat composer connector connection", () => {
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     expect(authorizationWrites).toBe(1);
     expect(summaryReads).toBe(summaryReadsBeforeSelection);
+
+    await user.click(document.body);
+    await waitFor(() => {
+      expect(connectorsButton).toHaveAttribute("aria-expanded", "false");
+    });
   });
 
   it("keeps the selected account visible when search has no matches", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8472,7 +8472,7 @@ function ComposerConnectorAccountMenuContent({
 
   return (
     <div className="flex max-h-[min(25rem,var(--available-height))] min-h-0 flex-col overflow-hidden">
-      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border/60 px-2 text-sm font-medium text-foreground">
+      <div className="flex h-12 shrink-0 items-center gap-0.5 border-b border-border/60 pl-1.5 pr-2 text-sm font-medium text-foreground">
         <Button
           type="button"
           variant="quiet"

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -34,6 +34,7 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import {
   AlertTriangle,
+  ArrowLeft,
   ArrowUp,
   Bolt,
   Check,
@@ -8471,10 +8472,23 @@ function ComposerConnectorAccountMenuContent({
 
   return (
     <div className="flex max-h-[min(25rem,var(--available-height))] min-h-0 flex-col overflow-hidden">
-      <div className="shrink-0 border-b border-border/60 px-3 py-2 text-sm font-medium text-foreground">
-        {t(($) => {
-          return $.chat.connectors.accountForThread;
-        })}
+      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border/60 px-2 text-sm font-medium text-foreground">
+        <Button
+          type="button"
+          variant="quiet"
+          size="icon-xs"
+          aria-label={t(($) => {
+            return $.chat.connectors.back;
+          })}
+          onClick={closeMenu}
+        >
+          <ArrowLeft size={16} aria-hidden="true" />
+        </Button>
+        <span className="min-w-0 flex-1 truncate">
+          {t(($) => {
+            return $.chat.connectors.accountForThread;
+          })}
+        </span>
       </div>
       {showSearch ? (
         <div className="shrink-0 border-b border-border/50 px-3 py-2">
@@ -8635,6 +8649,7 @@ function ConnectorsPopoverButton({
   const accountSummariesLoadable = useLastLoadable(
     signals.connector.accounts.summaryByTarget$,
   );
+  const accountMenuOpen = useGet(signals.connector.accounts.menuOpen$);
   const closeAccountMenu = useSet(signals.connector.accounts.closeMenu$);
   const openAccountsPopover = useSet(signals.connector.accounts.openPopover$);
   const search = connectorUi.popoverSearch;
@@ -8739,7 +8754,20 @@ function ConnectorsPopoverButton({
   };
 
   return (
-    <Popover onOpenChange={handleOpenChange}>
+    <Popover
+      onOpenChange={(open, eventDetails) => {
+        if (
+          !open &&
+          accountMenuOpen &&
+          eventDetails.reason === "outside-press"
+        ) {
+          eventDetails.cancel();
+          closeAccountMenu();
+          return;
+        }
+        handleOpenChange(open);
+      }}
+    >
       <TooltipProvider delayDuration={300}>
         <Tooltip>
           <PopoverTrigger asChild>


### PR DESCRIPTION
## Summary

- add a taller connector account picker header with a localized Back control
- keep the parent connector list open when the nested picker handles the first outside press
- cover Back, nested outside dismissal, parent dismissal, and existing account selection behavior through the chat page

## Scope

This is a Platform-only presentation and popover-dismissal change. It does not change connector authorization, account selection semantics, API contracts, persisted state, runner behavior, or rollout policy.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit full-repository Knip and `pnpm check-types`
- pre-commit Prettier, file-size check, and commitlint

Closes #29669

Parent context: #28571
