### PR TITLE
refactor(api): cut over machine secret writers to canonical alias

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -261,7 +261,6 @@ runs:
           fi
           if [[ -n "$machine_secret_key" ]]; then
             add_env OKOU_MACHINE_SECRET_KEY "$machine_secret_key"
-            add_env VM0_MACHINE_SECRET_KEY "$machine_secret_key"
           fi
         fi
         # Inject the checked-out build commit explicitly so OTel / Sentry can

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -146,14 +146,12 @@ assert_api_backend_url_canonical_only() {
   assert_env_key_count "$env_file" VM0_API_BACKEND_URL 0
 }
 
-assert_machine_secret_aliases_equal_dual() {
+assert_machine_secret_canonical_only() {
   local env_file="$1"
   local expected="$2"
   assert_env_key_count "$env_file" OKOU_MACHINE_SECRET_KEY 1
-  assert_env_key_count "$env_file" VM0_MACHINE_SECRET_KEY 1
   assert_env_value "$env_file" OKOU_MACHINE_SECRET_KEY "$expected"
-  assert_env_value "$env_file" VM0_MACHINE_SECRET_KEY "$expected"
-  assert_env_values_equal "$env_file" OKOU_MACHINE_SECRET_KEY VM0_MACHINE_SECRET_KEY
+  assert_env_key_count "$env_file" VM0_MACHINE_SECRET_KEY 0
 }
 
 assert_web_url_canonical_only() {
@@ -512,7 +510,7 @@ assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-se
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
 assert_env_value "$success_env_file" UNSPLASH_ACCESS_KEY "github-unsplash-access-key"
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
-assert_machine_secret_aliases_equal_dual "$success_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical_only "$success_env_file" "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
 assert_env_key_count "$success_env_file" OKOU_PREVIEW_JOB_REF 1
 assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
@@ -578,7 +576,7 @@ assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
 assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
 assert_api_backend_url_canonical_only "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
-assert_machine_secret_aliases_equal_dual "$empty_job_ref_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical_only "$empty_job_ref_env_file" "github-atom-machine-secret"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -589,7 +587,7 @@ assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_debug_aliases_equal_dual "$empty_env_file"
 assert_api_backend_url_canonical_only "$empty_env_file" "https://pr-123-api-backend.vm0.test"
-assert_machine_secret_aliases_equal_dual "$empty_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical_only "$empty_env_file" "github-atom-machine-secret"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -641,7 +639,7 @@ assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"
 assert_env_value "$production_api_env_file" ATOM_URL "https://atom.github.test"
-assert_machine_secret_aliases_equal_dual "$production_api_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical_only "$production_api_env_file" "github-atom-machine-secret"
 assert_env_value "$production_api_env_file" JOGGAI_WEBHOOK_SECRET "github-joggai-webhook-secret"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_ID "github-teams-bot-app-id"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_PASSWORD "github-teams-bot-app-password"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -17,7 +17,6 @@ APP_URL=https://app.vm7.ai:8443
 # Optional: Atom redeem service for onboarding codes
 ATOM_URL=https://atom-api.vm7.ai:8442
 OKOU_MACHINE_SECRET_KEY=op://Development/clerk/OKOU_MACHINE_SECRET_KEY
-VM0_MACHINE_SECRET_KEY=op://Development/clerk/OKOU_MACHINE_SECRET_KEY
 
 # Required: API deploy stage tag
 ENV=development

--- a/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
@@ -90,10 +90,9 @@ function getAtomUrl(): string | undefined {
   return undefined;
 }
 
-// Production deployment and local configuration still write only the legacy
-// alias. Remove it after #28914 retires every pre-reader API rollback target,
-// switches all writers to canonical-only, and observes zero legacy-only
-// resolutions through the supported rollback window.
+// Repository-owned deployment and local writers emit only the canonical alias.
+// Keep the dual reader and telemetry for external input and supported rollback
+// compatibility until #28914 retires the legacy alias after the rollback window.
 function resolveMachineSecretKey(): MachineSecretKeyResolution {
   const canonical = optionalEnv("OKOU_MACHINE_SECRET_KEY");
   const legacy = optionalEnv("VM0_MACHINE_SECRET_KEY");


### PR DESCRIPTION
## Summary

- Stop the repository-owned API deployment action from emitting `VM0_MACHINE_SECRET_KEY`; it now writes only `OKOU_MACHINE_SECRET_KEY` while retaining the legacy-named GitHub secret as its unchanged value source.
- Tighten the action contract test to prove canonical-only output in preview, production, empty-job-ref, and branded-empty scenarios, while preserving the existing no-secret diagnostics.
- Stop the repository-owned local API template from emitting the legacy runtime alias and update the billing resolver comment to describe the retained dual-reader rollback boundary.

## Preserved compatibility and non-goals

- The legacy-named GitHub secret lookup and `op://Development/clerk/OKOU_MACHINE_SECRET_KEY` item reference are unchanged.
- The dual environment reader, alias-resolution telemetry, Turbo pass-through, billing behavior, env schema, test stub, namespace guard, and rollback compatibility are unchanged.
- This PR does not create, rename, read, print, rotate, or mutate any external secret or configuration.
- This PR does not release, deploy, approve an environment, perform production QA, remove the reader, clean up telemetry, or remove namespace guards.

## Open PR overlap audit

- Before editing, all 26 open PRs and every changed-file page were fetched: GitHub declared 332 files and 332 were retrieved, with zero pagination mismatches.
- Immediately before commit (`2026-08-27T03:21:22Z`), the audit was repeated across all 33 open PRs: GitHub declared 349 files and 349 were retrieved, again with zero pagination mismatches.
- [#25722](https://github.com/vm0-ai/vm0/pull/25722) is the only overlapping PR. It is stale and high-conflict: 185 files, last updated `2026-08-13T15:03:45Z`, base `505aae73170efd5b484599eb7d433f404f5c3d2f`, head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, and based on the retired legacy-only writer contract. Its Worker allowlist also lacks the canonical key. Any future refresh must accept the canonical key without restoring the legacy repository writer and must retain the no-disclosure boundary; no Worker changes are copied into this PR.
- `main` advanced after implementation base only through unrelated runner test commit `35963881e3c31ec8a4546210a2c03bbb0aa39e5e`; it does not touch this PR's four files or either alias.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm exec prettier --check --ignore-unknown` on all four changed files
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; existing warnings only)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Bash syntax checks and ShellCheck 0.11.0 for the action contract and extracted composite-action script
- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/billing-redeem-code.test.ts` (17/17 passed against a local ephemeral PostgreSQL test database)
- `pnpm --filter api exec vitest run src/__tests__/api-namespace-compatibility.test.ts` (11/11 passed against a local ephemeral PostgreSQL test database)
- Semantic guards prove two unchanged legacy source lookups, exactly one canonical runtime writer, zero legacy runtime writers, exactly one canonical local writer, zero legacy local writers, four canonical-only contract assertions, and zero diffs across preserved compatibility surfaces.
- `git diff --check`

No full Vitest suite or local app server was run, per repository instructions.

## Review anchors

- `.github/actions/web-api-env/action.yml:217,235,263`: retain both legacy-named source reads and emit only the canonical runtime key.
- `.github/scripts/tests/web-api-env-action-test.sh:149-154,513,579,590,642`: enforce canonical-only output across all API action fixtures.
- `turbo/apps/api/.env.local.tpl:19`: keep the existing 1Password item reference under only the canonical runtime name.
- `turbo/apps/api/src/signals/routes/billing-redeem-code.ts:93-98`: comment-only boundary update; the dual reader remains intact.
- Comparable merged canonical-writer cuts: [#29650](https://github.com/vm0-ai/vm0/pull/29650) and [#29664](https://github.com/vm0-ai/vm0/pull/29664). Equal-dual predecessor: [#29628](https://github.com/vm0-ai/vm0/pull/29628).

## Rollout and fallback boundaries

- Implementation base: `58656533202285c048d5d86b60923d6f225fd182`
- Reviewed live base before opening: `35963881e3c31ec8a4546210a2c03bbb0aa39e5e`
- Head: `45fe4981c9045d2e3b8b91749a691a38efc042c6`
- The controller must deploy the exact merged SHA later; this PR performs no production-boundary action.
- Unit fallback: revert this PR to restore equal-dual repository runtime/local output from the unchanged legacy-named source. The retained dual reader continues to support rollback.
- Post-release gate (outside this PR): exact event `billing_machine_secret_alias_resolution` must show positive `canonical-only` and zero `legacy-only`, `equal-dual`, `conflicting-dual`, and `absent` throughout the supported rollback window before issue #28914 can retire compatibility surfaces.

Closes #29716

Parent: #28914
