### PR TITLE
fix(platform): close connector popover before permissions

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -92,6 +92,16 @@ function connectorStatus({
   };
 }
 
+function buttonByText(text: string, container: ParentNode): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!button) {
+    throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
 function customConnector(
   overrides: Partial<CustomConnectorHttpResponse> = {},
 ): CustomConnectorHttpResponse {
@@ -274,6 +284,59 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
+  it("makes connector permissions interactive on the first click", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockThread();
+    mockConnectors([{ connectorSlug: "axiom", authMethod: "api-token" }]);
+    mockAgentConnectorAuthorizations(["axiom"]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    const connectorsTrigger = within(composer).getByLabelText("Connectors");
+    await user.click(connectorsTrigger);
+    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(
+      await screen.findByLabelText("Configure Axiom permissions"),
+    );
+
+    const permissionsDialog = await screen.findByRole("dialog", {
+      name: /Axiom permissions/u,
+    });
+    await waitFor(() => {
+      expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByText("Add connectors")).not.toBeInTheDocument();
+    });
+
+    const permissionName =
+      await within(permissionsDialog).findByText("annotations|create");
+    const permissionRow = permissionName.parentElement?.parentElement;
+    if (!(permissionRow instanceof HTMLElement)) {
+      throw new Error("Expected an Axiom permission row");
+    }
+    const denyButton = buttonByText("Deny", permissionRow);
+    const applyButton = buttonByText("Apply", permissionsDialog);
+    expect(denyButton).toHaveAttribute("aria-pressed", "false");
+    expect(applyButton).toBeDisabled();
+
+    await user.click(denyButton);
+
+    expect(denyButton).toHaveAttribute("aria-pressed", "true");
+    expect(applyButton).toBeEnabled();
+
+    await user.click(buttonByText("Cancel", permissionsDialog));
+    await waitFor(() => {
+      expect(permissionsDialog).not.toBeInTheDocument();
+    });
+    expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("keeps permissioned connector row height stable while toggling access", async () => {
     const user = userEvent.setup({ delay: null });
     let authorizationWrites = 0;

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8872,27 +8872,30 @@ function ConnectorsPopoverButton({
                             showPermissionAction || accountAction ? (
                               <>
                                 {showPermissionAction ? (
-                                  <Button
-                                    showTooltip
-                                    type="button"
-                                    onClick={() => {
-                                      updateConnectorUi({
-                                        permissionConnectorSlug: connector.slug,
-                                      });
-                                    }}
-                                    aria-label={t(
-                                      ($) => {
-                                        return $.chat.connectors
-                                          .configurePermissions;
-                                      },
-                                      { connectorName: connector.label },
-                                    )}
-                                    variant="quiet"
-                                    size="icon-2xs"
-                                    className="shrink-0"
-                                  >
-                                    <SlidersHorizontal size={15} />
-                                  </Button>
+                                  <PopoverClose asChild>
+                                    <Button
+                                      showTooltip
+                                      type="button"
+                                      onClick={() => {
+                                        updateConnectorUi({
+                                          permissionConnectorSlug:
+                                            connector.slug,
+                                        });
+                                      }}
+                                      aria-label={t(
+                                        ($) => {
+                                          return $.chat.connectors
+                                            .configurePermissions;
+                                        },
+                                        { connectorName: connector.label },
+                                      )}
+                                      variant="quiet"
+                                      size="icon-2xs"
+                                      className="shrink-0"
+                                    >
+                                      <SlidersHorizontal size={15} />
+                                    </Button>
+                                  </PopoverClose>
                                 ) : null}
                                 {accountAction}
                               </>


### PR DESCRIPTION
## Summary

- close the thread connector popover when launching a connector permission dialog
- prevent the parent floating layer from consuming the first permission-dialog interaction
- cover the full thread entry flow, including the first policy click and dialog close behavior

## Scope

This change only adjusts platform UI interaction ownership. It does not change permission draft semantics, API contracts, persistence, database schema, runner behavior, or deployment protocols.

## Validation

- `pnpm exec prettier --write apps/platform/src/views/okou-page/chat-composer.tsx apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx --silent=passed-only` (18 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-event-action-cards.test.tsx --silent=passed-only` (50 passed)
- `pnpm -F @okouai/app exec vitest run --maxWorkers=1 --silent=passed-only` (2145 passed)
- pre-commit hook: repository Knip, repository type checking, file-size validation, and commitlint passed

Closes #29667
