### PR TITLE
fix(vsock-guest): mark incomplete exec output truncated

### DIFF
--- a/crates/vsock-guest/src/drain.rs
+++ b/crates/vsock-guest/src/drain.rs
@@ -63,6 +63,7 @@ pub(crate) struct BoundedStreamConfig {
 pub(crate) struct BoundedDrainResult {
     pub(crate) captured: Option<Vec<u8>>,
     pub(crate) capture_truncated: bool,
+    pub(crate) stream_truncated: bool,
 }
 
 /// Drain `pipe` until EOF or `cancel` is set, calling `on_chunk` for each
@@ -229,6 +230,7 @@ where
     BoundedDrainResult {
         captured,
         capture_truncated,
+        stream_truncated,
     }
 }
 
@@ -451,6 +453,7 @@ mod tests {
 
         assert_eq!(result.captured, None);
         assert!(!result.capture_truncated);
+        assert!(!result.stream_truncated);
     }
 
     #[test]
@@ -516,6 +519,7 @@ mod tests {
 
         assert_eq!(result.captured, Some(input));
         assert!(!result.capture_truncated);
+        assert!(result.stream_truncated);
         assert_eq!(chunks, vec![(stream_limit, false), (0, true)]);
     }
 
@@ -543,6 +547,7 @@ mod tests {
 
         assert_eq!(result.captured, Some(b"abcdef".to_vec()));
         assert!(!result.capture_truncated);
+        assert!(result.stream_truncated);
         assert_eq!(
             chunks,
             vec![
@@ -577,6 +582,7 @@ mod tests {
         );
 
         assert_eq!(result.captured, None);
+        assert!(!result.stream_truncated);
         assert_eq!(
             chunks,
             vec![(b"ab".to_vec(), false), (b"cd".to_vec(), false)]
@@ -606,6 +612,7 @@ mod tests {
         );
 
         assert_eq!(result.captured, None);
+        assert!(result.stream_truncated);
         assert_eq!(chunks, vec![(Vec::new(), true)]);
     }
 
@@ -632,6 +639,7 @@ mod tests {
         );
 
         assert_eq!(result.captured, None);
+        assert!(result.stream_truncated);
         assert_eq!(chunks, vec![(Vec::new(), true)]);
     }
 
@@ -660,5 +668,6 @@ mod tests {
         assert_eq!(chunks, vec![(b"ab".to_vec(), false)]);
         assert_eq!(result.captured, Some(b"abcdef".to_vec()));
         assert!(!result.capture_truncated);
+        assert!(!result.stream_truncated);
     }
 }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -696,6 +696,7 @@ impl ExecSetupWithStdout {
         self,
         stderr_handle: JoinHandle<()>,
         stderr_result_rx: mpsc::Receiver<BoundedDrainResult>,
+        stream_writer: Option<SharedExecStreamWriter>,
     ) -> RunningExec {
         let ExecSetupWithStdout {
             setup,
@@ -722,6 +723,7 @@ impl ExecSetupWithStdout {
             stdout_result_rx,
             stderr_handle,
             stderr_result_rx,
+            stream_writer,
             drain_cancel,
             drain_done_rx,
         }
@@ -744,6 +746,7 @@ struct RunningExec {
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
     stderr_handle: JoinHandle<()>,
     stderr_result_rx: mpsc::Receiver<BoundedDrainResult>,
+    stream_writer: Option<SharedExecStreamWriter>,
     drain_cancel: Arc<DrainCancellation>,
     drain_done_rx: mpsc::Receiver<()>,
 }
@@ -765,6 +768,7 @@ impl RunningExec {
             stdout_result_rx,
             stderr_handle,
             stderr_result_rx,
+            stream_writer,
             drain_cancel,
             drain_done_rx,
         } = self;
@@ -823,10 +827,38 @@ impl RunningExec {
             );
         }
 
-        let _ = stdout_handle.join();
-        let _ = stderr_handle.join();
-        let stdout_result = stdout_result_rx.recv().unwrap_or_default();
-        let stderr_result = stderr_result_rx.recv().unwrap_or_default();
+        let stdout_join_failed = stdout_handle.join().is_err();
+        let stderr_join_failed = stderr_handle.join().is_err();
+        let stdout_result = stdout_result_rx.recv().ok();
+        let stderr_result = stderr_result_rx.recv().ok();
+        let drains_incomplete = completed < 2
+            || stdout_join_failed
+            || stderr_join_failed
+            || stdout_result.is_none()
+            || stderr_result.is_none();
+        let stdout_settings = output_settings(request.stdout);
+        let stderr_settings = output_settings(request.stderr);
+        let stdout_result =
+            finalize_exec_drain_result(stdout_result, stdout_settings, drains_incomplete);
+        let stderr_result =
+            finalize_exec_drain_result(stderr_result, stderr_settings, drains_incomplete);
+        if drains_incomplete {
+            emit_exec_stream_truncation_markers(
+                stream_writer.as_ref(),
+                [
+                    (
+                        ExecOutputStream::Stdout,
+                        stdout_settings,
+                        stdout_result.stream_truncated,
+                    ),
+                    (
+                        ExecOutputStream::Stderr,
+                        stderr_settings,
+                        stderr_result.stream_truncated,
+                    ),
+                ],
+            );
+        }
 
         let containment_error = containment_result.as_ref().err().map(ToString::to_string);
         let (termination, diagnostic) =
@@ -858,6 +890,75 @@ impl RunningExec {
             captured_output(&stderr_result),
             &diagnostic,
         );
+    }
+}
+
+fn finalize_exec_drain_result(
+    result: Option<BoundedDrainResult>,
+    settings: OutputSettings,
+    drains_incomplete: bool,
+) -> BoundedDrainResult {
+    let mut result = result.unwrap_or_else(|| BoundedDrainResult {
+        captured: settings.capture_limit_bytes.map(|_| Vec::new()),
+        capture_truncated: false,
+        stream_truncated: false,
+    });
+    if drains_incomplete && result.captured.is_some() {
+        result.capture_truncated = true;
+    }
+    result
+}
+
+fn emit_exec_stream_truncation_markers(
+    stream_writer: Option<&SharedExecStreamWriter>,
+    streams: [(ExecOutputStream, OutputSettings, bool); 2],
+) {
+    let Some(stream_writer) = stream_writer else {
+        return;
+    };
+    let mut writer = match stream_writer.lock() {
+        Ok(writer) => writer,
+        Err(_) => {
+            log(
+                "ERROR",
+                "exec operation: terminal stream writer mutex poisoned",
+            );
+            return;
+        }
+    };
+    for (stream, settings, stream_truncated) in streams {
+        if settings.stream.is_none() || stream_truncated {
+            continue;
+        }
+        match writer.write_output(stream, &[], true) {
+            Ok(()) => {}
+            Err(ExecStreamWriteError::Encode(e)) => {
+                log(
+                    "ERROR",
+                    &format!(
+                        "exec operation: failed to encode terminal output truncation seq={} label={} process_class={} operation_kind={}: {e}",
+                        writer.seq,
+                        writer.label_preview,
+                        writer.process_class,
+                        writer.operation_kind,
+                    ),
+                );
+                return;
+            }
+            Err(ExecStreamWriteError::Write(e)) => {
+                log(
+                    "WARN",
+                    &format!(
+                        "exec operation: failed to send terminal output truncation seq={} label={} process_class={} operation_kind={}: {e}",
+                        writer.seq,
+                        writer.label_preview,
+                        writer.process_class,
+                        writer.operation_kind,
+                    ),
+                );
+                return;
+            }
+        }
     }
 }
 
