### PR TITLE
refactor(runner): make guest process roles explicit

### DIFF
--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -164,6 +164,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let mut handle = connection
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            role: vsock_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 30_000 },
             command: &command,
             env: &env,
@@ -291,6 +292,7 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
     let handle = connection
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            role: vsock_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 30_000 },
             command: &command,
             env: &env,

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -313,7 +313,7 @@ async fn hard_cancelled_job_not_parked() {
         0,
         "hard-cancelled job must not park"
     );
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(overrides.park_call_count(), 0);
     assert_eq!(overrides.destroy_call_count(), 1);
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -256,7 +256,7 @@ async fn uncertain_reserved_cleanup_fails_claim_without_starting_replacement() {
         Some("reserved idle sandbox cleanup was uncertain; fresh replacement was not started")
     );
     assert!(
-        counter.start_process_calls().is_empty(),
+        counter.start_agent_process_calls().is_empty(),
         "uncertain cleanup must not start a fresh sandbox"
     );
     assert_eq!(counter.park_call_count(), 0);

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -134,7 +134,7 @@ async fn exact_reuse_restores_guest_while_claim_is_blocked() {
     assert_eq!(restore_timezones, [Some("Asia/Shanghai".into())]);
     assert_eq!(overrides.unpark_call_count(), 1);
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent process must not start before claim succeeds"
     );
     let (idle_reuse_keys, active_runs) =
