### PR TITLE
fix(python): reject incomplete zstd capture bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -375,9 +375,15 @@ def _decode_zstd_for_network_log_capture(data: bytes, max_output: int) -> bytes 
             data,
             read_across_frames=True,
         ) as reader:
-            return reader.read(max_output)
+            body = reader.read(max_output)
     except zstandard.ZstdError:
         return None
+
+    if len(body) >= max_output:
+        return body
+    if _validate_complete_zstd_frames(data, max_output) is not None:
+        return None
+    return body
 
 
 def decode_response_body_for_network_log_capture(
@@ -404,8 +410,8 @@ def decode_response_body_for_network_log_capture(
       requires a complete stream unless the decoded-output bound is reached.
     - ``br`` rejects invalid or incomplete input, except that reaching the
       decoded-output bound returns the bounded prefix.
-    - ``zstd`` reads concatenated frames up to ``max_output`` bytes and returns
-      ``None`` when the reader reports malformed or invalid trailing input.
+    - ``zstd`` reads concatenated frames up to ``max_output`` bytes and rejects
+      malformed or incomplete frames unless the decoded-output bound is reached.
 
     This is stricter than the best-effort ``decompress_body()`` path used for
     retained streaming buffers, which can preserve original wire bytes or

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -474,6 +474,42 @@ class TestAddCaptureFields:
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
 
+    def test_response_incomplete_zstd_frame_skips_body(self, real_flow):
+        compressed = zstandard.ZstdCompressor().compress(b"incomplete response body")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed[:-1],
+            response_encoding="zstd",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
+    def test_response_incomplete_trailing_zstd_frame_skips_body(self, real_flow):
+        compressor = zstandard.ZstdCompressor()
+        compressed = (
+            compressor.compress(b"first response frame")
+            + compressor.compress(b"incomplete trailing frame")[:-1]
+        )
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed,
+            response_encoding="zstd",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
     def test_response_zstd_concatenated_frames_capture_all_frames(self, real_flow):
         first = b"first response frame"
         second = b" and second response frame"


### PR DESCRIPTION
## Summary

- reject incomplete zstd frames on the strict buffered response-capture path
- preserve valid concatenated frames and the bounded-prefix behavior once the decoded-output limit is reached
- add capture-entry integration coverage for an incomplete first frame and an incomplete trailing frame

## Scope

This changes only buffered `flow.response.raw_content` decoding. Explicitly truncated response stream buffers continue to use the existing best-effort decoder. There are no API, schema, database, protocol, persisted-state, migration, or deployment-order changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_capture_fields.py tests/test_body_capture_decompression.py tests/test_body_decoding.py` (180 passed)
- `uv run --no-sync python -m pytest tests/` (6666 passed)

Closes #29708
