### PR TITLE
perf(python): avoid repeated unicode hostname normalization

### DIFF
--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -345,6 +345,16 @@ def _validate_normalized_label_text(normalized_label: str) -> None:
     _validate_normalized_label_bidi(normalized_label)
 
 
+def _encode_normalized_label(normalized_label: str) -> str:
+    try:
+        payload = normalized_label.encode("punycode").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise UnicodeError("invalid IDNA label") from exc
+    if not payload:
+        raise UnicodeError("invalid IDNA label")
+    return f"{_PUNYCODE_PREFIX}{payload}"
+
+
 def _canonical_punycode_label(label: str) -> str:
     if _has_unsafe_uts46_mapping_chars(label):
         raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
@@ -355,20 +365,19 @@ def _canonical_punycode_label(label: str) -> str:
     if len(normalized_label) > _PUNYCODE_INPUT_MAX_CODEPOINTS:
         raise UnicodeError("IDNA label too long")
 
-    try:
-        payload = normalized_label.encode("punycode").decode("ascii").lower()
-    except UnicodeError as exc:
-        raise UnicodeError("invalid IDNA label") from exc
-    if not payload:
-        raise UnicodeError("invalid IDNA label")
-    return f"{_PUNYCODE_PREFIX}{payload}"
+    return _encode_normalized_label(normalized_label)
 
 
 def _encode_unicode_label(label: str) -> str:
     normalized_label = _normalize_label_text(label)
+    if len(normalized_label) > _PUNYCODE_INPUT_MAX_CODEPOINTS:
+        raise UnicodeError("IDNA label too long")
+    _validate_normalized_label_text(normalized_label)
     if _is_ascii(normalized_label):
         raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
-    return _canonical_punycode_label(label)
+    if _has_unsafe_uts46_mapping_chars(label):
+        raise UnsafeIdnaCompatibilityMappingError("unsafe IDNA compatibility mapping")
+    return _encode_normalized_label(normalized_label)
 
 
 def _is_valid_alabel(label: str) -> bool:
@@ -400,7 +409,8 @@ def _has_invalid_alabel(ascii_host: str) -> bool:
 def _normalize_label(label: str) -> str:
     if not label:
         raise UnicodeError("empty IDNA label")
-    if _is_ascii(label):
+    input_is_ascii = _is_ascii(label)
+    if input_is_ascii:
         if any(
             char <= _ASCII_SPACE or char == _ASCII_DELETE or char in _FORBIDDEN_ASCII_LABEL_CHARS
             for char in label
@@ -408,12 +418,10 @@ def _normalize_label(label: str) -> str:
             raise UnicodeError("invalid IDNA label")
         ascii_label = label.lower()
     else:
-        normalized_label = _normalize_label_text(label)
-        _validate_normalized_label_text(normalized_label)
         ascii_label = _encode_unicode_label(label)
     if len(ascii_label) > _DNS_LABEL_MAX_LENGTH:
         raise UnicodeError("IDNA label too long")
-    if not _is_valid_alabel(ascii_label):
+    if input_is_ascii and not _is_valid_alabel(ascii_label):
         raise UnicodeError("invalid IDNA A-label")
     return ascii_label
 

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -37,6 +37,47 @@ def test_ascii_hostname_bypasses_unicode_pipeline():
     unicode_bidirectional.assert_not_called()
 
 
+def test_unicode_label_reuses_normalized_text():
+    with (
+        patch.object(
+            host_normalization,
+            "_normalize_label_text",
+            wraps=host_normalization._normalize_label_text,
+        ) as normalize_label_text,
+        patch.object(
+            host_normalization,
+            "_validate_normalized_label_text",
+            wraps=host_normalization._validate_normalized_label_text,
+        ) as validate_normalized_label_text,
+    ):
+        normalized = host_normalization.normalize_idna_label("faß")
+
+    assert normalized == "xn--fa-hia"
+    normalize_label_text.assert_called_once_with("faß")
+    validate_normalized_label_text.assert_called_once_with("faß")
+
+
+def test_overlength_unicode_label_skips_normalized_text_validation():
+    oversized_label = "".join(chr(0x4E00 + index) for index in range(1365))
+    with (
+        patch.object(
+            host_normalization,
+            "_normalize_label_text",
+            wraps=host_normalization._normalize_label_text,
+        ) as normalize_label_text,
+        patch.object(
+            host_normalization,
+            "_validate_normalized_label_text",
+            wraps=host_normalization._validate_normalized_label_text,
+        ) as validate_normalized_label_text,
+        pytest.raises(UnicodeError, match="IDNA label too long"),
+    ):
+        host_normalization.normalize_idna_label(oversized_label)
+
+    normalize_label_text.assert_called_once_with(oversized_label)
+    validate_normalized_label_text.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("label", "expected"),
     [

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import flow_metadata_keys as metadata_keys
+import host_normalization
 import mitm_addon
 import request_authority
 import upstream_destination_binding
@@ -276,10 +277,21 @@ async def test_rejects_oversized_unicode_authority_before_punycode_encoding(
     if flow.request.is_http2 or flow.request.is_http3:
         flow.request.authority = oversized_label
     original_headers = tuple(flow.request.headers.fields)
+    real_normalize_label_text = host_normalization._normalize_label_text
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
+        patch.object(
+            host_normalization,
+            "_normalize_label_text",
+            wraps=real_normalize_label_text,
+        ) as normalize_label_text,
+        patch.object(
+            host_normalization,
+            "_validate_normalized_label_text",
+            side_effect=AssertionError("oversized authority reached normalized text validation"),
+        ) as validate_normalized_label_text,
         patch.object(
             encodings.punycode,
             "punycode_encode",
@@ -295,6 +307,8 @@ async def test_rejects_oversized_unicode_authority_before_punycode_encoding(
     assert tuple(flow.request.headers.fields) == original_headers
     assert flow.request.headers["Authorization"] == "Bearer sandbox-token"
     auth_fetch.assert_not_called()
+    normalize_label_text.assert_called_once_with(oversized_label)
+    validate_normalized_label_text.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- reuse one normalized Unicode label through validation and punycode encoding
- reject normalized labels above the DNS input bound before category and bidi validation
- skip round-trip validation for generated A-labels while retaining canonical validation for external `xn--` input
- lock the work bound through the public label entry point and real request-hook integration coverage

## Scope

This is a private mitm-addon normalization refactor. It does not change the public hostname policy, API or runner protocol, persisted state, configuration, or deployment contract.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_host_normalization.py tests/test_request_handler_authority_validation.py` (106 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6,666 passed)

Closes #29705
