### PR TITLE
fix(platform): use chat terminology for account selector

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1938,7 +1938,7 @@
       "yourComputer": "Your computer"
     },
     "connectors": {
-      "accountForThread": "Account for this thread",
+      "accountForThread": "Account for this chat",
       "add": "Add {{connectorName}}",
       "addConnectors": "Add connectors",
       "authorizationFailed": "{{connectorName}} connected but could not be authorized for {{agentName}}",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -570,7 +570,7 @@ describe("chat composer connector connection", () => {
 
     await user.click(defaultMode);
     await expect(
-      screen.findByText("Account for this thread"),
+      screen.findByText("Account for this chat"),
     ).resolves.toBeVisible();
     await user.click(screen.getByLabelText("Back"));
     await waitFor(() => {
@@ -612,7 +612,7 @@ describe("chat composer connector connection", () => {
       "GitHub · Selected account: Work",
     );
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveClass("text-muted-foreground");
@@ -620,11 +620,11 @@ describe("chat composer connector connection", () => {
 
     await user.click(selectedWorkMode);
     await expect(
-      screen.findByText("Account for this thread"),
+      screen.findByText("Account for this chat"),
     ).resolves.toBeVisible();
     await user.keyboard("{Escape}");
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     expect(selectedWorkMode).toHaveFocus();
@@ -635,7 +635,7 @@ describe("chat composer connector connection", () => {
       expect(selectionWrites).toBe(2);
     });
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
     await expect(
@@ -650,7 +650,7 @@ describe("chat composer connector connection", () => {
       expect(selectionClears).toBe(1);
     });
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     await expect(
       screen.findByLabelText("GitHub · Using default account: Work"),
@@ -740,7 +740,7 @@ describe("chat composer connector connection", () => {
 
     await user.keyboard("{Escape}");
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(requestedSearches).toStrictEqual(["", "missing"]);
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -574,23 +574,23 @@ describe("chat composer connector connection", () => {
     ).resolves.toBeVisible();
     await user.click(screen.getByLabelText("Back"));
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
-      screen.findByText("Account for this thread"),
+      screen.findByText("Account for this chat"),
     ).resolves.toBeVisible();
     await user.click(document.body);
     await waitFor(() => {
-      expect(screen.queryByText("Account for this thread")).toBeNull();
+      expect(screen.queryByText("Account for this chat")).toBeNull();
     });
     expect(connectorsButton).toHaveAttribute("aria-expanded", "true");
 
     await user.click(defaultMode);
     await expect(
-      screen.findByText("Account for this thread"),
+      screen.findByText("Account for this chat"),
     ).resolves.toBeVisible();
     const summaryReadsBeforeSelection = summaryReads;
     expect(screen.getByText("GitHub")).toBeVisible();


### PR DESCRIPTION
## Summary

- change the English connector account selector heading and accessible label to “Account for this chat”
- update the existing page-level integration expectations for the revised copy

## Scope

Internal `thread` identifiers, APIs, behavior, and non-English localized values remain unchanged.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx --maxWorkers=4 --silent=passed-only`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: Prettier, full Knip, full Turbo type checks, file-size check, and commitlint
- `git diff --check`

Closes #29683
