### PR TITLE
perf(platform): enable name-preserving identifier mangling

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -10,9 +10,10 @@
     "test": "vitest run",
     "i18n:extract": "i18next-cli extract",
     "i18n:check": "i18next-cli extract --ci --quiet && i18next-cli status",
+    "lint:build-config": "node --test scripts/check-production-minification.node.mjs",
     "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
-    "lint": "pnpm lint:static-assets && pnpm lint:localized-ui && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "pnpm lint:static-assets && pnpm lint:localized-ui && pnpm lint:build-config && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {

--- a/turbo/apps/platform/scripts/check-production-minification.node.mjs
+++ b/turbo/apps/platform/scripts/check-production-minification.node.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { URL } from "node:url";
+
+import { loadConfigFromFile } from "vite";
+
+await test("production minification mangles identifiers while preserving names", async () => {
+  const loaded = await loadConfigFromFile(
+    { command: "build", mode: "production" },
+    new URL("../vite.config.ts", import.meta.url).pathname,
+  );
+
+  assert.ok(loaded);
+  const output = loaded.config.build?.rolldownOptions?.output;
+  assert.equal(output?.keepNames, true);
+  assert.equal(output?.minify?.mangle, true);
+});

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -40,11 +40,12 @@ export default defineConfig({
     sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
     rolldownOptions: {
       output: {
-        // Open-source project: compress and strip whitespace, but keep
-        // original identifiers readable (no name mangling).
+        // Mangle identifiers for smaller bundles while preserving runtime
+        // function and class names for framework semantics and diagnostics.
+        keepNames: true,
         minify: {
           compress: true,
-          mangle: false,
+          mangle: true,
           codegen: true,
         },
       },


### PR DESCRIPTION
## Summary

- enable Rolldown identifier mangling for the platform production bundle while preserving runtime function and class names with `keepNames: true`
- add a fast, lint-wired configuration guard so both the size optimization and name-preservation safety property cannot drift silently
- leave the existing Vite source-map and Sentry upload/injection flow unchanged

## Context

This is a second-stage entry-module follow-up to #29576. The fully aggressive mangling alternative was intentionally rejected because changing `Function.name` and class-name semantics would increase framework, diagnostics, and debugging risk. This PR does not add route splitting, manual chunks, dependency substitutions, or caching changes.

## Bundle size

Measured from fresh production builds of the sole `dist/assets/main-*.js` entry module. Gzip uses Node `gzipSync` at level 9; Brotli uses `brotliCompressSync` at quality 11.

| Encoding | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Raw | 11,017,789 B | 9,387,918 B | -1,629,871 B (-14.79%) |
| Gzip-9 | 2,723,716 B | 2,554,091 B | -169,625 B (-6.23%) |
| Brotli-11 | 2,105,786 B | 1,960,588 B | -145,198 B (-6.90%) |

Reproduction:

```bash
cd turbo
pnpm --filter @okouai/app build
node --input-type=module -e 'import { readFileSync, readdirSync } from "node:fs"; import { gzipSync, brotliCompressSync, constants } from "node:zlib"; const dir="apps/platform/dist/assets"; const name=readdirSync(dir).find((entry)=>/^main-.*\.js$/.test(entry)); if(!name) throw new Error("Missing main bundle"); const data=readFileSync(`${dir}/${name}`); console.log({file:name,rawBytes:data.length,gzipBytes:gzipSync(data,{level:9}).length,brotliBytes:brotliCompressSync(data,{params:{[constants.BROTLI_PARAM_QUALITY]:11}}).length});'
```

## Verification

- `pnpm exec prettier --write apps/platform/vite.config.ts apps/platform/package.json apps/platform/scripts/check-production-minification.node.mjs`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app run check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm --filter @okouai/app build`
- `pnpm --filter @okouai/app exec vite build --sourcemap --logLevel warn`
- `pnpm --filter @okouai/app exec sentry-cli sourcemaps inject dist`
- verified the injected main bundle and source map share one Sentry debug ID; the map contains 2,032 sources and 2,032 embedded source contents
- generated a focused Vite fixture with the exact output options and verified its function and class names remain unchanged at runtime
- `git diff --check`

Preview acceptance remains with the parent thread's staging-browser Mode C gate.
