### PR TITLE
fix(platform): prevent growth entry layout shift

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1249,6 +1249,68 @@ test("chat page displays tagline after onboarding", async ({ page }) => {
   });
 });
 
+test("home content stays fixed while the growth entry loads", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const slackStatusRequested = deferred();
+  const releaseSlackStatus = deferred();
+  await page.route("**/api/integrations/slack", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    slackStatusRequested.resolve();
+    await releaseSlackStatus.promise;
+    await route.fulfill({
+      json: {
+        connectUrl: null,
+        environment: {
+          missingSecrets: [],
+          missingVars: [],
+          requiredSecrets: [],
+          requiredVars: [],
+        },
+        installUrl: null,
+        isAdmin: true,
+        isConnected: false,
+        isInstalled: true,
+        reinstallUrl: null,
+        scopeMismatch: false,
+        workspaceName: null,
+      },
+    });
+  });
+
+  await page.goto(appUrl);
+  await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
+  await slackStatusRequested.promise;
+
+  const growthEntry = page.getByTestId("growth-entry");
+  const main = page.locator("main");
+  const tagline = page.getByTestId("chat-tagline");
+  await expect(tagline).toBeVisible({ timeout: 20_000 });
+  await expect(growthEntry).not.toBeAttached();
+  const mainBefore = await main.boundingBox();
+  const taglineBefore = await tagline.boundingBox();
+  if (!mainBefore || !taglineBefore) {
+    throw new Error("Home content has no measurable layout before entry load");
+  }
+
+  releaseSlackStatus.resolve();
+  await expect(growthEntry).toBeVisible();
+  await expect(growthEntry).toContainText("Invite humans 🤝");
+  const mainAfter = await main.boundingBox();
+  const taglineAfter = await tagline.boundingBox();
+  if (!mainAfter || !taglineAfter) {
+    throw new Error("Home content has no measurable layout after entry load");
+  }
+
+  expect(mainAfter.y).toBe(mainBefore.y);
+  expect(mainAfter.height).toBe(mainBefore.height);
+  expect(taglineAfter.y).toBe(taglineBefore.y);
+});
+
 test("checkmark keeps its column across selection states and previews deactivation", async ({
   page,
 }) => {

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -267,12 +267,15 @@ function GrowthEntry({ slackInstalled }: { slackInstalled: boolean }) {
  *
  * The row spans the page rather than the 900px content column, so the entry
  * lands in the top-right corner — the position the invite button has always
- * held, and the one the menu's `align="end"` is drawn against.
+ * held, and the one the menu's `align="end"` is drawn against. It stays outside
+ * the page's flex layout so loading it cannot shift the home content.
  */
 function CornerHeader({ children }: { children: ReactNode }) {
   return (
-    <header className="hidden shrink-0 bg-transparent px-4 pb-2 pt-4 md:block sm:px-6">
-      <div className="flex items-center justify-end gap-2">{children}</div>
+    <header className="pointer-events-none absolute inset-x-0 top-0 z-10 hidden bg-transparent px-4 pb-2 pt-4 md:block sm:px-6">
+      <div className="pointer-events-auto flex items-center justify-end gap-2">
+        {children}
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- keep the asynchronously loaded home growth entry outside the page flex layout
- preserve the top-right placement and limit pointer handling to the entry controls

## Verification
- `npx --yes pnpm@10.33.4 -F @okouai/app lint`
- `npx --yes pnpm@10.33.4 -F @okouai/app check-types`
- `npx --yes pnpm@10.33.4 -F @okouai/app exec vitest run src/views/okou-page/__tests__/home-growth-entry.test.tsx --maxWorkers=1 --silent=passed-only` (7 tests passed)
- `npx --yes pnpm@10.33.4 knip --workspace @okouai/app`

Browser verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested.
