### PR TITLE
fix(db): restore launch snapshot caller inventory

### DIFF
--- a/turbo/packages/db/scripts/test-agent-run-launch-snapshot.ts
+++ b/turbo/packages/db/scripts/test-agent-run-launch-snapshot.ts
@@ -361,7 +361,9 @@ function validateCallerIsolation(): void {
     "turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts",
     "turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts",
     "turbo/apps/api/src/signals/routes/test-runtime-state.ts",
+    "turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts",
     "turbo/apps/api/src/signals/services/agent-run-create.service.ts",
+    "turbo/apps/api/src/signals/services/agent-tool-event-normalization.ts",
     "turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts",
     "turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts",
     "turbo/apps/api/src/signals/services/log-detail-run-selection.ts",
@@ -618,9 +620,7 @@ export async function validateAgentRunLaunchSnapshotMigration(): Promise<void> {
     );
     console.log("   ✅ ordinary DML remains healthy under validation lock");
     console.log("   ✅ migration retries are exact and idempotent");
-    console.log(
-      "   ✅ runtime callers contain no launch-snapshot dependency\n",
-    );
+    console.log("   ✅ runtime launch-snapshot caller inventory is exact\n");
   } finally {
     await blocker.query("ROLLBACK");
     await migrator.query("ROLLBACK");


### PR DESCRIPTION
## Summary

- audit both #29665 launch-snapshot references as intentional durable-framework consumers
- add both paths to the exhaustive, sorted caller-isolation inventory
- keep the repair limited to the existing launch-snapshot validation script

## Caller audit

- `agent-event-consumer-run-output.service.ts` intentionally reads the immutable Run launch snapshot so output materialization dispatches each event through the framework that launched that Run.
- `agent-tool-event-normalization.ts` intentionally uses the DB-owned launch-snapshot framework type for the exact Claude Code, Codex, Pi, and historical-null dispatch contract.

No runtime coupling was removed because both references are required by #29665's durable-framework dispatch behavior.

## Verification

- `pnpm format`
- `git diff --check`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip` (configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/postgres pnpm --filter @okouai/db exec tsx scripts/test-agent-run-launch-snapshot.ts`

The focused standalone PostgreSQL harness passed the exhaustive caller assertion, strict v1 value checks, online migration behavior, and retry/idempotency checks. The full local Vitest suite and a development server were intentionally not run; the PR pipeline remains the supported-environment authority.

## Scope guard

- no migration, snapshot, schema, or Official Workflow changes
- auto-merge remains disabled pending independent controller review of this exact head

Closes #29673
Refs #29626
Refs #29660
Refs #28905
