### PR TITLE
fix(platform): update initial document title once

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
@@ -24,8 +24,6 @@ export const syncPrimaryThread$ = command(
     meta: ThreadMeta,
     signal: AbortSignal,
   ): Promise<void> => {
-    set(resetDocumentTitle$);
-
     const currentAgentId = await get(currentChatAgentId$);
     signal.throwIfAborted();
     if (currentAgentId !== meta.agentId) {

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
@@ -53,12 +53,6 @@ export const setupAgentChatPage$ = command(
     set(reloadTagline$);
     set(resetChatPageModelSelection$);
     set(updatePage$, createElement(AgentChatPage), "sidebar");
-    set(
-      updateDocumentTitle$,
-      i18n.t(($) => {
-        return $.chat.documentTitle;
-      }),
-    );
 
     await set(hideAppSkeleton$, signal);
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx
@@ -171,6 +171,32 @@ async function expectActiveThread(
 }
 
 describe("chat thread metadata readiness", () => {
+  it("sets a cold thread document title without an intermediate title", async () => {
+    context.mocks.api(chatThreadMetadataContract.get, ({ respond }) => {
+      return respond(200, shellMetadata(THREAD_ID, "Cold thread"));
+    });
+    context.mocks.api(chatThreadsContract.snapshot, ({ never }) => {
+      return never();
+    });
+    const titleSetter = vi.spyOn(document, "title", "set");
+
+    try {
+      setupChatPage();
+
+      await expectActiveThread(THREAD_ID, "Cold thread");
+      await waitFor(() => {
+        expect(document.title).toBe("Cold thread | VM0");
+      });
+      expect(
+        titleSetter.mock.calls.map(([title]) => {
+          return title;
+        }),
+      ).toStrictEqual(["Cold thread | VM0"]);
+    } finally {
+      titleSetter.mockRestore();
+    }
+  });
+
   it("uses in-memory event metadata without another metadata request", async () => {
     const metadataThreadIds: string[] = [];
     context.mocks.api(chatThreadMetadataContract.get, ({ params, respond }) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
@@ -5,7 +5,7 @@ import {
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   detachedSetupPage,
@@ -136,6 +136,36 @@ function installBootstrapSkeleton(): HTMLDivElement {
 }
 
 describe("home route", () => {
+  it("sets the resolved agent document title without an intermediate title", async () => {
+    context.store.set(clearLastUsedAgentId$);
+    context.mocks.data.onboardingStatus({
+      defaultAgentId: DEFAULT_AGENT_ID,
+    });
+    const team = deferAgentsResponse([
+      agentResponse(DEFAULT_AGENT_ID, "Default agent"),
+    ]);
+    const titleSetter = vi.spyOn(document, "title", "set");
+
+    try {
+      detachedSetupPage({ context, path: "/" });
+
+      await team.started.promise;
+      expect(titleSetter).not.toHaveBeenCalled();
+
+      team.release.resolve(undefined);
+      await waitFor(() => {
+        expect(document.title).toBe("Default agent | VM0");
+      });
+      expect(
+        titleSetter.mock.calls.map(([title]) => {
+          return title;
+        }),
+      ).toStrictEqual(["Default agent | VM0"]);
+    } finally {
+      titleSetter.mockRestore();
+    }
+  });
+
   it("routes a first-time user to the default agent before the agents list resolves", async () => {
     context.store.set(clearLastUsedAgentId$);
     context.mocks.data.onboardingStatus({


### PR DESCRIPTION
## Summary

- avoid the intermediate `Chat | VM0` title while the agent list resolves on initial agent chat load
- preserve the current title until cold thread metadata is ready, then apply the final thread title directly
- add regression coverage that asserts the document title setter receives exactly one initial assignment

## Testing

- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/home-route.test.tsx src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx`
- `pnpm --filter @okouai/app check-types`
- targeted Prettier, Oxlint, and ESLint checks