@@ -455,7 +455,7 @@ async fn unavailable_claim_reparks_speculative_sandbox() {
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(!env.start_observer.active_run_status_was_published(run_id));
     let requests = reuse_preparation_requests(&overrides);
     assert_eq!(requests.len(), 1);
@@ -540,7 +540,7 @@ async fn cleanup_failure_destroys_lost_speculative_sandbox() {
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(!env.start_observer.active_run_status_was_published(run_id));
 
     shutdown(&env, run_handle).await;
@@ -604,7 +604,7 @@ async fn mismatched_claim_run_id_reparks_speculative_sandbox() {
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     {
         let completions = env.handle.completions.lock().unwrap();
         assert!(
@@ -679,7 +679,7 @@ async fn cancellation_during_claim_completes_without_starting_agent_and_reparks(
     assert_eq!(completion.sandbox_id, None);
     wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
     assert!(!env.start_observer.active_run_status_was_published(run_id));
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(overrides.park_call_count(), 1);
 
     shutdown(&env, run_handle).await;
@@ -738,7 +738,7 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
     assert!(!env.start_observer.active_run_status_was_published(run_id));
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
 
     exec_gate.release_one();
     exec_gate
@@ -759,7 +759,7 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
     assert!(!env.start_observer.active_run_status_was_published(run_id));
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);
 
@@ -818,7 +818,7 @@ async fn cancellation_during_speculative_cleanup_does_not_start_fresh_agent() {
     let (_, active_runs) =
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
 
     destroy_gate.release_one();
     let completion = env
@@ -835,7 +835,7 @@ async fn cancellation_during_speculative_cleanup_does_not_start_fresh_agent() {
     wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
     assert!(!env.start_observer.active_run_status_was_published(run_id));
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
@@ -910,7 +910,7 @@ async fn cancellation_wins_when_speculative_cleanup_is_uncertain() {
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
     assert!(!env.start_observer.active_run_status_was_published(run_id));
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
@@ -971,7 +971,7 @@ async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
 
     shutdown(&env, run_handle).await;
 }
@@ -1162,7 +1162,7 @@ async fn assert_speculation_failure_falls_back_to_fresh(
         completion.reuse_result,
         Some(SandboxReuseResult::UnparkFailed)
     );
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -16,8 +16,8 @@ use guest_contracts::session_history_identity::{
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessCancelHandle,
-    GuestProcessControlHandle, GuestProcessHandle, ProcessControlMode, ProcessOutputMode, Sandbox,
-    StartProcessRequest,
+    GuestProcessControlHandle, GuestProcessHandle, ProcessOutputMode, Sandbox,
+    StartAgentProcessRequest, StartProcessRequest,
 };
 use shell_quote::quote_shell_arg;
 use tokio_util::sync::CancellationToken;
@@ -879,17 +879,10 @@ where
 
 async fn send_cooperative_user_cancellation(
     run_id: crate::ids::RunId,
-    process_control: Option<&GuestProcessControlHandle>,
+    process_control: &GuestProcessControlHandle,
     hard_cancel: &CancellationToken,
     timeout: Duration,
 ) -> bool {
-    let Some(process_control) = process_control else {
-        warn!(
-            run_id = %run_id,
-            "guest process does not support cooperative user cancellation"
-        );
-        return false;
-    };
     let message_id = format!("user-cancellation:{run_id}");
     tokio::select! {
         biased;
@@ -926,7 +919,7 @@ async fn send_cooperative_user_cancellation(
 async fn wait_for_cooperative_user_cancellation<F>(
     run_id: crate::ids::RunId,
     guest_process_pid: u32,
-    process_control: Option<&GuestProcessControlHandle>,
+    process_control: &GuestProcessControlHandle,
     process_cancel: &mut Option<GuestProcessCancelHandle>,
     hard_cancel: &CancellationToken,
     process_cancel_timeouts: ProcessCancelTimeouts,
@@ -1299,6 +1292,7 @@ impl RunControls {
 
 struct PreparedAgentProcess {
     handle: GuestProcessHandle,
+    process_control: GuestProcessControlHandle,
     agent_started_at: Instant,
     host_oom_evidence_since: super::diagnostics::HostOomEvidenceSince,
     deferred_background_fill: Option<crate::storage_cache::DeferredBackgroundFill>,
@@ -2165,19 +2159,20 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let host_oom_evidence_since = host_oom_evidence_since_now();
     let t = Instant::now();
     let handle = sandbox
-        .start_process(&StartProcessRequest {
-            cmd: &agent_cmd,
-            timeout: job_supervisor_timeout(),
-            env: &env_refs,
-            sudo: false,
-            output: ProcessOutputMode::stream_with_stderr_capture(
-                AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES,
-            ),
-            control: ProcessControlMode::Enabled,
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: &agent_cmd,
+                timeout: job_supervisor_timeout(),
+                env: &env_refs,
+                sudo: false,
+                output: ProcessOutputMode::stream_with_stderr_capture(
+                    AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES,
+                ),
+            },
         })
         .await;
 
-    let handle = match handle {
+    let agent_handle = match handle {
         Ok(h) => {
             let spawned_at = Instant::now();
             telemetry.record(
@@ -2206,9 +2201,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             return Err(e.into());
         }
     };
+    let (handle, process_control) = agent_handle.into_parts();
 
             RunnerResult::Ok(PreparedAgentProcess {
                 handle,
+                process_control,
                 agent_started_at: t,
                 host_oom_evidence_since,
                 deferred_background_fill,
@@ -2247,6 +2244,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
     let PreparedAgentProcess {
         mut handle,
+        process_control,
         agent_started_at: t,
         host_oom_evidence_since,
         deferred_background_fill,
@@ -2266,11 +2264,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     // Start locally owned input and output work, then release deferred cache
     // fill now that process spawn has succeeded.
-    let process_control = handle.control_handle();
     let active_input_forwarder = super::active_input::ActiveInputForwarder::start(
         context.run_id,
         active_input_source,
-        process_control.clone(),
+        Some(process_control.clone()),
         cancel.clone(),
     );
     // Spawn background task to drain stdout chunks and write to the host stream log file.
@@ -2319,7 +2316,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     wait_for_cooperative_user_cancellation(
                         context.run_id,
                         guest_process_pid,
-                        process_control.as_ref(),
+                        &process_control,
                         &mut process_cancel,
                         &hard_cancel,
                         process_cancel_timeouts,

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{
-    ExecOutputLimits, ExecTermination, GuestProcessCancelHandle, GuestProcessHandle,
-    ProcessControlMode, ProcessExit, ProcessOutputMode, Sandbox, StartProcessRequest,
+    ExecOutputLimits, ExecTermination, GuestProcessCancelHandle, GuestProcessHandle, ProcessExit,
+    ProcessOutputMode, Sandbox, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -93,7 +93,6 @@ impl StartedCodexModelCatalogPrefetch {
                 0,
                 PREFETCH_STDERR_LIMIT_BYTES,
             )),
-            control: ProcessControlMode::None,
         };
         let result = tokio::select! {
             biased;

--- a/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
@@ -180,7 +180,7 @@ async fn run_in_sandbox_reports_cancelled_while_workspace_sidecar_read_is_pendin
     let failure = result.failure.expect("cancelled run should fail");
     assert_eq!(failure.exit_code, EXIT_SIGKILL);
     assert_eq!(failure.error, "cancelled by user");
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }
 
@@ -273,7 +273,7 @@ async fn run_in_sandbox_reports_cancelled_while_session_history_download_is_pend
     let failure = result.failure.expect("cancelled run should fail");
     assert_eq!(failure.exit_code, EXIT_SIGKILL);
     assert_eq!(failure.error, "cancelled by user");
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }
 
@@ -310,7 +310,7 @@ async fn run_in_sandbox_starts_no_guest_work_when_already_cancelled() {
     assert!(overrides.exec_calls().is_empty());
     assert!(overrides.write_file_calls().is_empty());
     assert!(overrides.private_write_file_calls().is_empty());
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }
 
@@ -343,7 +343,7 @@ async fn run_in_sandbox_observes_cancellation_while_guest_helper_is_pending() {
     assert_eq!(failure.error, "cancelled by user");
     assert!(overrides.exec_calls().is_empty());
     assert!(overrides.private_write_file_calls().is_empty());
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }
 
@@ -376,7 +376,7 @@ async fn run_in_sandbox_preserves_ready_start_result_when_cancellation_arrives()
 
     assert!(cancel.is_cancelled());
     assert!(result.failure.is_none());
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(overrides.wait_process_calls().len(), 1);
     assert!(overrides.process_cancel_calls().is_empty());
 }
@@ -542,12 +542,10 @@ async fn run_in_sandbox_falls_back_when_cooperative_cancellation_fails() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_falls_back_when_process_control_is_unavailable() {
+async fn run_in_sandbox_fails_startup_when_process_control_is_unavailable() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.set_process_control_supported(false);
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
@@ -559,29 +557,22 @@ async fn run_in_sandbox_falls_back_when_process_control_is_unavailable() {
         cancellation.signals(),
         PROCESS_CANCEL_TIMEOUTS,
     );
-    wait_gate
-        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
-        .await
-        .expect("run should enter process wait before cancellation");
-
-    cancellation.request_cooperative_user_cancellation().await;
-    assert!(
-        overrides
-            .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
-            .await
-    );
-
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await
         .unwrap()
-        .unwrap()
         .unwrap();
-    assert!(overrides.process_control_calls().is_empty());
-    assert_eq!(overrides.process_cancel_calls().len(), 1);
-    assert_eq!(
-        result.failure.as_ref().map(|failure| failure.exit_code),
-        Some(EXIT_SIGKILL)
+    let error = match result {
+        Ok(_) => panic!("Agent run unexpectedly started without process control"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("provider returned an Agent process without process control")
     );
+    assert!(overrides.process_control_calls().is_empty());
+    assert!(overrides.process_cancel_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -192,6 +192,7 @@ async fn codex_catalog_prefetch_start_observes_run_cancellation() {
         Some(EXIT_SIGKILL)
     );
     assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
     assert!(overrides.process_cancel_calls().is_empty());
 }
@@ -221,7 +222,8 @@ async fn codex_catalog_prefetch_start_timeout_does_not_delay_agent() {
 
     let result = run_task.await.unwrap().unwrap();
     assert!(result.failure.is_none());
-    let start_calls = overrides.start_process_calls();
+    assert!(overrides.start_process_calls().is_empty());
+    let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
     assert!(!start_calls[0].cmd.contains("codex --version"));
 }
@@ -501,7 +503,7 @@ async fn assert_codex_catalog_prefetch_skipped(
     .unwrap();
 
     assert!(result.failure.is_none(), "{scenario}");
-    let start_calls = overrides.start_process_calls();
+    let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1, "{scenario}");
     assert!(
         !start_calls[0].cmd.contains("codex --version"),
@@ -671,7 +673,8 @@ async fn fresh_codex_oauth_run_prefetches_catalog_while_agent_prepares() {
 
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
         loop {
-            if overrides.start_process_calls().len() == 2
+            if overrides.start_process_calls().len() == 1
+                && overrides.start_agent_process_calls().len() == 1
                 && overrides.wait_process_calls().len() == 2
             {
                 break;
@@ -689,13 +692,12 @@ async fn fresh_codex_oauth_run_prefetches_catalog_while_agent_prepares() {
             .cmd
             .contains("X-VM0-Codex-Model-Catalog-Prefetch: 1")
     );
-    assert_eq!(start_calls[0].control, sandbox::ProcessControlMode::None);
     assert!(matches!(
         start_calls[0].output,
         ProcessOutputMode::Buffered { .. }
     ));
-    assert_eq!(start_calls[1].control, sandbox::ProcessControlMode::Enabled);
-    assert!(!start_calls[1].cmd.contains("codex --version"));
+    let agent_calls = overrides.start_agent_process_calls();
+    assert!(!agent_calls[0].cmd.contains("codex --version"));
 
     wait_gate.notify_waiters();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
@@ -1086,7 +1086,7 @@ async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
     }
 
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent process must not start before workspace session restore completes"
     );
     assert!(
@@ -1110,7 +1110,7 @@ async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
     );
     assert_eq!(writes[0].content, history.as_bytes());
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert!(
         sandbox
             .exec_calls()

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -344,7 +344,7 @@ async fn run_in_sandbox_drops_checkpointed_identity_when_agent_is_cancelled() {
     );
     assert!(result.reusable_session_identity.is_none());
     assert_eq!(overrides.exec_calls().len(), 1);
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
     assert!(overrides.process_cancel_calls().is_empty());
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -832,7 +832,7 @@ async fn execute_inner_guest_process_timeout_waits_for_terminal_grace_and_copies
         .await
         .unwrap();
 
-    let start_calls = overrides.start_process_calls();
+    let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
     assert_eq!(start_calls[0].timeout, job_supervisor_timeout());
 
@@ -1285,7 +1285,7 @@ async fn execute_inner_codex_enospc_preserves_structured_failure_and_collects_re
             .failure_kind,
         Some(ResourceFailureKind::GuestRootFilesystemFull)
     );
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(
         overrides
             .exec_calls()

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -235,9 +235,11 @@ async fn execute_inner_carries_early_codex_catalog_prefetch_into_agent_run() {
     assert_eq!(exit_code, 0);
     assert!(error_msg.is_none());
     let start_calls = overrides.start_process_calls();
-    assert_eq!(start_calls.len(), 2);
+    assert_eq!(start_calls.len(), 1);
     assert!(start_calls[0].cmd.contains("codex --version"));
-    assert!(!start_calls[1].cmd.contains("codex --version"));
+    let agent_calls = overrides.start_agent_process_calls();
+    assert_eq!(agent_calls.len(), 1);
+    assert!(!agent_calls[0].cmd.contains("codex --version"));
     assert_proxy_registry_empty(dir.path()).await;
 }
 
@@ -270,6 +272,7 @@ async fn execute_inner_does_not_prefetch_after_early_guest_state_failure() {
         overrides.start_process_calls().is_empty(),
         "neither prefetch nor agent may start after guest state failure"
     );
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_proxy_registry_empty(dir.path()).await;
 }
 
@@ -507,7 +510,7 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
     assert_eq!(outcome.exit_code(), 0);
     assert_eq!(overrides.create_configs().len(), 2);
     assert_eq!(overrides.destroy_call_count(), 1);
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(notifications.load(Ordering::SeqCst), 1);
     assert_proxy_registry_empty(dir.path()).await;
     assert_telemetry_action(
@@ -570,6 +573,7 @@ async fn execute_new_sandbox_does_not_replace_guest_exec_timing_failures() {
         assert_eq!(overrides.create_configs().len(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert!(overrides.start_process_calls().is_empty());
+        assert!(overrides.start_agent_process_calls().is_empty());
         assert_proxy_registry_empty(dir.path()).await;
         assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
     }
@@ -671,6 +675,7 @@ async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
     assert_eq!(overrides.create_configs().len(), 2);
     assert_eq!(overrides.destroy_call_count(), 2);
     assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_proxy_registry_empty(dir.path()).await;
     assert_telemetry_action(
         &telemetry,
@@ -767,6 +772,7 @@ async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
     assert_eq!(overrides.create_configs().len(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
     assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_telemetry_action(
         &telemetry,
         "runner_fresh_sandbox_dns_readiness_retry",
@@ -1079,7 +1085,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert_eq!(exit_code, 0);
     assert!(error_msg.is_none());
 
-    let start_calls = overrides.start_process_calls();
+    let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
     let expected_user_env_file = guest_user_env_file_path(ctx.run_id).unwrap();
@@ -1237,7 +1243,7 @@ async fn execute_inner_continues_when_connector_account_context_write_fails() {
         private_writes[1].path,
         guest_run_payload_file_path(context.run_id).unwrap()
     );
-    let start_calls = overrides.start_process_calls();
+    let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
     assert!(!start_env.contains_key(USER_ENV_FILE_ENV_KEY));
@@ -1290,7 +1296,7 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
         private_writes[2].path
     );
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent must not start after run payload write failure"
     );
     assert_eq!(
@@ -1349,13 +1355,12 @@ async fn execute_inner_launches_agent_stream_only_without_guest_log_tee() {
     assert_eq!(exit_code, 0);
     assert!(error_msg.is_none());
 
-    let calls = overrides.start_process_calls();
+    let calls = overrides.start_agent_process_calls();
     assert_eq!(calls.len(), 1);
     assert_eq!(
         calls[0].output,
         ProcessOutputMode::stream_with_stderr_capture(64 * 1024)
     );
-    assert_eq!(calls[0].control, ProcessControlMode::Enabled);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -11,9 +11,9 @@ use guest_contracts::diagnostics::{
     FailureDiagnostic, PromptMetadata,
 };
 use sandbox::{
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ExecTermination, ProcessControlMode, ProcessExit,
-    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxError, SandboxFactory,
-    SandboxGuestDnsReadinessReason, SandboxId, SandboxOperationReason,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ExecTermination, ProcessExit, ProcessOutputChunk,
+    ProcessOutputMode, Sandbox, SandboxError, SandboxFactory, SandboxGuestDnsReadinessReason,
+    SandboxId, SandboxOperationReason,
 };
 use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -178,7 +178,7 @@ async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_
     assert!(outcome.network_log_session.is_none());
     assert_eq!(overrides.destroy_call_count(), 1);
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent must not start when proxy registry registration fails"
     );
 }
@@ -219,7 +219,7 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
     assert!(outcome.sandbox.is_some());
     assert!(outcome.network_log_session.is_none());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start an agent when proxy registration fails"
     );
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -125,7 +125,7 @@ async fn execute_job_reuse_model_provider_env_validation_failure_returns_sandbox
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.network_log_session.is_none());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after env validation failure"
     );
 }
@@ -153,7 +153,7 @@ async fn execute_job_reuse_claude_tool_validation_failure_returns_sandbox() {
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.network_log_session.is_none());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after tool validation failure"
     );
 }
@@ -189,7 +189,7 @@ async fn execute_job_reuse_invalid_resume_session_does_not_lease_workspace_image
     assert!(reuse_outcome.network_log_session.is_none());
     assert!(reuse_outcome.workspace_image.is_none());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after resume session validation failure"
     );
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -477,10 +477,12 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     assert_eq!(overrides.create_configs().len(), 2);
     assert_eq!(overrides.destroy_call_count(), 1);
     let start_calls = overrides.start_process_calls();
-    assert_eq!(start_calls.len(), 3);
+    assert_eq!(start_calls.len(), 2);
     assert!(start_calls[0].cmd.contains("codex --version"));
     assert!(start_calls[1].cmd.contains("codex --version"));
-    assert!(!start_calls[2].cmd.contains("codex --version"));
+    let agent_calls = overrides.start_agent_process_calls();
+    assert_eq!(agent_calls.len(), 1);
+    assert!(!agent_calls[0].cmd.contains("codex --version"));
     assert_eq!(
         telemetry
             .pending_ops_snapshot()
@@ -748,6 +750,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
     );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert!(!expected_seed.exists());
     assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
     assert_no_telemetry_action(
@@ -1271,7 +1274,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     );
     assert_eq!(overrides.destroy_call_count(), 1);
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent must not start when proxy registry registration fails"
     );
     assert!(
@@ -1399,7 +1402,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     assert!(error.contains("workspace promotion identity mismatch"));
     assert!(!error.contains(session_id));
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "agent must not start after workspace promotion identity mismatch"
     );
     assert!(
@@ -1547,7 +1550,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.workspace_image.is_some());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after env validation failure"
     );
 
@@ -1602,7 +1605,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.workspace_image.is_some());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after resume session validation failure"
     );
 
@@ -1670,7 +1673,7 @@ async fn cached_reuse_invalid_resume_session_without_promotion_skips_workspace_l
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.workspace_image.is_none());
     assert!(
-        overrides.start_process_calls().is_empty(),
+        overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start a process after resume session validation failure"
     );
 }

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -322,6 +322,13 @@ impl Sandbox for ObservedStartSandbox {
         self.inner.start_process(request).await
     }
 
+    async fn start_agent_process(
+        &self,
+        request: &sandbox::StartAgentProcessRequest<'_>,
+    ) -> sandbox::Result<sandbox::GuestAgentProcessHandle> {
+        self.inner.start_agent_process(request).await
+    }
+
     async fn wait_process(
         &self,
         handle: sandbox::GuestProcessHandle,
@@ -1314,7 +1321,7 @@ async fn assert_reused_private_write_timeout_telemetry(
     );
     assert_action_bounded_outcome(&telemetry, expected_action, expected_outcome);
     assert_lacks_action(&telemetry, "runner_agent_start_process");
-    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
     assert_eq!(
         overrides.private_write_file_calls().len(),
         successful_writes_before + 1
@@ -1372,7 +1379,7 @@ async fn reused_connector_account_context_timeout_records_failure_and_continues(
         Some("connector account context unavailable"),
     );
     assert_has_action(&telemetry, "runner_agent_start_process");
-    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(overrides.private_write_file_calls().len(), 2);
 }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3855,6 +3855,13 @@ mod tests {
             self.inner.start_process(request).await
         }
 
+        async fn start_agent_process(
+            &self,
+            request: &sandbox::StartAgentProcessRequest<'_>,
+        ) -> sandbox::Result<sandbox::GuestAgentProcessHandle> {
+            self.inner.start_agent_process(request).await
+        }
+
         async fn wait_process(
             &self,
             handle: sandbox::GuestProcessHandle,

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -18,8 +18,9 @@ use guest_contracts::session_history_identity::{
     SessionHistorySidecarRepresentation, SessionHistorySourceRef,
 };
 use sandbox::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
-    Sandbox, SandboxFactory, SandboxId, StartProcessRequest,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
+    GuestProcessHandle, ProcessExit, Sandbox, SandboxFactory, SandboxId, StartAgentProcessRequest,
+    StartProcessRequest,
 };
 use sandbox_mock::{ExecMatcher, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 use sha2::{Digest, Sha256};
@@ -191,6 +192,13 @@ impl Sandbox for PostCopyGateSandbox {
         self.inner.start_process(request).await
     }
 
+    async fn start_agent_process(
+        &self,
+        request: &StartAgentProcessRequest<'_>,
+    ) -> sandbox::Result<GuestAgentProcessHandle> {
+        self.inner.start_agent_process(request).await
+    }
+
     async fn wait_process(
         &self,
         handle: GuestProcessHandle,
@@ -284,6 +292,13 @@ impl Sandbox for PanicExecSandbox {
         _request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
         panic!("unused start_process");
+    }
+
+    async fn start_agent_process(
+        &self,
+        _request: &StartAgentProcessRequest<'_>,
+    ) -> sandbox::Result<GuestAgentProcessHandle> {
+        panic!("unused start_agent_process");
     }
 
     async fn wait_process(

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -7,18 +7,18 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestMemorySnapshot,
-    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
-    GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
-    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
-    ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
-    ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkHandoff,
-    SandboxFinalExecParkHandoffOutcome, SandboxFinalExecParkHandoffPoint,
-    SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome, SandboxFinalExecParkStage,
-    SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition,
-    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
+    GuestMemorySnapshot, GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle,
+    GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
+    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
+    ProcessControlWriteState, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox,
+    SandboxConfig, SandboxError, SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
+    SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
+    SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
+    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
     SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
-    SevereMemoryRetentionDiagnostics, StartProcessRequest, StorageManifestRequest, WriteFileEntry,
+    SevereMemoryRetentionDiagnostics, StartAgentProcessRequest, StartProcessRequest,
+    StorageManifestRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -30,7 +30,7 @@ use vsock_host::{
     NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest, VsockHost,
 };
 use vsock_proto::{
-    ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy,
+    ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTimeoutPolicy,
     GuestStateRestoreTimezone as VsockGuestStateRestoreTimezone,
 };
 
@@ -1913,6 +1913,107 @@ fn exec_capture_request<'a>(
 }
 
 impl FirecrackerSandbox {
+    async fn start_process_with_contract(
+        &self,
+        request: &StartProcessRequest<'_>,
+        operation: SandboxOperation,
+        role: ExecProcessRole,
+        control: SupervisedExecControl,
+    ) -> sandbox::Result<GuestProcessHandle> {
+        let vsock = self.begin_guest_operation(operation).await?;
+        Self::validate_exec_env_keys(operation, request.env)?;
+        request.output.validate(operation)?;
+
+        let start_future = async move {
+            vsock
+                .start_supervised_exec(SupervisedExecRequest {
+                    role,
+                    timeout: process_timeout_policy(request.timeout_ms()),
+                    command: request.cmd,
+                    env: request.env,
+                    sudo: request.sudo,
+                    label: request.cmd,
+                    stdout: process_stdout_policy(request.output),
+                    stderr: process_stderr_policy(request.output),
+                    expected_exit_codes: &[],
+                    stdin_bytes: None,
+                    control,
+                    stream_queue_capacity: process_stream_queue_capacity(request.output),
+                    start_timeout: PROCESS_START_ACK_TIMEOUT,
+                })
+                .await
+        };
+
+        tokio::select! {
+            result = start_future => {
+                let mut handle = match result {
+                    Ok(handle) => handle,
+                    Err(error) => {
+                        let backend_crashed = self.has_backend_crashed();
+                        return Err(Self::operation_error(operation, error, backend_crashed));
+                    }
+                };
+                let guest_pid = handle.pid();
+                let process_control = handle.control_handle().map(|control| {
+                    let coordinator = self.park_coordinator.clone();
+                    let state = Arc::clone(&self.state);
+                    let state_rx = self.state_tx.subscribe();
+                    GuestProcessControlHandle::new_with_outcome(
+                        move |message_id, payload, timeout| {
+                            let control = control.clone();
+                            let coordinator = coordinator.clone();
+                            let state = Arc::clone(&state);
+                            let state_rx = state_rx.clone();
+                            Box::pin(async move {
+                                Self::exec_process_control(
+                                    coordinator, state, state_rx, control, message_id, payload, timeout,
+                                )
+                                .await
+                            })
+                        },
+                    )
+                });
+                let (stdout_rx, close_stdout) = if request.output.streams_stdout() {
+                    match handle.take_stream_receiver() {
+                        Some(stream_rx) => {
+                            let queue_capacity = process_stream_queue_capacity(request.output)
+                                .unwrap_or(ProcessOutputMode::DEFAULT_QUEUE_CAPACITY);
+                            let (stdout_rx, close_stdout) =
+                                supervised_stdout_receiver(stream_rx, queue_capacity);
+                            (Some(stdout_rx), Some(close_stdout))
+                        }
+                        None => (None, None),
+                    }
+                } else {
+                    (None, None)
+                };
+                let process_cancel = handle.take_cancel_handle().map(|cancel| {
+                    GuestProcessCancelHandle::new(move |timeout| {
+                        Box::pin(async move { cancel.cancel(timeout).await })
+                    })
+                });
+                let wait = GuestProcessWaiter::new(move |timeout| {
+                    Box::pin(async move {
+                        let result = handle.wait(timeout).await?;
+                        Ok(supervised_exec_result_to_process_exit(guest_pid, result))
+                    })
+                });
+                let mut public_handle =
+                    GuestProcessHandle::new(guest_pid, stdout_rx, process_control, wait);
+                if let Some(process_cancel) = process_cancel {
+                    public_handle = public_handle.with_cancel_handle(process_cancel);
+                }
+                Ok(match close_stdout {
+                    Some(close_stdout) => public_handle.with_unclaimed_stdout_cleanup(close_stdout),
+                    None => public_handle,
+                })
+            }
+            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
+                Err(Self::backend_crashed_error(operation))
+            }
+        }
+    }
+
     async fn final_exec_and_park_with_optional_observer(
         &mut self,
         request: &ExecRequest<'_>,
@@ -2563,103 +2664,28 @@ impl Sandbox for FirecrackerSandbox {
         &self,
         request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
-        let operation = SandboxOperation::StartProcess;
-        let vsock = self.begin_guest_operation(operation).await?;
-        Self::validate_exec_env_keys(operation, request.env)?;
-        request.output.validate()?;
+        self.start_process_with_contract(
+            request,
+            SandboxOperation::StartProcess,
+            ExecProcessRole::Workload,
+            SupervisedExecControl::Disabled,
+        )
+        .await
+    }
 
-        let start_future = async move {
-            vsock
-                .start_supervised_exec(SupervisedExecRequest {
-                    timeout: process_timeout_policy(request.timeout_ms()),
-                    command: request.cmd,
-                    env: request.env,
-                    sudo: request.sudo,
-                    label: request.cmd,
-                    stdout: process_stdout_policy(request.output),
-                    stderr: process_stderr_policy(request.output),
-                    expected_exit_codes: &[],
-                    stdin_bytes: None,
-                    control: match request.control {
-                        ProcessControlMode::None => SupervisedExecControl::Disabled,
-                        ProcessControlMode::Enabled => {
-                            SupervisedExecControl::Enabled { sink: true }
-                        }
-                    },
-                    stream_queue_capacity: process_stream_queue_capacity(request.output),
-                    start_timeout: PROCESS_START_ACK_TIMEOUT,
-                })
-                .await
-        };
-
-        tokio::select! {
-            result = start_future => {
-                let mut handle = match result {
-                    Ok(handle) => handle,
-                    Err(error) => {
-                        let backend_crashed = self.has_backend_crashed();
-                        return Err(Self::operation_error(operation, error, backend_crashed));
-                    }
-                };
-                let guest_pid = handle.pid();
-                let process_control = handle.control_handle().map(|control| {
-                    let coordinator = self.park_coordinator.clone();
-                    let state = Arc::clone(&self.state);
-                    let state_rx = self.state_tx.subscribe();
-                    GuestProcessControlHandle::new_with_outcome(
-                        move |message_id, payload, timeout| {
-                        let control = control.clone();
-                        let coordinator = coordinator.clone();
-                        let state = Arc::clone(&state);
-                        let state_rx = state_rx.clone();
-                        Box::pin(async move {
-                            Self::exec_process_control(
-                                coordinator, state, state_rx, control, message_id, payload, timeout,
-                            )
-                            .await
-                        })
-                        },
-                    )
-                });
-                let (stdout_rx, close_stdout) = if request.output.streams_stdout() {
-                    match handle.take_stream_receiver() {
-                        Some(stream_rx) => {
-                            let queue_capacity = process_stream_queue_capacity(request.output)
-                                .unwrap_or(ProcessOutputMode::DEFAULT_QUEUE_CAPACITY);
-                            let (stdout_rx, close_stdout) =
-                                supervised_stdout_receiver(stream_rx, queue_capacity);
-                            (Some(stdout_rx), Some(close_stdout))
-                        }
-                        None => (None, None),
-                    }
-                } else {
-                    (None, None)
-                };
-                let process_cancel = handle.take_cancel_handle().map(|cancel| {
-                    GuestProcessCancelHandle::new(move |timeout| {
-                        Box::pin(async move { cancel.cancel(timeout).await })
-                    })
-                });
-                let wait = GuestProcessWaiter::new(move |timeout| {
-                    Box::pin(async move {
-                        let result = handle.wait(timeout).await?;
-                        Ok(supervised_exec_result_to_process_exit(guest_pid, result))
-                    })
-                });
-                let mut public_handle =
-                    GuestProcessHandle::new(guest_pid, stdout_rx, process_control, wait);
-                if let Some(process_cancel) = process_cancel {
-                    public_handle = public_handle.with_cancel_handle(process_cancel);
-                }
-                Ok(match close_stdout {
-                    Some(close_stdout) => public_handle.with_unclaimed_stdout_cleanup(close_stdout),
-                    None => public_handle,
-                })
-            }
-            () = wait_for_backend_crash(self.state_tx.subscribe()) => {
-                Err(Self::backend_crashed_error(operation))
-            }
-        }
+    async fn start_agent_process(
+        &self,
+        request: &StartAgentProcessRequest<'_>,
+    ) -> sandbox::Result<GuestAgentProcessHandle> {
+        let process = self
+            .start_process_with_contract(
+                &request.process,
+                SandboxOperation::StartAgentProcess,
+                ExecProcessRole::Agent,
+                SupervisedExecControl::Enabled { sink: true },
+            )
+            .await?;
+        GuestAgentProcessHandle::try_from_process(process)
     }
 
     async fn wait_process(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -322,6 +322,7 @@ async fn setup_exec_process_control_fixture() -> ExecProcessControlFixture {
     let start_task = tokio::spawn(async move {
         start_host
             .start_supervised_exec(SupervisedExecRequest {
+                role: vsock_proto::ExecProcessRole::Agent,
                 timeout: ExecTimeoutPolicy::Duration { timeout_ms: 60_000 },
                 command: "sleep 60",
                 env: &[],
@@ -2303,7 +2304,6 @@ async fn start_process_output_rejects_invalid_stream_configuration() {
                 env: &[],
                 sudo: false,
                 output,
-                control: ProcessControlMode::None,
             })
             .await
         {
@@ -2341,7 +2341,6 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
         env: &[],
         sudo: false,
         output,
-        control: ProcessControlMode::None,
     };
 
     let start_process = sandbox.start_process(&request);
@@ -2349,6 +2348,8 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
         let start = read_vsock_message(&mut guest).await;
         assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
         let decoded = vsock_proto::decode_exec_start(&start.payload).unwrap();
+        assert_eq!(decoded.role, vsock_proto::ExecProcessRole::Workload);
+        assert_eq!(decoded.control, vsock_proto::ExecControlPolicy::Disabled);
         assert_eq!(
             decoded.stdout,
             ExecOutputPolicy::Stream {
@@ -2370,6 +2371,65 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
     send_exec_exit(&mut guest, exec_seq).await;
     let exit = sandbox
         .wait_process(handle, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        exit.termination,
+        sandbox::ExecTermination::Exited { exit_code: 0 }
+    );
+}
+
+#[tokio::test]
+async fn start_agent_process_maps_to_agent_role_and_control_sink() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let request = StartAgentProcessRequest {
+        process: StartProcessRequest {
+            cmd: "agent",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            output: ProcessOutputMode::buffered(sandbox::EXEC_OUTPUT_LIMIT_1_MIB),
+        },
+    };
+
+    let start_agent = sandbox.start_agent_process(&request);
+    let acknowledge_start = async {
+        let start = read_vsock_message(&mut guest).await;
+        let decoded = vsock_proto::decode_exec_start(&start.payload).unwrap();
+        assert_eq!(decoded.role, vsock_proto::ExecProcessRole::Agent);
+        assert!(matches!(
+            decoded.control,
+            vsock_proto::ExecControlPolicy::Enabled { sink: true, .. }
+        ));
+
+        let payload = vsock_proto::encode_exec_started(73).unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        start.seq
+    };
+    let (handle, exec_seq) = tokio::join!(start_agent, acknowledge_start);
+    let (process, _control) = handle.unwrap().into_parts();
+
+    let payload = vsock_proto::encode_exec_result(
+        vsock_proto::ExecTermination::Exited { exit_code: 0 },
+        1,
+        vsock_proto::ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        vsock_proto::ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        "",
+    )
+    .unwrap();
+    let response = vsock_proto::encode(vsock_proto::MSG_EXEC_RESULT, exec_seq, &payload).unwrap();
+    guest.write_all(&response).await.unwrap();
+    let exit = sandbox
+        .wait_process(process, Duration::from_secs(5))
         .await
         .unwrap();
     assert_eq!(

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ::sandbox::{ExecOutputLimits, ProcessControlMode, ProcessOutputMode, SandboxControlTarget};
+use ::sandbox::{ExecOutputLimits, ProcessOutputMode, SandboxControlTarget};
 
 /// Behavior override applied to exec calls whose command contains the pattern.
 ///
@@ -115,8 +115,6 @@ pub struct StartProcessCall {
     pub sudo: bool,
     /// Output mode requested for the guest process.
     pub output: ProcessOutputMode,
-    /// Control mode requested for the guest process.
-    pub control: ProcessControlMode,
 }
 
 /// Captured `wait_process` request fields recorded for test assertions.

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -156,6 +156,9 @@ pub(crate) struct ProcessOverrideState {
     /// Recorded start_process output modes across all sandboxes built from
     /// this override set.
     pub(crate) start_process_calls: Mutex<Vec<StartProcessCall>>,
+    /// Recorded start_agent_process calls across all sandboxes built from this
+    /// override set.
+    pub(crate) start_agent_process_calls: Mutex<Vec<StartProcessCall>>,
     /// FIFO queue of stdout chunk batches emitted by factory-created
     /// sandboxes during streaming start_process calls.
     pub(crate) start_process_stdout_chunks: Mutex<VecDeque<Vec<ProcessOutputChunk>>>,
@@ -201,6 +204,7 @@ impl Default for ProcessOverrideState {
             wait_process_result_cancellations: Mutex::new(VecDeque::new()),
             wait_process_calls: Mutex::new(Vec::new()),
             start_process_calls: Mutex::new(Vec::new()),
+            start_agent_process_calls: Mutex::new(Vec::new()),
             start_process_stdout_chunks: Mutex::new(VecDeque::new()),
             keep_stdout_sender_open: Mutex::new(false),
             process_cancel_supported: Mutex::new(true),
@@ -776,6 +780,15 @@ impl MockSandboxOverrides {
     pub fn start_process_calls(&self) -> Vec<StartProcessCall> {
         self.process
             .start_process_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Return recorded start-Agent-process calls across all sandboxes built
+    /// from this override set.
+    pub fn start_agent_process_calls(&self) -> Vec<StartProcessCall> {
+        self.process
+            .start_agent_process_calls
             .lock_ignoring_poison()
             .clone()
     }

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -358,6 +358,158 @@ impl MockSandbox {
     pub fn clear_write_file_lifecycle_gate(&self) {
         *self.write_file_gate.lock_ignoring_poison() = None;
     }
+
+    async fn start_process_with_contract(
+        &self,
+        request: &StartProcessRequest<'_>,
+        operation: SandboxOperation,
+        controlled: bool,
+    ) -> Result<GuestProcessHandle> {
+        if let Some(overrides) = &self.overrides
+            && let Some(error) = overrides
+                .process
+                .start_process_errors
+                .lock_ignoring_poison()
+                .pop_front()
+        {
+            return Err(error);
+        }
+        let (mut tx, rx) = match request.output {
+            ProcessOutputMode::Stream { queue_capacity, .. } => {
+                let (tx, rx) = tokio::sync::mpsc::channel(queue_capacity.max(1));
+                (Some(tx), Some(rx))
+            }
+            ProcessOutputMode::Buffered { .. } => (None, None),
+        };
+        if let Some(overrides) = &self.overrides {
+            let chunks = overrides
+                .process
+                .start_process_stdout_chunks
+                .lock_ignoring_poison()
+                .pop_front();
+            if let Some(chunks) = chunks {
+                let Some(sender) = tx.as_ref() else {
+                    return Err(SandboxError::Operation {
+                        operation,
+                        reason: SandboxOperationReason::Other,
+                        message: "mock stdout chunks require streaming output".to_string(),
+                    });
+                };
+                for chunk in chunks {
+                    sender
+                        .try_send(chunk)
+                        .map_err(|_| SandboxError::Operation {
+                            operation,
+                            reason: SandboxOperationReason::Other,
+                            message: "mock stdout chunks exceeded process stream capacity"
+                                .to_string(),
+                        })?;
+                }
+            }
+        }
+        if self.overrides.as_ref().is_some_and(|overrides| {
+            *overrides
+                .process
+                .keep_stdout_sender_open
+                .lock_ignoring_poison()
+        }) && let Some(tx) = tx.take()
+        {
+            *self.stdout_tx.lock_ignoring_poison() = Some(tx);
+        }
+        let process_control_supported = self.overrides.as_ref().is_none_or(|overrides| {
+            *overrides
+                .process
+                .process_control_supported
+                .lock_ignoring_poison()
+        });
+        let control = (controlled && process_control_supported).then(|| {
+            let overrides = self.overrides.clone();
+            GuestProcessControlHandle::new_with_outcome(move |message_id, payload, timeout| {
+                let overrides = overrides.clone();
+                Box::pin(async move {
+                    if let Some(overrides) = overrides {
+                        overrides
+                            .process
+                            .process_control_calls
+                            .lock_ignoring_poison()
+                            .push(ProcessControlCall {
+                                message_id: message_id.clone(),
+                                payload,
+                                timeout,
+                            });
+                        overrides.process.process_control_notify.notify_waiters();
+                        if let Some(outcome) = overrides
+                            .process
+                            .process_control_outcomes
+                            .lock_ignoring_poison()
+                            .pop_front()
+                        {
+                            return outcome;
+                        }
+                    }
+                    ProcessControlOutcome::Delivered(ProcessControlAck { message_id })
+                })
+            })
+        });
+        let process_cancel = self.overrides.as_ref().and_then(|overrides| {
+            if !*overrides
+                .process
+                .process_cancel_supported
+                .lock_ignoring_poison()
+            {
+                return None;
+            }
+            let overrides = Arc::clone(overrides);
+            Some(GuestProcessCancelHandle::new(move |timeout| {
+                Box::pin(async move {
+                    overrides
+                        .process
+                        .process_cancel_calls
+                        .lock_ignoring_poison()
+                        .push(ProcessCancelCall { timeout });
+                    overrides.process.process_cancel_notify.notify_waiters();
+                    if let Some(message) = overrides
+                        .process
+                        .process_cancel_errors
+                        .lock_ignoring_poison()
+                        .pop_front()
+                    {
+                        return Err(std::io::Error::other(message));
+                    }
+                    if *overrides
+                        .process
+                        .process_cancel_releases_wait_gate
+                        .lock_ignoring_poison()
+                    {
+                        overrides.release_wait_process_gate();
+                    }
+                    Ok(())
+                })
+            }))
+        });
+
+        let mut handle = GuestProcessHandle::new(
+            1,
+            rx,
+            control,
+            GuestProcessWaiter::new(|_timeout| {
+                Box::pin(std::future::pending::<std::io::Result<ProcessExit>>())
+            }),
+        );
+        if let Some(process_cancel) = process_cancel {
+            handle = handle.with_cancel_handle(process_cancel);
+        }
+        if let Some(cancel) = self.overrides.as_ref().and_then(|overrides| {
+            overrides
+                .process
+                .start_process_result_cancellations
+                .lock_ignoring_poison()
+                .pop_front()
+        }) {
+            cancel.cancel();
+        }
+        Ok(handle)
+    }
 }
 
 fn default_exec_result() -> ExecResult {
@@ -945,8 +1097,9 @@ impl Sandbox for MockSandbox {
         if let Some(overrides) = &self.overrides {
             wait_lifecycle_gate(&overrides.process.start_process_lifecycle_gate).await;
         }
-        validate_mock_exec_env_keys(SandboxOperation::StartProcess, request.env)?;
-        request.output.validate()?;
+        let operation = SandboxOperation::StartProcess;
+        validate_mock_exec_env_keys(operation, request.env)?;
+        request.output.validate(operation)?;
         if let Some(overrides) = &self.overrides {
             overrides
                 .process
@@ -962,154 +1115,44 @@ impl Sandbox for MockSandbox {
                         .collect(),
                     sudo: request.sudo,
                     output: request.output,
-                    control: request.control,
                 });
         }
-        if let Some(overrides) = &self.overrides
-            && let Some(error) = overrides
-                .process
-                .start_process_errors
-                .lock_ignoring_poison()
-                .pop_front()
-        {
-            return Err(error);
-        }
-        let (mut tx, rx) = match request.output {
-            ProcessOutputMode::Stream { queue_capacity, .. } => {
-                let (tx, rx) = tokio::sync::mpsc::channel(queue_capacity.max(1));
-                (Some(tx), Some(rx))
-            }
-            ProcessOutputMode::Buffered { .. } => (None, None),
-        };
-        if let Some(overrides) = &self.overrides {
-            let chunks = overrides
-                .process
-                .start_process_stdout_chunks
-                .lock_ignoring_poison()
-                .pop_front();
-            if let Some(chunks) = chunks {
-                let Some(sender) = tx.as_ref() else {
-                    return Err(SandboxError::Operation {
-                        operation: SandboxOperation::StartProcess,
-                        reason: SandboxOperationReason::Other,
-                        message: "mock stdout chunks require streaming output".to_string(),
-                    });
-                };
-                for chunk in chunks {
-                    sender
-                        .try_send(chunk)
-                        .map_err(|_| SandboxError::Operation {
-                            operation: SandboxOperation::StartProcess,
-                            reason: SandboxOperationReason::Other,
-                            message: "mock stdout chunks exceeded process stream capacity"
-                                .to_string(),
-                        })?;
-                }
-            }
-        }
-        if self.overrides.as_ref().is_some_and(|overrides| {
-            *overrides
-                .process
-                .keep_stdout_sender_open
-                .lock_ignoring_poison()
-        }) && let Some(tx) = tx.take()
-        {
-            *self.stdout_tx.lock_ignoring_poison() = Some(tx);
-        }
-        let process_control_supported = self.overrides.as_ref().is_none_or(|overrides| {
-            *overrides
-                .process
-                .process_control_supported
-                .lock_ignoring_poison()
-        });
-        let control = (request.control == ProcessControlMode::Enabled && process_control_supported)
-            .then(|| {
-                let overrides = self.overrides.clone();
-                GuestProcessControlHandle::new_with_outcome(move |message_id, payload, timeout| {
-                    let overrides = overrides.clone();
-                    Box::pin(async move {
-                        if let Some(overrides) = overrides {
-                            overrides
-                                .process
-                                .process_control_calls
-                                .lock_ignoring_poison()
-                                .push(ProcessControlCall {
-                                    message_id: message_id.clone(),
-                                    payload,
-                                    timeout,
-                                });
-                            overrides.process.process_control_notify.notify_waiters();
-                            if let Some(outcome) = overrides
-                                .process
-                                .process_control_outcomes
-                                .lock_ignoring_poison()
-                                .pop_front()
-                            {
-                                return outcome;
-                            }
-                        }
-                        ProcessControlOutcome::Delivered(ProcessControlAck { message_id })
-                    })
-                })
-            });
-        let process_cancel = self.overrides.as_ref().and_then(|overrides| {
-            if !*overrides
-                .process
-                .process_cancel_supported
-                .lock_ignoring_poison()
-            {
-                return None;
-            }
-            let overrides = Arc::clone(overrides);
-            Some(GuestProcessCancelHandle::new(move |timeout| {
-                Box::pin(async move {
-                    overrides
-                        .process
-                        .process_cancel_calls
-                        .lock_ignoring_poison()
-                        .push(ProcessCancelCall { timeout });
-                    overrides.process.process_cancel_notify.notify_waiters();
-                    if let Some(message) = overrides
-                        .process
-                        .process_cancel_errors
-                        .lock_ignoring_poison()
-                        .pop_front()
-                    {
-                        return Err(std::io::Error::other(message));
-                    }
-                    if *overrides
-                        .process
-                        .process_cancel_releases_wait_gate
-                        .lock_ignoring_poison()
-                    {
-                        overrides.release_wait_process_gate();
-                    }
-                    Ok(())
-                })
-            }))
-        });
+        self.start_process_with_contract(request, operation, false)
+            .await
+    }
 
-        let mut handle = GuestProcessHandle::new(
-            1,
-            rx,
-            control,
-            GuestProcessWaiter::new(|_timeout| {
-                Box::pin(std::future::pending::<std::io::Result<ProcessExit>>())
-            }),
-        );
-        if let Some(process_cancel) = process_cancel {
-            handle = handle.with_cancel_handle(process_cancel);
+    async fn start_agent_process(
+        &self,
+        request: &StartAgentProcessRequest<'_>,
+    ) -> Result<GuestAgentProcessHandle> {
+        if let Some(overrides) = &self.overrides {
+            wait_lifecycle_gate(&overrides.process.start_process_lifecycle_gate).await;
         }
-        if let Some(cancel) = self.overrides.as_ref().and_then(|overrides| {
+        let operation = SandboxOperation::StartAgentProcess;
+        validate_mock_exec_env_keys(operation, request.process.env)?;
+        request.process.output.validate(operation)?;
+        if let Some(overrides) = &self.overrides {
             overrides
                 .process
-                .start_process_result_cancellations
+                .start_agent_process_calls
                 .lock_ignoring_poison()
-                .pop_front()
-        }) {
-            cancel.cancel();
+                .push(StartProcessCall {
+                    cmd: request.process.cmd.to_string(),
+                    timeout: request.process.timeout,
+                    env: request
+                        .process
+                        .env
+                        .iter()
+                        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                        .collect(),
+                    sudo: request.process.sudo,
+                    output: request.process.output,
+                });
         }
-        Ok(handle)
+        let process = self
+            .start_process_with_contract(&request.process, operation, true)
+            .await?;
+        GuestAgentProcessHandle::try_from_process(process)
     }
 
     async fn wait_process(

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -13,7 +13,6 @@ async fn overrides_record_start_process_output_modes_in_order() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -26,7 +25,6 @@ async fn overrides_record_start_process_output_modes_in_order() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::stream(),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -41,7 +39,6 @@ async fn overrides_record_start_process_output_modes_in_order() {
                 env: Vec::new(),
                 sudo: false,
                 output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-                control: ProcessControlMode::None,
             },
             StartProcessCall {
                 cmd: "agent".to_string(),
@@ -49,7 +46,6 @@ async fn overrides_record_start_process_output_modes_in_order() {
                 env: Vec::new(),
                 sudo: false,
                 output: ProcessOutputMode::stream(),
-                control: ProcessControlMode::None,
             },
         ]
     );
@@ -70,7 +66,6 @@ async fn start_process_emits_queued_stdout_chunks() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::stream(),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -84,7 +79,7 @@ async fn start_process_emits_queued_stdout_chunks() {
 }
 
 #[tokio::test]
-async fn start_process_returns_control_handle_when_requested() {
+async fn start_agent_process_returns_mandatory_control_handle() {
     let runtime = MockSandboxRuntime::new();
     let factory = runtime.create_factory(test_factory_config()).await.unwrap();
     let sandbox = factory.create(test_sandbox_config()).await.unwrap();
@@ -96,26 +91,24 @@ async fn start_process_returns_control_handle_when_requested() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
     assert!(without_control.control_handle().is_none());
 
     let with_control = sandbox
-        .start_process(&StartProcessRequest {
-            cmd: "agent",
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-            output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::Enabled,
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
         })
         .await
         .unwrap();
-    let control = with_control
-        .control_handle()
-        .expect("enabled control should expose a handle");
+    let (_process, control) = with_control.into_parts();
     let ack = control
         .control("msg-1", b"payload", Duration::from_secs(5))
         .await
@@ -124,23 +117,56 @@ async fn start_process_returns_control_handle_when_requested() {
 }
 
 #[tokio::test]
+async fn start_agent_process_fails_when_control_is_unavailable() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.set_process_control_supported(false);
+    let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+
+    let error = match sandbox
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
+        })
+        .await
+    {
+        Ok(_) => panic!("Agent start unexpectedly succeeded without control"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        SandboxError::Operation {
+            operation: SandboxOperation::StartAgentProcess,
+            reason: SandboxOperationReason::Other,
+            ..
+        }
+    ));
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
+}
+
+#[tokio::test]
 async fn process_control_calls_are_recorded_when_overrides_are_enabled() {
     let overrides = Arc::new(MockSandboxOverrides::new());
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let handle = sandbox
-        .start_process(&StartProcessRequest {
-            cmd: "agent",
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-            output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::Enabled,
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
         })
         .await
         .unwrap();
-    let control = handle
-        .control_handle()
-        .expect("enabled control should expose a handle");
+    let (_process, control) = handle.into_parts();
 
     control
         .control("msg-1", b"payload", Duration::from_millis(250))
@@ -164,19 +190,18 @@ async fn queued_process_control_errors_are_consumed_fifo() {
     overrides.push_process_control_error("second control failed");
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let handle = sandbox
-        .start_process(&StartProcessRequest {
-            cmd: "agent",
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-            output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::Enabled,
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
         })
         .await
         .unwrap();
-    let control = handle
-        .control_handle()
-        .expect("enabled control should expose a handle");
+    let (_process, control) = handle.into_parts();
 
     let outcome = control
         .control_outcome("msg-1", b"payload-1", Duration::from_secs(1))
@@ -217,19 +242,18 @@ async fn queued_structured_process_control_outcomes_are_preserved() {
     });
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let handle = sandbox
-        .start_process(&StartProcessRequest {
-            cmd: "agent",
-            timeout: Duration::from_secs(5),
-            env: &[],
-            sudo: false,
-            output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::Enabled,
+        .start_agent_process(&StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
         })
         .await
         .unwrap();
-    let control = handle
-        .control_handle()
-        .expect("enabled control should expose a handle");
+    let (_process, control) = handle.into_parts();
 
     let outcome = control
         .control_outcome("msg-1", b"payload", Duration::from_secs(1))
@@ -330,7 +354,6 @@ async fn start_process_validates_stream_configuration() {
                 env: &[],
                 sudo: false,
                 output,
-                control: ProcessControlMode::None,
             })
             .await
         {
@@ -359,7 +382,6 @@ async fn start_process_validates_stream_configuration() {
             env: &[],
             sudo: false,
             output,
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -381,7 +403,6 @@ async fn start_process_rejects_invalid_env_key() {
             env: &[("1BAD", "x")],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await;
     let err = match result {
@@ -418,7 +439,6 @@ async fn queued_start_process_errors_are_consumed_fifo() {
         env: &[],
         sudo: false,
         output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-        control: ProcessControlMode::None,
     };
 
     let first_error = match sandbox.start_process(&request).await {
@@ -465,7 +485,6 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
                     env: &[],
                     sudo: false,
                     output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-                    control: ProcessControlMode::None,
                 })
                 .await
         })
@@ -490,7 +509,6 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -514,7 +532,6 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
             env: &[("1BAD", "value")],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await;
     assert!(invalid_start.is_err());
@@ -528,7 +545,6 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -542,7 +558,6 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -555,7 +570,6 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -603,7 +617,6 @@ async fn wait_process_rejects_consumed_guest_process_handle() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -639,7 +652,6 @@ async fn wait_process_returns_queued_process_exit() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -666,7 +678,6 @@ async fn wait_process_default_exit_is_unchanged_without_queued_exit() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -723,7 +734,6 @@ async fn wait_process_lifecycle_gate_blocks_until_released() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -755,7 +765,6 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -781,7 +790,6 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();
@@ -818,7 +826,6 @@ async fn process_cancel_releases_wait_process_lifecycle_gate() {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
         })
         .await
         .unwrap();

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -123,6 +123,8 @@ pub enum SandboxOperation {
     WriteFile,
     /// [`Sandbox::start_process`](crate::Sandbox::start_process).
     StartProcess,
+    /// [`Sandbox::start_agent_process`](crate::Sandbox::start_agent_process).
+    StartAgentProcess,
     /// [`GuestProcessControlHandle::control`](crate::GuestProcessControlHandle::control).
     ProcessControl,
     /// [`Sandbox::wait_process`](crate::Sandbox::wait_process).
@@ -137,6 +139,7 @@ impl fmt::Display for SandboxOperation {
             Self::CopyFile => f.write_str("copy file"),
             Self::WriteFile => f.write_str("write file"),
             Self::StartProcess => f.write_str("start process"),
+            Self::StartAgentProcess => f.write_str("start Agent process"),
             Self::ProcessControl => f.write_str("process control"),
             Self::WaitProcess => f.write_str("wait process"),
         }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -57,10 +57,11 @@ pub use snapshot::{
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
-    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessControlOutcomeFuture,
-    GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone,
-    ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
-    ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
-    ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest, StorageManifestRequest,
+    GuestAgentProcessHandle, GuestProcessCancelHandle, GuestProcessControlHandle,
+    GuestProcessControlOutcomeFuture, GuestProcessHandle, GuestProcessWaiter,
+    GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
+    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
+    ProcessControlWriteState, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
+    ProcessOutputReceiver, StartAgentProcessRequest, StartProcessRequest, StorageManifestRequest,
     WriteFileEntry,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -9,9 +9,9 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
-    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle,
-    GuestStateRestoreRequest, ProcessExit, StartProcessRequest, StorageManifestRequest,
-    WriteFileEntry,
+    CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
+    GuestProcessHandle, GuestStateRestoreRequest, ProcessExit, StartAgentProcessRequest,
+    StartProcessRequest, StorageManifestRequest, WriteFileEntry,
 };
 
 /// Eligibility result after a sandbox successfully reaches the parked state.
@@ -833,6 +833,13 @@ pub trait Sandbox: Send + Sync + Any {
     /// [`GuestProcessHandle::take_stdout_receiver`]. Callers that take the
     /// receiver are responsible for draining it while the process runs.
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle>;
+    /// Start the controlled guest Agent process.
+    ///
+    /// A successful result always includes process control by construction.
+    async fn start_agent_process(
+        &self,
+        request: &StartAgentProcessRequest<'_>,
+    ) -> Result<GuestAgentProcessHandle>;
     /// Wait for the process behind `handle` to exit, up to `timeout`.
     ///
     /// Consumes the handle. If `stdout_rx` was not taken before waiting, the

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -166,8 +166,6 @@ pub struct StartProcessRequest<'a> {
     pub sudo: bool,
     /// Buffered or streamed stdout behavior.
     pub output: ProcessOutputMode,
-    /// Optional operation-bound control sink requested for the started process.
-    pub control: ProcessControlMode,
 }
 
 impl StartProcessRequest<'_> {
@@ -177,6 +175,22 @@ impl StartProcessRequest<'_> {
     /// accidentally turn a bounded process into an unbounded one.
     pub fn timeout_ms(&self) -> u32 {
         duration_ms(self.timeout)
+    }
+}
+
+/// Request for the controlled guest Agent process.
+///
+/// Agent startup is intentionally separate from ordinary supervised process
+/// startup so generic callers cannot select the controlled Agent topology.
+pub struct StartAgentProcessRequest<'a> {
+    /// Common process startup fields.
+    pub process: StartProcessRequest<'a>,
+}
+
+impl StartAgentProcessRequest<'_> {
+    /// Return the timeout as milliseconds, saturating at `u32::MAX`.
+    pub fn timeout_ms(&self) -> u32 {
+        self.process.timeout_ms()
     }
 }
 
@@ -853,6 +867,36 @@ impl GuestProcessHandle {
     }
 }
 
+/// Handle returned by
+/// [`Sandbox::start_agent_process`](crate::Sandbox::start_agent_process).
+///
+/// A successful Agent start always includes the process-control capability.
+/// The process handle remains the sole owner of wait, cancellation, stdout,
+/// and drop cleanup state.
+pub struct GuestAgentProcessHandle {
+    process: GuestProcessHandle,
+    control: GuestProcessControlHandle,
+}
+
+impl GuestAgentProcessHandle {
+    /// Convert a provider process handle into a controlled Agent handle.
+    pub fn try_from_process(mut process: GuestProcessHandle) -> crate::Result<Self> {
+        let Some(control) = process.control.take() else {
+            return Err(crate::SandboxError::Operation {
+                operation: crate::SandboxOperation::StartAgentProcess,
+                reason: crate::SandboxOperationReason::Other,
+                message: "provider returned an Agent process without process control".into(),
+            });
+        };
+        Ok(Self { process, control })
+    }
+
+    /// Consume the Agent handle into its process owner and control capability.
+    pub fn into_parts(self) -> (GuestProcessHandle, GuestProcessControlHandle) {
+        (self.process, self.control)
+    }
+}
+
 impl Drop for GuestProcessHandle {
     fn drop(&mut self) {
         self.drop_unclaimed_stdout();
@@ -904,20 +948,6 @@ pub enum ProcessOutputMode {
     },
 }
 
-/// Process-control mode for a process started with
-/// [`Sandbox::start_process`](crate::Sandbox::start_process).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ProcessControlMode {
-    /// Do not request a process-control sink.
-    None,
-    /// Request a provider-backed process-control sink.
-    ///
-    /// Providers may still return a process handle without a control handle.
-    /// Callers must check [`GuestProcessHandle::control_handle`] on the returned
-    /// process handle before sending control messages.
-    Enabled,
-}
-
 impl ProcessOutputMode {
     /// Default stream byte budget for long-running process logs.
     pub const DEFAULT_STREAM_LIMIT_BYTES: u32 = 64 * 1024 * 1024;
@@ -961,26 +991,26 @@ impl ProcessOutputMode {
     ///
     /// Stream chunk limits and queue capacities must be positive, and queue
     /// capacities must not exceed [`MAX_QUEUE_CAPACITY`](Self::MAX_QUEUE_CAPACITY).
-    pub fn validate(self) -> crate::Result<()> {
+    pub fn validate(self, operation: crate::SandboxOperation) -> crate::Result<()> {
         match self {
             Self::Stream {
                 chunk_limit_bytes: 0,
                 ..
             } => Err(crate::SandboxError::Operation {
-                operation: crate::SandboxOperation::StartProcess,
+                operation,
                 reason: crate::SandboxOperationReason::Other,
                 message: "process stream chunk limit must be positive".into(),
             }),
             Self::Stream {
                 queue_capacity: 0, ..
             } => Err(crate::SandboxError::Operation {
-                operation: crate::SandboxOperation::StartProcess,
+                operation,
                 reason: crate::SandboxOperationReason::Other,
                 message: "process stream queue capacity must be positive".into(),
             }),
             Self::Stream { queue_capacity, .. } if queue_capacity > Self::MAX_QUEUE_CAPACITY => {
                 Err(crate::SandboxError::Operation {
-                    operation: crate::SandboxOperation::StartProcess,
+                    operation,
                     reason: crate::SandboxOperationReason::Other,
                     message: format!(
                         "process stream queue capacity must be at most {}",
@@ -1112,7 +1142,20 @@ mod tests {
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
-            control: ProcessControlMode::None,
+        };
+        assert_eq!(req.timeout_ms(), 1);
+    }
+
+    #[test]
+    fn start_agent_process_timeout_uses_common_process_request() {
+        let req = StartAgentProcessRequest {
+            process: StartProcessRequest {
+                cmd: "true",
+                timeout: Duration::from_nanos(1),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            },
         };
         assert_eq!(req.timeout_ms(), 1);
     }
@@ -1396,6 +1439,55 @@ mod tests {
         handle.drop_unclaimed_stdout();
 
         assert!(!closed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn guest_agent_process_handle_requires_control() {
+        let process = GuestProcessHandle::new(
+            42,
+            None,
+            None,
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        );
+
+        let error = match GuestAgentProcessHandle::try_from_process(process) {
+            Ok(_) => panic!("Agent handle unexpectedly accepted missing control"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            crate::SandboxError::Operation {
+                operation: crate::SandboxOperation::StartAgentProcess,
+                reason: crate::SandboxOperationReason::Other,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn guest_agent_process_handle_transfers_process_and_control() {
+        let control = GuestProcessControlHandle::new(|message_id, _, _| {
+            Box::pin(async move { Ok(ProcessControlAck { message_id }) })
+        });
+        let process = GuestProcessHandle::new(
+            42,
+            None,
+            Some(control),
+            GuestProcessWaiter::new(|_| {
+                Box::pin(async { Ok(ProcessExit::new(42, 0, Vec::new(), Vec::new())) })
+            }),
+        );
+
+        let agent = GuestAgentProcessHandle::try_from_process(process).unwrap();
+        let (process, control) = agent.into_parts();
+        assert_eq!(process.guest_pid, 42);
+        let ack = control
+            .control("message", b"payload", Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(ack.message_id, "message");
     }
 
     #[test]

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -436,6 +436,11 @@ impl ConnectionDispatcher {
                 };
             request.attach_exec_control(registration.guard, registration.bootstrap_endpoint);
         }
+        if let Err(error) = request.validate_control_attachment() {
+            operation_guard.release();
+            send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+            return Ok(());
+        }
         start_exec_operation(
             request,
             operation_guard,

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -57,8 +57,8 @@ use guest_contracts::process_containment::{
 };
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
-    ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
-    MSG_EXEC_STARTED,
+    ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTermination, ExecTimeoutPolicy,
+    MSG_ERROR, MSG_EXEC_STARTED,
 };
 
 #[cfg(test)]
@@ -108,10 +108,18 @@ pub(crate) struct ExecOperationRegistry {
 struct ExecOperationRegistryEntry {
     cancel: Arc<AtomicBool>,
     label_preview: String,
+    process_class: &'static str,
+    operation_kind: &'static str,
 }
 
 impl ExecOperationRegistry {
-    pub(crate) fn register(&self, seq: u32, label: &str) -> Result<ExecOperationRegistration, ()> {
+    pub(crate) fn register(
+        &self,
+        seq: u32,
+        label: &str,
+        process_class: &'static str,
+        operation_kind: &'static str,
+    ) -> Result<ExecOperationRegistration, ()> {
         let mut active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if active.contains_key(&seq) {
             return Err(());
@@ -123,6 +131,8 @@ impl ExecOperationRegistry {
             ExecOperationRegistryEntry {
                 cancel: cancel.clone(),
                 label_preview: truncate_command_preview(label),
+                process_class,
+                operation_kind,
             },
         );
         Ok(ExecOperationRegistration {
@@ -132,11 +142,15 @@ impl ExecOperationRegistry {
         })
     }
 
-    pub(crate) fn cancel(&self, seq: u32) -> Option<String> {
+    pub(crate) fn cancel(&self, seq: u32) -> Option<(String, &'static str, &'static str)> {
         let active = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let cancel = active.get(&seq)?;
         cancel.cancel.store(true, Ordering::Release);
-        Some(cancel.label_preview.clone())
+        Some((
+            cancel.label_preview.clone(),
+            cancel.process_class,
+            cancel.operation_kind,
+        ))
     }
 
     fn remove_if_same(&self, seq: u32, cancel: &Arc<AtomicBool>) {
@@ -215,6 +229,7 @@ impl ExecOperationTimeout {
 pub(crate) struct ExecOperationWorkerRequest {
     seq: u32,
     lifecycle: ExecOperationLifecycle,
+    role: ExecProcessRole,
     timeout: ExecOperationTimeout,
     command: String,
     env: Vec<(String, String)>,
@@ -232,12 +247,34 @@ pub(crate) struct ExecOperationWorkerRequest {
 }
 
 impl ExecOperationWorkerRequest {
+    fn process_class(&self) -> &'static str {
+        match self.role {
+            ExecProcessRole::Workload => "contained_workload",
+            ExecProcessRole::Agent => "controlled_agent",
+        }
+    }
+
+    fn operation_kind(&self) -> &'static str {
+        match (self.role, self.lifecycle) {
+            (ExecProcessRole::Workload, ExecOperationLifecycle::OneShot) => "exec",
+            (ExecProcessRole::Workload, ExecOperationLifecycle::Supervised) => "start_process",
+            (ExecProcessRole::Agent, ExecOperationLifecycle::Supervised) => "start_agent_process",
+            (ExecProcessRole::Agent, ExecOperationLifecycle::OneShot) => "invalid",
+        }
+    }
+
     pub(crate) fn from_decoded(
         seq: u32,
         decoded: vsock_proto::DecodedExecStart<'_>,
         process_containment_mode: ProcessContainmentMode,
         drain_deadline: Duration,
     ) -> io::Result<Self> {
+        vsock_proto::validate_exec_process_contract(
+            decoded.role,
+            decoded.lifecycle,
+            decoded.control,
+        )
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
         let lifecycle = match decoded.lifecycle {
             ExecLifecyclePolicy::OneShot => ExecOperationLifecycle::OneShot,
             ExecLifecyclePolicy::Supervised => ExecOperationLifecycle::Supervised,
@@ -274,6 +311,7 @@ impl ExecOperationWorkerRequest {
         Ok(Self {
             seq,
             lifecycle,
+            role: decoded.role,
             timeout,
             command: decoded.command.to_owned(),
             env: decoded
@@ -314,6 +352,20 @@ impl ExecOperationWorkerRequest {
         self.exec_control_guard = Some(guard);
         self.exec_control_bootstrap_endpoint = bootstrap_endpoint;
     }
+
+    pub(crate) fn validate_control_attachment(&self) -> io::Result<()> {
+        match (self.role, self.exec_control_bootstrap_endpoint.is_some()) {
+            (ExecProcessRole::Workload, false) | (ExecProcessRole::Agent, true) => Ok(()),
+            (ExecProcessRole::Workload, true) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "workload process received an Agent control bootstrap endpoint",
+            )),
+            (ExecProcessRole::Agent, false) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Agent process did not receive a control bootstrap endpoint",
+            )),
+        }
+    }
 }
 
 struct DrainWorker {
@@ -333,16 +385,26 @@ struct ExecStreamWriter {
     writer: GuestWriter,
     output_seq: u32,
     frame: Vec<u8>,
+    process_class: &'static str,
+    operation_kind: &'static str,
 }
 
 impl ExecStreamWriter {
-    fn new(seq: u32, label_preview: String, writer: GuestWriter) -> Self {
+    fn new(
+        seq: u32,
+        label_preview: String,
+        writer: GuestWriter,
+        process_class: &'static str,
+        operation_kind: &'static str,
+    ) -> Self {
         Self {
             seq,
             label_preview,
             writer,
             output_seq: 0,
             frame: Vec::new(),
+            process_class,
+            operation_kind,
         }
     }
 
@@ -751,9 +813,11 @@ impl RunningExec {
             log(
                 "WARN",
                 &format!(
-                    "exec operation: drain deadline reached seq={} label={} after {:?}",
+                    "exec operation: drain deadline reached seq={} label={} process_class={} operation_kind={} after {:?}",
                     request.seq,
                     truncate_command_preview(&request.label),
+                    request.process_class(),
+                    request.operation_kind(),
                     request.drain_deadline,
                 ),
             );
@@ -904,7 +968,9 @@ where
     S: ThreadSpawner,
 {
     let seq = request.seq;
-    let registration = match registry.register(seq, &request.label) {
+    let process_class = request.process_class();
+    let operation_kind = request.operation_kind();
+    let registration = match registry.register(seq, &request.label, process_class, operation_kind) {
         Ok(registration) => registration,
         Err(()) => {
             return send_error_response(seq, "exec operation already active", &writer);
@@ -937,7 +1003,9 @@ where
             let diagnostic = format!("Failed to spawn exec operation worker thread: {e}");
             log(
                 "ERROR",
-                &format!("exec operation: worker spawn failed seq={seq}: {e}"),
+                &format!(
+                    "exec operation: worker spawn failed seq={seq} process_class={process_class} operation_kind={operation_kind}: {e}"
+                ),
             );
             send_exec_result_after_lock(
                 ExecResultFrame {
@@ -956,10 +1024,12 @@ where
 }
 
 pub(crate) fn cancel_exec_operation(registry: &ExecOperationRegistry, seq: u32) {
-    if let Some(label_preview) = registry.cancel(seq) {
+    if let Some((label_preview, process_class, operation_kind)) = registry.cancel(seq) {
         log(
             "INFO",
-            &format!("exec operation: cancel requested seq={seq} label={label_preview}"),
+            &format!(
+                "exec operation: cancel requested seq={seq} label={label_preview} process_class={process_class} operation_kind={operation_kind}"
+            ),
         );
     }
 }
@@ -1011,7 +1081,7 @@ fn run_exec_operation_worker<S>(
     let process_containment = match ExecProcessContainment::create(
         request.seq,
         request.process_containment_mode,
-        request.exec_control_bootstrap_endpoint.is_some(),
+        request.role,
     ) {
         Ok(process_containment) => process_containment,
         Err(error) => {
@@ -1093,9 +1163,11 @@ fn run_exec_operation_worker<S>(
         log(
             "WARN",
             &format!(
-                "exec operation: failed to send exec_started seq={} label={}: {e}",
+                "exec operation: failed to send exec_started seq={} label={} process_class={} operation_kind={}: {e}",
                 request.seq,
-                truncate_command_preview(&request.label)
+                truncate_command_preview(&request.label),
+                request.process_class(),
+                request.operation_kind(),
             ),
         );
         setup.abort_exec_started_send_failed(&completion);
@@ -1142,6 +1214,8 @@ fn run_exec_operation_worker<S>(
             request.seq,
             truncate_command_preview(&request.label),
             writer.clone(),
+            request.process_class(),
+            request.operation_kind(),
         )))
     });
 
@@ -1344,8 +1418,11 @@ where
                             log(
                                 "ERROR",
                                 &format!(
-                                    "exec operation: failed to encode output seq={} label={}: {e}",
-                                    writer.seq, writer.label_preview
+                                    "exec operation: failed to encode output seq={} label={} process_class={} operation_kind={}: {e}",
+                                    writer.seq,
+                                    writer.label_preview,
+                                    writer.process_class,
+                                    writer.operation_kind,
                                 ),
                             );
                             exec_cancel.store(true, Ordering::Release);
@@ -1356,8 +1433,11 @@ where
                             log(
                                 "WARN",
                                 &format!(
-                                    "exec operation: failed to send output chunk seq={} label={}: {e}",
-                                    writer.seq, writer.label_preview
+                                    "exec operation: failed to send output chunk seq={} label={} process_class={} operation_kind={}: {e}",
+                                    writer.seq,
+                                    writer.label_preview,
+                                    writer.process_class,
+                                    writer.operation_kind,
                                 ),
                             );
                             exec_cancel.store(true, Ordering::Release);
@@ -1737,9 +1817,11 @@ struct ExecTerminalLogMessageInput<'a> {
 fn exec_terminal_log_message(input: ExecTerminalLogMessageInput<'_>) -> Option<String> {
     let terminal_reason = exec_terminal_log_reason(input.slow, input.notable)?;
     Some(format!(
-        "exec result: seq={} label={} elapsed_ms={} slow={} notable={} terminal_reason={} termination={:?} stdout_len={} stderr_len={} stdout_truncated={} stderr_truncated={} diagnostic_present={}",
+        "exec result: seq={} label={} process_class={} operation_kind={} elapsed_ms={} slow={} notable={} terminal_reason={} termination={:?} stdout_len={} stderr_len={} stdout_truncated={} stderr_truncated={} diagnostic_present={}",
         input.request.seq,
         truncate_command_preview(&input.request.label),
+        input.request.process_class(),
+        input.request.operation_kind(),
         input.elapsed_ms,
         input.slow,
         input.notable,
@@ -1814,6 +1896,7 @@ mod tests {
         ExecOperationWorkerRequest {
             seq,
             lifecycle: ExecOperationLifecycle::OneShot,
+            role: ExecProcessRole::Workload,
             timeout: ExecOperationTimeout::Duration { timeout_ms: 0 },
             command: command.to_string(),
             env: Vec::new(),
@@ -1831,12 +1914,93 @@ mod tests {
         }
     }
 
+    fn decoded_request(
+        role: ExecProcessRole,
+        lifecycle: ExecLifecyclePolicy,
+        control: ExecControlPolicy,
+    ) -> vsock_proto::DecodedExecStart<'static> {
+        vsock_proto::DecodedExecStart {
+            lifecycle,
+            role,
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+            command: "true",
+            env: Vec::new(),
+            sudo: false,
+            label: "test",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: Vec::new(),
+            control,
+            stdin_bytes: None,
+        }
+    }
+
     fn operation_guard() -> OperationGuard {
         crate::quiesce::OperationState::default().acquire().unwrap()
     }
 
+    #[test]
+    fn worker_boundary_rejects_invalid_process_contracts() {
+        for decoded in [
+            decoded_request(
+                ExecProcessRole::Agent,
+                ExecLifecyclePolicy::OneShot,
+                ExecControlPolicy::Disabled,
+            ),
+            decoded_request(
+                ExecProcessRole::Workload,
+                ExecLifecyclePolicy::Supervised,
+                ExecControlPolicy::Enabled {
+                    control_nonce: [1; vsock_proto::EXEC_CONTROL_NONCE_LEN],
+                    sink: true,
+                },
+            ),
+        ] {
+            let error = match ExecOperationWorkerRequest::from_decoded(
+                1,
+                decoded,
+                ProcessContainmentMode::TestNoop,
+                EXEC_OUTPUT_DRAIN_DEADLINE,
+            ) {
+                Ok(_) => panic!("worker accepted invalid process contract"),
+                Err(error) => error,
+            };
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn worker_boundary_rejects_role_and_control_endpoint_mismatches() {
+        let mut workload = request(1, "true");
+        workload.exec_control_bootstrap_endpoint = Some("endpoint".to_string());
+        assert_eq!(
+            workload.validate_control_attachment().unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+
+        let mut agent = request(2, "true");
+        agent.role = ExecProcessRole::Agent;
+        agent.lifecycle = ExecOperationLifecycle::Supervised;
+        agent.control = ExecControlPolicy::Enabled {
+            control_nonce: [2; vsock_proto::EXEC_CONTROL_NONCE_LEN],
+            sink: true,
+        };
+        assert_eq!(
+            agent.validate_control_attachment().unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    fn register_test_operation(
+        registry: &ExecOperationRegistry,
+        seq: u32,
+        label: &str,
+    ) -> Result<ExecOperationRegistration, ()> {
+        registry.register(seq, label, "contained_workload", "exec")
+    }
+
     fn assert_registry_released(registry: &ExecOperationRegistry, seq: u32) {
-        let registration = registry.register(seq, "test");
+        let registration = register_test_operation(registry, seq, "test");
         assert!(
             registration.is_ok(),
             "exec operation registry entry for seq={seq} was not released"
@@ -2110,17 +2274,20 @@ mod tests {
     #[test]
     fn registry_rejects_duplicate_active_sequence_and_cleans_on_drop() {
         let registry = ExecOperationRegistry::default();
-        let first = registry.register(7, "first").unwrap();
-        assert!(registry.register(7, "duplicate").is_err());
+        let first = register_test_operation(&registry, 7, "first").unwrap();
+        assert!(register_test_operation(&registry, 7, "duplicate").is_err());
         drop(first);
-        assert!(registry.register(7, "second").is_ok());
+        assert!(register_test_operation(&registry, 7, "second").is_ok());
     }
 
     #[test]
     fn registry_cancel_sets_token_and_unknown_cancel_is_noop() {
         let registry = ExecOperationRegistry::default();
-        let registration = registry.register(8, "cancel-me").unwrap();
-        assert_eq!(registry.cancel(8).as_deref(), Some("cancel-me"));
+        let registration = register_test_operation(&registry, 8, "cancel-me").unwrap();
+        assert_eq!(
+            registry.cancel(8),
+            Some(("cancel-me".to_string(), "contained_workload", "exec"))
+        );
         assert!(registration.cancel.load(Ordering::Acquire));
         assert!(registry.cancel(9).is_none());
     }
@@ -2129,10 +2296,12 @@ mod tests {
     fn registry_cancel_returns_truncated_label_preview() {
         let registry = ExecOperationRegistry::default();
         let long_label = format!("{}🔥tail", "a".repeat(99));
-        let registration = registry.register(10, &long_label).unwrap();
+        let registration = register_test_operation(&registry, 10, &long_label).unwrap();
 
-        let preview = registry.cancel(10).unwrap();
+        let (preview, process_class, operation_kind) = registry.cancel(10).unwrap();
         assert_eq!(preview, truncate_command_preview(&long_label));
+        assert_eq!(process_class, "contained_workload");
+        assert_eq!(operation_kind, "exec");
         assert!(preview.ends_with("..."));
         assert!(preview.len() < long_label.len());
         assert!(!preview.contains('🔥'));
@@ -2171,7 +2340,7 @@ mod tests {
         host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
         let writer = GuestWriter::new(guest);
         let registry = ExecOperationRegistry::default();
-        let _registration = registry.register(11, "duplicate").unwrap();
+        let _registration = register_test_operation(&registry, 11, "duplicate").unwrap();
 
         start_exec_operation_with_spawner(
             request(11, "echo duplicate"),
@@ -2197,7 +2366,7 @@ mod tests {
         let registry = ExecOperationRegistry::default();
         let mut request = request(47, "sleep 60");
         request.lifecycle = ExecOperationLifecycle::Supervised;
-        let registration = registry.register(request.seq, &request.label).unwrap();
+        let registration = register_test_operation(&registry, request.seq, &request.label).unwrap();
         let exec_cancel = registration.cancel_token();
 
         run_exec_operation_worker(
@@ -2359,7 +2528,7 @@ mod tests {
             chunk_limit_bytes: 8,
         };
         let seq = request.seq;
-        let registration = registry.register(request.seq, &request.label).unwrap();
+        let registration = register_test_operation(&registry, request.seq, &request.label).unwrap();
         let exec_cancel = registration.cancel_token();
 
         run_exec_operation_worker(

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -297,17 +297,20 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             );
         }
     };
-    let process_containment =
-        match ExecProcessContainment::create(seq, process_containment_mode, false) {
-            Ok(process_containment) => process_containment,
-            Err(error) => {
-                return failed_output(
-                    ExecTermination::StartFailed,
-                    started,
-                    format!("Failed to initialize storage helper process containment: {error}"),
-                );
-            }
-        };
+    let process_containment = match ExecProcessContainment::create(
+        seq,
+        process_containment_mode,
+        vsock_proto::ExecProcessRole::Workload,
+    ) {
+        Ok(process_containment) => process_containment,
+        Err(error) => {
+            return failed_output(
+                ExecTermination::StartFailed,
+                started,
+                format!("Failed to initialize storage helper process containment: {error}"),
+            );
+        }
+    };
     let mut prepared_containment = match process_containment.prepare_command() {
         Ok(prepared) => prepared,
         Err(error) => {

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -23,6 +23,7 @@ use guest_contracts::process_containment::{
     WORKLOAD_CGROUP_NAME, WORKLOAD_MEMORY_OOM_GROUP, WorkloadResourceEvents,
     WorkloadResourcePolicy,
 };
+use vsock_proto::ExecProcessRole;
 
 use crate::log::log;
 
@@ -163,7 +164,7 @@ impl ExecProcessContainment {
     pub(crate) fn create(
         sequence: u32,
         mode: ProcessContainmentMode,
-        trusted_control: bool,
+        role: ExecProcessRole,
     ) -> Result<Self, ProcessContainmentError> {
         if use_test_noop_backend(mode) {
             return Ok(Self {
@@ -171,7 +172,7 @@ impl ExecProcessContainment {
             });
         }
 
-        CgroupGuard::create(sequence, trusted_control).map(|guard| Self {
+        CgroupGuard::create(sequence, role).map(|guard| Self {
             backend: ContainmentBackend::Cgroup(guard),
         })
     }
@@ -276,22 +277,18 @@ fn verify_exec_process_containment_empty_in(
 }
 
 impl CgroupGuard {
-    fn create(sequence: u32, trusted_control: bool) -> Result<Self, ProcessContainmentError> {
+    fn create(sequence: u32, role: ExecProcessRole) -> Result<Self, ProcessContainmentError> {
         let policy = workload_resource_policy()?;
-        Self::create_in(
-            Path::new(EXEC_CGROUP_BASE_PATH),
-            sequence,
-            trusted_control,
-            policy,
-        )
+        Self::create_in(Path::new(EXEC_CGROUP_BASE_PATH), sequence, role, policy)
     }
 
     fn create_in(
         base_path: &Path,
         sequence: u32,
-        trusted_control: bool,
+        role: ExecProcessRole,
         policy: WorkloadResourcePolicy,
     ) -> Result<Self, ProcessContainmentError> {
+        let trusted_control = role == ExecProcessRole::Agent;
         let started = Instant::now();
         let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
         let group_name = format!(
@@ -1773,7 +1770,7 @@ mod tests {
         let policy =
             WorkloadResourcePolicy::for_guest_capacity(2, u64::from(4096_u32) * 1024 * 1024)
                 .unwrap();
-        let result = CgroupGuard::create_in(base.path(), 17, false, policy);
+        let result = CgroupGuard::create_in(base.path(), 17, ExecProcessRole::Workload, policy);
         let Err(error) = result else {
             panic!("placement-file open unexpectedly succeeded");
         };

--- a/crates/vsock-guest/tests/connection/exec_basic.rs
+++ b/crates/vsock-guest/tests/connection/exec_basic.rs
@@ -39,6 +39,7 @@ fn exec_operation_expected_nonzero_exit_still_returns_result() {
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
             command: "exit 66",
             env: &[],

--- a/crates/vsock-guest/tests/connection/exec_control.rs
+++ b/crates/vsock-guest/tests/connection/exec_control.rs
@@ -124,6 +124,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         target_seq,
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: vsock_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::None,
             command: &command,
             env: &[(process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint")],

--- a/crates/vsock-guest/tests/connection/exec_helpers.rs
+++ b/crates/vsock-guest/tests/connection/exec_helpers.rs
@@ -34,6 +34,7 @@ pub(super) fn send_supervised_exec_start(
         seq,
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout,
             command,
             env: &[],

--- a/crates/vsock-guest/tests/connection/exec_stdin.rs
+++ b/crates/vsock-guest/tests/connection/exec_stdin.rs
@@ -32,6 +32,7 @@ fn send_exec_start_with_stdin_timeout(
         seq,
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms },
             command,
             env: &[],
@@ -149,6 +150,7 @@ fn exec_operation_timeout_with_stdin_kills_child() {
         125,
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration {
                 timeout_ms: EXEC_OPERATION_TIMEOUT_TEST_MS,
             },
@@ -213,6 +215,7 @@ fn supervised_exec_writes_stdin_and_closes_pipe() {
         211,
         ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
             command: "cat; printf ':after'",
             env: &[],

--- a/crates/vsock-guest/tests/connection/exec_validation.rs
+++ b/crates/vsock-guest/tests/connection/exec_validation.rs
@@ -31,6 +31,7 @@ fn exec_operation_rejects_invalid_one_shot_start_policies() {
         103,
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "printf should-not-run",
             env: &[],
@@ -58,7 +59,7 @@ fn exec_operation_rejects_invalid_one_shot_start_policies() {
         ExecOutputPolicy::Discard,
     )
     .unwrap();
-    zero_timeout_payload[2..6].copy_from_slice(&0u32.to_be_bytes());
+    zero_timeout_payload[3..7].copy_from_slice(&0u32.to_be_bytes());
     let zero_timeout_msg = vsock_proto::encode(MSG_EXEC_START, 104, &zero_timeout_payload).unwrap();
     host_stream.write_all(&zero_timeout_msg).unwrap();
     assert_eq!(
@@ -66,12 +67,11 @@ fn exec_operation_rejects_invalid_one_shot_start_policies() {
         "invalid payload: exec start timeout duration must be positive"
     );
 
-    send_exec_start_request(
-        &mut host_stream,
-        105,
+    let mut invalid_control_payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
-            lifecycle: ExecLifecyclePolicy::OneShot,
-            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
+            lifecycle: ExecLifecyclePolicy::Supervised,
+            role: vsock_proto::ExecProcessRole::Workload,
+            timeout: ExecTimeoutPolicy::None,
             command: "printf should-not-run",
             env: &[],
             sudo: false,
@@ -85,10 +85,15 @@ fn exec_operation_rejects_invalid_one_shot_start_policies() {
             },
             stdin_bytes: None,
         },
-    );
+    )
+    .unwrap();
+    invalid_control_payload[0] = zero_timeout_payload[0];
+    let invalid_control_msg =
+        vsock_proto::encode(MSG_EXEC_START, 105, &invalid_control_payload).unwrap();
+    host_stream.write_all(&invalid_control_msg).unwrap();
     assert_eq!(
         read_error_response(&mut host_stream, 105),
-        "exec control policy requires supervised lifecycle"
+        "invalid payload: exec start role, lifecycle, and control combination invalid"
     );
 
     send_quiesce_operations(&mut host_stream, 106);

--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -115,6 +115,7 @@ fn production_exec_identity_matches_sandbox_user() {
     let command = "printf 'uid=%s\\ngid=%s\\ngroups=%s\\ncwd=%s\\nhome=%s\\nuser=%s\\nlogname=%s\\n' \"$(id -u)\" \"$(id -g)\" \"$(id -G)\" \"$(pwd -P)\" \"${HOME-}\" \"${USER-}\" \"${LOGNAME-}\"";
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: vsock_proto::ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5_000 },
         command,
         env: &[],
@@ -306,6 +307,7 @@ fn send_write_file(stream: &mut UnixStream, sequence: u32, path: &str, sudo: boo
 fn send_supervised_env_exec(stream: &mut UnixStream, sequence: u32) {
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::Supervised,
+        role: vsock_proto::ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::None,
         command: "printf '%s' \"$OKOU_TEST_ENV_SCRIPT_READY\"; sleep 60",
         env: &[("OKOU_TEST_ENV_SCRIPT_READY", "ready")],

--- a/crates/vsock-host/src/exec_operation/diagnostics.rs
+++ b/crates/vsock-host/src/exec_operation/diagnostics.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use tokio::time::Instant;
-use vsock_proto::{ExecCapturedOutput, ExecTermination};
+use vsock_proto::{ExecCapturedOutput, ExecProcessRole, ExecTermination};
 
 use super::state::ExecOperationLifecycle;
 use super::{EXEC_OPERATION_LABEL_LOG_PREFIX_MAX_BYTES, EXEC_OPERATION_STAGE_SLOW_THRESHOLD};
@@ -68,12 +68,16 @@ pub(in crate::exec_operation) struct ExecOperationDiagnostic {
     pub(in crate::exec_operation) label_log: String,
     pub(in crate::exec_operation) registered_at: Instant,
     pub(in crate::exec_operation) first_output_at: Option<Instant>,
+    pub(in crate::exec_operation) process_class: &'static str,
+    pub(in crate::exec_operation) operation_kind: &'static str,
 }
 
 pub(in crate::exec_operation) struct ExecOperationSnapshot {
     pub(in crate::exec_operation) seq: u32,
     pub(in crate::exec_operation) label_log: String,
     pub(in crate::exec_operation) elapsed_ms: u128,
+    pub(in crate::exec_operation) process_class: &'static str,
+    pub(in crate::exec_operation) operation_kind: &'static str,
 }
 
 pub(crate) struct ExecOperationCloseSnapshot {
@@ -85,15 +89,34 @@ pub(in crate::exec_operation) struct ExecOperationFrameDiagnostic {
     pub(in crate::exec_operation) seq: u32,
     pub(in crate::exec_operation) label_log: String,
     pub(in crate::exec_operation) frame: &'static str,
+    pub(in crate::exec_operation) process_class: &'static str,
+    pub(in crate::exec_operation) operation_kind: &'static str,
 }
 
 impl ExecOperationDiagnostic {
-    pub(in crate::exec_operation) fn new(seq: u32, label: &str) -> Self {
+    pub(in crate::exec_operation) fn new(
+        seq: u32,
+        label: &str,
+        role: ExecProcessRole,
+        supervised: bool,
+    ) -> Self {
+        let process_class = match role {
+            ExecProcessRole::Workload => "contained_workload",
+            ExecProcessRole::Agent => "controlled_agent",
+        };
+        let operation_kind = match (role, supervised) {
+            (ExecProcessRole::Workload, false) => "exec",
+            (ExecProcessRole::Workload, true) => "start_process",
+            (ExecProcessRole::Agent, true) => "start_agent_process",
+            (ExecProcessRole::Agent, false) => "invalid",
+        };
         Self {
             seq,
             label_log: exec_operation_label_log(label),
             registered_at: Instant::now(),
             first_output_at: None,
+            process_class,
+            operation_kind,
         }
     }
 
@@ -105,6 +128,8 @@ impl ExecOperationDiagnostic {
             seq: self.seq,
             label_log: self.label_log.clone(),
             frame,
+            process_class: self.process_class,
+            operation_kind: self.operation_kind,
         }
     }
 
@@ -117,6 +142,8 @@ impl ExecOperationDiagnostic {
             seq: self.seq,
             label_log: self.label_log.clone(),
             elapsed_ms: self.elapsed_ms(),
+            process_class: self.process_class,
+            operation_kind: self.operation_kind,
         }
     }
 
@@ -132,6 +159,8 @@ impl ExecOperationDiagnostic {
                 seq: self.seq,
                 label_log: self.label_log.clone(),
                 elapsed_ms,
+                process_class: self.process_class,
+                operation_kind: self.operation_kind,
             });
         }
 
@@ -182,6 +211,8 @@ impl ExecOperationDiagnostic {
                     stderr_truncated,
                     diagnostic_present,
                     host_cancel_requested,
+                    process_class = self.process_class,
+                    operation_kind = self.operation_kind,
                     "exec operation terminal result"
                 )
             };
@@ -199,6 +230,8 @@ impl ExecOperationDiagnostic {
             label = %self.label_log,
             elapsed_ms = self.elapsed_ms(),
             error = %error,
+            process_class = self.process_class,
+            operation_kind = self.operation_kind,
             "exec operation error response"
         );
     }
@@ -312,8 +345,12 @@ pub(crate) fn log_operations_closed(reason: &'static str, snapshot: &ExecOperati
         .iter()
         .map(|operation| {
             format!(
-                "seq={} label={} elapsed_ms={}",
-                operation.seq, operation.label_log, operation.elapsed_ms
+                "seq={} label={} elapsed_ms={} process_class={} operation_kind={}",
+                operation.seq,
+                operation.label_log,
+                operation.elapsed_ms,
+                operation.process_class,
+                operation.operation_kind
             )
         })
         .collect::<Vec<_>>()

--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -241,6 +241,8 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
             seq = snapshot.seq,
             label = %snapshot.label_log,
             elapsed_ms = snapshot.elapsed_ms,
+            process_class = snapshot.process_class,
+            operation_kind = snapshot.operation_kind,
             "slow exec operation first output"
         );
     }

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -348,6 +348,8 @@ async fn write_encoded_frame_with_pre_write_decision(
             seq = diagnostic.seq,
             label = %diagnostic.label_log,
             frame = diagnostic.frame,
+            process_class = diagnostic.process_class,
+            operation_kind = diagnostic.operation_kind,
             wait_elapsed_ms,
             "slow exec operation frame writer lock wait"
         );
@@ -361,6 +363,8 @@ async fn write_encoded_frame_with_pre_write_decision(
             seq = diagnostic.seq,
             label = %diagnostic.label_log,
             frame = diagnostic.frame,
+            process_class = diagnostic.process_class,
+            operation_kind = diagnostic.operation_kind,
             write_elapsed_ms,
             "slow exec operation frame write"
         );
@@ -372,6 +376,8 @@ async fn write_encoded_frame_with_pre_write_decision(
                 seq = diagnostic.seq,
                 label = %diagnostic.label_log,
                 frame = diagnostic.frame,
+                process_class = diagnostic.process_class,
+                operation_kind = diagnostic.operation_kind,
                 write_elapsed_ms,
                 error = %e,
                 "exec operation frame write failed"

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -127,6 +127,8 @@ impl ExecWaitLifecycle {
                 tracing::info!(
                     seq = seq,
                     label = %diagnostic.label_log,
+                    process_class = diagnostic.process_class,
+                    operation_kind = diagnostic.operation_kind,
                     elapsed_ms = diagnostic.elapsed_ms(),
                     "exec operation cancel sent"
                 );
@@ -135,6 +137,8 @@ impl ExecWaitLifecycle {
                 tracing::info!(
                     seq = seq,
                     label = %diagnostic.label_log,
+                    process_class = diagnostic.process_class,
+                    operation_kind = diagnostic.operation_kind,
                     elapsed_ms = diagnostic.elapsed_ms(),
                     "supervised exec operation cancel sent"
                 );
@@ -232,6 +236,8 @@ impl ExecWaitCore {
                 tracing::warn!(
                     seq = seq,
                     label = %self.diagnostic.label_log,
+                    process_class = self.diagnostic.process_class,
+                    operation_kind = self.diagnostic.operation_kind,
                     elapsed_ms = self.diagnostic.elapsed_ms(),
                     poison_connection = poison_on_timeout,
                     "exec operation wait timeout"
@@ -241,6 +247,8 @@ impl ExecWaitCore {
                 tracing::warn!(
                     seq = seq,
                     label = %self.diagnostic.label_log,
+                    process_class = self.diagnostic.process_class,
+                    operation_kind = self.diagnostic.operation_kind,
                     elapsed_ms = self.diagnostic.elapsed_ms(),
                     poison_connection = poison_on_timeout,
                     "supervised exec operation wait timeout"
@@ -463,6 +471,8 @@ impl ExecWaitCore {
                         tracing::warn!(
                             seq = seq,
                             label = %diagnostic.label_log,
+                            process_class = diagnostic.process_class,
+                            operation_kind = diagnostic.operation_kind,
                             elapsed_ms = diagnostic.elapsed_ms(),
                             "{}",
                             match lifecycle {
@@ -685,6 +695,8 @@ impl SupervisedExecCancelHandle {
             tracing::warn!(
                 seq = self.route_id.wire_seq(),
                 label = %self.diagnostic.label_log,
+                process_class = self.diagnostic.process_class,
+                operation_kind = self.diagnostic.operation_kind,
                 elapsed_ms = self.diagnostic.elapsed_ms(),
                 "supervised exec operation cancel write timed out"
             );
@@ -1025,6 +1037,8 @@ impl Drop for ExecOperationCancelOnDropGuard {
                 tracing::warn!(
                     seq = seq,
                     label = %diagnostic.label_log,
+                    process_class = diagnostic.process_class,
+                    operation_kind = diagnostic.operation_kind,
                     elapsed_ms = diagnostic.elapsed_ms(),
                     error = %err,
                     "exec operation cancel on drop admission failed"
@@ -1054,6 +1068,8 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     tracing::info!(
                         seq = seq,
                         label = %diagnostic.label_log,
+                        process_class = diagnostic.process_class,
+                        operation_kind = diagnostic.operation_kind,
                         elapsed_ms = diagnostic.elapsed_ms(),
                         "exec operation cancel sent on drop"
                     );
@@ -1062,6 +1078,8 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     tracing::warn!(
                         seq = seq,
                         label = %diagnostic.label_log,
+                        process_class = diagnostic.process_class,
+                        operation_kind = diagnostic.operation_kind,
                         elapsed_ms = diagnostic.elapsed_ms(),
                         error = %err,
                         "exec operation cancel on drop failed"
@@ -1071,6 +1089,8 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     tracing::warn!(
                         seq = seq,
                         label = %diagnostic.label_log,
+                        process_class = diagnostic.process_class,
+                        operation_kind = diagnostic.operation_kind,
                         elapsed_ms = diagnostic.elapsed_ms(),
                         "exec operation cancel on drop timed out"
                     );

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::time::{self, Instant};
 use vsock_proto::{
-    ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecTimeoutPolicy, MSG_EXEC_CANCEL,
+    ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecProcessRole, ExecTimeoutPolicy,
+    MSG_EXEC_CANCEL,
 };
 
 use crate::{CompositeNormalOperation, FrameWriteObserver, Shared};
@@ -105,6 +106,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::OneShot,
+            role: ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration {
                 timeout_ms: request.timeout_ms,
             },
@@ -137,6 +139,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
             stderr: request.stderr,
             stream_queue_capacity,
             lifecycle: ExecOperationLifecycle::OneShot,
+            role: ExecProcessRole::Workload,
             tracking,
         },
     )?;
@@ -221,6 +224,7 @@ where
     let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(
         vsock_proto::ExecStartEncodeRequest {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: request.role,
             timeout: request.timeout,
             command: request.command,
             env: request.env,
@@ -255,6 +259,7 @@ where
                 start_tx: Some(start_tx),
                 control_nonce,
             },
+            role: request.role,
             tracking: ExecOperationTracking::Tracked,
         },
     )?;
@@ -330,6 +335,8 @@ where
                 tracing::warn!(
                     seq = seq,
                     label = %diagnostic.label_log,
+                    process_class = diagnostic.process_class,
+                    operation_kind = diagnostic.operation_kind,
                     elapsed_ms = diagnostic.elapsed_ms(),
                     "supervised exec start timeout cancel write timed out"
                 );

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -3,7 +3,9 @@ use std::io;
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
-use vsock_proto::{ExecControlNonce, ExecControlStatus, ExecOutputPolicy, ExecTermination};
+use vsock_proto::{
+    ExecControlNonce, ExecControlStatus, ExecOutputPolicy, ExecProcessRole, ExecTermination,
+};
 
 use crate::{
     CompositeNormalOperation, ConnectionState, RouteId, Shared, normal_operation_transition_error,
@@ -390,6 +392,7 @@ pub(in crate::exec_operation) struct ExecOperationRegistrationInput<'a> {
     pub(in crate::exec_operation) stderr: ExecOutputPolicy,
     pub(in crate::exec_operation) stream_queue_capacity: Option<usize>,
     pub(in crate::exec_operation) lifecycle: ExecOperationLifecycle,
+    pub(in crate::exec_operation) role: ExecProcessRole,
     pub(in crate::exec_operation) tracking: ExecOperationTracking<'a>,
 }
 
@@ -545,6 +548,7 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
         stderr,
         stream_queue_capacity,
         lifecycle,
+        role,
         tracking,
     } = input;
     let (stream_tx, stream_rx) = match stream_queue_capacity {
@@ -566,7 +570,11 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
     };
     let tracks_normal_operation = normal_operation.is_some();
     let (route_id, diagnostic) = shared.register_route(|route_id, state| {
-        let diagnostic = ExecOperationDiagnostic::new(route_id.wire_seq(), label);
+        let supervised = matches!(
+            lifecycle,
+            ExecOperationLifecycle::SupervisedAwaitingStart { .. }
+        );
+        let diagnostic = ExecOperationDiagnostic::new(route_id.wire_seq(), label, role, supervised);
         let operation = ExecOperation {
             route_id,
             normal_operation,

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -36,7 +36,12 @@ fn exec_operation_for_snapshot(seq: u32, label: &str) -> ExecOperation {
             normal_operations.reserve().unwrap(),
         )),
         lifecycle: ExecOperationLifecycle::OneShot,
-        diagnostic: ExecOperationDiagnostic::new(seq, label),
+        diagnostic: ExecOperationDiagnostic::new(
+            seq,
+            label,
+            vsock_proto::ExecProcessRole::Workload,
+            false,
+        ),
         result_tx,
         stream_tx: None,
         stdout_capture: ExecCaptureState::Discard,
@@ -87,7 +92,12 @@ fn capture_terminal_log_events_with_context(
     stream_overflowed: bool,
     host_cancel_requested: bool,
 ) -> Vec<CapturedEvent> {
-    let mut diagnostic = ExecOperationDiagnostic::new(7, "terminal-log");
+    let mut diagnostic = ExecOperationDiagnostic::new(
+        7,
+        "terminal-log",
+        vsock_proto::ExecProcessRole::Workload,
+        false,
+    );
     if slow {
         diagnostic.registered_at =
             Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
@@ -427,7 +437,8 @@ fn shared_with_logged_operation(
         close_notify: tokio::sync::Notify::new(),
         exec_output_before_copy_hook: std::sync::Mutex::new(None),
     });
-    let mut diagnostic = ExecOperationDiagnostic::new(7, label);
+    let mut diagnostic =
+        ExecOperationDiagnostic::new(7, label, vsock_proto::ExecProcessRole::Workload, false);
     diagnostic.registered_at =
         Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
     {
@@ -1023,7 +1034,8 @@ fn exec_operation_diagnostic_keeps_only_truncated_label_log() {
         "{}secret-tail",
         "a".repeat(EXEC_OPERATION_LABEL_LOG_PREFIX_MAX_BYTES)
     );
-    let mut diagnostic = ExecOperationDiagnostic::new(7, &label);
+    let mut diagnostic =
+        ExecOperationDiagnostic::new(7, &label, vsock_proto::ExecProcessRole::Workload, false);
     diagnostic.registered_at =
         Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
 
@@ -1037,10 +1049,27 @@ fn exec_operation_diagnostic_keeps_only_truncated_label_log() {
     assert!(!diagnostic.label_log.contains("secret-tail"));
     assert_eq!(diagnostic.frame("start").label_log, diagnostic.label_log);
     assert_eq!(diagnostic.snapshot().label_log, diagnostic.label_log);
+    assert_eq!(diagnostic.process_class, "contained_workload");
+    assert_eq!(diagnostic.operation_kind, "exec");
     assert_eq!(
         diagnostic.mark_first_output().unwrap().label_log,
         diagnostic.label_log
     );
+}
+
+#[test]
+fn exec_operation_diagnostic_derives_agent_class_and_operation_kind() {
+    let diagnostic =
+        ExecOperationDiagnostic::new(8, "agent", vsock_proto::ExecProcessRole::Agent, true);
+
+    assert_eq!(diagnostic.process_class, "controlled_agent");
+    assert_eq!(diagnostic.operation_kind, "start_agent_process");
+    let frame = diagnostic.frame("start");
+    assert_eq!(frame.process_class, "controlled_agent");
+    assert_eq!(frame.operation_kind, "start_agent_process");
+    let snapshot = diagnostic.snapshot();
+    assert_eq!(snapshot.process_class, "controlled_agent");
+    assert_eq!(snapshot.operation_kind, "start_agent_process");
 }
 
 #[test]
@@ -1052,6 +1081,8 @@ fn exec_operation_diagnostic_marks_only_first_slow_output() {
             - EXEC_OPERATION_STAGE_SLOW_THRESHOLD
             - Duration::from_millis(1),
         first_output_at: None,
+        process_class: "contained_workload",
+        operation_kind: "exec",
     };
 
     let snapshot = diagnostic.mark_first_output().unwrap();

--- a/crates/vsock-host/src/exec_operation/types.rs
+++ b/crates/vsock-host/src/exec_operation/types.rs
@@ -2,7 +2,8 @@ use std::io;
 use std::time::Duration;
 
 use vsock_proto::{
-    ExecControlStatus, ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy,
+    ExecControlStatus, ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTermination,
+    ExecTimeoutPolicy,
 };
 
 /// Owned terminal stdout or stderr representation selected by the requested
@@ -203,6 +204,8 @@ pub enum SupervisedExecControl {
 
 /// Request parameters for starting a supervised exec operation.
 pub struct SupervisedExecRequest<'a> {
+    /// Semantic role selected by the provider-level start entry point.
+    pub role: ExecProcessRole,
     /// Guest-side process timeout policy.
     ///
     /// `ExecTimeoutPolicy::None` lets the process run until it exits, is

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -30,6 +30,7 @@ async fn test_exec() {
             vsock_proto::ExecTimeoutPolicy::Duration { timeout_ms: 5000 }
         );
         assert_eq!(d.lifecycle, vsock_proto::ExecLifecyclePolicy::OneShot);
+        assert_eq!(d.role, vsock_proto::ExecProcessRole::Workload);
         assert_eq!(d.control, vsock_proto::ExecControlPolicy::Disabled);
         assert!(d.env.is_empty());
         assert!(!d.sudo);

--- a/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
@@ -25,6 +25,7 @@ async fn supervised_exec_returns_handle_after_exec_started() {
 
     let decoded = vsock_proto::decode_exec_start(&pending.start.msg.payload).unwrap();
     assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::Supervised);
+    assert_eq!(decoded.role, vsock_proto::ExecProcessRole::Workload);
     assert_eq!(decoded.timeout, ExecTimeoutPolicy::None);
     assert_eq!(decoded.control, ExecControlPolicy::Disabled);
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
@@ -22,6 +22,7 @@ use crate::{ExecOperationResult, VsockHost};
 
 pub(super) fn supervised_request(command: &str) -> SupervisedExecRequest<'_> {
     SupervisedExecRequest {
+        role: vsock_proto::ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::None,
         command,
         env: &[],
@@ -168,6 +169,7 @@ pub(super) async fn start_control_supervised_exec_fixture(
     command: &'static str,
 ) -> StartedControlSupervisedExec {
     let started = start_supervised_exec_fixture(SupervisedExecRequest {
+        role: vsock_proto::ExecProcessRole::Agent,
         control: SupervisedExecControl::Enabled { sink: true },
         ..supervised_request(command)
     })

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -80,6 +80,7 @@
 //!
 //! ```text
 //! [1B lifecycle]
+//! [1B process_role]
 //! [timeout_policy]
 //! [1B flags]
 //! [4B cmd_len][command]
@@ -96,6 +97,11 @@
 //!
 //! - `0x00`: one-shot.
 //! - `0x01`: supervised.
+//!
+//! `process_role` values:
+//!
+//! - `0x00`: ordinary contained workload.
+//! - `0x01`: controlled Agent operation.
 //!
 //! `timeout_policy` values:
 //!
@@ -199,14 +205,14 @@ pub use payloads::exec_operation::{
     DecodedExecControl, DecodedExecControlResult, DecodedExecOutput, DecodedExecResult,
     DecodedExecStart, DecodedExecStarted, EXEC_CONTROL_MAX_PAYLOAD_BYTES, EXEC_CONTROL_NONCE_LEN,
     ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecControlStatus,
-    ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecStartEncodeRequest,
-    ExecTermination, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES, decode_exec_cancel,
-    decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
-    decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
-    encode_exec_control_frame_into, encode_exec_control_result, encode_exec_output,
-    encode_exec_output_frame_into, encode_exec_result, encode_exec_result_frame_into,
-    encode_exec_start, encode_exec_start_with_expected_exit_codes, encode_exec_started,
-    validate_exec_control,
+    ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecProcessRole,
+    ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES,
+    decode_exec_cancel, decode_exec_control, decode_exec_control_result, decode_exec_output,
+    decode_exec_result, decode_exec_start, decode_exec_started, encode_exec_cancel,
+    encode_exec_control, encode_exec_control_frame_into, encode_exec_control_result,
+    encode_exec_output, encode_exec_output_frame_into, encode_exec_result,
+    encode_exec_result_frame_into, encode_exec_start, encode_exec_start_with_expected_exit_codes,
+    encode_exec_started, validate_exec_control, validate_exec_process_contract,
 };
 pub use payloads::guest_dns_readiness::{
     DecodedGuestDnsReadinessRequest, DecodedGuestDnsReadinessResult,

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -21,9 +21,9 @@ pub use result::{
     encode_exec_result_frame_into,
 };
 pub use start::{
-    DecodedExecStart, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy,
+    DecodedExecStart, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecProcessRole,
     ExecStartEncodeRequest, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES, decode_exec_start,
-    encode_exec_start, encode_exec_start_with_expected_exit_codes,
+    encode_exec_start, encode_exec_start_with_expected_exit_codes, validate_exec_process_contract,
 };
 pub use started_cancel::{
     DecodedExecStarted, decode_exec_cancel, decode_exec_started, encode_exec_cancel,
@@ -37,7 +37,8 @@ use crate::error::ProtocolError;
 #[cfg(test)]
 use start::{
     EXEC_LIFECYCLE_ONE_SHOT, EXEC_OUTPUT_POLICY_CAPTURE, EXEC_OUTPUT_POLICY_DISCARD,
-    EXEC_TIMEOUT_DURATION, MAX_EXEC_ENV_VARS, MAX_EXEC_EXPECTED_EXIT_CODES,
+    EXEC_PROCESS_ROLE_AGENT, EXEC_PROCESS_ROLE_WORKLOAD, EXEC_TIMEOUT_DURATION, MAX_EXEC_ENV_VARS,
+    MAX_EXEC_EXPECTED_EXIT_CODES,
 };
 
 #[cfg(test)]

--- a/crates/vsock-proto/src/payloads/exec_operation/start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/start.rs
@@ -16,6 +16,9 @@ pub(super) const EXEC_OUTPUT_POLICY_CAPTURE_AND_STREAM: u8 = 0x03;
 pub(super) const EXEC_LIFECYCLE_ONE_SHOT: u8 = 0x00;
 pub(super) const EXEC_LIFECYCLE_SUPERVISED: u8 = 0x01;
 
+pub(super) const EXEC_PROCESS_ROLE_WORKLOAD: u8 = 0x00;
+pub(super) const EXEC_PROCESS_ROLE_AGENT: u8 = 0x01;
+
 pub(super) const EXEC_TIMEOUT_DURATION: u8 = 0x00;
 pub(super) const EXEC_TIMEOUT_NONE: u8 = 0x01;
 
@@ -77,6 +80,15 @@ pub enum ExecLifecyclePolicy {
     Supervised,
 }
 
+/// Semantic role of a process started through the exec transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecProcessRole {
+    /// Ordinary contained workload.
+    Workload,
+    /// Controlled guest Agent operation.
+    Agent,
+}
+
 /// Exec timeout policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecTimeoutPolicy {
@@ -107,6 +119,8 @@ pub enum ExecControlPolicy {
 pub struct ExecStartEncodeRequest<'a> {
     /// Process lifecycle policy to encode.
     pub lifecycle: ExecLifecyclePolicy,
+    /// Semantic process role to encode.
+    pub role: ExecProcessRole,
     /// Protocol timeout policy to encode.
     pub timeout: ExecTimeoutPolicy,
     /// UTF-8 command string to execute.
@@ -140,6 +154,8 @@ pub struct ExecStartEncodeRequest<'a> {
 pub struct DecodedExecStart<'a> {
     /// Decoded process lifecycle policy.
     pub lifecycle: ExecLifecyclePolicy,
+    /// Decoded semantic process role.
+    pub role: ExecProcessRole,
     /// Decoded protocol timeout policy.
     pub timeout: ExecTimeoutPolicy,
     /// Command string borrowed from the decoded payload.
@@ -226,6 +242,13 @@ fn append_exec_lifecycle(p: &mut Vec<u8>, lifecycle: ExecLifecyclePolicy) {
     });
 }
 
+fn append_exec_process_role(p: &mut Vec<u8>, role: ExecProcessRole) {
+    p.push(match role {
+        ExecProcessRole::Workload => EXEC_PROCESS_ROLE_WORKLOAD,
+        ExecProcessRole::Agent => EXEC_PROCESS_ROLE_AGENT,
+    });
+}
+
 fn append_exec_timeout_policy(p: &mut Vec<u8>, timeout: ExecTimeoutPolicy) {
     match timeout {
         ExecTimeoutPolicy::Duration { timeout_ms } => {
@@ -270,6 +293,35 @@ fn validate_exec_timeout_policy(timeout: ExecTimeoutPolicy) -> Result<(), Protoc
     Ok(())
 }
 
+/// Validate the semantic role, lifecycle, and transport-control combination.
+pub fn validate_exec_process_contract(
+    role: ExecProcessRole,
+    lifecycle: ExecLifecyclePolicy,
+    control: ExecControlPolicy,
+) -> Result<(), ProtocolError> {
+    match (role, lifecycle, control) {
+        (ExecProcessRole::Workload, ExecLifecyclePolicy::OneShot, ExecControlPolicy::Disabled)
+        | (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Disabled,
+        )
+        | (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled { sink: false, .. },
+        )
+        | (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled { sink: true, .. },
+        ) => Ok(()),
+        _ => Err(ProtocolError::InvalidPayload(
+            "exec start role, lifecycle, and control combination invalid",
+        )),
+    }
+}
+
 fn append_exec_output_policy(p: &mut Vec<u8>, policy: ExecOutputPolicy) {
     match policy {
         ExecOutputPolicy::Discard => p.push(EXEC_OUTPUT_POLICY_DISCARD),
@@ -310,6 +362,7 @@ pub fn encode_exec_start(
 ) -> Result<Vec<u8>, ProtocolError> {
     encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms },
         command,
         env,
@@ -359,8 +412,9 @@ pub fn encode_exec_start_with_expected_exit_codes(
     let control_policy_len = exec_control_policy_encoded_len(request.control);
     let stdin_policy_len = exec_stdin_policy_encoded_len(request.stdin_bytes)?;
     validate_exec_timeout_policy(request.timeout)?;
+    validate_exec_process_contract(request.role, request.lifecycle, request.control)?;
 
-    let mut payload_len = 1 + timeout_policy_len + 1 + 4;
+    let mut payload_len = 1 + 1 + timeout_policy_len + 1 + 4;
     payload_len = checked_payload_len_add(payload_len, cmd.len())?;
     payload_len = checked_payload_len_add(payload_len, 4)?;
     for (key, val) in request.env {
@@ -384,6 +438,7 @@ pub fn encode_exec_start_with_expected_exit_codes(
 
     let mut p = Vec::with_capacity(payload_len);
     append_exec_lifecycle(&mut p, request.lifecycle);
+    append_exec_process_role(&mut p, request.role);
     append_exec_timeout_policy(&mut p, request.timeout);
     p.push(if request.sudo { EXEC_FLAG_SUDO } else { 0 });
     p.extend_from_slice(&cmd_len.to_be_bytes());
@@ -474,6 +529,19 @@ fn decode_exec_lifecycle(
     }
 }
 
+fn decode_exec_process_role(
+    payload: &[u8],
+    offset: &mut usize,
+) -> Result<ExecProcessRole, ProtocolError> {
+    match read_u8(payload, offset, "exec start process role truncated")? {
+        EXEC_PROCESS_ROLE_WORKLOAD => Ok(ExecProcessRole::Workload),
+        EXEC_PROCESS_ROLE_AGENT => Ok(ExecProcessRole::Agent),
+        _ => Err(ProtocolError::InvalidPayload(
+            "exec start process role invalid",
+        )),
+    }
+}
+
 fn decode_exec_timeout_policy(
     payload: &[u8],
     offset: &mut usize,
@@ -552,6 +620,7 @@ fn decode_exec_stdin_policy<'a>(
 pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, ProtocolError> {
     let mut offset = 0;
     let lifecycle = decode_exec_lifecycle(payload, &mut offset)?;
+    let role = decode_exec_process_role(payload, &mut offset)?;
     let timeout = decode_exec_timeout_policy(payload, &mut offset)?;
     let flags = read_u8(payload, &mut offset, "exec start flags truncated")?;
     if flags & !EXEC_FLAG_SUDO != 0 {
@@ -640,8 +709,10 @@ pub fn decode_exec_start(payload: &[u8]) -> Result<DecodedExecStart<'_>, Protoco
     let control = decode_exec_control_policy(payload, &mut offset)?;
     let stdin_bytes = decode_exec_stdin_policy(payload, &mut offset)?;
     expect_consumed(payload, offset, "exec start trailing bytes")?;
+    validate_exec_process_contract(role, lifecycle, control)?;
     Ok(DecodedExecStart {
         lifecycle,
+        role,
         timeout,
         command,
         env,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start.rs
@@ -28,6 +28,7 @@ fn env_label_exec_start_payload() -> Vec<u8> {
 fn supervised_control_exec_start_payload() -> Vec<u8> {
     encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::Supervised,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::None,
         command: "cmd",
         env: &[],
@@ -45,9 +46,31 @@ fn supervised_control_exec_start_payload() -> Vec<u8> {
     .unwrap()
 }
 
+fn encode_exec_start_contract(
+    role: ExecProcessRole,
+    lifecycle: ExecLifecyclePolicy,
+    control: ExecControlPolicy,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle,
+        role,
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        sudo: false,
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control,
+        stdin_bytes: None,
+    })
+}
+
 fn stdin_exec_start_payload(stdin_bytes: &[u8]) -> Vec<u8> {
     encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],
@@ -80,6 +103,7 @@ fn exec_start_roundtrip_discard_policies() {
         decoded,
         DecodedExecStart {
             lifecycle: ExecLifecyclePolicy::OneShot,
+            role: ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5000 },
             command: "echo ready",
             env: Vec::new(),
@@ -200,6 +224,7 @@ fn exec_start_roundtrip_stream_policy_allows_zero_stream_limit() {
 fn exec_start_roundtrip_expected_exit_codes() {
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1000 },
         command: "optional-file",
         env: &[],
@@ -221,6 +246,7 @@ fn exec_start_roundtrip_expected_exit_codes() {
 fn exec_start_roundtrip_stdin_bytes() {
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1000 },
         command: "cat",
         env: &[],
@@ -241,6 +267,7 @@ fn exec_start_roundtrip_stdin_bytes() {
 fn exec_start_roundtrip_empty_stdin_bytes() {
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1000 },
         command: "cat",
         env: &[],
@@ -262,6 +289,7 @@ fn exec_start_roundtrip_max_stdin_bytes() {
     let stdin_bytes = vec![0xA5; MAX_EXEC_STDIN_BYTES];
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1000 },
         command: "cat",
         env: &[],
@@ -282,6 +310,7 @@ fn exec_start_roundtrip_max_stdin_bytes() {
 fn exec_start_roundtrip_supervised_no_timeout_and_control_enabled() {
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::Supervised,
+        role: ExecProcessRole::Agent,
         timeout: ExecTimeoutPolicy::None,
         command: "daemon",
         env: &[("A", "B")],
@@ -307,6 +336,7 @@ fn exec_start_roundtrip_supervised_no_timeout_and_control_enabled() {
 
     let decoded = decode_exec_start(&payload).unwrap();
     assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::Supervised);
+    assert_eq!(decoded.role, ExecProcessRole::Agent);
     assert_eq!(decoded.timeout, ExecTimeoutPolicy::None);
     assert!(decoded.sudo);
     assert_eq!(
@@ -316,6 +346,215 @@ fn exec_start_roundtrip_supervised_no_timeout_and_control_enabled() {
             sink: true,
         }
     );
+}
+
+#[test]
+fn exec_start_accepts_every_valid_process_contract() {
+    for (role, lifecycle, control) in [
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        ),
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Disabled,
+        ),
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: false,
+            },
+        ),
+        (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: true,
+            },
+        ),
+    ] {
+        let timeout = match lifecycle {
+            ExecLifecyclePolicy::OneShot => ExecTimeoutPolicy::Duration { timeout_ms: 1 },
+            ExecLifecyclePolicy::Supervised => ExecTimeoutPolicy::None,
+        };
+        let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+            lifecycle,
+            role,
+            timeout,
+            command: "cmd",
+            env: &[],
+            sudo: false,
+            label: "",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            control,
+            stdin_bytes: None,
+        })
+        .unwrap();
+        let decoded = decode_exec_start(&payload).unwrap();
+        assert_eq!(decoded.role, role);
+        assert_eq!(decoded.lifecycle, lifecycle);
+        assert_eq!(decoded.control, control);
+    }
+}
+
+#[test]
+fn exec_start_encoder_rejects_every_invalid_process_contract() {
+    for (role, lifecycle, control) in [
+        (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        ),
+        (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Disabled,
+        ),
+        (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: false,
+            },
+        ),
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: false,
+            },
+        ),
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: true,
+            },
+        ),
+        (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce: NONCE,
+                sink: true,
+            },
+        ),
+    ] {
+        let error = encode_exec_start_contract(role, lifecycle, control).unwrap_err();
+        assert_invalid_payload(
+            error,
+            "exec start role, lifecycle, and control combination invalid",
+        );
+    }
+}
+
+#[test]
+fn exec_start_decoder_rejects_every_invalid_process_contract() {
+    let layout = ExecStartLayout::one_shot_duration_discard("cmd", &[], "");
+    let mut agent_one_shot_disabled = default_exec_start_payload();
+    set_byte_at(
+        &mut agent_one_shot_disabled,
+        layout.role_offset,
+        EXEC_PROCESS_ROLE_AGENT,
+    );
+
+    let workload_supervised_disabled = encode_exec_start_contract(
+        ExecProcessRole::Workload,
+        ExecLifecyclePolicy::Supervised,
+        ExecControlPolicy::Disabled,
+    )
+    .unwrap();
+    let disabled_layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    });
+    let mut agent_supervised_disabled = workload_supervised_disabled;
+    set_byte_at(
+        &mut agent_supervised_disabled,
+        disabled_layout.role_offset,
+        EXEC_PROCESS_ROLE_AGENT,
+    );
+
+    let workload_supervised_control = supervised_control_exec_start_payload();
+    let control_layout = ExecStartLayout::new(ExecStartLayoutRequest {
+        timeout: ExecTimeoutPolicy::None,
+        command: "cmd",
+        env: &[],
+        label: "",
+        stdout: ExecOutputPolicy::Discard,
+        stderr: ExecOutputPolicy::Discard,
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: false,
+        },
+        stdin_bytes: None,
+    });
+    let mut agent_supervised_without_sink = workload_supervised_control.clone();
+    set_byte_at(
+        &mut agent_supervised_without_sink,
+        control_layout.role_offset,
+        EXEC_PROCESS_ROLE_AGENT,
+    );
+    let mut workload_one_shot_with_control = workload_supervised_control;
+    set_byte_at(
+        &mut workload_one_shot_with_control,
+        control_layout.lifecycle_offset,
+        EXEC_LIFECYCLE_ONE_SHOT,
+    );
+
+    let agent_supervised_control = encode_exec_start_contract(
+        ExecProcessRole::Agent,
+        ExecLifecyclePolicy::Supervised,
+        ExecControlPolicy::Enabled {
+            control_nonce: NONCE,
+            sink: true,
+        },
+    )
+    .unwrap();
+    let mut workload_supervised_with_sink = agent_supervised_control.clone();
+    set_byte_at(
+        &mut workload_supervised_with_sink,
+        control_layout.role_offset,
+        EXEC_PROCESS_ROLE_WORKLOAD,
+    );
+    let mut agent_one_shot_with_sink = agent_supervised_control;
+    set_byte_at(
+        &mut agent_one_shot_with_sink,
+        control_layout.lifecycle_offset,
+        EXEC_LIFECYCLE_ONE_SHOT,
+    );
+
+    for payload in [
+        agent_one_shot_disabled,
+        agent_supervised_disabled,
+        agent_supervised_without_sink,
+        workload_one_shot_with_control,
+        workload_supervised_with_sink,
+        agent_one_shot_with_sink,
+    ] {
+        assert_invalid_payload(
+            decode_exec_start(&payload).unwrap_err(),
+            "exec start role, lifecycle, and control combination invalid",
+        );
+    }
 }
 #[test]
 fn exec_start_rejects_zero_duration_timeout() {
@@ -487,22 +726,44 @@ fn exec_start_rejects_truncated_fields() {
     assert!(matches!(
         decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT]),
         Err(ProtocolError::InvalidPayload(
+            "exec start process role truncated"
+        ))
+    ));
+    assert!(matches!(
+        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_PROCESS_ROLE_WORKLOAD]),
+        Err(ProtocolError::InvalidPayload(
             "exec start timeout policy truncated"
         ))
     ));
     assert!(matches!(
-        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_TIMEOUT_DURATION, 0, 0, 0]),
+        decode_exec_start(&[
+            EXEC_LIFECYCLE_ONE_SHOT,
+            EXEC_PROCESS_ROLE_WORKLOAD,
+            EXEC_TIMEOUT_DURATION,
+            0,
+            0,
+            0,
+        ]),
         Err(ProtocolError::InvalidPayload(
             "exec start timeout truncated"
         ))
     ));
     assert!(matches!(
-        decode_exec_start(&[EXEC_LIFECYCLE_ONE_SHOT, EXEC_TIMEOUT_DURATION, 0, 0, 0, 1,]),
+        decode_exec_start(&[
+            EXEC_LIFECYCLE_ONE_SHOT,
+            EXEC_PROCESS_ROLE_WORKLOAD,
+            EXEC_TIMEOUT_DURATION,
+            0,
+            0,
+            0,
+            1,
+        ]),
         Err(ProtocolError::InvalidPayload("exec start flags truncated"))
     ));
     assert!(matches!(
         decode_exec_start(&[
             EXEC_LIFECYCLE_ONE_SHOT,
+            EXEC_PROCESS_ROLE_WORKLOAD,
             EXEC_TIMEOUT_DURATION,
             0,
             0,
@@ -695,6 +956,7 @@ fn exec_start_rejects_expected_exit_count_above_limit() {
     let expected_exit_codes = vec![0; MAX_EXEC_EXPECTED_EXIT_CODES + 1];
     let err = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],
@@ -738,6 +1000,7 @@ fn exec_start_rejects_truncated_expected_exit_count() {
 fn exec_start_rejects_truncated_expected_exit_codes() {
     let mut payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],
@@ -863,6 +1126,24 @@ fn exec_start_rejects_invalid_lifecycle_timeout_and_control() {
     ));
 
     let mut payload = default_exec_start_payload();
+    set_byte_at(&mut payload, layout.role_offset, 0xFE);
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start process role invalid"
+        ))
+    ));
+
+    let mut payload = default_exec_start_payload();
+    payload.truncate(layout.role_offset);
+    assert!(matches!(
+        decode_exec_start(&payload),
+        Err(ProtocolError::InvalidPayload(
+            "exec start process role truncated"
+        ))
+    ));
+
+    let mut payload = default_exec_start_payload();
     set_byte_at(&mut payload, layout.timeout_policy_offset, 0xFE);
     assert!(matches!(
         decode_exec_start(&payload),
@@ -982,6 +1263,7 @@ fn exec_start_rejects_stdin_above_limit() {
     let stdin_bytes = vec![0; MAX_EXEC_STDIN_BYTES + 1];
     let err = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::OneShot,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::Duration { timeout_ms: 1 },
         command: "cmd",
         env: &[],

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start_properties.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_start_properties.rs
@@ -16,6 +16,7 @@ const MAX_ARBITRARY_PAYLOAD_BYTES: usize = 512;
 #[derive(Debug, Clone)]
 struct OwnedExecStart {
     lifecycle: ExecLifecyclePolicy,
+    role: ExecProcessRole,
     timeout: ExecTimeoutPolicy,
     command: String,
     env: Vec<(String, String)>,
@@ -40,6 +41,7 @@ impl OwnedExecStart {
         let env = self.env_refs();
         encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
             lifecycle: self.lifecycle,
+            role: self.role,
             timeout: self.timeout,
             command: &self.command,
             env: &env,
@@ -71,6 +73,7 @@ impl OwnedExecStart {
     fn assert_decoded(&self, decoded: &DecodedExecStart<'_>) -> TestCaseResult {
         let env = self.env_refs();
         prop_assert_eq!(decoded.lifecycle, self.lifecycle);
+        prop_assert_eq!(decoded.role, self.role);
         prop_assert_eq!(decoded.timeout, self.timeout);
         prop_assert_eq!(decoded.command, self.command.as_str());
         prop_assert_eq!(decoded.env.as_slice(), env.as_slice());
@@ -93,6 +96,10 @@ impl OwnedExecStart {
             (
                 "invalid lifecycle tag",
                 with_byte(payload, layout.lifecycle_offset, u8::MAX),
+            ),
+            (
+                "invalid process role tag",
+                with_byte(payload, layout.role_offset, u8::MAX),
             ),
             (
                 "invalid timeout tag",
@@ -240,10 +247,35 @@ fn nonzero_u32_strategy() -> impl Strategy<Value = u32> {
     prop_oneof![Just(1), Just(u32::MAX), 1..u32::MAX]
 }
 
-fn lifecycle_strategy() -> impl Strategy<Value = ExecLifecyclePolicy> {
+fn process_contract_strategy()
+-> impl Strategy<Value = (ExecProcessRole, ExecLifecyclePolicy, ExecControlPolicy)> {
     prop_oneof![
-        Just(ExecLifecyclePolicy::OneShot),
-        Just(ExecLifecyclePolicy::Supervised),
+        Just((
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::OneShot,
+            ExecControlPolicy::Disabled,
+        )),
+        Just((
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Disabled,
+        )),
+        any::<ExecControlNonce>().prop_map(|control_nonce| (
+            ExecProcessRole::Workload,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce,
+                sink: false,
+            },
+        )),
+        any::<ExecControlNonce>().prop_map(|control_nonce| (
+            ExecProcessRole::Agent,
+            ExecLifecyclePolicy::Supervised,
+            ExecControlPolicy::Enabled {
+                control_nonce,
+                sink: true,
+            },
+        )),
     ]
 }
 
@@ -281,18 +313,6 @@ fn output_policy_strategy() -> impl Strategy<Value = ExecOutputPolicy> {
     ]
 }
 
-fn control_strategy() -> impl Strategy<Value = ExecControlPolicy> {
-    prop_oneof![
-        Just(ExecControlPolicy::Disabled),
-        (any::<ExecControlNonce>(), any::<bool>()).prop_map(|(control_nonce, sink)| {
-            ExecControlPolicy::Enabled {
-                control_nonce,
-                sink,
-            }
-        }),
-    ]
-}
-
 fn expected_exit_strategy() -> impl Strategy<Value = i32> {
     prop_oneof![
         Just(i32::MIN),
@@ -306,7 +326,7 @@ fn expected_exit_strategy() -> impl Strategy<Value = i32> {
 
 fn exec_start_strategy() -> impl Strategy<Value = OwnedExecStart> {
     (
-        lifecycle_strategy(),
+        process_contract_strategy(),
         timeout_strategy(),
         text_strategy(),
         proptest::collection::vec(
@@ -318,7 +338,6 @@ fn exec_start_strategy() -> impl Strategy<Value = OwnedExecStart> {
         output_policy_strategy(),
         output_policy_strategy(),
         proptest::collection::vec(expected_exit_strategy(), 0..=MAX_GENERATED_EXPECTED_EXITS),
-        control_strategy(),
         proptest::option::of(proptest::collection::vec(
             any::<u8>(),
             0..=MAX_GENERATED_STDIN_BYTES,
@@ -326,7 +345,7 @@ fn exec_start_strategy() -> impl Strategy<Value = OwnedExecStart> {
     )
         .prop_map(
             |(
-                lifecycle,
+                (role, lifecycle, control),
                 timeout,
                 command,
                 env,
@@ -335,10 +354,10 @@ fn exec_start_strategy() -> impl Strategy<Value = OwnedExecStart> {
                 stdout,
                 stderr,
                 expected_exit_codes,
-                control,
                 stdin_bytes,
             )| OwnedExecStart {
                 lifecycle,
+                role,
                 timeout,
                 command,
                 env,
@@ -399,6 +418,7 @@ proptest! {
 
             let reencoded = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
                 lifecycle: decoded.lifecycle,
+                role: decoded.role,
                 timeout: decoded.timeout,
                 command: decoded.command,
                 env: &decoded.env,
@@ -440,6 +460,7 @@ fn exec_start_roundtrips_collection_limits_and_unicode() {
         .collect::<Vec<_>>();
     let payload = encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
         lifecycle: ExecLifecyclePolicy::Supervised,
+        role: ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::None,
         command: "打印“你好”",
         env: &env,
@@ -461,6 +482,7 @@ fn exec_start_roundtrips_collection_limits_and_unicode() {
         decoded,
         DecodedExecStart {
             lifecycle: ExecLifecyclePolicy::Supervised,
+            role: ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "打印“你好”",
             env,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/shared.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/shared.rs
@@ -290,6 +290,7 @@ impl ExecStartStdinLayout {
 
 pub(super) struct ExecStartLayout {
     pub lifecycle_offset: usize,
+    pub role_offset: usize,
     pub timeout_policy_offset: usize,
     pub timeout_value_offset: Option<usize>,
     pub flags_offset: usize,
@@ -312,6 +313,9 @@ impl ExecStartLayout {
         let mut offset = 0;
 
         let lifecycle_offset = offset;
+        offset += 1;
+
+        let role_offset = offset;
         offset += 1;
 
         let timeout_policy_offset = offset;
@@ -380,6 +384,7 @@ impl ExecStartLayout {
 
         Self {
             lifecycle_offset,
+            role_offset,
             timeout_policy_offset,
             timeout_value_offset,
             flags_offset,

--- a/crates/vsock-test/tests/integration/exec.rs
+++ b/crates/vsock-test/tests/integration/exec.rs
@@ -138,6 +138,7 @@ async fn test_exec_while_waiting_for_exit() {
     let handle = h
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "exec sleep 60",
             env: &[],

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -140,6 +140,7 @@ async fn blocked_write_allows_exec_cancel_and_quiesce() {
     let handle = h
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            role: vsock_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "exec sleep 60",
             env: &[],

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -1,0 +1,84 @@
+# Runner Guest Process Lifecycle
+
+This document is the provider-neutral map of every production child process in
+the guest from sandbox boot through the Agent CLI and managed tools. It records
+which boundary is allowed to select each process class, where the process runs,
+and which owner proves completion and cleanup.
+
+The four process classes are exhaustive:
+
+- **sandbox service**: fixed image services that live for the sandbox lifetime;
+- **bounded setup helper**: a fixed program selected by a typed guest handler;
+- **contained workload**: user-influenced work in an operation-owned workload
+  cgroup;
+- **controlled Agent**: the Agent operation with authenticated runtime and tool
+  placement capabilities.
+
+Generic sandbox callers can request only contained workload or the one sealed
+controlled Agent entry point. They cannot request guest-root execution,
+bounded-helper placement, or an arbitrary containment policy.
+
+## Process Map
+
+| Process or operation | Class and selecting authority | Input and trust boundary | Placement and resource policy | Completion and cleanup owner | Relationship to Agent start |
+| --- | --- | --- | --- | --- | --- |
+| `guest-init` (PID 1) | Sandbox service selected by the guest image entry point | Fixed image program and boot configuration | Guest root; sandbox-lifetime VM policy | VM lifetime; PID 1 owns guest shutdown | Required and serial before guest readiness |
+| `vsock-guest` | Sandbox service forked and supervised by `guest-init` | Fixed embedded binary and fixed service arguments | Guest root; sandbox-lifetime VM policy | `guest-init` supervision and VM lifetime | Required and serial before host operations |
+| DNS `getent ahostsv4` | Bounded setup helper selected only by the typed DNS handler | Bounded hostname and deadline; no caller-selected program | Guest root in an owned process group | Single-active DNS worker, operation guard, kill, and reap | Required for a fresh sandbox; serial before Agent start |
+| `guest-reseed --restore-state` | Bounded setup helper selected only by the typed guest-state handler | Typed time, entropy, and timezone request with a deadline | Guest root in an owned process group | Single-active restore worker, operation guard, kill, and reap | Required state preparation; serial before Agent start |
+| `guest-write-file` single, batch, and private variants | Bounded setup helper selected only by typed file handlers | Typed path/content request with handler validation and deadline | Guest root in an owned process group | File worker, operation guard, kill, and reap | Required when its prepared input exists; serial before Agent start |
+| Generic one-shot shell operations, including mount, timezone, cleanup, and verification fallbacks | Contained workload selected by `Sandbox::exec` | Caller command and environment are untrusted workload input | Per-operation `workload` cgroup with the standard CPU, memory, PID, and OOM policy | Exec worker and `ExecProcessContainment`; terminal result or forced cleanup removes descendants and hierarchy | Required or optional by caller; serial when part of preparation |
+| `guest-download --manifest-stdin` | Contained workload selected only by the typed storage-manifest handler | User-influenced manifest, download, extraction, cache, and filesystem work | Per-operation `workload` cgroup with the standard workload policy | Storage worker, operation guard, output drains, and containment cleanup | Required when storage preparation is requested; serial, with deferred background fill allowed only after Agent spawn |
+| Codex model-catalog prefetch | Contained workload selected by ordinary `Sandbox::start_process` | Fixed prefetch shell, but network response and process execution remain workload data | Per-operation `workload` cgroup; no Agent control or placement capability | Prefetch task owns process wait/cancel; guest exec worker owns containment cleanup | Optional and deferrable; may run concurrently with later preparation and Agent start |
+| Agent wrapper shell and Guest Agent | Controlled Agent selected only by `Sandbox::start_agent_process` | Runner constructs the command/environment; the Agent subsequently handles user-controlled work | Per-operation `control` cgroup; the outer containment owns the standard workload resource hierarchy | Runner owns the typed process handle and mandatory control capability; guest control registry, placement brokers, exec worker, and containment own guest cleanup | Required final pre-spawn operation; its current `exec_started` acknowledgement remains the shell-spawn boundary |
+| Agent CLI or Codex app server | Controlled Agent child selected by the Guest Agent's typed CLI startup path | Framework-specific Agent input and user session data | `workload/runtime`, entered through an authenticated pre-exec placement descriptor | Guest Agent CLI owner plus outer Agent containment | Required after wrapper startup; serial with CLI launch, then concurrent with supervision |
+| `guest-tool-exec` and its requested shell command | Controlled Agent child selected by the managed tool envelope | Tool request and shell command are user/Agent influenced | A unique `workload/tools/tool-N` leaf obtained from the authenticated placement broker | Tool wrapper/process group plus tool-placement broker and outer Agent containment | Optional, concurrent after Agent readiness, and independently completed |
+
+Read, copy, mount, and other protocol handlers that do not spawn a process are
+not child-process rows. They still participate in their normal sandbox
+operation ownership and quiesce rules.
+
+## Controlled Topology
+
+```text
+vm0-exec-<guest-pid>-<sequence>-<id>/
+├── control/                    Agent wrapper and Guest Agent
+└── workload/
+    ├── runtime/                CLI or Codex app server
+    └── tools/
+        ├── tool-1/             one managed tool process tree
+        ├── tool-2/
+        └── ...
+```
+
+The exec-start protocol carries the semantic role independently from
+lifecycle and transport control. `Workload` selects ordinary workload
+containment. `Agent` selects the controlled topology and requires supervised
+lifecycle plus an enabled control sink. The bootstrap endpoint starts the
+control and placement brokers; its presence is validated against the role but
+does not select containment.
+
+The wrapper and Guest Agent remain in `control`. The Guest Agent authenticates
+to the workload placement endpoint, receives the runtime `cgroup.procs`
+descriptor, and places the CLI in `runtime` immediately before exec. Each
+managed tool authenticates separately and receives a fresh `tool-N`
+descriptor. Controlled processes deny process inspection across the boundary.
+
+## Ownership and Reuse
+
+All fixed helpers and workload operations hold operation guards. Reuse first
+fences new operations, waits for active ownership to reach zero, and verifies
+that the `vm0-exec` hierarchy is empty before parking. A terminal result does
+not replace descendant cleanup: the operation's containment owner remains
+responsible for graceful or forced cleanup and hierarchy removal.
+
+Storage remains contained even though it has a typed entry point because its
+download, extraction, cache, and filesystem work is user influenced. The DNS,
+state, and file helpers use process groups at guest root only because their
+typed handlers select fixed programs, validate bounded inputs, enforce
+single-active admission and deadlines, and own kill/reap. That authority is
+not available through generic exec APIs.
+
+This contract intentionally preserves the existing shell-spawn timing
+boundary. A distinct Guest Agent ready acknowledgement and the corresponding
+metric correction belong to #29643.


### PR DESCRIPTION
## Summary

- separate ordinary workload starts from the sealed controlled Agent start API, with a mandatory process-control handle for successful Agent starts
- carry an explicit workload/Agent role through the vsock protocol, validate the complete role/lifecycle/control matrix, and use the role for containment and low-cardinality diagnostics
- update runner callers, providers, mocks, integration tests, and add a provider-neutral guest process lifecycle map

## Exclusions

- does not change the existing shell-spawn readiness boundary or Agent-ready timing metrics; that work remains in #29643
- does not change workload resource limits, placement broker authentication, or sandbox reuse policy

## Validation

- `cargo check --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p vsock-proto`
- `cargo test -p vsock-host`
- `cargo test -p vsock-guest --all-features`
- `cargo test -p sandbox -p sandbox-fc -p sandbox-mock`
- `cargo test -p runner`
- `cargo test -p guest-agent --test process_control_channel`
- `cargo test -p vsock-test --test integration`

Closes #29642

Parent context: #29631
