### PR TITLE
fix(connectors): maintain granted scopes across refresh

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-firewall.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-firewall.ts
@@ -219,11 +219,13 @@ export function createFirewallApi(context: TestContext) {
       accessToken: string;
       refreshToken?: string;
       expiresIn?: number;
+      scope?: string;
     }): Response {
       return HttpResponse.json({
         access_token: args.accessToken,
         ...(args.refreshToken ? { refresh_token: args.refreshToken } : {}),
         ...(args.expiresIn !== undefined ? { expires_in: args.expiresIn } : {}),
+        ...(args.scope === undefined ? {} : { scope: args.scope }),
       });
     },
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -35,10 +35,14 @@ import {
   awsVerificationCode,
   createConnectorBddApi,
   mockAwsExternalCodeProvider,
+  mockTestOAuthAuthCodeProvider,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { setConnectorCredentialStorageState } from "./helpers/connector-credential-storage-state";
+import {
+  setConnectorCredentialStorageState,
+  setLegacyBuiltinOAuthScopes,
+} from "./helpers/connector-credential-storage-state";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
@@ -883,6 +887,120 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     }
     expect(refreshed.body.headers.Authorization).toBe("Bearer forced-access");
     expect(refreshed.body.refreshedConnectors).toStrictEqual(["test-oauth"]);
