### PR TITLE
fix(auth): align clerk page action styling

### DIFF
--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -767,6 +767,38 @@ describe("app auth pages", () => {
     expect(getComputedStyle(link).borderStyle).toBe("solid");
   });
 
+  it("presents Clerk page actions with the standard button and link treatment", async () => {
+    setBrowserUrl("https://app.vm0.ai/sign-in");
+
+    detachedSetupPage({ context, path: "/sign-in" });
+
+    const clerkSurface = await screen.findByTestId("clerk-sign-in");
+    clerkSurface.style.setProperty("--background", "0, 0%, 100%");
+    clerkSurface.style.setProperty("--foreground", "220, 18%, 10%");
+
+    const primaryAction = document.createElement("button");
+    primaryAction.className = "cl-formButtonPrimary";
+    primaryAction.type = "submit";
+    const primaryLabel = document.createElement("span");
+    primaryLabel.textContent = "Continue";
+    primaryAction.append(primaryLabel);
+
+    const footerAction = document.createElement("div");
+    footerAction.className = "cl-footerAction";
+    const footerLink = document.createElement("a");
+    footerLink.className = "cl-footerActionLink";
+    footerLink.href = "/sign-up";
+    footerLink.textContent = "Sign up";
+    footerAction.append(footerLink);
+    clerkSurface.append(primaryAction, footerAction);
+
+    expect(getComputedStyle(primaryAction).backgroundColor).toBe(
+      "hsl(220, 18%, 10%)",
+    );
+    expect(getComputedStyle(primaryLabel).color).toBe("hsl(0, 0%, 100%)");
+    expect(getComputedStyle(footerLink).textDecoration).toBe("none");
+  });
+
   it("routes ad-attributed sign-up visits through onboarding", async () => {
     const path = "/sign-up?gclid=click-123&utm_campaign=summer";
     setBrowserUrl(`https://app.vm0.ai${path}`);

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -773,8 +773,8 @@ describe("app auth pages", () => {
     detachedSetupPage({ context, path: "/sign-in" });
 
     const clerkSurface = await screen.findByTestId("clerk-sign-in");
-    clerkSurface.style.setProperty("--background", "0, 0%, 100%");
-    clerkSurface.style.setProperty("--foreground", "220, 18%, 10%");
+    clerkSurface.style.setProperty("--primary", "20, 99%, 47%");
+    clerkSurface.style.setProperty("--primary-foreground", "0, 0%, 100%");
 
     const primaryAction = document.createElement("button");
     primaryAction.className = "cl-formButtonPrimary";
@@ -793,7 +793,7 @@ describe("app auth pages", () => {
     clerkSurface.append(primaryAction, footerAction);
 
     expect(getComputedStyle(primaryAction).backgroundColor).toBe(
-      "hsl(220, 18%, 10%)",
+      "hsl(20, 99%, 47%)",
     );
     expect(getComputedStyle(primaryLabel).color).toBe("hsl(0, 0%, 100%)");
     expect(getComputedStyle(footerLink).textDecoration).toBe("none");

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -150,17 +150,17 @@ const CLERK_CSS = `
   color: hsl(var(--muted-foreground)) !important;
 }
 
-/* Primary page action - match the neutral-dark shared page button while
-   removing Clerk's gradients and borders (exclude social buttons). */
+/* Primary action - mirror @vm0/ui's default Button treatment while removing
+   Clerk's gradients and borders (exclude social buttons). */
 .cl-formButtonPrimary,
 button[type="submit"]:not(.cl-socialButtonsBlockButton),
 [data-localization-key="formButtonPrimary"],
 .cl-formButtonPrimary > * {
   background-image: none !important;
-  background: hsl(var(--foreground)) !important;
+  background: hsl(var(--primary)) !important;
   border: none !important;
   box-shadow: none !important;
-  color: hsl(var(--background)) !important;
+  color: hsl(var(--primary-foreground)) !important;
 }
 
 /* Button hover state (exclude social buttons) */
@@ -168,14 +168,14 @@ button[type="submit"]:not(.cl-socialButtonsBlockButton),
 button[type="submit"]:not(.cl-socialButtonsBlockButton):hover,
 [data-localization-key="formButtonPrimary"]:hover {
   background-image: none !important;
-  background: var(--color-foreground-hover) !important;
+  background: var(--color-primary-hover) !important;
   box-shadow: none !important;
 }
 
 .cl-formButtonPrimary:active,
 button[type="submit"]:not(.cl-socialButtonsBlockButton):active,
 [data-localization-key="formButtonPrimary"]:active {
-  background: var(--color-foreground-pressed) !important;
+  background: var(--color-primary-pressed) !important;
 }
 
 /* Remove pseudo elements (exclude social buttons) */

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -150,15 +150,17 @@ const CLERK_CSS = `
   color: hsl(var(--muted-foreground)) !important;
 }
 
-/* Button styles - remove gradients and borders (exclude social buttons) */
+/* Primary page action - match the neutral-dark shared page button while
+   removing Clerk's gradients and borders (exclude social buttons). */
 .cl-formButtonPrimary,
 button[type="submit"]:not(.cl-socialButtonsBlockButton),
 [data-localization-key="formButtonPrimary"],
 .cl-formButtonPrimary > * {
   background-image: none !important;
-  background: hsl(var(--primary)) !important;
+  background: hsl(var(--foreground)) !important;
   border: none !important;
   box-shadow: none !important;
+  color: hsl(var(--background)) !important;
 }
 
 /* Button hover state (exclude social buttons) */
@@ -166,8 +168,14 @@ button[type="submit"]:not(.cl-socialButtonsBlockButton),
 button[type="submit"]:not(.cl-socialButtonsBlockButton):hover,
 [data-localization-key="formButtonPrimary"]:hover {
   background-image: none !important;
-  background: hsl(var(--primary) / 0.9) !important;
+  background: var(--color-foreground-hover) !important;
   box-shadow: none !important;
+}
+
+.cl-formButtonPrimary:active,
+button[type="submit"]:not(.cl-socialButtonsBlockButton):active,
+[data-localization-key="formButtonPrimary"]:active {
+  background: var(--color-foreground-pressed) !important;
 }
 
 /* Remove pseudo elements (exclude social buttons) */
@@ -251,11 +259,13 @@ button[class*="socialButtonsBlockButton"] img,
 .cl-footerActionLink,
 [class*="footerActionLink"] {
   color: hsl(var(--primary)) !important;
+  text-decoration: none !important;
 }
 
 .cl-footerActionLink:hover,
 [class*="footerActionLink"]:hover {
   color: hsl(var(--primary) / 0.9) !important;
+  text-decoration: none !important;
 }
 
 /* The discoverable passkey action is rendered by Clerk as a footer link even


### PR DESCRIPTION
## Summary

- mirror the `@vm0/ui` default Primary Button tokens for Clerk primary form actions
- remove the underline from Clerk footer action links while preserving link semantics
- keep the passkey outline action unchanged and cover the rendered styles with an auth-page regression test

## Testing

- `pnpm --filter @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx`
- targeted Prettier 3.8.1, Oxlint, type-aware Oxlint, and ESLint checks
- `pnpm --filter @okouai/app run check-types`
- Lefthook pre-commit checks (Prettier, Knip, monorepo typecheck) and commitlint