### PR TITLE
feat(platform): give intro-video templates their own picker category

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -656,6 +656,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}} Folie",
       "importedSlides_other": "{{count}} Folien",
+      "introVideo": "Intro-Video",
       "multiAccent": "Multi-Akzent",
       "nextSlide": "Vorschau der nächsten Folie",
       "noMatches": "Keine Übereinstimmungen",
@@ -673,6 +674,7 @@
       "searchConnector": "Vorlagen suchen",
       "searchConnectors": "Vorlagen suchen",
       "selected": "Vorlage: {{title}}",
+      "selectIntroVideo": "Wählen Sie die Intro-Video-Vorlage {{title}} aus.",
       "selectStyle": "Stil auswählen {{style}}",
       "selectTemplate": "Wählen Sie die Vorlage {{title}} aus.",
       "selectVideo": "Wählen Sie die Videovorlage {{title}} aus.",
@@ -2255,6 +2257,7 @@
     "templates": {
       "categories": {
         "illustration": "Illustration",
+        "introVideo": "Intro-Video",
         "presentation": "Präsentation",
         "video": "Video",
         "website": "Webseite",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -656,6 +656,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}} slide",
       "importedSlides_other": "{{count}} slides",
+      "introVideo": "Intro video",
       "multiAccent": "Multi-accent",
       "nextSlide": "Preview next slide",
       "noMatches": "No matches",
@@ -673,6 +674,7 @@
       "searchConnector": "Search templates",
       "searchConnectors": "Search templates",
       "selected": "Template: {{title}}",
+      "selectIntroVideo": "Select intro video template {{title}}",
       "selectStyle": "Select style {{style}}",
       "selectTemplate": "Select template {{title}}",
       "selectVideo": "Select video template {{title}}",
