### PR TITLE
refactor(runner): establish guest agent readiness

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -1138,7 +1138,7 @@ restart_agent_ready_benchmark_runner() {
 for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
   thread_id=$(cat /proc/sys/kernel/random/uuid)
   record_agent_ready_benchmark_sample \
-    fresh PoolMiss "" "$thread_id" "agent-ready-fresh-$index"
+    fresh PoolMiss CacheMiss "$thread_id" "agent-ready-fresh-$index"
 done
 
 declare -a WORKSPACE_BENCHMARK_THREADS=()

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -1120,21 +1120,6 @@ record_agent_ready_benchmark_sample() {
     }' >> "$AGENT_READY_BENCHMARK_RAW"
 }
 
-restart_agent_ready_benchmark_runner() {
-  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-  wait_for_unit_inactive
-  sudo "$BIN_DIR/runner" service start --name "$SVC" \
-    --config "$RUNNER_DIR/runner.yaml" --local \
-    --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
-  INVOCATION_ID=""
-  for _ in $(seq 1 30); do
-    INVOCATION_ID=$(sudo systemctl show "$UNIT" --property=InvocationID --value 2>/dev/null) || true
-    [ -n "$INVOCATION_ID" ] && break
-    sleep 1
-  done
-  [ -n "$INVOCATION_ID" ] || fail "runner invocation ID unavailable after benchmark restart"
-}
-
 for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
   thread_id=$(cat /proc/sys/kernel/random/uuid)
   record_agent_ready_benchmark_sample \
@@ -1142,6 +1127,7 @@ for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
 done
 
 WORKSPACE_BENCHMARK_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$WORKSPACE_BENCHMARK_THREAD_ID" \
   --session-id agent-ready-workspace \
@@ -1150,10 +1136,15 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   || fail "workspace-cache Agent-ready benchmark warmup failed"
 
 for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  # Restarting destroys the owned idle sandbox while retaining its promoted
-  # workspace-cache image, so every sample exercises the same cache-hit path
-  # without accumulating one full workspace image per requested sample.
-  restart_agent_ready_benchmark_runner
+  # Pool-pressure eviction promotes the measured workspace. Alternate with a
+  # second key so every sample checks out that promoted image instead of taking
+  # the exact sandbox-reuse path or relying on service-stop promotion.
+  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --chat-thread-id "$WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID" \
+    --session-id agent-ready-workspace-evictor \
+    --feature-flag sandboxReuse=true \
+    --prompt 'true' >/dev/null \
+    || fail "workspace-cache Agent-ready benchmark eviction failed"
   record_agent_ready_benchmark_sample \
     workspace-cache PoolMiss Reused \
     "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -40,16 +40,24 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
 echo "=== Running process-containment test ==="
-ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GROUP_DIR}" <<'REMOTE_SCRIPT'
+ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GROUP_DIR}" "${AGENT_READY_BENCHMARK_SAMPLES:-3}" <<'REMOTE_SCRIPT'
 set -euo pipefail
-BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
+BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5; AGENT_READY_BENCHMARK_SAMPLES=$6
 UNIT="vm0-runner-${SVC}.service"
 SESSION_ID="e2e-process-containment-session"
 CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 PRESSURE_SUBMIT_PID=""
 PRESSURE_SUBMIT_OUTPUT=""
+AGENT_READY_BENCHMARK_RAW=""
 
 fail() { echo "FAIL: $1"; exit 1; }
+
+case "$AGENT_READY_BENCHMARK_SAMPLES" in
+  ''|*[!0-9]*) fail "Agent-ready benchmark sample count must be an integer" ;;
+esac
+[ "$AGENT_READY_BENCHMARK_SAMPLES" -ge 1 ] \
+  && [ "$AGENT_READY_BENCHMARK_SAMPLES" -le 100 ] \
+  || fail "Agent-ready benchmark sample count must be between 1 and 100"
 
 wait_for_unit_inactive() {
   for _ in $(seq 1 30); do
@@ -69,6 +77,9 @@ cleanup() {
   fi
   if [ -n "$PRESSURE_SUBMIT_OUTPUT" ]; then
     rm -f "$PRESSURE_SUBMIT_OUTPUT"
+  fi
+  if [ -n "$AGENT_READY_BENCHMARK_RAW" ]; then
+    rm -f "$AGENT_READY_BENCHMARK_RAW"
   fi
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   wait_for_unit_inactive
@@ -969,6 +980,245 @@ printf '%s\n' "$LOGS" \
 if grep -F 'process control latency exceeded calibrated bound' <<<"$LOGS" >/dev/null; then
   fail "process control exceeded the calibrated 750ms bound under pressure"
 fi
+
+echo "--- Benchmark: Guest Agent ready boundary ---"
+AGENT_READY_BENCHMARK_RAW=$(mktemp)
+
+record_agent_ready_benchmark_failure() {
+  local path=$1
+  local run_id=$2
+  local error=$3
+  error=$(printf '%s' "$error" | tail -c 512)
+  jq -cn \
+    --arg path "$path" \
+    --arg run_id "$run_id" \
+    --arg error "$error" \
+    '{path: $path, success: false, run_id: $run_id, error: $error}' \
+    >> "$AGENT_READY_BENCHMARK_RAW"
+}
+
+agent_ready_log_field() {
+  local line=$1
+  local field=$2
+  sed -n "s/.*${field}=\\([^ ]*\\).*/\\1/p" <<<"$line"
+}
+
+read_agent_ready_log() {
+  local run_id=$1
+  local line=""
+  for _ in $(seq 1 50); do
+    line=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1 \
+      | grep -F "run_id=$run_id" \
+      | grep -F 'agent startup timing' \
+      | tail -n 1) || true
+    if [ -n "$line" ]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+record_agent_ready_benchmark_sample() {
+  local path=$1
+  local expected_sandbox_reuse=$2
+  local expected_workspace_reuse=$3
+  local chat_thread_id=$4
+  local session_id=$5
+  local result=""
+  local result_json=""
+  local run_id=""
+  local ready_log=""
+  local sandbox_reuse=""
+  local workspace_reuse=""
+  local shell_spawn_ms=""
+  local agent_ready_ms=""
+  local containment_create_us=""
+  local placement_broker_setup_us=""
+  local shell_spawn_component_us=""
+  local bootstrap_ready_wait_us=""
+
+  if ! result=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --chat-thread-id "$chat_thread_id" \
+    --session-id "$session_id" \
+    --feature-flag sandboxReuse=true \
+    --prompt 'true' 2>&1); then
+    record_agent_ready_benchmark_failure "$path" "" "local submit failed: $result"
+    return
+  fi
+  result_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$result")
+  run_id=$(jq -r '.run_id // empty' <<<"$result_json" 2>/dev/null) || true
+  if [ -z "$run_id" ]; then
+    record_agent_ready_benchmark_failure "$path" "" "local submit omitted run ID"
+    return
+  fi
+  if ! ready_log=$(read_agent_ready_log "$run_id"); then
+    record_agent_ready_benchmark_failure "$path" "$run_id" "Agent-ready log was not found"
+    return
+  fi
+
+  sandbox_reuse=$(agent_ready_log_field "$ready_log" sandbox_reuse)
+  workspace_reuse=$(agent_ready_log_field "$ready_log" workspace_reuse)
+  if [ "$sandbox_reuse" != "$expected_sandbox_reuse" ]; then
+    record_agent_ready_benchmark_failure "$path" "$run_id" \
+      "expected sandbox_reuse=$expected_sandbox_reuse, observed $sandbox_reuse"
+    return
+  fi
+  if [ -n "$expected_workspace_reuse" ] \
+    && [ "$workspace_reuse" != "$expected_workspace_reuse" ]; then
+    record_agent_ready_benchmark_failure "$path" "$run_id" \
+      "expected workspace_reuse=$expected_workspace_reuse, observed $workspace_reuse"
+    return
+  fi
+
+  shell_spawn_ms=$(agent_ready_log_field "$ready_log" shell_spawn_ms)
+  agent_ready_ms=$(agent_ready_log_field "$ready_log" agent_ready_ms)
+  containment_create_us=$(agent_ready_log_field "$ready_log" containment_create_us)
+  placement_broker_setup_us=$(agent_ready_log_field "$ready_log" placement_broker_setup_us)
+  shell_spawn_component_us=$(agent_ready_log_field "$ready_log" shell_spawn_component_us)
+  bootstrap_ready_wait_us=$(agent_ready_log_field "$ready_log" bootstrap_ready_wait_us)
+  for value in \
+    "$shell_spawn_ms" \
+    "$agent_ready_ms" \
+    "$containment_create_us" \
+    "$placement_broker_setup_us" \
+    "$shell_spawn_component_us" \
+    "$bootstrap_ready_wait_us"; do
+    case "$value" in
+      ''|*[!0-9]*)
+        record_agent_ready_benchmark_failure "$path" "$run_id" \
+          "Agent-ready log contained a missing or invalid duration"
+        return
+        ;;
+    esac
+  done
+
+  jq -cn \
+    --arg path "$path" \
+    --arg run_id "$run_id" \
+    --arg sandbox_reuse "$sandbox_reuse" \
+    --arg workspace_reuse "$workspace_reuse" \
+    --argjson shell_spawn_ms "$shell_spawn_ms" \
+    --argjson agent_ready_ms "$agent_ready_ms" \
+    --argjson containment_create_us "$containment_create_us" \
+    --argjson placement_broker_setup_us "$placement_broker_setup_us" \
+    --argjson shell_spawn_component_us "$shell_spawn_component_us" \
+    --argjson bootstrap_ready_wait_us "$bootstrap_ready_wait_us" \
+    '{
+      path: $path,
+      success: true,
+      run_id: $run_id,
+      sandbox_reuse: $sandbox_reuse,
+      workspace_reuse: $workspace_reuse,
+      shell_spawn_ms: $shell_spawn_ms,
+      agent_ready_ms: $agent_ready_ms,
+      containment_create_us: $containment_create_us,
+      placement_broker_setup_us: $placement_broker_setup_us,
+      shell_spawn_component_us: $shell_spawn_component_us,
+      bootstrap_ready_wait_us: $bootstrap_ready_wait_us
+    }' >> "$AGENT_READY_BENCHMARK_RAW"
+}
+
+restart_agent_ready_benchmark_runner() {
+  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+  wait_for_unit_inactive
+  sudo "$BIN_DIR/runner" service start --name "$SVC" \
+    --config "$RUNNER_DIR/runner.yaml" --local \
+    --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+  INVOCATION_ID=""
+  for _ in $(seq 1 30); do
+    INVOCATION_ID=$(sudo systemctl show "$UNIT" --property=InvocationID --value 2>/dev/null) || true
+    [ -n "$INVOCATION_ID" ] && break
+    sleep 1
+  done
+  [ -n "$INVOCATION_ID" ] || fail "runner invocation ID unavailable after benchmark restart"
+}
+
+for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  thread_id=$(cat /proc/sys/kernel/random/uuid)
+  record_agent_ready_benchmark_sample \
+    fresh PoolMiss "" "$thread_id" "agent-ready-fresh-$index"
+done
+
+declare -a WORKSPACE_BENCHMARK_THREADS=()
+for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  thread_id=$(cat /proc/sys/kernel/random/uuid)
+  WORKSPACE_BENCHMARK_THREADS+=("$thread_id")
+  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --chat-thread-id "$thread_id" \
+    --session-id "agent-ready-workspace-$index" \
+    --feature-flag sandboxReuse=true \
+    --prompt 'true' >/dev/null \
+    || fail "workspace-cache Agent-ready benchmark warmup failed"
+done
+
+# A runner restart destroys its owned idle sandboxes while retaining promoted
+# workspace-cache images, so the measured turns cannot fall through to exact reuse.
+restart_agent_ready_benchmark_runner
+for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  thread_id=${WORKSPACE_BENCHMARK_THREADS[$((index - 1))]}
+  record_agent_ready_benchmark_sample \
+    workspace-cache PoolMiss Reused "$thread_id" "agent-ready-workspace-$index"
+done
+
+EXACT_REUSE_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --chat-thread-id "$EXACT_REUSE_THREAD_ID" \
+  --session-id agent-ready-exact-reuse \
+  --feature-flag sandboxReuse=true \
+  --prompt 'true' >/dev/null \
+  || fail "exact-reuse Agent-ready benchmark warmup failed"
+for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  record_agent_ready_benchmark_sample \
+    exact-reuse Reused SandboxReused \
+    "$EXACT_REUSE_THREAD_ID" agent-ready-exact-reuse
+done
+
+echo "AGENT_READY_BENCHMARK_RAW_BEGIN"
+cat "$AGENT_READY_BENCHMARK_RAW"
+echo "AGENT_READY_BENCHMARK_RAW_END"
+jq -s '
+  def percentile($values; $ratio):
+    ($values | sort) as $ordered
+    | if ($ordered | length) == 0 then null
+      else $ordered[((($ordered | length) * $ratio | ceil) - 1)]
+      end;
+  def metric_summary($rows; $field):
+    [$rows[] | select(.success) | .[$field]] as $values
+    | {
+        p50: percentile($values; 0.50),
+        p90: percentile($values; 0.90),
+        p95: percentile($values; 0.95),
+        p99: percentile($values; 0.99)
+      };
+  . as $records
+  | ["fresh", "workspace-cache", "exact-reuse"]
+  | map(
+      . as $path
+      | [$records[] | select(.path == $path)] as $rows
+      | {
+          path: $path,
+          sample_count: ($rows | length),
+          failures: ([$rows[] | select(.success | not)] | length),
+          metrics: {
+            shell_spawn_ms: metric_summary($rows; "shell_spawn_ms"),
+            agent_ready_ms: metric_summary($rows; "agent_ready_ms"),
+            containment_create_us: metric_summary($rows; "containment_create_us"),
+            placement_broker_setup_us: metric_summary($rows; "placement_broker_setup_us"),
+            shell_spawn_component_us: metric_summary($rows; "shell_spawn_component_us"),
+            bootstrap_ready_wait_us: metric_summary($rows; "bootstrap_ready_wait_us")
+          }
+        }
+    )
+' "$AGENT_READY_BENCHMARK_RAW"
+
+AGENT_READY_BENCHMARK_FAILURES=$(jq -s '[.[] | select(.success | not)] | length' \
+  "$AGENT_READY_BENCHMARK_RAW")
+[ "$AGENT_READY_BENCHMARK_FAILURES" -eq 0 ] \
+  || fail "Agent-ready benchmark recorded $AGENT_READY_BENCHMARK_FAILURES failures"
+rm -f "$AGENT_READY_BENCHMARK_RAW"
+AGENT_READY_BENCHMARK_RAW=""
 
 echo "PASS: detached user/root descendants were reclaimed"
 echo "PASS: mixed-identity leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -1141,25 +1141,22 @@ for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
     fresh PoolMiss CacheMiss "$thread_id" "agent-ready-fresh-$index"
 done
 
-declare -a WORKSPACE_BENCHMARK_THREADS=()
-for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  thread_id=$(cat /proc/sys/kernel/random/uuid)
-  WORKSPACE_BENCHMARK_THREADS+=("$thread_id")
-  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-    --chat-thread-id "$thread_id" \
-    --session-id "agent-ready-workspace-$index" \
-    --feature-flag sandboxReuse=true \
-    --prompt 'true' >/dev/null \
-    || fail "workspace-cache Agent-ready benchmark warmup failed"
-done
+WORKSPACE_BENCHMARK_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --chat-thread-id "$WORKSPACE_BENCHMARK_THREAD_ID" \
+  --session-id agent-ready-workspace \
+  --feature-flag sandboxReuse=true \
+  --prompt 'true' >/dev/null \
+  || fail "workspace-cache Agent-ready benchmark warmup failed"
 
-# A runner restart destroys its owned idle sandboxes while retaining promoted
-# workspace-cache images, so the measured turns cannot fall through to exact reuse.
-restart_agent_ready_benchmark_runner
-for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  thread_id=${WORKSPACE_BENCHMARK_THREADS[$((index - 1))]}
+for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  # Restarting destroys the owned idle sandbox while retaining its promoted
+  # workspace-cache image, so every sample exercises the same cache-hit path
+  # without accumulating one full workspace image per requested sample.
+  restart_agent_ready_benchmark_runner
   record_agent_ready_benchmark_sample \
