### PR TITLE
refactor: remove composer flat feedback note feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -59,12 +59,6 @@ export const composerImageAnnotationEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerImageAnnotation] ?? false;
 });
 
-export const composerFlatFeedbackNoteEnabled$ = computed((get): boolean => {
-  return (
-    get(featureSwitch$)[FeatureSwitchKey.ComposerFlatFeedbackNote] ?? false
-  );
-});
-
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -27,7 +27,6 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
-import { composerFlatFeedbackNoteEnabled$ } from "../external/feature-switch.ts";
 import { onRef, resetSignal } from "../utils.ts";
 import type { DraftInputSyncTarget, DraftSignals } from "./chat-draft.ts";
 import {
@@ -569,103 +568,15 @@ function createFeedbackQuoteChip(): FeedbackQuoteChip {
   return { quoteDom, quoteText, removeButton };
 }
 
-function createFeedbackItemNodeView(
-  node: ProseMirrorNode,
-  removeFeedback: (id: number) => void,
-  localizedUi: Set<() => void>,
-): NodeView {
-  const dom = document.createElement("div");
-  dom.dataset.feedbackItem = "";
-
-  const { quoteDom, quoteText, removeButton } = createFeedbackQuoteChip();
-
-  const noteDom = document.createElement("div");
-  const placeholderDom = document.createElement("span");
-  placeholderDom.className =
-    "pointer-events-none absolute left-1 top-1 text-[0.9375rem] " +
-    "leading-snug text-muted-foreground/40";
-  placeholderDom.setAttribute("aria-hidden", "true");
-  const contentDOM = document.createElement("div");
-  contentDOM.dataset.feedbackNote = "";
-  contentDOM.setAttribute("role", "textbox");
-  contentDOM.setAttribute("aria-multiline", "true");
-  noteDom.append(placeholderDom, contentDOM);
-  dom.append(quoteDom, noteDom);
-
-  let currentNode = node;
-  function localize(): void {
-    const removeLabel = i18n.t(($) => {
-      return $.chat.feedback.remove;
-    });
-    const placeholder = i18n.t(($) => {
-      return $.chat.feedback.placeholder;
-    });
-    removeButton.setAttribute("aria-label", removeLabel);
-    removeButton.title = removeLabel;
-    placeholderDom.textContent = placeholder;
-    contentDOM.setAttribute("aria-label", placeholder);
-  }
-  function render(nextNode: ProseMirrorNode): void {
-    const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
-    // The top padding is breathing room for the dashed divider, so only the
-    // items that draw one get it. The first item keeps the editor's own pt-4.
-    dom.className = `flex flex-col gap-1.5 pb-1.5${
-      showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
-    }`;
-    noteDom.className = `relative${fill ? " min-h-[96px]" : ""}`;
-    placeholderDom.hidden = nodeText(nextNode).length > 0;
-    contentDOM.className =
-      "relative w-full px-1 py-1 text-[0.9375rem] leading-snug " +
-      `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`;
-    quoteText.textContent = quote;
-  }
-  removeButton.addEventListener("mousedown", (event) => {
-    event.preventDefault();
-  });
-  removeButton.addEventListener("click", () => {
-    removeFeedback(feedbackItemNodeAttributes(currentNode).feedbackId);
-  });
-  localizedUi.add(localize);
-  localize();
-  render(currentNode);
-
-  return {
-    dom,
-    contentDOM,
-    update(nextNode) {
-      if (nextNode.type !== currentNode.type) {
-        return false;
-      }
-      currentNode = nextNode;
-      render(nextNode);
-      return true;
-    },
-    stopEvent(event) {
-      return (
-        event.target instanceof globalThis.Node &&
-        quoteDom.contains(event.target)
-      );
-    },
-    ignoreMutation(mutation) {
-      return (
-        mutation.type !== "selection" && !contentDOM.contains(mutation.target)
-      );
-    },
-    destroy() {
-      localizedUi.delete(localize);
-    },
-  };
-}
-
 /**
- * The flat quote block: the node view's dom IS the content element, so every
+ * The quote block's node view dom is the content element, so every
  * mutation anywhere in the block is visible to ProseMirror and its default
  * dirty-node redraw self-heals any damage the browser causes (#27787). The
  * quote chip and the placeholder are not part of this view at all — they are
  * a widget decoration, which ProseMirror renders non-editable, preserves
  * across redraws, and skips when re-parsing the DOM.
  */
-function createFlatFeedbackItemNodeView(
+function createFeedbackItemNodeView(
   node: ProseMirrorNode,
   localizedUi: Set<() => void>,
 ): NodeView {
@@ -740,7 +651,7 @@ function buildFeedbackItemChrome(
 
 // Rendered through ::before so an empty note never gains or loses real DOM
 // nodes: the placeholder text lives in an attribute and appears via CSS.
-const FLAT_PLACEHOLDER_PARAGRAPH_CLASS =
+const FEEDBACK_PLACEHOLDER_PARAGRAPH_CLASS =
   "before:pointer-events-none before:float-left before:h-0 " +
   "before:text-muted-foreground/40 before:content-[attr(data-placeholder)]";
 
@@ -786,7 +697,7 @@ function buildFeedbackChromeDecorations(
           childPosition + 1,
           childPosition + 1 + child.child(0).nodeSize,
           {
-            class: FLAT_PLACEHOLDER_PARAGRAPH_CLASS,
+            class: FEEDBACK_PLACEHOLDER_PARAGRAPH_CLASS,
             "data-placeholder": i18n.t(($) => {
               return $.chat.feedback.placeholder;
             }),
@@ -803,9 +714,6 @@ function createFeedbackChromePlugin(runtime: WorkflowComposerRuntime): Plugin {
     key: new PluginKey("feedbackItemChrome"),
     props: {
       decorations(state) {
-        if (!runtime.flatFeedbackNote) {
-          return DecorationSet.empty;
-        }
         return buildFeedbackChromeDecorations(state.doc, runtime);
       },
     },
@@ -1663,8 +1571,6 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
-  /** Resolved ComposerFlatFeedbackNote switch, set while mounted. */
-  flatFeedbackNote: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1830,16 +1736,7 @@ function createFeedbackItemNode(
     },
     addNodeView() {
       return ({ node }) => {
-        if (runtime.flatFeedbackNote) {
-          return createFlatFeedbackItemNodeView(node, runtime.localizedUi);
-        }
-        return createFeedbackItemNodeView(
-          node,
-          (id) => {
-            runtime.removeFeedback(id);
-          },
-          runtime.localizedUi,
-        );
+        return createFeedbackItemNodeView(node, runtime.localizedUi);
       };
     },
     addProseMirrorPlugins() {
@@ -2010,7 +1907,6 @@ function resetMountedWorkflowRuntime(runtime: WorkflowComposerRuntime): void {
   runtime.blur = () => {};
   runtime.replaceFeedbackItems = () => {};
   runtime.removeFeedback = () => {};
-  runtime.flatFeedbackNote = false;
 }
 
 function applyWorkflowNames(editor: Editor, names: readonly string[]): void {
@@ -2227,7 +2123,6 @@ function createMountEditorCommand({
       runtime.removeFeedback = (id) => {
         set(feedback.signals.remove$, id);
       };
-      runtime.flatFeedbackNote = get(composerFlatFeedbackNoteEnabled$);
       configureMountedWorkflowEditor(editor, singleLineOnMobile);
       setWorkflowComposerDocument(
         editor,
@@ -2638,7 +2533,6 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
-    flatFeedbackNote: false,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-inline-feedback.test.tsx
@@ -232,7 +232,7 @@ async function findForwardFeedbackNote(
 ): Promise<HTMLElement> {
   return await waitFor((): HTMLElement => {
     const note = dialog.querySelector(
-      "[data-chat-composer] [data-feedback-item] [data-feedback-note]",
+      "[data-chat-composer] [data-feedback-item][data-feedback-note]",
     );
     if (!(note instanceof HTMLElement)) {
       throw new Error("Forward feedback note not found");
@@ -878,7 +878,7 @@ describe("chat inline feedback", () => {
 
     const feedbackComment = await findFeedbackNote();
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
-    expect(feedbackComment).toHaveTextContent("");
+    expect(feedbackComment.querySelector(":scope > p")).toHaveTextContent(/^$/);
     expect(composerEditor).toHaveTextContent(
       "Mention the dates before the risk summary.",
     );
@@ -1508,7 +1508,7 @@ describe("chat inline feedback", () => {
     expect(sentPrompts[0]).toContain("补充具体日期");
   });
 
-  async function setupFlatFeedbackNoteThread(caseName: string): Promise<{
+  async function setupFeedbackNoteThread(caseName: string): Promise<{
     readonly assistantReply: string;
     readonly sentMessages: RunCreateCapture[];
   }> {
@@ -1519,17 +1519,17 @@ describe("chat inline feedback", () => {
       threadTitle: "Feedback review",
       chatEvents: [
         {
-          id: `msg-feedback-flat-${caseName}-user`,
+          id: `msg-feedback-note-${caseName}-user`,
           role: "user",
           content: "Review this launch summary",
-          runId: `run-feedback-flat-${caseName}`,
+          runId: `run-feedback-note-${caseName}`,
           createdAt: "2026-06-09T10:00:00Z",
         },
         {
-          id: `msg-feedback-flat-${caseName}-assistant`,
+          id: `msg-feedback-note-${caseName}-assistant`,
           role: "assistant",
           content: assistantReply,
-          runId: `run-feedback-flat-${caseName}`,
+          runId: `run-feedback-note-${caseName}`,
           createdAt: "2026-06-09T10:01:00Z",
         },
       ],
@@ -1540,24 +1540,21 @@ describe("chat inline feedback", () => {
     detachedSetupPage({
       context,
       path: `/chats/${FEEDBACK_THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerFlatFeedbackNote]: true,
-      },
     });
     await findComposerEditor();
     return { assistantReply, sentMessages };
   }
 
-  it("renders the flat quote block and submits typed text with the flat note switch enabled", async () => {
+  it("renders the quote block and submits typed text", async () => {
     const user = userEvent.setup({ delay: null });
     const { assistantReply, sentMessages } =
-      await setupFlatFeedbackNoteThread("submit");
+      await setupFeedbackNoteThread("submit");
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await user.click(await screen.findByText("Quote"));
 
     const note = await findFeedbackNote();
-    // The flat block is its own content element: no nested note wrapper.
+    // The block is its own content element: no nested note wrapper.
     expect(note.dataset.feedbackItem).toBe("");
     expect(note.querySelector("[data-feedback-note]")).toBeNull();
     // The chrome widget carries the quote chip; the empty-note placeholder is
@@ -1592,7 +1589,7 @@ describe("chat inline feedback", () => {
     // to the caret; at an IME composition boundary WebKit loses the caret.
     // The widget must survive both transitions with the same DOM element.
     const user = userEvent.setup({ delay: null });
-    const { assistantReply } = await setupFlatFeedbackNoteThread("stable");
+    const { assistantReply } = await setupFeedbackNoteThread("stable");
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await user.click(await screen.findByText("Quote"));
@@ -1619,10 +1616,10 @@ describe("chat inline feedback", () => {
     expect(note.firstElementChild).toBe(chrome);
   });
 
-  it("stays editable after the flat quote block is damaged in place", async () => {
+  it("stays editable after the quote block is damaged in place", async () => {
     const user = userEvent.setup({ delay: null });
     const { assistantReply, sentMessages } =
-      await setupFlatFeedbackNoteThread("damage");
+      await setupFeedbackNoteThread("damage");
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await user.click(await screen.findByText("Quote"));
@@ -1660,82 +1657,9 @@ describe("chat inline feedback", () => {
     expect(sentMessages[0]?.prompt).toContain("typed after damage");
   });
 
-  it("keeps dropping input after the legacy note wrappers collapse", async () => {
-    // Control for the flat-note tests: with the switch off, the legacy
-    // structure swallows the traced WebKit collapse (wrapper removed, <br>
-    // left behind) and silently drops everything typed afterwards — the
-    // #27787 failure the flat block exists to remove.
+  it("removes the quote block from its widget chrome button", async () => {
     const user = userEvent.setup({ delay: null });
-    const assistantReply = "The rollout dates are unclear in this summary.";
-    const sentMessages: RunCreateCapture[] = [];
-    mockChatLifecycle(context, {
-      threadId: FEEDBACK_THREAD_ID,
-      threadTitle: "Feedback review",
-      chatEvents: [
-        {
-          id: "msg-feedback-flat-control-user",
-          role: "user",
-          content: "Review this launch summary",
-          runId: "run-feedback-flat-control",
-          createdAt: "2026-06-09T10:00:00Z",
-        },
-        {
-          id: "msg-feedback-flat-control-assistant",
-          role: "assistant",
-          content: assistantReply,
-          runId: "run-feedback-flat-control",
-          createdAt: "2026-06-09T10:01:00Z",
-        },
-      ],
-      onRunCreate: (body) => {
-        sentMessages.push(body);
-      },
-    });
-    detachedSetupPage({
-      context,
-      path: `/chats/${FEEDBACK_THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerFlatFeedbackNote]: false,
-      },
-    });
-    await findComposerEditor();
-
-    selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Quote"));
-
-    const note = await findFeedbackNote();
-    await user.click(note);
-    pastePlainText(note, "Make the dates");
-    await waitFor(() => {
-      expect(note).toHaveTextContent("Make the dates");
-    });
-
-    const item = note.closest("[data-feedback-item]");
-    const wrapper = note.parentElement;
-    if (!(item instanceof HTMLElement) || !(wrapper instanceof HTMLElement)) {
-      throw new Error("Legacy feedback structure not found");
-    }
-    wrapper.remove();
-    item.append(document.createElement("br"));
-    await waitFor(() => {
-      expect(document.querySelector("[data-feedback-note]")).toBeNull();
-    });
-
-    // Later typing lands in the collapsed block; the legacy ignoreMutation
-    // discards it, so it never reaches the document or the submission.
-    item.append(document.createTextNode(" typed after damage"));
-
-    await user.click(screen.getByLabelText("Send"));
-    await waitFor(() => {
-      expect(sentMessages).toHaveLength(1);
-    });
-    expect(sentMessages[0]?.prompt).toContain("Make the dates");
-    expect(sentMessages[0]?.prompt).not.toContain("typed after damage");
-  });
-
-  it("removes the flat quote block from its widget chrome button", async () => {
-    const user = userEvent.setup({ delay: null });
-    const { assistantReply } = await setupFlatFeedbackNoteThread("remove");
+    const { assistantReply } = await setupFeedbackNoteThread("remove");
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await user.click(await screen.findByText("Quote"));
@@ -2381,7 +2305,7 @@ describe("chat inline feedback", () => {
     // The first note persists on top; the newest fragment sits below it with
     // an empty note, taking the composer position nearest Send.
     expect(comments[0]).toHaveTextContent("Assign each risk to an owner.");
-    expect(comments[1]).toHaveTextContent("");
+    expect(comments[1]?.querySelector(":scope > p")).toHaveTextContent(/^$/);
 
     // Removing the empty draft row leaves the noted fragment intact.
     await user.click(screen.getAllByLabelText("Remove feedback")[1]);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -144,9 +144,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.ChatToolActivity]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
 
@@ -179,9 +176,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ManagedSocialKit]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
-      false,
-    );
     expect(otherOrgStates[FeatureSwitchKey.ChatToolActivity]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
   });
@@ -198,22 +192,6 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(otherStaffStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
-  });
-
-  it("should enable the composer flat feedback note for the staff org only", () => {
-    const staffStates = getAllFeatureStates({
-      email: "ethan@vm0.ai",
-      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-    });
-    expect(staffStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(true);
-
-    const otherOrgStates = getAllFeatureStates({
-      email: "bingjie@vm0.ai",
-      orgId: "org_nonexistent",
-    });
-    expect(otherOrgStates[FeatureSwitchKey.ComposerFlatFeedbackNote]).toBe(
-      false,
-    );
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -79,6 +79,5 @@ export enum FeatureSwitchKey {
   ChatConversationLocator = "chatConversationLocator",
   SharedChatDatabase = "sharedChatDatabase",
   ComposerImageAnnotation = "composerImageAnnotation",
-  ComposerFlatFeedbackNote = "composerFlatFeedbackNote",
   GradientColorThemes = "gradientColorThemes",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -376,13 +376,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // flatten and two-file send are still unexercised outside tests.
     enabledEmailHashes: ["56bef1aa"], // fnv1a("tongx@vm0.ai")
   },
-  [FeatureSwitchKey.ComposerFlatFeedbackNote]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Rebuild the composer quote block on ProseMirror's native machinery: the note content element is the block itself and the quote chip is a widget decoration, removing the editable wrapper elements and the custom mutation filtering that let WebKit damage go unnoticed.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Permanently enable the ProseMirror-native feedback note structure for every user.
- Remove the `composerFlatFeedbackNote` registry entry, platform signal, runtime state, staff-only branch, and legacy wrapper node view.
- Keep the positive IME and damaged-DOM regression coverage on the permanent path while removing disabled-branch tests and switch overrides.

## Rollout decision

- Terminal state: `fully-rolled-out`.
- Decision basis: requested in this task after the staff rollout. PR #29257 widened the feature to the staff org after dogfooding, and PR #29354 fixed the remaining WebKit caret issue before this cleanup.
- Introducing commit: `626a055c38c9dfd936d5011c875fcd39a82c91b2` (#29137).

## Commit archaeology

- Parent `0921d618b6daf04c515322bc24c2027bee77e387` used nested quote/note wrappers and a custom `ignoreMutation` filter.
- #29137 added the gated path where the feedback item node view is its own content element and the quote chrome is a widget decoration.
- #29257 changed the audience from the maintainer allowlist to the staff org.
- #29354 stabilized widget identity across empty/filled transitions and moved the placeholder to a node decoration.
- The final diff preserves the enabled path including the #29354 fix and removes the disabled fallback rather than reverting surrounding composer evolution.

## Cleanup scope

- Delete the legacy wrapper node view and its mutation filtering.
- Make the native feedback item node view and chrome decorations unconditional.
- Remove the switch import, computed signal, runtime field, mount/reset/default plumbing, registry entry, enum key, and staff rollout assertions.
- Remove the disabled legacy failure-control test and switch true/false setup.
- Update existing forward-composer selectors and empty-note assertions for the permanent DOM structure.

## Search and Knip

- Second-pass terms: `composerFlatFeedbackNote`, `ComposerFlatFeedbackNote`, kebab/snake/space variants, `flatFeedbackNote`, `createFlatFeedbackItemNodeView`, `FLAT_PLACEHOLDER`, `setupFlatFeedbackNoteThread`, `feedback-flat`, `flat quote block`, `flat-note`, and `legacy note wrappers`.
- No switch or legacy-path matches remain.
- `data-feedback-note`, `feedbackItemChrome`, `feedback-chrome`, and `FEEDBACK_PLACEHOLDER_PARAGRAPH_CLASS` intentionally remain as permanent product-path identifiers. Remaining `ignoreMutation` methods belong to unrelated chat-thread mention, template, inline-template, and agent-mention node views.
- Knip baseline: clean for `@okouai/app` and `@okouai/core`.
- Knip after: clean with the same scoped command and issue categories.

## Validation

- `pnpm exec prettier --check` on all six changed files
- `git diff --check`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=4 --silent=passed-only` (26 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx --maxWorkers=4 --silent=passed-only` (34 passed)
- `pnpm exec knip --workspace @okouai/app --workspace @okouai/core --include files,dependencies,exports,types --reporter compact`

The full local Vitest suite was not run per repository policy; the PR pipeline will run the broader checks.
