### PR TITLE
refactor: disable chat tool activity for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -126,7 +126,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ChatToolActivity]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatToolActivity]).toBe(false);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -347,7 +347,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Generate and deliver redacted tool activity events in Chat history.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.BuiltInModelProviderFallback]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- Remove the staff organization allowlist from `FeatureSwitchKey.ChatToolActivity` while keeping its registry entry globally disabled.
- Update the existing staff rollout matrix to verify that both staff and non-staff organizations resolve the switch to `false` from the registry configuration.

## Migration compatibility retained

This Stage 1 hard-off intentionally leaves the migration surface unchanged:

- `FeatureSwitchKey.ChatToolActivity` and the `chatToolActivity` registry entry
- V6 `output.tool` contracts and database schema
- the immutable `agent_runs.chat_tool_activity_enabled` decision
- Claude, Codex, and Pi tool activity materialization paths
- full and tool-redacted snapshot infrastructure
- UI compatibility paths and all existing migration machinery

Runs that already persisted `chat_tool_activity_enabled = true` may continue draining after deployment.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (26 tests passed)
- `git diff --check`

## Production drain gate

This PR does not perform production mutations or claim that the post-deployment gate has passed. Before Stage 2 proceeds, verify after the deployment/drain watermark:

- zero nonterminal runs with `chat_tool_activity_enabled = true`
- zero new `output.tool` rows