@@ -1250,7 +1351,7 @@ fn run_exec_operation_worker<S>(
         DrainWorker {
             stream: ExecOutputStream::Stderr,
             policy: stderr_settings,
-            stream_writer,
+            stream_writer: stream_writer.clone(),
             drain_cancel: setup.drain_cancel(),
             exec_cancel: exec_cancel.clone(),
             drain_done_tx: setup.drain_done_tx(),
@@ -1259,7 +1360,7 @@ fn run_exec_operation_worker<S>(
     );
     let running = match stderr_spawn {
         Ok((stderr_handle, stderr_result_rx)) => {
-            setup.into_running(stderr_handle, stderr_result_rx)
+            setup.into_running(stderr_handle, stderr_result_rx, stream_writer)
         }
         Err(e) => {
             setup.abort_wait_failed(
@@ -2220,6 +2321,7 @@ mod tests {
         let stderr = BoundedDrainResult {
             captured: Some(b"stderr".to_vec()),
             capture_truncated: true,
+            stream_truncated: false,
         };
 
         let message = exec_terminal_log_message(ExecTerminalLogMessageInput {

--- a/crates/vsock-guest/src/guest_state_restore.rs
+++ b/crates/vsock-guest/src/guest_state_restore.rs
@@ -506,6 +506,7 @@ fn failed_output(
         stderr: BoundedDrainResult {
             captured: Some(Vec::new()),
             capture_truncated: false,
+            stream_truncated: false,
         },
         diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
     }

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -634,10 +634,12 @@ fn failed_output(
         stdout: BoundedDrainResult {
             captured: Some(Vec::new()),
             capture_truncated: false,
+            stream_truncated: false,
         },
         stderr: BoundedDrainResult {
             captured: Some(Vec::new()),
             capture_truncated: false,
+            stream_truncated: false,
         },
         diagnostic: truncate_utf8(diagnostic, MAX_DIAGNOSTIC_BYTES),
     }

--- a/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
+++ b/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
@@ -278,7 +278,10 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         ))
         .unwrap();
     let orphan = OrphanProcessGuard::new("orphan-exec-operation-sleep");
-    let command = orphan_sleep_command("orphan-exec-operation", orphan.pid_path());
+    let command = format!(
+        "{}; printf stderr-marker >&2",
+        orphan_sleep_command("orphan-exec-operation", orphan.pid_path()),
+    );
     let start = Instant::now();
     send_exec_start(
         &mut host_stream,
@@ -290,7 +293,11 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
             stream_limit_bytes: 1024,
             chunk_limit_bytes: 64,
         },
-        ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1024,
+            stream_limit_bytes: 4,
+            chunk_limit_bytes: 4,
+        },
     );
     let (chunks, result) = read_exec_result(&mut host_stream, 122);
     let elapsed = start.elapsed();
@@ -304,22 +311,30 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         "expected stdout to contain 'orphan-exec-operation', got: {:?}",
         String::from_utf8_lossy(&stdout),
     );
+    assert_eq!(result.stderr.unwrap_or_default(), b"stderr-marker".to_vec());
     let streamed_stdout = stdout_data(&chunks);
     assert!(
         String::from_utf8_lossy(&streamed_stdout).contains("orphan-exec-operation"),
         "expected streamed stdout to contain 'orphan-exec-operation', got: {:?}",
         String::from_utf8_lossy(&streamed_stdout),
     );
-    let truncation_markers = chunks
+    assert_eq!(stderr_data(&chunks), b"stde".to_vec());
+    let stdout_truncation_markers = chunks
         .iter()
         .filter(|chunk| chunk.stream == ExecOutputStream::Stdout && chunk.truncated)
         .collect::<Vec<_>>();
-    assert_eq!(truncation_markers.len(), 1);
-    assert!(truncation_markers[0].chunk.is_empty());
+    assert_eq!(stdout_truncation_markers.len(), 1);
+    assert!(stdout_truncation_markers[0].chunk.is_empty());
     assert_eq!(
-        usize::try_from(truncation_markers[0].output_seq).unwrap(),
+        usize::try_from(stdout_truncation_markers[0].output_seq).unwrap(),
         chunks.len() - 1,
     );
+    let stderr_truncation_markers = chunks
+        .iter()
+        .filter(|chunk| chunk.stream == ExecOutputStream::Stderr && chunk.truncated)
+        .collect::<Vec<_>>();
+    assert_eq!(stderr_truncation_markers.len(), 1);
+    assert!(stderr_truncation_markers[0].chunk.is_empty());
     assert!(
         elapsed < EXEC_OUTPUT_DRAIN_DEADLINE,
         "test exec result should arrive before the production drain deadline, took {elapsed:?}",

--- a/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
+++ b/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
@@ -285,18 +285,40 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         122,
         &command,
         LONG_RUNNING_EXEC_TIMEOUT_MS,
-        ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        ExecOutputPolicy::CaptureAndStream {
+            capture_limit_bytes: 1024,
+            stream_limit_bytes: 1024,
+            chunk_limit_bytes: 64,
+        },
         ExecOutputPolicy::Capture { limit_bytes: 1024 },
     );
-    let (_chunks, result) = read_exec_result(&mut host_stream, 122);
+    let (chunks, result) = read_exec_result(&mut host_stream, 122);
     let elapsed = start.elapsed();
 
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(result.stdout_truncated);
+    assert!(result.stderr_truncated);
     let stdout = result.stdout.unwrap_or_default();
     assert!(
         String::from_utf8_lossy(&stdout).contains("orphan-exec-operation"),
         "expected stdout to contain 'orphan-exec-operation', got: {:?}",
         String::from_utf8_lossy(&stdout),
+    );
+    let streamed_stdout = stdout_data(&chunks);
+    assert!(
+        String::from_utf8_lossy(&streamed_stdout).contains("orphan-exec-operation"),
+        "expected streamed stdout to contain 'orphan-exec-operation', got: {:?}",
+        String::from_utf8_lossy(&streamed_stdout),
+    );
+    let truncation_markers = chunks
+        .iter()
+        .filter(|chunk| chunk.stream == ExecOutputStream::Stdout && chunk.truncated)
+        .collect::<Vec<_>>();
+    assert_eq!(truncation_markers.len(), 1);
+    assert!(truncation_markers[0].chunk.is_empty());
+    assert_eq!(
+        usize::try_from(truncation_markers[0].output_seq).unwrap(),
+        chunks.len() - 1,
     );
     assert!(
         elapsed < EXEC_OUTPUT_DRAIN_DEADLINE,


### PR DESCRIPTION
## Summary

- treat exec drains that miss their shared deadline or fail to return a worker result as incomplete
- preserve requested capture policies and conservatively mark incomplete captured output truncated
- emit ordered terminal truncation frames for streamed output without duplicating existing limit markers
- extend the real orphaned-grandchild connection scenario to cover captured and streamed truncation

## Scope

- changes only the bundled `vsock-guest` exec drain/finalization behavior and its tests
- reuses the existing captured truncation flag and empty streamed truncation frame
- does not change the wire format, host decoding, runner APIs, persisted data, migrations, or deployment sequencing

## Validation

- `cargo test -p vsock-guest --test connection exec_operation_returns_when_orphaned_grandchild_holds_stdout`
- `cargo test -p vsock-guest`
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-guest --no-deps`
- `git diff --check`
- pre-commit workspace Rust fmt, docs, Clippy, file-size, and commit-message checks

Closes #29710