-    workspace-cache PoolMiss Reused "$thread_id" "agent-ready-workspace-$index"
+    workspace-cache PoolMiss Reused \
+    "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace
 done
 
 EXACT_REUSE_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -29,7 +29,7 @@ use guest_contracts::process_containment::{
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
 const CGROUP2_SUPER_MAGIC: u64 = 0x6367_7270;
-const WORKLOAD_BOOTSTRAP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const WORKLOAD_BOOTSTRAP_IO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(debug_assertions)]
 const TEST_ALLOW_UNMANAGED_PROCESS_CONTROL_ENV: &str = "OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL";
 
@@ -210,14 +210,17 @@ impl WorkloadContainment {
         tool_endpoint_source: CgroupPlacementEnvSource,
     ) -> io::Result<Self> {
         let stream = process_control_ipc::connect_abstract(endpoint)?;
-        stream.set_read_timeout(Some(WORKLOAD_BOOTSTRAP_READ_TIMEOUT))?;
+        stream.set_read_timeout(Some(WORKLOAD_BOOTSTRAP_IO_TIMEOUT))?;
+        stream.set_write_timeout(Some(WORKLOAD_BOOTSTRAP_IO_TIMEOUT))?;
         let placement = process_control_ipc::receive_workload_placement(&stream)?;
-        Self::adopt(
+        let containment = Self::adopt(
             placement,
             tool_endpoint,
             workload_endpoint_source,
             tool_endpoint_source,
-        )
+        )?;
+        process_control_ipc::write_workload_placement_confirmation(&stream)?;
+        Ok(containment)
     }
 
     fn adopt(

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -19,8 +19,9 @@
 //!
 //! Two companion placement endpoints are derived from the same operation-local
 //! control name. The one-shot runtime endpoint transfers a root-opened
-//! `workload/runtime/cgroup.procs` descriptor to Guest Agent. The tool endpoint
-//! serves repeated authenticated Bash-launcher connections: root creates a
+//! `workload/runtime/cgroup.procs` descriptor to Guest Agent, which confirms
+//! after validating and adopting it. The tool endpoint serves repeated
+//! authenticated Bash-launcher connections: root creates a
 //! unique tool cgroup, transfers its write-only `cgroup.procs` descriptor, and
 //! acknowledges only after the launcher confirms and root revalidates exact
 //! placement. User shell code does not run before that acknowledgement.
@@ -77,9 +78,10 @@ pub use codec::{
 };
 pub use transport::{
     accept_with_timeout, bind_abstract_listener, connect_abstract, endpoint_name,
-    read_tool_placement_ack, read_tool_placement_confirmation, receive_tool_placement,
-    receive_workload_placement, send_tool_placement, send_workload_placement,
-    write_tool_placement_ack, write_tool_placement_confirmation,
+    read_tool_placement_ack, read_tool_placement_confirmation,
+    read_workload_placement_confirmation, receive_tool_placement, receive_workload_placement,
+    send_tool_placement, send_workload_placement, write_tool_placement_ack,
+    write_tool_placement_confirmation, write_workload_placement_confirmation,
 };
 
 /// Environment variable carrying the operation-control abstract socket name.

--- a/crates/process-control-ipc/src/transport.rs
+++ b/crates/process-control-ipc/src/transport.rs
@@ -8,6 +8,7 @@ const ENDPOINT_PREFIX: &str = "vm0-process-control-";
 const MAX_U32_DECIMAL_DIGITS: usize = 10;
 const NONCE_HEX_LEN: usize = 16 * 2;
 const WORKLOAD_PLACEMENT_MARKER: u8 = 0x57;
+const WORKLOAD_PLACEMENT_CONFIRM_MARKER: u8 = 0x52;
 const TOOL_PLACEMENT_MARKER: u8 = 0x54;
 const TOOL_PLACEMENT_CONFIRM_MARKER: u8 = 0x43;
 const TOOL_PLACEMENT_ACK_MARKER: u8 = 0x41;
@@ -286,6 +287,25 @@ fn receive_placement(stream: &UnixStream, expected_marker: u8) -> io::Result<Own
     Ok(unsafe { OwnedFd::from_raw_fd(descriptor) })
 }
 
+/// Confirm that Guest Agent validated and adopted the workload placement.
+///
+/// # Errors
+///
+/// Stream write errors are returned unchanged.
+pub fn write_workload_placement_confirmation(stream: &UnixStream) -> io::Result<()> {
+    write_marker(stream, WORKLOAD_PLACEMENT_CONFIRM_MARKER)
+}
+
+/// Read Guest Agent's workload-placement adoption confirmation.
+///
+/// # Errors
+///
+/// EOF, stream errors, and an unexpected marker are returned as
+/// [`io::Error`] values.
+pub fn read_workload_placement_confirmation(stream: &UnixStream) -> io::Result<()> {
+    read_marker(stream, WORKLOAD_PLACEMENT_CONFIRM_MARKER)
+}
+
 /// Confirm that the launcher wrote itself into the supplied tool cgroup.
 ///
 /// # Errors
@@ -338,7 +358,7 @@ fn read_marker(stream: &UnixStream, expected: u8) -> io::Result<()> {
     } else {
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "invalid tool placement handshake marker",
+            "invalid placement handshake marker",
         ))
     }
 }
