### PR TITLE
fix(platform): place account action before permissions

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -337,6 +337,58 @@ describe("chat composer connector connection", () => {
     expect(connectorsTrigger).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("places the account action before connector permissions", async () => {
+    const user = userEvent.setup({ delay: null });
+    const defaultAccount: ConnectorAccountConnection = {
+      ...githubAccount("10000000-0000-4000-8000-000000000004", "Work", true),
+      target: { kind: "builtin", connectorSlug: "axiom" },
+      authMethod: "api-token",
+    };
+    mockThread();
+    mockConnectors([{ connectorSlug: "axiom", authMethod: "api-token" }]);
+    mockAgentConnectorAuthorizations(["axiom"]);
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: defaultAccount.target,
+            accountCount: 2,
+            attentionCount: 0,
+            defaultConnection: defaultAccount,
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      chatThreadConnectorSelectionContract.get,
+      ({ respond }) => {
+        return respond(200, { selections: [], selectedConnections: [] });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    await user.click(within(composer).getByLabelText("Connectors"));
+    const accountAction = await screen.findByLabelText(
+      "Axiom · Using default account: Work",
+    );
+    const permissionAction = screen.getByLabelText(
+      "Configure Axiom permissions",
+    );
+
+    expect(
+      accountAction.compareDocumentPosition(permissionAction) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it("keeps permissioned connector row height stable while toggling access", async () => {
     const user = userEvent.setup({ delay: null });
     let authorizationWrites = 0;

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8899,6 +8899,7 @@ function ConnectorsPopoverButton({
                           actions={
                             showPermissionAction || accountAction ? (
                               <>
+                                {accountAction}
                                 {showPermissionAction ? (
                                   <PopoverClose asChild>
                                     <Button
@@ -8925,7 +8926,6 @@ function ConnectorsPopoverButton({
                                     </Button>
                                   </PopoverClose>
                                 ) : null}
-                                {accountAction}
                               </>
                             ) : null
                           }


### PR DESCRIPTION
## Summary

- render the connector account selector before permission configuration when both actions are visible
- keep DOM, visual, keyboard, and assistive-technology traversal order aligned
- add page-level integration coverage for a permission-capable connector with multiple accounts

## Scope

- preserves existing permission and account visibility rules, tooltips, handlers, and authorization behavior
- leaves custom connector rendering, API contracts, persistence, and localization unchanged

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit: repository Prettier, full Knip, full Turbo type checking, file-size check, and commitlint

Closes #29717