+  });
+
+  it("maintains authoritative and unknown OAuth grants across refresh", async () => {
+    const fw = createFirewallApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, headers } = await firewallRun();
+    if (!actor.orgId) {
+      throw new Error("Expected firewall actor to have an organization");
+    }
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+    mockTestOAuthAuthCodeProvider({
+      accessToken: "initial-scoped-access",
+      refreshToken: "initial-scoped-refresh",
+      scope: "read provider-added",
+    });
+    const start = await connectors.startOauth(actor, "test-oauth", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected test OAuth authorization state");
+    }
+    await connectors.completeOauthCallback("test-oauth", {
+      code: "scoped-refresh-code",
+      state,
+    });
+
+    const connected = await connectors.readConnectorBySlug(actor, "test-oauth");
+    expect(connected.oauthScopes).toStrictEqual(["read", "provider-added"]);
+    expect(connected.connectionStatus).toBe("connected");
+    const connectorSources = await exactSecretConnectorSources(actor, {
+      TEST_OAUTH_TOKEN: "test-oauth",
+    });
+    const forceRefresh = async (currentAccessToken: string) => {
+      const response = await fw.requestFirewallAuth(
+        headers,
+        {
+          encryptedSecrets: fw.encryptedSecretsBody({
+            TEST_OAUTH_TOKEN: currentAccessToken,
+          }),
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+          },
+          ...connectorSources,
+          forceRefresh: true,
+        },
+        [200],
+      );
+      if (response.status !== 200) {
+        throw new Error("Expected scoped connector refresh to succeed");
+      }
+      return response.body;
+    };
+
+    fw.mockTestOauthTokenRefresh(() => {
+      return fw.oauthTokenResponse({
+        accessToken: "narrow-scoped-access",
+        refreshToken: "narrow-scoped-refresh",
+        expiresIn: 3600,
+        scope: "provider-added",
+      });
+    });
+    const narrowed = await forceRefresh("initial-scoped-access");
+    expect(narrowed.headers.Authorization).toBe("Bearer narrow-scoped-access");
+    const narrowedConnector = await connectors.readConnectorBySlug(
+      actor,
+      "test-oauth",
+    );
+    expect(narrowedConnector.oauthScopes).toStrictEqual(["provider-added"]);
+    expect(narrowedConnector.connectionStatus).toBe("connected");
+    await expect(
+      connectors.readScopeDiff(actor, "test-oauth"),
+    ).resolves.toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes: ["read"],
+      storedScopes: ["read"],
+    });
+
+    fw.mockTestOauthTokenRefresh(() => {
+      return fw.oauthTokenResponse({
+        accessToken: "omitted-scope-access",
+        refreshToken: "omitted-scope-refresh",
+        expiresIn: 3600,
+      });
+    });
+    await forceRefresh("narrow-scoped-access");
+    const preservedConnector = await connectors.readConnectorBySlug(
+      actor,
+      "test-oauth",
+    );
+    expect(preservedConnector.oauthScopes).toStrictEqual(["provider-added"]);
+
+    await setLegacyBuiltinOAuthScopes(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorSlug: "test-oauth",
+      oauthScopes: ["legacy-requested"],
+    });
+    fw.mockTestOauthTokenRefresh(() => {
+      return fw.oauthTokenResponse({
+        accessToken: "legacy-unknown-access",
+        refreshToken: "legacy-unknown-refresh",
+        expiresIn: 3600,
+      });
+    });
+    await forceRefresh("omitted-scope-access");
+    const legacyUnknownConnector = await connectors.readConnectorBySlug(
+      actor,
+      "test-oauth",
+    );
+    expect(legacyUnknownConnector.oauthScopes).toStrictEqual([
+      "legacy-requested",
+    ]);
   });
 
   it("resolves a current connector token missing from the runtime namespace", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2245,7 +2245,10 @@ async function markRefreshSuccess(
   prepared: PreparedRefreshTokenContext,
   context: RefreshTokenContext,
   outputs: readonly ValidatedRefreshOutput[],
-  expiresIn: number | undefined,
+  refresh: {
+    readonly expiresIn?: number;
+    readonly scopes?: readonly string[];
+  },
 ): Promise<Record<string, string>> {
   const returnedSecretValues = await persistRefreshOutputValues(
     args,
@@ -2256,7 +2259,7 @@ async function markRefreshSuccess(
 
   const expiresAt = new Date(
     nowDate().getTime() +
-      (expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
+      (refresh.expiresIn ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS) * 1000,
   );
   if (prepared.sourceType === "model-provider") {
     if (args.sourceId) {
@@ -2319,6 +2322,9 @@ async function markRefreshSuccess(
   await args.db
     .update(connectors)
     .set({
+      ...(refresh.scopes === undefined
+        ? {}
+        : { oauthGrantedScopes: JSON.stringify(refresh.scopes) }),
       tokenExpiresAt: expiresAt,
       storageVersion: prepared.runtimeMethod.method.storage.version,
       needsReconnect: false,
@@ -2796,7 +2802,7 @@ async function refreshLockedAccessToken(args: {
     args.prepared,
     args.prepared.context,
     outputValidation.outputs,
-    refreshResult.value.expiresIn,
+    refreshResult.value,
   );
   const refreshedSecrets = runtimeSecretsFromRefreshResult({
     accessSourceKey: args.refreshArgs.accessSourceKey,

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -355,6 +355,7 @@ async function persistConnectorRefresh(
     readonly inputs: Readonly<Record<string, string>>;
     readonly orgId: string;
     readonly outputs: Readonly<Record<string, string | undefined>>;
+    readonly scopes?: readonly string[];
     readonly userId: string;
     readonly expiresIn: number | undefined;
   },
@@ -444,6 +445,9 @@ async function persistConnectorRefresh(
     await tx
       .update(connectors)
       .set({
+        ...(args.scopes === undefined
+          ? {}
+          : { oauthGrantedScopes: JSON.stringify(args.scopes) }),
         tokenExpiresAt,
         storageVersion: args.connection.runtimeMethod.method.storage.version,
         needsReconnect: false,
@@ -699,6 +703,9 @@ export async function refreshConnectorCredentialAccess(
           outputs: refreshed.value.outputs,
           userId: args.userId,
           expiresIn: refreshed.value.expiresIn,
+          ...(refreshed.value.scopes === undefined
+            ? {}
+            : { scopes: refreshed.value.scopes }),
           ...(args.featureSwitchContext === undefined
             ? {}
             : { featureSwitchContext: args.featureSwitchContext }),

--- a/turbo/packages/connectors/src/auth-providers/__tests__/effective-oauth-scopes.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/__tests__/effective-oauth-scopes.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { HttpResponse, http } from "msw";
 
 import type { ConnectorAuthMethodRuntimeConfig } from "../../connector-config";
-import { exchangeConnectorAuthCodeWithMethod } from "../connector-auth";
+import {
+  exchangeConnectorAuthCodeWithMethod,
+  refreshConnectorAuthProviderAccessTokenWithMethod,
+} from "../connector-auth";
 import { server } from "./test-server";
 
 const AUTH_CLIENT = {
@@ -88,6 +91,21 @@ async function exchangeWithAuthorizationUrl(
   });
 }
 
+async function refreshWithReportedScope(reportedScope?: string) {
+  vi.stubEnv("VM0_API_BACKEND_URL", "https://provider.example");
+  mockTestOAuthProvider(reportedScope);
+  return await refreshConnectorAuthProviderAccessTokenWithMethod(
+    {
+      connectorSlug: "test-oauth",
+      authMethodId: "oauth",
+      method: authMethod(["catalog-changed"]),
+      authClient: AUTH_CLIENT,
+      inputs: { refreshToken: "refresh-token" },
+    },
+    new AbortController().signal,
+  );
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -139,5 +157,25 @@ describe("effective OAuth scopes", () => {
     );
 
     expect(result.scopes).toEqual(["catalog-changed"]);
+  });
+});
+
+describe("reported OAuth refresh scopes", () => {
+  it("preserves a reported refresh grant", async () => {
+    const result = await refreshWithReportedScope("read provider-added");
+
+    expect(result.scopes).toEqual(["read", "provider-added"]);
+  });
+
+  it("preserves an explicitly reported empty refresh grant", async () => {
+    const result = await refreshWithReportedScope("");
+
+    expect(result.scopes).toEqual([]);
+  });
+
+  it("omits refresh scope metadata when the provider omits scope", async () => {
+    const result = await refreshWithReportedScope();
+
+    expect(result).not.toHaveProperty("scopes");
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/cloudflare.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/cloudflare.test.ts
@@ -192,6 +192,7 @@ describe("connector/providers/cloudflare", () => {
         accessToken: "new-cloudflare-access-token",
         refreshToken: "new-cloudflare-refresh-token",
         expiresIn: 7200,
+        scopes: null,
       });
     });
 
@@ -216,6 +217,7 @@ describe("connector/providers/cloudflare", () => {
         accessToken: "new-cloudflare-access-token",
         refreshToken: null,
         expiresIn: 7200,
+        scopes: null,
       });
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
@@ -302,6 +302,9 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
           access_token: `access-token-${tokenRequests}`,
           expires_in: 1800,
           id_token: `id-token-${tokenRequests}`,
+          ...(tokenRequests === 1
+            ? { scope: "openid user user.birthday" }
+            : {}),
           token_type: "Bearer",
         });
       }),
@@ -353,6 +356,7 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
         }),
       },
       expiresIn: 1800,
+      scopes: ["openid", "user", "user.birthday"],
     });
     expect(catalogHeaders?.get("authorization")).toBe("Bearer id-token-1");
     expect(catalogHeaders?.get("x-moon-app-language")).toBe("fr");

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/playstation.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/playstation.test.ts
@@ -326,6 +326,7 @@ describe("PlayStation external-code provider", () => {
         idToken: jwtPayload({ sub: "psn-account-123" }),
       },
       expiresIn: 1800,
+      scopes: ["psn:mobile.v2.core", "psn:clientapp"],
     });
 
     expect(captured.tokenRequestBody?.get("grant_type")).toBe("refresh_token");

--- a/turbo/packages/connectors/src/auth-providers/connectors/ahrefs/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/ahrefs/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const AHREFS_TOKEN_URL = "https://app.ahrefs.com/api/token";
 
@@ -29,6 +29,7 @@ interface AhrefsRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -143,6 +144,7 @@ export async function refreshAhrefsToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -160,6 +162,7 @@ export async function refreshAhrefsToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const AIRTABLE_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
 
@@ -28,6 +28,7 @@ interface AirtableRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -185,6 +186,7 @@ export async function refreshAirtableToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -202,6 +204,7 @@ export async function refreshAirtableToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/asana/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/asana/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const ASANA_TOKEN_URL = "https://app.asana.com/-/oauth_token";
 
@@ -25,6 +26,7 @@ interface AsanaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -186,6 +188,7 @@ export async function refreshAsanaToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
     })
     .parse(await response.json());
@@ -202,5 +205,6 @@ export async function refreshAsanaToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/base44/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/base44/oauth.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../provider-flow-types";
 import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const BASE44_DEVICE_AUTH_URL = "https://app.base44.com/oauth/device/code";
 const BASE44_TOKEN_URL = "https://app.base44.com/oauth/token";
@@ -212,6 +213,7 @@ export async function refreshBase44Token(
     accessToken: requireAccessToken(data, "refresh"),
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, /\s+/),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const BOX_TOKEN_URL = "https://api.box.com/oauth2/token";
 
@@ -28,6 +28,7 @@ interface BoxRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 export function buildBoxAuthorizationUrl(
@@ -133,6 +134,7 @@ export async function refreshBoxToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -149,6 +151,7 @@ export async function refreshBoxToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/cal-com/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/cal-com/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const AUTHORIZATION_URL = "https://app.cal.com/auth/oauth2/authorize";
 const TOKEN_URL = "https://api.cal.com/v2/auth/oauth2/token";
@@ -118,5 +118,6 @@ export async function refreshCalComToken(
     accessToken: token.access_token,
     refreshToken: token.refresh_token ?? null,
     expiresIn: token.expires_in,
+    scopes: reportedOAuthScopes(token.scope, /[ ,]+/),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const CANVA_TOKEN_URL = "https://api.canva.com/rest/v1/oauth/token";
 
@@ -30,6 +30,7 @@ interface CanvaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -127,6 +128,7 @@ export async function refreshCanvaToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -144,6 +146,7 @@ export async function refreshCanvaToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const CLOSE_TOKEN_URL = "https://api.close.com/oauth2/token/";
 
@@ -26,6 +26,7 @@ interface CloseRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -143,6 +144,7 @@ export async function refreshCloseToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -160,6 +162,7 @@ export async function refreshCloseToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth";
 const CLOUDFLARE_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
@@ -27,6 +27,7 @@ interface CloudflareRefreshResult {
   readonly accessToken: string;
   readonly refreshToken: string | null;
   readonly expiresIn?: number;
+  readonly scopes: readonly string[] | null;
 }
 
 function basicAuthHeader(clientId: string, clientSecret: string): string {
@@ -141,6 +142,7 @@ export async function refreshCloudflareToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -157,6 +159,7 @@ export async function refreshCloudflareToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/datadog/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/datadog/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const AUTHORIZATION_URL = "https://app.datadoghq.com/oauth2/v1/authorize";
 const DATADOG_DOMAINS = new Set([
@@ -170,5 +170,6 @@ export async function refreshDatadogToken(
     accessToken: token.access_token,
     refreshToken: token.refresh_token ?? null,
     expiresIn: token.expires_in,
+    scopes: reportedOAuthScopes(token.scope, " "),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const DEEL_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
 
@@ -29,6 +29,7 @@ interface DeelRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 const deelPersonSchema = z
@@ -145,6 +146,7 @@ export async function refreshDeelToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -162,6 +164,7 @@ export async function refreshDeelToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const DOCUSIGN_TOKEN_URL = "https://account-d.docusign.com/oauth/token";
 
@@ -29,6 +29,7 @@ interface DocuSignRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -192,6 +193,7 @@ export async function refreshDocuSignToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -209,6 +211,7 @@ export async function refreshDocuSignToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const DROPBOX_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
 
@@ -30,6 +30,7 @@ interface DropboxRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -147,6 +148,7 @@ export async function refreshDropboxToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -164,6 +166,7 @@ export async function refreshDropboxToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
@@ -88,7 +88,6 @@ export async function exchangeFigmaCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
-      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })

--- a/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/figma/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const FIGMA_TOKEN_URL = "https://api.figma.com/v1/oauth/token";
 
@@ -27,6 +28,7 @@ interface FigmaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -86,6 +88,7 @@ export async function exchangeFigmaCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -148,6 +151,7 @@ export async function refreshFigmaToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -165,6 +169,7 @@ export async function refreshFigmaToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
@@ -128,7 +128,6 @@ export async function exchangeGarminConnectCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
-      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })

--- a/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const GARMIN_CONNECT_TOKEN_URL =
   "https://diauth.garmin.com/di-oauth2-service/oauth/token";
@@ -30,6 +31,7 @@ interface GarminConnectRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -126,6 +128,7 @@ export async function exchangeGarminConnectCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -185,6 +188,7 @@ export async function refreshGarminConnectToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -202,6 +206,7 @@ export async function refreshGarminConnectToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const GUMROAD_TOKEN_URL = "https://gumroad.com/oauth/token";
 
@@ -29,6 +29,7 @@ interface GumroadRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 export function buildGumroadAuthorizationUrl(
@@ -132,6 +133,7 @@ export async function refreshGumroadToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().nullable().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -149,6 +151,7 @@ export async function refreshGumroadToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in ?? undefined,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/hubspot/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/hubspot/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const HUBSPOT_TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
 
@@ -27,6 +28,7 @@ interface HubSpotRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -81,6 +83,7 @@ export async function exchangeHubSpotCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -138,6 +141,7 @@ export async function refreshHubSpotToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -155,6 +159,7 @@ export async function refreshHubSpotToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/hubspot/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/hubspot/oauth.ts
@@ -83,7 +83,6 @@ export async function exchangeHubSpotCode(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
-      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
 
@@ -30,6 +30,7 @@ interface LinearRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -147,6 +148,7 @@ export async function refreshLinearToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -164,6 +166,7 @@ export async function refreshLinearToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, ","),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const MERCURY_ENDPOINTS = {
   production: {
@@ -76,6 +76,7 @@ interface MercuryRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -198,6 +199,7 @@ export async function refreshMercuryToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -215,6 +217,7 @@ export async function refreshMercuryToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/monday/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/monday/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const MONDAY_TOKEN_URL = "https://auth.monday.com/oauth2/token";
 
@@ -26,6 +26,7 @@ interface MondayRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 const MONDAY_GRAPHQL_URL = "https://api.monday.com/v2";
@@ -142,6 +143,7 @@ export async function refreshMondayToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -159,6 +161,7 @@ export async function refreshMondayToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/neon/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/neon/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const NEON_TOKEN_URL = "https://oauth2.neon.tech/oauth2/token";
 
@@ -28,6 +28,7 @@ interface NeonRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -144,6 +145,7 @@ export async function refreshNeonToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -161,6 +163,7 @@ export async function refreshNeonToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-account.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-account.ts
@@ -33,7 +33,7 @@ export interface NintendoAccountToken {
   readonly accessToken: string;
   readonly expiresIn?: number;
   readonly idToken: string;
-  readonly scopes: readonly string[];
+  readonly scopes: readonly string[] | null;
   readonly tokenType: string;
 }
 
@@ -259,9 +259,9 @@ export async function exchangeNintendoAccountSessionTokenCode(
 
 function normalizeScopes(
   scope: string | readonly string[] | undefined,
-): readonly string[] {
+): readonly string[] | null {
   if (typeof scope !== "string") {
-    return scope ?? [];
+    return scope ?? null;
   }
   return scope.split(/\s+/u).filter((value: string) => {
     return value.length > 0;

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
@@ -71,7 +71,7 @@ function createNintendoStoreExternalCodeGrantProvider(): ExternalCodeConnectorAu
         },
         expiresIn: token.expiresIn,
         scopes:
-          token.scopes.length > 0
+          token.scopes !== null && token.scopes.length > 0
             ? token.scopes
             : args.externalCodeGrant.scopes,
         userInfo: nintendoStoreUserInfo(token.idToken),
@@ -107,6 +107,7 @@ function createNintendoStoreRefreshTokenAccessProvider(): RefreshTokenAccessProv
           locale: locale.locale,
         },
         expiresIn: token.expiresIn,
+        ...(token.scopes === null ? {} : { scopes: token.scopes }),
       };
     },
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
@@ -96,7 +96,7 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
         },
         expiresIn: token.expiresIn,
         scopes:
-          token.scopes.length > 0
+          token.scopes !== null && token.scopes.length > 0
             ? token.scopes
             : args.externalCodeGrant.scopes,
         userInfo: nintendoSwitchParentalControlsUserInfo(token.idToken),
@@ -166,6 +166,7 @@ function createRefreshTokenAccessProvider(): RefreshTokenAccessProvider<
           ...(deviceCatalog === undefined ? {} : { deviceCatalog }),
         },
         expiresIn: token.expiresIn,
+        ...(token.scopes === null ? {} : { scopes: token.scopes }),
       };
     },
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/notion/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/notion/oauth.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
 
@@ -25,6 +26,7 @@ interface NotionRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -157,6 +159,7 @@ export async function refreshNotionToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -174,5 +177,6 @@ export async function refreshNotionToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/playstation/api.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/playstation/api.ts
@@ -22,7 +22,7 @@ interface PlaystationAuthToken {
   readonly idToken: string;
   readonly refreshToken: string;
   readonly refreshTokenExpiresIn?: number;
-  readonly scope: string;
+  readonly scope: string | null;
   readonly tokenType: string;
 }
 
@@ -205,7 +205,7 @@ function playstationTokenFromResponse(
     ...(raw.refresh_token_expires_in === undefined
       ? {}
       : { refreshTokenExpiresIn: raw.refresh_token_expires_in }),
-    scope: raw.scope ?? "",
+    scope: raw.scope ?? null,
     tokenType: raw.token_type ?? "bearer",
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/playstation/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/playstation/provider.ts
@@ -2,6 +2,7 @@ import type {
   ExternalCodeConnectorAuthProvider,
   RefreshTokenAccessProvider,
 } from "../../types";
+import { reportedOAuthScopes } from "../../oauth/scope";
 import {
   buildPlaystationNpssoUrl,
   exchangePlaystationAccessCodeForAuthTokens,
@@ -79,6 +80,7 @@ function createPlaystationRefreshTokenAccessProvider(): RefreshTokenAccessProvid
         },
         signal,
       );
+      const scopes = reportedOAuthScopes(token.scope, " ");
       return {
         outputs: {
           accessToken: token.accessToken,
@@ -86,6 +88,7 @@ function createPlaystationRefreshTokenAccessProvider(): RefreshTokenAccessProvid
           idToken: token.idToken,
         },
         expiresIn: token.expiresIn,
+        ...(scopes === null ? {} : { scopes }),
       };
     },
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/posthog/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/posthog/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const POSTHOG_TOKEN_URL = "https://us.posthog.com/oauth/token";
 
@@ -28,6 +28,7 @@ interface PosthogRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -141,6 +142,7 @@ export async function refreshPosthogToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -158,6 +160,7 @@ export async function refreshPosthogToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const QUICKBOOKS_TOKEN_URL =
   "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
@@ -32,6 +32,7 @@ interface QuickBooksRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 export function buildQuickBooksAuthorizationUrl(
@@ -164,6 +165,7 @@ export async function refreshQuickBooksToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -180,6 +182,7 @@ export async function refreshQuickBooksToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/reddit/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/reddit/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const REDDIT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token";
 
@@ -152,6 +152,7 @@ interface RedditRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -188,6 +189,7 @@ export async function refreshRedditToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -205,5 +207,6 @@ export async function refreshRedditToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/sentry/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/sentry/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const SENTRY_TOKEN_URL = "https://sentry.io/oauth/token/";
 
@@ -26,6 +26,7 @@ interface SentryRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -154,6 +155,7 @@ export async function refreshSentryToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -171,5 +173,6 @@ export async function refreshSentryToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/slock/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slock/oauth.ts
@@ -431,5 +431,6 @@ export async function refreshSlockToken(
     accessToken,
     refreshToken: data.refreshToken ?? null,
     expiresIn: accessTokenExpiresIn(accessToken),
+    scopes: null,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
@@ -28,6 +28,7 @@ interface SpotifyRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -148,6 +149,7 @@ export async function refreshSpotifyToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -165,6 +167,7 @@ export async function refreshSpotifyToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/strava/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/strava/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 
@@ -28,6 +28,7 @@ interface StravaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -162,6 +163,7 @@ export async function refreshStravaToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -179,6 +181,7 @@ export async function refreshStravaToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, /[ ,]+/),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const STRIPE_TOKEN_URL = "https://connect.stripe.com/oauth/token";
 
@@ -28,6 +28,7 @@ interface StripeRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -146,6 +147,7 @@ export async function refreshStripeToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -163,6 +165,7 @@ export async function refreshStripeToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const SUPABASE_TOKEN_URL = "https://api.supabase.com/v1/oauth/token";
 
@@ -30,6 +30,7 @@ interface SupabaseRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -127,6 +128,7 @@ export async function refreshSupabaseToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -144,6 +146,7 @@ export async function refreshSupabaseToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 const TEST_OAUTH_AUTHORIZATION_URL = "/api/test/oauth-provider/authorize";
 const TEST_OAUTH_TOKEN_URL = "/api/test/oauth-provider/token";
@@ -26,6 +26,10 @@ interface TokenResponse {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
+}
+
+interface GrantTokenResponse extends Omit<TokenResponse, "scopes"> {
   scopes: string[];
 }
 
@@ -185,7 +189,6 @@ const tokenResponseSchema = z.object({
 async function postToken(
   body: URLSearchParams,
   operation: "exchange" | "refresh",
-  authorizationScopes: readonly string[],
   signal: AbortSignal | undefined,
 ): Promise<TokenResponse> {
   const response = await fetch(getTestOAuthTokenUrl(), {
@@ -208,7 +211,7 @@ async function postToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: effectiveOAuthScopes(data.scope, authorizationScopes, " "),
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 
@@ -218,8 +221,8 @@ export async function exchangeTestOAuthCode(
   clientSecret: string,
   code: string,
   redirectUri: string,
-): Promise<TokenResponse> {
-  return postToken(
+): Promise<GrantTokenResponse> {
+  const token = await postToken(
     new URLSearchParams({
       grant_type: "authorization_code",
       client_id: clientId,
@@ -228,9 +231,12 @@ export async function exchangeTestOAuthCode(
       redirect_uri: redirectUri,
     }),
     "exchange",
-    authCodeGrant.scopes,
     undefined,
   );
+  return {
+    ...token,
+    scopes: token.scopes ?? [...authCodeGrant.scopes],
+  };
 }
 
 export async function refreshTestOAuthToken(
@@ -247,7 +253,6 @@ export async function refreshTestOAuthToken(
       refresh_token: refreshToken,
     }),
     "refresh",
-    [],
     signal,
   );
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -35,6 +35,7 @@ interface TestOAuthApiRefreshResult {
     readonly refreshedTenantId?: string;
   };
   readonly expiresIn?: number;
+  readonly scopes?: readonly string[];
 }
 
 interface TestOAuthApiTokenRefreshResult {
@@ -212,6 +213,7 @@ function createTestOauthApiAccess(): RefreshTokenAccessProvider<
         ...(result.expiresIn === undefined
           ? {}
           : { expiresIn: result.expiresIn }),
+        ...(result.scopes === null ? {} : { scopes: result.scopes }),
       };
       return providerResult;
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/x/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/x/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const X_TOKEN_URL = "https://api.x.com/2/oauth2/token";
 
@@ -29,6 +29,7 @@ interface XRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -126,6 +127,7 @@ export async function refreshXToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -143,6 +145,7 @@ export async function refreshXToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
 
@@ -30,6 +30,7 @@ interface XeroRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -146,6 +147,7 @@ export async function refreshXeroToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -163,6 +165,7 @@ export async function refreshXeroToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
-import { effectiveOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const ZOOM_TOKEN_URL = "https://zoom.us/oauth/token";
 
@@ -28,6 +28,7 @@ interface ZoomRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -151,6 +152,7 @@ export async function refreshZoomToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -168,6 +170,7 @@ export async function refreshZoomToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/model-providers/codex-oauth/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/model-providers/codex-oauth/oauth.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { throwOAuthError } from "../../oauth/error";
+import { reportedOAuthScopes } from "../../oauth/scope";
 
 export const CHATGPT_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const CHATGPT_OAUTH_ISSUER = "https://auth.openai.com";
@@ -46,6 +47,7 @@ interface ChatgptRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 const refreshResponseSchema = z.object({
@@ -53,6 +55,7 @@ const refreshResponseSchema = z.object({
   access_token: z.string().optional(),
   refresh_token: z.string().nullable().optional(),
   expires_in: z.number().optional(),
+  scope: z.string().optional(),
 });
 
 const refreshErrorBodySchema = z.object({
@@ -120,6 +123,7 @@ export async function refreshChatgptToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/google.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/google.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "./error";
-import { effectiveOAuthScopes } from "./scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "./scope";
 
 type GoogleOAuthConnectorSlug =
   | "gmail"
@@ -47,6 +47,7 @@ interface GoogleRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -169,6 +170,7 @@ export async function refreshGoogleToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -186,6 +188,7 @@ export async function refreshGoogleToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/microsoft.ts
@@ -2,7 +2,7 @@ import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-
 import { z } from "zod";
 
 import { throwOAuthError } from "./error";
-import { effectiveOAuthScopes } from "./scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "./scope";
 
 const MICROSOFT_TOKEN_URL =
   "https://login.microsoftonline.com/common/oauth2/v2.0/token";
@@ -35,6 +35,7 @@ interface MicrosoftRefreshResult {
   accessToken: string;
   refreshToken: string | null;
   expiresIn?: number;
+  scopes: string[] | null;
 }
 
 /**
@@ -156,6 +157,7 @@ export async function refreshMicrosoftToken(
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
       expires_in: z.number().optional(),
+      scope: z.string().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -173,6 +175,7 @@ export async function refreshMicrosoftToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
   };
 }
 

--- a/turbo/packages/connectors/src/auth-providers/oauth/scope.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/scope.ts
@@ -14,7 +14,16 @@ export function effectiveOAuthScopes(
   authorizationScopes: readonly string[],
   separator: string | RegExp,
 ): string[] {
+  return (
+    reportedOAuthScopes(reportedScopes, separator) ?? [...authorizationScopes]
+  );
+}
+
+export function reportedOAuthScopes(
+  reportedScopes: string | null | undefined,
+  separator: string | RegExp,
+): string[] | null {
   return reportedScopes === null || reportedScopes === undefined
-    ? [...authorizationScopes]
+    ? null
     : reportedScopes.split(separator).filter(Boolean);
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/types.ts
@@ -2,6 +2,7 @@ export interface OAuthRefreshResult {
   readonly accessToken: string;
   readonly refreshToken: string | null;
   readonly expiresIn?: number;
+  readonly scopes: readonly string[] | null;
 }
 
 export function oauthRefreshResultToProviderResult(
@@ -12,6 +13,7 @@ export function oauthRefreshResultToProviderResult(
     readonly refreshToken?: string;
   };
   readonly expiresIn?: number;
+  readonly scopes?: readonly string[];
 } {
   return {
     outputs: {
@@ -19,5 +21,6 @@ export function oauthRefreshResultToProviderResult(
       ...(result.refreshToken ? { refreshToken: result.refreshToken } : {}),
     },
     ...(result.expiresIn === undefined ? {} : { expiresIn: result.expiresIn }),
+    ...(result.scopes === null ? {} : { scopes: result.scopes }),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -158,6 +158,7 @@ type ConnectorRefreshAuthClientArgs<
 export interface ConnectorAuthProviderRefreshResultBase {
   readonly outputs: Readonly<Record<string, string | undefined>>;
   readonly expiresIn?: number;
+  readonly scopes?: readonly string[];
 }
 
 export interface ConnectorAuthProviderRefreshResult<


### PR DESCRIPTION
## Summary

- propagate OAuth scopes reported by refresh responses through connector auth providers
- persist refreshed granted scopes in both connector credential and webhook firewall refresh paths
- preserve the existing grant when a provider omits scope metadata, while retaining explicit empty grants
- cover refreshed, omitted, empty, and legacy unknown-grant behavior with integration tests

## Scope

- keeps the legacy requested `oauthScopes` mirror unchanged
- does not add a cleanup or backfill; broader migration work remains tracked by #29462

## Validation

- `pnpm format`
- `pnpm -F @okouai/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F api check-types`
- `pnpm check-types` (pre-commit, 14/14 tasks passed)
- `pnpm -F @okouai/connectors test` (44 files, 1080 tests passed)
- focused connector refresh tests (4 files, 26 tests passed)
- focused API webhook firewall suite (1 file, 54 tests passed)
- `pnpm knip` (pre-commit, no issues)
- `pnpm knip --workspace @okouai/connectors`
- `pnpm knip --workspace api`
- `git diff --check`

The full API suite was also attempted three times locally, including with one worker. It did not complete cleanly because unchanged `chat-events.bdd.test.ts` Pi/S3 fixtures reported archive-size mismatches and an unrelated timeout. The affected webhook firewall suite passes independently.

Closes #29582

Parent: #29462
