### PR TITLE
docs(mitm-addon): document auth.base worker shutdown contract

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -156,7 +156,23 @@ def reset_forward_request_state_for_tests() -> None:
 
 
 def shutdown_forward_request_workers(*, wait: bool) -> None:
-    """Shut down auth.base forwarding workers."""
+    """Close admission and shut down the auth.base forwarding worker lifecycle.
+
+    This is a one-way production transition: new forwards are rejected, and the
+    admission state is cleared. Admitted waiters are woken so they can observe
+    shutdown, pending worker futures are cancelled, and active DNS lookups or
+    upstream sockets are best-effort aborted. Affected forwards therefore become
+    terminal instead of waiting indefinitely for admission or upstream work.
+
+    Both values of `wait` perform those shutdown actions. `wait=True` additionally
+    joins the tracked daemon worker threads, while `wait=False` returns without
+    joining them and does not wait for slow upstream responses. The latter is used
+    by production teardown to keep process shutdown bounded.
+
+    Production shutdown cannot re-enable admission. The test-only
+    `reset_forward_request_state_for_tests()` helper is the mechanism that resets
+    worker and admission state and re-enables forwarding between tests.
+    """
     global _forward_request_admission_state
     global _forward_request_accepting
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1978,14 +1978,15 @@ def done():
     executor. It also performs a final JSONL marker observation and joins the
     marker watcher before the JSONL writer stops. Any retryable usage outcome
     retained by completed workers is then retried synchronously.
-    Auth.base forwarding does not need to finish running work during shutdown,
-    so its worker shutdown stops new forwards and best-effort closes active
-    upstream sockets without waiting for slow upstream responses. JSONL writer
-    shutdown is also bounded and best-effort; if it times out, process shutdown
-    continues with accepted log entries possibly still pending. After joining
-    the usage executor, retained billing and diagnostic work is drained through
-    synchronous delivery. Model-provider failure delivery stops admission and
-    receives one bounded drain window.
+    Auth.base forwarding does not need to finish running work during shutdown.
+    Its `wait=False` worker shutdown closes admission, wakes or terminates
+    affected forwards, cancels pending futures, and best-effort aborts active
+    upstream work without joining daemon workers or waiting for slow upstream
+    responses. JSONL writer shutdown is also bounded and best-effort; if it times
+    out, process shutdown continues with accepted log entries possibly still
+    pending. After joining the usage executor, retained billing and diagnostic
+    work is drained through synchronous delivery. Model-provider failure delivery
+    stops admission and receives one bounded drain window.
     """
     try:
         runner_flush_lifecycle.drain_and_close()


### PR DESCRIPTION
## Summary

- Document the one-way auth.base forwarding shutdown transition and its effects on new, waiting,
  pending, and active forwards.
- Clarify that `wait=True` joins worker threads after the same shutdown actions that `wait=False`
  initiates, while production teardown remains bounded.
- Keep the `mitm_addon.done()` teardown documentation aligned with the worker lifecycle contract.

## Scope

Documentation-only change. Runtime behavior, shutdown ordering, worker handling, admission state,
and tests are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_lifecycle.py`
- `uv run --no-sync python -m pytest tests/test_done_hook.py`

Closes #29704