@@ -630,9 +650,11 @@ mod tests {
         let expected = placement.metadata().unwrap();
         let send = std::thread::spawn(move || {
             send_workload_placement(&sender, placement.as_fd()).unwrap();
+            read_workload_placement_confirmation(&sender).unwrap();
         });
 
         let received = receive_workload_placement(&receiver).unwrap();
+        write_workload_placement_confirmation(&receiver).unwrap();
         send.join().unwrap();
         let received = std::fs::File::from(received);
         let actual = received.metadata().unwrap();
@@ -642,6 +664,16 @@ mod tests {
         let flags = unsafe { libc::fcntl(received.as_raw_fd(), libc::F_GETFD) };
         assert!(flags >= 0);
         assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[test]
+    fn workload_placement_confirmation_rejects_wrong_marker() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        sender.write_all(&[TOOL_PLACEMENT_ACK_MARKER]).unwrap();
+
+        let error = read_workload_placement_confirmation(&receiver).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/process-control-ipc/tests/workload_placement.rs
+++ b/crates/process-control-ipc/tests/workload_placement.rs
@@ -4,7 +4,10 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::UnixStream;
 
-use process_control_ipc::receive_workload_placement;
+use process_control_ipc::{
+    read_workload_placement_confirmation, receive_workload_placement,
+    write_workload_placement_confirmation,
+};
 
 const WORKLOAD_PLACEMENT_MARKER: u8 = 0x57;
 const RECEIVER_ANCILLARY_BUFFER_WORDS: usize = 8;
@@ -101,8 +104,14 @@ fn assert_raw_rights_sender_round_trips() -> io::Result<()> {
     let expected = placement.metadata()?;
     let (sender, receiver) = UnixStream::pair()?;
 
-    send_rights(&sender, WORKLOAD_PLACEMENT_MARKER, &[placement.as_raw_fd()])?;
+    let send = std::thread::spawn(move || {
+        send_rights(&sender, WORKLOAD_PLACEMENT_MARKER, &[placement.as_raw_fd()])?;
+        read_workload_placement_confirmation(&sender)
+    });
     let received = std::fs::File::from(receive_workload_placement(&receiver)?);
+    write_workload_placement_confirmation(&receiver)?;
+    send.join()
+        .map_err(|_| io::Error::other("workload placement sender panicked"))??;
     let actual = received.metadata()?;
 
     assert_eq!(actual.dev(), expected.dev());

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -53,7 +53,7 @@ use super::session_restore::{
     MaterializedResumeSession, SessionRestoreDiagnostics, restore_session,
 };
 use super::storage::download_storages;
-use super::telemetry::{RunnerSpawnTiming, record_api_to_spawn};
+use super::telemetry::{RunnerSpawnTiming, record_api_startup_boundaries};
 use super::workspace_session_history_materializer::{
     WorkspaceSessionHistoryMaterialization, WorkspaceSessionHistoryPhaseTiming,
     WorkspaceSessionHistoryTimings,
@@ -2174,19 +2174,72 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     let agent_handle = match handle {
         Ok(h) => {
-            let spawned_at = Instant::now();
+            let timing = h.start_timing();
             telemetry.record(
                 "runner_agent_start_process",
-                spawned_at.saturating_duration_since(t),
+                timing.shell_started_at.saturating_duration_since(t),
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_agent_start_to_ready",
+                timing.ready_at.saturating_duration_since(t),
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_agent_containment_create",
+                timing.containment_create,
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_agent_placement_broker_setup",
+                timing.placement_broker_setup,
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_agent_shell_spawn",
+                timing.shell_spawn,
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_agent_bootstrap_ready_wait",
+                timing.bootstrap_ready_wait,
                 true,
                 None,
             );
             if let Some(spawn_timing) = spawn_timing {
-                spawn_timing.record_spawn_success_at(telemetry, spawned_at);
+                spawn_timing.record_agent_ready_success_at(
+                    telemetry,
+                    timing.shell_started_at,
+                    timing.ready_at,
+                );
             }
-            // The guest process handle is the api_to_spawn boundary. Releasing here keeps
-            // steady-state execution outside the burst gate while every pre-spawn early return
-            // continues to release through RAII.
+            record_api_startup_boundaries(
+                context,
+                telemetry,
+                start.reuse_result,
+                start.workspace_reuse_result,
+                timing.shell_started_at,
+                timing.ready_at,
+            );
+            info!(
+                run_id = %context.run_id,
+                sandbox_reuse = ?start.reuse_result,
+                workspace_reuse = ?start.workspace_reuse_result,
+                shell_spawn_ms = timing.shell_started_at.saturating_duration_since(t).as_millis(),
+                agent_ready_ms = timing.ready_at.saturating_duration_since(t).as_millis(),
+                containment_create_us = timing.containment_create.as_micros(),
+                placement_broker_setup_us = timing.placement_broker_setup.as_micros(),
+                shell_spawn_component_us = timing.shell_spawn.as_micros(),
+                bootstrap_ready_wait_us = timing.bootstrap_ready_wait.as_micros(),
+                "agent startup timing"
+            );
+            // Keep the burst gate through the authenticated Agent-ready boundary.
+            // Every pre-ready return continues to release through RAII.
             drop(pre_spawn_admission_lease.take());
             h
         }
@@ -2253,14 +2306,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         env_diagnostics,
         env_pairs,
     } = prepared_agent;
-
-    // Claude Code process has a PID now — record end-to-end startup latency.
-    record_api_to_spawn(
-        context,
-        telemetry,
-        start.reuse_result,
-        start.workspace_reuse_result,
-    );
 
     // Start locally owned input and output work, then release deferred cache
     // fill now that process spawn has succeeded.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -459,9 +459,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         sandbox_prepared,
     } = hooks;
     // The gate intentionally starts before every fresh preparation stage and remains held through
-    // the real process spawn. Current production tails span both factory work and the later
-    // mount/restore/storage stages, so a narrower Firecracker-only gate would allow the same cohort
-    // to reconverge before api_to_spawn completes.
+    // the authenticated Agent-ready boundary. Current production tails span both factory work and
+    // the later mount/restore/storage/bootstrap stages, so a narrower Firecracker-only gate would
+    // allow the same cohort to reconverge before Agent readiness completes.
     let admission_started = Instant::now();
     let admission_lease = match config
         .pre_spawn_admission

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -507,10 +507,24 @@ pub(super) fn record_api_startup_boundaries(
     } else {
         RunnerStartupPath::Cold
     };
-    if let Some(duration) = api_latency_duration_at("api_to_spawn", context, shell_started_at) {
+    let observed_at = Instant::now();
+    let observed_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    if let Some(duration) = api_latency_duration_at(
+        "api_to_spawn",
+        context,
+        shell_started_at,
+        observed_at,
+        observed_ms,
+    ) {
         telemetry.record_api_to_spawn(duration, runner_startup_path, sandbox_reuse_result);
     }
-    if let Some(duration) = api_latency_duration_at("api_to_agent_ready", context, agent_ready_at) {
+    if let Some(duration) = api_latency_duration_at(
+        "api_to_agent_ready",
+        context,
+        agent_ready_at,
+        observed_at,
+        observed_ms,
+    ) {
         telemetry.record_api_to_agent_ready(duration, runner_startup_path, sandbox_reuse_result);
     }
     telemetry.finish_runner_pre_spawn_attribution();
@@ -520,20 +534,16 @@ fn api_latency_duration_at(
     action_type: &str,
     context: &ExecutionContext,
     completed_at: Instant,
+    observed_at: Instant,
+    observed_ms: u64,
 ) -> Option<Duration> {
-    let observed_at = Instant::now();
-    let observed_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
-    let completed_ago_ms = u64::try_from(
-        observed_at
-            .saturating_duration_since(completed_at)
-            .as_millis(),
-    )
-    .unwrap_or(u64::MAX);
-    api_latency_duration_from_ms(
-        action_type,
-        context,
-        observed_ms.saturating_sub(completed_ago_ms),
-    )
+    let completed_ago = observed_at.saturating_duration_since(completed_at);
+    let completed_ago_ms = completed_ago
+        .as_secs()
+        .saturating_mul(1_000)
+        .saturating_add(u64::from(completed_ago.subsec_millis()));
+    let completed_ms = observed_ms.saturating_sub(completed_ago_ms);
+    api_latency_duration_from_ms(action_type, context, completed_ms)
 }
 
 fn api_latency_duration(action_type: &str, context: &ExecutionContext) -> Option<Duration> {

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -412,10 +412,11 @@ impl RunnerSpawnTiming {
         }
     }
 
-    pub(super) fn record_spawn_success_at(
+    pub(super) fn record_agent_ready_success_at(
         mut self,
         telemetry: &mut JobTelemetry,
         spawned_at: Instant,
+        ready_at: Instant,
     ) {
         telemetry.record(
             "runner_executor_start_to_spawn",
@@ -427,6 +428,20 @@ impl RunnerSpawnTiming {
             telemetry.record(
                 "runner_claim_to_spawn",
                 pre_spawn_timing.elapsed_at(spawned_at),
+                true,
+                None,
+            );
+        }
+        telemetry.record(
+            "runner_executor_start_to_agent_ready",
+            ready_at.saturating_duration_since(self.executor_started_at),
+            true,
+            None,
+        );
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing.as_ref() {
+            telemetry.record(
+                "runner_claim_to_agent_ready",
+                pre_spawn_timing.elapsed_at(ready_at),
                 true,
                 None,
             );
@@ -477,11 +492,13 @@ pub(super) fn record_api_latency(
     }
 }
 
-pub(super) fn record_api_to_spawn(
+pub(super) fn record_api_startup_boundaries(
     context: &ExecutionContext,
     telemetry: &mut JobTelemetry,
     sandbox_reuse_result: SandboxReuseResult,
     workspace_reuse_result: WorkspaceReuseResult,
+    shell_started_at: Instant,
+    agent_ready_at: Instant,
 ) {
     let runner_startup_path = if sandbox_reuse_result == SandboxReuseResult::Reused {
         RunnerStartupPath::Sandbox
@@ -490,16 +507,47 @@ pub(super) fn record_api_to_spawn(
     } else {
         RunnerStartupPath::Cold
     };
-    if let Some(duration) = api_latency_duration("api_to_spawn", context) {
+    if let Some(duration) = api_latency_duration_at("api_to_spawn", context, shell_started_at) {
         telemetry.record_api_to_spawn(duration, runner_startup_path, sandbox_reuse_result);
+    }
+    if let Some(duration) = api_latency_duration_at("api_to_agent_ready", context, agent_ready_at) {
+        telemetry.record_api_to_agent_ready(duration, runner_startup_path, sandbox_reuse_result);
     }
     telemetry.finish_runner_pre_spawn_attribution();
 }
 
+fn api_latency_duration_at(
+    action_type: &str,
+    context: &ExecutionContext,
+    completed_at: Instant,
+) -> Option<Duration> {
+    let observed_at = Instant::now();
+    let observed_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let completed_ago_ms = u64::try_from(
+        observed_at
+            .saturating_duration_since(completed_at)
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX);
+    api_latency_duration_from_ms(
+        action_type,
+        context,
+        observed_ms.saturating_sub(completed_ago_ms),
+    )
+}
+
 fn api_latency_duration(action_type: &str, context: &ExecutionContext) -> Option<Duration> {
+    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    api_latency_duration_from_ms(action_type, context, now_ms)
+}
+
+fn api_latency_duration_from_ms(
+    action_type: &str,
+    context: &ExecutionContext,
+    completed_ms: u64,
+) -> Option<Duration> {
     if let Some(api_start_ms) = context.api_start_time {
-        let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
-        if let Some(duration) = elapsed_since_api_start_ms(api_start_ms, now_ms) {
+        if let Some(duration) = elapsed_since_api_start_ms(api_start_ms, completed_ms) {
             return Some(duration);
         } else {
             warn_invalid_api_start_time_once(action_type, context, api_start_ms);

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -106,7 +106,7 @@ async fn fresh_pre_spawn_admission_cancels_before_factory_create() {
 }
 
 #[tokio::test]
-async fn fresh_pre_spawn_admission_releases_after_process_spawn() {
+async fn fresh_pre_spawn_admission_releases_after_agent_ready() {
     let dir = tempfile::tempdir().unwrap();
     let config = Arc::new(test_executor_config(dir.path()).await);
     let total_tokens = config.pre_spawn_admission.total_tokens();
@@ -157,7 +157,7 @@ async fn fresh_pre_spawn_admission_releases_after_process_spawn() {
         .unwrap();
     tokio::time::timeout(Duration::from_secs(2), admission_probe)
         .await
-        .expect("fresh admission remained held after process spawn")
+        .expect("fresh admission remained held after Agent ready")
         .unwrap();
     wait_gate.release_one();
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -14,7 +14,8 @@ use sandbox::{
 use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
 use super::super::telemetry::{
-    RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_to_spawn, record_reuse_result,
+    RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_startup_boundaries,
+    record_reuse_result,
 };
 use super::super::{
     ExactReuseSpeculationTiming, ExecutionHooks, FinalizingHandoffOutcome, NewSandboxDispatch,
@@ -56,7 +57,7 @@ fn elapsed_since_api_start_ms_rejects_seconds_shaped_start() {
 }
 
 #[test]
-fn api_to_spawn_records_the_effective_startup_path_and_exact_reuse_result() {
+fn api_startup_boundaries_record_the_effective_path_and_exact_reuse_result() {
     for (reuse_result, workspace_reuse_result, expected_path) in [
         (
             SandboxReuseResult::Reused,
@@ -75,23 +76,35 @@ fn api_to_spawn_records_the_effective_startup_path_and_exact_reuse_result() {
         ),
     ] {
         let mut context = minimal_context();
-        context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+        context.api_start_time =
+            Some((chrono::Utc::now().timestamp_millis().max(0) as u64).saturating_sub(1_000));
         let mut telemetry = new_telemetry();
 
-        record_api_to_spawn(
+        let agent_ready_at = Instant::now();
+        let shell_started_at = agent_ready_at - Duration::from_millis(1);
+        record_api_startup_boundaries(
             &context,
             &mut telemetry,
             reuse_result,
             workspace_reuse_result,
+            shell_started_at,
+            agent_ready_at,
         );
 
         let operations = telemetry.pending_ops_with_runner_startup_snapshot();
-        let [operation] = operations.as_slice() else {
-            panic!("expected one api_to_spawn operation, got {operations:?}");
+        let [spawn, ready] = operations.as_slice() else {
+            panic!("expected API spawn and ready operations, got {operations:?}");
         };
-        assert_eq!(operation.action_type, "api_to_spawn");
-        assert_eq!(operation.runner_startup_path, Some(expected_path));
-        assert_eq!(operation.sandbox_reuse_result, Some(reuse_result));
+        assert_eq!(spawn.action_type, "api_to_spawn");
+        assert_eq!(ready.action_type, "api_to_agent_ready");
+        for operation in [spawn, ready] {
+            assert_eq!(operation.runner_startup_path, Some(expected_path));
+            assert_eq!(operation.sandbox_reuse_result, Some(reuse_result));
+        }
+        let durations = telemetry.pending_ops_with_duration_snapshot();
+        assert_eq!(durations[0].0, "api_to_spawn");
+        assert_eq!(durations[1].0, "api_to_agent_ready");
+        assert!(durations[1].1 > durations[0].1);
     }
 }
 
@@ -788,6 +801,8 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
+        "runner_executor_start_to_agent_ready",
+        "runner_claim_to_agent_ready",
         "runner_claim_finalizing_handoff",
         "runner_fresh_sandbox_prepare",
         "runner_fresh_sandbox_factory_create",
@@ -797,6 +812,11 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_user_env_write",
         "runner_agent_env_build",
         "runner_agent_start_process",
+        "runner_agent_start_to_ready",
+        "runner_agent_containment_create",
+        "runner_agent_placement_broker_setup",
+        "runner_agent_shell_spawn",
+        "runner_agent_bootstrap_ready_wait",
         "sandbox_reuse_miss",
         "sandbox_create",
         "workspace_drive_mount",
@@ -901,6 +921,7 @@ async fn execute_job_attributes_overlapping_pre_spawn_work_and_releases_membersh
             "runner_fresh_sandbox_prepare",
             "runner_agent_start_process",
             "api_to_spawn",
+            "api_to_agent_ready",
         ] {
             assert_pre_spawn_concurrency_bucket(&telemetry, action, Some(expected_bucket));
         }
@@ -934,6 +955,11 @@ async fn execute_job_attributes_overlapping_pre_spawn_work_and_releases_membersh
     assert_pre_spawn_concurrency_bucket(
         &baseline_telemetry,
         "api_to_spawn",
+        Some(RunnerPreSpawnConcurrencyBucket::One),
+    );
+    assert_pre_spawn_concurrency_bucket(
+        &baseline_telemetry,
+        "api_to_agent_ready",
         Some(RunnerPreSpawnConcurrencyBucket::One),
     );
 }
@@ -1238,11 +1264,18 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
+        "runner_executor_start_to_agent_ready",
+        "runner_claim_to_agent_ready",
         "runner_reused_sandbox_prepare",
         "runner_guest_state_restore",
         "runner_user_env_write",
         "runner_agent_env_build",
         "runner_agent_start_process",
+        "runner_agent_start_to_ready",
+        "runner_agent_containment_create",
+        "runner_agent_placement_broker_setup",
+        "runner_agent_shell_spawn",
+        "runner_agent_bootstrap_ready_wait",
         "sandbox_reuse_hit",
         "agent_execute",
     ] {
@@ -1450,6 +1483,9 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
     assert_lacks_api_claim_timing(&telemetry);
     assert_lacks_action(&telemetry, "runner_executor_start_to_spawn");
     assert_lacks_action(&telemetry, "runner_claim_to_spawn");
+    assert_lacks_action(&telemetry, "runner_executor_start_to_agent_ready");
+    assert_lacks_action(&telemetry, "runner_claim_to_agent_ready");
+    assert_lacks_action(&telemetry, "runner_agent_start_to_ready");
     assert_pre_spawn_concurrency_bucket(
         &telemetry,
         "runner_agent_start_process",
@@ -1481,6 +1517,11 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
     assert_pre_spawn_concurrency_bucket(
         &recovery_telemetry,
         "api_to_spawn",
+        Some(RunnerPreSpawnConcurrencyBucket::One),
+    );
+    assert_pre_spawn_concurrency_bucket(
+        &recovery_telemetry,
+        "api_to_agent_ready",
         Some(RunnerPreSpawnConcurrencyBucket::One),
     );
 }

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -154,7 +154,7 @@ impl JobTelemetry {
         self.runner_pre_spawn_attribution = Some(attribution);
     }
 
-    /// Stop decorating operations after the success-only `api_to_spawn` boundary.
+    /// Stop decorating operations after the success-only Agent-ready boundary.
     pub(crate) fn finish_runner_pre_spawn_attribution(&mut self) {
         self.runner_pre_spawn_attribution = None;
     }
@@ -212,7 +212,36 @@ impl JobTelemetry {
         runner_startup_path: RunnerStartupPath,
         sandbox_reuse_result: SandboxReuseResult,
     ) {
-        let mut op = sandbox_op("api_to_spawn", duration, true, None, None, None);
+        self.record_api_startup_boundary(
+            "api_to_spawn",
+            duration,
+            runner_startup_path,
+            sandbox_reuse_result,
+        );
+    }
+
+    pub(crate) fn record_api_to_agent_ready(
+        &mut self,
+        duration: Duration,
+        runner_startup_path: RunnerStartupPath,
+        sandbox_reuse_result: SandboxReuseResult,
+    ) {
+        self.record_api_startup_boundary(
+            "api_to_agent_ready",
+            duration,
+            runner_startup_path,
+            sandbox_reuse_result,
+        );
+    }
+
+    fn record_api_startup_boundary(
+        &mut self,
+        action_type: &'static str,
+        duration: Duration,
+        runner_startup_path: RunnerStartupPath,
+        sandbox_reuse_result: SandboxReuseResult,
+    ) {
+        let mut op = sandbox_op(action_type, duration, true, None, None, None);
         op.runner_startup_path = Some(runner_startup_path);
         op.sandbox_reuse_result = Some(sandbox_reuse_result);
         self.push_operation(op);
@@ -699,13 +728,18 @@ mod tests {
     }
 
     #[test]
-    fn api_to_spawn_serializes_bounded_startup_metadata() {
+    fn api_startup_boundaries_serialize_bounded_startup_metadata() {
         let mut telemetry = JobTelemetry::new(http_client(), RunId::nil(), "tok".to_string(), None);
         telemetry.start_runner_pre_spawn_attribution(RunnerPreSpawnAttribution::new(
             RunnerPreSpawnConcurrencyBucket::ThreeToFour,
         ));
         telemetry.record_api_to_spawn(
             Duration::from_millis(125),
+            RunnerStartupPath::Workspace,
+            SandboxReuseResult::PoolMiss,
+        );
+        telemetry.record_api_to_agent_ready(
+            Duration::from_millis(150),
             RunnerStartupPath::Workspace,
             SandboxReuseResult::PoolMiss,
         );
@@ -716,6 +750,18 @@ mod tests {
                 "ts": telemetry.pending_ops[0].ts.clone(),
                 "action_type": "api_to_spawn",
                 "duration_ms": 125,
+                "success": true,
+                "runner_startup_path": "workspace",
+                "sandbox_reuse_result": "poolMiss",
+                "runner_pre_spawn_concurrency_bucket": "3_4",
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(&telemetry.pending_ops[1]).unwrap(),
+            serde_json::json!({
+                "ts": telemetry.pending_ops[1].ts.clone(),
+                "action_type": "api_to_agent_ready",
+                "duration_ms": 150,
                 "success": true,
                 "runner_startup_path": "workspace",
                 "sandbox_reuse_result": "poolMiss",

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,11 +8,12 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
-    GuestMemorySnapshot, GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle,
-    GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
-    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
-    ProcessControlWriteState, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox,
-    SandboxConfig, SandboxError, SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
+    GuestAgentStartTiming, GuestMemorySnapshot, GuestProcessCancelHandle,
+    GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest,
+    GuestStateRestoreTimezone, ProcessControlAck, ProcessControlFailureKind,
+    ProcessControlGuestStatus, ProcessControlOutcome, ProcessControlWriteState, ProcessExit,
+    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxError,
+    SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
     SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
     SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
     SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
@@ -27,7 +28,8 @@ use tracing::{info, warn};
 use vsock_host::{
     ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, FrameWriteObserver,
     GuestStateRestoreResult, GuestStorageManifestResult, NormalOperationFence,
-    NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest, VsockHost,
+    NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest,
+    SupervisedExecStartTiming, VsockHost,
 };
 use vsock_proto::{
     ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTimeoutPolicy,
@@ -1919,7 +1921,7 @@ impl FirecrackerSandbox {
         operation: SandboxOperation,
         role: ExecProcessRole,
         control: SupervisedExecControl,
-    ) -> sandbox::Result<GuestProcessHandle> {
+    ) -> sandbox::Result<(GuestProcessHandle, SupervisedExecStartTiming)> {
         let vsock = self.begin_guest_operation(operation).await?;
         Self::validate_exec_env_keys(operation, request.env)?;
         request.output.validate(operation)?;
@@ -1954,6 +1956,7 @@ impl FirecrackerSandbox {
                     }
                 };
                 let guest_pid = handle.pid();
+                let start_timing = handle.start_timing();
                 let process_control = handle.control_handle().map(|control| {
                     let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
@@ -2003,10 +2006,11 @@ impl FirecrackerSandbox {
                 if let Some(process_cancel) = process_cancel {
                     public_handle = public_handle.with_cancel_handle(process_cancel);
                 }
-                Ok(match close_stdout {
+                let public_handle = match close_stdout {
                     Some(close_stdout) => public_handle.with_unclaimed_stdout_cleanup(close_stdout),
                     None => public_handle,
-                })
+                };
+                Ok((public_handle, start_timing))
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
                 Err(Self::backend_crashed_error(operation))
@@ -2664,20 +2668,22 @@ impl Sandbox for FirecrackerSandbox {
         &self,
         request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<GuestProcessHandle> {
-        self.start_process_with_contract(
-            request,
-            SandboxOperation::StartProcess,
-            ExecProcessRole::Workload,
-            SupervisedExecControl::Disabled,
-        )
-        .await
+        let (process, _) = self
+            .start_process_with_contract(
+                request,
+                SandboxOperation::StartProcess,
+                ExecProcessRole::Workload,
+                SupervisedExecControl::Disabled,
+            )
+            .await?;
+        Ok(process)
     }
 
     async fn start_agent_process(
         &self,
         request: &StartAgentProcessRequest<'_>,
     ) -> sandbox::Result<GuestAgentProcessHandle> {
-        let process = self
+        let (process, timing) = self
             .start_process_with_contract(
                 &request.process,
                 SandboxOperation::StartAgentProcess,
@@ -2685,7 +2691,35 @@ impl Sandbox for FirecrackerSandbox {
                 SupervisedExecControl::Enabled { sink: true },
             )
             .await?;
-        GuestAgentProcessHandle::try_from_process(process)
+        let ready_at = timing.agent_ready_at.ok_or_else(|| {
+            Self::operation_error(
+                SandboxOperation::StartAgentProcess,
+                io::Error::other("guest Agent start completed without readiness timestamp"),
+                self.has_backend_crashed(),
+            )
+        })?;
+        let ready = timing.agent_ready.ok_or_else(|| {
+            Self::operation_error(
+                SandboxOperation::StartAgentProcess,
+                io::Error::other("guest Agent start completed without readiness timing"),
+                self.has_backend_crashed(),
+            )
+        })?;
+        GuestAgentProcessHandle::try_from_process(
+            process,
+            GuestAgentStartTiming {
+                shell_started_at: timing.shell_started_at,
+                ready_at,
+                containment_create: Duration::from_micros(u64::from(ready.containment_create_us)),
+                placement_broker_setup: Duration::from_micros(u64::from(
+                    ready.placement_broker_setup_us,
+                )),
+                shell_spawn: Duration::from_micros(u64::from(ready.shell_spawn_us)),
+                bootstrap_ready_wait: Duration::from_micros(u64::from(
+                    ready.bootstrap_ready_wait_us,
+                )),
+            },
+        )
     }
 
     async fn wait_process(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -351,10 +351,7 @@ async fn setup_exec_process_control_fixture() -> ExecProcessControlFixture {
         vsock_proto::ExecControlPolicy::Enabled { sink: true, .. }
     ));
 
-    let pid = 73;
-    let payload = vsock_proto::encode_exec_started(pid).unwrap();
-    let response = vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
-    guest.write_all(&response).await.unwrap();
+    send_agent_started_and_ready(&mut guest, start.seq, 73).await;
     let handle = start_task.await.unwrap();
 
     ExecProcessControlFixture {
@@ -517,6 +514,21 @@ async fn send_exec_exit(stream: &mut UnixStream, exec_seq: u32) {
     .unwrap();
     let response = vsock_proto::encode(vsock_proto::MSG_EXEC_RESULT, exec_seq, &payload).unwrap();
     stream.write_all(&response).await.unwrap();
+}
+
+async fn send_agent_started_and_ready(stream: &mut UnixStream, exec_seq: u32, pid: u32) {
+    let started = vsock_proto::encode_exec_started(pid).unwrap();
+    let started = vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, exec_seq, &started).unwrap();
+    stream.write_all(&started).await.unwrap();
+
+    let ready = vsock_proto::encode_exec_agent_ready(vsock_proto::ExecAgentReadyTiming {
+        containment_create_us: 11,
+        placement_broker_setup_us: 12,
+        shell_spawn_us: 13,
+        bootstrap_ready_wait_us: 14,
+    });
+    let ready = vsock_proto::encode(vsock_proto::MSG_EXEC_AGENT_READY, exec_seq, &ready).unwrap();
+    stream.write_all(&ready).await.unwrap();
 }
 
 fn monitored_cat_process() -> tokio::process::Child {
@@ -2403,14 +2415,18 @@ async fn start_agent_process_maps_to_agent_role_and_control_sink() {
             vsock_proto::ExecControlPolicy::Enabled { sink: true, .. }
         ));
 
-        let payload = vsock_proto::encode_exec_started(73).unwrap();
-        let response =
-            vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
-        guest.write_all(&response).await.unwrap();
+        send_agent_started_and_ready(&mut guest, start.seq, 73).await;
         start.seq
     };
     let (handle, exec_seq) = tokio::join!(start_agent, acknowledge_start);
-    let (process, _control) = handle.unwrap().into_parts();
+    let handle = handle.unwrap();
+    let timing = handle.start_timing();
+    assert_eq!(timing.containment_create, Duration::from_micros(11));
+    assert_eq!(timing.placement_broker_setup, Duration::from_micros(12));
+    assert_eq!(timing.shell_spawn, Duration::from_micros(13));
+    assert_eq!(timing.bootstrap_ready_wait, Duration::from_micros(14));
+    assert!(timing.ready_at >= timing.shell_started_at);
+    let (process, _control) = handle.into_parts();
 
     let payload = vsock_proto::encode_exec_result(
         vsock_proto::ExecTermination::Exited { exit_code: 0 },

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -1152,7 +1152,18 @@ impl Sandbox for MockSandbox {
         let process = self
             .start_process_with_contract(&request.process, operation, true)
             .await?;
-        GuestAgentProcessHandle::try_from_process(process)
+        let ready_at = Instant::now();
+        GuestAgentProcessHandle::try_from_process(
+            process,
+            GuestAgentStartTiming {
+                shell_started_at: ready_at,
+                ready_at,
+                containment_create: Duration::ZERO,
+                placement_broker_setup: Duration::ZERO,
+                shell_spawn: Duration::ZERO,
+                bootstrap_ready_wait: Duration::ZERO,
+            },
+        )
     }
 
     async fn wait_process(

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -57,9 +57,9 @@ pub use snapshot::{
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
-    GuestAgentProcessHandle, GuestProcessCancelHandle, GuestProcessControlHandle,
-    GuestProcessControlOutcomeFuture, GuestProcessHandle, GuestProcessWaiter,
-    GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
+    GuestAgentProcessHandle, GuestAgentStartTiming, GuestProcessCancelHandle,
+    GuestProcessControlHandle, GuestProcessControlOutcomeFuture, GuestProcessHandle,
+    GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
     ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
     ProcessControlWriteState, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
     ProcessOutputReceiver, StartAgentProcessRequest, StartProcessRequest, StorageManifestRequest,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -835,7 +835,8 @@ pub trait Sandbox: Send + Sync + Any {
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle>;
     /// Start the controlled guest Agent process.
     ///
-    /// A successful result always includes process control by construction.
+    /// A successful result always includes process control and timing captured
+    /// after the Agent has confirmed runtime placement.
     async fn start_agent_process(
         &self,
         request: &StartAgentProcessRequest<'_>,

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
@@ -876,11 +876,32 @@ impl GuestProcessHandle {
 pub struct GuestAgentProcessHandle {
     process: GuestProcessHandle,
     control: GuestProcessControlHandle,
+    start_timing: GuestAgentStartTiming,
+}
+
+/// Provider-neutral timing captured at the controlled Agent readiness boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GuestAgentStartTiming {
+    /// Host monotonic instant when the guest shell was spawned.
+    pub shell_started_at: Instant,
+    /// Host monotonic instant when Agent runtime placement was confirmed.
+    pub ready_at: Instant,
+    /// Guest time spent creating the per-exec process containment hierarchy.
+    pub containment_create: Duration,
+    /// Guest time spent creating workload and tool placement brokers.
+    pub placement_broker_setup: Duration,
+    /// Guest time spent spawning the supervised shell.
+    pub shell_spawn: Duration,
+    /// Guest time from shell spawn through confirmed runtime placement.
+    pub bootstrap_ready_wait: Duration,
 }
 
 impl GuestAgentProcessHandle {
     /// Convert a provider process handle into a controlled Agent handle.
-    pub fn try_from_process(mut process: GuestProcessHandle) -> crate::Result<Self> {
+    pub fn try_from_process(
+        mut process: GuestProcessHandle,
+        start_timing: GuestAgentStartTiming,
+    ) -> crate::Result<Self> {
         let Some(control) = process.control.take() else {
             return Err(crate::SandboxError::Operation {
                 operation: crate::SandboxOperation::StartAgentProcess,
@@ -888,7 +909,16 @@ impl GuestAgentProcessHandle {
                 message: "provider returned an Agent process without process control".into(),
             });
         };
-        Ok(Self { process, control })
+        Ok(Self {
+            process,
+            control,
+            start_timing,
+        })
+    }
+
+    /// Return timing captured while the controlled Agent became ready.
+    pub fn start_timing(&self) -> GuestAgentStartTiming {
+        self.start_timing
     }
 
     /// Consume the Agent handle into its process owner and control capability.
@@ -1091,6 +1121,18 @@ impl ProcessExit {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn guest_agent_start_timing() -> GuestAgentStartTiming {
+        let ready_at = Instant::now();
+        GuestAgentStartTiming {
+            shell_started_at: ready_at,
+            ready_at,
+            containment_create: Duration::ZERO,
+            placement_broker_setup: Duration::ZERO,
+            shell_spawn: Duration::ZERO,
+            bootstrap_ready_wait: Duration::ZERO,
+        }
+    }
 
     #[test]
     fn timeout_ms_normal() {
@@ -1452,10 +1494,11 @@ mod tests {
             }),
         );
 
-        let error = match GuestAgentProcessHandle::try_from_process(process) {
-            Ok(_) => panic!("Agent handle unexpectedly accepted missing control"),
-            Err(error) => error,
-        };
+        let error =
+            match GuestAgentProcessHandle::try_from_process(process, guest_agent_start_timing()) {
+                Ok(_) => panic!("Agent handle unexpectedly accepted missing control"),
+                Err(error) => error,
+            };
         assert!(matches!(
             error,
             crate::SandboxError::Operation {
@@ -1480,7 +1523,8 @@ mod tests {
             }),
         );
 
-        let agent = GuestAgentProcessHandle::try_from_process(process).unwrap();
+        let agent =
+            GuestAgentProcessHandle::try_from_process(process, guest_agent_start_timing()).unwrap();
         let (process, control) = agent.into_parts();
         assert_eq!(process.guest_pid, 42);
         let ack = control

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -56,9 +56,9 @@ use guest_contracts::process_containment::{
     TOOL_CGROUP_PROCS_ENDPOINT_ENV, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
 };
 use vsock_proto::{
-    self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
-    ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTermination, ExecTimeoutPolicy,
-    MSG_ERROR, MSG_EXEC_STARTED,
+    self, ExecAgentReadyTiming, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy,
+    ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTermination,
+    ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_AGENT_READY, MSG_EXEC_STARTED,
 };
 
 #[cfg(test)]
@@ -98,6 +98,7 @@ const EXEC_RESULT_MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
 const EXEC_CAPTURED_OUTPUT_OVERHEAD: usize = 1 + 1 + 4;
 const EXEC_DISCARDED_OUTPUT_LEN: usize = 1;
 const EXEC_OPERATION_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
+const AGENT_READY_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Default)]
 pub(crate) struct ExecOperationRegistry {
@@ -751,13 +752,76 @@ struct RunningExec {
     drain_done_rx: mpsc::Receiver<()>,
 }
 
+#[derive(Clone, Copy)]
+struct AgentStartStages {
+    containment_create: Duration,
+    placement_broker_setup: Duration,
+    shell_spawn: Duration,
+    shell_spawned_at: Instant,
+}
+
+enum AgentReadyWaitOutcome {
+    Ready(ExecAgentReadyTiming),
+    Terminal,
+    Failed(String),
+}
+
 impl RunningExec {
+    fn wait_for_agent_ready(
+        &mut self,
+        stages: AgentStartStages,
+        connection_cancel: &AtomicBool,
+        exec_cancel: &AtomicBool,
+    ) -> AgentReadyWaitOutcome {
+        loop {
+            if connection_cancel.load(Ordering::Acquire) || exec_cancel.load(Ordering::Acquire) {
+                return AgentReadyWaitOutcome::Terminal;
+            }
+
+            let bootstrap_ready = match self.placement_bootstrap.as_ref() {
+                Some(bootstrap) => match bootstrap.try_ready() {
+                    Ok(Ok(())) => true,
+                    Ok(Err(error)) => {
+                        return AgentReadyWaitOutcome::Failed(format!(
+                            "workload placement bootstrap failed: {error}"
+                        ));
+                    }
+                    Err(mpsc::TryRecvError::Empty) => false,
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        return AgentReadyWaitOutcome::Failed(
+                            "workload placement bootstrap stopped before confirmation".to_owned(),
+                        );
+                    }
+                },
+                None => true,
+            };
+            if bootstrap_ready {
+                return match exec_agent_ready_timing(stages) {
+                    Ok(timing) => AgentReadyWaitOutcome::Ready(timing),
+                    Err(error) => AgentReadyWaitOutcome::Failed(error.to_string()),
+                };
+            }
+
+            match self.child.try_wait() {
+                Ok(Some(_)) => return AgentReadyWaitOutcome::Terminal,
+                Ok(None) => {}
+                Err(error) => {
+                    return AgentReadyWaitOutcome::Failed(format!(
+                        "failed to observe Agent before readiness: {error}"
+                    ));
+                }
+            }
+            std::thread::sleep(AGENT_READY_POLL_INTERVAL);
+        }
+    }
+
     fn finish(
         self,
         request: &ExecOperationWorkerRequest,
         completion: &ExecCompletion<'_>,
         connection_cancel: &AtomicBool,
         exec_cancel: &AtomicBool,
+        startup_failure: Option<&str>,
     ) {
         let RunningExec {
             child,
@@ -861,8 +925,13 @@ impl RunningExec {
         }
 
         let containment_error = containment_result.as_ref().err().map(ToString::to_string);
-        let (termination, diagnostic) =
-            resolve_exec_result(outcome, request.lifecycle, containment_error.as_deref());
+        let (termination, diagnostic) = match startup_failure {
+            Some(diagnostic) => (
+                ExecTermination::StartFailed,
+                append_containment_cleanup_failure(diagnostic, containment_error.as_deref()),
+            ),
+            None => resolve_exec_result(outcome, request.lifecycle, containment_error.as_deref()),
+        };
         let containment_evidence = containment_result
             .as_ref()
             .ok()
@@ -1192,6 +1261,7 @@ fn run_exec_operation_worker<S>(
             return;
         }
     };
+    let containment_create = process_containment.create_elapsed();
     let workload_bootstrap =
         if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
             let expected_uid = match crate::user::shell_command_uid(request.sudo) {
@@ -1217,6 +1287,9 @@ fn run_exec_operation_worker<S>(
         } else {
             None
         };
+    let placement_broker_setup = workload_bootstrap
+        .as_ref()
+        .map_or(Duration::ZERO, WorkloadPlacementBootstrap::setup_elapsed);
     let env_refs = env_refs(&request.env);
     let mut env_with_control;
     let effective_env = if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
@@ -1233,6 +1306,7 @@ fn run_exec_operation_worker<S>(
     } else {
         env_refs.as_slice()
     };
+    let shell_spawn_started = Instant::now();
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
         effective_env,
@@ -1250,6 +1324,8 @@ fn run_exec_operation_worker<S>(
             return;
         }
     };
+    let shell_spawn = shell_spawn_started.elapsed();
+    let shell_spawned_at = Instant::now();
     let SpawnedShellCommand {
         child,
         env_script,
@@ -1358,7 +1434,7 @@ fn run_exec_operation_worker<S>(
         },
         spawner.clone(),
     );
-    let running = match stderr_spawn {
+    let mut running = match stderr_spawn {
         Ok((stderr_handle, stderr_result_rx)) => {
             setup.into_running(stderr_handle, stderr_result_rx, stream_writer)
         }
@@ -1372,7 +1448,68 @@ fn run_exec_operation_worker<S>(
         }
     };
 
-    running.finish(&request, &completion, &connection_cancel, &exec_cancel);
+    if request.role == ExecProcessRole::Agent {
+        let stages = AgentStartStages {
+            containment_create,
+            placement_broker_setup,
+            shell_spawn,
+            shell_spawned_at,
+        };
+        match running.wait_for_agent_ready(stages, &connection_cancel, &exec_cancel) {
+            AgentReadyWaitOutcome::Ready(timing) => {
+                if let Err(error) = send_exec_agent_ready(request.seq, timing, &writer) {
+                    log(
+                        "WARN",
+                        &format!(
+                            "exec operation: failed to send exec_agent_ready seq={} label={} process_class={} operation_kind={}: {error}",
+                            request.seq,
+                            truncate_command_preview(&request.label),
+                            request.process_class(),
+                            request.operation_kind(),
+                        ),
+                    );
+                    exec_cancel.store(true, Ordering::Release);
+                    running.finish(
+                        &request,
+                        &completion,
+                        &connection_cancel,
+                        &exec_cancel,
+                        None,
+                    );
+                    return;
+                }
+            }
+            AgentReadyWaitOutcome::Terminal => {
+                running.finish(
+                    &request,
+                    &completion,
+                    &connection_cancel,
+                    &exec_cancel,
+                    None,
+                );
+                return;
+            }
+            AgentReadyWaitOutcome::Failed(diagnostic) => {
+                exec_cancel.store(true, Ordering::Release);
+                running.finish(
+                    &request,
+                    &completion,
+                    &connection_cancel,
+                    &exec_cancel,
+                    Some(&diagnostic),
+                );
+                return;
+            }
+        }
+    }
+
+    running.finish(
+        &request,
+        &completion,
+        &connection_cancel,
+        &exec_cancel,
+        None,
+    );
 }
 
 fn validate_request(request: &ExecOperationWorkerRequest) -> Result<(), String> {
@@ -1816,6 +1953,43 @@ fn send_exec_started(seq: u32, pid: u32, writer: &GuestWriter) -> io::Result<()>
     let payload = vsock_proto::encode_exec_started(pid).map_err(to_io_error)?;
     let encoded = vsock_proto::encode(MSG_EXEC_STARTED, seq, &payload).map_err(to_io_error)?;
     writer.write_frame(&encoded)
+}
+
+fn send_exec_agent_ready(
+    seq: u32,
+    timing: ExecAgentReadyTiming,
+    writer: &GuestWriter,
+) -> io::Result<()> {
+    let payload = vsock_proto::encode_exec_agent_ready(timing);
+    let encoded = vsock_proto::encode(MSG_EXEC_AGENT_READY, seq, &payload).map_err(to_io_error)?;
+    writer.write_frame(&encoded)
+}
+
+fn exec_agent_ready_timing(stages: AgentStartStages) -> io::Result<ExecAgentReadyTiming> {
+    Ok(ExecAgentReadyTiming {
+        containment_create_us: duration_micros_u32(
+            stages.containment_create,
+            "containment creation",
+        )?,
+        placement_broker_setup_us: duration_micros_u32(
+            stages.placement_broker_setup,
+            "placement broker setup",
+        )?,
+        shell_spawn_us: duration_micros_u32(stages.shell_spawn, "shell spawn")?,
+        bootstrap_ready_wait_us: duration_micros_u32(
+            stages.shell_spawned_at.elapsed(),
+            "bootstrap ready wait",
+        )?,
+    })
+}
+
+fn duration_micros_u32(duration: Duration, stage: &str) -> io::Result<u32> {
+    u32::try_from(duration.as_micros()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Agent startup {stage} duration exceeds the wire limit"),
+        )
+    })
 }
 
 fn send_exec_result_after_lock<F>(

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -98,7 +98,7 @@ const EXEC_RESULT_MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
 const EXEC_CAPTURED_OUTPUT_OVERHEAD: usize = 1 + 1 + 4;
 const EXEC_DISCARDED_OUTPUT_LEN: usize = 1;
 const EXEC_OPERATION_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
-const AGENT_READY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const AGENT_READY_OBSERVATION_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Default)]
 pub(crate) struct ExecOperationRegistry {
@@ -779,20 +779,23 @@ impl RunningExec {
             }
 
             let bootstrap_ready = match self.placement_bootstrap.as_ref() {
-                Some(bootstrap) => match bootstrap.try_ready() {
-                    Ok(Ok(())) => true,
-                    Ok(Err(error)) => {
-                        return AgentReadyWaitOutcome::Failed(format!(
-                            "workload placement bootstrap failed: {error}"
-                        ));
+                Some(bootstrap) => {
+                    match bootstrap.recv_ready_timeout(AGENT_READY_OBSERVATION_INTERVAL) {
+                        Ok(Ok(())) => true,
+                        Ok(Err(error)) => {
+                            return AgentReadyWaitOutcome::Failed(format!(
+                                "workload placement bootstrap failed: {error}"
+                            ));
+                        }
+                        Err(mpsc::RecvTimeoutError::Timeout) => false,
+                        Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            return AgentReadyWaitOutcome::Failed(
+                                "workload placement bootstrap stopped before confirmation"
+                                    .to_owned(),
+                            );
+                        }
                     }
-                    Err(mpsc::TryRecvError::Empty) => false,
-                    Err(mpsc::TryRecvError::Disconnected) => {
-                        return AgentReadyWaitOutcome::Failed(
-                            "workload placement bootstrap stopped before confirmation".to_owned(),
-                        );
-                    }
-                },
+                }
                 None => true,
             };
             if bootstrap_ready {
@@ -811,7 +814,6 @@ impl RunningExec {
                     ));
                 }
             }
-            std::thread::sleep(AGENT_READY_POLL_INTERVAL);
         }
     }
 

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -8,6 +8,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -106,6 +107,8 @@ impl PreparedProcessContainmentCommand {
 pub(crate) struct WorkloadPlacementBootstrap {
     endpoint: String,
     tool_endpoint: String,
+    setup_elapsed: Duration,
+    ready_rx: mpsc::Receiver<io::Result<()>>,
     cancel: Arc<AtomicBool>,
     cancel_wake_writer: Option<OwnedFd>,
     active_tool_placement: Arc<ActiveToolPlacement>,
@@ -192,6 +195,14 @@ impl WorkloadPlacementBootstrap {
     pub(crate) fn tool_endpoint(&self) -> &str {
         &self.tool_endpoint
     }
+
+    pub(crate) fn setup_elapsed(&self) -> Duration {
+        self.setup_elapsed
+    }
+
+    pub(crate) fn try_ready(&self) -> Result<io::Result<()>, mpsc::TryRecvError> {
+        self.ready_rx.try_recv()
+    }
 }
 
 impl Drop for WorkloadPlacementBootstrap {
@@ -271,6 +282,15 @@ impl ExecProcessContainment {
                 outer_placement: None,
                 deny_process_inspection: false,
             }),
+        }
+    }
+
+    pub(crate) fn create_elapsed(&self) -> Duration {
+        match &self.backend {
+            ContainmentBackend::Cgroup(guard) => guard.create_elapsed,
+            ContainmentBackend::TestNoop => Duration::ZERO,
+            #[cfg(test)]
+            ContainmentBackend::TestDirectory(_) => Duration::ZERO,
         }
     }
 
@@ -487,6 +507,7 @@ impl CgroupGuard {
         control_endpoint: &str,
         expected_uid: libc::uid_t,
     ) -> Result<WorkloadPlacementBootstrap, ProcessContainmentError> {
+        let started = Instant::now();
         let placement = self
             .workload_placement
             .as_ref()
@@ -528,11 +549,12 @@ impl CgroupGuard {
         let worker_active_tool_placement = Arc::clone(&active_tool_placement);
         let mut cancel_wake_writer = Some(cancel_wake_writer);
         let cancel = Arc::new(AtomicBool::new(false));
+        let (ready_tx, ready_rx) = mpsc::channel();
         let worker_cancel = Arc::clone(&cancel);
         let workload_worker = thread::Builder::new()
             .name(THREAD_WORKLOAD_BOOTSTRAP.to_owned())
             .spawn(move || {
-                serve_workload_placement(
+                let result = serve_workload_placement(
                     listener,
                     placement,
                     expected_uid,
@@ -540,6 +562,7 @@ impl CgroupGuard {
                     &worker_cancel,
                     workload_cancel_reader.as_raw_fd(),
                 );
+                let _ = ready_tx.send(result);
             })
             .map_err(|error| {
                 ProcessContainmentError::new("start workload placement bootstrap worker", error)
@@ -572,6 +595,8 @@ impl CgroupGuard {
         Ok(WorkloadPlacementBootstrap {
             endpoint,
             tool_endpoint,
+            setup_elapsed: started.elapsed(),
+            ready_rx,
             cancel,
             cancel_wake_writer,
             active_tool_placement,
@@ -1055,31 +1080,31 @@ fn serve_workload_placement(
     expected_cgroup: &Path,
     cancel: &AtomicBool,
     cancel_fd: RawFd,
-) {
+) -> io::Result<()> {
     loop {
         let stream = match accept_placement_or_cancelled(&listener, cancel, cancel_fd) {
             Ok(Some(stream)) => stream,
-            Ok(None) => return,
-            Err(error) => {
-                log(
-                    "WARN",
-                    &format!("workload placement bootstrap accept failed: {error}"),
-                );
-                return;
-            }
+            Ok(None) => return Err(workload_bootstrap_cancelled()),
+            Err(error) => return Err(error),
         };
 
         match workload_bootstrap_peer_matches(&stream, expected_uid, expected_cgroup) {
             Ok(true) => {
-                if let Err(error) =
-                    process_control_ipc::send_workload_placement(&stream, placement.as_fd())
-                {
-                    log(
-                        "WARN",
-                        &format!("workload placement descriptor send failed: {error}"),
-                    );
+                stream.set_nonblocking(true)?;
+                send_workload_placement_or_cancelled(
+                    &stream,
+                    placement.as_fd(),
+                    cancel,
+                    cancel_fd,
+                )?;
+                read_workload_confirmation_or_cancelled(&stream, cancel, cancel_fd)?;
+                if !workload_bootstrap_peer_matches(&stream, expected_uid, expected_cgroup)? {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "workload placement peer left the control cgroup before confirmation",
+                    ));
                 }
-                return;
+                return Ok(());
             }
             Ok(false) => {
                 log(
@@ -1095,6 +1120,120 @@ fn serve_workload_placement(
             }
         }
     }
+}
+
+fn send_workload_placement_or_cancelled(
+    stream: &UnixStream,
+    placement: std::os::fd::BorrowedFd<'_>,
+    cancel: &AtomicBool,
+    cancel_fd: RawFd,
+) -> io::Result<()> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            return Err(workload_bootstrap_cancelled());
+        }
+        match process_control_ipc::send_workload_placement(stream, placement) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                wait_placement_stream_or_cancelled(stream, libc::POLLOUT, cancel, cancel_fd)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn read_workload_confirmation_or_cancelled(
+    stream: &UnixStream,
+    cancel: &AtomicBool,
+    cancel_fd: RawFd,
+) -> io::Result<()> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            return Err(workload_bootstrap_cancelled());
+        }
+        match process_control_ipc::read_workload_placement_confirmation(stream) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                wait_placement_stream_or_cancelled(stream, libc::POLLIN, cancel, cancel_fd)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn wait_placement_stream_or_cancelled(
+    stream: &UnixStream,
+    events: libc::c_short,
+    cancel: &AtomicBool,
+    cancel_fd: RawFd,
+) -> io::Result<()> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            return Err(workload_bootstrap_cancelled());
+        }
+        let mut pollfds = [
+            libc::pollfd {
+                fd: stream.as_raw_fd(),
+                events,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: cancel_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        // SAFETY: both poll entries reference live descriptors owned by the
+        // bootstrap for the duration of this call.
+        let result = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1) };
+        if result > 0 {
+            let stream_revents = pollfds[0].revents;
+            let cancel_revents = pollfds[1].revents;
+            if cancel.load(Ordering::Acquire)
+                || cancel_revents & (libc::POLLIN | libc::POLLHUP) != 0
+            {
+                return Err(workload_bootstrap_cancelled());
+            }
+            if cancel_revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                return Err(io::Error::other(
+                    "placement cancellation descriptor became unavailable",
+                ));
+            }
+            if stream_revents & events != 0 {
+                return Ok(());
+            }
+            if stream_revents & libc::POLLNVAL != 0 {
+                return Err(io::Error::other(
+                    "workload placement stream descriptor became unavailable",
+                ));
+            }
+            if stream_revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+                return Err(stream.take_error()?.unwrap_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "workload placement stream closed before confirmation",
+                    )
+                }));
+            }
+            continue;
+        }
+        if result == 0 {
+            continue;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn workload_bootstrap_cancelled() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Interrupted,
+        "workload placement bootstrap cancelled",
+    )
 }
 
 fn serve_tool_placement(
@@ -1549,6 +1688,15 @@ mod tests {
 
     struct ChildGuard(Child);
 
+    fn current_cgroup_path() -> PathBuf {
+        let current_cgroup = fs::read_to_string("/proc/self/cgroup").unwrap();
+        let relative = current_cgroup
+            .lines()
+            .find_map(|line| line.strip_prefix("0::/"))
+            .unwrap();
+        Path::new(CGROUP_V2_MOUNT_PATH).join(relative)
+    }
+
     impl Drop for ChildGuard {
         fn drop(&mut self) {
             let _ = self.0.kill();
@@ -1684,12 +1832,7 @@ mod tests {
         let (peer, _server) = std::os::unix::net::UnixStream::pair().unwrap();
         // SAFETY: geteuid is a simple scalar getter with no preconditions.
         let uid = unsafe { libc::geteuid() };
-        let current_cgroup = fs::read_to_string("/proc/self/cgroup").unwrap();
-        let relative = current_cgroup
-            .lines()
-            .find_map(|line| line.strip_prefix("0::/"))
-            .unwrap();
-        let expected = Path::new(CGROUP_V2_MOUNT_PATH).join(relative);
+        let expected = current_cgroup_path();
 
         assert!(workload_bootstrap_peer_matches(&peer, uid, &expected).unwrap());
         assert!(!workload_bootstrap_peer_matches(&peer, uid.wrapping_add(1), &expected).unwrap());
@@ -1697,6 +1840,83 @@ mod tests {
             !workload_bootstrap_peer_matches(&peer, uid, &expected.join("not-the-peer-cgroup"))
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn workload_bootstrap_completes_after_authenticated_descriptor_confirmation() {
+        let endpoint_id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
+        let endpoint = format!(
+            "vm0-test-workload-confirm-{}-{endpoint_id}",
+            std::process::id()
+        );
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let placement: OwnedFd = tempfile::tempfile().unwrap().into();
+        let (cancel_reader, _cancel_writer) = placement_cancel_pipe().unwrap();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let server_cancel = Arc::clone(&cancel);
+        // SAFETY: geteuid is a simple scalar getter with no preconditions.
+        let uid = unsafe { libc::geteuid() };
+        let expected = current_cgroup_path();
+        let server = thread::spawn(move || {
+            serve_workload_placement(
+                listener,
+                placement,
+                uid,
+                &expected,
+                &server_cancel,
+                cancel_reader.as_raw_fd(),
+            )
+        });
+
+        let client = process_control_ipc::connect_abstract(&endpoint).unwrap();
+        let descriptor = process_control_ipc::receive_workload_placement(&client).unwrap();
+        process_control_ipc::write_workload_placement_confirmation(&client).unwrap();
+
+        server.join().unwrap().unwrap();
+        drop(descriptor);
+    }
+
+    #[test]
+    fn workload_bootstrap_fails_when_descriptor_recipient_disconnects_before_confirmation() {
+        let endpoint_id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
+        let endpoint = format!(
+            "vm0-test-workload-disconnect-{}-{endpoint_id}",
+            std::process::id()
+        );
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let placement: OwnedFd = tempfile::tempfile().unwrap().into();
+        let (cancel_reader, _cancel_writer) = placement_cancel_pipe().unwrap();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let server_cancel = Arc::clone(&cancel);
+        // SAFETY: geteuid is a simple scalar getter with no preconditions.
+        let uid = unsafe { libc::geteuid() };
+        let expected = current_cgroup_path();
+        let server = thread::spawn(move || {
+            serve_workload_placement(
+                listener,
+                placement,
+                uid,
+                &expected,
+                &server_cancel,
+                cancel_reader.as_raw_fd(),
+            )
+        });
+
+        let client = process_control_ipc::connect_abstract(&endpoint).unwrap();
+        let descriptor = process_control_ipc::receive_workload_placement(&client).unwrap();
+        drop(client);
+
+        let error = server
+            .join()
+            .unwrap()
+            .expect_err("missing placement confirmation must fail readiness");
+        assert!(matches!(
+            error.kind(),
+            io::ErrorKind::UnexpectedEof
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::BrokenPipe
+        ));
+        drop(descriptor);
     }
 
     #[test]
@@ -1796,9 +2016,12 @@ mod tests {
             .unwrap();
         let cancel = Arc::new(AtomicBool::new(false));
         let cancel_after_drop = Arc::clone(&cancel);
+        let (_bootstrap_ready_tx, bootstrap_ready_rx) = mpsc::channel();
         let bootstrap = WorkloadPlacementBootstrap {
             endpoint,
             tool_endpoint,
+            setup_elapsed: Duration::ZERO,
+            ready_rx: bootstrap_ready_rx,
             cancel,
             cancel_wake_writer: Some(cancel_writer),
             active_tool_placement: Arc::new(ActiveToolPlacement::default()),
@@ -1953,9 +2176,12 @@ mod tests {
                 tool_done.fetch_add(1, Ordering::Release);
             })
             .unwrap();
+        let (_bootstrap_ready_tx, bootstrap_ready_rx) = mpsc::channel();
         let bootstrap = WorkloadPlacementBootstrap {
             endpoint,
             tool_endpoint: tool_endpoint.clone(),
+            setup_elapsed: Duration::ZERO,
+            ready_rx: bootstrap_ready_rx,
             cancel,
             cancel_wake_writer: Some(cancel_writer),
             active_tool_placement,

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -200,8 +200,11 @@ impl WorkloadPlacementBootstrap {
         self.setup_elapsed
     }
 
-    pub(crate) fn try_ready(&self) -> Result<io::Result<()>, mpsc::TryRecvError> {
-        self.ready_rx.try_recv()
+    pub(crate) fn recv_ready_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<io::Result<()>, mpsc::RecvTimeoutError> {
+        self.ready_rx.recv_timeout(timeout)
     }
 }
 

--- a/crates/vsock-guest/tests/connection/exec_control.rs
+++ b/crates/vsock-guest/tests/connection/exec_control.rs
@@ -145,6 +145,8 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
         },
     );
     assert!(read_exec_started(&mut host_stream, target_seq) > 0);
+    let ready = read_exec_agent_ready(&mut host_stream, target_seq);
+    assert!(ready.shell_spawn_us > 0);
     let pid = child_guard.read_pid();
     assert_eq!(
         read_exec_stdout_output(&mut host_stream, target_seq),

--- a/crates/vsock-guest/tests/connection/exec_helpers.rs
+++ b/crates/vsock-guest/tests/connection/exec_helpers.rs
@@ -1,7 +1,8 @@
 use vsock_proto::{
     self, ExecControlNonce, ExecControlPolicy, ExecControlStatus, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecStartEncodeRequest, ExecTimeoutPolicy, MSG_ERROR,
-    MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_STARTED,
+    MSG_EXEC_AGENT_READY, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT,
+    MSG_EXEC_RESULT, MSG_EXEC_STARTED,
 };
 
 use super::support::{read_message, send_exec_start_request};
@@ -54,6 +55,16 @@ pub(super) fn read_exec_started(stream: &mut impl std::io::Read, seq: u32) -> u3
     assert_eq!(msg.msg_type, MSG_EXEC_STARTED);
     assert_eq!(msg.seq, seq);
     vsock_proto::decode_exec_started(&msg.payload).unwrap().pid
+}
+
+pub(super) fn read_exec_agent_ready(
+    stream: &mut impl std::io::Read,
+    seq: u32,
+) -> vsock_proto::ExecAgentReadyTiming {
+    let msg = read_message(stream);
+    assert_eq!(msg.msg_type, MSG_EXEC_AGENT_READY);
+    assert_eq!(msg.seq, seq);
+    vsock_proto::decode_exec_agent_ready(&msg.payload).unwrap()
 }
 
 pub(super) fn read_exec_stdout_output(stream: &mut impl std::io::Read, seq: u32) -> Vec<u8> {

--- a/crates/vsock-host/src/exec_operation/diagnostics.rs
+++ b/crates/vsock-host/src/exec_operation/diagnostics.rs
@@ -266,6 +266,7 @@ pub(in crate::exec_operation) fn exec_terminal_log_lifecycle(
     match lifecycle {
         ExecOperationLifecycle::OneShot => ExecTerminalLogLifecycle::OneShot,
         ExecOperationLifecycle::SupervisedAwaitingStart { .. }
+        | ExecOperationLifecycle::SupervisedAwaitingAgentReady { .. }
         | ExecOperationLifecycle::SupervisedStarted { .. } => ExecTerminalLogLifecycle::Supervised,
     }
 }

--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -1,10 +1,12 @@
 use std::io;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::mpsc;
 use vsock_proto::{
     BorrowedRawMessage, ExecCapturedOutput, ExecControlStatus, ExecOutputStream, MSG_ERROR,
-    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_STARTED,
+    MSG_EXEC_AGENT_READY, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT,
+    MSG_EXEC_STARTED,
 };
 
 use crate::{ConnectionState, Shared, normal_operation_transition_error};
@@ -12,7 +14,7 @@ use crate::{ConnectionState, Shared, normal_operation_transition_error};
 use super::state::{ExecCaptureState, ExecOperation, ExecOperationLifecycle};
 use super::types::{
     ExecControlAck, ExecControlGuestStatus, ExecControlOutcome, ExecOperationResult,
-    ExecOutputEvent, ExecOwnedCapturedOutput,
+    ExecOutputEvent, ExecOwnedCapturedOutput, SupervisedExecStartTiming,
 };
 use super::{exec_operation_guest_error, exec_operation_protocol_error};
 
@@ -151,6 +153,20 @@ fn owned_result(
     }
 }
 
+fn supervised_start_failure_message(result: &ExecOperationResult) -> String {
+    if !result.diagnostic.is_empty() {
+        return result.diagnostic.clone();
+    }
+    if let ExecOwnedCapturedOutput::Captured { bytes, .. } = &result.stderr {
+        let stderr = String::from_utf8_lossy(bytes);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            return stderr.to_owned();
+        }
+    }
+    "supervised exec start failed".to_owned()
+}
+
 /// Returns true when exec handling consumed the frame; false lets the normal
 /// pending-response dispatcher handle it.
 pub(crate) fn dispatch_incoming_frame(
@@ -161,6 +177,7 @@ pub(crate) fn dispatch_incoming_frame(
         MSG_ERROR => dispatch_error(shared, msg),
         MSG_EXEC_OUTPUT => dispatch_output(shared, msg).map(|_| true),
         MSG_EXEC_STARTED => dispatch_started(shared, msg).map(|_| true),
+        MSG_EXEC_AGENT_READY => dispatch_agent_ready(shared, msg).map(|_| true),
         MSG_EXEC_RESULT => dispatch_result(shared, msg).map(|_| true),
         MSG_EXEC_CONTROL_RESULT => dispatch_control_result(shared, msg).map(|_| true),
         _ => Ok(false),
@@ -265,14 +282,48 @@ fn dispatch_started(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Re
                 match lifecycle {
                     ExecOperationLifecycle::SupervisedAwaitingStart {
                         mut start_tx,
+                        role,
                         control_nonce,
                     } => {
                         let start_tx = start_tx.take();
-                        operation.lifecycle = ExecOperationLifecycle::SupervisedStarted {
-                            pid: decoded.pid,
-                            control_nonce,
-                        };
-                        start_tx.map(|start_tx| (start_tx, decoded.pid))
+                        let shell_started_at = Instant::now();
+                        match role {
+                            vsock_proto::ExecProcessRole::Workload => {
+                                operation.lifecycle = ExecOperationLifecycle::SupervisedStarted {
+                                    pid: decoded.pid,
+                                    control_nonce,
+                                };
+                                start_tx.map(|start_tx| {
+                                    (
+                                        start_tx,
+                                        decoded.pid,
+                                        SupervisedExecStartTiming {
+                                            shell_started_at,
+                                            agent_ready_at: None,
+                                            agent_ready: None,
+                                        },
+                                    )
+                                })
+                            }
+                            vsock_proto::ExecProcessRole::Agent => {
+                                operation.lifecycle =
+                                    ExecOperationLifecycle::SupervisedAwaitingAgentReady {
+                                        start_tx,
+                                        pid: decoded.pid,
+                                        shell_started_at,
+                                        control_nonce,
+                                    };
+                                None
+                            }
+                        }
+                    }
+                    lifecycle @ ExecOperationLifecycle::SupervisedAwaitingAgentReady {
+                        pid, ..
+                    } => {
+                        operation.lifecycle = lifecycle;
+                        return Err(exec_operation_protocol_error(format!(
+                            "duplicate exec_started for Agent pid {pid}",
+                        )));
                     }
                     lifecycle @ ExecOperationLifecycle::SupervisedStarted { pid, .. } => {
                         operation.lifecycle = lifecycle;
@@ -291,8 +342,73 @@ fn dispatch_started(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Re
         }
     };
 
-    if let Some((start_tx, pid)) = start {
-        let _ = start_tx.send(Ok(pid));
+    if let Some((start_tx, pid, timing)) = start {
+        let _ = start_tx.send(Ok((pid, timing)));
+    }
+
+    Ok(())
+}
+
+fn dispatch_agent_ready(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+    let start = {
+        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        match &mut *guard {
+            ConnectionState::Connected { operations, .. } => {
+                let Some(operation) = operations.get_mut_by_seq(msg.seq) else {
+                    return Ok(());
+                };
+                let decoded = vsock_proto::decode_exec_agent_ready(msg.payload)
+                    .map_err(exec_operation_protocol_error)?;
+                let lifecycle =
+                    std::mem::replace(&mut operation.lifecycle, ExecOperationLifecycle::OneShot);
+                match lifecycle {
+                    ExecOperationLifecycle::SupervisedAwaitingAgentReady {
+                        mut start_tx,
+                        pid,
+                        shell_started_at,
+                        control_nonce,
+                    } => {
+                        let start_tx = start_tx.take();
+                        let agent_ready_at = Instant::now();
+                        operation.lifecycle =
+                            ExecOperationLifecycle::SupervisedStarted { pid, control_nonce };
+                        start_tx.map(|start_tx| {
+                            (
+                                start_tx,
+                                pid,
+                                SupervisedExecStartTiming {
+                                    shell_started_at,
+                                    agent_ready_at: Some(agent_ready_at),
+                                    agent_ready: Some(decoded),
+                                },
+                            )
+                        })
+                    }
+                    lifecycle @ ExecOperationLifecycle::SupervisedAwaitingStart { .. } => {
+                        operation.lifecycle = lifecycle;
+                        return Err(exec_operation_protocol_error(
+                            "exec_agent_ready received before exec_started",
+                        ));
+                    }
+                    lifecycle @ ExecOperationLifecycle::SupervisedStarted { pid, .. } => {
+                        operation.lifecycle = lifecycle;
+                        return Err(exec_operation_protocol_error(format!(
+                            "unexpected exec_agent_ready for started pid {pid}",
+                        )));
+                    }
+                    ExecOperationLifecycle::OneShot => {
+                        return Err(exec_operation_protocol_error(
+                            "exec_agent_ready received for one-shot exec operation",
+                        ));
+                    }
+                }
+            }
+            ConnectionState::Closed => None,
+        }
+    };
+
+    if let Some((start_tx, pid, timing)) = start {
+        let _ = start_tx.send(Ok((pid, timing)));
     }
 
     Ok(())
@@ -331,11 +447,7 @@ pub(in crate::exec_operation) fn dispatch_result(
     );
     let result = owned_result(decoded, terminal.stream_overflowed);
     if let Some(start_tx) = terminal.start_tx {
-        let message = if result.diagnostic.is_empty() {
-            "supervised exec start failed".to_owned()
-        } else {
-            result.diagnostic.clone()
-        };
+        let message = supervised_start_failure_message(&result);
         let _ = start_tx.send(Err(io::Error::other(message)));
     }
     let _ = terminal.result_tx.send(Ok(result));

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -20,7 +20,7 @@ use super::frame::{
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
     ExecControlAck, ExecControlOutcome, ExecOperationResult, ExecOutputEvent,
-    exec_control_status_error,
+    SupervisedExecStartTiming, exec_control_status_error,
 };
 
 /// Handle for a host-side exec operation.
@@ -654,6 +654,7 @@ impl Drop for ExecOperationHandle {
 pub struct SupervisedExecHandle {
     pub(in crate::exec_operation) wait_core: ExecWaitCore,
     pub(in crate::exec_operation) pid: u32,
+    pub(in crate::exec_operation) start_timing: SupervisedExecStartTiming,
     pub(in crate::exec_operation) cancel_handle_taken: bool,
     pub(in crate::exec_operation) stream_rx: Option<mpsc::Receiver<ExecOutputEvent>>,
     pub(in crate::exec_operation) control: Option<ExecControlHandle>,
@@ -712,6 +713,11 @@ impl SupervisedExecHandle {
     /// Guest process id reported by the `exec_started` acknowledgement.
     pub fn pid(&self) -> u32 {
         self.pid
+    }
+
+    /// Host and guest timing captured while the supervised start completed.
+    pub fn start_timing(&self) -> SupervisedExecStartTiming {
+        self.start_timing
     }
 
     /// Return a cloneable exec-control handle when control was enabled.

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -15,7 +15,7 @@ pub use handle::{
 pub use types::{
     ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus, ExecControlOutcome,
     ExecOperationRequest, ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput,
-    ExecStreamRequest, SupervisedExecControl, SupervisedExecRequest,
+    ExecStreamRequest, SupervisedExecControl, SupervisedExecRequest, SupervisedExecStartTiming,
 };
 
 pub(crate) use diagnostics::log_operations_closed;

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -257,6 +257,7 @@ where
             stream_queue_capacity,
             lifecycle: ExecOperationLifecycle::SupervisedAwaitingStart {
                 start_tx: Some(start_tx),
+                role: request.role,
                 control_nonce,
             },
             role: request.role,
@@ -289,11 +290,11 @@ where
     }
     after_start_write.await;
 
-    let pid = tokio::select! {
+    let (pid, start_timing) = tokio::select! {
         biased;
         result = start_rx => {
             match result {
-                Ok(Ok(pid)) => pid,
+                Ok(Ok(start)) => start,
                 Ok(Err(error)) => {
                     start_cancel_on_drop.disarm();
                     return Err(error);
@@ -360,6 +361,7 @@ where
     Ok(SupervisedExecHandle {
         wait_core: ExecWaitCore::new(Arc::clone(shared), route_id, diagnostic, result_rx),
         pid,
+        start_timing,
         cancel_handle_taken: false,
         stream_rx,
         control: control_nonce.map(|control_nonce| ExecControlHandle {

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{mpsc, oneshot};
 use vsock_proto::{
@@ -18,7 +19,8 @@ use super::diagnostics::{
 };
 use super::frame::remove_pending_exec_control;
 use super::types::{
-    ExecControlOutcome, ExecOperationResult, ExecOutputEvent, exec_control_status_error,
+    ExecControlOutcome, ExecOperationResult, ExecOutputEvent, SupervisedExecStartTiming,
+    exec_control_status_error,
 };
 use super::{
     DEFAULT_EXEC_STREAM_CAPACITY, EXEC_OPERATION_CLOSE_ACTIVE_LOG_LIMIT, MAX_EXEC_STREAM_CAPACITY,
@@ -234,7 +236,14 @@ pub(in crate::exec_operation) struct ExecOperation {
 pub(in crate::exec_operation) enum ExecOperationLifecycle {
     OneShot,
     SupervisedAwaitingStart {
-        start_tx: Option<oneshot::Sender<io::Result<u32>>>,
+        start_tx: Option<oneshot::Sender<io::Result<(u32, SupervisedExecStartTiming)>>>,
+        role: ExecProcessRole,
+        control_nonce: Option<ExecControlNonce>,
+    },
+    SupervisedAwaitingAgentReady {
+        start_tx: Option<oneshot::Sender<io::Result<(u32, SupervisedExecStartTiming)>>>,
+        pid: u32,
+        shell_started_at: Instant,
         control_nonce: Option<ExecControlNonce>,
     },
     SupervisedStarted {
@@ -260,7 +269,8 @@ pub(in crate::exec_operation) enum ExecOperationNormalTracking {
 pub(in crate::exec_operation) struct TerminalExecOperation {
     pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
     pub(in crate::exec_operation) result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
-    pub(in crate::exec_operation) start_tx: Option<oneshot::Sender<io::Result<u32>>>,
+    pub(in crate::exec_operation) start_tx:
+        Option<oneshot::Sender<io::Result<(u32, SupervisedExecStartTiming)>>>,
     pub(in crate::exec_operation) log_lifecycle: ExecTerminalLogLifecycle,
     pub(in crate::exec_operation) stream_overflowed: bool,
     pub(in crate::exec_operation) host_cancel_requested: bool,
@@ -270,7 +280,9 @@ impl ExecOperation {
     pub(in crate::exec_operation) fn allows_output(&self) -> bool {
         matches!(
             self.lifecycle,
-            ExecOperationLifecycle::OneShot | ExecOperationLifecycle::SupervisedStarted { .. }
+            ExecOperationLifecycle::OneShot
+                | ExecOperationLifecycle::SupervisedAwaitingAgentReady { .. }
+                | ExecOperationLifecycle::SupervisedStarted { .. }
         )
     }
 
@@ -314,7 +326,8 @@ impl ExecOperation {
                 "exec control is not supported by this operation",
             )),
             ExecOperationLifecycle::OneShot
-            | ExecOperationLifecycle::SupervisedAwaitingStart { .. } => {
+            | ExecOperationLifecycle::SupervisedAwaitingStart { .. }
+            | ExecOperationLifecycle::SupervisedAwaitingAgentReady { .. } => {
                 Err(exec_control_status_error(
                     ExecControlStatus::Inactive,
                     "exec operation is not active",
@@ -335,7 +348,8 @@ impl ExecOperation {
         } = self;
         let log_lifecycle = exec_terminal_log_lifecycle(&lifecycle);
         let start_tx = match lifecycle {
-            ExecOperationLifecycle::SupervisedAwaitingStart { start_tx, .. } => start_tx,
+            ExecOperationLifecycle::SupervisedAwaitingStart { start_tx, .. }
+            | ExecOperationLifecycle::SupervisedAwaitingAgentReady { start_tx, .. } => start_tx,
             ExecOperationLifecycle::OneShot | ExecOperationLifecycle::SupervisedStarted { .. } => {
                 None
             }

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -11,7 +11,8 @@ use tracing::Level;
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 use vsock_proto::{
-    ExecCapturedOutput, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_RESULT, RawMessage,
+    ExecCapturedOutput, ExecProcessRole, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_RESULT,
+    RawMessage,
 };
 
 use crate::tests::support::read_guest_message;
@@ -662,6 +663,7 @@ fn exec_terminal_log_lifecycle_maps_supervised_states() {
     let (start_tx, _start_rx) = oneshot::channel();
     let awaiting_start = ExecOperationLifecycle::SupervisedAwaitingStart {
         start_tx: Some(start_tx),
+        role: ExecProcessRole::Workload,
         control_nonce: None,
     };
     let started = ExecOperationLifecycle::SupervisedStarted {

--- a/crates/vsock-host/src/exec_operation/types.rs
+++ b/crates/vsock-host/src/exec_operation/types.rs
@@ -1,10 +1,21 @@
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
-    ExecControlStatus, ExecOutputPolicy, ExecOutputStream, ExecProcessRole, ExecTermination,
-    ExecTimeoutPolicy,
+    ExecAgentReadyTiming, ExecControlStatus, ExecOutputPolicy, ExecOutputStream, ExecProcessRole,
+    ExecTermination, ExecTimeoutPolicy,
 };
+
+/// Host-observed shell and optional Agent-ready timing for a supervised start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SupervisedExecStartTiming {
+    /// Monotonic host instant when `MSG_EXEC_STARTED` was received.
+    pub shell_started_at: Instant,
+    /// Monotonic host instant when `MSG_EXEC_AGENT_READY` was received.
+    pub agent_ready_at: Option<Instant>,
+    /// Guest-reported component timing at Agent ready.
+    pub agent_ready: Option<ExecAgentReadyTiming>,
+}
 
 /// Owned terminal stdout or stderr representation selected by the requested
 /// [`ExecOutputPolicy`](vsock_proto::ExecOutputPolicy).

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -98,7 +98,7 @@ pub use exec_operation::{
     ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus, ExecControlHandle,
     ExecControlOutcome, ExecOperationHandle, ExecOperationRequest, ExecOperationResult,
     ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest, SupervisedExecCancelHandle,
-    SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest,
+    SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest, SupervisedExecStartTiming,
 };
 pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
 pub use guest_dns_readiness::GuestDnsReadinessResult;
@@ -354,7 +354,8 @@ impl VsockHost {
     /// Start a supervised exec operation and wait for its PID acknowledgement.
     ///
     /// `request.start_timeout` bounds both start-frame writing and waiting for
-    /// `MSG_EXEC_STARTED`. If it elapses after the complete start frame is
+    /// `MSG_EXEC_STARTED` for workloads or `MSG_EXEC_AGENT_READY` for Agents.
+    /// If it elapses after the complete start frame is
     /// written, the host sends `MSG_EXEC_CANCEL` before returning a timeout
     /// error. If the bounded cancel write also times out, the connection is
     /// poisoned. If the cancel write succeeds, the connection remains open but

--- a/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
@@ -8,8 +8,8 @@ use vsock_proto::{
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
-    read_guest_message, send_exec_output, send_exec_result, send_exec_started,
-    setup_host_and_guest,
+    read_guest_message, send_discarded_exec_result, send_exec_output, send_exec_result,
+    send_exec_started, setup_host_and_guest,
 };
 use super::super::start_capture_operation;
 use super::support::{
@@ -49,6 +49,106 @@ async fn supervised_exec_returns_handle_after_exec_started() {
         normal_operation_readiness(&started.host),
         NormalOperationReadiness::Idle
     );
+}
+
+#[tokio::test]
+async fn supervised_agent_waits_for_ready_after_started_and_accepts_output() {
+    let mut pending = start_pending_supervised_exec(SupervisedExecRequest {
+        role: vsock_proto::ExecProcessRole::Agent,
+        control: crate::SupervisedExecControl::Enabled { sink: true },
+        ..supervised_stream_request("agent-ready")
+    })
+    .await;
+    let start_seq = pending.start.seq();
+
+    pending.send_started(321).await;
+    pending.assert_waiting_for_agent_ready();
+    send_exec_output(
+        &mut pending.guest,
+        start_seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"bootstrap output",
+        false,
+    )
+    .await;
+    pending.assert_waiting_for_agent_ready();
+
+    pending.send_agent_ready().await;
+    let mut started = pending.wait_start_result().await;
+    let mut handle = started.start_result.unwrap();
+    assert_eq!(handle.pid(), 321);
+    let timing = handle.start_timing();
+    assert!(timing.agent_ready_at.unwrap() >= timing.shell_started_at);
+    assert_eq!(
+        timing.agent_ready.unwrap(),
+        vsock_proto::ExecAgentReadyTiming {
+            containment_create_us: 1,
+            placement_broker_setup_us: 2,
+            shell_spawn_us: 3,
+            bootstrap_ready_wait_us: 4,
+        }
+    );
+    let event = handle.take_stream_receiver().unwrap().recv().await.unwrap();
+    assert_eq!(event.chunk, b"bootstrap output");
+
+    send_discarded_exec_result(
+        &mut started.guest,
+        start_seq,
+        ExecTermination::Exited { exit_code: 0 },
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn supervised_agent_terminal_before_ready_fails_start_and_releases_operation() {
+    let mut pending = start_pending_supervised_exec(SupervisedExecRequest {
+        role: vsock_proto::ExecProcessRole::Agent,
+        control: crate::SupervisedExecControl::Enabled { sink: true },
+        ..supervised_request("agent-exits-before-ready")
+    })
+    .await;
+    let start_seq = pending.start.seq();
+
+    pending.send_started(322).await;
+    pending.assert_waiting_for_agent_ready();
+    send_exec_result(
+        &mut pending.guest,
+        start_seq,
+        ExecTermination::Exited { exit_code: 7 },
+        b"",
+        b"bootstrap failed",
+    )
+    .await;
+
+    let finished = pending.wait_start_result().await;
+    let error = match finished.start_result {
+        Ok(_) => panic!("Agent start must fail when the child exits before readiness"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert_eq!(error.to_string(), "bootstrap failed");
+    assert_eq!(operation_count(&finished.host), 0);
+}
+
+#[tokio::test]
+async fn supervised_workload_rejects_agent_ready() {
+    let mut pending = start_pending_supervised_exec(supervised_request("workload-ready")).await;
+    let start_seq = pending.start.seq();
+
+    pending.send_started(323).await;
+    let mut started = pending.wait_start_result().await;
+    let handle = started.start_result.unwrap();
+    super::super::super::support::send_exec_agent_ready(&mut started.guest, start_seq).await;
+
+    started
+        .host
+        .wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    let error = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
@@ -12,7 +12,8 @@ use vsock_proto::{
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
-    read_guest_message, send_exec_result, send_exec_started, setup_host_and_guest,
+    read_guest_message, send_exec_agent_ready, send_exec_result, send_exec_started,
+    setup_host_and_guest,
 };
 use crate::operation_tracker::NormalOperationReadiness;
 use crate::{
@@ -88,6 +89,21 @@ impl PendingSupervisedExec {
         );
     }
 
+    pub(super) fn assert_waiting_for_agent_ready(&self) {
+        assert!(
+            !self.task.is_finished(),
+            "Agent supervised start must wait for exec_agent_ready"
+        );
+    }
+
+    pub(super) async fn send_started(&mut self, pid: u32) {
+        send_exec_started(&mut self.guest, self.start.seq(), pid).await;
+    }
+
+    pub(super) async fn send_agent_ready(&mut self) {
+        send_exec_agent_ready(&mut self.guest, self.start.seq()).await;
+    }
+
     pub(super) async fn wait_start_result(self) -> PendingSupervisedExecResult {
         let result = self.task.await.unwrap();
         PendingSupervisedExecResult {
@@ -103,6 +119,13 @@ impl PendingSupervisedExec {
 
     pub(super) async fn started_with_pid(mut self, pid: u32) -> StartedSupervisedExec {
         send_exec_started(&mut self.guest, self.start.seq(), pid).await;
+        if vsock_proto::decode_exec_start(&self.start.msg.payload)
+            .unwrap()
+            .role
+            == vsock_proto::ExecProcessRole::Agent
+        {
+            send_exec_agent_ready(&mut self.guest, self.start.seq()).await;
+        }
         let handle = self.task.await.unwrap().unwrap();
         StartedSupervisedExec {
             host: self.host,

--- a/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
@@ -14,11 +14,12 @@ use super::super::super::support::{
     setup_host_and_guest, wait_for_operation_count,
 };
 use super::support::supervised_request;
-use crate::SupervisedExecRequest;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
+use crate::{SupervisedExecControl, SupervisedExecRequest};
 
 const START_ACK_TEST_TIMEOUT: Duration = Duration::from_millis(50);
+const AGENT_READY_TEST_TIMEOUT: Duration = Duration::from_millis(200);
 
 #[tokio::test]
 async fn supervised_exec_terminal_wait_timeout_does_not_send_cancel() {
@@ -77,6 +78,44 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
         Ok(n) => panic!("start timeout must send exactly one exec cancel; read {n} extra bytes"),
         Err(err) => panic!("unexpected read error after start timeout: {err}"),
     }
+}
+
+#[tokio::test]
+async fn supervised_agent_ready_timeout_after_started_sends_cancel() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                role: vsock_proto::ExecProcessRole::Agent,
+                control: SupervisedExecControl::Enabled { sink: true },
+                start_timeout: AGENT_READY_TEST_TIMEOUT,
+                ..supervised_request("agent-ready-timeout")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    send_exec_started(&mut guest, start.seq, 123).await;
+    tokio::task::yield_now().await;
+    assert!(!task.is_finished());
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("Agent-ready wait should respect the start deadline")
+        .unwrap();
+    let err = match result {
+        Ok(_) => panic!("Agent start should time out before exec_agent_ready"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(operation_count(&host), 0);
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
 }
 
 #[tokio::test]
@@ -414,4 +453,40 @@ async fn supervised_exec_start_wait_cancellation_sends_cancel() {
         }
         Err(err) => panic!("unexpected read error after cancelled start wait: {err}"),
     }
+}
+
+#[tokio::test]
+async fn supervised_agent_start_wait_cancellation_after_started_sends_cancel() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                role: vsock_proto::ExecProcessRole::Agent,
+                control: SupervisedExecControl::Enabled { sink: true },
+                ..supervised_request("cancel-agent-ready-wait")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    send_exec_started(&mut guest, start.seq, 123).await;
+    tokio::task::yield_now().await;
+    assert!(!task.is_finished());
+
+    task.abort();
+    let err = match task.await {
+        Ok(_) => panic!("cancelled Agent-ready wait task should abort"),
+        Err(err) => err,
+    };
+    assert!(err.is_cancelled());
+    assert_eq!(operation_count(&host), 0);
+    let cancel = tokio::time::timeout(Duration::from_secs(5), read_guest_message(&mut guest))
+        .await
+        .expect("cancelled Agent-ready wait should send exec cancel");
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
 }

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -7,14 +7,14 @@ use tokio::net::UnixStream;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use vsock_proto::{
-    ExecCapturedOutput, ExecControlNonce, ExecControlStatus, ExecOutputStream, ExecTermination,
-    HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
-    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_MEMORY_SNAPSHOT,
-    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING,
-    MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
-    MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
-    MSG_WRITE_FILES_RESULT, RawMessage,
+    ExecAgentReadyTiming, ExecCapturedOutput, ExecControlNonce, ExecControlStatus,
+    ExecOutputStream, ExecTermination, HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR,
+    MSG_EXEC_AGENT_READY, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT,
+    MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, MSG_GUEST_DNS_READINESS,
+    MSG_GUEST_DNS_READINESS_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, RawMessage,
 };
 
 use crate::operation_tracker::NormalOperationReadiness;
@@ -155,6 +155,7 @@ fn message_type_name(msg_type: u8) -> &'static str {
         MSG_WRITE_FILES_RESULT => "write_files_result",
         MSG_EXEC_START => "exec_start",
         MSG_EXEC_STARTED => "exec_started",
+        MSG_EXEC_AGENT_READY => "exec_agent_ready",
         MSG_EXEC_OUTPUT => "exec_output",
         MSG_EXEC_RESULT => "exec_result",
         MSG_EXEC_CANCEL => "exec_cancel",
@@ -393,6 +394,17 @@ pub(crate) async fn send_exec_result(
 pub(crate) async fn send_exec_started(stream: &mut UnixStream, seq: u32, pid: u32) {
     let payload = vsock_proto::encode_exec_started(pid).unwrap();
     let frame = vsock_proto::encode(MSG_EXEC_STARTED, seq, &payload).unwrap();
+    stream.write_all(&frame).await.unwrap();
+}
+
+pub(crate) async fn send_exec_agent_ready(stream: &mut UnixStream, seq: u32) {
+    let payload = vsock_proto::encode_exec_agent_ready(ExecAgentReadyTiming {
+        containment_create_us: 1,
+        placement_broker_setup_us: 2,
+        shell_spawn_us: 3,
+        bootstrap_ready_wait_us: 4,
+    });
+    let frame = vsock_proto::encode(MSG_EXEC_AGENT_READY, seq, &payload).unwrap();
     stream.write_all(&frame).await.unwrap();
 }
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types currently occupy the contiguous range `0x00..=0x1B`
+//! Non-error message types currently occupy the contiguous range `0x00..=0x1C`
 //! in allocation order. Existing values are stable wire assignments: do not
 //! renumber or reuse them. Allocate new non-error messages at the next unused
 //! value below `0xFF`, even when related operations are not adjacent. `0xFF` is
@@ -57,6 +57,7 @@
 //! | 0x19 | G→H       | guest_storage_manifest_result | same payload as `exec_result`, with both streams captured and bounded to 1 MiB each |
 //! | 0x1A | H→G       | guest_state_restore | `[4B positive timeout_ms][8B unix_seconds][4B unix_nanoseconds][1B timezone_mode][2B timezone_len][timezone][256B entropy]` |
 //! | 0x1B | G→H       | guest_state_restore_result | same payload as `exec_result`, with empty stdout and stderr bounded to 64 KiB |
+//! | 0x1C | G→H       | exec_agent_ready | `[4B containment_create_us][4B placement_broker_setup_us][4B shell_spawn_us][4B bootstrap_ready_wait_us]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
@@ -204,15 +205,16 @@ pub use payloads::error::{decode_error, encode_error};
 pub use payloads::exec_operation::{
     DecodedExecControl, DecodedExecControlResult, DecodedExecOutput, DecodedExecResult,
     DecodedExecStart, DecodedExecStarted, EXEC_CONTROL_MAX_PAYLOAD_BYTES, EXEC_CONTROL_NONCE_LEN,
-    ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecControlStatus,
-    ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecProcessRole,
+    ExecAgentReadyTiming, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy,
+    ExecControlStatus, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream, ExecProcessRole,
     ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES,
-    decode_exec_cancel, decode_exec_control, decode_exec_control_result, decode_exec_output,
-    decode_exec_result, decode_exec_start, decode_exec_started, encode_exec_cancel,
-    encode_exec_control, encode_exec_control_frame_into, encode_exec_control_result,
-    encode_exec_output, encode_exec_output_frame_into, encode_exec_result,
-    encode_exec_result_frame_into, encode_exec_start, encode_exec_start_with_expected_exit_codes,
-    encode_exec_started, validate_exec_control, validate_exec_process_contract,
+    decode_exec_agent_ready, decode_exec_cancel, decode_exec_control, decode_exec_control_result,
+    decode_exec_output, decode_exec_result, decode_exec_start, decode_exec_started,
+    encode_exec_agent_ready, encode_exec_cancel, encode_exec_control,
+    encode_exec_control_frame_into, encode_exec_control_result, encode_exec_output,
+    encode_exec_output_frame_into, encode_exec_result, encode_exec_result_frame_into,
+    encode_exec_start, encode_exec_start_with_expected_exit_codes, encode_exec_started,
+    validate_exec_control, validate_exec_process_contract,
 };
 pub use payloads::guest_dns_readiness::{
     DecodedGuestDnsReadinessRequest, DecodedGuestDnsReadinessResult,
@@ -249,13 +251,13 @@ pub use payloads::write_file::{
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
-    MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
-    MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT, MSG_GUEST_STATE_RESTORE,
-    MSG_GUEST_STATE_RESTORE_RESULT, MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT,
-    MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY,
-    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
-    MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
-    WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
+    MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_AGENT_READY, MSG_EXEC_CANCEL,
+    MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START,
+    MSG_EXEC_STARTED, MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT,
+    MSG_GUEST_STATE_RESTORE, MSG_GUEST_STATE_RESTORE_RESULT, MSG_GUEST_STORAGE_MANIFEST,
+    MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
+    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT,
+    WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -1,3 +1,4 @@
+mod agent_ready;
 mod control;
 mod output;
 mod result;
@@ -6,6 +7,7 @@ mod started_cancel;
 
 pub use super::process_termination::ExecTermination;
 
+pub use agent_ready::{ExecAgentReadyTiming, decode_exec_agent_ready, encode_exec_agent_ready};
 pub use control::{
     DecodedExecControl, DecodedExecControlResult, EXEC_CONTROL_MAX_PAYLOAD_BYTES,
     EXEC_CONTROL_NONCE_LEN, ExecControlNonce, ExecControlStatus, decode_exec_control,

--- a/crates/vsock-proto/src/payloads/exec_operation/agent_ready.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/agent_ready.rs
@@ -1,0 +1,57 @@
+use crate::error::ProtocolError;
+use crate::read::{expect_consumed, read_u32};
+
+/// Guest-reported component timing at the Agent-ready boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecAgentReadyTiming {
+    /// Time spent creating the per-exec process-containment hierarchy.
+    pub containment_create_us: u32,
+    /// Time spent creating the workload and tool placement brokers.
+    pub placement_broker_setup_us: u32,
+    /// Time spent spawning the supervised shell child.
+    pub shell_spawn_us: u32,
+    /// Time from shell spawn through confirmed runtime-descriptor adoption.
+    pub bootstrap_ready_wait_us: u32,
+}
+
+/// Encode the fixed-width Agent-ready timing payload.
+pub fn encode_exec_agent_ready(timing: ExecAgentReadyTiming) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(16);
+    payload.extend_from_slice(&timing.containment_create_us.to_be_bytes());
+    payload.extend_from_slice(&timing.placement_broker_setup_us.to_be_bytes());
+    payload.extend_from_slice(&timing.shell_spawn_us.to_be_bytes());
+    payload.extend_from_slice(&timing.bootstrap_ready_wait_us.to_be_bytes());
+    payload
+}
+
+/// Decode the fixed-width Agent-ready timing payload.
+pub fn decode_exec_agent_ready(payload: &[u8]) -> Result<ExecAgentReadyTiming, ProtocolError> {
+    let mut offset = 0;
+    let containment_create_us = read_u32(
+        payload,
+        &mut offset,
+        "exec agent ready containment timing truncated",
+    )?;
+    let placement_broker_setup_us = read_u32(
+        payload,
+        &mut offset,
+        "exec agent ready broker timing truncated",
+    )?;
+    let shell_spawn_us = read_u32(
+        payload,
+        &mut offset,
+        "exec agent ready shell timing truncated",
+    )?;
+    let bootstrap_ready_wait_us = read_u32(
+        payload,
+        &mut offset,
+        "exec agent ready bootstrap timing truncated",
+    )?;
+    expect_consumed(payload, offset, "exec agent ready trailing bytes")?;
+    Ok(ExecAgentReadyTiming {
+        containment_create_us,
+        placement_broker_setup_us,
+        shell_spawn_us,
+        bootstrap_ready_wait_us,
+    })
+}

--- a/crates/vsock-proto/src/payloads/exec_operation/tests.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests.rs
@@ -1,3 +1,4 @@
+mod exec_agent_ready;
 mod exec_control;
 mod exec_control_result;
 mod exec_output;

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_agent_ready.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_agent_ready.rs
@@ -1,0 +1,42 @@
+use super::super::*;
+
+#[test]
+fn exec_agent_ready_round_trips_fixed_component_timing() {
+    let timing = ExecAgentReadyTiming {
+        containment_create_us: 1,
+        placement_broker_setup_us: 2,
+        shell_spawn_us: 3,
+        bootstrap_ready_wait_us: 4,
+    };
+
+    let payload = encode_exec_agent_ready(timing);
+
+    assert_eq!(payload.len(), 16);
+    assert_eq!(decode_exec_agent_ready(&payload).unwrap(), timing);
+}
+
+#[test]
+fn exec_agent_ready_rejects_truncated_and_trailing_payloads() {
+    let timing = ExecAgentReadyTiming {
+        containment_create_us: 1,
+        placement_broker_setup_us: 2,
+        shell_spawn_us: 3,
+        bootstrap_ready_wait_us: 4,
+    };
+    let payload = encode_exec_agent_ready(timing);
+
+    assert!(matches!(
+        decode_exec_agent_ready(&payload[..15]),
+        Err(ProtocolError::InvalidPayload(
+            "exec agent ready bootstrap timing truncated"
+        ))
+    ));
+    let mut trailing = payload;
+    trailing.push(0);
+    assert!(matches!(
+        decode_exec_agent_ready(&trailing),
+        Err(ProtocolError::InvalidPayload(
+            "exec agent ready trailing bytes"
+        ))
+    ));
+}

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -101,6 +101,9 @@ pub const MSG_GUEST_STATE_RESTORE: u8 = 0x1A;
 /// Guest-to-host result of restoring snapshot-sensitive guest state.
 pub const MSG_GUEST_STATE_RESTORE_RESULT: u8 = 0x1B;
 
+/// Guest-to-host acknowledgement that an Agent adopted runtime placement.
+pub const MSG_EXEC_AGENT_READY: u8 = 0x1C;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -182,6 +185,7 @@ mod tests {
                 MSG_GUEST_STATE_RESTORE_RESULT,
                 0x1B,
             ),
+            ("MSG_EXEC_AGENT_READY", MSG_EXEC_AGENT_READY, 0x1C),
             ("MSG_ERROR", MSG_ERROR, 0xFF),
         ];
 

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -85,13 +85,14 @@ not available through generic exec APIs.
 
 ## Agent Start Timing
 
-`runner_agent_start_process`, `runner_executor_start_to_spawn`, and
-`runner_claim_to_spawn` retain their historical shell-spawn boundary. Agent
-readiness is recorded separately by `runner_agent_start_to_ready`,
-`runner_executor_start_to_agent_ready`, `runner_claim_to_agent_ready`, and
-`api_to_agent_ready`.
-Bounded component series record containment creation, placement-broker setup,
-shell spawn, and bootstrap-ready wait. Fresh pre-spawn admission remains held
+`runner_agent_start_process`, `runner_executor_start_to_spawn`,
+`runner_claim_to_spawn`, and `api_to_spawn` retain their historical shell-spawn
+boundary. Agent readiness is recorded separately by
+`runner_agent_start_to_ready`, `runner_executor_start_to_agent_ready`,
+`runner_claim_to_agent_ready`, and `api_to_agent_ready`. The bounded component
+series are `runner_agent_containment_create`,
+`runner_agent_placement_broker_setup`, `runner_agent_shell_spawn`, and
+`runner_agent_bootstrap_ready_wait`. Fresh pre-spawn admission remains held
 until the ready event rather than shell creation.
 
 The production-path benchmark lives in

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -28,9 +28,9 @@ bounded-helper placement, or an arbitrary containment policy.
 | `guest-reseed --restore-state` | Bounded setup helper selected only by the typed guest-state handler | Typed time, entropy, and timezone request with a deadline | Guest root in an owned process group | Single-active restore worker, operation guard, kill, and reap | Required state preparation; serial before Agent start |
 | `guest-write-file` single, batch, and private variants | Bounded setup helper selected only by typed file handlers | Typed path/content request with handler validation and deadline | Guest root in an owned process group | File worker, operation guard, kill, and reap | Required when its prepared input exists; serial before Agent start |
 | Generic one-shot shell operations, including mount, timezone, cleanup, and verification fallbacks | Contained workload selected by `Sandbox::exec` | Caller command and environment are untrusted workload input | Per-operation `workload` cgroup with the standard CPU, memory, PID, and OOM policy | Exec worker and `ExecProcessContainment`; terminal result or forced cleanup removes descendants and hierarchy | Required or optional by caller; serial when part of preparation |
-| `guest-download --manifest-stdin` | Contained workload selected only by the typed storage-manifest handler | User-influenced manifest, download, extraction, cache, and filesystem work | Per-operation `workload` cgroup with the standard workload policy | Storage worker, operation guard, output drains, and containment cleanup | Required when storage preparation is requested; serial, with deferred background fill allowed only after Agent spawn |
+| `guest-download --manifest-stdin` | Contained workload selected only by the typed storage-manifest handler | User-influenced manifest, download, extraction, cache, and filesystem work | Per-operation `workload` cgroup with the standard workload policy | Storage worker, operation guard, output drains, and containment cleanup | Required when storage preparation is requested; serial, with deferred background fill allowed only after Agent readiness |
 | Codex model-catalog prefetch | Contained workload selected by ordinary `Sandbox::start_process` | Fixed prefetch shell, but network response and process execution remain workload data | Per-operation `workload` cgroup; no Agent control or placement capability | Prefetch task owns process wait/cancel; guest exec worker owns containment cleanup | Optional and deferrable; may run concurrently with later preparation and Agent start |
-| Agent wrapper shell and Guest Agent | Controlled Agent selected only by `Sandbox::start_agent_process` | Runner constructs the command/environment; the Agent subsequently handles user-controlled work | Per-operation `control` cgroup; the outer containment owns the standard workload resource hierarchy | Runner owns the typed process handle and mandatory control capability; guest control registry, placement brokers, exec worker, and containment own guest cleanup | Required final pre-spawn operation; its current `exec_started` acknowledgement remains the shell-spawn boundary |
+| Agent wrapper shell and Guest Agent | Controlled Agent selected only by `Sandbox::start_agent_process` | Runner constructs the command/environment; the Agent subsequently handles user-controlled work | Per-operation `control` cgroup; the outer containment owns the standard workload resource hierarchy | Runner owns the typed process handle, readiness timing, and mandatory control capability; guest control registry, placement brokers, exec worker, and containment own guest cleanup | Required final pre-spawn operation; `exec_started` records shell spawn and `exec_agent_ready` completes the typed Agent start |
 | Agent CLI or Codex app server | Controlled Agent child selected by the Guest Agent's typed CLI startup path | Framework-specific Agent input and user session data | `workload/runtime`, entered through an authenticated pre-exec placement descriptor | Guest Agent CLI owner plus outer Agent containment | Required after wrapper startup; serial with CLI launch, then concurrent with supervision |
 | `guest-tool-exec` and its requested shell command | Controlled Agent child selected by the managed tool envelope | Tool request and shell command are user/Agent influenced | A unique `workload/tools/tool-N` leaf obtained from the authenticated placement broker | Tool wrapper/process group plus tool-placement broker and outer Agent containment | Optional, concurrent after Agent readiness, and independently completed |
 
@@ -59,17 +59,21 @@ control and placement brokers; its presence is validated against the role but
 does not select containment.
 
 The wrapper and Guest Agent remain in `control`. The Guest Agent authenticates
-to the workload placement endpoint, receives the runtime `cgroup.procs`
-descriptor, and places the CLI in `runtime` immediately before exec. Each
-managed tool authenticates separately and receives a fresh `tool-N`
-descriptor. Controlled processes deny process inspection across the boundary.
+to the workload placement endpoint, receives and adopts the runtime
+`cgroup.procs` descriptor, and confirms adoption. The broker revalidates the
+same UID and current `control` membership before emitting Agent readiness. The
+Guest Agent places the CLI in `runtime` immediately before exec. Each managed
+tool authenticates separately and receives a fresh `tool-N` descriptor.
+Controlled processes deny process inspection across the boundary.
 
 ## Ownership and Reuse
 
-All fixed helpers and workload operations hold operation guards. Reuse first
-fences new operations, waits for active ownership to reach zero, and verifies
-that the `vm0-exec` hierarchy is empty before parking. A terminal result does
-not replace descendant cleanup: the operation's containment owner remains
+All fixed helpers and workload operations hold operation guards. Agent
+readiness keeps the exec operation, placement brokers, and containment owner
+active, so reuse cannot quiesce or park during bootstrap. Reuse first fences
+new operations, waits for active ownership to reach zero, and verifies that
+the `vm0-exec` hierarchy is empty before parking. A terminal result does not
+replace descendant cleanup: the operation's containment owner remains
 responsible for graceful or forced cleanup and hierarchy removal.
 
 Storage remains contained even though it has a typed entry point because its
@@ -79,6 +83,22 @@ typed handlers select fixed programs, validate bounded inputs, enforce
 single-active admission and deadlines, and own kill/reap. That authority is
 not available through generic exec APIs.
 
-This contract intentionally preserves the existing shell-spawn timing
-boundary. A distinct Guest Agent ready acknowledgement and the corresponding
-metric correction belong to #29643.
+## Agent Start Timing
+
+`runner_agent_start_process`, `runner_executor_start_to_spawn`, and
+`runner_claim_to_spawn` retain their historical shell-spawn boundary. Agent
+readiness is recorded separately by `runner_agent_start_to_ready`,
+`runner_executor_start_to_agent_ready`, `runner_claim_to_agent_ready`, and
+`api_to_agent_ready`.
+Bounded component series record containment creation, placement-broker setup,
+shell spawn, and bootstrap-ready wait. Fresh pre-spawn admission remains held
+until the ready event rather than shell creation.
+
+The production-path benchmark lives in
+`.github/scripts/runner-behavior-process-containment.sh`. It submits the
+deterministic mock CLI through the same-metal runner and Guest Agent path, then
+measures fresh sandbox, workspace-cache reuse, and exact sandbox reuse samples
+under one service profile. Set `AGENT_READY_BENCHMARK_SAMPLES` to choose the
+sample count; the script retains bounded raw JSONL evidence and reports the
+sample count, failures, and p50/p90/p95/p99 for the shell, ready, and component
+timings.


### PR DESCRIPTION
## Summary

- Make the typed Guest Agent start boundary wait for authenticated workload-placement readiness instead of treating supervised shell creation as Agent readiness.
- Preserve ordinary workload shell-start semantics and the historical shell-spawn metric while adding an explicit Agent-ready boundary, component timings, and aggregate telemetry.
- Extend the same-metal production-path behavior harness to report bounded fresh, workspace-cache, and exact-reuse readiness samples.

## Problem

`sandbox.start_agent_process(...)` previously completed when `vsock-guest` spawned the supervised shell. The shell was expected to `exec` Guest Agent, but this acknowledgement did not prove Guest Agent bootstrap succeeded or that the authenticated Agent received its `workload/runtime` placement descriptor. Runner admission and startup telemetry therefore used a boundary earlier than the capability the caller actually required.

## Solution

- Add a workload-placement confirmation after the broker validates the expected UID and current control-cgroup membership and transfers the runtime descriptor.
- Add an Agent-only `MSG_EXEC_AGENT_READY` event with bounded component timings. Host-side Agent starts now require `started -> agent ready`; ordinary Workload starts still complete at `started`.
- Start output drains before the readiness wait and route early terminal, timeout, cancellation, disconnect, and bootstrap failures through authoritative cleanup.
- Expose provider-neutral Agent startup timing through `sandbox`, `sandbox-fc`, and `sandbox-mock`.
- Record shell-spawn and Agent-ready aggregates separately so the existing metric retains its meaning, and hold pre-spawn admission until Agent ready.
- Add protocol, guest, host, sandbox, Runner, cleanup, ordering, telemetry, and benchmark-harness coverage.

## Scope exclusions

- No API, queue, database, persisted-state, billing, firewall, or user-visible configuration changes.
- No timezone, private-write, workspace-mount, storage, session-lifecycle, or latency optimization changes.
- No broad `VM0_API_BACKEND_URL` compatibility-alias removal; that remains part of the staged migration tracked by #28914.

## Risks

- The stricter boundary can surface real Agent bootstrap failures and add the bootstrap wait to admission duration; both are now explicit rather than hidden after a successful shell-start response.
- Runner and Guest Agent must ship the new wire event together. The protocol deliberately has no fallback because these artifacts are released atomically.
- The behavior lane performs additional production-path samples inside its existing five-minute job budget; CI must confirm the lane remains bounded.
- This branch was rebased after #29729 merged. The combined `RunningExec::finish` path retains #29729's incomplete-drain truncation semantics alongside Agent readiness failure diagnostics and cleanup; the overlap received a focused full-package regression run.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cd crates && env -u OKOU_API_BACKEND_URL -u VM0_API_BACKEND_URL cargo test --workspace --all-targets --all-features --quiet`
- After rebasing over #29729: `cd crates && cargo clippy -p vsock-guest --all-targets --all-features`
- After rebasing over #29729: `cd crates && env -u OKOU_API_BACKEND_URL -u VM0_API_BACKEND_URL cargo test -p vsock-guest --all-targets --all-features --quiet`
- `cd crates && cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `git diff --check origin/main...HEAD`

Closes #29643

Parent: #29631

Related: #29729, #28914
