### PR TITLE
fix: align permission controls across scrollbar gutter

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
@@ -1531,7 +1531,7 @@ function LoadedPermissionsDrawerContent({
             )}
           </div>
           {!groups && !searchActive && (
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center justify-between gap-2 overflow-y-auto [scrollbar-gutter:stable]">
               <span className="text-xs font-medium text-foreground">
                 {readOnly
                   ? t(($) => {
@@ -1553,7 +1553,7 @@ function LoadedPermissionsDrawerContent({
         </div>
 
         <div
-          className={`flex-1 overflow-y-auto -mx-6 px-3 ${displayedGroups ? "pt-1" : ""}`}
+          className={`flex-1 overflow-y-auto -mx-6 px-3 [scrollbar-gutter:stable] ${displayedGroups ? "pt-1" : ""}`}
           onScroll={(e) => {
             const target = e.currentTarget;
             setScrolled(stateKey, target.scrollTop > 0, initialUiState);


### PR DESCRIPTION
## Summary

- reserve matching stable native-scrollbar gutters for the select-all row and the permission list
- keep Allow/Deny controls aligned with and without vertical overflow
- apply the fix to both dialog and sheet surfaces through their shared permission component

## Testing

- `pnpm exec prettier --write apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx --silent=passed-only` (24 tests)
- `pnpm knip --workspace apps/platform`
- pre-commit full Turbo type checks (14/14 tasks)
- browser verification on dialog and sheet surfaces with overflowing and non-overflowing lists, search filtering, Allow/Deny states, and narrow layout; measured 0 px right-edge difference between select-all and permission-row controls

## Scope

No permission policy behavior, API, data, or scrolling implementation changes.

Closes #29668
