### PR TITLE
fix: remove legacy sign-in fallback from auth v2

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1084,7 +1084,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Aktuelle Anmeldung verwenden",
         "addAccount": "Konto hinzufügen",
         "appleMethod": "Weiter mit Apple",
         "back": "Zurück",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1084,7 +1084,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Use current sign-in",
         "addAccount": "Add account",
         "appleMethod": "Continue with Apple",
         "back": "Back",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1103,7 +1103,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Usar el inicio de sesión actual",
         "addAccount": "Añadir cuenta",
         "appleMethod": "Continuar con Apple",
         "back": "Atrás",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1103,7 +1103,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Utiliser la connexion actuelle",
         "addAccount": "Ajouter un compte",
         "appleMethod": "Continuer avec Apple",
         "back": "Retour",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1084,7 +1084,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "मौजूदा साइन-इन का उपयोग करें",
         "addAccount": "खाता जोड़ें",
         "appleMethod": "Apple के साथ जारी रखें",
         "back": "वापस",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1083,7 +1083,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Gunakan proses masuk saat ini",
         "addAccount": "Tambah akun",
         "appleMethod": "Lanjutkan dengan Apple",
         "back": "Kembali",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1103,7 +1103,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Usa l'accesso attuale",
         "addAccount": "Aggiungi account",
         "appleMethod": "Continua con Apple",
         "back": "Indietro",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1083,7 +1083,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "現在のサインインを使用",
         "addAccount": "アカウントを追加",
         "appleMethod": "Appleで続ける",
         "back": "戻る",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1083,7 +1083,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "현재 로그인 사용",
         "addAccount": "계정 추가",
         "appleMethod": "Apple로 계속하기",
         "back": "돌아가기",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1103,7 +1103,6 @@
         "google": "Google"
       },
       "signIn": {
-        "action": "Usar o login atual",
         "addAccount": "Adicionar conta",
         "appleMethod": "Continuar com Apple",
         "back": "Voltar",

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -114,11 +114,11 @@ describe("auth v2 presentation", () => {
     expect(announcer).toHaveAttribute("aria-atomic", "true");
     expect(announcer).toHaveAttribute("aria-live", "polite");
 
-    const currentSignInAction = linkByText("Use current sign-in");
-    expect(currentSignInAction).toHaveAttribute("href", "/sign-in");
     expect(
-      currentSignInAction.closest('[data-testid="app-auth-v2"]'),
-    ).toBeNull();
+      queryAllByRoleFast("link").some((candidate) => {
+        return candidate.getAttribute("href") === "/sign-in";
+      }),
+    ).toBeFalsy();
   });
 
   it("keeps password controls and fallback navigation in their accessible regions", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -113,12 +113,6 @@ describe("auth v2 presentation", () => {
     const announcer = screen.getByTestId("auth-v2-announcer");
     expect(announcer).toHaveAttribute("aria-atomic", "true");
     expect(announcer).toHaveAttribute("aria-live", "polite");
-
-    expect(
-      queryAllByRoleFast("link").some((candidate) => {
-        return candidate.getAttribute("href") === "/sign-in";
-      }),
-    ).toBeFalsy();
   });
 
   it("keeps password controls and fallback navigation in their accessible regions", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -23,6 +23,8 @@ import {
   type MockedSignInResourceState,
 } from "../../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
+import { ROUTES } from "../../../../signals/route-paths.ts";
+import { detachedNavigateTo$ } from "../../../../signals/route.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
 import { mockNow } from "../../../../lib/time.ts";
 import { renderedIdentityEditPresentation } from "../../__tests__/auth-v2-button-style-assertions.ts";
@@ -146,6 +148,18 @@ async function waitForRoleElement(
     throw new Error(`Expected ${role} named ${name}`);
   }
   return element;
+}
+
+function expectNoLegacySignInLink(): void {
+  expect(
+    queryAllByRoleFast("link").some((candidate) => {
+      return candidate.getAttribute("href") === "/sign-in";
+    }),
+  ).toBeFalsy();
+}
+
+function navigateToLegacySignIn(): void {
+  context.store.set(detachedNavigateTo$, ROUTES.signIn);
 }
 
 function expectFieldErrorAssociation(
@@ -456,7 +470,7 @@ describe("auth v2 sign-in flow", () => {
 
     await expect(screen.findByLabelText("Password")).resolves.toBeVisible();
     expect(roleElement("link", "Sign up")).toBeUndefined();
-    expect(roleElement("link", "Use current sign-in")).toBeDefined();
+    expectNoLegacySignInLink();
     const editIdentifier = await waitForRoleElement(
       "button",
       "Edit identifier",
@@ -855,7 +869,7 @@ describe("auth v2 sign-in flow", () => {
       throw new Error("Expected Google One Tap callbacks to be registered");
     }
 
-    fireEvent.click(await waitForRoleElement("link", "Use current sign-in"));
+    navigateToLegacySignIn();
     await expect(
       screen.findByTestId("clerk-sign-in"),
     ).resolves.toBeInTheDocument();
@@ -912,7 +926,7 @@ describe("auth v2 sign-in flow", () => {
     });
     await expect(screen.findByRole("alert")).resolves.toBeVisible();
 
-    fireEvent.click(await waitForRoleElement("link", "Use current sign-in"));
+    navigateToLegacySignIn();
     await expect(
       screen.findByTestId("clerk-sign-in"),
     ).resolves.toBeInTheDocument();
@@ -1521,7 +1535,7 @@ describe("auth v2 sign-in flow", () => {
     const passwordInput = await screen.findByLabelText("Password");
     fireEvent.change(passwordInput, { target: { value: "route-secret" } });
 
-    fireEvent.click(await waitForRoleElement("link", "Use current sign-in"));
+    navigateToLegacySignIn();
     await expect(
       screen.findByTestId("clerk-sign-in"),
     ).resolves.toBeInTheDocument();
@@ -1755,7 +1769,7 @@ describe("auth v2 sign-in flow", () => {
       waitForRoleElement("link", "Email support"),
     ).resolves.toHaveAttribute("href", "mailto:support@vm0.ai");
     expect(roleElement("link", "Sign up")).toBeUndefined();
-    expect(roleElement("link", "Use current sign-in")).toBeDefined();
+    expectNoLegacySignInLink();
     expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
 
     fireEvent.click(await waitForRoleElement("button", "Back"));

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -150,15 +150,10 @@ async function waitForRoleElement(
   return element;
 }
 
-function expectNoLegacySignInLink(): void {
-  expect(
-    queryAllByRoleFast("link").some((candidate) => {
-      return candidate.getAttribute("href") === "/sign-in";
-    }),
-  ).toBeFalsy();
-}
-
 function navigateToLegacySignIn(): void {
+  // These cases exercise teardown after address-bar navigation. JSDOM cannot
+  // perform a document navigation, and the removed fallback leaves no rendered
+  // control for this transition, so invoke the production router command.
   context.store.set(detachedNavigateTo$, ROUTES.signIn);
 }
 
@@ -470,7 +465,6 @@ describe("auth v2 sign-in flow", () => {
 
     await expect(screen.findByLabelText("Password")).resolves.toBeVisible();
     expect(roleElement("link", "Sign up")).toBeUndefined();
-    expectNoLegacySignInLink();
     const editIdentifier = await waitForRoleElement(
       "button",
       "Edit identifier",
@@ -1769,7 +1763,6 @@ describe("auth v2 sign-in flow", () => {
       waitForRoleElement("link", "Email support"),
     ).resolves.toHaveAttribute("href", "mailto:support@vm0.ai");
     expect(roleElement("link", "Sign up")).toBeUndefined();
-    expectNoLegacySignInLink();
     expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
 
     fireEvent.click(await waitForRoleElement("button", "Back"));

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -1,11 +1,7 @@
-import { Button } from "@okouai/ui";
 import { useGet, useSet } from "ccstate-react";
 
 import type { AuthV2Navigation } from "../../../signals/auth-v2/navigation.ts";
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
-import { ROUTES } from "../../../signals/route-paths.ts";
-import { Link } from "../../router/link.tsx";
-import { AUTH_V2_LINK_ACTION_CLASS } from "../auth-v2-action-styles.ts";
 import { AuthV2IdentityPreview } from "../auth-v2-identity-preview.tsx";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
 import {
@@ -61,26 +57,6 @@ export function AuthV2SignInCard({
       }
       description={description}
       focusKey={focusKey}
-      footer={
-        <div className="flex justify-center">
-          <Button
-            asChild
-            className={AUTH_V2_LINK_ACTION_CLASS}
-            size="sm"
-            variant="link"
-          >
-            <Link
-              pathname={ROUTES.signIn}
-              options={{
-                hash: location.hash,
-                searchParams: new URLSearchParams(location.search),
-              }}
-            >
-              {copy.legacySignIn}
-            </Link>
-          </Button>
-        </div>
-      }
       headerDetail={
         showsIdentifierPreview ? (
           <AuthV2IdentityPreview

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
@@ -45,7 +45,6 @@ export interface AuthV2SignInCopy {
   readonly helpTitle: string;
   readonly identifierLabel: string;
   readonly identifierPlaceholder: string;
-  readonly legacySignIn: string;
   readonly loading: string;
   readonly methodsHelpPrompt: string;
   readonly newPasswordLabel: string;
@@ -323,9 +322,6 @@ function signInTerminalCopy(
     }),
     helpTitle: t(($) => {
       return $.auth.v2.signIn.helpTitle;
-    }),
-    legacySignIn: t(($) => {
-      return $.auth.v2.signIn.action;
     }),
     loading: t(($) => {
       return $.auth.loading;

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -448,11 +448,6 @@ describe("app auth pages", () => {
     expect(fallbackLink?.getAttribute("href") ?? null).toBe(
       routeCase.fallback?.path ?? null,
     );
-    expect(
-      queryAllByRoleFast("link").some((candidate) => {
-        return candidate.getAttribute("href") === "/sign-in";
-      }),
-    ).toBeFalsy();
     expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
     expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
     expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
@@ -475,11 +470,6 @@ describe("app auth pages", () => {
       screen.findByRole("region", { name: "Choose an organization" }),
     ).resolves.toBeVisible();
     expect(authV2Button("Continue with Route Organization")).toBeVisible();
-    expect(
-      queryAllByRoleFast("link").some((candidate) => {
-        return candidate.getAttribute("href") === "/sign-in";
-      }),
-    ).toBeFalsy();
     expect(screen.queryByText(/create organization/i)).not.toBeInTheDocument();
     expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
     expect(document.title).toBe("Sign in | VM0");

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -413,24 +413,21 @@ describe("app auth pages", () => {
 
   it.each([
     {
-      action: "Use current sign-in",
       documentTitle: "Sign in | VM0",
+      fallback: null,
       heading: "Sign in to VM0",
-      legacyPath: "/sign-in",
       path: "/v2/sign-in",
     },
     {
-      action: "Use current sign-up",
       documentTitle: "Sign up | VM0",
+      fallback: { action: "Use current sign-up", path: "/sign-up" },
       heading: "Create your account",
-      legacyPath: "/sign-up",
       path: "/v2/sign-up",
     },
     {
-      action: "Use current sign-up",
       documentTitle: "Sign up | VM0",
+      fallback: { action: "Use current sign-up", path: "/sign-up" },
       heading: "Create your account",
-      legacyPath: "/sign-up",
       path: "/v2/sign-up/verify-email-address",
     },
   ])("renders the auth v2 scaffold at $path", async (routeCase) => {
@@ -442,9 +439,20 @@ describe("app auth pages", () => {
       screen.findByRole("region", { name: routeCase.heading }),
     ).resolves.toBeVisible();
     expect(screen.getByTestId("app-auth-v2")).toBeVisible();
-    const actionLink = authV2ActionLink(routeCase.action);
-    expect(actionLink).toHaveTextContent(routeCase.action);
-    expect(actionLink).toHaveAttribute("href", routeCase.legacyPath);
+    const fallbackLink = routeCase.fallback
+      ? authV2ActionLink(routeCase.fallback.action)
+      : null;
+    expect(fallbackLink?.textContent?.trim() ?? null).toBe(
+      routeCase.fallback?.action ?? null,
+    );
+    expect(fallbackLink?.getAttribute("href") ?? null).toBe(
+      routeCase.fallback?.path ?? null,
+    );
+    expect(
+      queryAllByRoleFast("link").some((candidate) => {
+        return candidate.getAttribute("href") === "/sign-in";
+      }),
+    ).toBeFalsy();
     expect(screen.queryByTestId("clerk-sign-in")).not.toBeInTheDocument();
     expect(screen.queryByTestId("clerk-sign-up")).not.toBeInTheDocument();
     expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
@@ -469,7 +477,7 @@ describe("app auth pages", () => {
     expect(authV2Button("Continue with Route Organization")).toBeVisible();
     expect(
       queryAllByRoleFast("link").some((candidate) => {
-        return candidate.textContent?.trim() === "Use current sign-in";
+        return candidate.getAttribute("href") === "/sign-in";
       }),
     ).toBeFalsy();
     expect(screen.queryByText(/create organization/i)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- remove the legacy sign-in fallback from every auth v2 sign-in state
- delete the unused sign-in copy and translations across all supported locales
- update auth v2 page tests while preserving route cleanup coverage

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm --filter @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx --maxWorkers=1 --silent=passed-only`
