### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,8 +113,8 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.0"
-CLAUDE_CODE_VERSION="2.1.246"
-CODEX_CLI_VERSION="0.149.1"
+CLAUDE_CODE_VERSION="2.1.247"
+CODEX_CLI_VERSION="0.150.1"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.246` to `2.1.247`.
- Update Codex CLI from `0.149.1` to `0.150.1`.

The pinned Go, Google Workspace CLI, xurl, agent-browser, pnpm, and Chromium versions remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Confirmed Claude Code 2.1.247 standalone binaries and manifest are available for linux-x64 and linux-arm64.
- Confirmed Codex CLI 0.150.1 is published and supports the Node.js 24 LTS runtime.