### PR TITLE
feat(platform): add usage pack configuration action

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
@@ -159,6 +159,18 @@ export const openSettingsMemberUsagePacks$ = command(
   },
 );
 
+export const openSettingsUsagePackConfiguration$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const management = await get(usagePackManagementAsync$);
+    signal.throwIfAborted();
+    if (!management) {
+      set(openSettingsBillingPlans$);
+      return;
+    }
+    set(openSettingsMemberUsagePacks$, management);
+  },
+);
+
 export const openSettingsUsagePackUpgrade$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const management = await get(usagePackManagementAsync$);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -1,6 +1,8 @@
 import {
   billingStatusContract,
+  billingUsagePackCatalogContract,
   billingUsagePackCreditsContract,
+  billingUsagePackManagementContract,
   type UsagePackCreditsResponse,
 } from "@okouai/api-contracts/contracts/billing";
 import {
@@ -333,6 +335,11 @@ describe("personal usage settings", () => {
     expect(screen.queryByText("Team usage")).toBeNull();
     expect(screen.queryByText("Today")).toBeNull();
     expect(screen.queryByText("Quarterly planning chat")).toBeNull();
+    expect(
+      queryAllByRoleFast("button", card).some((button) => {
+        return button.textContent?.trim() === "Configure member packages";
+      }),
+    ).toBeFalsy();
 
     await user.hover(within(card).getByTestId("usage-pack-credit-purchased"));
     await expect(
@@ -450,6 +457,92 @@ describe("personal usage settings", () => {
         }),
       ).toBeFalsy();
     });
+  });
+
+  it("opens member package configuration from admin usage pack credits", async () => {
+    const user = userEvent.setup();
+    mockPersonalUsageStory(usageRows(), "pro", false, "admin");
+    context.mocks.data.orgMembers({
+      name: "Test Org",
+      role: "admin",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      members: [
+        {
+          userId: "test-user-123",
+          email: "linghan@example.com",
+          firstName: "Linghan",
+          lastName: "Hu",
+          imageUrl: "",
+          role: "admin",
+          joinedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      pendingInvitations: [],
+      membershipRequests: [],
+    });
+    context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
+      return respond(200, {
+        totalCredits: 20_400,
+        purchasedCredits: 20_000,
+        bonusCredits: 400,
+        creditGrants: [],
+        hasUsagePack: true,
+        memberCredits: [],
+      });
+    });
+    context.mocks.api(billingUsagePackManagementContract.get, ({ respond }) => {
+      return respond(200, {
+        tier: "pro",
+        currentPeriodEnd: "2026-04-01T00:00:00.000Z",
+        allocations: [
+          {
+            id: "a99c2cd1-b012-4ba5-952f-3aa9b707d0c6",
+            memberId: "test-user-123",
+            usagePackUsd: 20,
+            currentPeriodEnd: "2026-04-01T00:00:00.000Z",
+            pendingChange: null,
+          },
+        ],
+      });
+    });
+    context.mocks.api(billingUsagePackCatalogContract.get, ({ respond }) => {
+      return respond(200, {
+        usagePacks: [
+          {
+            usagePackUsd: 20,
+            priceUsd: 20,
+            purchasedCredits: 20_000,
+            bonusCredits: 400,
+            totalCredits: 20_400,
+          },
+        ],
+      });
+    });
+
+    await openUsageSettings();
+
+    const card = await screen.findByTestId("usage-pack-credit-card");
+    const configureButton = queryAllByRoleFast("button", card).find(
+      (button) => {
+        return button.textContent?.trim() === "Configure member packages";
+      },
+    );
+    if (!configureButton) {
+      throw new Error("Configure member packages button not found");
+    }
+    await user.click(configureButton);
+
+    const configureDialog = await screen.findByRole("dialog", {
+      name: "Configure member packages",
+    });
+    expect(
+      within(configureDialog).getByText("Step 2 of 3"),
+    ).toBeInTheDocument();
+    expect(
+      within(configureDialog).getByRole("combobox", {
+        name: "Usage for Test User",
+      }),
+    ).toHaveTextContent("20,400 credits · 2% off");
   });
 
   it("shows every member's usage pack balance to an admin", async () => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
 import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import type { OrgMember } from "@okouai/api-contracts/contracts/org-members";
 import type { UsagePackCreditsResponse } from "@okouai/api-contracts/contracts/billing";
-import { ArrowRight, ChevronRight, Users } from "lucide-react";
+import { ArrowRight, ChevronRight, Loader2, Users } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -26,9 +27,13 @@ import {
 } from "../../org-manage/org-usage-tab.tsx";
 import { UserAvatar } from "../../../../components/avatar.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
+import { pageSignal$ } from "../../../../../signals/page-signal.ts";
 import { orgMembers$ } from "../../../../../signals/external/org-members.ts";
 import { usagePackCreditsAsync$ } from "../../../../../signals/okou-page/billing.ts";
-import { setSettingsActiveSection$ } from "../../../../../signals/okou-page/settings/settings-dialog.ts";
+import {
+  openSettingsUsagePackConfiguration$,
+  setSettingsActiveSection$,
+} from "../../../../../signals/okou-page/settings/settings-dialog.ts";
 import {
   requestBuyCreditsScroll$,
   setBillingSubPage$,
@@ -40,6 +45,7 @@ import {
   usagePackMembersDialogOpen$,
 } from "../../../../../signals/okou-page/settings/personal-usage-record.ts";
 import { formatLocalizedNumber } from "../../../../../i18n/format.ts";
+import { detach, Reason } from "../../../../../signals/utils.ts";
 
 interface UsagePackSegment {
   readonly key: "purchased" | "bonus";
@@ -501,7 +507,38 @@ function UsagePackMemberBalancesDialog({
   );
 }
 
+function UsagePackCreditActions({
+  loading,
+  onConfigure,
+}: {
+  loading: boolean;
+  onConfigure: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="-mx-5 -mb-4 mt-4 flex items-center justify-end gap-3 border-t border-border px-5 py-[18px]">
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        data-testid="usage-pack-credit-configure"
+        disabled={loading}
+        onClick={onConfigure}
+      >
+        {loading ? <Loader2 className="animate-spin" /> : null}
+        {t(($) => {
+          return $.billing.plans.usagePacks.configurePackages;
+        })}
+      </Button>
+    </div>
+  );
+}
+
 function UsagePackCreditCard({ isAdmin }: { isAdmin: boolean }) {
+  const pageSignal = useGet(pageSignal$);
+  const [configureLoadable, openConfiguration] = useLoadableSet(
+    openSettingsUsagePackConfiguration$,
+  );
   const creditsLoadable = useLoadable(usagePackCreditsAsync$);
   if (creditsLoadable.state === "hasError") {
     return null;
@@ -538,6 +575,14 @@ function UsagePackCreditCard({ isAdmin }: { isAdmin: boolean }) {
             totalCredits={data.totalCredits}
           />
           <UsagePackCreditDetails data={data} />
+          {isAdmin && data.hasUsagePack ? (
+            <UsagePackCreditActions
+              loading={configureLoadable.state === "loading"}
+              onConfigure={() => {
+                detach(openConfiguration(pageSignal), Reason.DomCallback);
+              }}
+            />
+          ) : null}
         </>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

- add an admin-only `Configure member packages` action to active usage pack credit cards
- open the existing billing configuration flow directly at step 2 with the current package selections
- cover member visibility and the admin navigation flow with a page-level integration test

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm exec knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/personal-usage-tab.test.tsx --silent=passed-only` (14 passed)
