### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -5,7 +5,6 @@ import {
   OFFICIAL_TELEGRAM_BOT_ID,
   integrationsTelegramContract,
 } from "@okouai/api-contracts/contracts/integrations-telegram";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type {
   TestTelegramStateActionBody,
   TestTelegramStateActionResponse,
@@ -34,7 +33,6 @@ import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { testTelegramStateRoutes } from "../test-telegram-state";
 import { integrationsTelegramRoutes } from "../integrations-telegram";
 
@@ -725,13 +723,6 @@ async function seedPendingUserLink(
     action: "seed-pending-user-link",
     installation_id: fixture.telegramBotId,
     user_id: fixture.userId,
-  });
-}
-
-async function redriveLegacyTelegramChatCallback(runId: string): Promise<void> {
-  await postTelegramStateAction({
-    action: "redrive-legacy-chat-callback",
-    run_id: runId,
   });
 }
 
@@ -2037,82 +2028,6 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(
       stateRecords((await readTelegramState(fixture.telegramBotId)).routes),
     ).toHaveLength(1);
-  });
-
-  it("falls back to the custom-bot binding brand for legacy delivery callbacks", async () => {
-    mockEnv("APP_URL", "https://app.vm0.ai");
-    const runnerGroup = configureCanonicalTelegramRunner();
-    const fixture = await trackFixture(
-      seedTelegramPostFixture({ linkTelegramUser: true }),
-    );
-    await seedModelPolicies({
-      fixture,
-      selectedModel: "claude-sonnet-5",
-    });
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: fixture.userId,
-        orgId: fixture.orgId,
-        orgRole: "org:admin",
-      },
-      { [FeatureSwitchKey.OkouDebug]: true },
-    );
-    const telegramMocks = telegramApiMocks();
-    const botUsername = `bot_${fixture.telegramBotId}`;
-    const prompt = "verify legacy Telegram callback branding";
-
-    const response = await postWebhook({
-      telegramBotId: fixture.telegramBotId,
-      secret: fixture.webhookSecret,
-      apiOrigin: "https://api.okou.ai",
-      body: {
-        update_id: 250,
-        message: {
-          message_id: 2250,
-          chat: { id: -77_250, type: "supergroup" },
-          from: {
-            id: Number(fixture.telegramUserId),
-            username: "alice",
-            first_name: "Alice",
-          },
-          text: `@${botUsername} ${prompt}`,
-          entities: [mentionEntity(botUsername)],
-        },
-      },
-    });
-    expect(response.status).toBe(200);
-    await flushWaitUntilForTest();
-
-    const runState = await telegramPostRunState(fixture, prompt);
-    const claim = await claimTelegramRun(runState.run!.id, runnerGroup);
-    await completeCanonicalChatRun({
-      runId: runState.run!.id,
-      sandboxToken: claim.sandboxToken,
-    });
-
-    expect(telegramMocks.sentMessages).toHaveLength(1);
-    expect(telegramMocks.sentMessages[0]?.text).toContain(
-      `https://app.okou.ai/activities/${runState.run!.id}`,
-    );
-
-    await redriveLegacyTelegramChatCallback(runState.run!.id);
-
-    expect(telegramMocks.sentMessages).toHaveLength(2);
-    expect(telegramMocks.sentMessages[1]?.text).toContain(
-      `https://app.vm0.ai/activities/${runState.run!.id}`,
-    );
-    expect(telegramMocks.sentMessages[1]?.text).not.toContain(
-      "https://app.okou.ai/activities/",
-    );
-    const redrivenState = await telegramPostRunState(fixture, prompt);
-    const redrivenCallback = redrivenState.callbacks.find((callback) => {
-      return callback.internalKind === "telegram:chat";
-    });
-    expect(redrivenCallback?.status).toBe("delivered");
-    expect(stateRecord(redrivenCallback?.payload)).not.toHaveProperty(
-      "publicBrand",
-    );
   });
 
   it("keeps Telegram callbacks typed when VM0_API_BACKEND_URL is set", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -14,9 +14,7 @@ import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import {
-  dispatchLegacyGitHubChatCallbackWithoutPublicBrandFixture,
   enqueueGitHubChatEventFixture,
-  setChatCallbackGitHubDeliveryFixture,
   setGitHubInstallationAppIdentityFixture,
 } from "../../../test-fixtures/chat-events";
 import { verifyOkouToken } from "../../auth/tokens";
@@ -949,89 +947,6 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       /https:\/\/app\.okou\.ai\/activities\/[0-9a-f-]+/u,
     );
     expect(postedComments[0]).not.toContain("https://app.vm0.ai/activities/");
