### PR TITLE
fix(platform): use current workspace agent after onboarding

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -23,8 +23,11 @@ import { assistantName$ } from "./branding.ts";
 
 const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
 
-const { get$: lastUsedAgentIdRaw$, set$: setLastUsedAgentIdRaw$ } =
-  localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
+const {
+  get$: lastUsedAgentIdRaw$,
+  set$: setLastUsedAgentIdRaw$,
+  clear$: clearLastUsedAgentIdRaw$,
+} = localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
 
 export const defaultAgentId$ = computed(async (get) => {
   const status = await get(onboardingStatus$);
@@ -102,6 +105,10 @@ const lastUsedAgentId$ = computed((get) => {
 
 export const rememberLastUsedAgentId$ = command(({ set }, agentId: string) => {
   set(setLastUsedAgentIdRaw$, agentId);
+});
+
+export const clearLastUsedAgentId$ = command(({ set }) => {
+  set(clearLastUsedAgentIdRaw$);
 });
 
 const internalReloadAgents$ = state(0);

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -5,6 +5,7 @@ import {
   billingUsagePackCheckoutContract,
 } from "@okouai/api-contracts/contracts/billing";
 import { accept } from "../../lib/accept.ts";
+import { clearLastUsedAgentId$ } from "../agent.ts";
 import { apiClient$ } from "../api-client.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
 import { ROUTES } from "../route-paths.ts";
@@ -57,6 +58,7 @@ export const completeOnboarding$ = command(
     if (role) {
       set(capturePaidOnboardingRoleConfirmed$, role);
     }
+    set(clearLastUsedAgentId$);
     set(reloadOnboardingStatus$);
     set(resetOnboardingDraft$);
   },

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -19,6 +19,10 @@ import {
   connectorManualGrantContract,
   connectorOauthStartContract,
 } from "@okouai/api-contracts/contracts/connectors";
+import {
+  agentsMainContract,
+  type AgentResponse,
+} from "@okouai/api-contracts/contracts/agents";
 
 import {
   click,
@@ -32,6 +36,7 @@ import {
   PRESENTATION_SHOWCASE_URL,
 } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import { pathname } from "../../../signals/location.ts";
+import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { ONBOARDING_CHECKOUT_STATE_PARAM } from "../../../signals/onboarding/onboarding-state.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detachedNavigateTo$, searchParams$ } from "../../../signals/route.ts";
@@ -39,6 +44,26 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { mockChatLifecycle } from "../../okou-page/__tests__/chat-test-helpers.ts";
 
 const context = testContext();
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000099";
+const { set$: setLastUsedAgentId$ } = localStorageSignals(
+  "zero.lastUsedAgentId",
+);
+
+function onboardingAgent(agentId: string): AgentResponse {
+  return {
+    agentId,
+    ownerId: "user_mock",
+    displayName: "Default agent",
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    modelProviderId: null,
+    selectedModel: null,
+    preferPersonalProvider: false,
+    visibility: "private",
+  };
+}
 
 const MARKETING_PRESENTATION_PROMPT = [
   "/gen presentation with template `html-ppt-playful-launch`, create a 15-slide launch deck for SproutPop, a playful habit-building app for remote teams introducing a shared 30-day wellness challenge.",
@@ -309,6 +334,34 @@ describe("onboarding flow", () => {
       });
     },
   );
+
+  it("opens product templates with the new workspace default agent", async () => {
+    context.store.set(setLastUsedAgentId$, STALE_AGENT_ID);
+    let firstAgentRoute: string | null = null;
+    context.mocks.api(agentsMainContract.list, ({ respond }) => {
+      const currentPath = pathname();
+      if (firstAgentRoute === null && currentPath.startsWith("/agents/")) {
+        firstAgentRoute = currentPath;
+      }
+      return respond(200, [onboardingAgent(DEFAULT_AGENT_ID)]);
+    });
+
+    await openMakePage();
+    chooseMakeOption("Generate a presentation");
+
+    await waitFor(() => {
+      expect(firstAgentRoute).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+    });
+    await waitFor(() => {
+      const presentationTab = queryAllByRoleFast("tab").find((candidate) => {
+        return (
+          candidate.textContent === "Presentation" &&
+          candidate.getAttribute("aria-selected") === "true"
+        );
+      });
+      expect(presentationTab).toBeInTheDocument();
+    });
+  });
 
   it("shows the website choice illustration", async () => {
     await openMakePage();


### PR DESCRIPTION
## Summary

- clear the globally persisted last-used agent after onboarding completes
- let the home handoff resolve the newly created workspace default agent before opening product templates
- cover a stale cross-workspace agent ID in the onboarding integration test

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@okouai/app"`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx` (42 passed)