@@ -2255,6 +2257,7 @@
     "templates": {
       "categories": {
         "illustration": "Illustration",
+        "introVideo": "Intro video",
         "presentation": "Presentation",
         "video": "Video",
         "website": "Website",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -675,6 +675,7 @@
       "importedSlides_one": "{{count}} diapositiva",
       "importedSlides_many": "{{count}} diapositivas",
       "importedSlides_other": "{{count}} diapositivas",
+      "introVideo": "Vídeo de introducción",
       "multiAccent": "Multiacentos",
       "nextSlide": "Vista previa de la diapositiva siguiente",
       "noMatches": "Sin coincidencias",
@@ -692,6 +693,7 @@
       "searchConnector": "Buscar plantillas",
       "searchConnectors": "Buscar plantillas",
       "selected": "Plantilla: {{title}}",
+      "selectIntroVideo": "Seleccionar plantilla de vídeo de introducción {{title}}",
       "selectStyle": "Selecciona el estilo {{style}}",
       "selectTemplate": "Seleccionar plantilla {{title}}",
       "selectVideo": "Seleccionar plantilla de vídeo {{title}}",
@@ -2299,6 +2301,7 @@
     "templates": {
       "categories": {
         "illustration": "Ilustración",
+        "introVideo": "Vídeo de introducción",
         "presentation": "Presentación",
         "video": "Vídeo",
         "website": "Sitio web",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -675,6 +675,7 @@
       "importedSlides_one": "{{count}} diapositive",
       "importedSlides_many": "{{count}} diapositives",
       "importedSlides_other": "{{count}} diapositives",
+      "introVideo": "Vidéo d'intro",
       "multiAccent": "Multi-accents",
       "nextSlide": "Aperçu de la diapositive suivante",
       "noMatches": "Aucun résultat",
@@ -692,6 +693,7 @@
       "searchConnector": "Rechercher des modèles",
       "searchConnectors": "Rechercher des modèles",
       "selected": "Modèle : {{title}}",
+      "selectIntroVideo": "Sélectionner le modèle de vidéo d'intro {{title}}",
       "selectStyle": "Sélectionner le style {{style}}",
       "selectTemplate": "Sélectionner le modèle {{title}}",
       "selectVideo": "Sélectionner le modèle vidéo {{title}}",
@@ -2299,6 +2301,7 @@
     "templates": {
       "categories": {
         "illustration": "Illustration",
+        "introVideo": "Vidéo d'intro",
         "presentation": "Présentation",
         "video": "Vidéo",
         "website": "Site web",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -656,6 +656,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}} स्लाइड",
       "importedSlides_other": "{{count}} स्लाइड",
+      "introVideo": "इंट्रो वीडियो",
       "multiAccent": "बहु-उच्चारण",
       "nextSlide": "अगली स्लाइड का पूर्वावलोकन करें",
       "noMatches": "कोई मेल नहीं",
@@ -673,6 +674,7 @@
       "searchConnector": "टेम्पलेट खोजें",
       "searchConnectors": "टेम्पलेट खोजें",
       "selected": "टेम्पलेट: {{title}}",
+      "selectIntroVideo": "इंट्रो वीडियो टेम्पलेट {{title}} चुनें",
       "selectStyle": "शैली {{style}} चुनें",
       "selectTemplate": "टेम्पलेट {{title}} चुनें",
       "selectVideo": "वीडियो टेम्पलेट {{title}} चुनें",
@@ -2255,6 +2257,7 @@
     "templates": {
       "categories": {
         "illustration": "चित्रण",
+        "introVideo": "इंट्रो वीडियो",
         "presentation": "प्रस्तुति",
         "video": "वीडियो",
         "website": "वेबसाइट",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -655,6 +655,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}} slide",
       "importedSlides_other": "{{count}} slide",
+      "introVideo": "Video intro",
       "multiAccent": "Multi-aksen",
       "nextSlide": "Pratinjau slide berikutnya",
       "noMatches": "Tidak ada hasil",
@@ -672,6 +673,7 @@
       "searchConnector": "Cari templat",
       "searchConnectors": "Cari templat",
       "selected": "Templat: {{title}}",
+      "selectIntroVideo": "Pilih template video intro {{title}}",
       "selectStyle": "Pilih gaya {{style}}",
       "selectTemplate": "Pilih template {{title}}",
       "selectVideo": "Pilih template video {{title}}",
@@ -2251,6 +2253,7 @@
     "templates": {
       "categories": {
         "illustration": "Ilustrasi",
+        "introVideo": "Video intro",
         "presentation": "Presentasi",
         "video": "Video",
         "website": "Situs web",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -675,6 +675,7 @@
       "importedSlides_one": "{{count}} diapositiva",
       "importedSlides_many": "{{count}} diapositive",
       "importedSlides_other": "{{count}} diapositive",
+      "introVideo": "Video introduttivo",
       "multiAccent": "Multiaccento",
       "nextSlide": "Anteprima della diapositiva successiva",
       "noMatches": "Nessuna corrispondenza",
@@ -692,6 +693,7 @@
       "searchConnector": "Cerca modelli",
       "searchConnectors": "Cerca modelli",
       "selected": "Modello: {{title}}",
+      "selectIntroVideo": "Seleziona il modello di video introduttivo {{title}}",
       "selectStyle": "Seleziona lo stile {{style}}",
       "selectTemplate": "Seleziona il modello {{title}}",
       "selectVideo": "Seleziona il modello video {{title}}",
@@ -2299,6 +2301,7 @@
     "templates": {
       "categories": {
         "illustration": "Illustrazione",
+        "introVideo": "Video introduttivo",
         "presentation": "Presentazione",
         "video": "Video",
         "website": "Sito web",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -655,6 +655,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}} 枚",
       "importedSlides_other": "{{count}} 枚",
+      "introVideo": "イントロビデオ",
       "multiAccent": "マルチアクセント",
       "nextSlide": "次のスライドをプレビューする",
       "noMatches": "一致しません",
@@ -672,6 +673,7 @@
       "searchConnector": "テンプレートを検索",
       "searchConnectors": "テンプレートを検索",
       "selected": "テンプレート: {{title}}",
+      "selectIntroVideo": "イントロビデオ テンプレート {{title}} を選択してください",
       "selectStyle": "スタイル {{style}} を選択してください",
       "selectTemplate": "テンプレート {{title}} を選択します",
       "selectVideo": "ビデオ テンプレート {{title}} を選択してください",
@@ -2251,6 +2253,7 @@
     "templates": {
       "categories": {
         "illustration": "イラストレーション",
+        "introVideo": "イントロビデオ",
         "presentation": "プレゼンテーション",
         "video": "ビデオ",
         "website": "ウェブサイト",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -655,6 +655,7 @@
       "importDeckHint": "(.pptx, .ppt, .pdf)",
       "importedSlides_one": "{{count}}장",
       "importedSlides_other": "{{count}}장",
+      "introVideo": "인트로 비디오",
       "multiAccent": "다중 악센트",
       "nextSlide": "다음 슬라이드 미리보기",
       "noMatches": "일치하는 항목 없음",
@@ -672,6 +673,7 @@
       "searchConnector": "템플릿 검색",
       "searchConnectors": "템플릿 검색",
       "selected": "템플릿: {{title}}",
+      "selectIntroVideo": "인트로 비디오 템플릿 선택 {{title}}",
       "selectStyle": "스타일 선택 {{style}}",
       "selectTemplate": "템플릿 선택 {{title}}",
       "selectVideo": "비디오 템플릿 선택 {{title}}",
@@ -2251,6 +2253,7 @@
     "templates": {
       "categories": {
         "illustration": "일러스트",
+        "introVideo": "인트로 비디오",
         "presentation": "프레젠테이션",
         "video": "비디오",
         "website": "웹사이트",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -675,6 +675,7 @@
       "importedSlides_one": "{{count}} slide",
       "importedSlides_many": "{{count}} slides",
       "importedSlides_other": "{{count}} slides",
+      "introVideo": "Vídeo de introdução",
       "multiAccent": "Várias cores de destaque",
       "nextSlide": "Visualizar próximo slide",
       "noMatches": "Nenhum resultado",
@@ -692,6 +693,7 @@
       "searchConnector": "Buscar modelos",
       "searchConnectors": "Buscar modelos",
       "selected": "Modelo: {{title}}",
+      "selectIntroVideo": "Selecionar modelo de vídeo de introdução {{title}}",
       "selectStyle": "Selecionar estilo {{style}}",
       "selectTemplate": "Selecionar modelo {{title}}",
       "selectVideo": "Selecionar modelo de vídeo {{title}}",
@@ -2299,6 +2301,7 @@
     "templates": {
       "categories": {
         "illustration": "Ilustração",
+        "introVideo": "Vídeo de introdução",
         "presentation": "Apresentação",
         "video": "Vídeo",
         "website": "Site",

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -940,9 +940,14 @@ function templateAttachmentTypeLabel(
       return $.chat.templates.categories.illustration;
     });
   }
-  if (type === "video" || type === "intro-video") {
+  if (type === "video") {
     return i18n.t(($) => {
       return $.chat.templates.categories.video;
+    });
+  }
+  if (type === "intro-video") {
+    return i18n.t(($) => {
+      return $.chat.templates.categories.introVideo;
     });
   }
   if (type === "avatar") {

--- a/turbo/apps/platform/src/signals/okou-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/okou-page/user-message-document-codec.ts
@@ -450,10 +450,7 @@ function templateAttachmentType(template: GenerationTemplateRequest): string {
 
 function templateCategory(template: GenerationTemplateRequest): string {
   const type = templateAttachmentType(template);
-  if (type === "presentation") {
-    return "slides";
-  }
-  return type === "intro-video" ? "video" : type;
+  return type === "presentation" ? "slides" : type;
 }
 
 function templatePreviewImageUrl(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -51,6 +51,7 @@ import {
   SUGGESTED_THREAD_ID,
   linkByText,
   tabByText,
+  queryTabByText,
   presentationTemplateGridScrollContainer,
   mockActiveTemplateThread,
   mockAgent,
@@ -574,7 +575,7 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("keeps the intro-video placeholder out of the picker while switched off", async () => {
+  it("keeps the intro-video category out of the picker while switched off", async () => {
     const user = userEvent.setup({ delay: null });
     const template = INTRO_VIDEO_TEMPLATE_ITEMS[0]!;
     mockChatLifecycle(context, { threadId: THREAD_ID });
@@ -588,13 +589,15 @@ describe("chat composer templates", () => {
     });
 
     await user.click(await screen.findByLabelText("Template"));
+    expect(queryTabByText("Intro video")).toBeNull();
+
     await user.click(tabByText("Video"));
     expect(
-      screen.queryByLabelText(`Select video template ${template.title}`),
+      screen.queryByLabelText(`Select intro video template ${template.title}`),
     ).not.toBeInTheDocument();
   });
 
-  it("selects Interview as a switched-on intro-video template", async () => {
+  it("selects Interview from its own intro-video category", async () => {
     const user = userEvent.setup({ delay: null });
     const template = INTRO_VIDEO_TEMPLATE_ITEMS[0]!;
     let submittedUserMessage: UserMessageDocument | undefined;
@@ -614,9 +617,17 @@ describe("chat composer templates", () => {
     });
 
     await user.click(await screen.findByLabelText("Template"));
+
+    // The video category keeps text-to-video presets only; intro videos own
+    // their own category rather than sharing that grid.
     await user.click(tabByText("Video"));
+    expect(
+      screen.queryByLabelText(`Select intro video template ${template.title}`),
+    ).not.toBeInTheDocument();
+
+    await user.click(tabByText("Intro video"));
     const select = await screen.findByLabelText(
-      `Select video template ${template.title}`,
+      `Select intro video template ${template.title}`,
     );
     expect(
       select.closest("[class*='aspect-']")?.querySelector("video"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -86,7 +86,7 @@ export function expectTextBefore(firstText: string, secondText: string): void {
   ).toBeTruthy();
 }
 
-function queryTabByText(text: string): HTMLElement | null {
+export function queryTabByText(text: string): HTMLElement | null {
   return (
     queryAllByRoleFast("tab").find((candidate) => {
       return candidate.textContent?.replace(/\s+/g, " ").trim() === text;

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -38,6 +38,7 @@ import {
   ArrowUp,
   Bolt,
   Check,
+  Clapperboard,
   Download,
   Globe,
   Image as ImageIcon,
@@ -1302,35 +1303,46 @@ function VideoTemplateCard({
 
 function VideoTemplateGrid({
   items,
-  introVideoItems,
   value,
   onSelect,
-  onSelectIntroVideo,
 }: {
   items: readonly VideoTemplateItem[];
-  introVideoItems: readonly IntroVideoTemplateItem[];
   value: GenerationTemplateRequest | undefined;
   onSelect: (item: VideoTemplateItem) => void;
-  onSelectIntroVideo: (item: IntroVideoTemplateItem) => void;
 }) {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {introVideoItems.map((item) => {
-        return (
-          <IntroVideoTemplateCard
-            key={item.id}
-            item={item}
-            selected={isSelectedIntroVideoTemplate(item, value)}
-            onSelect={onSelectIntroVideo}
-          />
-        );
-      })}
       {items.map((item) => {
         return (
           <VideoTemplateCard
             key={item.id}
             item={item}
             selected={isSelectedVideoTemplate(item, value)}
+            onSelect={onSelect}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function IntroVideoTemplateGrid({
+  items,
+  value,
+  onSelect,
+}: {
+  items: readonly IntroVideoTemplateItem[];
+  value: GenerationTemplateRequest | undefined;
+  onSelect: (item: IntroVideoTemplateItem) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => {
+        return (
+          <IntroVideoTemplateCard
+            key={item.id}
+            item={item}
+            selected={isSelectedIntroVideoTemplate(item, value)}
             onSelect={onSelect}
           />
         );
@@ -1391,7 +1403,7 @@ function IntroVideoTemplateCard({
           type="button"
           aria-label={t(
             ($) => {
-              return $.artifacts.templates.selectVideo;
+              return $.artifacts.templates.selectIntroVideo;
             },
             { title: item.title },
           )}
@@ -4713,6 +4725,7 @@ function resolveTemplatePickerCategory({
   hasPptTab,
   hasIllustrationTab,
   hasVideoTab,
+  hasIntroVideoTab,
   hasAvatarTab,
   hasWorkflowTab,
 }: {
@@ -4720,6 +4733,7 @@ function resolveTemplatePickerCategory({
   hasPptTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
+  hasIntroVideoTab: boolean;
   hasAvatarTab: boolean;
   hasWorkflowTab: boolean;
 }): string {
@@ -4733,6 +4747,9 @@ function resolveTemplatePickerCategory({
   }
   if (hasVideoTab) {
     categories.push("video");
+  }
+  if (hasIntroVideoTab) {
+    categories.push("intro-video");
   }
   if (hasAvatarTab) {
     categories.push("avatar");
@@ -4749,6 +4766,7 @@ function TemplatePickerCategoryNav({
   hasPptTab,
   hasIllustrationTab,
   hasVideoTab,
+  hasIntroVideoTab,
   hasAvatarTab,
   hasWorkflowTab,
   onChange,
@@ -4757,6 +4775,7 @@ function TemplatePickerCategoryNav({
   hasPptTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
+  hasIntroVideoTab: boolean;
   hasAvatarTab: boolean;
   hasWorkflowTab: boolean;
   onChange: (value: string) => void;
@@ -4799,6 +4818,15 @@ function TemplatePickerCategoryNav({
         return $.artifacts.kinds.video;
       }),
       Icon: Video,
+    });
+  }
+  if (hasIntroVideoTab) {
+    categoryOptions.push({
+      value: "intro-video",
+      label: t(($) => {
+        return $.artifacts.templates.introVideo;
+      }),
+      Icon: Clapperboard,
     });
   }
   if (hasAvatarTab) {
@@ -6359,10 +6387,7 @@ function TemplatePickerDialog({
 }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
-  const introVideoTemplatesEnabled = useGet(introVideoTemplatesEnabled$);
-  const introVideoItems = introVideoTemplatesEnabled
-    ? INTRO_VIDEO_TEMPLATE_ITEMS
-    : [];
+  const hasIntroVideoTab = useGet(introVideoTemplatesEnabled$);
   const category = useGet(signals.template.templatePickerCategory$);
   const setCategory = useSet(signals.template.setTemplatePickerCategory$);
   const search = useGet(signals.template.templatePickerSearch$);
@@ -6463,6 +6488,7 @@ function TemplatePickerDialog({
     hasPptTab,
     hasIllustrationTab,
     hasVideoTab,
+    hasIntroVideoTab,
     hasAvatarTab,
     hasWorkflowTab,
   });
@@ -6751,6 +6777,7 @@ function TemplatePickerDialog({
               hasPptTab={hasPptTab}
               hasIllustrationTab={hasIllustrationTab}
               hasVideoTab={hasVideoTab}
+              hasIntroVideoTab={hasIntroVideoTab}
               hasAvatarTab={hasAvatarTab}
               hasWorkflowTab={hasWorkflowTab}
               onChange={handleCategoryChange}
@@ -6779,13 +6806,14 @@ function TemplatePickerDialog({
                 selectedCategory={selectedCategory}
                 hasPptTab={hasPptTab}
                 hasVideoTab={hasVideoTab}
+                hasIntroVideoTab={hasIntroVideoTab}
                 hasAvatarTab={hasAvatarTab}
                 hasWorkflowTab={hasWorkflowTab}
                 pptItems={presentationItems}
                 websiteItems={WEBSITE_TEMPLATE_ITEMS}
                 illustrationItems={ILLUSTRATION_TEMPLATE_ITEMS}
                 videoItems={VIDEO_TEMPLATE_ITEMS}
-                introVideoItems={introVideoItems}
+                introVideoItems={INTRO_VIDEO_TEMPLATE_ITEMS}
                 workflowCatalog={workflowCatalog}
                 value={value}
                 illustrationVariantIndex={illustrationVariantIndex}
@@ -6838,6 +6866,7 @@ function TemplatePickerCategoryContent({
   selectedCategory,
   hasPptTab,
   hasVideoTab,
+  hasIntroVideoTab,
   hasAvatarTab,
   hasWorkflowTab,
   pptItems,
@@ -6870,6 +6899,7 @@ function TemplatePickerCategoryContent({
   selectedCategory: string;
   hasPptTab: boolean;
   hasVideoTab: boolean;
+  hasIntroVideoTab: boolean;
   hasAvatarTab: boolean;
   hasWorkflowTab: boolean;
   pptItems: readonly PresentationTemplateItem[];
@@ -6996,13 +7026,30 @@ function TemplatePickerCategoryContent({
         data-video-template-grid-scroll=""
         className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6 pt-0.5"
       >
-        {videoItems.length > 0 || introVideoItems.length > 0 ? (
+        {videoItems.length > 0 ? (
           <VideoTemplateGrid
             items={videoItems}
-            introVideoItems={introVideoItems}
             value={value}
             onSelect={onSelectVideo}
-            onSelectIntroVideo={onSelectIntroVideo}
+          />
+        ) : (
+          <TemplateEmptyPanel />
+        )}
+      </div>
+    );
+  }
+
+  if (selectedCategory === "intro-video" && hasIntroVideoTab) {
+    return (
+      <div
+        data-intro-video-template-grid-scroll=""
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6 pt-0.5"
+      >
+        {introVideoItems.length > 0 ? (
+          <IntroVideoTemplateGrid
+            items={introVideoItems}
+            value={value}
+            onSelect={onSelectIntroVideo}
           />
         ) : (
           <TemplateEmptyPanel />
@@ -7125,7 +7172,7 @@ function selectedComposerTemplateAttachment(
     return {
       type: "intro-video",
       title: introVideoItem.title,
-      category: "video",
+      category: "intro-video",
     };
   }
   const workflowItem = selectedWorkflowTemplateItem(value);
@@ -7331,11 +7378,13 @@ function TemplatePickerButton({
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
   const importedTemplates = useImportedPresentationTemplates(signals);
   const selectedTitle = selectedTemplateTitle(picker.value, importedTemplates);
+  const hasIntroVideoTab = useGet(introVideoTemplatesEnabled$);
   const selectedCategory = resolveTemplatePickerCategory({
     category,
     hasPptTab,
     hasIllustrationTab,
     hasVideoTab,
+    hasIntroVideoTab,
     hasAvatarTab,
     hasWorkflowTab,
   });

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -6707,6 +6707,11 @@ function generationTemplateTypeLabel(
       return $.chat.templates.categories.video;
     });
   }
+  if (value.type === "intro-video") {
+    return i18n.t(($) => {
+      return $.chat.templates.categories.introVideo;
+    });
+  }
   if (value.type === "illustration") {
     return i18n.t(($) => {
       return $.chat.templates.categories.illustration;


### PR DESCRIPTION
## Summary

- promote `intro-video` to its own template-picker category instead of rendering its cards inside the video grid
- split `IntroVideoTemplateGrid` out of `VideoTemplateGrid`, restoring the video grid to text-to-video presets only
- route the composer chip's category and its reopen target to `intro-video`, so clicking the chip returns to the right tab
- label a sent intro-video template chip as intro video in the thread, instead of falling through to the presentation default

Follow-up to #29370, which introduced the intro-video type but surfaced it inside the video category.

## Rollout notes

- still gated by the same `IntroVideoTemplates` switch, which stays off for every org; when it is off the new category is absent from the nav and `resolveTemplatePickerCategory` falls back to the first available tab
- `video` and avatar selections are unchanged
- the `chat-thread-page.tsx` label fix resolves the P1 raised in the #29370 review, where an intro-video chip's tooltip read `Presentation · <title>`
- adds three localized keys (`artifacts.templates.introVideo`, `artifacts.templates.selectIntroVideo`, `chat.templates.categories.introVideo`) across all ten locales

## Verification

- Prettier for every changed file
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app lint` (includes `i18n:check`) — exit 0, no errors
- `pnpm knip` — exit 0
- app template-picker tests: 49 passed, including the reworked switched-off case (asserts the category tab is absent) and the switched-on case (asserts the video tab does not carry the intro card, then selects from the intro-video tab and checks the submitted `userMessage`)
- app composer editor/suggestion tests: 22 passed