-  });
-
-  it("delivers a pre-brand nested GitHub callback with installation metadata", async () => {
-    mockEnv("APP_URL", "https://app.vm0.ai");
-    const { actor, agentId, workflowId } = await setupFixture();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped GitHub callback actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.OkouDebug]: true },
-    );
-    const installed = await gh.installGithubApp(actor, agentId);
-    mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", GITHUB_WEBHOOK_SECRET);
-    await accept(
-      automationsClient().create({
-        headers: authHeaders(),
-        params: { workflowId },
-        body: githubPullRequestMergedAutomationBody(),
-      }),
-      [201],
-    );
-    const response = await postGithubWebhook({
-      event: "pull_request",
-      deliveryId: `delivery-${randomUUID()}`,
-      rawBody: githubPullRequestPayload({
-        action: "closed",
-        merged: true,
-        installationId: installed.remoteInstallationId,
-      }),
-    });
-    expect(response).toStrictEqual({ status: 200, text: "OK" });
-    await flushWaitUntilForTest();
-    await runsApi.heartbeatRunner();
-    const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
-    const runId = listedRuns.runs[0]?.id;
-    if (!runId || listedRuns.runs.length !== 1) {
-      throw new Error("Expected one GitHub callback run");
-    }
-    await runsApi.claimRunnerJob(runId);
-    await setChatCallbackGitHubDeliveryFixture({
-      runId,
-      remoteInstallationId: installed.remoteInstallationId,
-      repo: "vm0-ai/vm0",
-      subjectNumber: 82_001,
-      subjectKind: "issue",
-      agentId,
-    });
-
-    const postedComments: string[] = [];
-    server.use(
-      http.post(
-        "https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments",
-        async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
-          if (typeof body.body === "string") {
-            postedComments.push(body.body);
-          }
-          return HttpResponse.json({ id: 1 });
-        },
-      ),
-    );
-    await dispatchLegacyGitHubChatCallbackWithoutPublicBrandFixture(
-      {
-        runId,
-        remoteInstallationId: installed.remoteInstallationId,
-        repo: "vm0-ai/vm0",
-        subjectNumber: 82_001,
-        subjectKind: "issue",
-        agentId,
-        messageContent: "Historical nested GitHub callback",
-      },
-      context.signal,
-    );
-
-    expect(postedComments).toHaveLength(1);
-    expect(postedComments[0]).toContain(
-      `https://app.okou.ai/activities/${runId}`,
-    );
-    expect(postedComments[0]).not.toContain(
-      `https://app.vm0.ai/activities/${runId}`,
-    );
   });
 
   it("validates pull request review actions before dispatching", async () => {

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -35,7 +35,6 @@ import { nowDate } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
 import { resolveTestOrgId$, testUserId$ } from "../services/cli-auth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
-import { dispatchTelegramChatDeliveryOnce } from "../services/internal-telegram-chat-run-callback.service";
 import {
   normalizeRunMetadata,
   writeRunMetadata,
@@ -1440,68 +1439,6 @@ async function seedPendingUserLinkForAction(
   return actionOk();
 }
 
-async function redriveLegacyChatCallbackForAction(
-  db: Db,
-  body: Record<string, unknown>,
-  signal: AbortSignal,
-) {
-  const runId = readActionString(body, "run_id");
-  if (!runId) {
-    return actionBadRequest("run_id is required");
-  }
-  const [callback] = await db
-    .select({
-      id: agentRunCallbacks.id,
-      payload: agentRunCallbacks.payload,
-    })
-    .from(agentRunCallbacks)
-    .where(
-      and(
-        eq(agentRunCallbacks.runId, runId),
-        eq(agentRunCallbacks.internalKind, "telegram:chat"),
-        eq(agentRunCallbacks.status, "delivered"),
-      ),
-    )
-    .limit(1);
-  signal.throwIfAborted();
-  if (
-    !callback ||
-    typeof callback.payload !== "object" ||
-    callback.payload === null ||
-    Array.isArray(callback.payload) ||
-    !Object.hasOwn(callback.payload, "publicBrand")
-  ) {
-    return actionBadRequest(
-      "A branded delivered Telegram callback is required",
-    );
-  }
-
-  // Current writers cannot author this historical shape. Remove only the
-  // rollout field, then redrive the real Telegram callback consumer.
-  const legacyPayload: Record<string, unknown> = { ...callback.payload };
-  delete legacyPayload.publicBrand;
-  const [requeued] = await db
-    .update(agentRunCallbacks)
-    .set({
-      payload: legacyPayload,
-      status: "pending",
-      attempts: 0,
-      lastAttemptAt: null,
-      lastError: null,
-      deliveredAt: null,
-    })
-    .where(eq(agentRunCallbacks.id, callback.id))
-    .returning({ id: agentRunCallbacks.id });
-  signal.throwIfAborted();
-  if (!requeued) {
-    return actionBadRequest("Failed to requeue Telegram callback");
-  }
-
-  await dispatchTelegramChatDeliveryOnce(db, requeued.id, "completed", signal);
-  signal.throwIfAborted();
-  return actionOk({ callback_id: requeued.id });
-}
-
 async function updateRunCallbackForAction(
   db: Db,
   body: Record<string, unknown>,
@@ -1905,7 +1842,6 @@ const telegramStateActionHandlers = {
   "seed-org-credits": seedOrgCreditsForAction,
   "get-selected-model": getSelectedModelForAction,
   "seed-pending-user-link": seedPendingUserLinkForAction,
-  "redrive-legacy-chat-callback": redriveLegacyChatCallbackForAction,
   "update-run-callback": updateRunCallbackForAction,
   "update-run": updateRunForAction,
   "get-run": getRunForAction,

--- a/turbo/apps/api/src/signals/services/agentphone-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-chat-callback-payload.ts
@@ -22,9 +22,5 @@ export type AgentPhoneDeliveryTarget = z.infer<
 export const agentphoneChatCallbackPayloadSchema =
   agentphoneDeliveryTargetSchema.extend({
     chatEventId: z.string().uuid(),
-    // API/backend persisted-callback rollout compatibility: mixed versions have
-    // overlapped for up to about 102 minutes, and an old API omitted this field.
-    // Remove with #27750 after old/rollback APIs are gone and every pre-rollout
-    // AgentPhone delivery callback has drained.
-    publicBrand: publicBrandSchema.optional(),
+    publicBrand: publicBrandSchema,
   });

--- a/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
@@ -18,9 +18,5 @@ export type GitHubDeliveryTarget = z.infer<typeof githubDeliveryTargetSchema>;
 export const githubChatCallbackPayloadSchema =
   githubDeliveryTargetSchema.extend({
     chatEventId: z.string().uuid(),
-    // Callbacks persisted before GitHub ingress branding did not carry this.
-    // Old runners can create them for up to two hours, while persisted retries
-    // have no time bound. Remove under #27750 only after stored pending rows are
-    // proven branded and the pre-brand rollback target is retired.
-    publicBrand: publicBrandSchema.optional(),
+    publicBrand: publicBrandSchema,
   });

--- a/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
@@ -106,9 +106,9 @@ async function loadAgentPhoneRouteBinding(
     readonly run: AgentPhoneChatRunContext;
   },
   signal: AbortSignal,
-): Promise<{ readonly publicBrand: PublicBrand } | undefined> {
+): Promise<{ readonly userLinkId: string } | undefined> {
   const [route] = await args.db
-    .select({ publicBrand: agentphoneUserLinks.publicBrand })
+    .select({ userLinkId: agentphoneUserLinks.id })
     .from(agentphoneChatThreadRoutes)
     .innerJoin(
       agentphoneUserLinks,
@@ -327,18 +327,12 @@ async function deliverClaimedAgentPhoneChatCallback(
   if (!binding) {
     return "skipped_revoked";
   }
-  // API/backend persisted-callback rollout compatibility: mixed versions have
-  // overlapped for up to about 102 minutes, and callbacks created by an old API
-  // have no snapshot. Remove with #27750 after old/rollback APIs are gone and
-  // all pre-rollout AgentPhone callbacks have drained from persisted state.
-  const publicBrand = payload.publicBrand ?? binding.publicBrand;
-
   const presentation = await resolveAgentPhonePresentation(
     {
       db: args.db,
       runId: args.callback.runId,
       run,
-      publicBrand,
+      publicBrand: payload.publicBrand,
     },
     signal,
   );
@@ -359,7 +353,7 @@ async function deliverClaimedAgentPhoneChatCallback(
     target: payload,
     sent,
     body,
-    publicBrand,
+    publicBrand: payload.publicBrand,
   });
   return "delivered";
 }

--- a/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
@@ -163,7 +163,6 @@ async function loadGitHubChatDeliveryContext(
   const [installation] = await args.db
     .select({
       installationId: githubInstallations.installationId,
-      publicBrand: githubInstallations.publicBrand,
     })
     .from(githubChatThreadRoutes)
     .innerJoin(
@@ -188,10 +187,7 @@ async function loadGitHubChatDeliveryContext(
     run: runContext,
     messageContent: event.content,
     installation: installation?.installationId
-      ? {
-          ghInstallationId: installation.installationId,
-          publicBrand: installation.publicBrand,
-        }
+      ? { ghInstallationId: installation.installationId }
       : undefined,
   };
 }
@@ -319,8 +315,7 @@ async function deliverClaimedGitHubChatCallback(
       run: context.run,
       target: context.payload,
       messageContent: context.messageContent,
-      publicBrand:
-        context.payload.publicBrand ?? context.installation.publicBrand,
+      publicBrand: context.payload.publicBrand,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
@@ -63,7 +63,6 @@ interface TelegramChatRunContext {
 interface TelegramOwnerBinding {
   readonly botToken: string;
   readonly ownerLink: TelegramOwnerLink;
-  readonly publicBrand: PublicBrand;
 }
 
 async function markDelivered(db: Db, callbackId: string): Promise<void> {
@@ -142,10 +141,7 @@ async function loadTelegramOwnerBinding(
       return undefined;
     }
     const [link] = await args.db
-      .select({
-        id: telegramOfficialUserLinks.id,
-        publicBrand: telegramOfficialUserLinks.publicBrand,
-      })
+      .select({ id: telegramOfficialUserLinks.id })
       .from(telegramOfficialUserLinks)
       .where(
         and(
@@ -161,7 +157,6 @@ async function loadTelegramOwnerBinding(
       ? {
           botToken,
           ownerLink: { kind: "official", id: link.id },
-          publicBrand: link.publicBrand,
         }
       : undefined;
   }
@@ -174,7 +169,6 @@ async function loadTelegramOwnerBinding(
       id: telegramUserLinks.id,
       encryptedBotToken: telegramInstallations.encryptedBotToken,
       ownerUserId: telegramInstallations.ownerUserId,
-      publicBrand: telegramInstallations.publicBrand,
     })
     .from(telegramUserLinks)
     .innerJoin(
@@ -204,7 +198,6 @@ async function loadTelegramOwnerBinding(
       ),
     ),
     ownerLink: { kind: "custom", id: binding.id },
-    publicBrand: binding.publicBrand,
   };
 }
 
@@ -544,12 +537,7 @@ async function deliverClaimedTelegramChatCallback(
       run,
       runId: args.callback.runId,
       installationId: payload.installationId,
-      // Backend/runner rollout compatibility: callbacks created by the old
-      // API omit publicBrand and can finish while runner/sandbox instances
-      // drain for up to 2 hours. Remove under #27750 after old API rollback
-      // targets and runners have drained and no deliverable Telegram callback
-      // payload lacks publicBrand.
-      publicBrand: payload.publicBrand ?? binding.publicBrand,
+      publicBrand: payload.publicBrand,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/telegram-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/telegram-chat-callback-payload.ts
@@ -21,5 +21,5 @@ export type TelegramDeliveryTarget = z.infer<
 export const telegramChatCallbackPayloadSchema =
   telegramDeliveryTargetSchema.extend({
     chatEventId: z.string().uuid(),
-    publicBrand: publicBrandSchema.optional(),
+    publicBrand: publicBrandSchema,
   });

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -66,7 +66,6 @@ import { visibleChatEventCondition } from "../signals/services/chat-event-shared
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { buildFeishuChatOpenUrl } from "../signals/services/feishu-config";
 import { createUserMessageDocument } from "../signals/services/chat-user-message.service";
-import { dispatchGitHubChatDeliveryOnce } from "../signals/services/internal-github-chat-run-callback.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -1556,86 +1555,6 @@ export async function setGitHubInstallationAppIdentityFixture(args: {
   if (installations.length !== 1) {
     throw new Error("Expected one GitHub installation identity to update");
   }
-}
-
-/**
- * Reproduce and dispatch the nested GitHub callback shape persisted before
- * publicBrand existed. The observable boundary is the provider comment POST.
- */
-export async function dispatchLegacyGitHubChatCallbackWithoutPublicBrandFixture(
-  args: {
-    readonly runId: string;
-    readonly remoteInstallationId: string;
-    readonly repo: string;
-    readonly subjectNumber: number;
-    readonly subjectKind: "issue" | "pull_request";
-    readonly agentId: string;
-    readonly messageContent: string;
-  },
-  signal: AbortSignal,
-): Promise<void> {
-  const callbackId = await db().transaction(async (tx) => {
-    const [run] = await tx
-      .select({ chatThreadId: agentRuns.chatThreadId })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, args.runId))
-      .limit(1);
-    if (!run?.chatThreadId) {
-      throw new Error("Expected one thread-bound GitHub run");
-    }
-    const [installation] = await tx
-      .select({ id: githubInstallations.id })
-      .from(githubInstallations)
-      .where(eq(githubInstallations.installationId, args.remoteInstallationId))
-      .limit(1);
-    if (!installation) {
-      throw new Error("Expected one GitHub installation");
-    }
-    const [sourceCallback] = await tx
-      .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-      .from(agentRunCallbacks)
-      .where(
-        and(
-          eq(agentRunCallbacks.runId, args.runId),
-          eq(agentRunCallbacks.internalKind, "chat"),
-        ),
-      )
-      .limit(1);
-    if (!sourceCallback) {
-      throw new Error("Expected one canonical chat callback");
-    }
-    const event = await insertChatEvent(tx, {
-      chatThreadId: run.chatThreadId,
-      eventType: "output.message",
-      content: args.messageContent,
-      runId: args.runId,
-    });
-    if (!event) {
-      throw new Error("Expected one GitHub callback output event");
-    }
-    const [callback] = await tx
-      .insert(agentRunCallbacks)
-      .values({
-        runId: args.runId,
-        internalKind: "github:chat",
-        encryptedSecret: sourceCallback.encryptedSecret,
-        payload: {
-          installationId: installation.id,
-          repo: args.repo,
-          subjectNumber: args.subjectNumber,
-          subjectKind: args.subjectKind,
-          agentId: args.agentId,
-          chatEventId: event.id,
-        },
-      })
-      .returning({ id: agentRunCallbacks.id });
-    if (!callback) {
-      throw new Error("Expected one legacy GitHub delivery callback");
-    }
-    return callback.id;
-  });
-
-  await dispatchGitHubChatDeliveryOnce(db(), callbackId, "completed", signal);
 }
 
 async function transitiveBlockedWaiterCount(

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
@@ -42,7 +42,6 @@ export const testTelegramStateActionBodySchema = z
       "seed-org-credits",
       "get-selected-model",
       "seed-pending-user-link",
-      "redrive-legacy-chat-callback",
       "update-run-callback",
       "update-run",
       "get-run",


### PR DESCRIPTION
Removes the last bounded #27750 rollout fallback on the persisted chat-run delivery callbacks. Slack and Teams already require `publicBrand`; Feishu was contracted in #29405. This finishes AgentPhone, Telegram, and GitHub on the same evidence shape.

## Cohort — persisted delivery callback `publicBrand` (AgentPhone, Telegram, GitHub)

**Old boundary:** during the additive brand rollout an older API could persist an `agentphone:chat`, `telegram:chat`, or `github:chat` `agent_run_callbacks` row whose payload omitted `publicBrand`, so each consumer fell back to the AgentPhone user link, Telegram installation/official-link, or GitHub installation brand.

**New boundary:** `publicBrand` is required on all three persisted payload schemas and each consumer reads it directly.

Removed:
- `publicBrand: publicBrandSchema.optional()` → required in `agentphone-chat-callback-payload.ts`, `telegram-chat-callback-payload.ts`, `github-chat-callback-payload.ts`
- `payload.publicBrand ?? binding.publicBrand` (AgentPhone and Telegram) and `context.payload.publicBrand ?? context.installation.publicBrand` (GitHub)
- the brand columns those fallbacks were the only readers of: `agentphoneUserLinks.publicBrand` in `loadAgentPhoneRouteBinding` (now a pure route-still-binds check), `telegramOfficialUserLinks.publicBrand` and `telegramInstallations.publicBrand` in the Telegram owner-binding loader, `TelegramOwnerBinding.publicBrand`, and `githubInstallations.publicBrand` in the GitHub delivery context
- the test-only `redrive-legacy-chat-callback` action, its contract entry, and `redriveLegacyChatCallbackForAction`, which existed only to strip `publicBrand` from a delivered callback and redrive it
- `dispatchLegacyGitHubChatCallbackWithoutPublicBrandFixture` and the two tests that only asserted the pre-brand path (`falls back to the custom-bot binding brand for legacy delivery callbacks`, `delivers a pre-brand nested GitHub callback with installation metadata`)

**Windows:** latest applicable expiry per consumer — canonical window 1 for the old API writer, plus the ~102-minute observed mixed-version skew and canonical window 3 (2 h) for a run/sandbox that outlives its writer.

**Rollout evidence (observed):**

| Rollout | Merged | First `api/production` deployment containing it | Elapsed at this change | Later production deployments |
| --- | --- | --- | --- | --- |
| #28942 GitHub (`3d4bdf623e7`) | `2026-08-24T13:45:12Z` | `5cdeba4b32`, `2026-08-24T14:15:03Z` | **54.7 h** | 29 |
| #28953 AgentPhone (`e7fcd06ba26`) | `2026-08-24T14:57:39Z` | `d751eed41c`, `2026-08-24T22:19:58Z` | **46.7 h** | 28 |
| #28945 Telegram (`c5f6b87adc0`) | `2026-08-24T15:25:37Z` | `d751eed41c`, `2026-08-24T22:19:58Z` | **46.7 h** | 28 |

Containment was checked with `git merge-base --is-ancestor` against each deployment SHA, walking the `api/production` deployment list forward from oldest. The API build preceding `d751eed41c` was marked `inactive` at `2026-08-24T22:20:22Z`, so no pre-rollout writer has been serving for over 46 hours and it is no longer the rollback target.

**MaskDB evidence (read-only, `vm0-prod-ro`, structured API only):** this is the decisive proof for the persisted-state gate each comment named.

- Freshness: the newest `agent_run_callbacks` row observed is `2026-08-26T21:04:31Z`, so this is live production state, not a stale snapshot.
- `agent_run_callbacks` census by `internal_kind` (both `internal_kind` and `status` are unmasked and filterable): `agentphone:chat` **0 rows in total**, `telegram:chat` **3 rows, all `delivered`**, `github:chat` **1 row, `delivered`**.
- Non-delivered rows across the whole table are confined to other kinds: `chat` pending 76 / failed 6, `null` pending 30 / failed 20, `trigger:loop` failed 2, `workflow-automation:cron` pending 1. Zero pending or failed rows exist for any of the three kinds being contracted.
- This directly satisfies the gates the comments stated — "every pre-rollout AgentPhone delivery callback has drained", "no deliverable Telegram callback payload lacks publicBrand", and "stored pending rows are proven branded". Deletion of old `delivered` rows does not weaken it: only a non-terminal row would ever be decoded again, and there are none.
- No row-level data is reproduced here; only aggregate counts over unmasked, filterable columns.

**Axiom evidence (read-only):** dataset `vm0-web-logs-prod`, explicit range `2026-08-24T14:15:03Z` → `2026-08-26T21:00:00Z` (59,581 rows examined). No AgentPhone, Telegram, or GitHub delivery-brand error signature appears. Coverage for that window is established by the same `level == "error"` distribution, which does capture route-thrown text including `Unhandled request error: duplicate key value violates unique constraint "chat_threads_pkey"`, so a decode failure on these payloads would have surfaced.

**Persisted data:** all three writers on current `main` take a required `PublicBrand` (`insertAgentPhoneChatDeliveryCallback`, `insertTelegramChatDeliveryCallback`, and the GitHub delivery insert), so every newly persisted payload carries the field.

## Explicitly deferred

- **Queued-launch-context brand reads** (`telegram-queued-launch-context.service.ts`, `agentphone-queued-launch-context.service.ts`, and the Feishu equivalents). Their gates require proving no pending context row has a null `public_brand`, and MaskDB's projection of `chat_telegram_context`, `chat_agentphone_context`, and `chat_feishu_context` does not expose `public_brand` at all (`feishu_chat_ingress` is still absent from the projection). Recorded as an evidence gap; the callback cohort above did not need it.
- **`agentphone-connect-params.ts` `parseBrandState`.** Its stated gate is that the client floor excludes the pre-rollout Platform version. `turbo/apps/api/src/lib/web-client-compatibility.json` sets `minimumSupportedVersion` to `0.781.1`, while the app version at the #28953 merge commit is `0.788.0`, so the floor does not exclude it. Blocked on a floor raise, not on time.
- **`APPS_API_CONNECT_CHANNEL` in `integrations-agentphone.ts`.** Its own comment states the retained rollback lifetime "has no fixed maximum evidenced", so no expiry can be computed.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F api lint` (no new warnings on changed files), `pnpm -F api check-types`, `pnpm -F @okouai/api-contracts check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F api exec vitest run` on `integrations-telegram-post` + `integrations-telegram` (100), `webhooks-github-workflow` + `agentphone.bdd` (31), `integrations.bdd` + `chat-events.bdd` (172) — all passing against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
