### PR TITLE
docs(nbd-cow): clarify relocation ordering contract

### DIFF
--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -241,8 +241,10 @@ impl PooledNbdCowDevice {
     /// The caller must move the same backing file within one filesystem before
     /// calling this method. This updates only path metadata used by bitmap
     /// persistence and cleanup; it does not reopen, reset, or rebind the COW
-    /// layer or NBD device. Any in-flight COW operation completes before the
-    /// path metadata is updated.
+    /// layer or NBD device. Relocation waits for a COW operation that already
+    /// holds the `CowLayer` mutex to complete before the path metadata is
+    /// updated. A submitted COW operation that has not yet acquired the mutex
+    /// is not waited on and may run after relocation returns.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

- Clarify the `PooledNbdCowDevice::relocate_cow_file_after_rename` ordering contract.
- Document that relocation waits for operations already holding the `CowLayer` mutex, while submitted operations still waiting for that mutex may run after relocation returns.
- Preserve the existing synchronization, API, and runtime behavior.

## Scope

- Documentation-only change in `crates/nbd-cow/src/device/pooled.rs`.
- No public signature, dependency, protocol, or runtime changes.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-features` (296 passed, 13 ignored)
- `git diff --check`

Closes #29703
