### PR TITLE
perf(platform): trim eager clerk localization and posthog code

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserOptions } from "@sentry/browser";
-import type { PostHogConfig } from "posthog-js";
+import type { PostHogConfig } from "posthog-js/dist/module.slim";
 import { isOkouProductionHostname } from "../lib/platform-host.ts";
 import { sentryLogContext } from "../lib/sentry-config.ts";
 import { initSharedDatabaseWorkerSentry } from "../shared-database/worker-sentry.ts";
@@ -34,7 +34,7 @@ const {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return {
     posthog: {
       capture: vi.fn(),

--- a/turbo/apps/platform/src/i18n/clerk-localization.ts
+++ b/turbo/apps/platform/src/i18n/clerk-localization.ts
@@ -1,0 +1,158 @@
+import { enUS } from "@clerk/localizations/en-US";
+import { command, computed, state } from "ccstate";
+import deDEUrl from "./clerk-localizations/de-DE.json?url";
+import esESUrl from "./clerk-localizations/es-ES.json?url";
+import frFRUrl from "./clerk-localizations/fr-FR.json?url";
+import hiINUrl from "./clerk-localizations/hi-IN.json?url";
+import idIDUrl from "./clerk-localizations/id-ID.json?url";
+import itITUrl from "./clerk-localizations/it-IT.json?url";
+import jaJPUrl from "./clerk-localizations/ja-JP.json?url";
+import koKRUrl from "./clerk-localizations/ko-KR.json?url";
+import ptBRUrl from "./clerk-localizations/pt-BR.json?url";
+import { logger } from "../signals/log.ts";
+import { tapError } from "../signals/utils.ts";
+import { DEFAULT_LOCALE, type SupportedLocale } from "./resources.ts";
+
+export type ClerkLocalization = typeof enUS;
+export type ClerkLocalizationCache = ReadonlyMap<
+  SupportedLocale,
+  ClerkLocalization
+>;
+type NonDefaultLocale = Exclude<SupportedLocale, typeof DEFAULT_LOCALE>;
+
+const L = logger("ClerkLocalization");
+const internalClerkLocalizations$ = state<ClerkLocalizationCache>(
+  new Map([[DEFAULT_LOCALE, enUS]]),
+);
+
+export const clerkLocalizations$ = computed((get) => {
+  return get(internalClerkLocalizations$);
+});
+
+function clerkLocalizationUrl(locale: NonDefaultLocale): string {
+  switch (locale) {
+    case "pt-BR": {
+      return ptBRUrl;
+    }
+    case "ja-JP": {
+      return jaJPUrl;
+    }
+    case "ko-KR": {
+      return koKRUrl;
+    }
+    case "id-ID": {
+      return idIDUrl;
+    }
+    case "de-DE": {
+      return deDEUrl;
+    }
+    case "es-ES": {
+      return esESUrl;
+    }
+    case "it-IT": {
+      return itITUrl;
+    }
+    case "fr-FR": {
+      return frFRUrl;
+    }
+    case "hi-IN": {
+      return hiINUrl;
+    }
+  }
+}
+
+function isClerkLocalizationValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(isClerkLocalizationValue);
+}
+
+function isClerkLocalization(
+  value: unknown,
+  locale: NonDefaultLocale,
+): value is ClerkLocalization {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    "locale" in value &&
+    value.locale === locale &&
+    Object.values(value).every(isClerkLocalizationValue)
+  );
+}
+
+async function fetchClerkLocalization(
+  locale: NonDefaultLocale,
+  signal?: AbortSignal,
+): Promise<ClerkLocalization> {
+  const response = await fetch(
+    new URL(clerkLocalizationUrl(locale), location.href),
+    { signal },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load ${locale} Clerk localization (HTTP ${response.status})`,
+    );
+  }
+  const localization: unknown = JSON.parse(await response.text());
+  signal?.throwIfAborted();
+  if (!isClerkLocalization(localization, locale)) {
+    throw new Error(`Invalid ${locale} Clerk localization`);
+  }
+  return localization;
+}
+
+export const loadClerkLocalization$ = command(
+  async (
+    { get },
+    locale: SupportedLocale,
+    signal: AbortSignal,
+  ): Promise<ClerkLocalization | undefined> => {
+    signal.throwIfAborted();
+    if (locale === DEFAULT_LOCALE) {
+      return enUS;
+    }
+    const loaded = get(internalClerkLocalizations$).get(locale);
+    if (loaded) {
+      return loaded;
+    }
+
+    const localization = await tapError(
+      fetchClerkLocalization(locale, signal),
+      (error) => {
+        L.error(
+          `Failed to load ${locale} Clerk localization; falling back to ${DEFAULT_LOCALE}`,
+          error,
+        );
+      },
+    );
+    signal.throwIfAborted();
+    return localization;
+  },
+);
+
+export const cacheClerkLocalization$ = command(
+  (
+    { get, set },
+    locale: SupportedLocale,
+    localization: ClerkLocalization | undefined,
+  ) => {
+    if (!localization || get(internalClerkLocalizations$).has(locale)) {
+      return;
+    }
+    const next = new Map(get(internalClerkLocalizations$));
+    next.set(locale, localization);
+    set(internalClerkLocalizations$, next);
+  },
+);
+
+export function clerkLocalizationForLocale(
+  localizations: ClerkLocalizationCache,
+  locale: SupportedLocale,
+): ClerkLocalization {
+  return localizations.get(locale) ?? enUS;
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/de-DE.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/de-DE.json
@@ -1,0 +1,1446 @@
+{
+  "locale": "de-DE",
+  "apiKeys": {
+    "action__add": "Neuen API-Key hinzufügen",
+    "action__search": "Suche",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Kopieren und schließen",
+      "formHint": "Aus Sicherheitsgründen können Sie es später nicht mehr einsehen.",
+      "formTitle": "Kopieren Sie jetzt Ihren API-Key \"{{name}}\""
+    },
+    "createdAndExpirationStatus__expiresOn": "Erstellt {{ createdDate | shortDate('de-DE') }} • Läuft ab {{ expiresDate | longDate('de-DE') }}",
+    "createdAndExpirationStatus__never": "Erstellt {{ createdDate | shortDate('de-DE') }} • Läuft nie ab",
+    "detailsTitle__emptyRow": "Keine API-Keys gefunden",
+    "formButtonPrimary__add": "API-Key erstellen",
+    "formFieldCaption__expiration__expiresOn": "Läuft ab {{ date }}",
+    "formFieldCaption__expiration__never": "Dieser Key wird nie ablaufen",
+    "formFieldOption__expiration__180d": "180 Tage",
+    "formFieldOption__expiration__1d": "1 Tag",
+    "formFieldOption__expiration__1y": "1 Jahr",
+    "formFieldOption__expiration__30d": "30 Tage",
+    "formFieldOption__expiration__60d": "60 Tage",
+    "formFieldOption__expiration__7d": "7 Tage",
+    "formFieldOption__expiration__90d": "90 Tage",
+    "formFieldOption__expiration__never": "Niemals",
+    "formHint": "Geben Sie einen Namen an, um einen API-Key zu erstellen. Sie können ihn jederzeit widerrufen.",
+    "formTitle": "Neuen API-Key hinzufügen",
+    "lastUsed__days": "vor {{days}} Tagen",
+    "lastUsed__hours": "vor {{hours}} Stunden",
+    "lastUsed__minutes": "vor {{minutes}} Minuten",
+    "lastUsed__months": "vor {{months}} Monaten",
+    "lastUsed__seconds": "vor {{seconds}} Sekunden",
+    "lastUsed__years": "vor {{years}} Jahren",
+    "menuAction__revoke": "API-Key widerrufen",
+    "revokeConfirmation": {
+      "confirmationText": "Widerrufen",
+      "formButtonPrimary__revoke": "API-Key widerrufen",
+      "formHint": "Sind Sie sicher, dass Sie diesen API-Key löschen wollen?",
+      "formTitle": "API-Key \"{{apiKeyName}}\" widerrufen?"
+    }
+  },
+  "backButton": "Zurück",
+  "badge__activePlan": "Aktiv",
+  "badge__canceledEndsAt": "Storniert • Endet am {{ date | shortDate('de-DE') }}",
+  "badge__currentPlan": "Aktueller Plan",
+  "badge__default": "Standard",
+  "badge__endsAt": "Endet am {{ date | shortDate('de-DE') }}",
+  "badge__expired": "Abgelaufen",
+  "badge__freeTrial": "Kostenlose Testversion",
+  "badge__otherImpersonatorDevice": "Anderes Imitationsgerät",
+  "badge__pastDueAt": "Überfällig {{ date | shortDate('de-DE') }}",
+  "badge__pastDuePlan": "Überfällig",
+  "badge__primary": "Primär",
+  "badge__renewsAt": "Verlängert sich am {{ date | shortDate('de-DE') }}",
+  "badge__requiresAction": "Handlung erforderlich",
+  "badge__startsAt": "Startet am {{ date | shortDate('de-DE') }}",
+  "badge__thisDevice": "Dieses Gerät",
+  "badge__trialEndsAt": "Testversion endet {{ date | shortDate('de-DE') }}",
+  "badge__unverified": "Unbestätigt",
+  "badge__upcomingPlan": "Bevorstehend",
+  "badge__userDevice": "Benutzergerät",
+  "badge__you": "Du",
+  "billing": {
+    "addPaymentMethod__label": "Zahlungsmethode hinzufügen",
+    "alwaysFree": "Immer kostenlos",
+    "annually": "Jährlich",
+    "availableFeatures": "Verfügbare Funktionen",
+    "billedAnnually": "Jährlich abgerechnet",
+    "billedMonthlyOnly": "Nur monatlich abgerechnet",
+    "cancelFreeTrial": "Kostenlose Testversion kündigen",
+    "cancelFreeTrialAccessUntil": "Ihre Testversion bleibt bis zum {{ date | longDate('de-DE') }} aktiv. Danach verlieren Sie den Zugang zu Testfunktionen. Es fallen keine Kosten an.",
+    "cancelFreeTrialTitle": "Kostenlose Testversion für {{plan}} Plan kündigen?",
+    "cancelSubscription": "Abonnement kündigen",
+    "cancelSubscriptionAccessUntil": "Sie haben Zugriff auf '{{plan}}' Funktionen bis zum {{ date | longDate('de-DE') }}. Danach haben Sie keinen Zugriff mehr.",
+    "cancelSubscriptionNoCharge": "Für dieses Abonnement fallen keine Kosten an.",
+    "cancelSubscriptionTitle": "{{plan}} Abonnement kündigen?",
+    "cannotSubscribeMonthly": "Sie können diesen Plan nicht monatlich abonnieren, da nur eine jährliche Abrechnung verfügbar ist.",
+    "cannotSubscribeUnrecoverable": "Sie können diesen Plan nicht abonnieren. Ihr vorhandenes Abonnement ist teurer als dieser Plan.",
+    "checkout": {
+      "description__paymentSuccessful": "Ihre Bezahlung war erfolgreich.",
+      "description__subscriptionSuccessful": "Ihr Abonnement wurde erfolgreich aktiviert.",
+      "downgradeNotice": "Sie behalten Ihr aktuelles Abonnement bis zum Ende des Abrechnungszeitraums. So lange können Sie weiterhin alle Funktionen nutzen, danach werden Sie auf dieses Abonnement umgestellt.",
+      "emailForm": {
+        "subtitle": "Geben Sie eine E-Mail-Adresse an, um Abrechnungsbelege zu erhalten.",
+        "title": "E-Mail-Adresse hinzufügen"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "Testversion endet am",
+        "title__paymentMethod": "Bezahlmethode",
+        "title__statementId": "Statement-ID",
+        "title__subscriptionBegins": "Abonnement beginnt",
+        "title__totalPaid": "Insgesamt bezahlt"
+      },
+      "pastDueNotice": "Ihr vorheriges Abonnement war überfällig, ohne Zahlung.",
+      "perMonth": "pro Monat",
+      "title": "Bezahlung",
+      "title__paymentSuccessful": "Zahlung erfolgreich!",
+      "title__subscriptionSuccessful": "Geschafft!",
+      "title__trialSuccess": "Testversion erfolgreich gestartet!",
+      "totalDueAfterTrial": "Gesamtbetrag fällig nach Testende in {{days}} Tagen"
+    },
+    "credit": "Guthaben",
+    "creditRemainder": "Verbleibendes Guthaben für den restlichen Abrechnungszeitraum.",
+    "defaultFreePlanActive": "Sie nutzen aktuell den kostenlosen Plan.",
+    "free": "Kostenlos",
+    "getStarted": "Jetzt starten",
+    "highlightedPlanBadge": "Beliebt",
+    "keepFreeTrial": "Kostenlose Testversion behalten",
+    "keepSubscription": "Abonnement behalten",
+    "manage": "Verwalten",
+    "manageSubscription": "Mitgliedschaft verwalten",
+    "month": "Monat",
+    "monthly": "Monatlich",
+    "pastDue": "Überfällig",
+    "pay": "{{amount}} bezahlen",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "Jährlich abgerechnet",
+        "monthly": "Monatlich abgerechnet"
+      },
+      "dev": {
+        "anyNumbers": "Alle Zahlen",
+        "cardNumber": "Kartennummer",
+        "cvcZip": "CVC, PLZ",
+        "developmentMode": "Entwicklermodus",
+        "expirationDate": "Ablaufdatum",
+        "testCardInfo": "Test-Kreditkarteninformationen"
+      }
+    },
+    "paymentMethods__label": "Zahlungsmethoden",
+    "pricingTable": {
+      "billingCycle": "Abrechnungszyklus",
+      "included": "Enthalten",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "Erneut abonnieren",
+    "seeAllFeatures": "Alle Funktionen anzeigen",
+    "startFreeTrial": "Kostenlose Testversion starten",
+    "startFreeTrial__days": "{{days}}-tägige kostenlose Testversion starten",
+    "subscribe": "Abonnieren",
+    "subscriptionDetails": {
+      "beginsOn": "Beginnt am",
+      "currentBillingCycle": "Aktueller Abrechnungszeitraum",
+      "endsOn": "Endet am",
+      "firstPaymentAmount": "Erste Zahlungssumme",
+      "firstPaymentOn": "Erste Zahlung am",
+      "nextPaymentAmount": "Nächste Zahlungssumme",
+      "nextPaymentOn": "Nächste Zahlung am",
+      "pastDueAt": "Überfällig am",
+      "renewsAt": "Verlängert sich am",
+      "subscribedOn": "Abonniert am",
+      "title": "Abonnement",
+      "trialEndsOn": "Testversion endet am",
+      "trialStartedOn": "Testversion gestartet am"
+    },
+    "subtotal": "Zwischensumme",
+    "switchPlan": "Zu diesem Plan wechseln",
+    "switchToAnnual": "Wechsel zu jährlich",
+    "switchToAnnualWithAnnualPrice": "Auf jährlich wechseln {{price}} / Jahr",
+    "switchToMonthly": "Wechsel zu monatlich",
+    "switchToMonthlyWithPrice": "Auf monatlich wechseln {{price}} / Monat",
+    "totalDue": "Gesamtbetrag",
+    "totalDueToday": "Heute fällig",
+    "viewFeatures": "Funktionen anzeigen",
+    "viewPayment": "Zahlung anzeigen",
+    "year": "Jahr"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Wenden Sie sich an Ihren Organisationsadministrator, um Ihre Berechtigungen zu erweitern.",
+      "title": "Sie haben keine Berechtigung, Single Sign-On (SSO) zu verwalten"
+    },
+    "navbar": { "title": "Single Sign-On (SSO) konfigurieren" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Nicht verifiziert",
+        "badge__verified": "Verifiziert",
+        "txtRecord": {
+          "hostLabel": "Host / Name",
+          "instructions": "Fügen Sie diesen TXT-Eintrag bei Ihrem DNS-Anbieter hinzu. Wir verifizieren ihn automatisch, sobald der Eintrag aktiv ist.",
+          "typeLabel": "Typ",
+          "valueLabel": "Wert"
+        },
+        "verifiedAtLabel": "Verifiziert am {{ date | shortDate('de-DE') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "{{domain}} hinzufügen",
+        "messageLabel": "Ihre E-Mail verwendet {{domain}}. Möchten Sie sie hinzufügen?"
+      },
+      "formButtonPrimary__add": "Hinzufügen",
+      "formFieldInputPlaceholder__domain": "Domain hinzufügen",
+      "formFieldLabel__domain": "Domain",
+      "removeDomainDialog": {},
+      "subtitle": "Fügen Sie die Domains hinzu, die Ihre Organisation zur Anmeldung verwendet, und verifizieren Sie deren Eigentümerschaft.",
+      "title": "SSO-Domains hinzufügen"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Benutzerdefinierter SAML-Anbieter",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Wählen Sie den Anbieter, für den Sie SSO einrichten möchten.",
+      "title": "Anbieter auswählen",
+      "warning": "Sobald ein Anbieter ausgewählt ist, können Sie ihn nicht mehr ändern, bis die Konfiguration abgeschlossen ist"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Organisation erstellen",
+    "invitePage": { "formButtonReset": "Überspringen" },
+    "title": "Organisation erstellen"
+  },
+  "dates": {
+    "lastDay": "Gestern um {{ date | timeString('de-DE') }}",
+    "next6Days": "{{ date | weekday('de-DE','long') }} um {{ date | timeString('de-DE') }}",
+    "nextDay": "Morgen um {{ date | timeString('de-DE') }}",
+    "numeric": "{{ date | numeric('de-DE') }}",
+    "previous6Days": "Letzten {{ date | weekday('de-DE','long') }} um {{ date | timeString('de-DE') }}",
+    "sameDay": "Heute um {{ date | timeString('de-DE') }}"
+  },
+  "dividerText": "oder",
+  "footerActionLink__alternativePhoneCodeProvider": "Code stattdessen per SMS senden",
+  "footerActionLink__useAnotherMethod": "Verwenden Sie eine andere Methode",
+  "footerPageLink__help": "Hilfe",
+  "footerPageLink__privacy": "Datenschutz",
+  "footerPageLink__terms": "Bedingungen",
+  "formButtonPrimary": "Fortsetzen",
+  "formButtonPrimary__verify": "Verifizieren",
+  "formFieldAction__forgotPassword": "Passwort vergessen?",
+  "formFieldError__matchingPasswords": "Passwörter stimmen überein.",
+  "formFieldError__notMatchingPasswords": "Passwörter stimmen nicht überein.",
+  "formFieldError__verificationLinkExpired": "Der Bestätigungslink ist abgelaufen. Bitte fordern Sie einen neuen Link an.",
+  "formFieldHintText__optional": "Optional",
+  "formFieldHintText__slug": "Der Slug ist eine für Menschen lesbare ID. Sie muss einzigartig sein und wird oft in URLs verwendet.",
+  "formFieldInputPlaceholder__apiKeyDescription": "Geben Sie eine Beschreibung an",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "Geben Sie ein Ablaufdatum an",
+  "formFieldInputPlaceholder__apiKeyName": "Geben Sie einen Namen an",
+  "formFieldInputPlaceholder__backupCode": "Sicherheitscode eingeben",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Konto löschen",
+  "formFieldInputPlaceholder__emailAddress": "E-Mail-Adresse eingeben",
+  "formFieldInputPlaceholder__emailAddress_username": "E-Mail-Adresse oder Benutzername eingeben",
+  "formFieldInputPlaceholder__emailAddresses": "example@email.com, example2@email.com",
+  "formFieldInputPlaceholder__firstName": "Vorname eingeben",
+  "formFieldInputPlaceholder__lastName": "Nachname eingeben",
+  "formFieldInputPlaceholder__organizationDomain": "Organisations-Domain eingeben",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "E-Mail-Adresse der Organisations-Domain eingeben",
+  "formFieldInputPlaceholder__organizationName": "Name der Organisation eingeben",
+  "formFieldInputPlaceholder__organizationSlug": "my-org",
+  "formFieldInputPlaceholder__password": "Passwort eingeben",
+  "formFieldInputPlaceholder__phoneNumber": "Telefonnummer eingeben",
+  "formFieldInputPlaceholder__username": "Benutzername eingeben",
+  "formFieldLabel__apiKey": "API-Key",
+  "formFieldLabel__apiKeyDescription": "Beschreibung",
+  "formFieldLabel__apiKeyExpiration": "Ablaufdatum",
+  "formFieldLabel__apiKeyName": "Name",
+  "formFieldLabel__automaticInvitations": "Aktivieren Sie automatische Einladungen für diese Domain",
+  "formFieldLabel__backupCode": "Wiederherstellungscode",
+  "formFieldLabel__confirmDeletion": "Bestätigung",
+  "formFieldLabel__confirmPassword": "Passwort bestätigen",
+  "formFieldLabel__currentPassword": "Aktuelles Passwort",
+  "formFieldLabel__emailAddress": "E-Mail-Adresse",
+  "formFieldLabel__emailAddress_username": "E-Mail-Adresse oder Benutzername",
+  "formFieldLabel__emailAddresses": "E-Mail-Adressen",
+  "formFieldLabel__firstName": "Vorname",
+  "formFieldLabel__lastName": "Nachname",
+  "formFieldLabel__newPassword": "Neues Passwort",
+  "formFieldLabel__organizationDomain": "Domain",
+  "formFieldLabel__organizationDomainDeletePending": "Ausstehende Einladungen und Vorschläge löschen",
+  "formFieldLabel__organizationDomainEmailAddress": "E-Mail-Adresse für die Verifizierung",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Geben Sie eine E-Mail-Adresse dieser Domain ein, um einen Code zu erhalten und diese Domain zu verifizieren.",
+  "formFieldLabel__organizationName": "Organisationsname",
+  "formFieldLabel__organizationSlug": "Slug",
+  "formFieldLabel__passkeyName": "Name des Passkeys",
+  "formFieldLabel__password": "Passwort",
+  "formFieldLabel__phoneNumber": "Telefonnummer",
+  "formFieldLabel__role": "Rolle",
+  "formFieldLabel__signOutOfOtherSessions": "Alle anderen Geräte abmelden",
+  "formFieldLabel__username": "Benutzername",
+  "impersonationFab": {
+    "action__signOut": "Abmelden",
+    "title": "Angemeldet als {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Zuletzt verwendet",
+  "maintenanceMode": "Wir führen derzeit Wartungsarbeiten durch, aber keine Sorge, es sollte nicht länger als ein paar Minuten dauern.",
+  "membershipRole__admin": "Administrator",
+  "membershipRole__basicMember": "Mitglied",
+  "membershipRole__guestMember": "Gast",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Organisation erstellen",
+    "action__invitationAccept": "Beitreten",
+    "action__suggestionsAccept": "Beitritt anfragen",
+    "createOrganization": "Organisation erstellen",
+    "invitationAcceptedLabel": "Beitreten",
+    "subtitle": "um fortzufahren zu {{applicationName}}",
+    "suggestionsAcceptedLabel": "Genehmigung ausstehend",
+    "title": "Konto auswählen",
+    "titleWithoutPersonal": "Organisation auswählen"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "API-Keys" },
+    "badge__automaticInvitation": "Automatische Einladungen",
+    "badge__automaticSuggestion": "Automatische Vorschläge",
+    "badge__manualInvitation": "Keine automatische Aufnahme",
+    "badge__unverified": "Nicht verifiziert",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Kein Zahlungsverlauf",
+        "notFound": "Zahlungsversuch nicht gefunden",
+        "tableHeader__amount": "Betrag",
+        "tableHeader__date": "Datum",
+        "tableHeader__status": "Status"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Als Standard festlegen",
+        "actionLabel__remove": "Entfernen",
+        "add": "Neue Zahlungsmethode hinzufügen",
+        "addSubtitle": "Fügen Sie eine neue Zahlungsmethode hinzu.",
+        "cancelButton": "Abbrechen",
+        "formButtonPrimary__add": "Zahlungsmethode hinzufügen",
+        "formButtonPrimary__pay": "{{amount}} bezahlen",
+        "payWithTestCardButton": "Mit Test-Kreditkarte bezahlen",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} wird von diesem Konto entfernt.",
+          "messageLine2": "In Zukunft können Sie diese Zahlungsmethode nicht mehr verwenden. Alle laufenden Abonnements, die diese Zahlungsmethode verwenden, werden aufhören zu funktionieren.",
+          "successMessage": "{{paymentMethod}} wurde von diesem Konto entfernt.",
+          "title": "Zahlungsmethode entfernen"
+        },
+        "title": "Zahlungsmethoden"
+      },
+      "start": {
+        "headerTitle__payments": "Zahlungen",
+        "headerTitle__plans": "Pläne",
+        "headerTitle__statements": "Abrechnungen",
+        "headerTitle__subscriptions": "Abonnements"
+      },
+      "statementsSection": {
+        "empty": "Keine Abrechnungen verfügbar",
+        "itemCaption__paidForPlan": "Bezahlt für {{plan}} {{period}} Plan",
+        "itemCaption__proratedCredit": "Anteilige Gutschrift für teilweise Nutzung des vorherigen Abonnements",
+        "itemCaption__subscribedAndPaidForPlan": "Abonniert und bezahlt für {{plan}} {{period}} Plan",
+        "notFound": "Abrechnung nicht gefunden",
+        "tableHeader__amount": "Betrag",
+        "tableHeader__date": "Datum",
+        "title": "Abrechnungen",
+        "totalPaid": "Insgesamt bezahlt"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Verwalten",
+        "actionLabel__newSubscription": "Plan abonnieren",
+        "actionLabel__switchPlan": "Plan wechseln",
+        "tableHeader__edit": "Bearbeiten",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Startdatum",
+        "title": "Abonnement"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Verwalten" },
+      "switchPlansSection": { "title": "Plan wechseln" },
+      "title": "Abrechnung"
+    },
+    "createDomainPage": {
+      "subtitle": "Fügen Sie die zu überprüfende Domain hinzu. Benutzer mit E-Mail-Adressen von dieser Domain können der Organisation automatisch beitreten oder einen Antrag auf Beitritt stellen.",
+      "title": "Domain hinzufügen"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "Die Einladungen konnten nicht versendet werden. Beheben Sie Folgendes und versuchen Sie es erneut:",
+      "formButtonPrimary__continue": "Einladungen verschicken",
+      "selectDropdown__role": "Rolle wählen",
+      "subtitle": "Laden Sie neue Mitglieder zu dieser Organisation ein",
+      "successMessage": "Einladungen erfolgreich versendet",
+      "title": "Mitglieder einladen"
+    },
+    "membersPage": {
+      "action__invite": "Einladen",
+      "action__search": "Suchen",
+      "activeMembersTab": {
+        "menuAction__remove": "Mitglied entfernen",
+        "tableHeader__actions": "Aktionen",
+        "tableHeader__joined": "Beitrittsdatum",
+        "tableHeader__role": "Rolle",
+        "tableHeader__user": "Benutzer"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Wir aktualisieren die verfügbaren Rollen. Sobald dies abgeschlossen ist, können Sie die Rollen wieder aktualisieren.",
+          "title": "Rollen sind vorübergehend gesperrt"
+        }
+      },
+      "detailsTitle__emptyRow": "Keine Mitglieder zum Anzeigen",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Laden Sie Benutzer ein, indem Sie eine E-Mail-Domain mit Ihrer Organisation verbinden. Jeder, der sich mit dieser passenden E-Mail-Domain anmeldet, kann der Organisation jederzeit beitreten.",
+          "headerTitle": "Automatische Einladungen",
+          "primaryButton": "Verwalten Sie verifizierte Domains"
+        },
+        "table__emptyRow": "Keine Einladungen verfügbar"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Einladung widerrufen",
+        "tableHeader__invited": "Eingeladen"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Benutzer, die sich mit einer passenden E-Mail-Domain anmelden, können einen Vorschlag für eine Beitrittsanfrage zu Ihrer Organisation sehen.",
+          "headerTitle": "Automatische Vorschläge",
+          "primaryButton": "Verifizierte Domains verwalten"
+        },
+        "menuAction__approve": "Bestätigen",
+        "menuAction__reject": "Ablehnen",
+        "tableHeader__requested": "Angefragte Zugänge",
+        "table__emptyRow": "Keine Anfragen verfügbar"
+      },
+      "start": {
+        "headerTitle__invitations": "Einladungen",
+        "headerTitle__members": "Mitglieder",
+        "headerTitle__requests": "Anfragen"
+      }
+    },
+    "navbar": {
+      "apiKeys": "API-Keys",
+      "billing": "Abrechnung",
+      "description": "Verwalten Sie Ihre Organisation.",
+      "general": "Allgemein",
+      "members": "Mitglieder",
+      "title": "Organisation"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "Sie haben keine Berechtigung, die Abrechnungen für diese Organisation zu verwalten."
+      },
+      "title": "Pläne"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Geben Sie \"{{organizationName}}\" unten ein, um fortzufahren.",
+          "messageLine1": "Sind Sie sicher, dass Sie diese Organisation löschen wollen?",
+          "messageLine2": "Diese Aktion ist dauerhaft und irreversibel.",
+          "successMessage": "Sie haben die Organisation gelöscht.",
+          "title": "Organisation löschen"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Geben Sie \"{{organizationName}}\" unten ein, um fortzufahren.",
+          "messageLine1": "Möchten Sie diese Organisation wirklich verlassen? Sie verlieren den Zugriff auf diese Organisation und Ihre Anwendungen.",
+          "messageLine2": "Diese Aktion ist dauerhaft und irreversibel.",
+          "successMessage": "Sie haben die Organisation verlassen.",
+          "title": "Organisation verlassen"
+        },
+        "title": "Achtung"
+      },
+      "domainSection": {
+        "menuAction__manage": "Verwalten",
+        "menuAction__remove": "Löschen",
+        "menuAction__verify": "Verifizieren",
+        "primaryButton": "Domain hinzufügen",
+        "subtitle": "Erlauben Sie Benutzern, der Organisation automatisch beizutreten oder den Beitritt auf der Grundlage einer verifizierten E-Mail-Domain anzufragen.",
+        "title": "Verifizierte Domains"
+      },
+      "successMessage": "Die Organisation wurde aktualisiert.",
+      "title": "Organisationsprofil"
+    },
+    "removeDomainPage": {
+      "messageLine1": "Die E-Mail-Domain {{domain}} wird entfernt.",
+      "messageLine2": "Benutzer können der Organisation danach nicht mehr automatisch beitreten.",
+      "successMessage": "{{domain}} wurde entfernt.",
+      "title": "Domain entfernen"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "Allgemein",
+      "headerTitle__members": "Mitglieder",
+      "profileSection": {
+        "primaryButton": "Profil bearbeiten",
+        "title": "Organisationsprofil",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "Das Entfernen dieser Domain betrifft die eingeladenen Benutzer.",
+        "removeDomainActionLabel__remove": "Domain entfernen",
+        "removeDomainSubtitle": "Sie können diese Domain von den verifizierten Domains entfernen",
+        "removeDomainTitle": "Domain entfernen"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Benutzer werden bei der Anmeldung automatisch eingeladen, der Organisation beizutreten, und können jederzeit beitreten.",
+        "automaticInvitationOption__label": "Automatische Einladungen",
+        "automaticSuggestionOption__description": "Benutzer erhalten einen Vorschlag für eine Beitrittsanfrage, müssen aber von einem Administrator genehmigt werden, bevor sie der Organisation beitreten können.",
+        "automaticSuggestionOption__label": "Automatische Vorschläge",
+        "calloutInfoLabel": "Änderungen des Anmeldemodus wirken sich nur auf neue Benutzer aus.",
+        "calloutInvitationCountLabel": "Ausstehende Einladungen gesendet an Benutzer: {{count}}",
+        "calloutSuggestionCountLabel": "Ausstehende Vorschläge gesendet an Benutzer: {{count}}",
+        "manualInvitationOption__description": "Benutzer können nur manuell in die Organisation eingeladen werden.",
+        "manualInvitationOption__label": "Keine automatische Aufnahme",
+        "subtitle": "Wählen Sie, wie Benutzer mit dieser Domain der Organisation beitreten können."
+      },
+      "start": {
+        "headerTitle__danger": "Achtung",
+        "headerTitle__enrollment": "Optionen für die Aufnahme"
+      },
+      "subtitle": "Die Domain {{domain}} ist nun verifiziert. Bitte wählen Sie einen Aufnahmemodus aus.",
+      "title": "{{domain}} aktualisieren"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Geben Sie den an Ihre E-Mail-Adresse gesendeten Verifizierungscode ein",
+      "formTitle": "Verifizierungscode",
+      "resendButton": "Sie haben keinen Code erhalten? Erneut senden",
+      "subtitle": "Die Domain {{domainName}} muss per E-Mail verifiziert werden.",
+      "subtitleVerificationCodeScreen": "Ein Verifizierungscode wurde an {{emailAddress}} gesendet. Geben Sie den Code ein, um fortzufahren.",
+      "title": "Domain verifizieren"
+    }
+  },
+  "organizationSwitcher": {
+    "action__createOrganization": "Organisation erstellen",
+    "action__invitationAccept": "Beitreten",
+    "action__manageOrganization": "Organisation verwalten",
+    "action__suggestionsAccept": "Beitritt anfragen",
+    "notSelected": "Keine Organisation ausgewählt",
+    "personalWorkspace": "Persönlicher Arbeitsbereich",
+    "suggestionsAcceptedLabel": "Genehmigung ausstehend"
+  },
+  "paginationButton__next": "Nächste",
+  "paginationButton__previous": "Vorherige",
+  "paginationRowText__displaying": "Anzeigen",
+  "paginationRowText__of": "von",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Klicken Sie hier, um eine alternative Methode zu verwenden",
+      "actionText": "Verwenden Sie eine alternative Verifizierungsmethode",
+      "blockButton__backupCode": "Mit Wiederherstellungscode verifizieren",
+      "blockButton__emailCode": "Mit E-Mail-Code verifizieren",
+      "blockButton__passkey": "Verwenden Sie Ihren Passkey",
+      "blockButton__password": "Mit Passwort verifizieren",
+      "blockButton__phoneCode": "Mit SMS-Code verifizieren",
+      "blockButton__totp": "Mit TOTP verifizieren",
+      "getHelp": {
+        "blockButton__emailSupport": "E-Mail-Support kontaktieren",
+        "content": "Wenn Sie Hilfe benötigen, wenden Sie sich bitte an unseren Support.",
+        "title": "Hilfe erhalten"
+      },
+      "subtitle": "Wählen Sie eine Methode, um sich zu verifizieren",
+      "title": "Verifizierung erforderlich"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Verwenden Sie den Wiederherstellungscode, der Ihnen bei der Registrierung zur Verfügung gestellt wurde.",
+      "title": "Wiederherstellungscode Verifizierung"
+    },
+    "emailCode": {
+      "formTitle": "Geben Sie den Code ein, den wir an Ihre E-Mail-Adresse gesendet haben.",
+      "resendButton": "Code erneut senden",
+      "subtitle": "Überprüfen Sie Ihre E-Mail auf den Verifizierungscode.",
+      "title": "E-Mail-Code Verifizierung"
+    },
+    "noAvailableMethods": {
+      "message": "Es sind keine Verifizierungsmethoden mehr verfügbar.",
+      "subtitle": "Bitte kontaktieren Sie den Support, um Hilfe zu erhalten.",
+      "title": "Keine verfügbaren Methoden"
+    },
+    "passkey": {
+      "blockButton__passkey": "Verwenden Sie Ihren Passkey",
+      "subtitle": "Die Verwendung Ihres Passkeys bestätigt Ihre Identität. Ihr Gerät kann nach Ihrem Fingerabdruck, Gesicht oder Bildschirmsperre fragen.",
+      "title": "Verwenden Sie Ihren Passkey"
+    },
+    "password": {
+      "actionLink": "Passwort zurücksetzen",
+      "subtitle": "Geben Sie Ihr Passwort ein, um fortzufahren.",
+      "title": "Passwort-Verifizierung"
+    },
+    "phoneCode": {
+      "formTitle": "Geben Sie den Code ein, den wir an Ihre Telefonnummer gesendet haben.",
+      "resendButton": "Code erneut senden",
+      "subtitle": "Überprüfen Sie Ihre SMS-Nachricht auf den Verifizierungscode.",
+      "title": "SMS-Code Verifizierung"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Geben Sie den Code ein, den wir Ihnen per SMS gesendet haben.",
+      "resendButton": "Code erneut senden",
+      "subtitle": "Überprüfen Sie Ihre SMS auf den Verifizierungscode.",
+      "title": "SMS-Code (MFA) Verifizierung"
+    },
+    "totpMfa": {
+      "formTitle": "Geben Sie den Code aus Ihrer Authentifikator-App ein.",
+      "subtitle": "Verwenden Sie die Authentifikator-App, die Sie eingerichtet haben.",
+      "title": "TOTP-Verifizierung (MFA)"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Konto hinzufügen",
+      "action__signOutAll": "Von allen Konten abmelden",
+      "subtitle": "Wählen Sie das Konto, mit dem Sie fortfahren möchten.",
+      "title": "Wählen Sie ein Konto"
+    },
+    "alternativeMethods": {
+      "actionLink": "Hilfe",
+      "actionText": "Haben Sie keine davon?",
+      "blockButton__backupCode": "Verwenden Sie einen Wiederherstellungscode",
+      "blockButton__emailCode": "Code an {{identifier}} senden",
+      "blockButton__emailLink": "Link senden an {{identifier}}",
+      "blockButton__passkey": "Melden Sie sich mit Ihrem Passkey an",
+      "blockButton__password": "Melden Sie sich mit Ihrem Passwort an",
+      "blockButton__phoneCode": "Code an {{identifier}} senden",
+      "blockButton__totp": "Verwenden Sie Ihre Authentifizierungs-App",
+      "getHelp": {
+        "blockButton__emailSupport": "Unterstützung per E-Mail",
+        "content": "Wenn Sie Schwierigkeiten haben, sich mit Ihrem Konto anzumelden, senden Sie uns eine E-Mail und wir werden mit Ihnen zusammenarbeiten, um den Zugriff so schnell wie möglich wiederherzustellen.",
+        "title": "Hilfe"
+      },
+      "subtitle": "Haben Sie Probleme? Sie können eine der folgenden Methoden zur Anmeldung verwenden.",
+      "title": "Verwenden Sie eine andere Methode"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Bestätigungscode nicht erhalten? Erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Überprüfen Sie {{provider}}"
+    },
+    "backupCodeMfa": {
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Geben Sie einen Wiederherstellungscode ein"
+    },
+    "emailCode": {
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Code erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Überprüfen Sie Ihren Posteingang"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Überprüfen Sie Ihren Posteingang",
+      "resendButton": "Bestätigungscode nicht erhalten? Erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Überprüfen Sie Ihren Posteingang"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Die Anfrage stammt von einem nicht kompatiblen Client.",
+        "title": "Client-Kompatibilitätsfehler"
+      },
+      "expired": {
+        "subtitle": "Kehren Sie zum ursprünglichen Tab zurück, um fortzufahren.",
+        "title": "Dieser Bestätigungslink ist abgelaufen"
+      },
+      "failed": {
+        "subtitle": "Kehren Sie zum ursprünglichen Tab zurück, um fortzufahren.",
+        "title": "Dieser Bestätigungslink ist ungültig"
+      },
+      "formSubtitle": "Verwenden Sie den an Ihre E-Mail gesendeten Bestätigungslink",
+      "formTitle": "Bestätigungslink",
+      "loading": {
+        "subtitle": "Sie werden in Kürze weitergeleitet",
+        "title": "Einloggen..."
+      },
+      "resendButton": "Link erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Überprüfen Sie Ihren Posteingang",
+      "unusedTab": { "title": "Sie können diesen Tab schließen" },
+      "verified": {
+        "subtitle": "Sie werden in Kürze weitergeleitet",
+        "title": "Erfolgreich angemeldet"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Kehren Sie zum ursprünglichen Tab zurück, um fortzufahren",
+        "subtitleNewTab": "Kehren Sie zum neu geöffneten Tab zurück, um fortzufahren",
+        "titleNewTab": "In einem anderen Tab angemeldet"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Verwenden Sie den an Ihre E-Mail gesendeten Bestätigungslink",
+      "resendButton": "Keinen Link erhalten? Erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Überprüfen Sie Ihren Posteingang"
+    },
+    "enterpriseConnections": {},
+    "forgotPassword": {
+      "formTitle": "Passwort-Code zurücksetzen",
+      "resendButton": "Sie haben keinen Code erhalten? Erneut senden",
+      "subtitle": "um Passwort zurückzusetzen",
+      "subtitle_email": "Geben Sie zunächst den an Ihre E-Mail gesendeten Code ein",
+      "subtitle_phone": "Geben Sie zunächst den auf Ihr Mobiltelefon geschickten Code ein",
+      "title": "Passwort zurücksetzen"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Passwort zurücksetzen",
+      "label__alternativeMethods": "Oder melden Sie sich mit einer anderen Methode an",
+      "title": "Passwort vergessen?"
+    },
+    "newDeviceVerificationNotice": "Sie melden sich von einem neuen Gerät an. Wir bitten um eine Überprüfung, um Ihr Konto sicher zu halten.",
+    "noAvailableMethods": {
+      "message": "Die Anmeldung kann nicht fortgesetzt werden. Es ist kein Authentifizierungsfaktor verfügbar.",
+      "subtitle": "Ein Fehler ist aufgetreten",
+      "title": "Anmeldung nicht möglich"
+    },
+    "passkey": {
+      "subtitle": "Die Verwendung Ihres Passkeys bestätigt, dass Sie es sind. Ihr Gerät kann nach Ihrem Fingerabdruck, Ihrem Gesicht oder der Bildschirmsperre fragen.",
+      "title": "Verwenden Sie Ihren Passkey"
+    },
+    "password": {
+      "actionLink": "Verwenden Sie eine andere Methode",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Geben Sie Ihr Passwort ein"
+    },
+    "passwordCompromised": {},
+    "passwordPwned": { "title": "Passwort kompromittiert" },
+    "passwordUntrusted": {},
+    "phoneCode": {
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Code erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Schauen Sie auf Ihr Telefon"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Code erneut senden",
+      "subtitle": "Um fortzufahren, geben Sie bitte den Bestätigungscode ein, der an Ihre Telefonnummer gesendet wurde",
+      "title": "Schauen Sie auf Ihr Telefon"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Passwort zurücksetzen",
+      "requiredMessage": "Es existiert bereits ein Konto mit einer nicht verifizierten E-Mail Adresse. Bitte setzen Sie Ihr Passwort zur Sicherheit zurück.",
+      "successMessage": "Ihr Passwort wurde erfolgreich geändert. Bitte warten Sie einen Moment, um Sie anzumelden.",
+      "title": "Neues Passwort setzen"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Bevor wir Ihr Passwort zurücksetzen können, müssen wir Ihre Identität überprüfen."
+    },
+    "start": {
+      "actionLink": "Registrieren",
+      "actionLink__join_waitlist": "Warteliste beitreten",
+      "actionLink__use_email": "E-Mail nutzen",
+      "actionLink__use_email_username": "E-Mail oder Benutzernamen nutzen",
+      "actionLink__use_passkey": "Passkey nutzen",
+      "actionLink__use_phone": "Mobiltelefon nutzen",
+      "actionLink__use_username": "Benutzername nutzen",
+      "actionText": "Kein Account?",
+      "actionText__join_waitlist": "Warteliste beitreten",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Andere Methode verwenden",
+        "label": "{{provider}} Telefonnummer",
+        "subtitle": "Geben Sie Ihre Telefonnummer ein, um einen Bestätigungscode per {{provider}} zu erhalten.",
+        "title": "In {{applicationName}} mit {{provider}} einloggen"
+      },
+      "subtitle": "weiter zu {{applicationName}}",
+      "subtitleCombined": "Willkommen zurück! Bitte melden Sie sich an, um fortzufahren",
+      "title": "In {{applicationName}} einloggen",
+      "titleCombined": "Weiter zu {{applicationName}}"
+    },
+    "totpMfa": {
+      "formTitle": "Bestätigungscode",
+      "subtitle": "Um fortzufahren, geben Sie bitte den Verifizierungscode ein, der von Ihrer Authenticator-App generiert wurde.",
+      "title": "Bestätigung in zwei Schritten"
+    },
+    "web3Solana": {
+      "subtitle": "Wähle unten eine Wallet aus, um dich anzumelden",
+      "title": "Mit Solana anmelden"
+    }
+  },
+  "signInEnterPasswordTitle": "Geben Sie Ihr Passwort ein",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "Bestätigungscode nicht erhalten? Erneut senden",
+      "subtitle": "Geben Sie den Bestätigungscode ein, der an {{provider}} gesendet wurde",
+      "title": "{{provider}} verifizieren"
+    },
+    "continue": {
+      "actionLink": "Einloggen",
+      "actionText": "Haben Sie ein Konto?",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Füllen Sie fehlende Felder aus"
+    },
+    "emailCode": {
+      "formSubtitle": "Geben Sie den Bestätigungscode ein, der an Ihre E-Mail-Adresse gesendet wurde",
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Code erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Bestätigen Sie Ihre E-Mail"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Die Anfrage konnte nicht verarbeitet werden, da der Client nicht kompatibel ist.",
+        "title": "Fehler: Inkompatibler Client"
+      },
+      "formSubtitle": "Verwenden Sie den an Ihre E-Mail-Adresse gesendeten Bestätigungslink",
+      "formTitle": "Bestätigungslink",
+      "loading": { "title": "Anmeldung..." },
+      "resendButton": "Link erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Bestätigen Sie Ihre E-Mail",
+      "verified": { "title": "Erfolgreich angemeldet" },
+      "verifiedSwitchTab": {
+        "subtitle": "Kehren Sie zum neu geöffneten Tab zurück, um fortzufahren",
+        "subtitleNewTab": "Kehren Sie zum vorherigen Tab zurück, um fortzufahren",
+        "title": "E-Mail erfolgreich verifiziert"
+      }
+    },
+    "enterpriseConnections": {},
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "Ich stimme der {{ privacyPolicyLink || link(\"Datenschutzerklärung\") }} zu",
+        "label__onlyTermsOfService": "Ich stimme den {{ termsOfServiceLink || link(\"Nutzungsbedingungen\") }} zu",
+        "label__termsOfServiceAndPrivacyPolicy": "Ich stimme den {{ termsOfServiceLink || link(\"Nutzungsbedingungen\") }} und der {{ privacyPolicyLink || link(\"Datenschutzerklärung\") }} zu"
+      },
+      "continue": {
+        "subtitle": "Bitte lesen und akzeptieren Sie die Bedingungen, um fortzufahren",
+        "title": "Rechtliche Einwilligung"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Geben Sie den Bestätigungscode ein, der an Ihre Telefonnummer gesendet wurde",
+      "formTitle": "Bestätigungscode",
+      "resendButton": "Code erneut senden",
+      "subtitle": "weiter zu {{applicationName}}",
+      "title": "Verifizieren Sie Ihre Telefonnummer"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Mehr erfahren",
+      "actionText": "Zugang verweigert?",
+      "blockButton__emailSupport": "E-Mail-Support kontaktieren",
+      "blockButton__joinWaitlist": "Warteliste beitreten",
+      "subtitle": "Ihr Zugang ist momentan eingeschränkt.",
+      "subtitleWaitlist": "Treten Sie der Warteliste bei, um Benachrichtigungen zu erhalten.",
+      "title": "Zugang verweigert"
+    },
+    "start": {
+      "actionLink": "Einloggen",
+      "actionLink__use_email": "Mit E-Mail einloggen",
+      "actionLink__use_phone": "Mit Telefonnummer einloggen",
+      "actionText": "Haben Sie ein Konto?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Andere Methode verwenden",
+        "label": "{{provider}} Telefonnummer",
+        "subtitle": "Geben Sie Ihre Telefonnummer ein, um einen Bestätigungscode per {{provider}} zu erhalten.",
+        "title": "In {{applicationName}} mit {{provider}} anmelden"
+      },
+      "subtitle": "weiter zu {{applicationName}}",
+      "subtitleCombined": "weiter zu {{applicationName}}",
+      "title": "Erstellen Sie Ihr Konto",
+      "titleCombined": "Erstellen Sie Ihr Konto"
+    },
+    "web3Solana": {
+      "subtitle": "Wählen Sie unten eine Wallet aus, um sich zu registrieren",
+      "title": "Mit Solana registrieren"
+    }
+  },
+  "socialButtonsBlockButton": "Weiter mit {{provider|titleize}}",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "Für den erkannten Firmennamen ({{organizationName}}) und {{organizationDomain}} existiert bereits eine Organisation. Treten Sie per Einladung bei."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "Neue Organisation erstellen",
+      "action__invitationAccept": "Beitreten",
+      "action__suggestionsAccept": "Beitritt beantragen",
+      "subtitle": "Einer bestehenden Organisation beitreten oder eine neue erstellen",
+      "subtitle__createOrganizationDisabled": "Einer bestehenden Organisation beitreten",
+      "suggestionsAcceptedLabel": "Genehmigung ausstehend",
+      "title": "Organisation auswählen"
+    },
+    "createOrganization": {
+      "formButtonReset": "Abbrechen",
+      "formButtonSubmit": "Fortfahren",
+      "formFieldInputPlaceholder__name": "Meine Organisation",
+      "formFieldInputPlaceholder__slug": "meine-organisation",
+      "formFieldLabel__name": "Name",
+      "formFieldLabel__slug": "Slug",
+      "subtitle": "Geben Sie Ihre Organisationsdetails ein, um fortzufahren",
+      "title": "Organisation einrichten"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Kontaktieren Sie Ihren Organisationsadministrator für eine Einladung.",
+      "title": "Sie müssen einer Organisation angehören"
+    },
+    "signOut": {
+      "actionLink": "Abmelden",
+      "actionText": "Angemeldet als {{identifier}}"
+    }
+  },
+  "taskResetPassword": { "signOut": {} },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "Sie sind bereits Mitglied in dieser Organisation.",
+    "avatar_file_size_exceeded": "Die Dateigröße überschreitet das Maximum von 10 MB. Bitte wählen Sie eine kleinere Datei.",
+    "avatar_file_type_invalid": "Dateityp wird nicht unterstützt. Bitte laden Sie ein JPG-, PNG-, GIF- oder WEBP-Bild hoch.",
+    "captcha_invalid": "Anmeldung aufgrund fehlgeschlagener Sicherheitsüberprüfung nicht erfolgreich. Bitte versuchen Sie es erneut oder kontaktieren Sie uns für weitere Unterstützung.",
+    "captcha_unavailable": "Die Anmeldung ist aufgrund einer fehlgeschlagenen Bot-Validierung fehlgeschlagen. Bitte aktualisieren Sie die Seite, um es erneut zu versuchen, oder wenden Sie sich an den Support, um weitere Unterstützung zu erhalten.",
+    "form_code_incorrect": "Der eingegebene Code ist falsch. Bitte überprüfen Sie ihn und versuchen Sie es erneut.",
+    "form_email_address_blocked": "Temporäre E-Mail-Dienste werden nicht unterstützt. Bitte verwenden Sie Ihre reguläre E-Mail-Adresse, um ein Konto zu erstellen.",
+    "form_identifier_exists__email_address": "Diese E-Mail-Adresse ist bereits vergeben. Bitte wählen Sie eine andere.",
+    "form_identifier_exists__phone_number": "Diese Telefonnummer ist bereits vergeben. Bitte wählen Sie eine andere.",
+    "form_identifier_exists__username": "Dieser Benutzername ist bereits vergeben. Bitte wählen Sie einen anderen.",
+    "form_identifier_not_found": "Wir konnten kein Konto mit diesen Details finden.",
+    "form_param_format_invalid": "Das Format des eingegebenen Parameters ist ungültig.",
+    "form_param_format_invalid__email_address": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+    "form_param_format_invalid__phone_number": "Die Telefonnummer muss ein gültiges internationales Format haben.",
+    "form_param_max_length_exceeded__first_name": "Der Vorname sollte nicht mehr als 256 Zeichen umfassen.",
+    "form_param_max_length_exceeded__last_name": "Der Nachname sollte nicht mehr als 256 Zeichen umfassen.",
+    "form_param_max_length_exceeded__name": "Der Name sollte nicht länger als 256 Zeichen sein.",
+    "form_param_nil": "Ein erforderliches Feld wurde nicht ausgefüllt. Bitte überprüfen Sie Ihre Eingaben.",
+    "form_param_type_invalid": "Der eingegebene Parameter hat einen ungültigen Typ.",
+    "form_param_type_invalid__email_address": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+    "form_param_type_invalid__phone_number": "Bitte geben Sie eine gültige Telefonnummer ein.",
+    "form_param_value_invalid": "Der eingegebene Wert ist ungültig.",
+    "form_password_incorrect": "Das eingegebene Passwort ist falsch.",
+    "form_password_length_too_short": "Das Passwort ist zu kurz. Es muss mindestens 8 Zeichen lang sein.",
+    "form_password_not_strong_enough": "Passwort nicht stark genug.",
+    "form_password_or_identifier_incorrect": "Passwort oder E-Mail-Adresse ist falsch. Versuchen Sie es erneut oder verwenden Sie eine andere Methode.",
+    "form_password_pwned": "Das gewählte Passwort wurde bei einem Datenleck im Internet gefunden. Wählen Sie aus Sicherheitsgründen bitte ein anderes Passwort.",
+    "form_password_pwned__sign_in": "Dieses Passwort wurde in einem Datenleck gefunden und kann nicht verwendet werden. Bitte setzen Sie Ihr Passwort zurück.",
+    "form_password_size_in_bytes_exceeded": "Das Passwort hat die maximale Anzahl an Bytes überschritten. Bitte kürzen oder Sonderzeichen entfernen.",
+    "form_password_validation_failed": "Falsches Passwort.",
+    "form_username_invalid_character": "Der Benutzername enthält ungültige Zeichen. Bitte verwenden Sie nur alphanumerische Zeichen und Unterstriche.",
+    "form_username_invalid_length": "Der Benutzername muss zwischen 3 und 30 Zeichen lang sein.",
+    "form_username_needs_non_number_char": "Ihr Benutzername muss mindestens ein nicht-numerisches Zeichen enthalten.",
+    "identification_deletion_failed": "Sie können Ihre letzte Kennung nicht löschen.",
+    "not_allowed_access": "Die E-Mail-Adresse oder Telefonnummer ist für die Anmeldung nicht zulässig. Dies kann daran liegen, dass Ihre E-Mail-Adresse die Zeichen '+', '=', '#' oder '.' enthält, Sie eine Domain verwenden, die mit einem temporären E-Mail-Dienst verknüpft ist, oder dass Sie explizit gesperrt sind. Wenn Sie glauben, dass dies ein Fehler ist, wenden Sie sich bitte an den Support.",
+    "organization_domain_blocked": "Diese E-Mail-Provider-Domain ist gesperrt. Bitte verwenden Sie eine andere.",
+    "organization_domain_common": "Dies ist eine gängige E-Mail-Provider-Domain. Bitte verwenden Sie eine andere.",
+    "organization_domain_exists_for_enterprise_connection": "Diese Domain wird bereits für das SSO Ihrer Organisation verwendet",
+    "organization_membership_quota_exceeded": "Sie haben Ihr Limit an Organisationsmitgliedschaften einschließlich ausstehender Einladungen erreicht.",
+    "organization_minimum_permissions_needed": "Es muss mindestens ein Organisationsmitglied mit den erforderlichen Mindestberechtigungen geben.",
+    "organization_not_found_or_unauthorized": "Sie sind kein Mitglied dieser Organisation mehr. Bitte wählen Sie eine andere aus oder erstellen Sie eine neue.",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "Sie sind kein Mitglied dieser Organisation mehr. Bitte wählen Sie eine andere aus.",
+    "passkey_already_exists": "Auf diesem Gerät ist bereits ein Passkey registriert.",
+    "passkey_not_supported": "Passkeys werden auf diesem Gerät nicht unterstützt.",
+    "passkey_pa_not_supported": "Die Registrierung erfordert einen Plattformauthentifikator, der vom Gerät nicht unterstützt wird.",
+    "passkey_registration_cancelled": "Die Passkey-Registrierung wurde abgebrochen oder das Zeitlimit wurde überschritten.",
+    "passkey_retrieval_cancelled": "Die Passkey-Registrierung wurde abgebrochen oder das Zeitlimit wurde überschritten.",
+    "passwordComplexity": {
+      "maximumLength": "weniger als {{length}} Zeichen lang sein",
+      "minimumLength": "mindestens {{length}} Zeichen lang sein",
+      "requireLowercase": "einen Kleinbuchstaben enthalten",
+      "requireNumbers": "eine Zahl enthalten",
+      "requireSpecialCharacter": "ein Sonderzeichen enthalten",
+      "requireUppercase": "einen Großbuchstaben enthalten",
+      "sentencePrefix": "Das Passwort muss"
+    },
+    "phone_number_exists": "Diese Telefonnummer ist bereits vergeben. Bitte wählen Sie eine Andere.",
+    "session_exists": "Sie sind bereits angemeldet.",
+    "web3_missing_identifier": "Eine Web3 Wallet-Erweiterung wurde nicht gefunden. Bitte installieren Sie eine, um fortzufahren.",
+    "web3_signature_request_rejected": "Du hast die Signaturanfrage abgelehnt. Bitte versuche es erneut, um fortzufahren.",
+    "web3_solana_signature_generation_failed": "Beim Erstellen der Signatur ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut, um fortzufahren.",
+    "zxcvbn": {
+      "couldBeStronger": "Ihr Passwort funktioniert, könnte aber besser sein. Versuchen Sie, mehr Zeichen hinzuzufügen.",
+      "goodPassword": "Ihr Passwort erfüllt alle notwendigen Anforderungen.",
+      "notEnough": "Ihr Passwort ist nicht stark genug.",
+      "suggestions": {
+        "allUppercase": "Einige, aber nicht alle Buchstaben groß schreiben.",
+        "anotherWord": "Weitere Wörter, die weniger häufig vorkommen, hinzufügen.",
+        "associatedYears": "Jahre, die mit persönlichen Daten in Verbindung gebracht werden können, vermeiden.",
+        "capitalization": "Nicht nur den ersten Buchstaben groß schreiben.",
+        "dates": "Daten, die mit persönlichen Daten in Verbindung gebracht werden können, vermeiden.",
+        "l33t": "Vorhersehbare Buchstabenersetzungen wie '@' für 'a' vermeiden.",
+        "longerKeyboardPattern": "Längere Tastaturmuster in unterschiedlicher Tipprichtung verwenden.",
+        "noNeed": "Es ist möglich, starke Passwörter zu erstellen, ohne Symbole, Zahlen oder Großbuchstaben zu verwenden.",
+        "pwned": "Wenn Sie dieses Passwort an anderer Stelle verwenden, sollten Sie es ändern.",
+        "recentYears": "Die jüngsten Jahreszahlen vermeiden.",
+        "repeated": "Wort- und Zeichenwiederholungen vermeiden.",
+        "reverseWords": "Umgekehrte Schreibweise von gebräuchlichen Wörtern vermeiden.",
+        "sequences": "Häufige Zeichenfolgen vermeiden.",
+        "useWords": "Mehrere Wörter verwenden, aber allgemeine Phrasen vermeiden."
+      },
+      "warnings": {
+        "common": "Dies ist ein oft verwendetes Passwort.",
+        "commonNames": "Vornamen und Nachnamen sind leicht zu erraten.",
+        "dates": "Ein Datum ist leicht zu erraten.",
+        "extendedRepeat": "Sich wiederholende Zeichenmuster wie \"abcabcabc\" sind leicht zu erraten.",
+        "keyPattern": "Kurze Tastaturmuster sind leicht zu erraten.",
+        "namesByThemselves": "Einzelne Namen oder Nachnamen sind leicht zu erraten.",
+        "pwned": "Ihr Passwort wurde durch eine Datenpanne im Internet offengelegt.",
+        "recentYears": "Die jüngsten Jahreszahlen sind leicht zu erraten.",
+        "sequences": "Häufige Zeichenfolgen wie \"abc\" sind leicht zu erraten.",
+        "similarToCommon": "Dies weist Ähnlichkeit zu anderen oft verwendeten Passwörtern auf.",
+        "simpleRepeat": "Sich wiederholende Zeichen wie \"aaa\" sind leicht zu erraten.",
+        "straightRow": "Gerade Linien von Tasten auf der Tastatur sind leicht zu erraten.",
+        "topHundred": "Dies ist ein häufig verwendetes Passwort.",
+        "topTen": "Dies ist ein sehr häufig verwendetes Passwort.",
+        "userInputs": "Es sollten keine persönlichen oder Seiten relevanten Daten vorkommen.",
+        "wordByItself": "Einzelne Wörter sind leicht zu erraten."
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "Konto hinzufügen",
+    "action__closeUserMenu": "Benutzermenü schließen",
+    "action__manageAccount": "Konto verwalten",
+    "action__openUserMenu": "Benutzermenü öffnen",
+    "action__signOut": "Abmelden",
+    "action__signOutAll": "Melden Sie sich von allen Konten ab",
+    "label__accountActions": "Kontoaktionen",
+    "label__activeSessions": "Aktive Sitzungen",
+    "label__userButtonPopover": "Kontopanel"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "API-Keys" },
+    "backupCodePage": {
+      "actionLabel__copied": "Kopiert!",
+      "actionLabel__copy": "Kopiere alle",
+      "actionLabel__download": "Laden Sie .txt herunter",
+      "actionLabel__print": "Drucken",
+      "infoText1": "Wiederherstellungscodes werden für dieses Konto aktiviert.",
+      "infoText2": "Halten Sie die Wiederherstellungscodes geheim und bewahren Sie sie sicher auf. Sie können Wiederherstellungscodes neu generieren, wenn Sie vermuten, dass sie kompromittiert wurden.",
+      "subtitle__codelist": "Bewahren Sie die Codes sicher auf und halten Sie sie geheim.",
+      "successMessage": "Wiederherstellungscodes sind jetzt aktiviert. Sie können eines davon verwenden, um sich bei Ihrem Konto anzumelden, wenn Sie den Zugriff auf Ihr Authentifizierungsgerät verlieren. Jeder Code kann nur einmal verwendet werden.",
+      "successSubtitle": "Sie können diese Codes verwenden, um sich bei Ihrem Konto anzumelden, wenn Sie den Zugriff auf Ihr Authentifizierungsgerät verlieren.",
+      "title": "Wiederherstellungscode-Verifizierung hinzufügen",
+      "title__codelist": "Wiederherstellungscodes"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Kein Zahlungsverlauf",
+        "notFound": "Zahlungsversuch nicht gefunden",
+        "tableHeader__amount": "Betrag",
+        "tableHeader__date": "Datum",
+        "tableHeader__status": "Status"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Als Standard festlegen",
+        "actionLabel__remove": "Entfernen",
+        "add": "Neue Zahlungsmethode hinzufügen",
+        "addSubtitle": "Fügen Sie eine neue Zahlungsmethode hinzu.",
+        "cancelButton": "Abbrechen",
+        "formButtonPrimary__add": "Zahlungsmethode hinzufügen",
+        "formButtonPrimary__pay": "{{amount}} bezahlen",
+        "payWithTestCardButton": "Mit Test-Kreditkarte bezahlen",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} wird von diesem Konto entfernt.",
+          "messageLine2": "In Zukunft können Sie diese Zahlungsmethode nicht mehr verwenden. Alle laufenden Abonnements, die diese Zahlungsmethode verwenden, werden aufhören zu funktionieren.",
+          "successMessage": "{{paymentMethod}} wurde von diesem Konto entfernt.",
+          "title": "Zahlungsmethode entfernen"
+        },
+        "title": "Zahlungsmethoden"
+      },
+      "start": {
+        "headerTitle__payments": "Zahlungen",
+        "headerTitle__plans": "Pläne",
+        "headerTitle__statements": "Abrechnungen",
+        "headerTitle__subscriptions": "Abonnements"
+      },
+      "statementsSection": {
+        "empty": "Keine Abrechnungen verfügbar",
+        "itemCaption__paidForPlan": "Bezahlt für {{plan}} {{period}} Plan",
+        "itemCaption__proratedCredit": "Anteilige Gutschrift für teilweise Nutzung des vorherigen Abonnements",
+        "itemCaption__subscribedAndPaidForPlan": "Abonniert und bezahlt für {{plan}} {{period}} Plan",
+        "notFound": "Abrechnung nicht gefunden",
+        "tableHeader__amount": "Betrag",
+        "tableHeader__date": "Datum",
+        "title": "Abrechnungen",
+        "totalPaid": "Insgesamt bezahlt"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Verwalten",
+        "actionLabel__newSubscription": "Plan abonnieren",
+        "actionLabel__switchPlan": "Plan wechseln",
+        "tableHeader__edit": "Bearbeiten",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Startdatum",
+        "title": "Abonnement"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Verwalten" },
+      "switchPlansSection": { "title": "Plan wechseln" },
+      "title": "Abrechnung"
+    },
+    "connectedAccountPage": {
+      "formHint": "Wählen Sie einen Anbieter aus, um Ihr Konto zu verbinden.",
+      "formHint__noAccounts": "Es sind keine externen Kontoanbieter verfügbar.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} wird aus diesem Konto entfernt.",
+        "messageLine2": "Sie können dieses verbundene Konto nicht mehr verwenden und alle abhängigen Funktionen funktionieren nicht mehr.",
+        "successMessage": "{{connectedAccount}} wurde aus Ihrem Konto entfernt.",
+        "title": "Verbundenes Konto entfernen"
+      },
+      "socialButtonsBlockButton": "{{provider|titleize}}-Konto verbinden",
+      "successMessage": "Der Anbieter wurde Ihrem Konto hinzugefügt",
+      "title": "Verbundenes Konto hinzufügen"
+    },
+    "deletePage": {
+      "actionDescription": "Geben Sie \"Konto löschen\" ein, um fortzufahren.",
+      "confirm": "Konto löschen",
+      "messageLine1": "Möchten Sie Ihr Konto wirklich löschen? Einige zugehörige Daten können gespeichert bleiben. Um die vollständige Löschung der Daten anzufordern, wenden Sie sich bitte an den Support.",
+      "messageLine2": "Diese Aktion ist endgültig und kann nicht rückgängig gemacht werden.",
+      "title": "Konto löschen"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "An diese E-Mail-Adresse wird eine E-Mail mit einem Bestätigungscode gesendet.",
+        "formSubtitle": "Geben Sie den Bestätigungscode ein, der an {{identifier}} gesendet wird",
+        "formTitle": "Bestätigungscode",
+        "resendButton": "Code erneut senden",
+        "successMessage": "Die E-Mail-Adresse {{identifier}} wurde Ihrem Konto hinzugefügt."
+      },
+      "emailLink": {
+        "formHint": "An diese E-Mail-Adresse wird eine E-Mail mit einem Bestätigungslink gesendet.",
+        "formSubtitle": "Klicken Sie auf den Bestätigungslink in der an {{identifier}} gesendeten E-Mail",
+        "formTitle": "Bestätigungslink",
+        "resendButton": "Link erneut senden",
+        "successMessage": "Die E-Mail-Adresse {{identifier}} wurde Ihrem Konto hinzugefügt."
+      },
+      "enterpriseSSOLink": {
+        "formButton": "Klicken Sie zum Anmelden",
+        "formSubtitle": "Schließen Sie die Anmeldung mit {{identifier}} ab"
+      },
+      "formHint": "Sie müssen diese E-Mail-Adresse verifizieren, bevor sie Ihrem Konto hinzugefügt werden kann.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} wird aus diesem Konto entfernt.",
+        "messageLine2": "Sie können sich nicht mehr mit dieser E-Mail-Adresse anmelden.",
+        "successMessage": "{{emailAddress}} wurde aus Ihrem Konto entfernt.",
+        "title": "E-Mail-Adresse entfernen"
+      },
+      "title": "E-Mail-Adresse hinzufügen",
+      "verifyTitle": "E-Mail Adresse verifizieren"
+    },
+    "formButtonPrimary__add": "Hinzufügen",
+    "formButtonPrimary__continue": "Fortsetzen",
+    "formButtonPrimary__finish": "Fertig",
+    "formButtonPrimary__remove": "Entfernen",
+    "formButtonPrimary__save": "Speichern",
+    "formButtonReset": "Zurücksetzen",
+    "mfaPage": {
+      "formHint": "Wählen Sie eine Methode aus.",
+      "title": "Aktivieren Sie Zweifaktor-Authentifizierung"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "Vorhandene Nummer verwenden",
+      "primaryButton__addPhoneNumber": "Fügen Sie eine Telefonnummer hinzu",
+      "removeResource": {
+        "messageLine1": "{{identifier}} erhält bei der Anmeldung keine Bestätigungscodes mehr.",
+        "messageLine2": "Ihr Konto ist möglicherweise nicht so sicher. Sind Sie sich sicher, dass Sie fortfahren möchten?",
+        "successMessage": "SMS-Code-Bestätigung in zwei Schritten wurde für {{mfaPhoneCode}} entfernt",
+        "title": "Entfernen Sie die Bestätigung in zwei Schritten"
+      },
+      "subtitle__availablePhoneNumbers": "Wählen Sie eine Telefonnummer aus, um sich für die Bestätigung in zwei Schritten per SMS-Code zu registrieren.",
+      "subtitle__unavailablePhoneNumbers": "Es sind keine Telefonnummern verfügbar, um sich für die SMS-Code-Bestätigung in zwei Schritten zu registrieren.",
+      "successMessage1": "Wenn Sie sich anmelden, müssen Sie einen Bestätigungscode eingeben, der an diese Telefonnummer gesendet wird.",
+      "successMessage2": "Speichern Sie diese Wiederherstellungscodes und bewahren Sie sie an einem sicheren Ort auf. Falls Sie den Zugriff auf Ihr Authentifizierungsgerät verlieren, können Sie sich mit diesen Codes anmelden.",
+      "successTitle": "SMS-Code-Bestätigung aktiviert",
+      "title": "SMS-Code-Bestätigung hinzufügen"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "Scannen Sie stattdessen den QR-Code",
+        "buttonUnableToScan__nonPrimary": "QR-Code kann nicht gescannt werden?",
+        "infoText__ableToScan": "Richten Sie eine neue Anmeldemethode in Ihrer Authentifizierungs-App ein und scannen Sie den folgenden QR-Code, um ihn mit Ihrem Konto zu verknüpfen.",
+        "infoText__unableToScan": "Richten Sie eine neue Anmeldemethode in Ihrem Authentifikator ein und geben Sie den unten angegebenen Schlüssel ein.",
+        "inputLabel__unableToScan1": "Stellen Sie sicher, dass zeitbasierte oder einmalige Passwörter aktiviert sind, und schließen Sie dann die Verknüpfung Ihres Kontos ab.",
+        "inputLabel__unableToScan2": "Wenn Ihr Authentifikator TOTP-URIs unterstützt, können Sie alternativ auch die vollständige URI kopieren."
+      },
+      "removeResource": {
+        "messageLine1": "Bei der Anmeldung sind keine Bestätigungscodes von diesem Authentifikator mehr erforderlich.",
+        "messageLine2": "Ihr Konto ist möglicherweise nicht mehr so sicher. Sind Sie sich sicher, dass Sie fortfahren wollen?",
+        "successMessage": "Die zweistufige Verifizierung über die Authentifizierungs-App wurde entfernt.",
+        "title": "Entfernen Sie die Bestätigung in zwei Schritten"
+      },
+      "successMessage": "Die Bestätigung in zwei Schritten ist jetzt aktiviert. Bei der Anmeldung müssen Sie als zusätzlichen Schritt einen Bestätigungscode von diesem Authentifikator eingeben.",
+      "title": "Authentifizierungs-App hinzufügen",
+      "verifySubtitle": "Geben Sie den von Ihrem Authentifikator generierten Bestätigungscode ein",
+      "verifyTitle": "Bestätigungscode"
+    },
+    "mobileButton__menu": "Menü",
+    "navbar": {
+      "account": "Profil",
+      "apiKeys": "API-Keys",
+      "billing": "Abrechnung",
+      "description": "Verwalten Sie Ihre Kontoinformationen.",
+      "security": "Sicherheit",
+      "title": "Benutzerkonto"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "{{name}} wird von diesem Konto entfernt.",
+        "title": "Passkey entfernen"
+      },
+      "subtitle__rename": "Sie können den Namen des Passkeys ändern, um ihn leichter zu finden.",
+      "title__rename": "Passkey umbenennen"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "Es wird empfohlen, sich von allen anderen Geräten abzumelden, die möglicherweise Ihr altes Passwort verwendet haben.",
+      "readonly": "Ihr Passwort kann derzeit nicht geändert werden, da Sie sich nur über die Enterprise-Verbindung anmelden können.",
+      "successMessage__set": "Ihr Passwort wurde festgelegt.",
+      "successMessage__signOutOfOtherSessions": "Alle anderen Geräte wurden abgemeldet.",
+      "successMessage__update": "Dein Passwort wurde aktualisiert.",
+      "title__set": "Passwort festlegen",
+      "title__update": "Passwort ändern"
+    },
+    "phoneNumberPage": {
+      "infoText": "An diese Telefonnummer wird eine SMS mit einem Bestätigungslink gesendet.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} wird aus diesem Konto entfernt.",
+        "messageLine2": "Sie können sich nicht mehr mit dieser Telefonnummer anmelden.",
+        "successMessage": "{{phoneNumber}} wurde aus Ihrem Konto entfernt.",
+        "title": "Telefonnummer entfernen"
+      },
+      "successMessage": "{{identifier}} wurde Ihrem Konto hinzugefügt.",
+      "title": "Telefonnummer hinzufügen",
+      "verifySubtitle": "Geben Sie den Bestätigungscode ein, der an {{identifier}} gesendet wurde",
+      "verifyTitle": "Telefonnummer verifizieren"
+    },
+    "plansPage": { "title": "Pläne" },
+    "profilePage": {
+      "fileDropAreaHint": "Laden Sie ein JPG-, PNG-, GIF- oder WEBP-Bild hoch, das kleiner als 10 MB ist",
+      "imageFormDestructiveActionSubtitle": "Bild entfernen",
+      "imageFormSubtitle": "Bild hochladen",
+      "imageFormTitle": "Profilbild",
+      "readonly": "Ihre Profilinformationen wurden durch Ihr Unternehmen bereitgestellt und können nicht bearbeitet werden.",
+      "successMessage": "Ihr Profil wurde aktualisiert.",
+      "title": "Profil aktualisieren"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "Vom Gerät abmelden",
+        "title": "Aktive Geräte"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "Versuchen Sie es nochmal",
+        "actionLabel__reauthorize": "Jetzt autorisieren",
+        "destructiveActionTitle": "Entfernen",
+        "primaryButton": "Konto verbinden",
+        "subtitle__disconnected": "Ihr Konto ist derzeit getrennt. Bitte verbinden Sie es erneut.",
+        "subtitle__reauthorize": "Die erforderlichen Berechtigungen wurden aktualisiert, wodurch Ihre Funktionalität möglicherweise eingeschränkt ist. Bitte autorisieren Sie diese Anwendung erneut, um Probleme zu vermeiden.",
+        "title": "Verbundene Konten"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "Konto löschen",
+        "title": "Achtung"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "E-Mail-Adresse entfernen",
+        "detailsAction__nonPrimary": "Als primär festlegen",
+        "detailsAction__primary": "Verifizierung abschließen",
+        "detailsAction__unverified": "Verifizierung abschließen",
+        "primaryButton": "Fügen Sie eine E-Mail-Adresse hinzu",
+        "title": "E-Mail-Adressen"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "Konto verbinden",
+        "title": "Unternehmens-Konten"
+      },
+      "headerTitle__account": "Konto",
+      "headerTitle__security": "Sicherheit",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "Codes neu generieren",
+          "headerTitle": "Wiederherstellungscodes",
+          "subtitle__regenerate": "Generieren Sie einen neuen Satz sicherer Wiederherstellungscodes. Alte Wiederherstellungscodes werden gelöscht und können nicht mehr verwendet werden.",
+          "title__regenerate": "Wiederherstellungscodes neu generieren"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "Als Standard einstellen",
+          "destructiveActionLabel": "Telefonnummer entfernen"
+        },
+        "primaryButton": "Aktivieren Sie die Zweifaktor-Authentifizierung",
+        "title": "Zweifaktor-Authentifizierung",
+        "totp": {
+          "destructiveActionTitle": "Entfernen",
+          "headerTitle": "Authentifizierungs-App"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "Entfernen",
+        "menuAction__rename": "Umbenennen",
+        "primaryButton": "Passkey hinzufügen",
+        "title": "Passkeys"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "Passwort festlegen",
+        "primaryButton__updatePassword": "Passwort ändern",
+        "title": "Passwort"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "Telefonnummer entfernen",
+        "detailsAction__nonPrimary": "Als primär festlegen",
+        "detailsAction__primary": "Verifizierung abschließen",
+        "detailsAction__unverified": "Verifizierung abschließen",
+        "primaryButton": "Fügen Sie eine Telefonnummer hinzu",
+        "title": "Telefonnummern"
+      },
+      "profileSection": {
+        "primaryButton": "Profil bearbeiten",
+        "title": "Profil"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "Benutzernamen festlegen",
+        "primaryButton__updateUsername": "Benutzernamen ändern",
+        "title": "Nutzername"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "Wallet entfernen",
+        "detailsAction__nonPrimary": "Als primär festlegen",
+        "primaryButton": "Web3-Wallets",
+        "title": "Web3-Wallets",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Wählen Sie eine Solana-Wallet aus, um sie mit Ihrem Konto zu verbinden.",
+          "title": "Solana-Wallet hinzufügen"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "Ihr Benutzername wurde aktualisiert.",
+      "title__set": "Benutzernamen aktualisieren",
+      "title__update": "Benutzernamen aktualisieren"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} wird aus diesem Konto entfernt.",
+        "messageLine2": "Sie können sich nicht mehr mit diesem Web3-Wallet anmelden.",
+        "successMessage": "{{web3Wallet}} wurde aus Ihrem Konto entfernt.",
+        "title": "Entfernen Sie das Web3-Wallet"
+      },
+      "subtitle__availableWallets": "Wählen Sie ein Web3-Wallet aus, um sich mit Ihrem Konto zu verbinden.",
+      "subtitle__unavailableWallets": "Es sind keine Web3-Wallets verfügbar.",
+      "successMessage": "Die Brieftasche wurde Ihrem Konto hinzugefügt.",
+      "title": "Web3-Wallet hinzufügen",
+      "web3WalletButtonsBlockButton": "{{provider|titleize}}"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "Anmelden",
+      "actionText": "Bereits Zugang?",
+      "formButton": "Warteliste beitreten",
+      "subtitle": "Geben Sie Ihre E-Mail-Adresse ein und wir benachrichtigen Sie, sobald Ihr Zugang verfügbar ist.",
+      "title": "Warteliste beitreten"
+    },
+    "success": {
+      "message": "Sie wurden erfolgreich auf die Warteliste gesetzt. Wir benachrichtigen Sie, sobald der Zugang freigegeben wird.",
+      "subtitle": "Vielen Dank für Ihre Geduld. Sie erhalten eine Benachrichtigung, sobald der Zugang freigegeben wird.",
+      "title": "Erfolgreich auf die Warteliste gesetzt"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Mit {{walletName}} verbinden",
+    "continue": "Weiter mit {{walletName}}",
+    "noneAvailable": "Keine Solana-Web3-Wallets erkannt. Bitte installieren Sie eine Web3-unterstützte {{ solanaWalletsLink || link(\"wallet extension\") }}."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/es-ES.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/es-ES.json
@@ -1,0 +1,1314 @@
+{
+  "locale": "es-ES",
+  "apiKeys": {
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Copiar y cerrar",
+      "formHint": "Por razones de seguridad, no podrás verlo de nuevo más tarde.",
+      "formTitle": "Copia tu clave API \"{{name}}\" ahora"
+    },
+    "revokeConfirmation": {}
+  },
+  "backButton": "Atrás",
+  "badge__default": "Por defecto",
+  "badge__otherImpersonatorDevice": "Otro dispositivo de imitación",
+  "badge__primary": "Primario",
+  "badge__requiresAction": "Requiere acción",
+  "badge__thisDevice": "Este dispositivo",
+  "badge__unverified": "No confirmado",
+  "badge__userDevice": "Dispositivo de usuario",
+  "badge__you": "Usted",
+  "billing": {
+    "addPaymentMethod__label": "Añadir nuevo método de pago",
+    "alwaysFree": "Siempre gratis",
+    "annually": "Anualmente",
+    "availableFeatures": "Funciones disponibles",
+    "billedAnnually": "Facturado anualmente",
+    "billedMonthlyOnly": "Solo facturado mensualmente",
+    "cancelFreeTrial": "Cancelar prueba gratuita",
+    "cancelFreeTrialAccessUntil": "Tu prueba seguirá activa hasta el {{ date | longDate('es-ES') }}. Después perderás el acceso a las funciones de prueba. No se te cobrará nada.",
+    "cancelFreeTrialTitle": "¿Cancelar la prueba gratuita del plan {{plan}}?",
+    "cancelSubscription": "Cancelar suscripción",
+    "cancelSubscriptionAccessUntil": "Puedes seguir usando las funciones de '{{plan}}' hasta el {{ date | longDate('es-ES') }}, después ya no tendrás acceso.",
+    "cancelSubscriptionNoCharge": "No se te cobrará por esta suscripción.",
+    "cancelSubscriptionPastDue": "Tu suscripción finalizará inmediatamente y perderás el acceso a todas las funciones del plan. Se te pedirá que pagues el importe pendiente en tu próxima suscripción.",
+    "cancelSubscriptionTitle": "¿Cancelar la suscripción {{plan}}?",
+    "cannotSubscribeMonthly": "No puedes suscribirte a este plan con pago mensual. Para suscribirte, debes elegir el pago anual.",
+    "cannotSubscribeUnrecoverable": "No puedes suscribirte a este plan. Tu suscripción actual es más cara que este plan.",
+    "checkout": {
+      "description__paymentSuccessful": "Tu pago se ha realizado correctamente.",
+      "description__subscriptionSuccessful": "Tu nueva suscripción está lista.",
+      "downgradeNotice": "Mantendrás tu suscripción actual y sus funciones hasta el final del ciclo de facturación; después se te cambiará a esta suscripción.",
+      "emailForm": {
+        "subtitle": "Antes de completar la compra, debes añadir una dirección de correo electrónico donde se enviarán los recibos.",
+        "title": "Añadir dirección de correo electrónico"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "La prueba termina el",
+        "title__paymentMethod": "Método de pago",
+        "title__statementId": "ID del extracto",
+        "title__subscriptionBegins": "La suscripción comienza el",
+        "title__totalPaid": "Total pagado"
+      },
+      "pastDueNotice": "Tu suscripción anterior tenía un pago pendiente.",
+      "perMonth": "al mes",
+      "title": "Pago",
+      "title__paymentSuccessful": "¡Pago realizado con éxito!",
+      "title__subscriptionSuccessful": "¡Todo listo!",
+      "title__trialSuccess": "¡La prueba se ha iniciado correctamente!",
+      "totalDueAfterTrial": "Total a pagar cuando termine la prueba en {{days}} días"
+    },
+    "credit": "Crédito",
+    "creditRemainder": "Crédito por el tiempo restante de tu suscripción actual.",
+    "defaultFreePlanActive": "Actualmente estás en el plan gratuito",
+    "free": "Gratis",
+    "getStarted": "Empezar",
+    "highlightedPlanBadge": "Popular",
+    "keepFreeTrial": "Mantener prueba gratuita",
+    "keepSubscription": "Mantener suscripción",
+    "manage": "Gestionar",
+    "manageSubscription": "Gestionar suscripción",
+    "month": "Mes",
+    "monthly": "Mensual",
+    "pastDue": "Pago pendiente",
+    "pay": "Pagar {{amount}}",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "Pago anual",
+        "monthly": "Pago mensual"
+      },
+      "dev": {
+        "anyNumbers": "Cualquier número",
+        "cardNumber": "Número de tarjeta",
+        "cvcZip": "CVC, código postal",
+        "developmentMode": "Modo de desarrollo",
+        "expirationDate": "Fecha de caducidad",
+        "testCardInfo": "Información de tarjeta de prueba"
+      }
+    },
+    "paymentMethods__label": "Métodos de pago",
+    "pricingTable": {
+      "billingCycle": "Ciclo de facturación",
+      "included": "Incluido",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "Volver a suscribirse",
+    "seeAllFeatures": "Ver todas las funciones",
+    "startFreeTrial": "Iniciar prueba gratuita",
+    "startFreeTrial__days": "Iniciar prueba gratuita de {{days}} días",
+    "subscribe": "Suscribirse",
+    "subscriptionDetails": {
+      "beginsOn": "Comienza el",
+      "currentBillingCycle": "Ciclo de facturación actual",
+      "endsOn": "Finaliza el",
+      "firstPaymentAmount": "Importe del primer pago",
+      "firstPaymentOn": "Primer pago el",
+      "nextPaymentAmount": "Importe del próximo pago",
+      "nextPaymentOn": "Próximo pago el",
+      "pastDueAt": "Pago pendiente desde",
+      "renewsAt": "Se renueva el",
+      "subscribedOn": "Suscrito el",
+      "title": "Suscripción",
+      "trialEndsOn": "La prueba termina el",
+      "trialStartedOn": "La prueba comenzó el"
+    },
+    "subtotal": "Subtotal",
+    "switchPlan": "Cambiar a este plan",
+    "switchToAnnual": "Cambiar a anual",
+    "switchToAnnualWithAnnualPrice": "Cambiar a anual {{price}} / año",
+    "switchToMonthly": "Cambiar a mensual",
+    "switchToMonthlyWithPrice": "Cambiar a mensual {{price}} / mes",
+    "totalDue": "Total a pagar",
+    "totalDueToday": "Total a pagar hoy",
+    "viewFeatures": "Ver funciones",
+    "viewPayment": "Ver pago",
+    "year": "Año"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Contacte al administrador de su organización para ampliar sus permisos.",
+      "title": "No tiene permiso para gestionar el inicio de sesión único (SSO)"
+    },
+    "navbar": { "title": "Configurar inicio de sesión único (SSO)" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Sin verificar",
+        "badge__verified": "Verificado",
+        "txtRecord": {
+          "hostLabel": "Host / Nombre",
+          "instructions": "Añade este registro TXT a tu proveedor de DNS. Lo verificaremos automáticamente una vez que el registro esté activo.",
+          "typeLabel": "Tipo",
+          "valueLabel": "Valor"
+        },
+        "verifiedAtLabel": "Verificado el {{ date | shortDate('es-ES') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "Añadir {{domain}}",
+        "messageLabel": "Tu correo electrónico usa {{domain}}. ¿Quieres añadirlo?"
+      },
+      "formButtonPrimary__add": "Añadir",
+      "formFieldInputPlaceholder__domain": "Añadir dominio",
+      "formFieldLabel__domain": "Dominio",
+      "removeDomainDialog": {},
+      "subtitle": "Añade y verifica la propiedad de los dominios que tu organización usa para iniciar sesión.",
+      "title": "Añadir dominios SSO"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Proveedor SAML personalizado",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Selecciona el proveedor para el que vas a configurar SSO.",
+      "title": "Seleccionar proveedor",
+      "warning": "Una vez seleccionado un proveedor no podrás cambiarlo hasta que finalice la configuración"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Crear organización",
+    "invitePage": { "formButtonReset": "Saltar" },
+    "title": "Crear organización"
+  },
+  "dates": {
+    "lastDay": "Ayer a las {{ date | timeString('es-ES') }}",
+    "next6Days": "{{ date | weekday('es-ES','long') }} a las {{ date | timeString('es-ES') }}",
+    "nextDay": "Mañana a las {{ date | timeString('es-ES') }}",
+    "numeric": "{{ date | numeric('es-ES') }}",
+    "previous6Days": "Último {{ date | weekday('es-ES','long') }} en {{ date | timeString('es-ES') }}",
+    "sameDay": "Hoy a las {{ date | timeString('es-ES') }}"
+  },
+  "dividerText": "o",
+  "footerActionLink__useAnotherMethod": "Usar otro método",
+  "footerPageLink__help": "Ayuda",
+  "footerPageLink__privacy": "Privacidad",
+  "footerPageLink__terms": "Términos",
+  "formButtonPrimary": "Continuar",
+  "formButtonPrimary__verify": "Verificar",
+  "formFieldAction__forgotPassword": "Has olvidado tu contraseña?",
+  "formFieldError__matchingPasswords": "Las contraseñas coinciden.",
+  "formFieldError__notMatchingPasswords": "Las contraseñas no coinciden.",
+  "formFieldError__verificationLinkExpired": "El enlace de verificación ha expirado. Por favor solicite uno nuevo.",
+  "formFieldHintText__optional": "Opcional",
+  "formFieldHintText__slug": "Un slug es un ID legible que debe ser único. Es comúnmente usado en URLs.",
+  "formFieldInputPlaceholder__backupCode": "Ingrese su código de respaldo",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Eliminar cuenta",
+  "formFieldInputPlaceholder__emailAddress": "Ingrese su dirección de correo electrónico",
+  "formFieldInputPlaceholder__emailAddress_username": "Ingrese su correo electrónico o nombre de usuario",
+  "formFieldInputPlaceholder__emailAddresses": "Ingrese o pegue una o más direcciones de correo electrónico, separadas por espacios o comas",
+  "formFieldInputPlaceholder__firstName": "Ingrese su nombre",
+  "formFieldInputPlaceholder__lastName": "Ingrese su apellido",
+  "formFieldInputPlaceholder__organizationDomain": "Ingrese el dominio de la organización",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "Ingrese un correo electrónico del dominio",
+  "formFieldInputPlaceholder__organizationName": "Ingrese el nombre de la organización",
+  "formFieldInputPlaceholder__organizationSlug": "Ingrese un slug único para la organización",
+  "formFieldInputPlaceholder__password": "Ingrese su contraseña",
+  "formFieldInputPlaceholder__phoneNumber": "Ingrese su número telefónico",
+  "formFieldInputPlaceholder__username": "Ingrese su nombre de usuario",
+  "formFieldLabel__apiKey": "Clave API",
+  "formFieldLabel__apiKeyDescription": "Descripción",
+  "formFieldLabel__apiKeyExpiration": "Expiración",
+  "formFieldLabel__apiKeyName": "Nombre de clave secreta",
+  "formFieldLabel__automaticInvitations": "Activar invitaciones automáticas para este dominio",
+  "formFieldLabel__backupCode": "Código de respaldo",
+  "formFieldLabel__confirmDeletion": "Confirmación",
+  "formFieldLabel__confirmPassword": "Confirme la contraseña",
+  "formFieldLabel__currentPassword": "Contraseña actual",
+  "formFieldLabel__emailAddress": "Correo electrónico",
+  "formFieldLabel__emailAddress_username": "Correo electrónico o nombre de usuario",
+  "formFieldLabel__emailAddresses": "Direcciones de correo",
+  "formFieldLabel__firstName": "Nombre",
+  "formFieldLabel__lastName": "Apellido",
+  "formFieldLabel__newPassword": "Nueva contraseña",
+  "formFieldLabel__organizationDomain": "Dominio",
+  "formFieldLabel__organizationDomainDeletePending": "Borrar invitaciones y sugerencias pendientes",
+  "formFieldLabel__organizationDomainEmailAddress": "Correo de verificación",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Ingrese una dirección de correo electrónico bajo este dominio para recibir un código y verificarlo.",
+  "formFieldLabel__organizationName": "Nombre de la Organización",
+  "formFieldLabel__organizationSlug": "Slug",
+  "formFieldLabel__passkeyName": "Nombre de la clave de acceso",
+  "formFieldLabel__password": "Contraseña",
+  "formFieldLabel__phoneNumber": "Número telefónico",
+  "formFieldLabel__role": "Rol",
+  "formFieldLabel__signOutOfOtherSessions": "Cerrar sesión en todos los demás dispositivos",
+  "formFieldLabel__username": "Nombre de usuario",
+  "impersonationFab": {
+    "action__signOut": "Cerrar",
+    "title": "Registrado como {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Último uso",
+  "maintenanceMode": "Modo de mantenimiento",
+  "membershipRole__admin": "Administrador",
+  "membershipRole__basicMember": "Miembro",
+  "membershipRole__guestMember": "Invitado",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Crear organización",
+    "action__invitationAccept": "Unirse",
+    "action__suggestionsAccept": "Solicitud a unirse",
+    "createOrganization": "Crear Organización",
+    "invitationAcceptedLabel": "Unido",
+    "subtitle": "para continuar a {{applicationName}}",
+    "suggestionsAcceptedLabel": "Aprobación pendiente",
+    "title": "Choose an account",
+    "titleWithoutPersonal": "Escoja una organización"
+  },
+  "organizationProfile": {
+    "apiKeysPage": {},
+    "badge__automaticInvitation": "Invitaciones automáticas",
+    "badge__automaticSuggestion": "Sugerencias automáticas",
+    "badge__manualInvitation": "Sin inscripción automática",
+    "badge__unverified": "No verificado",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "No hay historial de pagos",
+        "notFound": "No se ha encontrado el intento de pago",
+        "tableHeader__amount": "Importe",
+        "tableHeader__date": "Fecha",
+        "tableHeader__status": "Estado"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Establecer como predeterminado",
+        "actionLabel__remove": "Eliminar",
+        "add": "Añadir nuevo método de pago",
+        "addSubtitle": "Añade un nuevo método de pago a tu cuenta.",
+        "cancelButton": "Cancelar",
+        "formButtonPrimary__add": "Añadir método de pago",
+        "formButtonPrimary__pay": "Pagar {{amount}}",
+        "payWithTestCardButton": "Pagar con tarjeta de prueba",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} se eliminará de esta cuenta.",
+          "messageLine2": "Ya no podrás usar este método de pago y cualquier suscripción recurrente que dependa de él dejará de funcionar.",
+          "successMessage": "{{paymentMethod}} se ha eliminado de tu cuenta.",
+          "title": "Eliminar método de pago"
+        },
+        "title": "Métodos de pago"
+      },
+      "start": {
+        "headerTitle__payments": "Pagos",
+        "headerTitle__plans": "Planes",
+        "headerTitle__statements": "Facturas",
+        "headerTitle__subscriptions": "Suscripción"
+      },
+      "statementsSection": {
+        "empty": "No hay facturas para mostrar",
+        "itemCaption__paidForPlan": "Pagado por el plan {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédito proporcional por el tiempo no utilizado de la suscripción anterior",
+        "itemCaption__subscribedAndPaidForPlan": "Suscrito y pagado por el plan {{plan}} {{period}}",
+        "notFound": "Factura no encontrada",
+        "tableHeader__amount": "Importe",
+        "tableHeader__date": "Fecha",
+        "title": "Facturas",
+        "totalPaid": "Total pagado"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gestionar",
+        "actionLabel__newSubscription": "Suscribirse a un plan",
+        "actionLabel__switchPlan": "Cambiar de plan",
+        "tableHeader__edit": "Editar",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Fecha de inicio",
+        "title": "Suscripción"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gestionar" },
+      "switchPlansSection": { "title": "Cambiar de plan" },
+      "title": "Facturación"
+    },
+    "createDomainPage": {
+      "subtitle": "Agregue el dominio para verificar. Los usuarios con direcciones de correo electrónico en este dominio pueden unirse a la organización automáticamente o solicitar unirse.",
+      "title": "Agregar dominio"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "No se pudieron enviar las invitaciones. Solucione lo siguiente y vuelva a intentarlo:",
+      "formButtonPrimary__continue": "Enviar invitaciones",
+      "selectDropdown__role": "Seleccionar rol",
+      "subtitle": "Invitar nuevos miembros a esta organización",
+      "successMessage": "Invitaciones enviadas con éxito",
+      "title": "Invitar miembros"
+    },
+    "membersPage": {
+      "action__invite": "Invitar",
+      "action__search": "Buscar",
+      "activeMembersTab": {
+        "menuAction__remove": "Quitar miembro",
+        "tableHeader__actions": "Acciones",
+        "tableHeader__joined": "Unido",
+        "tableHeader__role": "Rol",
+        "tableHeader__user": "Usuario"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Estamos actualizando los roles disponibles. Una vez hecho esto, podrás actualizar los roles de nuevo.",
+          "title": "Los roles están temporalmente bloqueados"
+        }
+      },
+      "detailsTitle__emptyRow": "No hay miembros para mostrar",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Invite a usuarios conectando un dominio de correo electrónico con su organización. Cualquiera que se registre con un dominio de correo electrónico coincidente podrá unirse a la organización en cualquier momento.",
+          "headerTitle": "Invitaciones automáticas",
+          "primaryButton": "Gestionar dominios verificados"
+        },
+        "table__emptyRow": "Sin invitaciones para mostrar"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Revocar invitación",
+        "tableHeader__invited": "Invitado"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Los usuarios que se registren con un dominio de correo electrónico coincidente podrán ver una sugerencia para solicitar unirse a su organización.",
+          "headerTitle": "Sugerencias automáticas",
+          "primaryButton": "Gestionar dominios verificados"
+        },
+        "menuAction__approve": "Aprobar",
+        "menuAction__reject": "Rechazar",
+        "tableHeader__requested": "Acceso solicitado",
+        "table__emptyRow": "Sin solicitudes para mostrar"
+      },
+      "start": {
+        "headerTitle__invitations": "Invitaciones",
+        "headerTitle__members": "Miembros",
+        "headerTitle__requests": "Solicitudes"
+      }
+    },
+    "navbar": {
+      "description": "Gestione su organización.",
+      "general": "General",
+      "members": "Miembros",
+      "title": "Organización"
+    },
+    "plansPage": { "alerts": {} },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Escriba \"{{organizationName}}\" a continuación para continuar.",
+          "messageLine1": "¿Está seguro de que desea eliminar esta organización?",
+          "messageLine2": "Esta acción es permanente e irreversible.",
+          "successMessage": "Ha eliminado la organización.",
+          "title": "Borrar organización"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Escriba \"{{organizationName}}\" a continuación para continuar.",
+          "messageLine1": "¿Está seguro de que desea abandonar esta organización? Perderá el acceso a esta organización y sus aplicaciones.",
+          "messageLine2": "Esta acción es permanente e irreversible.",
+          "successMessage": "Has dejado la organización.",
+          "title": "Abandonar la organización"
+        },
+        "title": "Peligro"
+      },
+      "domainSection": {
+        "menuAction__manage": "Gestione",
+        "menuAction__remove": "Eliminar",
+        "menuAction__verify": "Verificar",
+        "primaryButton": "Añadir dominio",
+        "subtitle": "Permita que los usuarios se unan a la organización automáticamente o soliciten unirse basándose en un dominio de correo electrónico verificado.",
+        "title": "Dominios verificados"
+      },
+      "successMessage": "La organización ha sido actualizada.",
+      "title": "Perfil de la organización"
+    },
+    "removeDomainPage": {
+      "messageLine1": "Se eliminará el dominio de correo electrónico {{domain}}.",
+      "messageLine2": "Los usuarios no podrán unirse a la organización automáticamente después de esto.",
+      "successMessage": "{{dominio}} ha sido eliminado.",
+      "title": "Eliminar dominio"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "General",
+      "headerTitle__members": "Miembros",
+      "profileSection": {
+        "primaryButton": "Actualizar perfil",
+        "title": "Perfil de la Organización",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "La eliminación de este dominio afectará a los usuarios invitados.",
+        "removeDomainActionLabel__remove": "Eliminar dominio",
+        "removeDomainSubtitle": "Elimine este dominio de sus dominios verificados",
+        "removeDomainTitle": "Eliminar dominio"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Los usuarios son invitados automáticamente a unirse a la organización cuando se registran y pueden unirse en cualquier momento.",
+        "automaticInvitationOption__label": "Invitaciones automáticas",
+        "automaticSuggestionOption__description": "Los usuarios reciben una sugerencia para solicitar unirse, pero deben ser aprobados por un administrador antes de poder unirse a la organización.",
+        "automaticSuggestionOption__label": "Sugerencias automáticas",
+        "calloutInfoLabel": "Cambiar el modo de inscripción solo afectará a nuevos usuarios.",
+        "calloutInvitationCountLabel": "Invitaciones pendientes enviadas a los usuarios: {{count}}",
+        "calloutSuggestionCountLabel": "Sugerencias pendientes enviadas a los usuarios: {{count}}",
+        "manualInvitationOption__description": "Los usuarios solo pueden ser invitados manualmente a la organización.",
+        "manualInvitationOption__label": "Sin inscripción automática",
+        "subtitle": "Elija cómo los usuarios de este dominio pueden unirse a la organización."
+      },
+      "start": {
+        "headerTitle__danger": "Peligro",
+        "headerTitle__enrollment": "Opciones de inscripción"
+      },
+      "subtitle": "El dominio {{domain}} está ahora verificado. Continúe seleccionando el modo de inscripción.",
+      "title": "Actualizar {{domain}}"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Ingrese el código de verificación enviado a su dirección de correo electrónico",
+      "formTitle": "Código de verificación",
+      "resendButton": "¿No recibió un código? Reenviar",
+      "subtitle": "El dominio {{domainName}} necesita ser verificado por correo electrónico.",
+      "subtitleVerificationCodeScreen": "Se envió un código de verificación a {{emailAddress}}. Ingrese el código para continuar.",
+      "title": "Verificar dominio"
+    }
+  },
+  "organizationSwitcher": {
+    "action__createOrganization": "Crear Organización",
+    "action__invitationAccept": "Unirse",
+    "action__manageOrganization": "Administrar Organización",
+    "action__suggestionsAccept": "Solicitar unirse",
+    "notSelected": "Ninguna organización seleccionada",
+    "personalWorkspace": "Espacio de trabajo personal",
+    "suggestionsAcceptedLabel": "Aprobación pendiente"
+  },
+  "paginationButton__next": "Próximo",
+  "paginationButton__previous": "Previo",
+  "paginationRowText__displaying": "Mostrando",
+  "paginationRowText__of": "de",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Probar otro método",
+      "actionText": "¿No tienes acceso a este método? Prueba otra opción.",
+      "blockButton__backupCode": "Usar código de respaldo",
+      "blockButton__emailCode": "Usar código de correo electrónico",
+      "blockButton__password": "Usar contraseña",
+      "blockButton__phoneCode": "Usar código de teléfono",
+      "blockButton__totp": "Usar verificación TOTP",
+      "getHelp": {
+        "blockButton__emailSupport": "Contactar soporte por correo electrónico",
+        "content": "Si no puedes verificar tu identidad con los métodos anteriores, comunícate con nuestro equipo de soporte.",
+        "title": "Necesitas ayuda con la verificación?"
+      },
+      "subtitle": "Selecciona uno de los métodos disponibles para verificar tu identidad.",
+      "title": "Reverificación de identidad"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Introduce tu código de respaldo para continuar con el acceso.",
+      "title": "Verificación por código de respaldo"
+    },
+    "emailCode": {
+      "formTitle": "Ingresa el código que hemos enviado a tu correo electrónico.",
+      "resendButton": "Reenviar código",
+      "subtitle": "Revisa tu bandeja de entrada para el código de verificación.",
+      "title": "Verificación por correo electrónico"
+    },
+    "noAvailableMethods": {
+      "message": "Lo sentimos, no tienes ningún método de verificación disponible. Contacta con soporte.",
+      "subtitle": "No se encontraron métodos alternativos disponibles.",
+      "title": "Métodos de verificación no disponibles"
+    },
+    "passkey": {},
+    "password": {
+      "actionLink": "¿Olvidaste tu contraseña? Recupérala aquí.",
+      "subtitle": "Usa tu contraseña para verificar tu identidad.",
+      "title": "Verificación por contraseña"
+    },
+    "phoneCode": {
+      "formTitle": "Introduce el código enviado a tu teléfono.",
+      "resendButton": "Reenviar código",
+      "subtitle": "Recibirás un código SMS para verificar tu identidad.",
+      "title": "Verificación por teléfono"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Código de verificación de 2 pasos",
+      "resendButton": "Reenviar código",
+      "subtitle": "Introduce el código de verificación de dos factores enviado a tu teléfono.",
+      "title": "Verificación por teléfono (2FA)"
+    },
+    "totpMfa": {
+      "formTitle": "Código TOTP",
+      "subtitle": "Introduce el código de autenticación TOTP para completar la verificación.",
+      "title": "Verificación por TOTP (2FA)"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Añadir cuenta",
+      "action__signOutAll": "Cerrar sesión de todas las cuentas",
+      "subtitle": "Seleccione la cuenta con la que desea continuar.",
+      "title": "Elija una cuenta"
+    },
+    "alternativeMethods": {
+      "actionLink": "Consigue ayuda",
+      "actionText": "¿No tienes ninguno de estos?",
+      "blockButton__backupCode": "Usa un código de respaldo",
+      "blockButton__emailCode": "Enviar código a {{identifier}}",
+      "blockButton__emailLink": "Enviar enlace a {{identifier}}",
+      "blockButton__passkey": "Usar llave de acceso",
+      "blockButton__password": "Entra con tu contraseña",
+      "blockButton__phoneCode": "Enviar código a {{identifier}}",
+      "blockButton__totp": "Usa tu aplicación de autenticación",
+      "getHelp": {
+        "blockButton__emailSupport": "Soporte de correo electrónico",
+        "content": "Si tiene dificultades para iniciar sesión en su cuenta, envíenos un correo electrónico y trabajaremos con usted para restablecer el acceso lo antes posible.",
+        "title": "Consigue ayuda"
+      },
+      "subtitle": "¿Tienes problemas? Puedes usar cualquiera de estos métodos para iniciar sesión.",
+      "title": "Usa otro método"
+    },
+    "alternativePhoneCodeProvider": {},
+    "backupCodeMfa": {
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Introduce un código de seguridad"
+    },
+    "emailCode": {
+      "formTitle": "Código de verificación",
+      "resendButton": "Reenviar código",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Revise su correo electrónico"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Revise su correo electrónico",
+      "resendButton": "¿No recibió un código? Reenviar",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Revise su correo electrónico"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "El cliente no coincide con el solicitado. Por favor, intente de nuevo.",
+        "title": "Error de cliente no coincidente"
+      },
+      "expired": {
+        "subtitle": "Regrese a la pestaña original para continuar.",
+        "title": "Este enlace de verificación ha expirado"
+      },
+      "failed": {
+        "subtitle": "Regrese a la pestaña original para continuar.",
+        "title": "Este enlace de verificación es inválido"
+      },
+      "formSubtitle": "Utilice el enlace de verificación enviado a su correo electrónico",
+      "formTitle": "Enlace de verificación",
+      "loading": {
+        "subtitle": "Serás redirigido pronto",
+        "title": "Iniciando sesión..."
+      },
+      "resendButton": "Reenviar enlace",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Revise su correo electrónico",
+      "unusedTab": { "title": "Puede cerrar esta pestaña" },
+      "verified": {
+        "subtitle": "Serás redirigido pronto",
+        "title": "Inició sesión con éxito"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Regrese a la pestaña original para continuar",
+        "subtitleNewTab": "Regrese a la pestaña recién abierta para continuar",
+        "titleNewTab": "Inició sesión en otra pestaña"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Utiliza el enlace de verificación enviado a tu correo electrónico",
+      "resendButton": "¿No recibiste el enlace? Reenviar",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Revisa tu correo electrónico"
+    },
+    "enterpriseConnections": {},
+    "forgotPassword": {
+      "formTitle": "Código de restablecimiento de contraseña",
+      "resendButton": "¿No recibiste un código? Reenviar",
+      "subtitle": "para restablecer tu contraseña",
+      "subtitle_email": "Primero, introduce el código enviado a tu correo electrónico",
+      "subtitle_phone": "Primero, introduce el código enviado a tu teléfono",
+      "title": "Restablecer contraseña"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Restablecer tu contraseña",
+      "label__alternativeMethods": "O, inicia sesión con otro método",
+      "title": "¿Olvidaste tu contraseña?"
+    },
+    "newDeviceVerificationNotice": "Estás iniciando sesión desde un dispositivo nuevo. Estamos pidiendo verificación para mantener tu cuenta segura.",
+    "noAvailableMethods": {
+      "message": "No se puede continuar con el inicio de sesión. No hay ningún factor de autenticación disponible.",
+      "subtitle": "Ocurrió un error",
+      "title": "No puedo iniciar sesión"
+    },
+    "passkey": {
+      "subtitle": "Use su clave de acceso para continuar con la autenticación.",
+      "title": "Clave de acceso"
+    },
+    "password": {
+      "actionLink": "Usa otro método",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Introduzca su contraseña"
+    },
+    "passwordCompromised": {},
+    "passwordPwned": { "title": "Tu contraseña ha sido comprometida" },
+    "passwordUntrusted": {},
+    "phoneCode": {
+      "formTitle": "Código de verificación",
+      "resendButton": "Reenviar código",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Revisa tu teléfono"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Código de verificación",
+      "resendButton": "Reenviar código",
+      "subtitle": "Introduce el código enviado a tu teléfono para continuar.",
+      "title": "Revisa tu teléfono"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Restablecer Contraseña",
+      "requiredMessage": "Por razones de seguridad, se requiere restablecer su contraseña.",
+      "successMessage": "Tu contraseña ha sido cambiada exitosamente. Iniciando sesión, por favor espera un momento.",
+      "title": "Establecer nueva contraseña"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Necesitamos verificar tu identidad antes de restablecer tu contraseña."
+    },
+    "start": {
+      "actionLink": "Regístrese",
+      "actionLink__join_waitlist": "Únase a la lista de espera",
+      "actionLink__use_email": "Usar correo electrónico",
+      "actionLink__use_email_username": "Usar correo electrónico o nombre de usuario",
+      "actionLink__use_passkey": "Usar una clave de acceso",
+      "actionLink__use_phone": "Usar teléfono",
+      "actionLink__use_username": "Usar nombre de usuario",
+      "actionText": "¿No tienes cuenta?",
+      "actionText__join_waitlist": "¿Te gustaría unirte a la lista de espera?",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Entrar"
+    },
+    "totpMfa": {
+      "formTitle": "Código de verificación",
+      "subtitle": "Introduce el código que te enviamos a tu dispositivo",
+      "title": "Verificación de dos pasos"
+    },
+    "web3Solana": {
+      "subtitle": "Selecciona una cartera abajo para iniciar sesión",
+      "title": "Iniciar sesión con Solana"
+    }
+  },
+  "signInEnterPasswordTitle": "Ingresa tu contraseña",
+  "signUp": {
+    "alternativePhoneCodeProvider": {},
+    "continue": {
+      "actionLink": "Entrar",
+      "actionText": "¿Tiene una cuenta?",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Rellene los campos que faltan"
+    },
+    "emailCode": {
+      "formSubtitle": "Introduzca el código de verificación enviado a su correo electrónico",
+      "formTitle": "Código de verificación",
+      "resendButton": "Re-enviar código",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Verifique su correo electrónico"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Parece que no estás usando el dispositivo correcto para verificar tu cuenta.",
+        "title": "Error de dispositivo"
+      },
+      "formSubtitle": "Utilice el enlace de verificación enviado a su dirección de correo electrónico",
+      "formTitle": "Enlace de verificación",
+      "loading": { "title": "Registrando..." },
+      "resendButton": "Reenviar enlace",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Verifica tu correo electrónico",
+      "verified": { "title": "Registrado con éxito" },
+      "verifiedSwitchTab": {
+        "subtitle": "Regrese a la pestaña recién abierta para continuar",
+        "subtitleNewTab": "Volver a la pestaña anterior para continuar",
+        "title": "Correo electrónico verificado con éxito"
+      }
+    },
+    "enterpriseConnections": {},
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "He leído y acepto la Política de Privacidad",
+        "label__onlyTermsOfService": "He leído y acepto los Términos de Servicio",
+        "label__termsOfServiceAndPrivacyPolicy": "He leído y acepto los {{ termsOfServiceLink || link(\"Términos de Servicio\") }} y la {{ privacyPolicyLink || link(\"Política de Privacidad\") }}"
+      },
+      "continue": {
+        "subtitle": "Al continuar, aceptas las condiciones mencionadas.",
+        "title": "Por favor, acepta nuestros términos y políticas para continuar"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Introduzca el código de verificación enviado a su número de teléfono",
+      "formTitle": "Código de verificación",
+      "resendButton": "Re-enviar código",
+      "subtitle": "para continuar a {{applicationName}}",
+      "title": "Verifique su teléfono"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Contáctanos para más información",
+      "actionText": "¿Tienes problemas? Obtén ayuda",
+      "blockButton__emailSupport": "Soporte por correo electrónico",
+      "blockButton__joinWaitlist": "Unirte a la lista de espera",
+      "subtitle": "El acceso a esta funcionalidad está restringido en este momento.",
+      "subtitleWaitlist": "Te has unido a la lista de espera. Nos pondremos en contacto contigo pronto.",
+      "title": "Acceso restringido"
+    },
+    "start": {
+      "actionLink": "Iniciar sesión",
+      "actionLink__use_email": "Usar correo electrónico",
+      "actionLink__use_phone": "Usar teléfono",
+      "actionText": "¿Ya tienes una cuenta?",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "para continuar en {{applicationName}}",
+      "subtitleCombined": "para continuar en {{applicationName}}",
+      "title": "Crea tu cuenta",
+      "titleCombined": "Crea tu cuenta"
+    },
+    "web3Solana": {
+      "subtitle": "Selecciona una cartera abajo para registrarte",
+      "title": "Registrarse con Solana"
+    }
+  },
+  "socialButtonsBlockButton": "Continuar con {{provider|titleize}}",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "Ya existe una organización para el nombre de empresa detectado ({{organizationName}}) y {{organizationDomain}}. Únete por invitación."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "Crear nueva organización",
+      "action__invitationAccept": "Unirse",
+      "action__suggestionsAccept": "Solicitar unirse",
+      "subtitle": "Unirse a una organización existente o crear una nueva",
+      "subtitle__createOrganizationDisabled": "Unirse a una organización existente",
+      "suggestionsAcceptedLabel": "Pendiente de aprobación",
+      "title": "Elegir una organización"
+    },
+    "createOrganization": {
+      "formButtonReset": "Cancelar",
+      "formButtonSubmit": "Continuar",
+      "formFieldInputPlaceholder__name": "Mi Organización",
+      "formFieldInputPlaceholder__slug": "mi-organizacion",
+      "formFieldLabel__name": "Nombre",
+      "formFieldLabel__slug": "Identificador",
+      "subtitle": "Ingrese los detalles de su organización para continuar",
+      "title": "Configurar su organización"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Contacte al administrador de su organización para obtener una invitación.",
+      "title": "Debe pertenecer a una organización"
+    },
+    "signOut": {
+      "actionLink": "Cerrar sesión",
+      "actionText": "Sesión iniciada como {{identifier}}"
+    }
+  },
+  "taskResetPassword": { "signOut": {} },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}} ya es miembro de la organización.",
+    "avatar_file_size_exceeded": "El tamaño del archivo supera el límite máximo de 10 MB. Por favor, elija un archivo más pequeño.",
+    "avatar_file_type_invalid": "Tipo de archivo no compatible. Por favor, suba una imagen JPG, PNG, GIF o WEBP.",
+    "captcha_invalid": "Registro fallido debido a validaciones de seguridad fallidas. Por favor, actualice la página para intentarlo de nuevo o comuníquese con el soporte para más asistencia.",
+    "captcha_unavailable": "Registro fallido debido a una validación de bot fallida. Por favor, actualice la página para intentarlo de nuevo o comuníquese con el soporte para más asistencia.",
+    "form_code_incorrect": "El código ingresado es incorrecto.",
+    "form_email_address_blocked": "Los servicios de correo electrónico temporal no están soportados. Por favor, use su dirección de correo electrónico regular para crear una cuenta.",
+    "form_identifier_exists__email_address": "Ya existe una cuenta con esta dirección de correo electrónico.",
+    "form_identifier_exists__phone_number": "Ya existe una cuenta con este número de teléfono.",
+    "form_identifier_exists__username": "Ya existe una cuenta con este nombre de usuario.",
+    "form_identifier_not_found": "No se ha encontrado ninguna cuenta con este identificador.",
+    "form_param_format_invalid": "Formato de parámetro inválido.",
+    "form_param_format_invalid__email_address": "La dirección de correo electrónico debe ser una dirección de correo electrónico válida.",
+    "form_param_format_invalid__phone_number": "El número de teléfono debe estar en un formato internacional válido.",
+    "form_param_max_length_exceeded__first_name": "El nombre no debe exceder los 256 caracteres.",
+    "form_param_max_length_exceeded__last_name": "El apellido no debe exceder los 256 caracteres.",
+    "form_param_max_length_exceeded__name": "El nombre no debe exceder los 256 caracteres.",
+    "form_param_nil": "Este campo es obligatorio.",
+    "form_param_value_invalid": "Valor inválido.",
+    "form_password_incorrect": "Contraseña incorrecta.",
+    "form_password_length_too_short": "La contraseña es demasiado corta.",
+    "form_password_not_strong_enough": "Tu contraseña no es lo suficientemente fuerte.",
+    "form_password_or_identifier_incorrect": "La contraseña o la dirección de correo electrónico es incorrecta. Inténtalo de nuevo o usa otro método.",
+    "form_password_pwned": "Tu contraseña ha sido comprometida en una violación de seguridad.",
+    "form_password_pwned__sign_in": "La contraseña ya está en uso en otro servicio.",
+    "form_password_size_in_bytes_exceeded": "Tu contraseña ha excedido el número máximo de bytes permitidos, por favor acórtala o elimina algunos caracteres especiales.",
+    "form_password_validation_failed": "La validación de la contraseña falló.",
+    "form_username_invalid_character": "El nombre de usuario contiene caracteres inválidos.",
+    "form_username_invalid_length": "El nombre de usuario debe tener entre 3 y 20 caracteres.",
+    "form_username_needs_non_number_char": "Tu nombre de usuario debe contener al menos un carácter no numérico.",
+    "identification_deletion_failed": "No puedes eliminar tu última identificación.",
+    "not_allowed_access": "La dirección de correo electrónico o el número de teléfono no está permitido para registrarse. Esto puede deberse al uso de '+', '=', '#' o '.' en tu dirección de correo electrónico, el uso de un dominio conectado a un servicio de correo electrónico temporal o la exclusión explícita. Si cree que se trata de un error, póngase en contacto con el soporte.",
+    "organization_domain_blocked": "Este es un dominio bloqueado, por favor usa otro.",
+    "organization_domain_common": "Este es un dominio común, por favor usa otro.",
+    "organization_membership_quota_exceeded": "Has alcanzado tu límite de miembros de la organización, incluyendo invitaciones pendientes.",
+    "organization_minimum_permissions_needed": "Es necesario que haya al menos un miembro de la organización con los permisos mínimos necesarios.",
+    "passkey_already_exists": "Ya existe una clave de acceso.",
+    "passkey_not_supported": "Las claves de acceso no son compatibles.",
+    "passkey_pa_not_supported": "La clave de acceso no es compatible con la autenticación de dispositivos.",
+    "passkey_registration_cancelled": "El registro de la clave de acceso fue cancelado.",
+    "passkey_retrieval_cancelled": "La recuperación de la clave de acceso fue cancelada.",
+    "passwordComplexity": {
+      "maximumLength": "Menos de {{length}} caracteres",
+      "minimumLength": "{{length}} caracteres o más",
+      "requireLowercase": "Al menos una letra minúscula",
+      "requireNumbers": "Al menos un número",
+      "requireSpecialCharacter": "Al menos un carácter especial",
+      "requireUppercase": "Al menos una letra mayúscula",
+      "sentencePrefix": "Tu contraseña debe contener:"
+    },
+    "phone_number_exists": "Este número de teléfono ya está en uso. Por favor, inténtelo con otro.",
+    "session_exists": "Ya has iniciado sesión",
+    "web3_signature_request_rejected": "Has rechazado la solicitud de firma. Inténtalo de nuevo para continuar.",
+    "web3_solana_signature_generation_failed": "Se produjo un error al generar la firma. Inténtalo de nuevo para continuar.",
+    "zxcvbn": { "suggestions": {}, "warnings": {} }
+  },
+  "userButton": {
+    "action__addAccount": "Añadir cuenta",
+    "action__closeUserMenu": "Cerrar menú de usuario",
+    "action__manageAccount": "Administrar cuenta",
+    "action__openUserMenu": "Abrir menú de usuario",
+    "action__signOut": "Cerrar sesión",
+    "action__signOutAll": "Salir de todas las cuentas",
+    "label__accountActions": "Acciones de cuenta",
+    "label__activeSessions": "Sesiones activas",
+    "label__userButtonPopover": "Panel de cuenta"
+  },
+  "userProfile": {
+    "apiKeysPage": {},
+    "backupCodePage": {
+      "actionLabel__copied": "¡Copiado!",
+      "actionLabel__copy": "Copiar todo",
+      "actionLabel__download": "Descargar .txt",
+      "actionLabel__print": "Imprimir",
+      "infoText1": "Se habilitarán códigos de respaldo para esta cuenta.",
+      "infoText2": "Mantenga los códigos de respaldo en secreto y guárdelos de forma segura. Puede regenerar códigos de respaldo si sospecha que se han visto comprometidos.",
+      "subtitle__codelist": "Guárdelos de forma segura y manténgalos en secreto.",
+      "successMessage": "Los códigos de respaldo ahora están habilitados. Puede usar uno de estos para iniciar sesión en su cuenta, si pierde el acceso a su dispositivo de autenticación. Cada código solo se puede utilizar una vez.",
+      "successSubtitle": "Puede usar uno de estos para iniciar sesión en su cuenta, si pierde el acceso a su dispositivo de autenticación.",
+      "title": "Agregar verificación de código de respaldo",
+      "title__codelist": "Códigos de respaldo"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "No hay historial de pagos",
+        "notFound": "No se ha encontrado el intento de pago",
+        "tableHeader__amount": "Importe",
+        "tableHeader__date": "Fecha",
+        "tableHeader__status": "Estado"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Establecer como predeterminado",
+        "actionLabel__remove": "Eliminar",
+        "add": "Añadir nuevo método de pago",
+        "addSubtitle": "Añade un nuevo método de pago a tu cuenta.",
+        "cancelButton": "Cancelar",
+        "formButtonPrimary__add": "Añadir método de pago",
+        "formButtonPrimary__pay": "Pagar {{amount}}",
+        "payWithTestCardButton": "Pagar con tarjeta de prueba",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} se eliminará de esta cuenta.",
+          "messageLine2": "Ya no podrás usar este método de pago y cualquier suscripción recurrente que dependa de él dejará de funcionar.",
+          "successMessage": "{{paymentMethod}} se ha eliminado de tu cuenta.",
+          "title": "Eliminar método de pago"
+        },
+        "title": "Métodos de pago"
+      },
+      "start": {
+        "headerTitle__payments": "Pagos",
+        "headerTitle__plans": "Planes",
+        "headerTitle__statements": "Facturas",
+        "headerTitle__subscriptions": "Suscripción"
+      },
+      "statementsSection": {
+        "empty": "No hay facturas para mostrar",
+        "itemCaption__paidForPlan": "Pagado por el plan {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédito proporcional por el tiempo no utilizado de la suscripción anterior",
+        "itemCaption__subscribedAndPaidForPlan": "Suscrito y pagado por el plan {{plan}} {{period}}",
+        "notFound": "Factura no encontrada",
+        "tableHeader__amount": "Importe",
+        "tableHeader__date": "Fecha",
+        "title": "Facturas",
+        "totalPaid": "Total pagado"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gestionar",
+        "actionLabel__newSubscription": "Suscribirse a un plan",
+        "actionLabel__switchPlan": "Cambiar de plan",
+        "tableHeader__edit": "Editar",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Fecha de inicio",
+        "title": "Suscripción"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gestionar" },
+      "switchPlansSection": { "title": "Cambiar de plan" },
+      "title": "Facturación"
+    },
+    "connectedAccountPage": {
+      "formHint": "Seleccione un proveedor para conectar su cuenta.",
+      "formHint__noAccounts": "No hay proveedores de cuentas externas disponibles.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} será eliminado de esta cuenta.",
+        "messageLine2": "Ya no podrá usar esta cuenta activa y las funciones dependientes ya no funcionarán.",
+        "successMessage": "{{connectedAccount}} ha sido eliminado de su cuenta.",
+        "title": "Eliminar cuenta conectada"
+      },
+      "socialButtonsBlockButton": "Conectar cuenta de {{provider | titleize}}",
+      "successMessage": "El proveedor ha sido agregado a su cuenta",
+      "title": "Agregar cuenta conectada"
+    },
+    "deletePage": {
+      "actionDescription": "Escribe \"Eliminar cuenta\" a continuación para continuar.",
+      "confirm": "Eliminar cuenta",
+      "messageLine1": "¿Está seguro de que desea eliminar su cuenta? Es posible que se conserven algunos datos asociados. Para solicitar la eliminación completa de datos, póngase en contacto con el soporte técnico.",
+      "messageLine2": "Esta acción es permanente e irreversible.",
+      "title": "Eliminar cuenta"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "A esta dirección de correo electrónico se le enviará un correo electrónico con un Código de verificación.",
+        "formSubtitle": "Introduzca el código de verificación enviado a {{identifier}}",
+        "formTitle": "Código de verificación",
+        "resendButton": "Re-enviar código",
+        "successMessage": "El correo electrónico {{identifier}} se ha agregado a su cuenta."
+      },
+      "emailLink": {
+        "formHint": "Se enviará un correo electrónico con un enlace de verificación a esta dirección de correo electrónico.",
+        "formSubtitle": "Haga clic en el enlace de verificación en el correo electrónico enviado a {{identifier}}",
+        "formTitle": "Enlace de verificación",
+        "resendButton": "Reenviar enlace",
+        "successMessage": "El correo electrónico {{identifier}} se ha agregado a su cuenta."
+      },
+      "enterpriseSSOLink": {},
+      "removeResource": {
+        "messageLine1": "{{identifier}} será eliminado de esta cuenta.",
+        "messageLine2": "Ya no podrá iniciar sesión con esta dirección de correo electrónico.",
+        "successMessage": "{{emailAddress}} ha sido eliminado de su cuenta.",
+        "title": "Eliminar dirección de correo electrónico"
+      },
+      "title": "Agregar dirección de correo electrónico",
+      "verifyTitle": "Verificar correo electrónico"
+    },
+    "formButtonPrimary__add": "Agregar",
+    "formButtonPrimary__continue": "Continuar",
+    "formButtonPrimary__finish": "Terminar",
+    "formButtonPrimary__remove": "Eliminar",
+    "formButtonPrimary__save": "Guardar",
+    "formButtonReset": "Cancelar",
+    "mfaPage": {
+      "formHint": "Seleccione un método para agregar.",
+      "title": "Agregar verificación en dos pasos"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "Usar número existente",
+      "primaryButton__addPhoneNumber": "Agregar un número de teléfono",
+      "removeResource": {
+        "messageLine1": "{{identifier}} dejará de recibir el Código de verificación al iniciar sesión.",
+        "messageLine2": "Es posible que su cuenta no sea tan segura. ¿Estás seguro de que quieres continuar?",
+        "successMessage": "Se eliminó la verificación de dos pasos del código SMS para {{mfaPhoneCode}}",
+        "title": "Eliminar la verificación en dos pasos"
+      },
+      "subtitle__availablePhoneNumbers": "Seleccione un número de teléfono para registrarse para la verificación en dos pasos del código SMS.",
+      "subtitle__unavailablePhoneNumbers": "No hay números de teléfono disponibles para registrarse para la verificación en dos pasos del código SMS.",
+      "successMessage1": "Al iniciar sesión, deberá ingresar un código de verificación enviado a este número de teléfono como un paso adicional.",
+      "successMessage2": "Guarde estos códigos de respaldo y almacénelos en un lugar seguro. Si pierde el acceso a su dispositivo de autenticación, puede usar los códigos de respaldo para iniciar sesión.",
+      "successTitle": "Verificación de código SMS habilitada",
+      "title": "Agregar verificación de código SMS"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "Escanea el código QR en su lugar",
+        "buttonUnableToScan__nonPrimary": "¿No puedes escanear el código QR?",
+        "infoText__ableToScan": "Configure un nuevo método de inicio de sesión en su aplicación de autenticación y escanee el siguiente código QR para vincularlo a su cuenta.",
+        "infoText__unableToScan": "Configure un nuevo método de inicio de sesión en su autenticador e ingrese la clave que se proporciona a continuación.",
+        "inputLabel__unableToScan1": "Asegúrese de que las contraseñas basadas en el tiempo o de un solo uso estén habilitadas, luego termine de vincular su cuenta.",
+        "inputLabel__unableToScan2": "Alternativamente, si su autenticador admite TOTP URIs, también puede copiar el URI completo."
+      },
+      "removeResource": {
+        "messageLine1": "El código de verificación de este autenticador ya no será necesario al iniciar sesión.",
+        "messageLine2": "Es posible que su cuenta no sea tan segura. ¿Estás seguro de que quieres continuar?",
+        "successMessage": "Se eliminó la verificación en dos pasos a través de la aplicación de autenticación.",
+        "title": "Eliminar la verificación en dos pasos"
+      },
+      "successMessage": "La verificación en dos pasos ahora está habilitada. Al iniciar sesión, deberá ingresar un código de verificación de este autenticador como un paso adicional.",
+      "title": "Agregar aplicación de autenticación",
+      "verifySubtitle": "Ingrese el código de verificación generado por su autenticador",
+      "verifyTitle": "Código de verificación"
+    },
+    "mobileButton__menu": "Menú",
+    "navbar": {
+      "account": "Perfil",
+      "description": "Gestiona la información de tu cuenta.",
+      "security": "Seguridad",
+      "title": "Cuenta"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "¿Estás seguro de que deseas eliminar este recurso?",
+        "title": "Eliminar Recurso"
+      },
+      "subtitle__rename": "Ingresa el nuevo nombre para la clave de acceso.",
+      "title__rename": "Renombrar Clave de Acceso"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "Se recomienda cerrar sesión en todos los demás dispositivos que puedan haber usado su contraseña anterior.",
+      "readonly": "Su contraseña actualmente no puede ser editada porque solo puede iniciar sesión a través de la conexión empresarial.",
+      "successMessage__set": "Su contraseña ha sido establecida.",
+      "successMessage__signOutOfOtherSessions": "Todos los demás dispositivos han cerrado sesión.",
+      "successMessage__update": "Tu contraseña ha sido actualizada.",
+      "title__set": "Configurar la clave",
+      "title__update": "Cambiar contraseña"
+    },
+    "phoneNumberPage": {
+      "infoText": "Se enviará un mensaje de texto con un enlace de verificación a este número de teléfono.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} será eliminado de esta cuenta.",
+        "messageLine2": "Ya no podrá iniciar sesión con este número de teléfono.",
+        "successMessage": "{{phoneNumber}} ha sido eliminado de su cuenta.",
+        "title": "Eliminar número de teléfono"
+      },
+      "successMessage": "{{identifier}} ha sido añadido a tu cuenta.",
+      "title": "Agregar el número de teléfono",
+      "verifySubtitle": "Introduzca el código de verificación enviado a {{identifier}}",
+      "verifyTitle": "Verificar número de teléfono"
+    },
+    "plansPage": {},
+    "profilePage": {
+      "fileDropAreaHint": "Cargue una imagen JPG, PNG, GIF o WEBP de menos de 10 MB",
+      "imageFormDestructiveActionSubtitle": "Eliminar la imagen",
+      "imageFormSubtitle": "Cargar imagen",
+      "imageFormTitle": "Imagen de perfil",
+      "readonly": "La información de su perfil ha sido proporcionada por la conexión empresarial y no puede ser editada.",
+      "successMessage": "Tu perfil ha sido actualizado.",
+      "title": "Actualizar Cuenta"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "Cerrar sesión en el dispositivo",
+        "title": "Dispositivos activos"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "Inténtelo nuevamente",
+        "actionLabel__reauthorize": "Autorizar ahora",
+        "destructiveActionTitle": "Quitar",
+        "primaryButton": "Conectar cuenta",
+        "subtitle__reauthorize": "Los permisos necesarios han sido actualizados, y podría estar experimentando funcionalidad limitada. Por favor, reautorice esta aplicación para evitar problemas.",
+        "title": "Cuentas conectadas"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "Eliminar cuenta",
+        "title": "Eliminar cuenta"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "Eliminar dirección de correo electrónico",
+        "detailsAction__nonPrimary": "Establecer como primario",
+        "detailsAction__primary": "Completar la verificación",
+        "detailsAction__unverified": "Completar la verificación",
+        "primaryButton": "Agregar una dirección de correo electrónico",
+        "title": "Correos electrónicos"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "Conectar cuenta",
+        "title": "Cuentas empresariales"
+      },
+      "headerTitle__account": "Cuenta",
+      "headerTitle__security": "Seguridad",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "Regenerar códigos",
+          "headerTitle": "Códigos de respaldo",
+          "subtitle__regenerate": "Obtenga un nuevo conjunto de códigos de respaldo seguros. Los códigos de respaldo anteriores se eliminarán y no podrán ser usados.",
+          "title__regenerate": "Regenerar códigos de respaldo"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "Establecer por defecto",
+          "destructiveActionLabel": "Eliminar número telefónico"
+        },
+        "primaryButton": "Añadir verificación de dos pasos",
+        "title": "Verificación de dos pasos",
+        "totp": {
+          "destructiveActionTitle": "Eliminar",
+          "headerTitle": "Aplicación de autenticación"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "Eliminar Clave de Acceso",
+        "menuAction__rename": "Renombrar Clave de Acceso",
+        "title": "Sección de Claves de Acceso"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "Establecer contraseña",
+        "primaryButton__updatePassword": "Cambiar contraseña",
+        "title": "Contraseña"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "Quitar número de teléfono",
+        "detailsAction__nonPrimary": "Establecer como primario",
+        "detailsAction__primary": "Completar la verificación",
+        "detailsAction__unverified": "Completar la verificación",
+        "primaryButton": "Agregar un número de teléfono",
+        "title": "Números telefónicos"
+      },
+      "profileSection": {
+        "primaryButton": "Actualizar perfil",
+        "title": "Perfil"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "Crear nombre de usuario",
+        "primaryButton__updateUsername": "Cambiar nombre de usuario",
+        "title": "Nombre de usuario"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "Quitar cartera",
+        "primaryButton": "Agregar cartera Web3",
+        "title": "Cartera Web3",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Selecciona una cartera de Solana para conectarla a tu cuenta.",
+          "title": "Añadir una cartera de Solana"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "Su nombre de usuario ha sido actualizado.",
+      "title__set": "Actualizar nombre de usuario",
+      "title__update": "Actualizar nombre de usuario"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} será eliminado de esta cuenta.",
+        "messageLine2": "Ya no podrá iniciar sesión con esta billetera web3.",
+        "successMessage": "{{web3Wallet}} ha sido eliminado de su cuenta.",
+        "title": "Eliminar la billetera web3"
+      },
+      "subtitle__availableWallets": "Seleccione una billetera web3 para conectarse a su cuenta.",
+      "subtitle__unavailableWallets": "No hay billeteras web3 disponibles.",
+      "successMessage": "La billetera ha sido agregada a su cuenta.",
+      "title": "Añadir billetera Web3",
+      "web3WalletButtonsBlockButton": "Conectar billetera"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "¡Únete a la lista de espera!",
+      "actionText": "Si no tienes acceso, puedes unirte a nuestra lista de espera para recibir una invitación más adelante.",
+      "formButton": "Unirse ahora",
+      "subtitle": "Sé uno de los primeros en acceder a {{applicationName}}.",
+      "title": "Únete a la lista de espera"
+    },
+    "success": {
+      "message": "¡Felicidades! Te has unido exitosamente a la lista de espera.",
+      "subtitle": "Recibirás una invitación para unirte cuando haya espacio disponible.",
+      "title": "¡Te has unido a la lista de espera!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Conectar con {{walletName}}",
+    "continue": "Continuar con {{walletName}}",
+    "noneAvailable": "No se detectaron carteras Solana Web3. Instala una {{ solanaWalletsLink || link(\"wallet extension\") }} compatible con Web3."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/fr-FR.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/fr-FR.json
@@ -1,0 +1,1440 @@
+{
+  "locale": "fr-FR",
+  "apiKeys": {
+    "action__add": "Ajouter une nouvelle clé",
+    "action__search": "Rechercher des clés",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Copier et fermer",
+      "formHint": "Pour des raisons de sécurité, nous ne vous permettrons pas de la consulter à nouveau plus tard.",
+      "formTitle": "Copiez votre clé API \"{{name}}\" maintenant"
+    },
+    "createdAndExpirationStatus__expiresOn": "Créée le {{ createdDate | shortDate('fr-FR') }} • Expire le {{ expiresDate | longDate('fr-FR') }}",
+    "createdAndExpirationStatus__never": "Créée le {{ createdDate | shortDate('fr-FR') }} • N’expire jamais",
+    "detailsTitle__emptyRow": "Aucune clé API trouvée",
+    "formButtonPrimary__add": "Créer une clé",
+    "formFieldCaption__expiration__expiresOn": "Expire le {{ date }}",
+    "formFieldCaption__expiration__never": "Cette clé n’expirera jamais",
+    "formFieldOption__expiration__180d": "180 jours",
+    "formFieldOption__expiration__1d": "1 jour",
+    "formFieldOption__expiration__1y": "1 an",
+    "formFieldOption__expiration__30d": "30 jours",
+    "formFieldOption__expiration__60d": "60 jours",
+    "formFieldOption__expiration__7d": "7 jours",
+    "formFieldOption__expiration__90d": "90 jours",
+    "formFieldOption__expiration__never": "Jamais",
+    "formHint": "Indiquez un nom pour générer une nouvelle clé. Vous pourrez la révoquer à tout moment.",
+    "formTitle": "Ajouter une nouvelle clé API",
+    "lastUsed__days": "il y a {{days}} j",
+    "lastUsed__hours": "il y a {{hours}} h",
+    "lastUsed__minutes": "il y a {{minutes}} min",
+    "lastUsed__months": "il y a {{months}} mois",
+    "lastUsed__seconds": "il y a {{seconds}} s",
+    "lastUsed__years": "il y a {{years}} an(s)",
+    "menuAction__revoke": "Révoquer la clé",
+    "revokeConfirmation": {
+      "confirmationText": "Révoquer",
+      "formButtonPrimary__revoke": "Révoquer la clé",
+      "formHint": "Êtes-vous sûr de vouloir supprimer cette clé secrète ?",
+      "formTitle": "Révoquer la clé secrète « {{apiKeyName}} » ?"
+    }
+  },
+  "backButton": "Retour",
+  "badge__activePlan": "Actif",
+  "badge__canceledEndsAt": "Annulé • Termine le {{ date | shortDate('fr-FR') }}",
+  "badge__currentPlan": "Plan actuel",
+  "badge__default": "Défaut",
+  "badge__endsAt": "Termine le {{ date | shortDate('fr-FR') }}",
+  "badge__expired": "Expiré",
+  "badge__freeTrial": "Essai gratuit",
+  "badge__otherImpersonatorDevice": "Autre dispositif d'imitation",
+  "badge__pastDueAt": "En retard depuis le {{ date | shortDate('fr-FR') }}",
+  "badge__pastDuePlan": "Paiement en retard",
+  "badge__primary": "Principal",
+  "badge__renewsAt": "Renouvelle le {{ date | shortDate('fr-FR') }}",
+  "badge__requiresAction": "Nécessite une action",
+  "badge__startsAt": "Débute le {{ date | shortDate('fr-FR') }}",
+  "badge__thisDevice": "Cet appareil",
+  "badge__trialEndsAt": "L’essai se termine le {{ date | shortDate('fr-FR') }}",
+  "badge__unverified": "Non vérifié",
+  "badge__upcomingPlan": "À venir",
+  "badge__userDevice": "Appareil utilisateur",
+  "badge__you": "Vous",
+  "billing": {
+    "addPaymentMethod__label": "Ajouter une méthode de paiement",
+    "alwaysFree": "Toujours gratuit",
+    "annually": "Annuel",
+    "availableFeatures": "Fonctionnalités disponibles",
+    "billedAnnually": "Facturé annuellement",
+    "billedMonthlyOnly": "Seulement facturé mensuellement",
+    "cancelFreeTrial": "Annuler l’essai gratuit",
+    "cancelFreeTrialAccessUntil": "Votre essai restera actif jusqu’au {{ date | longDate('fr-FR') }}. Après cette date, vous perdrez l’accès aux fonctionnalités d’essai. Aucun frais ne vous sera facturé.",
+    "cancelFreeTrialTitle": "Annuler l’essai gratuit du plan {{plan}} ?",
+    "cancelSubscription": "Annuler la souscription",
+    "cancelSubscriptionAccessUntil": "Souscription annulée. Vous pouvez continuer à utiliser les fonctionnalités de '{{plan}}' jusqu'au {{ date | longDate('fr-FR') }}, après quoi vous n'aurez plus accès.",
+    "cancelSubscriptionNoCharge": "Pas de charge",
+    "cancelSubscriptionPastDue": "Votre abonnement prendra fin immédiatement et vous perdrez l’accès à toutes les fonctionnalités du plan. Le montant dû sera demandé lors de votre prochaine souscription.",
+    "cancelSubscriptionTitle": "Annuler la souscription",
+    "cannotSubscribeMonthly": "Ne peut pas souscrire mensuellement. Pour souscrire à ce plan, il faut payer annuellement.",
+    "cannotSubscribeUnrecoverable": "Vous ne pouvez pas souscrire à ce plan. Votre abonnement actuel est plus cher que celui-ci.",
+    "checkout": {
+      "description__paymentSuccessful": "Votre paiement a été effectué avec succès.",
+      "description__subscriptionSuccessful": "Votre nouvel abonnement est prêt.",
+      "downgradeNotice": "Vous conserverez votre abonnement actuel et ses fonctionnalités jusqu'à la fin du cycle de facturation, puis vous passerez à cet abonnement.",
+      "emailForm": {
+        "subtitle": "Avant de pouvoir finaliser votre achat, vous devez ajouter une adresse e-mail où les reçus seront envoyés.",
+        "title": "Ajouter une adresse e-mail"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "L’essai se termine le",
+        "title__paymentMethod": "Méthode de paiement",
+        "title__statementId": "Identifiant du relevé",
+        "title__subscriptionBegins": "L'abonnement commence",
+        "title__totalPaid": "Total payé"
+      },
+      "pastDueNotice": "Votre abonnement précédent était en retard de paiement.",
+      "perMonth": "par mois",
+      "title": "Paiement",
+      "title__paymentSuccessful": "Le paiement a réussi !",
+      "title__subscriptionSuccessful": "Succès !",
+      "title__trialSuccess": "Essai démarré avec succès !",
+      "totalDueAfterTrial": "Total dû après la fin de l’essai dans {{days}} jours"
+    },
+    "credit": "Crédit",
+    "creditRemainder": "Crédit restant",
+    "defaultFreePlanActive": "Vous êtes actuellement sur le plan gratuit",
+    "free": "Gratuit",
+    "getStarted": "Commencer",
+    "highlightedPlanBadge": "Populaire",
+    "keepFreeTrial": "Conserver l’essai gratuit",
+    "keepSubscription": "Conserver l'abonnement",
+    "manage": "Gérer",
+    "manageSubscription": "Gérer l'abonnement",
+    "month": "Mois",
+    "monthly": "Mensuel",
+    "pastDue": "En retard",
+    "pay": "Payer {{amount}}",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "Paiement annuel",
+        "monthly": "Paiement mensuel"
+      },
+      "dev": {
+        "anyNumbers": "N’importe quels chiffres",
+        "cardNumber": "Numéro de carte",
+        "cvcZip": "CVC, ZIP",
+        "developmentMode": "Mode de développement",
+        "expirationDate": "Date d'expiration",
+        "testCardInfo": "Informations de carte de test"
+      }
+    },
+    "paymentMethods__label": "Méthodes de paiement",
+    "pricingTable": {
+      "billingCycle": "Cycle de facturation",
+      "included": "Inclus",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "Se réabonner",
+    "seeAllFeatures": "Voir toutes les fonctionnalités",
+    "startFreeTrial": "Commencer l’essai gratuit",
+    "startFreeTrial__days": "Commencer l’essai gratuit de {{days}} jours",
+    "subscribe": "S'abonner",
+    "subscriptionDetails": {
+      "beginsOn": "Commence le",
+      "currentBillingCycle": "Cycle de facturation en cours",
+      "endsOn": "Se termine le",
+      "firstPaymentAmount": "Montant du premier paiement",
+      "firstPaymentOn": "Premier paiement le",
+      "nextPaymentAmount": "Montant du prochain paiement",
+      "nextPaymentOn": "Prochain paiement le",
+      "pastDueAt": "En retard le",
+      "renewsAt": "Renouvelé le",
+      "subscribedOn": "Souscrit le",
+      "title": "Abonnement",
+      "trialEndsOn": "L’essai se termine le",
+      "trialStartedOn": "Essai commencé le"
+    },
+    "subtotal": "Total",
+    "switchPlan": "Changer de plan",
+    "switchToAnnual": "Passer à l'annuel",
+    "switchToAnnualWithAnnualPrice": "Passer à l’annuel {{price}} / an",
+    "switchToMonthly": "Passer au mensuel",
+    "switchToMonthlyWithPrice": "Passer au mensuel {{price}} / mois",
+    "totalDue": "Total dû",
+    "totalDueToday": "Total dû aujourd'hui",
+    "viewFeatures": "Voir les fonctionnalités",
+    "viewPayment": "Voir le paiement",
+    "year": "An"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Contactez l'administrateur de votre organisation pour étendre vos permissions.",
+      "title": "Vous n'avez pas la permission de gérer l'authentification unique (SSO)"
+    },
+    "navbar": { "title": "Configurer l'authentification unique (SSO)" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Non vérifié",
+        "badge__verified": "Vérifié",
+        "txtRecord": {
+          "hostLabel": "Hôte / Nom",
+          "instructions": "Ajoutez cet enregistrement TXT à votre fournisseur DNS. Nous le vérifierons automatiquement une fois l’enregistrement actif.",
+          "typeLabel": "Type",
+          "valueLabel": "Valeur"
+        },
+        "verifiedAtLabel": "Vérifié le {{ date | shortDate('fr-FR') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "Ajouter {{domain}}",
+        "messageLabel": "Votre e-mail utilise {{domain}}. Voulez-vous l’ajouter ?"
+      },
+      "formButtonPrimary__add": "Ajouter",
+      "formFieldInputPlaceholder__domain": "Ajouter un domaine",
+      "formFieldLabel__domain": "Domaine",
+      "removeDomainDialog": {},
+      "subtitle": "Ajoutez et vérifiez la propriété des domaines que votre organisation utilise pour se connecter.",
+      "title": "Ajouter des domaines SSO"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Fournisseur SAML personnalisé",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Sélectionnez le fournisseur pour lequel vous allez configurer le SSO.",
+      "title": "Sélectionner un fournisseur",
+      "warning": "Une fois un fournisseur sélectionné, vous ne pourrez plus en changer jusqu'à la fin de la configuration"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Créer l’organisation",
+    "invitePage": { "formButtonReset": "Passer" },
+    "title": "Créer une organisation"
+  },
+  "dates": {
+    "lastDay": "Hier à {{ date | timeString('fr-FR') }}",
+    "next6Days": "{{ date | weekday('fr-FR','long') }} à {{ date | timeString('fr-FR') }}",
+    "nextDay": "Demain à {{ date | timeString('fr-FR') }}",
+    "numeric": "{{ date | numeric('fr-FR') }}",
+    "previous6Days": "{{ date | weekday('fr-FR','long') }} dernier à {{ date | timeString('fr-FR') }}",
+    "sameDay": "Aujourd'hui à {{ date | timeString('fr-FR') }}"
+  },
+  "dividerText": "ou",
+  "footerActionLink__alternativePhoneCodeProvider": "Envoyer le code par SMS à la place",
+  "footerActionLink__useAnotherMethod": "Utiliser une autre méthode",
+  "footerPageLink__help": "Aide",
+  "footerPageLink__privacy": "Vie privée",
+  "footerPageLink__terms": "Conditions",
+  "formButtonPrimary": "Continuer",
+  "formButtonPrimary__verify": "Vérifier",
+  "formFieldAction__forgotPassword": "Mot de passe oublié ?",
+  "formFieldError__matchingPasswords": "Les mots de passe correspondent.",
+  "formFieldError__notMatchingPasswords": "Les mots de passe ne correspondent pas.",
+  "formFieldError__verificationLinkExpired": "Le lien de vérification a expiré. Merci de demander un nouveau lien.",
+  "formFieldHintText__optional": "Optionnel",
+  "formFieldHintText__slug": "Un slug est un identifiant lisible qui doit être unique. Il est souvent utilisé dans les URL.",
+  "formFieldInputPlaceholder__apiKeyDescription": "Expliquez pourquoi vous générez cette clé",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "Sélectionner une date",
+  "formFieldInputPlaceholder__apiKeyName": "Entrez le nom de votre clé secrète",
+  "formFieldInputPlaceholder__backupCode": "Code de sauvegarde",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Supprimer le compte",
+  "formFieldInputPlaceholder__emailAddress": "Adresse e-mail",
+  "formFieldInputPlaceholder__emailAddress_username": "Nom d'utilisateur ou adresse e-mail",
+  "formFieldInputPlaceholder__emailAddresses": "exemple@email.com, exemple2@email.com",
+  "formFieldInputPlaceholder__firstName": "Prénom",
+  "formFieldInputPlaceholder__lastName": "Nom",
+  "formFieldInputPlaceholder__organizationDomain": "Domaine de l'organisation",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "Adresse e-mail de l'organisation",
+  "formFieldInputPlaceholder__organizationName": "Nom de l'organisation",
+  "formFieldInputPlaceholder__organizationSlug": "Identifiant de l'organisation",
+  "formFieldInputPlaceholder__password": "Mot de passe",
+  "formFieldInputPlaceholder__phoneNumber": "Numéro de téléphone",
+  "formFieldInputPlaceholder__username": "Nom d'utilisateur",
+  "formFieldLabel__apiKey": "Clé API",
+  "formFieldLabel__apiKeyDescription": "Description",
+  "formFieldLabel__apiKeyExpiration": "Expiration",
+  "formFieldLabel__apiKeyName": "Nom de la clé secrète",
+  "formFieldLabel__automaticInvitations": "Activer les invitations automatiques pour ce domaine",
+  "formFieldLabel__backupCode": "Code de récupération",
+  "formFieldLabel__confirmDeletion": "Confirmation",
+  "formFieldLabel__confirmPassword": "Confirmer le mot de passe",
+  "formFieldLabel__currentPassword": "Mot de passe actuel",
+  "formFieldLabel__emailAddress": "Adresse e-mail",
+  "formFieldLabel__emailAddress_username": "Adresse e-mail ou nom d'utilisateur",
+  "formFieldLabel__emailAddresses": "Adresses e-mail",
+  "formFieldLabel__firstName": "Prénom",
+  "formFieldLabel__lastName": "Nom",
+  "formFieldLabel__newPassword": "Nouveau mot de passe",
+  "formFieldLabel__organizationDomain": "Domaine",
+  "formFieldLabel__organizationDomainDeletePending": "Supprimer les invitations et suggestions en attente",
+  "formFieldLabel__organizationDomainEmailAddress": "E-mail de vérification",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Entrer une adresse e-mail appartenant à ce domaine pour recevoir un code et vérifier ce domaine.",
+  "formFieldLabel__organizationName": "Nom de l'organisation",
+  "formFieldLabel__organizationSlug": "Slug URL",
+  "formFieldLabel__passkeyName": "Nom de la clé de sécurité",
+  "formFieldLabel__password": "Mot de passe",
+  "formFieldLabel__phoneNumber": "Numéro de téléphone",
+  "formFieldLabel__role": "Rôle",
+  "formFieldLabel__signOutOfOtherSessions": "Se déconnecter de tous les autres appareils",
+  "formFieldLabel__username": "Nom d'utilisateur",
+  "impersonationFab": {
+    "action__signOut": "Déconnexion",
+    "title": "Connecté en tant que {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Utilisé la dernière fois",
+  "maintenanceMode": "Nous effectuons des travaux de maintenance, mais ne vous en inquiétez pas, cela ne devrait pas prendre plus de quelques minutes.",
+  "membershipRole__admin": "Administrateur",
+  "membershipRole__basicMember": "Membre",
+  "membershipRole__guestMember": "Invité",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Créer une organisation",
+    "action__invitationAccept": "Rejoindre",
+    "action__suggestionsAccept": "Demande d'adhésion",
+    "createOrganization": "Créer une Organisation",
+    "invitationAcceptedLabel": "Acceptée",
+    "subtitle": "pour continuer vers {{applicationName}}",
+    "suggestionsAcceptedLabel": "En attente d’approbation",
+    "title": "Choisissez un compte",
+    "titleWithoutPersonal": "Choisissez une organisation"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "Clés API" },
+    "badge__automaticInvitation": "Invitations automatiques",
+    "badge__automaticSuggestion": "Suggestions automatiques",
+    "badge__manualInvitation": "Pas d'inscription automatique",
+    "badge__unverified": "Non vérifié",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Aucun historique de paiement",
+        "notFound": "Tentative de paiement introuvable",
+        "tableHeader__amount": "Montant",
+        "tableHeader__date": "Date",
+        "tableHeader__status": "Statut"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Rendre par défaut",
+        "actionLabel__remove": "Supprimer",
+        "add": "Ajouter une nouvelle méthode de paiement",
+        "addSubtitle": "Ajoutez une nouvelle méthode de paiement à votre compte.",
+        "cancelButton": "Annuler",
+        "formButtonPrimary__add": "Ajouter une méthode de paiement",
+        "formButtonPrimary__pay": "Payer {{amount}}",
+        "payWithTestCardButton": "Payer avec une carte de test",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+          "messageLine2": "Vous ne pourrez plus utiliser cette méthode de paiement et tous les abonnements récurrents qui en dépendent ne fonctionneront plus.",
+          "successMessage": "{{paymentMethod}} a été supprimé de votre compte.",
+          "title": "Supprimer une méthode de paiement"
+        },
+        "title": "Méthodes de paiement"
+      },
+      "start": {
+        "headerTitle__payments": "Paiements",
+        "headerTitle__plans": "Plans",
+        "headerTitle__statements": "Relevés",
+        "headerTitle__subscriptions": "Abonnements"
+      },
+      "statementsSection": {
+        "empty": "Aucun relevé à afficher",
+        "itemCaption__paidForPlan": "Payé pour le plan {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédit au prorata pour l’utilisation partielle de l’abonnement précédent",
+        "itemCaption__subscribedAndPaidForPlan": "Souscrit et payé pour le plan {{plan}} {{period}}",
+        "notFound": "Relevé introuvable",
+        "tableHeader__amount": "Montant",
+        "tableHeader__date": "Date",
+        "title": "Relevés",
+        "totalPaid": "Total payé"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gérer",
+        "actionLabel__newSubscription": "S'abonner à un plan",
+        "actionLabel__switchPlan": "Changer de plan",
+        "tableHeader__edit": "Modifier",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Date de début",
+        "title": "Abonnement"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gérer" },
+      "switchPlansSection": { "title": "Changer de plan" },
+      "title": "Abonnements"
+    },
+    "createDomainPage": {
+      "subtitle": "Ajoutez le domaine pour le vérifier. Les utilisateurs possédant une adresse e-mail sur ce domaine peuvent rejoindre l'organisation automatiquement ou demander à y adhérer.",
+      "title": "Ajouter un domaine"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "Les invitations suivantes n’ont pas pu être envoyées. Veuillez régler ce problème et réessayer:",
+      "formButtonPrimary__continue": "Envoyer des invitations",
+      "selectDropdown__role": "Sélectionner un rôle",
+      "subtitle": "Inviter des membres à rejoindre l’organisation",
+      "successMessage": "Les invitations ont été envoyées.",
+      "title": "Inviter des membres"
+    },
+    "membersPage": {
+      "action__invite": "Inviter",
+      "action__search": "Rechercher",
+      "activeMembersTab": {
+        "menuAction__remove": "Supprimer",
+        "tableHeader__actions": "Actions",
+        "tableHeader__joined": "Rejoint le",
+        "tableHeader__role": "Rôle",
+        "tableHeader__user": "Utilisateur"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Nous mettons à jour les rôles disponibles. Une fois terminé, vous pourrez de nouveau modifier les rôles.",
+          "title": "Les rôles sont temporairement verrouillés"
+        }
+      },
+      "detailsTitle__emptyRow": "Aucun membre",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Invitez des utilisateurs en connectant un domaine de messagerie à votre organisation. Toute personne s'inscrivant avec une adresse e-mail de ce domaine pourra rejoindre l'organisation.",
+          "headerTitle": "Invitations automatiques",
+          "primaryButton": "Gérer les domaines validés"
+        },
+        "table__emptyRow": "Pas d'invitations à afficher"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Révoquer l'invitation",
+        "tableHeader__invited": "Invité"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Les utilisateurs qui s'inscrivent avec un domaine de messagerie identique verront une suggestion pour demander à rejoindre votre organisation.",
+          "headerTitle": "Suggestions automatiques",
+          "primaryButton": "Gérer les domaines validés"
+        },
+        "menuAction__approve": "Approuver",
+        "menuAction__reject": "Rejeter",
+        "tableHeader__requested": "Accès demandé",
+        "table__emptyRow": "Pas de demandes à afficher"
+      },
+      "start": {
+        "headerTitle__invitations": "Invitations",
+        "headerTitle__members": "Membres",
+        "headerTitle__requests": "Demandes"
+      }
+    },
+    "navbar": {
+      "apiKeys": "Clés API",
+      "billing": "Facturation",
+      "description": "Gérer votre organisation.",
+      "general": "Général",
+      "members": "Membres",
+      "title": "Organisation"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "Vous n'avez pas les permissions pour gérer la facturation de cette organisation."
+      },
+      "title": "Plans"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Saisissez {{organizationName}} ci-dessous pour continuer.",
+          "messageLine1": "Êtes-vous sûr(e) de vouloir supprimer cette organisation ?",
+          "messageLine2": "Cette action est définitive et irréversible.",
+          "successMessage": "Vous avez supprimé l'organisation.",
+          "title": "Supprimer l'organisation"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Saisissez {{organizationName}} ci-dessous pour continuer.",
+          "messageLine1": "Êtes-vous sûr de vouloir quitter cette organisation ? Vous perdrez l'accès à cette organisation et à ses applications.",
+          "messageLine2": "Cette action est permanente et irréversible.",
+          "successMessage": "Vous avez quitté l'organisation.",
+          "title": "Quitter l'organisation"
+        },
+        "title": "Danger"
+      },
+      "domainSection": {
+        "menuAction__manage": "Gérer",
+        "menuAction__remove": "Supprimer",
+        "menuAction__verify": "Valider",
+        "primaryButton": "Ajouter un domaine",
+        "subtitle": "Permettre aux utilisateurs de rejoindre l'organisation automatiquement ou de faire une demande d'adhésion si leur domaine de messagerie est vérifié.",
+        "title": "Domaines vérifiés"
+      },
+      "successMessage": "L'organisation a été mise à jour.",
+      "title": "Profil de l’organisation"
+    },
+    "removeDomainPage": {
+      "messageLine1": "Le domaine de messagerie {{domain}} sera supprimé.",
+      "messageLine2": "Les utilisateurs ne pourront plus rejoindre l'organisation automatiquement après cela.",
+      "successMessage": "{{domain}} a été supprimé.",
+      "title": "Supprimer un domaine"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "Général",
+      "headerTitle__members": "Membres",
+      "profileSection": {
+        "primaryButton": "Mettre à jour le profil",
+        "title": "Profil de l'organisation",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "Supprimer ce domaine affectera les utilisateurs invités.",
+        "removeDomainActionLabel__remove": "Supprimer ce domaine",
+        "removeDomainSubtitle": "Supprimer ce domaine de vos domaines vérifiés",
+        "removeDomainTitle": "Supprimer un domaine"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Les utilisateurs sont automatiquement invités à rejoindre l'organisation lors de leur inscription et peuvent la rejoindre à tout moment.",
+        "automaticInvitationOption__label": "Invitations automatiques",
+        "automaticSuggestionOption__description": "Les utilisateurs reçoivent une suggestion d'adhésion à l'organisation, mais doivent être approuvés par un administrateur avant de pouvoir y adhérer.",
+        "automaticSuggestionOption__label": "Suggestions automatiques",
+        "calloutInfoLabel": "Changer le mode d'inscription n'affectera que les nouveaux utilisateurs.",
+        "calloutInvitationCountLabel": "Invitations en attente envoyées aux utilisateurs : {{count}}",
+        "calloutSuggestionCountLabel": "Suggestions en attente envoyées aux utilisateurs : {{count}}",
+        "manualInvitationOption__description": "Les utilisateurs peuvent uniquement être invités à l'organisation manuellement.",
+        "manualInvitationOption__label": "Pas d'inscription automatique",
+        "subtitle": "Choisissez comment les utilisateurs de ce domaine peuvent rejoindre l'organisation."
+      },
+      "start": {
+        "headerTitle__danger": "Danger",
+        "headerTitle__enrollment": "Option d'inscription"
+      },
+      "subtitle": "Le domaine {{domain}} est maintenant vérifié. Poursuivez en sélectionnant le mode d'inscription.",
+      "title": "Mettre à jour {{domain}}"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Saisissez le code de vérification envoyé à votre adresse e-mail",
+      "formTitle": "Code de vérification",
+      "resendButton": "Vous n'avez pas reçu de code ? Renvoyer",
+      "subtitle": "Le domaine {{domainName}} doit être vérifié par e-mail.",
+      "subtitleVerificationCodeScreen": "Un code de vérification a été envoyé à {{emailAddress}}. Saisissez le code pour continuer.",
+      "title": "Vérifier un domaine"
+    }
+  },
+  "organizationSwitcher": {
+    "action__createOrganization": "Créer une organisation",
+    "action__invitationAccept": "Rejoindre",
+    "action__manageOrganization": "Gérer l'organisation",
+    "action__suggestionsAccept": "Demander à rejoindre",
+    "notSelected": "Aucune organisation sélectionnée",
+    "personalWorkspace": "Espace de travail personnel",
+    "suggestionsAcceptedLabel": "En attente d'acceptation"
+  },
+  "paginationButton__next": "Suivant",
+  "paginationButton__previous": "Précédent",
+  "paginationRowText__displaying": "Affichage",
+  "paginationRowText__of": "de",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Utiliser une autre méthode",
+      "actionText": "Vous ne pouvez pas accéder à votre compte ?",
+      "blockButton__backupCode": "Utiliser un code de récupération",
+      "blockButton__emailCode": "Recevoir un code par e-mail",
+      "blockButton__passkey": "Utiliser une clé de sécurité",
+      "blockButton__password": "Utiliser le mot de passe",
+      "blockButton__phoneCode": "Recevoir un code par téléphone",
+      "blockButton__totp": "Utiliser un code d’application d’authentification",
+      "getHelp": {
+        "blockButton__emailSupport": "Contacter le support par e-mail",
+        "content": "Si vous ne pouvez pas accéder à votre compte, contactez notre équipe de support pour obtenir de l'aide.",
+        "title": "Obtenir de l'aide"
+      },
+      "subtitle": "Choisissez une méthode alternative pour vérifier votre identité.",
+      "title": "Vérification alternative"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Entrez l'un de vos codes de récupération pour vérifier votre compte.",
+      "title": "Vérification par code de récupération"
+    },
+    "emailCode": {
+      "formTitle": "Entrez le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "Un code a été envoyé à votre adresse e-mail.",
+      "title": "Vérification par e-mail"
+    },
+    "noAvailableMethods": {
+      "message": "Aucune méthode de vérification n'est disponible.",
+      "subtitle": "Impossible de procéder à la vérification.",
+      "title": "Aucune méthode disponible"
+    },
+    "passkey": {
+      "blockButton__passkey": "Utiliser votre clé de sécurité",
+      "subtitle": "L'utilisation de votre clé de sécurité confirme votre identité. Votre appareil peut vous demander votre empreinte digitale, votre visage ou votre code de sécurité.",
+      "title": "Utiliser votre clé de sécurité"
+    },
+    "password": {
+      "actionLink": "Réinitialiser le mot de passe",
+      "subtitle": "Entrez votre mot de passe pour continuer.",
+      "title": "Vérification par mot de passe"
+    },
+    "phoneCode": {
+      "formTitle": "Entrez le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "Un code a été envoyé à votre téléphone.",
+      "title": "Vérification par téléphone"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Entrez le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "Un code a été envoyé à votre téléphone pour vérification.",
+      "title": "Vérification par téléphone"
+    },
+    "totpMfa": {
+      "formTitle": "Entrez le code de vérification",
+      "subtitle": "Entrez le code généré par votre application d'authentification.",
+      "title": "Vérification par application d’authentification"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Ajouter un compte",
+      "action__signOutAll": "Se déconnecter de tous les comptes",
+      "subtitle": "Sélectionnez le compte avec lequel vous souhaitez continuer.",
+      "title": "Choisissez un compte"
+    },
+    "alternativeMethods": {
+      "actionLink": "Obtenir de l'aide",
+      "actionText": "Aucune de ces méthodes ne fonctionne ?",
+      "blockButton__backupCode": "Utiliser un code de récupération",
+      "blockButton__emailCode": "Envoyer le code à {{identifier}}",
+      "blockButton__emailLink": "Envoyer le lien à {{identifier}}",
+      "blockButton__passkey": "Utiliser une clé de sécurité",
+      "blockButton__password": "Connectez-vous avec votre mot de passe",
+      "blockButton__phoneCode": "Envoyer le code à {{identifier}}",
+      "blockButton__totp": "Utilisez votre application d'authentification",
+      "getHelp": {
+        "blockButton__emailSupport": "Assistance par e-mail",
+        "content": "Si vous rencontrez des difficultés pour vous connecter à votre compte, envoyez-nous un e-mail et nous travaillerons avec vous pour rétablir l'accès dès que possible.",
+        "title": "Obtenir de l'aide"
+      },
+      "subtitle": "Vous rencontrez des problèmes ? Vous pouvez utiliser l'une de ces méthodes pour vous connecter.",
+      "title": "Utiliser une autre méthode"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "Code de vérification",
+      "resendButton": "Vous n’avez pas reçu de code ? Renvoyer",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre {{provider}}"
+    },
+    "backupCodeMfa": {
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Entrez un code de récupération"
+    },
+    "emailCode": {
+      "formTitle": "Le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre messagerie"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Vérifiez votre messagerie",
+      "resendButton": "Vous n'avez pas reçu de code ? Renvoyer",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre messagerie"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Ce lien ne correspond pas à la demande en cours.",
+        "title": "Erreur de correspondance du client"
+      },
+      "expired": {
+        "subtitle": "Retournez à l'onglet d'origine pour continuer",
+        "title": "Ce lien de vérification a expiré"
+      },
+      "failed": {
+        "subtitle": "Retourner à l'onglet original pour continuer",
+        "title": "Ce lien de vérification n'est pas valide"
+      },
+      "formSubtitle": "Utilisez le lien de vérification envoyé par e-mail",
+      "formTitle": "lien de vérification",
+      "loading": {
+        "subtitle": "Vous allez bientôt être redirigé",
+        "title": "Connexion en cours..."
+      },
+      "resendButton": "Renvoyer le lien",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre messagerie",
+      "unusedTab": { "title": "Vous pouvez fermer cet onglet" },
+      "verified": {
+        "subtitle": "Vous serez bientôt redirigé",
+        "title": "Connexion réussie"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Revenir à l'onglet d'origine pour continuer",
+        "subtitleNewTab": "Revenez à l'onglet nouvellement ouvert pour continuer",
+        "titleNewTab": "Connecté sur un autre onglet"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Utilisez le lien de vérification envoyé par e-mail",
+      "resendButton": "Vous n'avez pas reçu de lien ? Renvoyer",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre messagerie"
+    },
+    "enterpriseConnections": {},
+    "forgotPassword": {
+      "formTitle": "Code de réinitialisation du mot de passe",
+      "resendButton": "Vous n'avez pas reçu de code ? Renvoyer",
+      "subtitle": "pour réinitialiser votre mot de passe",
+      "subtitle_email": "Tout d'abord, saisissez le code envoyé à votre adresse e-mail.",
+      "subtitle_phone": "Tout d'abord, saisissez le code envoyé à votre téléphone.",
+      "title": "Réinitialiser le mot de passe"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Réinitialiser votre mot de passe",
+      "label__alternativeMethods": "Ou connectez-vous avec une autre méthode.",
+      "title": "Mot de passe oublié ?"
+    },
+    "newDeviceVerificationNotice": "Vous vous connectez depuis un nouvel appareil. Nous demandons une vérification pour sécuriser votre compte.",
+    "noAvailableMethods": {
+      "message": "Impossible de poursuivre la connexion. Aucun facteur d'authentification n'est disponible.",
+      "subtitle": "Une erreur s'est produite",
+      "title": "Impossible de se connecter"
+    },
+    "passkey": {
+      "subtitle": "Utilisez une clé de sécurité pour continuer.",
+      "title": "Clé de sécurité"
+    },
+    "password": {
+      "actionLink": "Utiliser une autre méthode",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Entrez votre mot de passe"
+    },
+    "passwordCompromised": {},
+    "passwordPwned": { "title": "Mot de passe compromis" },
+    "passwordUntrusted": {},
+    "phoneCode": {
+      "formTitle": "Code de vérification",
+      "resendButton": "Vous n'avez pas reçu de code ? Renvoyer",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre téléphone"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Code de vérification",
+      "resendButton": "Vous n'avez pas reçu de code ? Renvoyer",
+      "subtitle": "Entrez le code envoyé à votre téléphone pour continuer.",
+      "title": "Vérifiez votre téléphone"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Réinitialiser",
+      "requiredMessage": "Pour des raisons de sécurité, il est nécessaire de réinitialiser votre mot de passe.",
+      "successMessage": "Votre mot de passe a été modifié avec succès. Nous vous reconnectons, veuillez patienter un instant.",
+      "title": "Réinitialiser le mot de passe"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Nous devons vérifier votre identité avant de réinitialiser votre mot de passe."
+    },
+    "start": {
+      "actionLink": "S'inscrire",
+      "actionLink__join_waitlist": "Rejoindre la liste d'attente",
+      "actionLink__use_email": "Utiliser e-mail",
+      "actionLink__use_email_username": "Utiliser l'e-mail ou le nom d'utilisateur",
+      "actionLink__use_passkey": "Utiliser une clé de sécurité",
+      "actionLink__use_phone": "Utiliser téléphone",
+      "actionLink__use_username": "Utiliser le nom d'utilisateur",
+      "actionText": "Vous n'avez pas encore de compte ?",
+      "actionText__join_waitlist": "Inscrivez-vous sur la liste d'attente",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Utiliser une autre méthode",
+        "label": "Numéro de téléphone {{provider}}",
+        "subtitle": "Entrez votre numéro de téléphone pour recevoir un code de vérification sur {{provider}}.",
+        "title": "Se connecter à {{applicationName}} avec {{provider}}"
+      },
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Se connecter",
+      "titleCombined": "Continuer vers {{applicationName}}"
+    },
+    "totpMfa": {
+      "formTitle": "Le code de vérification",
+      "subtitle": "Entrez le code de l'application d'authentification.",
+      "title": "Vérification en deux étapes"
+    },
+    "web3Solana": {
+      "subtitle": "Sélectionnez un portefeuille ci-dessous pour vous connecter",
+      "title": "Se connecter avec Solana"
+    }
+  },
+  "signInEnterPasswordTitle": "Entrez votre mot de passe",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "Vous n’avez pas reçu de code ? Renvoyer",
+      "subtitle": "Entrez le code de vérification envoyé à votre {{provider}}",
+      "title": "Vérifiez votre {{provider}}"
+    },
+    "continue": {
+      "actionLink": "Se connecter",
+      "actionText": "Vous avez déjà un compte ?",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Remplir les champs manquants"
+    },
+    "emailCode": {
+      "formSubtitle": "Entrez le code de vérification envoyé à votre adresse e-mail",
+      "formTitle": "Le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre e-mail"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Pour continuer, ouvrir le lien de vérification sur l'appareil et le navigateur depuis lequel vous avez initié l'inscription",
+        "title": "Erreur de correspondance du client"
+      },
+      "formSubtitle": "Utilisez le lien de vérification envoyé à votre adresse e-mail",
+      "formTitle": "lien de vérification",
+      "loading": { "title": "Création de votre compte..." },
+      "resendButton": "Renvoyer le lien",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre e-mail",
+      "verified": { "title": "Compte créé" },
+      "verifiedSwitchTab": {
+        "subtitle": "Revenez à l'onglet nouvellement ouvert pour continuer",
+        "subtitleNewTab": "Revenir à l'onglet précédent pour continuer",
+        "title": "E-mail vérifié avec succès"
+      }
+    },
+    "enterpriseConnections": {},
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "J'accepte la Politique de confidentialité.",
+        "label__onlyTermsOfService": "J'accepte les Conditions d'utilisation.",
+        "label__termsOfServiceAndPrivacyPolicy": "J'accepte les {{ termsOfServiceLink || link(\"Conditions d'utilisation\") }} et la {{ privacyPolicyLink || link(\"Politique de confidentialité\") }}."
+      },
+      "continue": {
+        "subtitle": "Lisez et acceptez les conditions pour continuer.",
+        "title": "Consentement légal"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Entrez le code de vérification envoyé à votre numéro de téléphone",
+      "formTitle": "Le code de vérification",
+      "resendButton": "Renvoyer le code",
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "title": "Vérifiez votre téléphone"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Contacter le support",
+      "actionText": "Accès restreint.",
+      "blockButton__emailSupport": "Contacter le support par e-mail",
+      "blockButton__joinWaitlist": "Rejoindre la liste d'attente",
+      "subtitle": "Vous n'avez pas la permission d'accéder à cette page.",
+      "subtitleWaitlist": "Inscrivez-vous pour demander l'accès.",
+      "title": "Accès restreint"
+    },
+    "start": {
+      "actionLink": "Se connecter",
+      "actionLink__use_email": "Utiliser votre adresse e-mail",
+      "actionLink__use_phone": "Utiliser votre téléphone",
+      "actionText": "Vous avez déjà un compte ?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Utiliser une autre méthode",
+        "label": "Numéro de téléphone {{provider}}",
+        "subtitle": "Entrez votre numéro de téléphone pour recevoir un code de vérification sur {{provider}}.",
+        "title": "S’inscrire à {{applicationName}} avec {{provider}}"
+      },
+      "subtitle": "pour continuer vers {{applicationName}}",
+      "subtitleCombined": "pour continuer vers {{applicationName}}",
+      "title": "Créez votre compte",
+      "titleCombined": "Créez votre compte"
+    },
+    "web3Solana": {
+      "subtitle": "Sélectionnez un portefeuille ci-dessous pour vous inscrire",
+      "title": "S'inscrire avec Solana"
+    }
+  },
+  "socialButtonsBlockButton": "Continuer avec {{provider|titleize}}",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {},
+    "chooseOrganization": {
+      "action__createOrganization": "Créer une nouvelle organisation",
+      "action__invitationAccept": "Rejoindre",
+      "action__suggestionsAccept": "Demander à rejoindre",
+      "subtitle": "Rejoignez une organisation existante ou créez-en une nouvelle",
+      "subtitle__createOrganizationDisabled": "Rejoignez une organisation existante",
+      "suggestionsAcceptedLabel": "En attente d’approbation",
+      "title": "Choisir une organisation"
+    },
+    "createOrganization": {
+      "formButtonReset": "Annuler",
+      "formButtonSubmit": "Continuer",
+      "formFieldInputPlaceholder__name": "Mon organisation",
+      "formFieldInputPlaceholder__slug": "mon-organisation",
+      "formFieldLabel__name": "Nom",
+      "formFieldLabel__slug": "Identifiant (slug)",
+      "subtitle": "Entrez les détails de votre organisation pour continuer",
+      "title": "Configurer votre organisation"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Contactez l'administrateur de votre organisation pour obtenir une invitation.",
+      "title": "Vous devez appartenir à une organisation"
+    },
+    "signOut": {
+      "actionLink": "Se déconnecter",
+      "actionText": "Connecté en tant que {{identifier}}"
+    }
+  },
+  "taskResetPassword": { "signOut": {} },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "Vous êtes déjà membre de cette organisation.",
+    "avatar_file_size_exceeded": "La taille du fichier dépasse la limite maximale de 10 Mo. Veuillez choisir un fichier plus petit.",
+    "avatar_file_type_invalid": "Type de fichier non pris en charge. Veuillez télécharger une image JPG, PNG, GIF ou WEBP.",
+    "captcha_invalid": "Inscription échouée en raison de validations de sécurité incorrectes. Veuillez rafraîchir la page pour réessayer ou contacter le support pour obtenir de l'aide.",
+    "captcha_unavailable": "Inscription échouée en raison d'une validation de captcha non réussie. Veuillez actualiser la page pour réessayer ou contacter le support pour obtenir de l'aide.",
+    "form_code_incorrect": "Code incorrect",
+    "form_email_address_blocked": "Les services de messagerie temporaire ne sont pas pris en charge. Veuillez utiliser votre adresse e-mail habituelle pour créer un compte.",
+    "form_identifier_exists__email_address": "Cette adresse e-mail existe déjà.",
+    "form_identifier_exists__phone_number": "Ce numéro de téléphone existe déjà.",
+    "form_identifier_exists__username": "Ce nom d'utilisateur existe déjà.",
+    "form_identifier_not_found": "Nous n'avons pas trouvé de compte avec ces détails.",
+    "form_param_format_invalid": "Le format est invalide",
+    "form_param_format_invalid__email_address": "L'adresse e-mail doit être une adresse e-mail valide.",
+    "form_param_format_invalid__phone_number": "Le numéro de téléphone doit être au format international.",
+    "form_param_max_length_exceeded__first_name": "Le prénom ne doit pas dépasser 256 caractères.",
+    "form_param_max_length_exceeded__last_name": "Le nom ne doit pas dépasser 256 caractères.",
+    "form_param_max_length_exceeded__name": "Le nom ne doit pas dépasser 256 caractères.",
+    "form_param_nil": "Ce champ est requis.",
+    "form_param_value_invalid": "La valeur fournie est invalide.",
+    "form_password_incorrect": "Mot de passe incorrect",
+    "form_password_length_too_short": "Votre mot de passe est trop court.",
+    "form_password_not_strong_enough": "Votre mot de passe n'est pas assez fort.",
+    "form_password_or_identifier_incorrect": "Le mot de passe ou l'adresse e-mail est incorrect. Réessayez ou utilisez une autre méthode.",
+    "form_password_pwned": "Ce mot de passe a été compromis et ne peut pas être utilisé. Veuillez essayer un autre mot de passe à la place.",
+    "form_password_pwned__sign_in": "Mot de passe compromis. Veuillez le réinitialiser.",
+    "form_password_size_in_bytes_exceeded": "Votre mot de passe a dépassé le nombre maximum d'octets autorisés. Veuillez le raccourcir ou supprimer certains caractères spéciaux.",
+    "form_password_validation_failed": "Mot de passe incorrect",
+    "form_username_invalid_character": "L'identifiant contient des caractères invalides.",
+    "form_username_invalid_length": "Le nombre de caractères de l'identifiant est invalide.",
+    "form_username_needs_non_number_char": "Votre nom d'utilisateur doit contenir au moins un caractère non numérique.",
+    "identification_deletion_failed": "Vous ne pouvez pas supprimer votre dernière identification.",
+    "not_allowed_access": "L'adresse e-mail ou le numéro de téléphone n'est pas autorisée à s'inscrire. Cela peut être dû à l'utilisation de '+', '=', '#' ou '.' dans votre adresse e-mail, l'utilisation d'un domaine connecté à un service de messagerie temporaire ou l'exclusion explicite. Si vous pensez que c'est une erreur, veuillez contacter le support.",
+    "organization_domain_blocked": "Ce domaine d'organisation est bloqué.",
+    "organization_domain_common": "Ce domaine est trop courant pour une organisation.",
+    "organization_membership_quota_exceeded": "Le quota de membres de l'organisation a été dépassé.",
+    "organization_minimum_permissions_needed": "Permissions minimales nécessaires pour accéder à cette organisation.",
+    "organization_not_found_or_unauthorized": "Vous n’êtes plus membre de cette organisation. Veuillez en choisir ou en créer une autre.",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "Vous n’êtes plus membre de cette organisation. Veuillez en choisir une autre.",
+    "passkey_already_exists": "Cette clé de sécurité existe déjà.",
+    "passkey_not_supported": "Les clés de sécurité ne sont pas prises en charge sur cet appareil.",
+    "passkey_pa_not_supported": "Les clés de sécurité ne sont pas prises en charge dans cet environnement.",
+    "passkey_registration_cancelled": "Enregistrement de la clé de sécurité annulé.",
+    "passkey_retrieval_cancelled": "Récupération de la clé de sécurité annulée.",
+    "passwordComplexity": {
+      "maximumLength": "moins de {{length}} caractères",
+      "minimumLength": "au moins {{length}} caractères",
+      "requireLowercase": "une lettre minuscule",
+      "requireNumbers": "un chiffre",
+      "requireSpecialCharacter": "un caractère spécial",
+      "requireUppercase": "une lettre majuscule",
+      "sentencePrefix": "Votre mot de passe doit contenir"
+    },
+    "phone_number_exists": "Ce numéro de téléphone est déjà utilisé. Veuillez essayer un autre.",
+    "session_exists": "Vous êtes déjà connecté.",
+    "web3_missing_identifier": "Aucune extension de portefeuille Web3 trouvée. Veuillez en installer une pour continuer.",
+    "web3_signature_request_rejected": "Vous avez refusé la demande de signature. Veuillez réessayer pour continuer.",
+    "web3_solana_signature_generation_failed": "Une erreur s'est produite lors de la génération de la signature. Veuillez réessayer pour continuer.",
+    "zxcvbn": {
+      "couldBeStronger": "Votre mot de passe fonctionne mais pourrait être plus sûr. Essayez d'ajouter des caractères.",
+      "goodPassword": "Bien joué. C'est un excellent mot de passe.",
+      "notEnough": "Votre mot de passe n'est pas assez fort.",
+      "suggestions": {
+        "allUppercase": "Mettez quelques lettres en majuscules, mais pas toutes.",
+        "anotherWord": "Ajoutez des mots moins courants.",
+        "associatedYears": "Évitez les années qui vous sont associées. (ex: date de naissance)",
+        "capitalization": "Capitalisez mais pas seulement la première lettre.",
+        "dates": "Évitez les dates et les années qui vous sont associées. (ex: date ou année de naissance)",
+        "l33t": "Évitez les substitutions de lettres prévisibles comme '@' pour 'a'.",
+        "longerKeyboardPattern": "Utilisez des motifs de clavier plus longs et changez de sens de frappe plusieurs fois.",
+        "noNeed": "Vous pouvez créer des mots de passe forts sans utiliser de symboles, de chiffres ou de lettres majuscules.",
+        "pwned": "Si vous utilisez ce mot de passe ailleurs, vous devriez le modifier.",
+        "recentYears": "Évitez les dernières années.",
+        "repeated": "Évitez les mots et les caractères répétés.",
+        "reverseWords": "Évitez les orthographes inversées des mots courants",
+        "sequences": "Évitez les séquences de caractères courantes.",
+        "useWords": "Utilisez plusieurs mots, mais évitez les phrases courantes."
+      },
+      "warnings": {
+        "common": "Ce mot de passe est couramment utilisé.",
+        "commonNames": "Les noms communs et les noms de famille sont faciles à deviner.",
+        "dates": "Les dates sont faciles à deviner.",
+        "extendedRepeat": "Les caractères répétés comme 'abcabcabc' sont faciles à deviner.",
+        "keyPattern": "Des motifs de clavier courts sont faciles à deviner.",
+        "namesByThemselves": "Des noms ou des prénoms simples sont faciles à deviner.",
+        "pwned": "Votre mot de passe a été divulgué suite à une violation de données sur Internet.",
+        "recentYears": "Les années récentes sont faciles à deviner.",
+        "sequences": "Des séquences de caractères communs comme 'abc' sont faciles à deviner.",
+        "similarToCommon": "Ce mot de passe est similaire à un mot de passe couramment utilisé.",
+        "simpleRepeat": "Les caractères répétés comme 'aaa' sont faciles à deviner.",
+        "straightRow": "Les lignes droites de touches de votre clavier sont faciles à deviner.",
+        "topHundred": "Ce mot de passe est fréquemment utilisé.",
+        "topTen": "Ce mot de passe est très utilisé.",
+        "userInputs": "Le mot de passe ne doit pas comporter de données personnelles ou liées au site.",
+        "wordByItself": "Les mots simples sont faciles à deviner."
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "Ajouter un compte",
+    "action__closeUserMenu": "Fermer le menu utilisateur",
+    "action__manageAccount": "Gérer mon compte",
+    "action__openUserMenu": "Ouvrir le menu utilisateur",
+    "action__signOut": "Déconnexion",
+    "action__signOutAll": "Se déconnecter de tous les comptes",
+    "label__accountActions": "Actions du compte",
+    "label__activeSessions": "Sessions actives",
+    "label__userButtonPopover": "Panneau du compte"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "Clés API" },
+    "backupCodePage": {
+      "actionLabel__copied": "Copié !",
+      "actionLabel__copy": "Copier tous les codes",
+      "actionLabel__download": "Télécharger en .txt",
+      "actionLabel__print": "Imprimer",
+      "infoText1": "Les codes de récupération seront activés pour ce compte.",
+      "infoText2": "Gardez les codes de récupération secrets et stockez-les en toute sécurité. Vous pouvez régénérer les codes de récupération si vous pensez qu'ils ont été compromis.",
+      "subtitle__codelist": "Conservez-les en toute sécurité et gardez-les secrets.",
+      "successMessage": "Les codes de récupération sont maintenant activés. Vous pouvez utiliser l'un d'entre eux pour vous connecter à votre compte, si vous perdez l'accès à votre dispositif d'authentification. Chaque code ne peut être utilisé qu'une seule fois.",
+      "successSubtitle": "Vous pouvez utiliser l'un d'entre eux pour vous connecter à votre compte, si vous perdez l'accès à votre dispositif d'authentification.",
+      "title": "Ajouter la vérification du code de récupération",
+      "title__codelist": "Codes de récupération"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Aucun historique de paiement",
+        "notFound": "Tentative de paiement introuvable",
+        "tableHeader__amount": "Montant",
+        "tableHeader__date": "Date",
+        "tableHeader__status": "Statut"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Rendre par défaut",
+        "actionLabel__remove": "Supprimer",
+        "add": "Ajouter une nouvelle méthode de paiement",
+        "addSubtitle": "Ajoutez une nouvelle méthode de paiement à votre compte.",
+        "cancelButton": "Annuler",
+        "formButtonPrimary__add": "Ajouter une méthode de paiement",
+        "formButtonPrimary__pay": "Payer {{amount}}",
+        "payWithTestCardButton": "Payer avec une carte de test",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+          "messageLine2": "Vous ne pourrez plus utiliser cette méthode de paiement et tous les abonnements récurrents qui en dépendent ne fonctionneront plus.",
+          "successMessage": "{{paymentMethod}} a été supprimé de votre compte.",
+          "title": "Supprimer une méthode de paiement"
+        },
+        "title": "Méthodes de paiement"
+      },
+      "start": {
+        "headerTitle__payments": "Paiements",
+        "headerTitle__plans": "Plans",
+        "headerTitle__statements": "Relevés",
+        "headerTitle__subscriptions": "Abonnement"
+      },
+      "statementsSection": {
+        "empty": "Aucun relevé à afficher",
+        "itemCaption__paidForPlan": "Payé pour le plan {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédit au prorata pour l’utilisation partielle de l’abonnement précédent",
+        "itemCaption__subscribedAndPaidForPlan": "Souscrit et payé pour le plan {{plan}} {{period}}",
+        "notFound": "Relevé introuvable",
+        "tableHeader__amount": "Montant",
+        "tableHeader__date": "Date",
+        "title": "Relevés",
+        "totalPaid": "Total payé"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gérer",
+        "actionLabel__newSubscription": "S'abonner à un plan",
+        "actionLabel__switchPlan": "Changer de plan",
+        "tableHeader__edit": "Modifier",
+        "tableHeader__plan": "Plan",
+        "tableHeader__startDate": "Date de début",
+        "title": "Abonnement"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gérer" },
+      "switchPlansSection": { "title": "Changer de plan" },
+      "title": "Facturation"
+    },
+    "connectedAccountPage": {
+      "formHint": "Sélectionnez un fournisseur pour connecter votre compte.",
+      "formHint__noAccounts": "Aucun fournisseur de compte externe n'est disponible.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+        "messageLine2": "Vous ne pourrez plus utiliser ce compte connecté et toutes les fonctionnalités dépendantes ne fonctionneront plus.",
+        "successMessage": "{{connectedAccount}} a été supprimé de votre compte.",
+        "title": "Supprimer le compte connecté"
+      },
+      "socialButtonsBlockButton": "Connecter un compte {{provider|titleize}}",
+      "successMessage": "Le fournisseur a été ajouté à votre compte",
+      "title": "Ajouter un compte connecté"
+    },
+    "deletePage": {
+      "actionDescription": "Saisissez \"Supprimer le compte\" ci-dessous pour continuer.",
+      "confirm": "Supprimer le compte",
+      "messageLine1": "Êtes-vous sûr de vouloir supprimer votre compte ? Certaines données associées peuvent être conservées. Pour demander la suppression complète des données, veuillez contacter l'assistance.",
+      "messageLine2": "Cette action est définitive et irréversible.",
+      "title": "Supprimer le compte"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "Un e-mail contenant un code de vérification sera envoyé à cette adresse e-mail.",
+        "formSubtitle": "Saisissez le code de vérification envoyé à {{identifier}}",
+        "formTitle": "Le code de vérification",
+        "resendButton": "Renvoyer le lien",
+        "successMessage": "L'e-mail {{identifier}} a été vérifié et ajouté à votre compte."
+      },
+      "emailLink": {
+        "formHint": "Un e-mail contenant un lien de vérification sera envoyé à cette adresse e-mail.",
+        "formSubtitle": "Cliquez sur le lien de vérification dans l'e-mail envoyé à {{identifier}}",
+        "formTitle": "lien de vérification",
+        "resendButton": "Renvoyer le lien",
+        "successMessage": "L'e-mail {{identifier}} a été vérifié et ajouté à votre compte."
+      },
+      "enterpriseSSOLink": {
+        "formButton": "Cliquez pour vous connecter",
+        "formSubtitle": "Terminez la connexion avec {{identifier}}"
+      },
+      "formHint": "Vous devrez vérifier cette adresse e-mail avant qu’elle puisse être ajoutée à votre compte.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+        "messageLine2": "Vous ne pourrez plus vous connecter avec cette adresse e-mail.",
+        "successMessage": "{{emailAddress}} a été supprimé de votre compte.",
+        "title": "Supprimer l'adresse e-mail"
+      },
+      "title": "Ajouter une adresse e-mail",
+      "verifyTitle": "Vérifier un e-mail"
+    },
+    "formButtonPrimary__add": "Ajouter",
+    "formButtonPrimary__continue": "Continuer",
+    "formButtonPrimary__finish": "Terminer",
+    "formButtonPrimary__remove": "Supprimer",
+    "formButtonPrimary__save": "Sauvegarder",
+    "formButtonReset": "Annuler",
+    "mfaPage": {
+      "formHint": "Sélectionnez une méthode à ajouter.",
+      "title": "Ajouter la vérification en deux étapes"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "Utiliser un numéro existant",
+      "primaryButton__addPhoneNumber": "Ajouter un numéro de téléphone",
+      "removeResource": {
+        "messageLine1": "{{identifier}} ne recevra plus de codes de validation lors de la connexion.",
+        "messageLine2": "Votre compte sera moins sécurisé. Souhaitez-vous continuer ?",
+        "successMessage": "La vérification en deux étapes du code SMS a été supprimée pour {{mfaPhoneCode}}",
+        "title": "Supprimer la vérification en deux étapes"
+      },
+      "subtitle__availablePhoneNumbers": "Sélectionnez un numéro de téléphone pour vous inscrire à la vérification en deux étapes du code SMS.",
+      "subtitle__unavailablePhoneNumbers": "Il n'y a pas de numéros de téléphone disponibles pour s'inscrire à la vérification en deux étapes du code SMS.",
+      "successMessage1": "Lors de la connexion, vous devrez entrer un code de vérification envoyé à ce numéro de téléphone comme étape supplémentaire.",
+      "successMessage2": "Enregistrez ces codes de récupérations et conservez-les en lieu sûr. Si vous perdez l'accès à votre appareil d'authentification, vous pourrez utiliser les codes de récupérations pour vous connecter.",
+      "successTitle": "Vérification par SMS activée",
+      "title": "Ajouter la vérification du code SMS"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "Scannez le QR code à la place",
+        "buttonUnableToScan__nonPrimary": "Vous ne pouvez pas scanner le QR code ?",
+        "infoText__ableToScan": "Configurez une nouvelle méthode de connexion dans votre application d'authentification et scannez le QR code suivant pour le lier à votre compte.",
+        "infoText__unableToScan": "Configurez une nouvelle méthode de connexion dans votre authentificateur et entrez la clé fournie ci-dessous.",
+        "inputLabel__unableToScan1": "Assurez-vous que les mots de passe basés sur le temps ou à usage unique sont activés, puis terminez la liaison de votre compte.",
+        "inputLabel__unableToScan2": "Alternativement, si votre authentificateur prend en charge les URI TOTP, vous pouvez également copier l'URI complet."
+      },
+      "removeResource": {
+        "messageLine1": "Les codes de vérification de cet authentificateur ne seront plus requis lors de la connexion.",
+        "messageLine2": "Votre compte sera moins sécurisé. Souhaitez-vous continuer ?",
+        "successMessage": "La vérification en deux étapes via l'application d'authentification a été supprimée.",
+        "title": "Supprimer la vérification en deux étapes"
+      },
+      "successMessage": "La vérification en deux étapes est maintenant activée. Lors de la connexion, vous devrez saisir un code de vérification de cet authentificateur comme étape supplémentaire.",
+      "title": "Ajouter une application d'authentification",
+      "verifySubtitle": "Entrez le code de vérification généré par votre application d'authentification",
+      "verifyTitle": "Le code de vérification"
+    },
+    "mobileButton__menu": "Menu",
+    "navbar": {
+      "account": "Compte",
+      "apiKeys": "Clés API",
+      "billing": "Facturation",
+      "description": "Gérer votre compte.",
+      "security": "Sécurité",
+      "title": "Profil"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "Êtes-vous sûr de vouloir supprimer cette clé de sécurité ?",
+        "title": "Supprimer la clé de sécurité"
+      },
+      "subtitle__rename": "Renommez votre clé de sécurité pour une identification facile.",
+      "title__rename": "Renommer la clé de sécurité"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "Il est recommandé de se déconnecter de tous les autres appareils qui pourraient avoir utilisé votre ancien mot de passe.",
+      "readonly": "Votre mot de passe ne peut pas être modifié pour l'instant car vous ne pouvez vous connecter qu'à l'aide de la connexion entreprise.",
+      "successMessage__set": "Votre mot de passe a été mis à jour.",
+      "successMessage__signOutOfOtherSessions": "Tous les autres appareils ont été déconnectés.",
+      "successMessage__update": "Votre mot de passe a été mis à jour.",
+      "title__set": "Mettre à jour le mot de passe",
+      "title__update": "Changer le mot de passe"
+    },
+    "phoneNumberPage": {
+      "infoText": "Un SMS contenant un lien de vérification sera envoyé à ce numéro de téléphone.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+        "messageLine2": "Vous ne pourrez plus vous connecter avec ce numéro de téléphone.",
+        "successMessage": "{{phoneNumber}} a été supprimé de votre compte.",
+        "title": "Supprimer le numéro de téléphone"
+      },
+      "successMessage": "{{identifier}} a été vérifié et ajouté à votre compte.",
+      "title": "Ajouter un numéro de téléphone",
+      "verifySubtitle": "Saisissez le code de vérification envoyé à {{identifier}}",
+      "verifyTitle": "Vérification du numéro de téléphone"
+    },
+    "plansPage": { "title": "Plans" },
+    "profilePage": {
+      "fileDropAreaHint": "Téléchargez une image JPG, PNG, GIF ou WEBP inférieure à 10 Mo",
+      "imageFormDestructiveActionSubtitle": "Supprimer l'image",
+      "imageFormSubtitle": "Télécharger une image",
+      "imageFormTitle": "Photo de profil",
+      "readonly": "Les informations de votre profil ont été fournies par la connexion d'entreprise et ne peuvent pas être modifiées.",
+      "successMessage": "Votre profil a été mis à jour.",
+      "title": "Mettre à jour le profil"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "Se déconnecter de l'appareil",
+        "title": "Appareils actifs"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "Réessayer",
+        "actionLabel__reauthorize": "Autoriser maintenant",
+        "destructiveActionTitle": "Retirer",
+        "primaryButton": "Connecter un compte",
+        "subtitle__disconnected": "Compte déconnecté. Connectez-vous à nouveau pour accéder aux fonctionnalités.",
+        "subtitle__reauthorize": "Les autorisations requises ont été mises à jour, ce qui peut entraîner des fonctionnalités limitées. Veuillez ré-autoriser cette application pour éviter tout problème.",
+        "title": "Comptes connectés"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "Supprimer le compte",
+        "title": "Danger"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "Supprimer l'adresse e-mail",
+        "detailsAction__nonPrimary": "Définir comme principale",
+        "detailsAction__primary": "Compléter la vérification",
+        "detailsAction__unverified": "Compléter la vérification",
+        "primaryButton": "Ajouter une adresse e-mail",
+        "title": "Adresses e-mail"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "Connecter un compte",
+        "title": "Comptes entreprises"
+      },
+      "headerTitle__account": "Compte",
+      "headerTitle__security": "Sécurité",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "Régénérer les codes",
+          "headerTitle": "Codes de récupération",
+          "subtitle__regenerate": "Obtenez de nouveaux codes de récupération sécurisés. Les codes de récupération antérieurs seront supprimés et ne pourront pas être utilisés.",
+          "title__regenerate": "Régénérer les codes de récupération"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "Définir par défaut",
+          "destructiveActionLabel": "Supprimer le numéro de téléphone"
+        },
+        "primaryButton": "Ajouter la vérification en deux étapes",
+        "title": "Vérification en deux étapes",
+        "totp": {
+          "destructiveActionTitle": "Désactiver",
+          "headerTitle": "Application d'authentification"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "Supprimer",
+        "menuAction__rename": "Renommer",
+        "primaryButton": "Ajouter une clé de sécurité",
+        "title": "Clés de sécurité"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "Définir le mot de passe",
+        "primaryButton__updatePassword": "Changer le mot de passe",
+        "title": "Mot de passe"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "Supprimer le numéro de téléphone",
+        "detailsAction__nonPrimary": "Définir comme principale",
+        "detailsAction__primary": "Compléter la vérification",
+        "detailsAction__unverified": "Compléter la vérification",
+        "primaryButton": "Ajouter un numéro de téléphone",
+        "title": "Numéros de téléphone"
+      },
+      "profileSection": {
+        "primaryButton": "Mettre à jour le profil",
+        "title": "Profil"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "Définir le nom d'utilisateur",
+        "primaryButton__updateUsername": "Changer le nom d'utilisateur",
+        "title": "Nom d'utilisateur"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "Supprimer le portefeuille",
+        "detailsAction__nonPrimary": "Définir comme principal",
+        "primaryButton": "Portefeuilles Web3",
+        "title": "Portefeuilles Web3",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Sélectionnez un portefeuille Solana à connecter à votre compte.",
+          "title": "Ajouter un portefeuille Solana"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "Votre nom d'utilisateur a été mis à jour.",
+      "title__set": "Mettre à jour le nom d'utilisateur",
+      "title__update": "Mettre à jour le nom d'utilisateur"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} sera supprimé de ce compte.",
+        "messageLine2": "Vous ne pourrez plus vous connecter avec ce portefeuille web3.",
+        "successMessage": "{{web3Wallet}} a été supprimé de votre compte.",
+        "title": "Supprimer le portefeuille Web3"
+      },
+      "subtitle__availableWallets": "Sélectionnez un portefeuille Web3 pour vous connecter à votre compte.",
+      "subtitle__unavailableWallets": "Il n'y a pas de portefeuilles Web3 disponibles.",
+      "successMessage": "Le portefeuille a été ajouté à votre compte.",
+      "title": "Ajouter un portefeuille Web3",
+      "web3WalletButtonsBlockButton": "Utiliser un portefeuille Web3"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "Rejoindre la liste d'attente",
+      "actionText": "Intéressé ? Rejoignez-nous !",
+      "formButton": "S'inscrire",
+      "subtitle": "Soyez parmi les premiers à découvrir notre nouveau service.",
+      "title": "Rejoindre la liste d'attente"
+    },
+    "success": {
+      "message": "Merci ! Vous avez été ajouté à la liste d'attente.",
+      "subtitle": "Nous vous contacterons bientôt avec plus de détails.",
+      "title": "Inscription réussie"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Se connecter avec {{walletName}}",
+    "continue": "Continuer avec {{walletName}}",
+    "noneAvailable": "Aucun portefeuille Solana Web3 détecté. Veuillez installer une {{ solanaWalletsLink || link(\"wallet extension\") }} compatible Web3."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/hi-IN.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/hi-IN.json
@@ -1,0 +1,1517 @@
+{
+  "locale": "hi-IN",
+  "apiKeys": {
+    "action__add": "नई कुंजी जोड़ें",
+    "action__search": "कुंजियाँ खोजें",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "कॉपी करें और बंद करें",
+      "formHint": "सुरक्षा कारणों से, हम आपको बाद में इसे फिर से देखने की अनुमति नहीं देंगे।",
+      "formTitle": "अभी अपना \"{{name}}\" API कुंजी कॉपी करें"
+    },
+    "createdAndExpirationStatus__expiresOn": "निर्मित {{ createdDate | shortDate('hi-IN') }} • समाप्त {{ expiresDate | longDate('hi-IN') }}",
+    "createdAndExpirationStatus__never": "निर्मित {{ createdDate | shortDate('hi-IN') }} • कभी समाप्त नहीं होती",
+    "detailsTitle__emptyRow": "कोई API कुंजी नहीं मिली",
+    "formButtonPrimary__add": "कुंजी बनाएँ",
+    "formFieldCaption__expiration__expiresOn": "समाप्त हो रही है {{ date }}",
+    "formFieldCaption__expiration__never": "यह कुंजी कभी समाप्त नहीं होगी",
+    "formFieldOption__expiration__180d": "180 दिन",
+    "formFieldOption__expiration__1d": "1 दिन",
+    "formFieldOption__expiration__1y": "1 वर्ष",
+    "formFieldOption__expiration__30d": "30 दिन",
+    "formFieldOption__expiration__60d": "60 दिन",
+    "formFieldOption__expiration__7d": "7 दिन",
+    "formFieldOption__expiration__90d": "90 दिन",
+    "formFieldOption__expiration__never": "कभी नहीं",
+    "formHint": "नई कुंजी बनाने के लिए एक नाम दें। आप इसे कभी भी रद्द कर सकते हैं।",
+    "formTitle": "नई API कुंजी जोड़ें",
+    "lastUsed__days": "{{days}} दिन पहले",
+    "lastUsed__hours": "{{hours}} घंटे पहले",
+    "lastUsed__minutes": "{{minutes}} मिनट पहले",
+    "lastUsed__months": "{{months}} माह पहले",
+    "lastUsed__seconds": "{{seconds}} सेकंड पहले",
+    "lastUsed__years": "{{years}} वर्ष पहले",
+    "menuAction__revoke": "कुंजी रद्द करें",
+    "revokeConfirmation": {
+      "confirmationText": "रद्द करें",
+      "formButtonPrimary__revoke": "कुंजी रद्द करें",
+      "formHint": "क्या आप वाकई इस सीक्रेट कुंजी को हटाना चाहते हैं?",
+      "formTitle": "\"{{apiKeyName}}\" सीक्रेट कुंजी रद्द करें?"
+    }
+  },
+  "backButton": "वापस",
+  "badge__activePlan": "सक्रिय",
+  "badge__canceledEndsAt": "रद्द • समाप्त {{ date | shortDate('hi-IN') }}",
+  "badge__currentPlan": "वर्तमान योजना",
+  "badge__default": "डिफ़ॉल्ट",
+  "badge__endsAt": "समाप्त {{ date | shortDate('hi-IN') }}",
+  "badge__expired": "समाप्त",
+  "badge__freeTrial": "निःशुल्क परीक्षण",
+  "badge__otherImpersonatorDevice": "अन्य प्रतिरूपण उपकरण",
+  "badge__pastDueAt": "बकाया {{ date | shortDate('hi-IN') }}",
+  "badge__pastDuePlan": "बकाया",
+  "badge__primary": "प्राथमिक",
+  "badge__renewsAt": "नवीनीकरण {{ date | shortDate('hi-IN') }}",
+  "badge__requiresAction": "कार्रवाई की आवश्यकता है",
+  "badge__startsAt": "आरंभ {{ date | shortDate('hi-IN') }}",
+  "badge__thisDevice": "यह उपकरण",
+  "badge__trialEndsAt": "परीक्षण समाप्त {{ date | shortDate('hi-IN') }}",
+  "badge__unverified": "असत्यापित",
+  "badge__upcomingPlan": "आगामी",
+  "badge__userDevice": "उपयोगकर्ता उपकरण",
+  "badge__you": "आप",
+  "billing": {
+    "addPaymentMethod__label": "भुगतान विधि जोड़ें",
+    "alwaysFree": "हमेशा निःशुल्क",
+    "annually": "वार्षिक",
+    "availableFeatures": "उपलब्ध सुविधाएँ",
+    "billedAnnually": "वार्षिक रूप से बिल किया गया",
+    "billedMonthlyOnly": "केवल मासिक बिल किया जाता है",
+    "cancelFreeTrial": "निःशुल्क परीक्षण रद्द करें",
+    "cancelFreeTrialAccessUntil": "आपका परीक्षण {{ date | longDate('hi-IN') }} तक सक्रिय रहेगा। उसके बाद, आप परीक्षण सुविधाओं तक पहुँच खो देंगे। आपसे कोई शुल्क नहीं लिया जाएगा।",
+    "cancelFreeTrialTitle": "{{plan}} योजना के लिए निःशुल्क परीक्षण रद्द करें?",
+    "cancelSubscription": "सदस्यता रद्द करें",
+    "cancelSubscriptionAccessUntil": "आप {{ date | longDate('hi-IN') }} तक '{{plan}}' सुविधाओं का उपयोग जारी रख सकते हैं, जिसके बाद आपके पास पहुँच नहीं रहेगी।",
+    "cancelSubscriptionNoCharge": "इस सदस्यता के लिए आपसे कोई शुल्क नहीं लिया जाएगा।",
+    "cancelSubscriptionPastDue": "आपकी सदस्यता तुरंत समाप्त हो जाएगी और आप सभी योजना सुविधाओं तक पहुँच खो देंगे। आपकी अगली सदस्यता पर आपसे बकाया राशि का भुगतान करने के लिए कहा जाएगा।",
+    "cancelSubscriptionTitle": "{{plan}} सदस्यता रद्द करें?",
+    "cannotSubscribeMonthly": "आप मासिक भुगतान करके इस योजना की सदस्यता नहीं ले सकते। इस योजना की सदस्यता लेने के लिए, आपको वार्षिक भुगतान करना चुनना होगा।",
+    "cannotSubscribeUnrecoverable": "आप इस योजना की सदस्यता नहीं ले सकते। आपकी मौजूदा सदस्यता इस योजना से अधिक महंगी है।",
+    "checkout": {
+      "description__paymentSuccessful": "आपका भुगतान सफल रहा।",
+      "description__subscriptionSuccessful": "आपकी नई सदस्यता पूरी तरह तैयार है।",
+      "downgradeNotice": "बिलिंग चक्र के अंत तक आप अपनी मौजूदा सदस्यता और उसकी सुविधाएँ रखेंगे, फिर आपको इस सदस्यता पर स्विच कर दिया जाएगा।",
+      "emailForm": {
+        "subtitle": "अपनी खरीद पूरी करने से पहले आपको एक ईमेल पता जोड़ना होगा जहाँ रसीदें भेजी जाएँगी।",
+        "title": "एक ईमेल पता जोड़ें"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "परीक्षण समाप्ति तिथि",
+        "title__paymentMethod": "भुगतान विधि",
+        "title__statementId": "स्टेटमेंट आईडी",
+        "title__subscriptionBegins": "सदस्यता आरंभ",
+        "title__totalPaid": "कुल भुगतान"
+      },
+      "pastDueNotice": "आपकी पिछली सदस्यता बकाया थी, बिना किसी भुगतान के।",
+      "perMonth": "प्रति माह",
+      "title": "चेकआउट",
+      "title__paymentSuccessful": "भुगतान सफल रहा!",
+      "title__subscriptionSuccessful": "सफल!",
+      "title__trialSuccess": "परीक्षण सफलतापूर्वक आरंभ हुआ!",
+      "totalDueAfterTrial": "{{days}} दिनों में परीक्षण समाप्त होने के बाद कुल देय"
+    },
+    "credit": "क्रेडिट",
+    "creditRemainder": "आपकी मौजूदा सदस्यता की शेष अवधि के लिए क्रेडिट।",
+    "defaultFreePlanActive": "आप वर्तमान में निःशुल्क योजना पर हैं",
+    "free": "मुफ्त",
+    "getStarted": "शुरू करें",
+    "highlightedPlanBadge": "लोकप्रिय",
+    "keepFreeTrial": "निःशुल्क परीक्षण रखें",
+    "keepSubscription": "सदस्यता रखें",
+    "manage": "प्रबंधित करें",
+    "manageSubscription": "सदस्यता प्रबंधित करें",
+    "month": "महीना",
+    "monthly": "मासिक",
+    "pastDue": "बकाया",
+    "pay": "{{amount}} भुगतान करें",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "वार्षिक भुगतान",
+        "monthly": "मासिक भुगतान"
+      },
+      "dev": {
+        "anyNumbers": "कोई भी संख्या",
+        "cardNumber": "कार्ड नंबर",
+        "cvcZip": "CVC, ZIP",
+        "developmentMode": "डेवलपमेंट मोड",
+        "expirationDate": "समाप्ति तिथि",
+        "testCardInfo": "टेस्ट कार्ड जानकारी"
+      }
+    },
+    "paymentMethods__label": "भुगतान विधियाँ",
+    "pricingTable": {
+      "billingCycle": "बिलिंग चक्र",
+      "included": "शामिल",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "पुनः सदस्यता लें",
+    "seeAllFeatures": "सभी सुविधाएँ देखें",
+    "startFreeTrial": "निःशुल्क परीक्षण आरंभ करें",
+    "startFreeTrial__days": "{{days}}-दिवसीय निःशुल्क परीक्षण आरंभ करें",
+    "subscribe": "सदस्यता लें",
+    "subscriptionDetails": {
+      "beginsOn": "आरंभ तिथि",
+      "currentBillingCycle": "वर्तमान बिलिंग चक्र",
+      "endsOn": "समाप्ति तिथि",
+      "firstPaymentAmount": "पहली भुगतान राशि",
+      "firstPaymentOn": "पहला भुगतान",
+      "nextPaymentAmount": "अगली भुगतान राशि",
+      "nextPaymentOn": "अगला भुगतान",
+      "pastDueAt": "बकाया तिथि",
+      "renewsAt": "नवीनीकरण",
+      "subscribedOn": "सदस्यता तिथि",
+      "title": "सदस्यता",
+      "trialEndsOn": "परीक्षण समाप्ति तिथि",
+      "trialStartedOn": "परीक्षण आरंभ तिथि"
+    },
+    "subtotal": "उप-योग",
+    "switchPlan": "इस योजना पर स्विच करें",
+    "switchToAnnual": "वार्षिक पर स्विच करें",
+    "switchToAnnualWithAnnualPrice": "वार्षिक पर स्विच करें {{price}} / वर्ष",
+    "switchToMonthly": "मासिक पर स्विच करें",
+    "switchToMonthlyWithPrice": "मासिक पर स्विच करें {{price}} / माह",
+    "totalDue": "कुल देय",
+    "totalDueToday": "आज का कुल देय",
+    "viewFeatures": "सुविधाएँ देखें",
+    "viewPayment": "भुगतान देखें",
+    "year": "वर्ष"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "अपनी अनुमतियाँ अपग्रेड करने के लिए अपने संगठन के व्यवस्थापक से संपर्क करें।",
+      "title": "आपके पास सिंगल साइन-ऑन (SSO) प्रबंधित करने की अनुमति नहीं है"
+    },
+    "navbar": { "title": "सिंगल साइन-ऑन (SSO) कॉन्फ़िगर करें" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "असत्यापित",
+        "badge__verified": "सत्यापित",
+        "txtRecord": {
+          "hostLabel": "होस्ट / नाम",
+          "instructions": "इस TXT रिकॉर्ड को अपने DNS प्रदाता में जोड़ें। रिकॉर्ड सक्रिय होते ही हम स्वतः सत्यापित कर देंगे।",
+          "typeLabel": "प्रकार",
+          "valueLabel": "मान"
+        },
+        "verifiedAtLabel": "{{ date | shortDate('hi-IN') }} को सत्यापित"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "{{domain}} जोड़ें",
+        "messageLabel": "आपका ईमेल {{domain}} का उपयोग करता है। क्या आप इसे जोड़ना चाहते हैं?"
+      },
+      "formButtonPrimary__add": "जोड़ें",
+      "formFieldInputPlaceholder__domain": "डोमेन जोड़ें",
+      "formFieldLabel__domain": "डोमेन",
+      "removeDomainDialog": {},
+      "subtitle": "अपने संगठन द्वारा साइन इन के लिए उपयोग किए जाने वाले डोमेन का स्वामित्व जोड़ें और सत्यापित करें।",
+      "title": "SSO डोमेन जोड़ें"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "कस्टम SAML प्रदाता",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "उस प्रदाता का चयन करें जिसके लिए आप SSO सेट अप कर रहे हैं।",
+      "title": "प्रदाता चुनें",
+      "warning": "एक बार प्रदाता का चयन करने के बाद आप कॉन्फ़िगरेशन समाप्त होने तक इसे बदल नहीं सकते"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "संगठन बनाएँ",
+    "invitePage": { "formButtonReset": "छोड़ें" },
+    "title": "संगठन बनाएँ"
+  },
+  "dates": {
+    "lastDay": "कल {{ date | timeString('hi-IN') }} बजे",
+    "next6Days": "{{ date | weekday('hi-IN','long') }} को {{ date | timeString('hi-IN') }} बजे",
+    "nextDay": "कल {{ date | timeString('hi-IN') }} बजे",
+    "numeric": "{{ date | numeric('hi-IN') }}",
+    "previous6Days": "पिछले {{ date | weekday('hi-IN','long') }} को {{ date | timeString('hi-IN') }} बजे",
+    "sameDay": "आज {{ date | timeString('hi-IN') }} बजे"
+  },
+  "dividerText": "या",
+  "footerActionLink__alternativePhoneCodeProvider": "इसके बजाय SMS के माध्यम से कोड भेजें",
+  "footerActionLink__useAnotherMethod": "दूसरी विधि का उपयोग करें",
+  "footerPageLink__help": "सहायता",
+  "footerPageLink__privacy": "गोपनीयता",
+  "footerPageLink__terms": "शर्तें",
+  "formButtonPrimary": "जारी रखें",
+  "formButtonPrimary__verify": "सत्यापित करें",
+  "formFieldAction__forgotPassword": "पासवर्ड भूल गए?",
+  "formFieldError__matchingPasswords": "पासवर्ड मेल खाते हैं।",
+  "formFieldError__notMatchingPasswords": "पासवर्ड मेल नहीं खाते।",
+  "formFieldError__verificationLinkExpired": "सत्यापन लिंक समाप्त हो गया है। कृपया एक नया लिंक अनुरोध करें।",
+  "formFieldHintText__optional": "वैकल्पिक",
+  "formFieldHintText__slug": "स्लग एक मानव-पठनीय आईडी है जो अद्वितीय होनी चाहिए। इसका उपयोग अक्सर URL में किया जाता है।",
+  "formFieldInputPlaceholder__apiKeyDescription": "बताएँ कि आप यह कुंजी क्यों बना रहे हैं",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "तिथि चुनें",
+  "formFieldInputPlaceholder__apiKeyName": "अपनी सीक्रेट कुंजी का नाम दर्ज करें",
+  "formFieldInputPlaceholder__backupCode": "बैकअप कोड दर्ज करें",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "खाता हटाएं",
+  "formFieldInputPlaceholder__emailAddress": "अपना ईमेल पता दर्ज करें",
+  "formFieldInputPlaceholder__emailAddress_username": "ईमेल या उपयोगकर्ता नाम दर्ज करें",
+  "formFieldInputPlaceholder__emailAddresses": "example@email.com, example2@email.com",
+  "formFieldInputPlaceholder__firstName": "पहला नाम",
+  "formFieldInputPlaceholder__lastName": "अंतिम नाम",
+  "formFieldInputPlaceholder__organizationDomain": "example.com",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "you@example.com",
+  "formFieldInputPlaceholder__organizationName": "संगठन का नाम",
+  "formFieldInputPlaceholder__organizationSlug": "my-org",
+  "formFieldInputPlaceholder__password": "अपना पासवर्ड दर्ज करें",
+  "formFieldInputPlaceholder__phoneNumber": "अपना फोन नंबर दर्ज करें",
+  "formFieldInputPlaceholder__username": "अपना उपयोगकर्ता नाम दर्ज करें",
+  "formFieldInput__emailAddress_format": "उदाहरण प्रारूप: name@example.com",
+  "formFieldLabel__apiKey": "API कुंजी",
+  "formFieldLabel__apiKeyDescription": "विवरण",
+  "formFieldLabel__apiKeyExpiration": "समाप्ति",
+  "formFieldLabel__apiKeyName": "गुप्त कुंजी का नाम",
+  "formFieldLabel__automaticInvitations": "इस डोमेन के लिए स्वचालित आमंत्रण सक्षम करें",
+  "formFieldLabel__backupCode": "बैकअप कोड",
+  "formFieldLabel__confirmDeletion": "पुष्टिकरण",
+  "formFieldLabel__confirmPassword": "पासवर्ड की पुष्टि करें",
+  "formFieldLabel__currentPassword": "वर्तमान पासवर्ड",
+  "formFieldLabel__emailAddress": "ईमेल पता",
+  "formFieldLabel__emailAddress_username": "ईमेल पता या उपयोगकर्ता नाम",
+  "formFieldLabel__emailAddresses": "ईमेल पते",
+  "formFieldLabel__firstName": "पहला नाम",
+  "formFieldLabel__lastName": "अंतिम नाम",
+  "formFieldLabel__newPassword": "नया पासवर्ड",
+  "formFieldLabel__organizationDomain": "डोमेन",
+  "formFieldLabel__organizationDomainDeletePending": "लंबित आमंत्रण और सुझाव हटाएं",
+  "formFieldLabel__organizationDomainEmailAddress": "सत्यापन ईमेल पता",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "इस डोमेन के तहत एक ईमेल पता दर्ज करें ताकि कोड प्राप्त करें और इस डोमेन को सत्यापित करें।",
+  "formFieldLabel__organizationName": "नाम",
+  "formFieldLabel__organizationSlug": "स्लग",
+  "formFieldLabel__passkeyName": "पासकी का नाम",
+  "formFieldLabel__password": "पासवर्ड",
+  "formFieldLabel__phoneNumber": "फोन नंबर",
+  "formFieldLabel__role": "भूमिका",
+  "formFieldLabel__signOutOfOtherSessions": "अन्य सभी उपकरणों से साइन आउट करें",
+  "formFieldLabel__username": "उपयोगकर्ता नाम",
+  "impersonationFab": {
+    "action__signOut": "साइन आउट",
+    "title": "{{identifier}} के रूप में साइन इन किया गया"
+  },
+  "lastAuthenticationStrategy": "अंतिम समय प्रयोग हुआ",
+  "maintenanceMode": "हम वर्तमान में रखरखाव कर रहे हैं, लेकिन चिंता न करें, इसमें कुछ मिनटों से अधिक समय नहीं लगना चाहिए।",
+  "membershipRole__admin": "व्यवस्थापक",
+  "membershipRole__basicMember": "सदस्य",
+  "membershipRole__guestMember": "अतिथि",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "संगठन बनाएँ",
+    "action__invitationAccept": "शामिल हों",
+    "action__suggestionsAccept": "शामिल होने का अनुरोध करें",
+    "createOrganization": "संगठन बनाएँ",
+    "invitationAcceptedLabel": "शामिल हुए",
+    "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+    "suggestionsAcceptedLabel": "अनुमोदन के लिए लंबित",
+    "title": "एक खाता चुनें",
+    "titleWithoutPersonal": "एक संगठन चुनें"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "API कुंजियाँ" },
+    "badge__automaticInvitation": "स्वचालित आमंत्रण",
+    "badge__automaticSuggestion": "स्वचालित सुझाव",
+    "badge__manualInvitation": "कोई स्वचालित नामांकन नहीं",
+    "badge__unverified": "असत्यापित",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "कोई भुगतान इतिहास नहीं",
+        "notFound": "भुगतान प्रयास नहीं मिला",
+        "tableHeader__amount": "राशि",
+        "tableHeader__date": "तिथि",
+        "tableHeader__status": "स्थिति"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "डिफ़ॉल्ट बनाएं",
+        "actionLabel__remove": "हटाएं",
+        "add": "नया भुगतान स्रोत जोड़ें",
+        "addSubtitle": "अपने खाते में एक नया भुगतान स्रोत जोड़ें।",
+        "cancelButton": "रद्द करें",
+        "formButtonPrimary__add": "भुगतान विधि जोड़ें",
+        "formButtonPrimary__pay": "{{amount}} का भुगतान करें",
+        "payWithTestCardButton": "टेस्ट कार्ड से भुगतान करें",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+          "messageLine2": "आप अब इस भुगतान स्रोत का उपयोग नहीं कर पाएंगे और इस पर निर्भर कोई भी आवर्ती सदस्यता अब काम नहीं करेगी।",
+          "successMessage": "{{paymentMethod}} को आपके खाते से हटा दिया गया है।",
+          "title": "भुगतान स्रोत हटाएं"
+        },
+        "title": "उपलब्ध विकल्प"
+      },
+      "start": {
+        "headerTitle__payments": "भुगतान",
+        "headerTitle__plans": "योजनाएँ",
+        "headerTitle__statements": "चालान",
+        "headerTitle__subscriptions": "सदस्यता"
+      },
+      "statementsSection": {
+        "empty": "प्रदर्शित करने के लिए कोई स्टेटमेंट नहीं",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} योजना के लिए भुगतान किया गया",
+        "itemCaption__proratedCredit": "पिछली सदस्यता के आंशिक उपयोग के लिए आनुपातिक क्रेडिट",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} योजना के लिए सदस्यता ली और भुगतान किया गया",
+        "notFound": "स्टेटमेंट नहीं मिला",
+        "tableHeader__amount": "राशि",
+        "tableHeader__date": "तिथि",
+        "title": "स्टेटमेंट",
+        "totalPaid": "कुल भुगतान"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "प्रबंधित करें",
+        "actionLabel__newSubscription": "किसी योजना की सदस्यता लें",
+        "actionLabel__switchPlan": "योजनाएँ बदलें",
+        "tableHeader__edit": "संपादित करें",
+        "tableHeader__plan": "योजना",
+        "tableHeader__startDate": "आरंभ तिथि",
+        "title": "सदस्यता"
+      },
+      "subscriptionsSection": { "actionLabel__default": "प्रबंधित करें" },
+      "switchPlansSection": { "title": "योजनाएँ बदलें" },
+      "title": "बिलिंग और भुगतान"
+    },
+    "createDomainPage": {
+      "subtitle": "सत्यापित करने के लिए डोमेन जोड़ें। इस डोमेन पर ईमेल पते वाले उपयोगकर्ता स्वचालित रूप से संगठन में शामिल हो सकते हैं या शामिल होने का अनुरोध कर सकते हैं।",
+      "title": "डोमेन जोड़ें"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "आमंत्रण नहीं भेजा जा सका। निम्नलिखित ईमेल पतों के लिए पहले से ही लंबित आमंत्रण हैं: {{email_addresses}}।",
+      "formButtonPrimary__continue": "आमंत्रण भेजें",
+      "selectDropdown__role": "भूमिका चुनें",
+      "subtitle": "एक या अधिक ईमेल पते दर्ज करें या पेस्ट करें, स्पेस या कॉमा से अलग किए गए।",
+      "successMessage": "आमंत्रण सफलतापूर्वक भेजे गए",
+      "title": "नए सदस्यों को आमंत्रित करें"
+    },
+    "membersPage": {
+      "action__invite": "आमंत्रित करें",
+      "action__search": "खोजें",
+      "activeMembersTab": {
+        "menuAction__remove": "सदस्य हटाएं",
+        "tableHeader__actions": "कार्रवाइयां",
+        "tableHeader__joined": "शामिल हुए",
+        "tableHeader__role": "भूमिका",
+        "tableHeader__user": "उपयोगकर्ता"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "हम उपलब्ध भूमिकाओं को अपडेट कर रहे हैं। एक बार यह हो जाने के बाद, आप फिर से भूमिकाएं अपडेट कर सकेंगे।",
+          "title": "भूमिकाएं अस्थायी रूप से लॉक हैं"
+        }
+      },
+      "detailsTitle__emptyRow": "प्रदर्शित करने के लिए कोई सदस्य नहीं",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "अपने संगठन के साथ एक ईमेल डोमेन को जोड़कर उपयोगकर्ताओं को आमंत्रित करें। जो भी मेल डोमेन से साइन अप करता है, वह कभी भी संगठन में शामिल हो सकता है।",
+          "headerTitle": "स्वचालित आमंत्रण",
+          "primaryButton": "सत्यापित डोमेन प्रबंधित करें"
+        },
+        "table__emptyRow": "प्रदर्शित करने के लिए कोई आमंत्रण नहीं"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "आमंत्रण रद्द करें",
+        "tableHeader__invited": "आमंत्रित"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "जो उपयोगकर्ता मिलते ईमेल डोमेन से साइन अप करते हैं, वे आपके संगठन में शामिल होने का अनुरोध करने का सुझाव देख पाएंगे।",
+          "headerTitle": "स्वचालित सुझाव",
+          "primaryButton": "सत्यापित डोमेन प्रबंधित करें"
+        },
+        "menuAction__approve": "स्वीकृत करें",
+        "menuAction__reject": "अस्वीकार करें",
+        "tableHeader__requested": "पहुंच का अनुरोध किया",
+        "table__emptyRow": "प्रदर्शित करने के लिए कोई अनुरोध नहीं"
+      },
+      "start": {
+        "headerTitle__invitations": "आमंत्रण",
+        "headerTitle__members": "सदस्य",
+        "headerTitle__requests": "अनुरोध"
+      }
+    },
+    "navbar": {
+      "apiKeys": "API कुंजियाँ",
+      "billing": "बिलिंग",
+      "description": "अपने संगठन का प्रबंधन करें।",
+      "general": "सामान्य",
+      "members": "सदस्य",
+      "title": "संगठन"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "आपके पास इस संगठन के लिए बिलिंग प्रबंधित करने की अनुमति नहीं है।"
+      },
+      "title": "योजनाएँ"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "जारी रखने के लिए नीचे \"{{organizationName}}\" टाइप करें।",
+          "messageLine1": "क्या आप वाकई इस संगठन को हटाना चाहते हैं?",
+          "messageLine2": "यह कार्रवाई स्थायी और अपरिवर्तनीय है।",
+          "successMessage": "आपने संगठन को हटा दिया है।",
+          "title": "संगठन हटाएं"
+        },
+        "leaveOrganization": {
+          "actionDescription": "जारी रखने के लिए नीचे \"{{organizationName}}\" टाइप करें।",
+          "messageLine1": "क्या आप वाकई इस संगठन को छोड़ना चाहते हैं? आप इस संगठन और इसके अनुप्रयोगों तक पहुंच खो देंगे।",
+          "messageLine2": "यह कार्रवाई स्थायी और अपरिवर्तनीय है।",
+          "successMessage": "आपने संगठन छोड़ दिया है।",
+          "title": "संगठन छोड़ें"
+        },
+        "title": "खतरा"
+      },
+      "domainSection": {
+        "menuAction__manage": "प्रबंधित करें",
+        "menuAction__remove": "हटाएं",
+        "menuAction__verify": "सत्यापित करें",
+        "primaryButton": "डोमेन जोड़ें",
+        "subtitle": "उपयोगकर्ताओं को स्वचालित रूप से संगठन में शामिल होने या सत्यापित ईमेल डोमेन के आधार पर शामिल होने का अनुरोध करने की अनुमति दें।",
+        "title": "सत्यापित डोमेन"
+      },
+      "successMessage": "संगठन अपडेट कर दिया गया है।",
+      "title": "प्रोफ़ाइल अपडेट करें"
+    },
+    "removeDomainPage": {
+      "messageLine1": "ईमेल डोमेन {{domain}} हटा दिया जाएगा।",
+      "messageLine2": "उपयोगकर्ता इसके बाद स्वचालित रूप से संगठन में शामिल नहीं हो पाएंगे।",
+      "successMessage": "{{domain}} हटा दिया गया है।",
+      "title": "डोमेन हटाएं"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "सामान्य",
+      "headerTitle__members": "सदस्य",
+      "profileSection": {
+        "primaryButton": "प्रोफ़ाइल अपडेट करें",
+        "title": "संगठन प्रोफ़ाइल",
+        "uploadAction__title": "लोगो"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "इस डोमेन को हटाने से आमंत्रित उपयोगकर्ता प्रभावित होंगे।",
+        "removeDomainActionLabel__remove": "डोमेन हटाएं",
+        "removeDomainSubtitle": "इस डोमेन को अपने सत्यापित डोमेन से हटाएं",
+        "removeDomainTitle": "डोमेन हटाएं"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "उपयोगकर्ताओं को साइन-अप करने पर स्वचालित रूप से संगठन में शामिल होने के लिए आमंत्रित किया जाता है और वे कभी भी शामिल हो सकते हैं।",
+        "automaticInvitationOption__label": "स्वचालित आमंत्रण",
+        "automaticSuggestionOption__description": "उपयोगकर्ताओं को शामिल होने का अनुरोध करने का सुझाव मिलता है, लेकिन संगठन में शामिल होने से पहले व्यवस्थापक द्वारा अनुमोदित किया जाना चाहिए।",
+        "automaticSuggestionOption__label": "स्वचालित सुझाव",
+        "calloutInfoLabel": "नामांकन मोड बदलने से केवल नए उपयोगकर्ता प्रभावित होंगे।",
+        "calloutInvitationCountLabel": "उपयोगकर्ताओं को भेजे गए लंबित आमंत्रण: {{count}}",
+        "calloutSuggestionCountLabel": "उपयोगकर्ताओं को भेजे गए लंबित सुझाव: {{count}}",
+        "manualInvitationOption__description": "उपयोगकर्ताओं को संगठन में केवल मैन्युअल रूप से आमंत्रित किया जा सकता है।",
+        "manualInvitationOption__label": "कोई स्वचालित नामांकन नहीं",
+        "subtitle": "चुनें कि इस डोमेन के उपयोगकर्ता कैसे संगठन में शामिल हो सकते हैं।"
+      },
+      "start": {
+        "headerTitle__danger": "खतरा",
+        "headerTitle__enrollment": "नामांकन विकल्प"
+      },
+      "subtitle": "डोमेन {{domain}} अब सत्यापित है। नामांकन मोड चुनकर जारी रखें।",
+      "title": "{{domain}} अपडेट करें"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "अपने ईमेल पते पर भेजा गया सत्यापन कोड दर्ज करें",
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "डोमेन {{domainName}} को ईमेल के माध्यम से सत्यापित करने की आवश्यकता है।",
+      "subtitleVerificationCodeScreen": "{{emailAddress}} पर एक सत्यापन कोड भेजा गया था। जारी रखने के लिए कोड दर्ज करें।",
+      "title": "डोमेन सत्यापित करें"
+    }
+  },
+  "organizationSwitcher": {
+    "action__closeOrganizationSwitcher": "संगठन स्विचर बंद करें",
+    "action__createOrganization": "संगठन बनाएँ",
+    "action__invitationAccept": "शामिल हों",
+    "action__manageOrganization": "प्रबंधित करें",
+    "action__openOrganizationSwitcher": "संगठन स्विचर खोलें",
+    "action__suggestionsAccept": "शामिल होने का अनुरोध करें",
+    "notSelected": "कोई संगठन चयनित नहीं",
+    "personalWorkspace": "व्यक्तिगत खाता",
+    "suggestionsAcceptedLabel": "अनुमोदन के लिए लंबित"
+  },
+  "paginationButton__next": "अगला",
+  "paginationButton__previous": "पिछला",
+  "paginationRowText__displaying": "प्रदर्शित",
+  "paginationRowText__of": "का",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "सहायता प्राप्त करें",
+      "actionText": "इनमें से कोई भी नहीं है?",
+      "blockButton__backupCode": "बैकअप कोड का उपयोग करें",
+      "blockButton__emailCode": "{{identifier}} पर ईमेल कोड",
+      "blockButton__passkey": "अपनी पासकी का उपयोग करें",
+      "blockButton__password": "अपने पासवर्ड के साथ जारी रखें",
+      "blockButton__phoneCode": "{{identifier}} पर SMS कोड भेजें",
+      "blockButton__totp": "अपने प्रमाणकर्ता ऐप का उपयोग करें",
+      "getHelp": {
+        "blockButton__emailSupport": "ईमेल सहायता",
+        "content": "यदि आपको अपने खाते का सत्यापन करने में समस्या हो रही है, तो हमें ईमेल करें और हम जितनी जल्दी हो सके पहुंच बहाल करने के लिए आपके साथ काम करेंगे।",
+        "title": "सहायता प्राप्त करें"
+      },
+      "subtitle": "समस्याओं का सामना कर रहे हैं? सत्यापन के लिए आप इनमें से किसी भी विधि का उपयोग कर सकते हैं।",
+      "title": "दूसरी विधि का उपयोग करें"
+    },
+    "backupCodeMfa": {
+      "subtitle": "दो-चरण प्रमाणीकरण सेट करते समय प्राप्त बैकअप कोड दर्ज करें",
+      "title": "बैकअप कोड दर्ज करें"
+    },
+    "emailCode": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "जारी रखने के लिए अपने ईमेल पर भेजे गए कोड को दर्ज करें",
+      "title": "सत्यापन आवश्यक है"
+    },
+    "noAvailableMethods": {
+      "message": "सत्यापन जारी नहीं रख सकते। कोई उपयुक्त प्रमाणीकरण कारक कॉन्फ़िगर नहीं है",
+      "subtitle": "एक त्रुटि हुई",
+      "title": "आपके खाते का सत्यापन नहीं किया जा सकता"
+    },
+    "passkey": {
+      "blockButton__passkey": "अपनी पासकी का उपयोग करें",
+      "subtitle": "अपनी पासकी का उपयोग करके आपकी पहचान की पुष्टि होती है। आपका डिवाइस आपके फिंगरप्रिंट, चेहरे या स्क्रीन लॉक के लिए पूछ सकता है।",
+      "title": "अपनी पासकी का उपयोग करें"
+    },
+    "password": {
+      "actionLink": "दूसरी विधि का उपयोग करें",
+      "subtitle": "जारी रखने के लिए अपना वर्तमान पासवर्ड दर्ज करें",
+      "title": "सत्यापन आवश्यक है"
+    },
+    "phoneCode": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "जारी रखने के लिए अपने फोन पर भेजे गए कोड को दर्ज करें",
+      "title": "सत्यापन आवश्यक है"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "जारी रखने के लिए अपने फोन पर भेजे गए कोड को दर्ज करें",
+      "title": "सत्यापन आवश्यक है"
+    },
+    "totpMfa": {
+      "formTitle": "सत्यापन कोड",
+      "subtitle": "जारी रखने के लिए अपने प्रमाणकर्ता ऐप द्वारा जनरेट किए गए कोड को दर्ज करें",
+      "title": "सत्यापन आवश्यक है"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "खाता जोड़ें",
+      "action__signOutAll": "सभी खातों से साइन आउट करें",
+      "subtitle": "वह खाता चुनें जिसके साथ आप जारी रखना चाहते हैं।",
+      "title": "एक खाता चुनें"
+    },
+    "alternativeMethods": {
+      "actionLink": "सहायता प्राप्त करें",
+      "actionText": "इनमें से कोई भी नहीं है?",
+      "blockButton__backupCode": "बैकअप कोड का उपयोग करें",
+      "blockButton__emailCode": "{{identifier}} पर ईमेल कोड",
+      "blockButton__emailLink": "{{identifier}} पर ईमेल लिंक",
+      "blockButton__passkey": "अपनी पासकी से साइन इन करें",
+      "blockButton__password": "अपने पासवर्ड से साइन इन करें",
+      "blockButton__phoneCode": "{{identifier}} पर SMS कोड भेजें",
+      "blockButton__totp": "अपने प्रमाणकर्ता ऐप का उपयोग करें",
+      "getHelp": {
+        "blockButton__emailSupport": "ईमेल सहायता",
+        "content": "यदि आपको अपने खाते में साइन इन करने में समस्या हो रही है, तो हमें ईमेल करें और हम जितनी जल्दी हो सके पहुंच बहाल करने के लिए आपके साथ काम करेंगे।",
+        "title": "सहायता प्राप्त करें"
+      },
+      "subtitle": "समस्याओं का सामना कर रहे हैं? साइन इन करने के लिए आप इनमें से किसी भी विधि का उपयोग कर सकते हैं।",
+      "title": "दूसरी विधि का उपयोग करें"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड प्राप्त नहीं हुआ? पुनः भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना {{provider}} जाँचें"
+    },
+    "backupCodeMfa": {
+      "subtitle": "आपका बैकअप कोड वही है जो आपको दो-चरण प्रमाणीकरण सेट करते समय मिला था।",
+      "title": "बैकअप कोड दर्ज करें"
+    },
+    "emailCode": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना ईमेल जांचें"
+    },
+    "emailCodeMfa": {
+      "formTitle": "अपना ईमेल जांचें",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना ईमेल जांचें"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "जारी रखने के लिए, सत्यापन लिंक को उस डिवाइस और ब्राउज़र पर खोलें जिससे आपने साइन-अप शुरू किया था",
+        "title": "यह सत्यापन लिंक इस डिवाइस के लिए अमान्य है"
+      },
+      "expired": {
+        "subtitle": "जारी रखने के लिए मूल टैब पर वापस जाएं।",
+        "title": "यह सत्यापन लिंक समाप्त हो गया है"
+      },
+      "failed": {
+        "subtitle": "जारी रखने के लिए मूल टैब पर वापस जाएं।",
+        "title": "यह सत्यापन लिंक अमान्य है"
+      },
+      "formSubtitle": "अपने ईमेल पते पर भेजे गए सत्यापन लिंक का उपयोग करें",
+      "formTitle": "सत्यापन लिंक",
+      "loading": {
+        "subtitle": "आप जल्द ही पुनर्निर्देशित किए जाएंगे",
+        "title": "साइन इन हो रहा है..."
+      },
+      "resendButton": "लिंक नहीं मिला? फिर से भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना ईमेल जांचें",
+      "unusedTab": { "title": "आप इस टैब को बंद कर सकते हैं" },
+      "verified": {
+        "subtitle": "आप जल्द ही पुनर्निर्देशित किए जाएंगे",
+        "title": "सफलतापूर्वक साइन इन हो गया"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "जारी रखने के लिए मूल टैब पर वापस जाएं",
+        "subtitleNewTab": "जारी रखने के लिए नए खोले गए टैब पर वापस जाएं",
+        "titleNewTab": "दूसरे टैब पर साइन इन हो गया"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "अपने ईमेल पर भेजे गए सत्यापन लिंक का उपयोग करें",
+      "resendButton": "लिंक नहीं मिला? पुनः भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना ईमेल जांचें"
+    },
+    "enterpriseConnections": {
+      "subtitle": "वह एंटरप्राइज़ खाता चुनें जिसके साथ आप जारी रखना चाहते हैं।",
+      "title": "अपना एंटरप्राइज़ खाता चुनें"
+    },
+    "forgotPassword": {
+      "formTitle": "पासवर्ड रीसेट कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "अपना पासवर्ड रीसेट करने के लिए",
+      "subtitle_email": "पहले, अपने ईमेल पते पर भेजा गया कोड दर्ज करें",
+      "subtitle_phone": "पहले, अपने फोन पर भेजा गया कोड दर्ज करें",
+      "title": "पासवर्ड रीसेट करें"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "अपना पासवर्ड रीसेट करें",
+      "label__alternativeMethods": "या, दूसरी विधि से साइन इन करें",
+      "title": "पासवर्ड भूल गए?"
+    },
+    "newDeviceVerificationNotice": "आप एक नए डिवाइस से साइन इन कर रहे हैं। हम आपके खाते को सुरक्षित रखने के लिए सत्यापन मांग रहे हैं।",
+    "noAvailableMethods": {
+      "message": "साइन इन जारी नहीं रख सकते। कोई उपलब्ध प्रमाणीकरण कारक नहीं है।",
+      "subtitle": "एक त्रुटि हुई",
+      "title": "साइन इन नहीं कर सकते"
+    },
+    "passkey": {
+      "subtitle": "अपनी पासकी का उपयोग करके पुष्टि होती है कि यह आप ही हैं। आपका डिवाइस आपके फिंगरप्रिंट, चेहरे या स्क्रीन लॉक के लिए पूछ सकता है।",
+      "title": "अपनी पासकी का उपयोग करें"
+    },
+    "password": {
+      "actionLink": "दूसरी विधि का उपयोग करें",
+      "subtitle": "अपने खाते से जुड़ा पासवर्ड दर्ज करें",
+      "title": "अपना पासवर्ड दर्ज करें"
+    },
+    "passwordCompromised": { "title": "पासवर्ड से समझौता हुआ" },
+    "passwordPwned": { "title": "पासवर्ड समझौता हो गया" },
+    "passwordUntrusted": { "title": "पासवर्ड अविश्वसनीय" },
+    "phoneCode": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना फोन जांचें"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "जारी रखने के लिए, कृपया अपने फोन पर भेजे गए सत्यापन कोड को दर्ज करें",
+      "title": "अपना फोन जांचें"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "पासवर्ड रीसेट करें",
+      "requiredMessage": "सुरक्षा कारणों से, आपका पासवर्ड रीसेट करना आवश्यक है।",
+      "successMessage": "आपका पासवर्ड सफलतापूर्वक बदल दिया गया है। आपको साइन इन किया जा रहा है, कृपया एक क्षण प्रतीक्षा करें।",
+      "title": "नया पासवर्ड सेट करें"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "आपका पासवर्ड रीसेट करने से पहले हमें आपकी पहचान सत्यापित करनी होगी।"
+    },
+    "start": {
+      "actionLink": "साइन अप करें",
+      "actionLink__join_waitlist": "प्रतीक्षा सूची में शामिल हों",
+      "actionLink__use_email": "ईमेल का उपयोग करें",
+      "actionLink__use_email_username": "ईमेल या उपयोगकर्ता नाम का उपयोग करें",
+      "actionLink__use_passkey": "इसके बजाय पासकी का उपयोग करें",
+      "actionLink__use_phone": "फोन का उपयोग करें",
+      "actionLink__use_username": "उपयोगकर्ता नाम का उपयोग करें",
+      "actionText": "खाता नहीं है?",
+      "actionText__join_waitlist": "जल्दी पहुंच चाहते हैं?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "दूसरी विधि का उपयोग करें",
+        "label": "{{provider}} फ़ोन नंबर",
+        "subtitle": "{{provider}} पर सत्यापन कोड प्राप्त करने के लिए अपना फ़ोन नंबर दर्ज करें।",
+        "title": "{{provider}} के साथ {{applicationName}} में साइन इन करें"
+      },
+      "subtitle": "वापस आने पर स्वागत है! जारी रखने के लिए कृपया साइन इन करें",
+      "title": "{{applicationName}} में साइन इन करें",
+      "titleCombined": "{{applicationName}} पर जारी रखें"
+    },
+    "totpMfa": {
+      "formTitle": "सत्यापन कोड",
+      "subtitle": "जारी रखने के लिए, कृपया अपने प्रमाणकर्ता ऐप द्वारा जनरेट किए गए कोड को दर्ज करें",
+      "title": "दो-चरण सत्यापन"
+    },
+    "web3Solana": {
+      "subtitle": "साइन इन करने के लिए नीचे एक वॉलेट चुनें",
+      "title": "Solana के साथ साइन इन करें"
+    }
+  },
+  "signInEnterPasswordTitle": "अपना पासवर्ड दर्ज करें",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "कोड प्राप्त नहीं हुआ? पुनः भेजें",
+      "subtitle": "अपने {{provider}} पर भेजा गया सत्यापन कोड दर्ज करें",
+      "title": "अपना {{provider}} सत्यापित करें"
+    },
+    "continue": {
+      "actionLink": "साइन इन करें",
+      "actionText": "पहले से ही खाता है?",
+      "subtitle": "जारी रखने के लिए कृपया शेष विवरण भरें।",
+      "title": "अधूरे फ़ील्ड भरें"
+    },
+    "emailCode": {
+      "formSubtitle": "अपने ईमेल पते पर भेजा गया सत्यापन कोड दर्ज करें",
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "अपने ईमेल पर भेजा गया सत्यापन कोड दर्ज करें",
+      "title": "अपना ईमेल सत्यापित करें"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "जारी रखने के लिए, सत्यापन लिंक को उस डिवाइस और ब्राउज़र पर खोलें जिससे आपने साइन-अप शुरू किया था",
+        "title": "यह सत्यापन लिंक इस डिवाइस के लिए अमान्य है"
+      },
+      "formSubtitle": "अपने ईमेल पते पर भेजे गए सत्यापन लिंक का उपयोग करें",
+      "formTitle": "सत्यापन लिंक",
+      "loading": { "title": "साइन अप हो रहा है..." },
+      "resendButton": "लिंक नहीं मिला? फिर से भेजें",
+      "subtitle": "{{applicationName}} पर जारी रखने के लिए",
+      "title": "अपना ईमेल सत्यापित करें",
+      "verified": { "title": "सफलतापूर्वक साइन अप हो गया" },
+      "verifiedSwitchTab": {
+        "subtitle": "जारी रखने के लिए नए खोले गए टैब पर वापस जाएं",
+        "subtitleNewTab": "जारी रखने के लिए पिछले टैब पर वापस जाएं",
+        "title": "सफलतापूर्वक ईमेल सत्यापित किया गया"
+      }
+    },
+    "enterpriseConnections": {
+      "subtitle": "वह एंटरप्राइज़ खाता चुनें जिसके साथ आप जारी रखना चाहते हैं।",
+      "title": "अपना एंटरप्राइज़ खाता चुनें"
+    },
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "मैं {{ privacyPolicyLink || link(\"गोपनीयता नीति\") }} से सहमत हूं",
+        "label__onlyTermsOfService": "मैं {{ termsOfServiceLink || link(\"सेवा की शर्तें\") }} से सहमत हूं",
+        "label__termsOfServiceAndPrivacyPolicy": "मैं {{ termsOfServiceLink || link(\"सेवा की शर्तें\") }} और {{ privacyPolicyLink || link(\"गोपनीयता नीति\") }} से सहमत हूं"
+      },
+      "continue": {
+        "subtitle": "जारी रखने के लिए कृपया शर्तों को पढ़ें और स्वीकार करें",
+        "title": "कानूनी सहमति"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "अपने फोन नंबर पर भेजा गया सत्यापन कोड दर्ज करें",
+      "formTitle": "सत्यापन कोड",
+      "resendButton": "कोड नहीं मिला? फिर से भेजें",
+      "subtitle": "अपने फोन पर भेजा गया सत्यापन कोड दर्ज करें",
+      "title": "अपना फोन सत्यापित करें"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "साइन इन करें",
+      "actionText": "पहले से ही खाता है?",
+      "blockButton__emailSupport": "ईमेल सहायता",
+      "blockButton__joinWaitlist": "प्रतीक्षा सूची में शामिल हों",
+      "subtitle": "साइन अप वर्तमान में अक्षम हैं। यदि आपका मानना है कि आपके पास पहुंच होनी चाहिए, तो कृपया सहायता से संपर्क करें।",
+      "subtitleWaitlist": "साइन अप वर्तमान में अक्षम हैं। जब हम लॉन्च करें तो सबसे पहले जानने के लिए, प्रतीक्षा सूची में शामिल हों।",
+      "title": "पहुंच सीमित है"
+    },
+    "start": {
+      "actionLink": "साइन इन करें",
+      "actionLink__use_email": "इसके बजाय ईमेल का उपयोग करें",
+      "actionLink__use_phone": "इसके बजाय फोन का उपयोग करें",
+      "actionText": "पहले से ही खाता है?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "दूसरी विधि का उपयोग करें",
+        "label": "{{provider}} फ़ोन नंबर",
+        "subtitle": "{{provider}} पर सत्यापन कोड प्राप्त करने के लिए अपना फ़ोन नंबर दर्ज करें।",
+        "title": "{{provider}} के साथ {{applicationName}} में साइन अप करें"
+      },
+      "subtitle": "स्वागत है! आरंभ करने के लिए कृपया विवरण भरें।",
+      "subtitleCombined": "स्वागत है! आरंभ करने के लिए कृपया विवरण भरें।",
+      "title": "अपना खाता बनाएं",
+      "titleCombined": "अपना खाता बनाएं"
+    },
+    "web3Solana": {
+      "subtitle": "साइन अप करने के लिए नीचे एक वॉलेट चुनें",
+      "title": "Solana के साथ साइन अप करें"
+    }
+  },
+  "socialButtonsBlockButton": "{{provider|titleize}} के साथ जारी रखें",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "पता लगाई गई कंपनी के नाम ({{organizationName}}) और {{organizationDomain}} के लिए एक संगठन पहले से मौजूद है। आमंत्रण द्वारा शामिल हों।"
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "नया संगठन बनाएं",
+      "action__invitationAccept": "शामिल हों",
+      "action__suggestionsAccept": "शामिल होने का अनुरोध करें",
+      "subtitle": "मौजूदा संगठन में शामिल हों या नया बनाएं",
+      "subtitle__createOrganizationDisabled": "मौजूदा संगठन में शामिल हों",
+      "suggestionsAcceptedLabel": "अनुमोदन की प्रतीक्षा",
+      "title": "एक संगठन चुनें"
+    },
+    "createOrganization": {
+      "formButtonReset": "रद्द करें",
+      "formButtonSubmit": "जारी रखें",
+      "formFieldInputPlaceholder__name": "मेरा संगठन",
+      "formFieldInputPlaceholder__slug": "mera-sangathan",
+      "formFieldLabel__name": "नाम",
+      "formFieldLabel__slug": "Slug",
+      "subtitle": "जारी रखने के लिए अपने संगठन का विवरण दर्ज करें",
+      "title": "अपने संगठन को सेटअप करें"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "आमंत्रण के लिए अपने संगठन के व्यवस्थापक से संपर्क करें।",
+      "title": "आपको किसी संगठन से संबंधित होना चाहिए"
+    },
+    "signOut": {
+      "actionLink": "साइन आउट",
+      "actionText": "{{identifier}} के रूप में साइन इन किया गया"
+    }
+  },
+  "taskResetPassword": {
+    "formButtonPrimary": "पासवर्ड रीसेट करें",
+    "signOut": {
+      "actionLink": "साइन आउट",
+      "actionText": "{{identifier}} के रूप में साइन इन किया गया"
+    },
+    "subtitle": "जारी रखने से पहले आपके खाते को एक नए पासवर्ड की आवश्यकता है",
+    "title": "अपना पासवर्ड रीसेट करें"
+  },
+  "taskSetupMfa": {
+    "badge": "दो-चरणीय सत्यापन सेटअप",
+    "signOut": {
+      "actionLink": "साइन आउट",
+      "actionText": "{{identifier}} के रूप में साइन इन किया गया"
+    },
+    "smsCode": {
+      "addPhone": {
+        "formButtonPrimary": "जारी रखें",
+        "infoText": "सत्यापन कोड युक्त एक टेक्स्ट संदेश इस फ़ोन नंबर पर भेजा जाएगा। संदेश और डेटा दरें लागू हो सकती हैं।"
+      },
+      "addPhoneNumber": "फ़ोन नंबर जोड़ें",
+      "cancel": "रद्द करें",
+      "subtitle": "वह फ़ोन नंबर चुनें जिसका उपयोग आप SMS कोड दो-चरणीय सत्यापन के लिए करना चाहते हैं",
+      "success": {
+        "finishButton": "जारी रखें",
+        "message1": "दो-चरणीय सत्यापन अब सक्षम है। साइन इन करते समय, एक अतिरिक्त चरण के रूप में आपको इस फ़ोन नंबर पर भेजा गया सत्यापन कोड दर्ज करना होगा।",
+        "message2": "इन बैकअप कोड को सहेजें और उन्हें कहीं सुरक्षित स्थान पर रखें। यदि आप अपने प्रमाणीकरण डिवाइस तक पहुँच खो देते हैं, तो आप साइन इन करने के लिए बैकअप कोड का उपयोग कर सकते हैं।",
+        "title": "SMS कोड सत्यापन सक्षम"
+      },
+      "title": "SMS कोड सत्यापन जोड़ें",
+      "verifyPhone": {
+        "formButtonPrimary": "जारी रखें",
+        "formTitle": "सत्यापन कोड",
+        "resendButton": "कोड प्राप्त नहीं हुआ? पुनः भेजें",
+        "subtitle": "इस पर भेजा गया सत्यापन कोड दर्ज करें",
+        "title": "अपना फ़ोन नंबर सत्यापित करें"
+      }
+    },
+    "start": {
+      "methodSelection": {
+        "phoneCode": "SMS कोड",
+        "totp": "प्रमाणक एप्लिकेशन"
+      },
+      "subtitle": "चुनें कि आप अतिरिक्त सुरक्षा स्तर के साथ अपने खाते की सुरक्षा के लिए कौन सी विधि पसंद करते हैं",
+      "title": "दो-चरणीय सत्यापन सेट करें"
+    },
+    "totpCode": {
+      "addAuthenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "इसके बजाय QR कोड स्कैन करें",
+        "buttonUnableToScan__nonPrimary": "QR कोड स्कैन नहीं कर सकते?",
+        "formButtonPrimary": "जारी रखें",
+        "formButtonReset": "रद्द करें",
+        "infoText__ableToScan": "अपने प्रमाणक ऐप में एक नई साइन-इन विधि सेट करें और इसे अपने खाते से लिंक करने के लिए निम्नलिखित QR कोड स्कैन करें।",
+        "infoText__unableToScan": "अपने प्रमाणक में एक नई साइन-इन विधि सेट करें और नीचे दी गई कुंजी दर्ज करें।",
+        "inputLabel__unableToScan1": "सुनिश्चित करें कि समय-आधारित या एक-बार के पासवर्ड सक्षम हैं, फिर अपने खाते को लिंक करना पूरा करें।"
+      },
+      "success": {
+        "finishButton": "जारी रखें",
+        "message1": "दो-चरणीय सत्यापन अब सक्षम है। साइन इन करते समय, एक अतिरिक्त चरण के रूप में आपको इस प्रमाणक से एक सत्यापन कोड दर्ज करना होगा।",
+        "message2": "इन बैकअप कोड को सहेजें और उन्हें कहीं सुरक्षित स्थान पर रखें। यदि आप अपने प्रमाणीकरण डिवाइस तक पहुँच खो देते हैं, तो आप साइन इन करने के लिए बैकअप कोड का उपयोग कर सकते हैं।",
+        "title": "प्रमाणक एप्लिकेशन सत्यापन सक्षम"
+      },
+      "title": "प्रमाणक एप्लिकेशन जोड़ें",
+      "verifyTotp": {
+        "formButtonPrimary": "जारी रखें",
+        "formButtonReset": "रद्द करें",
+        "formTitle": "सत्यापन कोड",
+        "subtitle": "अपने प्रमाणक द्वारा उत्पन्न सत्यापन कोड दर्ज करें",
+        "title": "प्रमाणक एप्लिकेशन जोड़ें"
+      }
+    }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}} पहले से ही संगठन का सदस्य है।",
+    "avatar_file_size_exceeded": "फ़ाइल का आकार 10MB की अधिकतम सीमा से अधिक है। कृपया एक छोटी फ़ाइल चुनें।",
+    "avatar_file_type_invalid": "फ़ाइल प्रकार समर्थित नहीं है। कृपया JPG, PNG, GIF या WEBP छवि अपलोड करें।",
+    "captcha_invalid": "असफल सुरक्षा सत्यापन के कारण साइन अप असफल रहा। पुनः प्रयास करने के लिए कृपया पृष्ठ को रिफ्रेश करें या अधिक सहायता के लिए सपोर्ट से संपर्क करें।",
+    "captcha_unavailable": "असफल बॉट सत्यापन के कारण साइन अप असफल रहा। पुनः प्रयास करने के लिए कृपया पृष्ठ को रिफ्रेश करें या अधिक सहायता के लिए सपोर्ट से संपर्क करें।",
+    "form_email_address_blocked": "अस्थायी ईमेल सेवाएं समर्थित नहीं हैं। कृपया खाता बनाने के लिए अपना नियमित ईमेल पता उपयोग करें।",
+    "form_identifier_exists__email_address": "यह ईमेल पता पहले से लिया गया है। कृपया दूसरा प्रयास करें।",
+    "form_identifier_exists__phone_number": "यह फोन नंबर पहले से लिया गया है। कृपया दूसरा प्रयास करें।",
+    "form_identifier_exists__username": "यह उपयोगकर्ता नाम पहले से लिया गया है। कृपया दूसरा प्रयास करें।",
+    "form_identifier_not_found": "इस पहचानकर्ता के साथ कोई खाता नहीं मिला। कृपया जांचें और पुनः प्रयास करें।",
+    "form_new_password_matches_current": "नया पासवर्ड वर्तमान पासवर्ड के समान नहीं हो सकता।",
+    "form_param_format_invalid": "दर्ज किया गया मान अमान्य प्रारूप में है। कृपया इसे जांचें और सही करें।",
+    "form_param_format_invalid__email_address": "ईमेल पता एक वैध ईमेल पता होना चाहिए।",
+    "form_param_format_invalid__phone_number": "फोन नंबर एक वैध अंतरराष्ट्रीय प्रारूप में होना चाहिए।",
+    "form_param_max_length_exceeded__first_name": "पहला नाम 256 अक्षरों से अधिक नहीं होना चाहिए।",
+    "form_param_max_length_exceeded__last_name": "अंतिम नाम 256 अक्षरों से अधिक नहीं होना चाहिए।",
+    "form_param_max_length_exceeded__name": "नाम 256 अक्षरों से अधिक नहीं होना चाहिए।",
+    "form_param_nil": "यह फ़ील्ड आवश्यक है और खाली नहीं हो सकता।",
+    "form_param_value_invalid": "दर्ज किया गया मान अमान्य है। कृपया इसे सही करें।",
+    "form_password_incorrect": "आपके द्वारा दर्ज किया गया पासवर्ड गलत है। कृपया पुनः प्रयास करें।",
+    "form_password_length_too_short": "आपका पासवर्ड बहुत छोटा है। इसमें कम से कम 8 अक्षर होने चाहिए।",
+    "form_password_not_strong_enough": "आपका पासवर्ड पर्याप्त मजबूत नहीं है।",
+    "form_password_or_identifier_incorrect": "पासवर्ड या ईमेल पता गलत है। कृपया पुनः प्रयास करें या किसी अन्य विधि का उपयोग करें।",
+    "form_password_pwned": "यह पासवर्ड डेटा उल्लंघन के हिस्से के रूप में पाया गया है और इसका उपयोग नहीं किया जा सकता, कृपया इसके बजाय दूसरा पासवर्ड आज़माएं।",
+    "form_password_pwned__sign_in": "यह पासवर्ड डेटा उल्लंघन के हिस्से के रूप में पाया गया है और इसका उपयोग नहीं किया जा सकता, कृपया अपना पासवर्ड रीसेट करें।",
+    "form_password_size_in_bytes_exceeded": "आपके पासवर्ड ने अनुमत बाइट्स की अधिकतम संख्या से अधिक हो गया है, कृपया इसे छोटा करें या कुछ विशेष वर्णों को हटा दें।",
+    "form_password_untrusted__sign_in": "आपके पासवर्ड से समझौता हो सकता है। अपने खाते की सुरक्षा के लिए, कृपया किसी वैकल्पिक साइन-इन विधि के साथ जारी रखें। साइन इन करने के बाद आपको अपना पासवर्ड रीसेट करना होगा।",
+    "form_password_validation_failed": "गलत पासवर्ड",
+    "form_username_invalid_character": "आपके उपयोगकर्ता नाम में अमान्य वर्ण हैं। कृपया केवल अक्षर, संख्या और अंडरस्कोर का उपयोग करें।",
+    "form_username_invalid_length": "आपका उपयोगकर्ता नाम {{min_length}} और {{max_length}} अक्षरों के बीच होना चाहिए।",
+    "form_username_needs_non_number_char": "आपके उपयोगकर्ता नाम में कम से कम एक गैर-संख्यात्मक वर्ण होना चाहिए।",
+    "identification_deletion_failed": "आप अपनी अंतिम पहचान को हटा नहीं सकते।",
+    "not_allowed_access": "आपके पास इस पेज तक पहुंचने की अनुमति नहीं है। यदि आपका मानना है कि यह एक त्रुटि है, तो कृपया सहायता से संपर्क करें।",
+    "organization_domain_blocked": "यह एक ब्लॉक किया गया ईमेल प्रदाता डोमेन है। कृपया दूसरा उपयोग करें।",
+    "organization_domain_common": "यह एक सामान्य ईमेल प्रदाता डोमेन है। कृपया दूसरा उपयोग करें।",
+    "organization_domain_exists_for_enterprise_connection": "यह डोमेन पहले से ही आपके संगठन के SSO के लिए उपयोग किया जाता है",
+    "organization_membership_quota_exceeded": "आप अपने संगठन की सदस्यता की सीमा तक पहुंच गए हैं, जिसमें बकाया आमंत्रण भी शामिल हैं।",
+    "organization_minimum_permissions_needed": "संगठन के कम से कम एक सदस्य के पास न्यूनतम आवश्यक अनुमतियां होनी चाहिए।",
+    "organization_not_found_or_unauthorized": "आप अब इस संगठन के सदस्य नहीं हैं। कृपया कोई दूसरा चुनें या बनाएँ।",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "आप अब इस संगठन के सदस्य नहीं हैं। कृपया कोई दूसरा चुनें।",
+    "passkey_already_exists": "इस डिवाइस के साथ पहले से ही एक पासकी पंजीकृत है।",
+    "passkey_not_supported": "इस डिवाइस पर पासकी समर्थित नहीं हैं।",
+    "passkey_pa_not_supported": "पंजीकरण के लिए प्लेटफॉर्म प्रमाणकर्ता की आवश्यकता होती है लेकिन डिवाइस इसका समर्थन नहीं करता।",
+    "passkey_registration_cancelled": "पासकी पंजीकरण रद्द कर दिया गया या समय समाप्त हो गया।",
+    "passkey_retrieval_cancelled": "पासकी सत्यापन रद्द कर दिया गया या समय समाप्त हो गया।",
+    "passwordComplexity": {
+      "maximumLength": "{{length}} अक्षरों से कम",
+      "minimumLength": "{{length}} या अधिक अक्षर",
+      "requireLowercase": "एक लोअरकेस अक्षर",
+      "requireNumbers": "एक संख्या",
+      "requireSpecialCharacter": "एक विशेष वर्ण",
+      "requireUppercase": "एक अपरकेस अक्षर",
+      "sentencePrefix": "आपके पासवर्ड में होना चाहिए"
+    },
+    "phone_number_exists": "यह फोन नंबर पहले से लिया गया है। कृपया दूसरा प्रयास करें।",
+    "web3_missing_identifier": "Web3 वॉलेट एक्सटेंशन नहीं मिल सका। जारी रखने के लिए कृपया एक इंस्टॉल करें।",
+    "web3_signature_request_rejected": "आपने सिग्नेचर अनुरोध अस्वीकार कर दिया है। जारी रखने के लिए कृपया फिर से प्रयास करें।",
+    "web3_solana_signature_generation_failed": "सिग्नेचर बनाते समय एक त्रुटि हुई। जारी रखने के लिए कृपया फिर से प्रयास करें।",
+    "zxcvbn": {
+      "couldBeStronger": "आपका पासवर्ड काम करता है, लेकिन मजबूत हो सकता है। अधिक अक्षर जोड़ने का प्रयास करें।",
+      "goodPassword": "आपका पासवर्ड सभी आवश्यक आवश्यकताओं को पूरा करता है।",
+      "notEnough": "आपका पासवर्ड पर्याप्त मजबूत नहीं है।",
+      "suggestions": {
+        "allUppercase": "कुछ अक्षरों को कैपिटलाइज़ करें, लेकिन सभी को नहीं।",
+        "anotherWord": "और अधिक शब्द जोड़ें जो कम सामान्य हों।",
+        "associatedYears": "ऐसे वर्षों से बचें जो आपसे जुड़े हों।",
+        "capitalization": "पहले अक्षर से अधिक को कैपिटलाइज़ करें।",
+        "dates": "ऐसी तारीखों और वर्षों से बचें जो आपसे जुड़े हों।",
+        "l33t": "'a' के लिए '@' जैसे अनुमानित अक्षर प्रतिस्थापनों से बचें।",
+        "longerKeyboardPattern": "लंबे कीबोर्ड पैटर्न का उपयोग करें और टाइपिंग दिशा को कई बार बदलें।",
+        "noNeed": "आप प्रतीकों, संख्याओं या अपरकेस अक्षरों का उपयोग किए बिना मजबूत पासवर्ड बना सकते हैं।",
+        "pwned": "यदि आप इस पासवर्ड का उपयोग कहीं और करते हैं, तो आपको इसे बदलना चाहिए।",
+        "recentYears": "हाल के वर्षों से बचें।",
+        "repeated": "दोहराए गए शब्दों और अक्षरों से बचें।",
+        "reverseWords": "सामान्य शब्दों की उलटी वर्तनी से बचें।",
+        "sequences": "सामान्य वर्ण अनुक्रमों से बचें।",
+        "useWords": "कई शब्दों का उपयोग करें, लेकिन सामान्य वाक्यांशों से बचें।"
+      },
+      "warnings": {
+        "common": "यह एक आमतौर पर उपयोग किया जाने वाला पासवर्ड है।",
+        "commonNames": "सामान्य नाम और उपनाम अनुमान लगाना आसान होते हैं।",
+        "dates": "तारीखों का अनुमान लगाना आसान होता है।",
+        "extendedRepeat": "\"abcabcabc\" जैसे दोहराए गए वर्ण पैटर्न का अनुमान लगाना आसान होता है।",
+        "keyPattern": "छोटे कीबोर्ड पैटर्न का अनुमान लगाना आसान होता है।",
+        "namesByThemselves": "एकल नाम या उपनाम का अनुमान लगाना आसान होता है।",
+        "pwned": "आपका पासवर्ड इंटरनेट पर डेटा उल्लंघन के कारण उजागर हुआ था।",
+        "recentYears": "हाल के वर्षों का अनुमान लगाना आसान होता है।",
+        "sequences": "\"abc\" जैसे सामान्य वर्ण अनुक्रमों का अनुमान लगाना आसान होता है।",
+        "similarToCommon": "यह एक आमतौर पर उपयोग किए जाने वाले पासवर्ड के समान है।",
+        "simpleRepeat": "\"aaa\" जैसे दोहराए गए अक्षरों का अनुमान लगाना आसान होता है।",
+        "straightRow": "आपके कीबोर्ड पर कुंजियों की सीधी पंक्तियों का अनुमान लगाना आसान होता है।",
+        "topHundred": "यह एक अक्सर उपयोग किया जाने वाला पासवर्ड है।",
+        "topTen": "यह एक अत्यधिक उपयोग किया जाने वाला पासवर्ड है।",
+        "userInputs": "किसी भी व्यक्तिगत या पृष्ठ संबंधित डेटा नहीं होना चाहिए।",
+        "wordByItself": "एकल शब्दों का अनुमान लगाना आसान होता है।"
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "खाता जोड़ें",
+    "action__closeUserMenu": "उपयोगकर्ता मेनू बंद करें",
+    "action__manageAccount": "खाता प्रबंधित करें",
+    "action__openUserMenu": "उपयोगकर्ता मेनू खोलें",
+    "action__signOut": "साइन आउट",
+    "action__signOutAll": "सभी खातों से साइन आउट करें",
+    "label__accountActions": "खाता क्रियाएं",
+    "label__activeSessions": "सक्रिय सत्र",
+    "label__userButtonPopover": "खाता पैनल"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "API कुंजियाँ" },
+    "backupCodePage": {
+      "actionLabel__copied": "कॉपी किया गया!",
+      "actionLabel__copy": "सभी कॉपी करें",
+      "actionLabel__download": ".txt डाउनलोड करें",
+      "actionLabel__print": "प्रिंट करें",
+      "infoText1": "बैकअप कोड इस खाते के लिए सक्षम किए जाएंगे।",
+      "infoText2": "बैकअप कोड को गुप्त रखें और सुरक्षित रूप से संग्रहित करें। यदि आपको संदेह है कि वे समझौता कर चुके हैं, तो आप बैकअप कोड पुनः जनरेट कर सकते हैं।",
+      "subtitle__codelist": "उन्हें सुरक्षित रूप से संग्रहित करें और गुप्त रखें।",
+      "successMessage": "बैकअप कोड अब सक्षम हैं। यदि आप अपने प्रमाणीकरण डिवाइस तक पहुंच खो देते हैं, तो आप अपने खाते में साइन इन करने के लिए इनमें से एक का उपयोग कर सकते हैं। प्रत्येक कोड का उपयोग केवल एक बार किया जा सकता है।",
+      "successSubtitle": "यदि आप अपने प्रमाणीकरण डिवाइस तक पहुंच खो देते हैं, तो आप अपने खाते में साइन इन करने के लिए इनमें से एक का उपयोग कर सकते हैं।",
+      "title": "बैकअप कोड सत्यापन जोड़ें",
+      "title__codelist": "बैकअप कोड"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "कोई भुगतान इतिहास नहीं",
+        "notFound": "भुगतान प्रयास नहीं मिला",
+        "tableHeader__amount": "राशि",
+        "tableHeader__date": "तिथि",
+        "tableHeader__status": "स्थिति"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "डिफ़ॉल्ट बनाएँ",
+        "actionLabel__remove": "हटाएँ",
+        "add": "नई भुगतान विधि जोड़ें",
+        "addSubtitle": "अपने खाते में एक नई भुगतान विधि जोड़ें।",
+        "cancelButton": "रद्द करें",
+        "formButtonPrimary__add": "भुगतान विधि जोड़ें",
+        "formButtonPrimary__pay": "{{amount}} भुगतान करें",
+        "payWithTestCardButton": "टेस्ट कार्ड से भुगतान करें",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+          "messageLine2": "आप अब इस भुगतान स्रोत का उपयोग नहीं कर पाएँगे और इस पर निर्भर कोई भी आवर्ती सदस्यता अब काम नहीं करेगी।",
+          "successMessage": "{{paymentMethod}} को आपके खाते से हटा दिया गया है।",
+          "title": "भुगतान विधि हटाएँ"
+        },
+        "title": "भुगतान विधियाँ"
+      },
+      "start": {
+        "headerTitle__payments": "भुगतान",
+        "headerTitle__plans": "योजनाएँ",
+        "headerTitle__statements": "स्टेटमेंट",
+        "headerTitle__subscriptions": "सदस्यता"
+      },
+      "statementsSection": {
+        "empty": "प्रदर्शित करने के लिए कोई स्टेटमेंट नहीं",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} योजना के लिए भुगतान किया गया",
+        "itemCaption__proratedCredit": "पिछली सदस्यता के आंशिक उपयोग के लिए आनुपातिक क्रेडिट",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} योजना के लिए सदस्यता ली और भुगतान किया गया",
+        "notFound": "स्टेटमेंट नहीं मिला",
+        "tableHeader__amount": "राशि",
+        "tableHeader__date": "तिथि",
+        "title": "स्टेटमेंट",
+        "totalPaid": "कुल भुगतान"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "प्रबंधित करें",
+        "actionLabel__newSubscription": "किसी योजना की सदस्यता लें",
+        "actionLabel__switchPlan": "योजनाएँ बदलें",
+        "tableHeader__edit": "संपादित करें",
+        "tableHeader__plan": "योजना",
+        "tableHeader__startDate": "आरंभ तिथि",
+        "title": "सदस्यता"
+      },
+      "subscriptionsSection": { "actionLabel__default": "प्रबंधित करें" },
+      "switchPlansSection": { "title": "योजनाएँ बदलें" },
+      "title": "बिलिंग"
+    },
+    "connectedAccountPage": {
+      "formHint": "अपने खाते को कनेक्ट करने के लिए एक प्रदाता चुनें।",
+      "formHint__noAccounts": "कोई उपलब्ध बाहरी खाता प्रदाता नहीं हैं।",
+      "removeResource": {
+        "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+        "messageLine2": "आप अब इस कनेक्टेड खाते का उपयोग नहीं कर पाएंगे और कोई भी निर्भर सुविधाएँ अब काम नहीं करेंगी।",
+        "successMessage": "{{connectedAccount}} को आपके खाते से हटा दिया गया है।",
+        "title": "कनेक्टेड खाता हटाएं"
+      },
+      "socialButtonsBlockButton": "{{provider|titleize}}",
+      "successMessage": "प्रदाता को आपके खाते में जोड़ दिया गया है",
+      "title": "कनेक्टेड खाता जोड़ें"
+    },
+    "deletePage": {
+      "actionDescription": "जारी रखने के लिए नीचे \"Delete account\" टाइप करें।",
+      "confirm": "खाता हटाएं",
+      "messageLine1": "क्या आप वाकई अपना खाता हटाना चाहते हैं? कुछ संबंधित डेटा रखा जा सकता है। पूर्ण डेटा हटाने का अनुरोध करने के लिए, कृपया सहायता से संपर्क करें।",
+      "messageLine2": "यह कार्रवाई स्थायी और अपरिवर्तनीय है।",
+      "title": "खाता हटाएं"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "इस ईमेल पते पर एक सत्यापन कोड वाला ईमेल भेजा जाएगा।",
+        "formSubtitle": "{{identifier}} पर भेजा गया सत्यापन कोड दर्ज करें",
+        "formTitle": "सत्यापन कोड",
+        "resendButton": "कोड नहीं मिला? फिर से भेजें",
+        "successMessage": "ईमेल {{identifier}} को आपके खाते में जोड़ दिया गया है।"
+      },
+      "emailLink": {
+        "formHint": "इस ईमेल पते पर एक सत्यापन लिंक वाला ईमेल भेजा जाएगा।",
+        "formSubtitle": "{{identifier}} पर भेजे गए ईमेल में सत्यापन लिंक पर क्लिक करें",
+        "formTitle": "सत्यापन लिंक",
+        "resendButton": "लिंक नहीं मिला? फिर से भेजें",
+        "successMessage": "ईमेल {{identifier}} को आपके खाते में जोड़ दिया गया है।"
+      },
+      "enterpriseSSOLink": {
+        "formButton": "साइन-इन करने के लिए क्लिक करें",
+        "formSubtitle": "{{identifier}} के साथ साइन-इन पूरा करें"
+      },
+      "formHint": "आपको इस ईमेल पते को अपने खाते में जोड़ने से पहले इसे सत्यापित करना होगा।",
+      "removeResource": {
+        "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+        "messageLine2": "आप अब इस ईमेल पते का उपयोग करके साइन इन नहीं कर पाएंगे।",
+        "successMessage": "{{emailAddress}} को आपके खाते से हटा दिया गया है।",
+        "title": "ईमेल पता हटाएं"
+      },
+      "title": "ईमेल पता जोड़ें",
+      "verifyTitle": "ईमेल पता सत्यापित करें"
+    },
+    "formButtonPrimary__add": "जोड़ें",
+    "formButtonPrimary__continue": "जारी रखें",
+    "formButtonPrimary__finish": "समाप्त करें",
+    "formButtonPrimary__remove": "हटाएं",
+    "formButtonPrimary__save": "सहेजें",
+    "formButtonReset": "रद्द करें",
+    "mfaPage": {
+      "formHint": "जोड़ने के लिए एक विधि चुनें।",
+      "title": "दो-चरण सत्यापन जोड़ें"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "मौजूदा नंबर का उपयोग करें",
+      "primaryButton__addPhoneNumber": "फोन नंबर जोड़ें",
+      "removeResource": {
+        "messageLine1": "{{identifier}} अब साइन इन करते समय सत्यापन कोड प्राप्त नहीं करेगा।",
+        "messageLine2": "आपका खाता उतना सुरक्षित नहीं हो सकता है। क्या आप वाकई जारी रखना चाहते हैं?",
+        "successMessage": "{{mfaPhoneCode}} के लिए SMS कोड दो-चरण सत्यापन हटा दिया गया है",
+        "title": "दो-चरण सत्यापन हटाएं"
+      },
+      "subtitle__availablePhoneNumbers": "SMS कोड दो-चरण सत्यापन के लिए पंजीकरण करने के लिए एक मौजूदा फोन नंबर चुनें या एक नया जोड़ें।",
+      "subtitle__unavailablePhoneNumbers": "SMS कोड दो-चरण सत्यापन के लिए पंजीकरण करने के लिए कोई उपलब्ध फोन नंबर नहीं हैं, कृपया एक नया जोड़ें।",
+      "successMessage1": "साइन इन करते समय, आपको एक अतिरिक्त चरण के रूप में इस फोन नंबर पर भेजे गए सत्यापन कोड दर्ज करने की आवश्यकता होगी।",
+      "successMessage2": "इन बैकअप कोड को सहेजें और उन्हें कहीं सुरक्षित रखें। यदि आप अपने प्रमाणीकरण डिवाइस तक पहुँच खो देते हैं, तो आप साइन इन करने के लिए बैकअप कोड का उपयोग कर सकते हैं।",
+      "successTitle": "SMS कोड सत्यापन सक्षम किया गया",
+      "title": "SMS कोड सत्यापन जोड़ें"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "इसके बजाय QR कोड स्कैन करें",
+        "buttonUnableToScan__nonPrimary": "QR कोड स्कैन नहीं कर सकते?",
+        "infoText__ableToScan": "अपने प्रमाणकर्ता ऐप में एक नई साइन-इन विधि सेट करें और इसे अपने खाते से लिंक करने के लिए निम्न QR कोड को स्कैन करें।",
+        "infoText__unableToScan": "अपने प्रमाणकर्ता में एक नई साइन-इन विधि सेट करें और नीचे प्रदान की गई कुंजी दर्ज करें।",
+        "inputLabel__unableToScan1": "सुनिश्चित करें कि समय-आधारित या वन-टाइम पासवर्ड सक्षम है, फिर अपने खाते को लिंक करना समाप्त करें।",
+        "inputLabel__unableToScan2": "वैकल्पिक रूप से, यदि आपका प्रमाणकर्ता TOTP URI का समर्थन करता है, तो आप पूर्ण URI को भी कॉपी कर सकते हैं।"
+      },
+      "removeResource": {
+        "messageLine1": "साइन इन करते समय इस प्रमाणकर्ता से सत्यापन कोड की अब आवश्यकता नहीं होगी।",
+        "messageLine2": "आपका खाता उतना सुरक्षित नहीं हो सकता है। क्या आप वाकई जारी रखना चाहते हैं?",
+        "successMessage": "प्रमाणकर्ता ऐप के माध्यम से दो-चरण सत्यापन हटा दिया गया है।",
+        "title": "दो-चरण सत्यापन हटाएं"
+      },
+      "successMessage": "दो-चरण सत्यापन अब सक्षम है। साइन इन करते समय, आपको एक अतिरिक्त चरण के रूप में इस प्रमाणकर्ता से सत्यापन कोड दर्ज करने की आवश्यकता होगी।",
+      "title": "प्रमाणकर्ता ऐप जोड़ें",
+      "verifySubtitle": "अपने प्रमाणकर्ता द्वारा जनरेट किया गया सत्यापन कोड दर्ज करें",
+      "verifyTitle": "सत्यापन कोड"
+    },
+    "mobileButton__menu": "मेनू",
+    "navbar": {
+      "account": "प्रोफ़ाइल",
+      "apiKeys": "API कुंजियाँ",
+      "billing": "बिलिंग",
+      "description": "अपनी खाता जानकारी प्रबंधित करें।",
+      "security": "सुरक्षा",
+      "title": "खाता"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "{{name}} को इस खाते से हटा दिया जाएगा।",
+        "title": "पासकी हटाएं"
+      },
+      "subtitle__rename": "आप पासकी का नाम बदल सकते हैं ताकि इसे खोजना आसान हो।",
+      "title__rename": "पासकी का नाम बदलें"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "यह अनुशंसा की जाती है कि आप अन्य सभी डिवाइसों से साइन आउट करें जिन्होंने आपके पुराने पासवर्ड का उपयोग किया हो सकता है।",
+      "readonly": "आपका पासवर्ड वर्तमान में संपादित नहीं किया जा सकता क्योंकि आप केवल एंटरप्राइज कनेक्शन के माध्यम से साइन इन कर सकते हैं।",
+      "successMessage__set": "आपका पासवर्ड सेट किया गया है।",
+      "successMessage__signOutOfOtherSessions": "अन्य सभी डिवाइसों को साइन आउट कर दिया गया है।",
+      "successMessage__update": "आपका पासवर्ड अपडेट किया गया है।",
+      "title__set": "पासवर्ड सेट करें",
+      "title__update": "पासवर्ड अपडेट करें"
+    },
+    "phoneNumberPage": {
+      "infoText": "इस फोन नंबर पर एक सत्यापन कोड वाला टेक्स्ट मैसेज भेजा जाएगा। मैसेज और डेटा दरें लागू हो सकती हैं।",
+      "removeResource": {
+        "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+        "messageLine2": "आप अब इस फोन नंबर का उपयोग करके साइन इन नहीं कर पाएंगे।",
+        "successMessage": "{{phoneNumber}} को आपके खाते से हटा दिया गया है।",
+        "title": "फोन नंबर हटाएं"
+      },
+      "successMessage": "{{identifier}} को आपके खाते में जोड़ दिया गया है।",
+      "title": "फोन नंबर जोड़ें",
+      "verifySubtitle": "{{identifier}} पर भेजा गया सत्यापन कोड दर्ज करें",
+      "verifyTitle": "फोन नंबर सत्यापित करें"
+    },
+    "plansPage": { "title": "योजनाएँ" },
+    "profilePage": {
+      "fileDropAreaHint": "अनुशंसित आकार 1:1, 10MB तक।",
+      "imageFormDestructiveActionSubtitle": "हटाएं",
+      "imageFormSubtitle": "अपलोड",
+      "imageFormTitle": "प्रोफ़ाइल छवि",
+      "readonly": "आपकी प्रोफ़ाइल जानकारी एंटरप्राइज कनेक्शन द्वारा प्रदान की गई है और इसे संपादित नहीं किया जा सकता।",
+      "successMessage": "आपकी प्रोफ़ाइल अपडेट कर दी गई है।",
+      "title": "प्रोफ़ाइल अपडेट करें"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "डिवाइस से साइन आउट करें",
+        "title": "सक्रिय डिवाइस"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "पुनः कनेक्ट करें",
+        "actionLabel__reauthorize": "अभी अधिकृत करें",
+        "destructiveActionTitle": "हटाएं",
+        "primaryButton": "खाता कनेक्ट करें",
+        "subtitle__disconnected": "यह खाता डिस्कनेक्ट कर दिया गया है।",
+        "subtitle__reauthorize": "आवश्यक स्कोप अपडेट किए गए हैं, और आप सीमित कार्यक्षमता का अनुभव कर सकते हैं। किसी भी समस्या से बचने के लिए कृपया इस एप्लिकेशन को फिर से अधिकृत करें",
+        "title": "कनेक्टेड खाते"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "खाता हटाएं",
+        "title": "खाता हटाएं"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "ईमेल हटाएं",
+        "detailsAction__nonPrimary": "प्राथमिक के रूप में सेट करें",
+        "detailsAction__primary": "सत्यापन पूरा करें",
+        "detailsAction__unverified": "सत्यापित करें",
+        "primaryButton": "ईमेल पता जोड़ें",
+        "title": "ईमेल पते"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "खाता कनेक्ट करें",
+        "title": "एंटरप्राइज खाते"
+      },
+      "headerTitle__account": "प्रोफ़ाइल विवरण",
+      "headerTitle__security": "सुरक्षा",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "पुनः जनरेट करें",
+          "headerTitle": "बैकअप कोड",
+          "subtitle__regenerate": "सुरक्षित बैकअप कोड का एक नया सेट प्राप्त करें। पिछले बैकअप कोड हटा दिए जाएंगे और उनका उपयोग नहीं किया जा सकेगा।",
+          "title__regenerate": "बैकअप कोड पुनः जनरेट करें"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "डिफ़ॉल्ट के रूप में सेट करें",
+          "destructiveActionLabel": "हटाएं"
+        },
+        "primaryButton": "दो-चरण सत्यापन जोड़ें",
+        "title": "दो-चरण सत्यापन",
+        "totp": {
+          "destructiveActionTitle": "हटाएं",
+          "headerTitle": "प्रमाणकर्ता ऐप"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "हटाएं",
+        "menuAction__rename": "नाम बदलें",
+        "primaryButton": "पासकी जोड़ें",
+        "title": "पासकी"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "पासवर्ड सेट करें",
+        "primaryButton__updatePassword": "पासवर्ड अपडेट करें",
+        "title": "पासवर्ड"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "फोन नंबर हटाएं",
+        "detailsAction__nonPrimary": "प्राथमिक के रूप में सेट करें",
+        "detailsAction__primary": "सत्यापन पूरा करें",
+        "detailsAction__unverified": "फोन नंबर सत्यापित करें",
+        "primaryButton": "फोन नंबर जोड़ें",
+        "title": "फोन नंबर"
+      },
+      "profileSection": {
+        "primaryButton": "प्रोफ़ाइल अपडेट करें",
+        "title": "प्रोफ़ाइल"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "उपयोगकर्ता नाम सेट करें",
+        "primaryButton__updateUsername": "उपयोगकर्ता नाम अपडेट करें",
+        "title": "उपयोगकर्ता नाम"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "वॉलेट हटाएं",
+        "detailsAction__nonPrimary": "प्राथमिक के रूप में सेट करें",
+        "primaryButton": "वॉलेट कनेक्ट करें",
+        "title": "Web3 वॉलेट",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "अपने खाते से कनेक्ट करने के लिए एक Solana वॉलेट चुनें।",
+          "title": "Solana वॉलेट जोड़ें"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "आपका उपयोगकर्ता नाम अपडेट किया गया है।",
+      "title__set": "उपयोगकर्ता नाम सेट करें",
+      "title__update": "उपयोगकर्ता नाम अपडेट करें"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} को इस खाते से हटा दिया जाएगा।",
+        "messageLine2": "आप अब इस web3 वॉलेट का उपयोग करके साइन इन नहीं कर पाएंगे।",
+        "successMessage": "{{web3Wallet}} को आपके खाते से हटा दिया गया है।",
+        "title": "web3 वॉलेट हटाएं"
+      },
+      "subtitle__availableWallets": "अपने खाते से कनेक्ट करने के लिए web3 वॉलेट चुनें।",
+      "subtitle__unavailableWallets": "कोई उपलब्ध web3 वॉलेट नहीं हैं।",
+      "successMessage": "वॉलेट को आपके खाते में जोड़ दिया गया है।",
+      "title": "web3 वॉलेट जोड़ें",
+      "web3WalletButtonsBlockButton": "{{provider|titleize}}"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "साइन इन करें",
+      "actionText": "पहले से ही पहुंच है?",
+      "formButton": "प्रतीक्षा सूची में शामिल हों",
+      "subtitle": "अपना ईमेल पता दर्ज करें और हम आपको बताएंगे जब आपका स्थान तैयार होगा",
+      "title": "प्रतीक्षा सूची में शामिल हों"
+    },
+    "success": {
+      "message": "आप जल्द ही पुनर्निर्देशित किए जाएंगे...",
+      "subtitle": "जब आपका स्थान तैयार होगा तो हम आपसे संपर्क करेंगे",
+      "title": "प्रतीक्षा सूची में शामिल होने के लिए धन्यवाद!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "{{walletName}} के साथ कनेक्ट करें",
+    "continue": "{{walletName}} के साथ जारी रखें",
+    "noneAvailable": "कोई Solana Web3 वॉलेट नहीं मिला। कृपया Web3 समर्थित {{ solanaWalletsLink || link(\"wallet extension\") }} इंस्टॉल करें।"
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/id-ID.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/id-ID.json
@@ -1,0 +1,1012 @@
+{
+  "locale": "id-ID",
+  "apiKeys": {
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Salin & Tutup",
+      "formHint": "Untuk alasan keamanan, kami tidak akan mengizinkan Anda untuk melihatnya lagi nanti.",
+      "formTitle": "Salin kunci API \"{{name}}\" Anda sekarang"
+    },
+    "revokeConfirmation": {}
+  },
+  "backButton": "Kembali",
+  "badge__default": "Default",
+  "badge__otherImpersonatorDevice": "Perangkat impersonator lain",
+  "badge__primary": "Utama",
+  "badge__requiresAction": "Memerlukan tindakan",
+  "badge__thisDevice": "Perangkat ini",
+  "badge__unverified": "Belum diverifikasi",
+  "badge__userDevice": "Perangkat pengguna",
+  "badge__you": "Anda",
+  "billing": {
+    "checkout": { "emailForm": {}, "lineItems": {} },
+    "paymentMethod": { "applePayDescription": {}, "dev": {} },
+    "pricingTable": { "seatCost": { "tooltip": {} } },
+    "subscriptionDetails": {}
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Hubungi administrator organisasi Anda untuk meningkatkan izin Anda.",
+      "title": "Anda tidak memiliki izin untuk mengelola Single Sign-On (SSO)"
+    },
+    "navbar": { "title": "Konfigurasi Single Sign-On (SSO)" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Belum terverifikasi",
+        "badge__verified": "Terverifikasi",
+        "txtRecord": {
+          "hostLabel": "Host / Nama",
+          "instructions": "Tambahkan data TXT ini ke penyedia DNS Anda. Kami akan memverifikasi secara otomatis setelah data aktif.",
+          "typeLabel": "Tipe",
+          "valueLabel": "Nilai"
+        },
+        "verifiedAtLabel": "Diverifikasi pada {{ date | shortDate('id-ID') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "Tambah {{domain}}",
+        "messageLabel": "Email Anda menggunakan {{domain}}. Apakah Anda ingin menambahkannya?"
+      },
+      "formButtonPrimary__add": "Tambah",
+      "formFieldInputPlaceholder__domain": "Tambah domain",
+      "formFieldLabel__domain": "Domain",
+      "removeDomainDialog": {},
+      "subtitle": "Tambahkan dan verifikasi kepemilikan domain yang digunakan organisasi Anda untuk masuk.",
+      "title": "Tambahkan domain SSO"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Penyedia SAML Khusus",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Pilih penyedia yang akan Anda atur untuk SSO.",
+      "title": "Pilih penyedia",
+      "warning": "Setelah penyedia dipilih, Anda tidak dapat mengubahnya lagi sampai konfigurasi selesai"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Buat organisasi",
+    "invitePage": { "formButtonReset": "Lewati" },
+    "title": "Buat organisasi"
+  },
+  "dates": {
+    "lastDay": "Kemarin pada {{ date | timeString('id-ID') }}",
+    "next6Days": "{{ date | weekday('id-ID','long') }} pada {{ date | timeString('id-ID') }}",
+    "nextDay": "Besok pada {{ date | timeString('id-ID') }}",
+    "numeric": "{{ date | numeric('id-ID') }}",
+    "previous6Days": "{{ date | weekday('id-ID','long') }} lalu pada {{ date | timeString('id-ID') }}",
+    "sameDay": "Hari ini pada {{ date | timeString('id-ID') }}"
+  },
+  "dividerText": "atau",
+  "footerActionLink__useAnotherMethod": "Gunakan metode lain",
+  "footerPageLink__help": "Bantuan",
+  "footerPageLink__privacy": "Privasi",
+  "footerPageLink__terms": "Ketentuan",
+  "formButtonPrimary": "Lanjutkan",
+  "formButtonPrimary__verify": "Verifikasi",
+  "formFieldAction__forgotPassword": "Lupa kata sandi?",
+  "formFieldError__matchingPasswords": "Kata sandi cocok.",
+  "formFieldError__notMatchingPasswords": "Kata sandi tidak cocok.",
+  "formFieldError__verificationLinkExpired": "Tautan verifikasi telah kedaluwarsa. Silakan minta tautan baru.",
+  "formFieldHintText__optional": "Opsional",
+  "formFieldHintText__slug": "Slug adalah ID yang mudah dibaca dan harus unik. Biasanya digunakan dalam URL.",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Hapus akun",
+  "formFieldInputPlaceholder__emailAddresses": "contoh@email.com, contoh2@email.com",
+  "formFieldInputPlaceholder__organizationSlug": "organisasi-saya",
+  "formFieldLabel__apiKey": "Kunci API",
+  "formFieldLabel__apiKeyDescription": "Deskripsi",
+  "formFieldLabel__apiKeyExpiration": "Kedaluwarsa",
+  "formFieldLabel__apiKeyName": "Nama kunci rahasia",
+  "formFieldLabel__automaticInvitations": "Aktifkan undangan otomatis untuk domain ini",
+  "formFieldLabel__backupCode": "Kode cadangan",
+  "formFieldLabel__confirmDeletion": "Konfirmasi",
+  "formFieldLabel__confirmPassword": "Konfirmasi kata sandi",
+  "formFieldLabel__currentPassword": "Kata sandi saat ini",
+  "formFieldLabel__emailAddress": "Alamat email",
+  "formFieldLabel__emailAddress_username": "Alamat email atau nama pengguna",
+  "formFieldLabel__emailAddresses": "Alamat email",
+  "formFieldLabel__firstName": "Nama depan",
+  "formFieldLabel__lastName": "Nama belakang",
+  "formFieldLabel__newPassword": "Kata sandi baru",
+  "formFieldLabel__organizationDomain": "Domain",
+  "formFieldLabel__organizationDomainDeletePending": "Hapus undangan dan saran yang tertunda",
+  "formFieldLabel__organizationDomainEmailAddress": "Alamat email verifikasi",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Masukkan alamat email dengan domain ini untuk menerima kode dan memverifikasi domain ini.",
+  "formFieldLabel__organizationName": "Nama",
+  "formFieldLabel__organizationSlug": "Slug",
+  "formFieldLabel__passkeyName": "Nama passkey",
+  "formFieldLabel__password": "Kata sandi",
+  "formFieldLabel__phoneNumber": "Nomor telepon",
+  "formFieldLabel__role": "Peran",
+  "formFieldLabel__signOutOfOtherSessions": "Keluar dari semua perangkat lain",
+  "formFieldLabel__username": "Nama pengguna",
+  "impersonationFab": {
+    "action__signOut": "Keluar",
+    "title": "Masuk sebagai {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Terakhir digunakan",
+  "maintenanceMode": "Kami sedang dalam pemeliharaan sistem, tapi jangan khawatir, ini tidak akan memakan waktu lebih dari beberapa menit.",
+  "membershipRole__admin": "Admin",
+  "membershipRole__basicMember": "Anggota",
+  "membershipRole__guestMember": "Tamu",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Buat organisasi",
+    "action__invitationAccept": "Gabung",
+    "action__suggestionsAccept": "Minta bergabung",
+    "createOrganization": "Buat Organisasi",
+    "invitationAcceptedLabel": "Bergabung",
+    "subtitle": "untuk melanjutkan ke {{applicationName}}",
+    "suggestionsAcceptedLabel": "Menunggu persetujuan",
+    "title": "Pilih akun",
+    "titleWithoutPersonal": "Pilih organisasi"
+  },
+  "organizationProfile": {
+    "apiKeysPage": {},
+    "badge__automaticInvitation": "Undangan otomatis",
+    "badge__automaticSuggestion": "Saran otomatis",
+    "badge__manualInvitation": "Tanpa pendaftaran otomatis",
+    "badge__unverified": "Belum diverifikasi",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {},
+      "paymentMethodsSection": { "removeMethod": {} },
+      "start": {},
+      "statementsSection": {},
+      "subscriptionsListSection": {},
+      "subscriptionsSection": {},
+      "switchPlansSection": {}
+    },
+    "createDomainPage": {
+      "subtitle": "Tambahkan domain untuk verifikasi. Pengguna dengan alamat email di domain ini dapat bergabung dengan organisasi secara otomatis atau meminta untuk bergabung.",
+      "title": "Tambah domain"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "Undangan tidak dapat dikirim. Sudah ada undangan tertunda untuk alamat email berikut: {{email_addresses}}.",
+      "formButtonPrimary__continue": "Kirim undangan",
+      "selectDropdown__role": "Pilih peran",
+      "subtitle": "Masukkan atau tempel satu atau lebih alamat email, dipisahkan dengan spasi atau koma.",
+      "successMessage": "Undangan berhasil dikirim",
+      "title": "Undang anggota baru"
+    },
+    "membersPage": {
+      "action__invite": "Undang",
+      "activeMembersTab": {
+        "menuAction__remove": "Hapus anggota",
+        "tableHeader__joined": "Bergabung",
+        "tableHeader__role": "Peran",
+        "tableHeader__user": "Pengguna"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Kami sedang memperbarui peran yang tersedia. Setelah selesai, Anda akan dapat memperbarui peran lagi.",
+          "title": "Peran untuk sementara terkunci"
+        }
+      },
+      "detailsTitle__emptyRow": "Tidak ada anggota untuk ditampilkan",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Undang pengguna dengan menghubungkan domain email ke organisasi Anda. Siapa pun yang mendaftar dengan domain email yang cocok akan dapat bergabung dengan organisasi kapan saja.",
+          "headerTitle": "Undangan otomatis",
+          "primaryButton": "Kelola domain terverifikasi"
+        },
+        "table__emptyRow": "Tidak ada undangan untuk ditampilkan"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Batalkan undangan",
+        "tableHeader__invited": "Diundang"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Pengguna yang mendaftar dengan domain email yang cocok akan dapat melihat saran untuk meminta bergabung dengan organisasi Anda.",
+          "headerTitle": "Saran otomatis",
+          "primaryButton": "Kelola domain terverifikasi"
+        },
+        "menuAction__approve": "Setujui",
+        "menuAction__reject": "Tolak",
+        "tableHeader__requested": "Meminta akses",
+        "table__emptyRow": "Tidak ada permintaan untuk ditampilkan"
+      },
+      "start": {
+        "headerTitle__invitations": "Undangan",
+        "headerTitle__members": "Anggota",
+        "headerTitle__requests": "Permintaan"
+      }
+    },
+    "navbar": {
+      "description": "Kelola organisasi Anda.",
+      "general": "Umum",
+      "members": "Anggota",
+      "title": "Organisasi"
+    },
+    "plansPage": { "alerts": {} },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Ketik \"{{organizationName}}\" di bawah untuk melanjutkan.",
+          "messageLine1": "Anda yakin ingin menghapus organisasi ini?",
+          "messageLine2": "Tindakan ini permanen dan tidak dapat dibatalkan.",
+          "successMessage": "Anda telah menghapus organisasi.",
+          "title": "Hapus organisasi"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Ketik \"{{organizationName}}\" di bawah untuk melanjutkan.",
+          "messageLine1": "Anda yakin ingin meninggalkan organisasi ini? Anda akan kehilangan akses ke organisasi ini dan aplikasinya.",
+          "messageLine2": "Tindakan ini permanen dan tidak dapat dibatalkan.",
+          "successMessage": "Anda telah meninggalkan organisasi.",
+          "title": "Tinggalkan organisasi"
+        },
+        "title": "Bahaya"
+      },
+      "domainSection": {
+        "menuAction__manage": "Kelola",
+        "menuAction__remove": "Hapus",
+        "menuAction__verify": "Verifikasi",
+        "primaryButton": "Tambah domain",
+        "subtitle": "Izinkan pengguna untuk bergabung dengan organisasi secara otomatis atau meminta bergabung berdasarkan domain email terverifikasi.",
+        "title": "Domain terverifikasi"
+      },
+      "successMessage": "Organisasi telah diperbarui.",
+      "title": "Perbarui profil"
+    },
+    "removeDomainPage": {
+      "messageLine1": "Domain email {{domain}} akan dihapus.",
+      "messageLine2": "Pengguna tidak akan dapat bergabung dengan organisasi secara otomatis setelah ini.",
+      "successMessage": "{{domain}} telah dihapus.",
+      "title": "Hapus domain"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "Umum",
+      "headerTitle__members": "Anggota",
+      "profileSection": {
+        "primaryButton": "Perbarui profil",
+        "title": "Profil Organisasi",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "Menghapus domain ini akan mempengaruhi pengguna yang diundang.",
+        "removeDomainActionLabel__remove": "Hapus domain",
+        "removeDomainSubtitle": "Hapus domain ini dari domain terverifikasi Anda",
+        "removeDomainTitle": "Hapus domain"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Pengguna otomatis diundang untuk bergabung dengan organisasi saat mereka mendaftar dan dapat bergabung kapan saja.",
+        "automaticInvitationOption__label": "Undangan otomatis",
+        "automaticSuggestionOption__description": "Pengguna menerima saran untuk meminta bergabung, tetapi harus disetujui oleh admin sebelum mereka dapat bergabung dengan organisasi.",
+        "automaticSuggestionOption__label": "Saran otomatis",
+        "calloutInfoLabel": "Mengubah mode pendaftaran hanya akan mempengaruhi pengguna baru.",
+        "calloutInvitationCountLabel": "Undangan tertunda yang dikirim ke pengguna: {{count}}",
+        "calloutSuggestionCountLabel": "Saran tertunda yang dikirim ke pengguna: {{count}}",
+        "manualInvitationOption__description": "Pengguna hanya dapat diundang secara manual ke organisasi.",
+        "manualInvitationOption__label": "Tanpa pendaftaran otomatis",
+        "subtitle": "Pilih bagaimana pengguna dari domain ini dapat bergabung dengan organisasi."
+      },
+      "start": {
+        "headerTitle__danger": "Bahaya",
+        "headerTitle__enrollment": "Opsi pendaftaran"
+      },
+      "subtitle": "Domain {{domain}} sekarang terverifikasi. Lanjutkan dengan memilih mode pendaftaran.",
+      "title": "Perbarui {{domain}}"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Masukkan kode verifikasi yang dikirim ke alamat email Anda",
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Domain {{domainName}} perlu diverifikasi melalui email.",
+      "subtitleVerificationCodeScreen": "Kode verifikasi telah dikirim ke {{emailAddress}}. Masukkan kode untuk melanjutkan.",
+      "title": "Verifikasi domain"
+    }
+  },
+  "organizationSwitcher": {
+    "action__createOrganization": "Buat organisasi",
+    "action__invitationAccept": "Gabung",
+    "action__manageOrganization": "Kelola",
+    "action__suggestionsAccept": "Minta bergabung",
+    "notSelected": "Tidak ada organisasi dipilih",
+    "personalWorkspace": "Akun pribadi",
+    "suggestionsAcceptedLabel": "Menunggu persetujuan"
+  },
+  "paginationButton__next": "Berikutnya",
+  "paginationButton__previous": "Sebelumnya",
+  "paginationRowText__displaying": "Menampilkan",
+  "paginationRowText__of": "dari",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Dapatkan bantuan",
+      "actionText": "Tidak memiliki salah satu dari ini?",
+      "blockButton__backupCode": "Gunakan kode cadangan",
+      "blockButton__emailCode": "Kirim kode ke {{identifier}}",
+      "blockButton__password": "Lanjutkan dengan kata sandi Anda",
+      "blockButton__phoneCode": "Kirim kode SMS ke {{identifier}}",
+      "blockButton__totp": "Gunakan aplikasi autentikator Anda",
+      "getHelp": {
+        "blockButton__emailSupport": "Email dukungan",
+        "content": "Jika Anda kesulitan memverifikasi akun, email kami dan kami akan membantu memulihkan akses secepat mungkin.",
+        "title": "Dapatkan bantuan"
+      },
+      "subtitle": "Mengalami masalah? Anda dapat menggunakan salah satu metode ini untuk verifikasi.",
+      "title": "Gunakan metode lain"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Masukkan kode cadangan yang Anda terima saat menyiapkan autentikasi dua langkah",
+      "title": "Masukkan kode cadangan"
+    },
+    "emailCode": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Masukkan kode yang dikirim ke email Anda untuk melanjutkan",
+      "title": "Verifikasi diperlukan"
+    },
+    "noAvailableMethods": {
+      "message": "Tidak dapat melanjutkan verifikasi. Tidak ada faktor autentikasi yang sesuai dikonfigurasi",
+      "subtitle": "Terjadi kesalahan",
+      "title": "Tidak dapat memverifikasi akun Anda"
+    },
+    "passkey": {},
+    "password": {
+      "actionLink": "Gunakan metode lain",
+      "subtitle": "Masukkan kata sandi Anda untuk melanjutkan",
+      "title": "Verifikasi diperlukan"
+    },
+    "phoneCode": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Masukkan kode yang dikirim ke telepon Anda untuk melanjutkan",
+      "title": "Verifikasi diperlukan"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Masukkan kode yang dikirim ke telepon Anda untuk melanjutkan",
+      "title": "Verifikasi diperlukan"
+    },
+    "totpMfa": {
+      "formTitle": "Kode verifikasi",
+      "subtitle": "Masukkan kode yang dihasilkan oleh aplikasi autentikator Anda untuk melanjutkan",
+      "title": "Verifikasi diperlukan"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Tambah akun",
+      "action__signOutAll": "Keluar dari semua akun",
+      "subtitle": "Pilih akun yang ingin Anda gunakan untuk melanjutkan.",
+      "title": "Pilih akun"
+    },
+    "alternativeMethods": {
+      "actionLink": "Dapatkan bantuan",
+      "actionText": "Tidak memiliki metode ini?",
+      "blockButton__backupCode": "Gunakan kode cadangan",
+      "blockButton__emailCode": "Kirim kode ke {{identifier}}",
+      "blockButton__emailLink": "Kirim tautan ke {{identifier}}",
+      "blockButton__passkey": "Masuk dengan passkey Anda",
+      "blockButton__password": "Masuk dengan kata sandi",
+      "blockButton__phoneCode": "Kirim kode SMS ke {{identifier}}",
+      "blockButton__totp": "Gunakan aplikasi autentikator",
+      "getHelp": {
+        "blockButton__emailSupport": "Email dukungan",
+        "content": "Jika Anda kesulitan masuk ke akun, email kami dan kami akan membantu memulihkan akses secepat mungkin.",
+        "title": "Dapatkan bantuan"
+      },
+      "subtitle": "Mengalami masalah? Anda dapat menggunakan salah satu metode ini untuk masuk.",
+      "title": "Gunakan metode lain"
+    },
+    "alternativePhoneCodeProvider": {},
+    "backupCodeMfa": {
+      "subtitle": "Kode cadangan Anda adalah yang Anda dapatkan saat menyiapkan verifikasi dua langkah.",
+      "title": "Masukkan kode cadangan"
+    },
+    "emailCode": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Periksa email Anda"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Periksa email Anda",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Periksa email Anda"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Untuk melanjutkan, buka tautan verifikasi di perangkat dan browser yang Anda gunakan untuk memulai masuk",
+        "title": "Tautan verifikasi tidak valid untuk perangkat ini"
+      },
+      "expired": {
+        "subtitle": "Kembali ke tab asal untuk melanjutkan.",
+        "title": "Tautan verifikasi ini telah kedaluwarsa"
+      },
+      "failed": {
+        "subtitle": "Kembali ke tab asal untuk melanjutkan.",
+        "title": "Tautan verifikasi ini tidak valid"
+      },
+      "formSubtitle": "Gunakan tautan verifikasi yang dikirim ke email Anda",
+      "formTitle": "Tautan verifikasi",
+      "loading": {
+        "subtitle": "Anda akan segera dialihkan",
+        "title": "Sedang masuk..."
+      },
+      "resendButton": "Tidak menerima tautan? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Periksa email Anda",
+      "unusedTab": { "title": "Anda dapat menutup tab ini" },
+      "verified": {
+        "subtitle": "Anda akan segera dialihkan",
+        "title": "Berhasil masuk"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Kembali ke tab asal untuk melanjutkan",
+        "subtitleNewTab": "Kembali ke tab yang baru dibuka untuk melanjutkan",
+        "titleNewTab": "Masuk di tab lain"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Gunakan tautan verifikasi yang dikirim ke email Anda",
+      "resendButton": "Tidak menerima tautan? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Periksa email Anda"
+    },
+    "enterpriseConnections": {},
+    "forgotPassword": {
+      "formTitle": "Kode reset kata sandi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "untuk mereset kata sandi Anda",
+      "subtitle_email": "Pertama, masukkan kode yang dikirim ke alamat email Anda",
+      "subtitle_phone": "Pertama, masukkan kode yang dikirim ke telepon Anda",
+      "title": "Reset kata sandi"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Reset kata sandi Anda",
+      "label__alternativeMethods": "Atau, masuk dengan metode lain",
+      "title": "Lupa Kata Sandi?"
+    },
+    "newDeviceVerificationNotice": "Anda masuk dari perangkat baru. Kami meminta verifikasi untuk menjaga keamanan akun Anda.",
+    "noAvailableMethods": {
+      "message": "Tidak dapat melanjutkan masuk. Tidak ada faktor autentikasi yang tersedia.",
+      "subtitle": "Terjadi kesalahan",
+      "title": "Tidak dapat masuk"
+    },
+    "passkey": {
+      "subtitle": "Menggunakan passkey mengonfirmasi bahwa ini adalah Anda. Perangkat Anda mungkin meminta sidik jari, wajah, atau kunci layar.",
+      "title": "Gunakan passkey Anda"
+    },
+    "password": {
+      "actionLink": "Gunakan metode lain",
+      "subtitle": "Masukkan kata sandi yang terkait dengan akun Anda",
+      "title": "Masukkan kata sandi Anda"
+    },
+    "passwordCompromised": {},
+    "passwordPwned": { "title": "Kata sandi terkompromi" },
+    "passwordUntrusted": {},
+    "phoneCode": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Periksa telepon Anda"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Untuk melanjutkan, masukkan kode verifikasi yang dikirim ke telepon Anda",
+      "title": "Periksa telepon Anda"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Reset Kata Sandi",
+      "requiredMessage": "Untuk alasan keamanan, Anda harus mereset kata sandi.",
+      "successMessage": "Kata sandi Anda berhasil diubah. Sedang memasukkan Anda, mohon tunggu sebentar.",
+      "title": "Atur kata sandi baru"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Kami perlu memverifikasi identitas Anda sebelum mereset kata sandi."
+    },
+    "start": {
+      "actionLink": "Daftar",
+      "actionLink__join_waitlist": "Gabung daftar tunggu",
+      "actionLink__use_email": "Gunakan email",
+      "actionLink__use_email_username": "Gunakan email atau nama pengguna",
+      "actionLink__use_passkey": "Gunakan passkey sebagai gantinya",
+      "actionLink__use_phone": "Gunakan telepon",
+      "actionLink__use_username": "Gunakan nama pengguna",
+      "actionText": "Belum punya akun?",
+      "actionText__join_waitlist": "Ingin akses awal?",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "Selamat datang kembali! Silakan masuk untuk melanjutkan",
+      "title": "Masuk ke {{applicationName}}"
+    },
+    "totpMfa": {
+      "formTitle": "Kode verifikasi",
+      "subtitle": "Untuk melanjutkan, masukkan kode verifikasi yang dihasilkan oleh aplikasi autentikator Anda",
+      "title": "Verifikasi dua langkah"
+    },
+    "web3Solana": {
+      "subtitle": "Pilih dompet di bawah untuk masuk",
+      "title": "Masuk dengan Solana"
+    }
+  },
+  "signInEnterPasswordTitle": "Masukkan kata sandi Anda",
+  "signUp": {
+    "alternativePhoneCodeProvider": {},
+    "continue": {
+      "actionLink": "Masuk",
+      "actionText": "Sudah punya akun?",
+      "subtitle": "Silakan isi detail yang tersisa untuk melanjutkan.",
+      "title": "Isi kolom yang kosong"
+    },
+    "emailCode": {
+      "formSubtitle": "Masukkan kode verifikasi yang dikirim ke alamat email Anda",
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Masukkan kode verifikasi yang dikirim ke email Anda",
+      "title": "Verifikasi email Anda"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Untuk melanjutkan, buka tautan verifikasi di perangkat dan browser yang Anda gunakan untuk memulai pendaftaran",
+        "title": "Tautan verifikasi tidak valid untuk perangkat ini"
+      },
+      "formSubtitle": "Gunakan tautan verifikasi yang dikirim ke alamat email Anda",
+      "formTitle": "Tautan verifikasi",
+      "loading": { "title": "Sedang mendaftar..." },
+      "resendButton": "Tidak menerima tautan? Kirim ulang",
+      "subtitle": "untuk melanjutkan ke {{applicationName}}",
+      "title": "Verifikasi email Anda",
+      "verified": { "title": "Berhasil mendaftar" },
+      "verifiedSwitchTab": {
+        "subtitle": "Kembali ke tab yang baru dibuka untuk melanjutkan",
+        "subtitleNewTab": "Kembali ke tab sebelumnya untuk melanjutkan",
+        "title": "Berhasil memverifikasi email"
+      }
+    },
+    "enterpriseConnections": {},
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "Saya menyetujui {{ privacyPolicyLink || link(\"Kebijakan Privasi\") }}",
+        "label__onlyTermsOfService": "Saya menyetujui {{ termsOfServiceLink || link(\"Ketentuan Layanan\") }}",
+        "label__termsOfServiceAndPrivacyPolicy": "Saya menyetujui {{ termsOfServiceLink || link(\"Ketentuan Layanan\") }} dan {{ privacyPolicyLink || link(\"Kebijakan Privasi\") }}"
+      },
+      "continue": {
+        "subtitle": "Silakan baca dan setujui ketentuan untuk melanjutkan",
+        "title": "Persetujuan hukum"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Masukkan kode verifikasi yang dikirim ke nomor telepon Anda",
+      "formTitle": "Kode verifikasi",
+      "resendButton": "Tidak menerima kode? Kirim ulang",
+      "subtitle": "Masukkan kode verifikasi yang dikirim ke telepon Anda",
+      "title": "Verifikasi telepon Anda"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Masuk",
+      "actionText": "Sudah punya akun?",
+      "blockButton__emailSupport": "Email dukungan",
+      "blockButton__joinWaitlist": "Gabung daftar tunggu",
+      "subtitle": "Pendaftaran saat ini dinonaktifkan. Jika Anda yakin seharusnya memiliki akses, silakan hubungi dukungan.",
+      "subtitleWaitlist": "Pendaftaran saat ini dinonaktifkan. Untuk menjadi yang pertama tahu saat kami meluncur, bergabunglah dengan daftar tunggu.",
+      "title": "Akses dibatasi"
+    },
+    "start": {
+      "actionLink": "Masuk",
+      "actionLink__use_email": "Gunakan email sebagai gantinya",
+      "actionLink__use_phone": "Gunakan telepon sebagai gantinya",
+      "actionText": "Sudah punya akun?",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "Selamat datang! Silakan isi detail untuk memulai.",
+      "subtitleCombined": "Selamat datang! Silakan isi detail untuk memulai.",
+      "title": "Buat akun Anda",
+      "titleCombined": "Buat akun Anda"
+    },
+    "web3Solana": {
+      "subtitle": "Pilih dompet di bawah untuk mendaftar",
+      "title": "Daftar dengan Solana"
+    }
+  },
+  "socialButtonsBlockButton": "Lanjutkan dengan {{provider|titleize}}",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "Organisasi sudah ada untuk nama perusahaan yang terdeteksi ({{organizationName}}) dan {{organizationDomain}}. Bergabung melalui undangan."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "Buat organisasi baru",
+      "action__invitationAccept": "Bergabung",
+      "action__suggestionsAccept": "Minta bergabung",
+      "subtitle": "Bergabung dengan organisasi yang ada atau buat yang baru",
+      "subtitle__createOrganizationDisabled": "Bergabung dengan organisasi yang ada",
+      "suggestionsAcceptedLabel": "Menunggu persetujuan",
+      "title": "Pilih organisasi"
+    },
+    "createOrganization": {
+      "formButtonReset": "Batal",
+      "formButtonSubmit": "Lanjutkan",
+      "formFieldInputPlaceholder__name": "Organisasi Saya",
+      "formFieldInputPlaceholder__slug": "organisasi-saya",
+      "formFieldLabel__name": "Nama",
+      "formFieldLabel__slug": "Slug",
+      "subtitle": "Masukkan detail organisasi Anda untuk melanjutkan",
+      "title": "Atur organisasi Anda"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Hubungi admin organisasi Anda untuk mendapatkan undangan.",
+      "title": "Anda harus menjadi anggota organisasi"
+    },
+    "signOut": {
+      "actionLink": "Keluar",
+      "actionText": "Masuk sebagai {{identifier}}"
+    }
+  },
+  "taskResetPassword": { "signOut": {} },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}} sudah menjadi anggota organisasi.",
+    "avatar_file_size_exceeded": "Ukuran file melebihi batas maksimum 10MB. Silakan pilih file yang lebih kecil.",
+    "avatar_file_type_invalid": "Jenis file tidak didukung. Silakan unggah gambar JPG, PNG, GIF, atau WEBP.",
+    "captcha_invalid": "Pendaftaran gagal karena validasi keamanan gagal. Silakan muat ulang halaman untuk mencoba lagi atau hubungi dukungan untuk bantuan lebih lanjut.",
+    "captcha_unavailable": "Pendaftaran gagal karena validasi bot gagal. Silakan muat ulang halaman untuk mencoba lagi atau hubungi dukungan untuk bantuan lebih lanjut.",
+    "form_email_address_blocked": "Layanan email sementara tidak didukung. Silakan gunakan alamat email reguler Anda untuk membuat akun.",
+    "form_identifier_exists__email_address": "Alamat email ini sudah digunakan. Silakan coba yang lain.",
+    "form_identifier_exists__phone_number": "Nomor telepon ini sudah digunakan. Silakan coba yang lain.",
+    "form_identifier_exists__username": "Nama pengguna ini sudah digunakan. Silakan coba yang lain.",
+    "form_identifier_not_found": "Kami tidak dapat menemukan akun dengan detail tersebut.",
+    "form_param_format_invalid__email_address": "Alamat email harus berupa alamat email yang valid.",
+    "form_param_format_invalid__phone_number": "Nomor telepon harus dalam format internasional yang valid",
+    "form_param_max_length_exceeded__first_name": "Nama depan tidak boleh lebih dari 256 karakter.",
+    "form_param_max_length_exceeded__last_name": "Nama belakang tidak boleh lebih dari 256 karakter.",
+    "form_param_max_length_exceeded__name": "Nama tidak boleh lebih dari 256 karakter.",
+    "form_password_not_strong_enough": "Kata sandi Anda tidak cukup kuat.",
+    "form_password_or_identifier_incorrect": "Kata sandi atau alamat email salah. Coba lagi atau gunakan metode lain.",
+    "form_password_pwned": "Kata sandi ini telah ditemukan sebagai bagian dari kebocoran data dan tidak dapat digunakan, silakan coba kata sandi lain.",
+    "form_password_pwned__sign_in": "Kata sandi ini telah ditemukan sebagai bagian dari kebocoran data dan tidak dapat digunakan, silakan reset kata sandi Anda.",
+    "form_password_size_in_bytes_exceeded": "Kata sandi Anda telah melebihi jumlah byte maksimum yang diizinkan, silakan persingkat atau hapus beberapa karakter khusus.",
+    "form_password_validation_failed": "Kata Sandi Salah",
+    "form_username_needs_non_number_char": "Nama pengguna Anda harus berisi setidaknya satu karakter non-numerik.",
+    "identification_deletion_failed": "Anda tidak dapat menghapus identifikasi terakhir Anda.",
+    "not_allowed_access": "Alamat email atau nomor telepon tidak diizinkan untuk mendaftar. Ini mungkin disebabkan oleh penggunaan '+', '=', '#' atau '.' dalam alamat email Anda, penggunaan domain yang terhubung dengan layanan email sementara, atau pengecualian eksplisit. Jika Anda menganggap ini sebagai kesalahan, silakan hubungi dukungan.",
+    "organization_domain_blocked": "Ini adalah domain penyedia email yang diblokir. Silakan gunakan yang lain.",
+    "organization_domain_common": "Ini adalah domain penyedia email umum. Silakan gunakan yang lain.",
+    "organization_membership_quota_exceeded": "Anda telah mencapai batas keanggotaan organisasi, termasuk undangan yang belum selesai.",
+    "organization_minimum_permissions_needed": "Harus ada setidaknya satu anggota organisasi dengan izin minimum yang diperlukan.",
+    "passkey_already_exists": "Passkey sudah terdaftar di perangkat ini.",
+    "passkey_not_supported": "Passkey tidak didukung di perangkat ini.",
+    "passkey_pa_not_supported": "Pendaftaran memerlukan platform autentikator tetapi perangkat tidak mendukungnya.",
+    "passkey_registration_cancelled": "Pendaftaran passkey dibatalkan atau waktu habis.",
+    "passkey_retrieval_cancelled": "Verifikasi passkey dibatalkan atau waktu habis.",
+    "passwordComplexity": {
+      "maximumLength": "kurang dari {{length}} karakter",
+      "minimumLength": "{{length}} karakter atau lebih",
+      "requireLowercase": "huruf kecil",
+      "requireNumbers": "angka",
+      "requireSpecialCharacter": "karakter khusus",
+      "requireUppercase": "huruf besar",
+      "sentencePrefix": "Kata sandi Anda harus mengandung"
+    },
+    "phone_number_exists": "Nomor telepon ini sudah digunakan. Silakan coba yang lain.",
+    "session_exists": "Anda sudah masuk.",
+    "web3_signature_request_rejected": "Anda menolak permintaan tanda tangan. Silakan coba lagi untuk melanjutkan.",
+    "web3_solana_signature_generation_failed": "Terjadi kesalahan saat membuat tanda tangan. Silakan coba lagi untuk melanjutkan.",
+    "zxcvbn": {
+      "couldBeStronger": "Kata sandi Anda berfungsi, tapi bisa lebih kuat. Coba tambahkan lebih banyak karakter.",
+      "goodPassword": "Kata sandi Anda memenuhi semua persyaratan yang diperlukan.",
+      "notEnough": "Kata sandi Anda tidak cukup kuat.",
+      "suggestions": {
+        "allUppercase": "Kapitalisasi beberapa, tapi tidak semua huruf.",
+        "anotherWord": "Tambahkan lebih banyak kata yang kurang umum.",
+        "associatedYears": "Hindari tahun yang terkait dengan Anda.",
+        "capitalization": "Kapitalisasi lebih dari huruf pertama.",
+        "dates": "Hindari tanggal dan tahun yang terkait dengan Anda.",
+        "l33t": "Hindari penggantian huruf yang dapat diprediksi seperti '@' untuk 'a'.",
+        "longerKeyboardPattern": "Gunakan pola keyboard yang lebih panjang dan ubah arah pengetikan beberapa kali.",
+        "noNeed": "Anda dapat membuat kata sandi yang kuat tanpa menggunakan simbol, angka, atau huruf besar.",
+        "pwned": "Jika Anda menggunakan kata sandi ini di tempat lain, Anda harus mengubahnya.",
+        "recentYears": "Hindari tahun-tahun terakhir.",
+        "repeated": "Hindari kata dan karakter yang berulang.",
+        "reverseWords": "Hindari ejaan terbalik dari kata-kata umum.",
+        "sequences": "Hindari urutan karakter umum.",
+        "useWords": "Gunakan beberapa kata, tapi hindari frasa umum."
+      },
+      "warnings": {
+        "common": "Ini adalah kata sandi yang umum digunakan.",
+        "commonNames": "Nama dan nama keluarga yang umum mudah ditebak.",
+        "dates": "Tanggal mudah ditebak.",
+        "extendedRepeat": "Pola karakter berulang seperti \"abcabcabc\" mudah ditebak.",
+        "keyPattern": "Pola keyboard pendek mudah ditebak.",
+        "namesByThemselves": "Nama tunggal atau nama keluarga mudah ditebak.",
+        "pwned": "Kata sandi Anda telah terekspos oleh kebocoran data di Internet.",
+        "recentYears": "Tahun-tahun terakhir mudah ditebak.",
+        "sequences": "Urutan karakter umum seperti \"abc\" mudah ditebak.",
+        "similarToCommon": "Ini mirip dengan kata sandi yang umum digunakan.",
+        "simpleRepeat": "Karakter berulang seperti \"aaa\" mudah ditebak.",
+        "straightRow": "Baris lurus tombol di keyboard Anda mudah ditebak.",
+        "topHundred": "Ini adalah kata sandi yang sering digunakan.",
+        "topTen": "Ini adalah kata sandi yang sangat sering digunakan.",
+        "userInputs": "Seharusnya tidak ada data pribadi atau terkait halaman.",
+        "wordByItself": "Kata tunggal mudah ditebak."
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "Tambah akun",
+    "action__manageAccount": "Kelola akun",
+    "action__signOut": "Keluar",
+    "action__signOutAll": "Keluar dari semua akun",
+    "label__accountActions": "Tindakan akun",
+    "label__activeSessions": "Sesi aktif",
+    "label__userButtonPopover": "Panel akun"
+  },
+  "userProfile": {
+    "apiKeysPage": {},
+    "backupCodePage": {
+      "actionLabel__copied": "Disalin!",
+      "actionLabel__copy": "Salin semua",
+      "actionLabel__download": "Unduh .txt",
+      "actionLabel__print": "Cetak",
+      "infoText1": "Kode cadangan akan diaktifkan untuk akun ini.",
+      "infoText2": "Jaga kerahasiaan kode cadangan dan simpan dengan aman. Anda dapat membuat ulang kode cadangan jika mencurigai telah disusupi.",
+      "subtitle__codelist": "Simpan dengan aman dan jaga kerahasiaannya.",
+      "successMessage": "Kode cadangan sekarang diaktifkan. Anda dapat menggunakan salah satu dari ini untuk masuk ke akun Anda, jika kehilangan akses ke perangkat autentikasi. Setiap kode hanya dapat digunakan sekali.",
+      "successSubtitle": "Anda dapat menggunakan salah satu dari ini untuk masuk ke akun Anda, jika kehilangan akses ke perangkat autentikasi.",
+      "title": "Tambah verifikasi kode cadangan",
+      "title__codelist": "Kode cadangan"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {},
+      "paymentMethodsSection": { "removeMethod": {} },
+      "start": {},
+      "statementsSection": {},
+      "subscriptionsListSection": {},
+      "subscriptionsSection": {},
+      "switchPlansSection": {}
+    },
+    "connectedAccountPage": {
+      "formHint": "Pilih penyedia untuk menghubungkan akun Anda.",
+      "formHint__noAccounts": "Tidak ada penyedia akun eksternal yang tersedia.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} akan dihapus dari akun ini.",
+        "messageLine2": "Anda tidak akan dapat menggunakan akun terhubung ini dan fitur terkait tidak akan berfungsi lagi.",
+        "successMessage": "{{connectedAccount}} telah dihapus dari akun Anda.",
+        "title": "Hapus akun terhubung"
+      },
+      "socialButtonsBlockButton": "{{provider|titleize}}",
+      "successMessage": "Penyedia telah ditambahkan ke akun Anda",
+      "title": "Tambah akun terhubung"
+    },
+    "deletePage": {
+      "actionDescription": "Ketik \"Delete account\" di bawah untuk melanjutkan.",
+      "confirm": "Hapus akun",
+      "messageLine1": "Apakah Anda yakin ingin menghapus akun Anda? Beberapa data terkait mungkin tetap disimpan. Untuk meminta penghapusan data lengkap, silakan hubungi dukungan.",
+      "messageLine2": "Tindakan ini permanen dan tidak dapat dibatalkan.",
+      "title": "Hapus akun"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "Email berisi kode verifikasi akan dikirim ke alamat email ini.",
+        "formSubtitle": "Masukkan kode verifikasi yang dikirim ke {{identifier}}",
+        "formTitle": "Kode verifikasi",
+        "resendButton": "Tidak menerima kode? Kirim ulang",
+        "successMessage": "Email {{identifier}} telah ditambahkan ke akun Anda."
+      },
+      "emailLink": {
+        "formHint": "Email berisi tautan verifikasi akan dikirim ke alamat email ini.",
+        "formSubtitle": "Klik tautan verifikasi di email yang dikirim ke {{identifier}}",
+        "formTitle": "Tautan verifikasi",
+        "resendButton": "Tidak menerima tautan? Kirim ulang",
+        "successMessage": "Email {{identifier}} telah ditambahkan ke akun Anda."
+      },
+      "enterpriseSSOLink": {},
+      "removeResource": {
+        "messageLine1": "{{identifier}} akan dihapus dari akun ini.",
+        "messageLine2": "Anda tidak akan dapat masuk menggunakan alamat email ini.",
+        "successMessage": "{{emailAddress}} telah dihapus dari akun Anda.",
+        "title": "Hapus alamat email"
+      },
+      "title": "Tambah alamat email",
+      "verifyTitle": "Verifikasi alamat email"
+    },
+    "formButtonPrimary__add": "Tambah",
+    "formButtonPrimary__continue": "Lanjutkan",
+    "formButtonPrimary__finish": "Selesai",
+    "formButtonPrimary__remove": "Hapus",
+    "formButtonPrimary__save": "Simpan",
+    "formButtonReset": "Batal",
+    "mfaPage": {
+      "formHint": "Pilih metode untuk ditambahkan.",
+      "title": "Tambah verifikasi dua langkah"
+    },
+    "mfaPhoneCodePage": { "removeResource": {} },
+    "mfaTOTPPage": { "authenticatorApp": {}, "removeResource": {} },
+    "navbar": {
+      "account": "Profil",
+      "description": "Kelola info akun Anda.",
+      "security": "Keamanan",
+      "title": "Akun"
+    },
+    "passkeyScreen": { "removeResource": {} },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "Disarankan untuk keluar dari semua perangkat lain yang mungkin menggunakan kata sandi lama Anda.",
+      "readonly": "Kata sandi Anda saat ini tidak dapat diedit karena Anda hanya dapat masuk melalui koneksi enterprise.",
+      "successMessage__set": "Kata sandi Anda telah diatur.",
+      "successMessage__signOutOfOtherSessions": "Semua perangkat lain telah dikeluarkan.",
+      "successMessage__update": "Kata sandi Anda telah diperbarui.",
+      "title__set": "Atur kata sandi",
+      "title__update": "Perbarui kata sandi"
+    },
+    "phoneNumberPage": {
+      "infoText": "Pesan teks berisi kode verifikasi akan dikirim ke nomor telepon ini. Biaya pesan dan data mungkin berlaku.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} akan dihapus dari akun ini.",
+        "messageLine2": "Anda tidak akan dapat masuk menggunakan nomor telepon ini.",
+        "successMessage": "{{phoneNumber}} telah dihapus dari akun Anda.",
+        "title": "Hapus nomor telepon"
+      },
+      "successMessage": "{{identifier}} telah ditambahkan ke akun Anda.",
+      "title": "Tambah nomor telepon",
+      "verifySubtitle": "Masukkan kode verifikasi yang dikirim ke {{identifier}}",
+      "verifyTitle": "Verifikasi nomor telepon"
+    },
+    "plansPage": {},
+    "profilePage": {
+      "fileDropAreaHint": "Ukuran yang disarankan 1:1, hingga 10MB.",
+      "imageFormDestructiveActionSubtitle": "Hapus",
+      "imageFormSubtitle": "Unggah",
+      "imageFormTitle": "Gambar profil",
+      "readonly": "Informasi profil Anda telah disediakan oleh koneksi enterprise dan tidak dapat diedit.",
+      "successMessage": "Profil Anda telah diperbarui.",
+      "title": "Perbarui profil"
+    },
+    "start": {
+      "activeDevicesSection": {},
+      "connectedAccountsSection": {},
+      "dangerSection": {},
+      "emailAddressesSection": {},
+      "enterpriseAccountsSection": { "primaryButton": "Hubungkan akun" },
+      "mfaSection": { "backupCodes": {}, "phoneCode": {}, "totp": {} },
+      "passkeysSection": {},
+      "passwordSection": {},
+      "phoneNumbersSection": {},
+      "profileSection": {},
+      "usernameSection": {},
+      "web3WalletsSection": {
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Pilih dompet Solana untuk dihubungkan ke akun Anda.",
+          "title": "Tambahkan dompet Solana"
+        }
+      }
+    },
+    "usernamePage": {},
+    "web3WalletPage": { "removeResource": {} }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "Masuk",
+      "actionText": "Sudah punya akses?",
+      "formButton": "Gabung daftar tunggu",
+      "subtitle": "Masukkan alamat email Anda dan kami akan memberi tahu ketika tempat Anda siap",
+      "title": "Gabung daftar tunggu"
+    },
+    "success": {
+      "message": "Anda akan segera dialihkan...",
+      "subtitle": "Kami akan menghubungi ketika tempat Anda siap",
+      "title": "Terima kasih telah bergabung dengan daftar tunggu!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Hubungkan dengan {{walletName}}",
+    "continue": "Lanjutkan dengan {{walletName}}",
+    "noneAvailable": "Tidak ada dompet Solana Web3 yang terdeteksi. Silakan instal {{ solanaWalletsLink || link(\"wallet extension\") }} yang mendukung Web3."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/it-IT.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/it-IT.json
@@ -1,0 +1,1337 @@
+{
+  "locale": "it-IT",
+  "apiKeys": {
+    "action__add": "Aggiungi nuova chiave",
+    "action__search": "Cerca chiavi",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Copia e chiudi",
+      "formHint": "Per motivi di sicurezza, non ti permetteremo di visualizzarlo di nuovo in seguito.",
+      "formTitle": "Copia la tua chiave API \"{{name}}\" ora"
+    },
+    "createdAndExpirationStatus__expiresOn": "Creata {{ createdDate | shortDate('it-IT') }} • Scadenza {{ expiresDate | longDate('it-IT') }}",
+    "createdAndExpirationStatus__never": "Creata {{ createdDate | shortDate('it-IT') }} • Nessuna scadenza",
+    "detailsTitle__emptyRow": "Nessuna chiave API trovata",
+    "formButtonPrimary__add": "Crea chiave",
+    "formFieldCaption__expiration__expiresOn": "Scadenza {{ date }}",
+    "formFieldCaption__expiration__never": "Questa chiave non ha scadenza",
+    "formFieldOption__expiration__180d": "180 Giorni",
+    "formFieldOption__expiration__1d": "1 Giorno",
+    "formFieldOption__expiration__1y": "1 Anno",
+    "formFieldOption__expiration__30d": "30 Giorni",
+    "formFieldOption__expiration__60d": "60 Giorni",
+    "formFieldOption__expiration__7d": "7 Giorni",
+    "formFieldOption__expiration__90d": "90 Giorni",
+    "formFieldOption__expiration__never": "Never",
+    "formHint": "Fornisci un nome per generare una nuova chiave. Sarai in grado di revocarla in qualsiasi momento.",
+    "formTitle": "Aggiungi chiave API",
+    "lastUsed__days": "{{days}}d fa",
+    "lastUsed__hours": "{{hours}}h fa",
+    "lastUsed__minutes": "{{minutes}}m fa",
+    "lastUsed__months": "{{months}}mo fa",
+    "lastUsed__seconds": "{{seconds}}s fa",
+    "lastUsed__years": "{{years}}y fa",
+    "menuAction__revoke": "Revoca chiave",
+    "revokeConfirmation": {
+      "confirmationText": "Revoca",
+      "formButtonPrimary__revoke": "Revoca chiave",
+      "formHint": "Sei sicuro di voler eliminare questa Chiave Segreta?",
+      "formTitle": "Revoca \"{{apiKeyName}}\" chiave segreta?"
+    }
+  },
+  "backButton": "Indietro",
+  "badge__activePlan": "Attivo",
+  "badge__canceledEndsAt": "Cancellato • Termina {{ date | shortDate('it-IT') }}",
+  "badge__currentPlan": "Piano attuale",
+  "badge__default": "Predefinito",
+  "badge__endsAt": "Termina {{ date | shortDate('it-IT') }}",
+  "badge__expired": "Scaduto",
+  "badge__otherImpersonatorDevice": "Altro dispositivo impersonato",
+  "badge__pastDueAt": "Scaduto {{ date | shortDate('it-IT') }}",
+  "badge__pastDuePlan": "Scaduto",
+  "badge__primary": "Primario",
+  "badge__renewsAt": "Si rinnova {{ date | shortDate('it-IT') }}",
+  "badge__requiresAction": "Richiede azione",
+  "badge__startsAt": "Inizia {{ date | shortDate('it-IT') }}",
+  "badge__thisDevice": "Questo dispositivo",
+  "badge__unverified": "Non verificato",
+  "badge__upcomingPlan": "In arrivo",
+  "badge__userDevice": "Dispositivo utente",
+  "badge__you": "Tu",
+  "billing": {
+    "addPaymentMethod__label": "Aggiungi metodo di pagamento",
+    "alwaysFree": "Sempre gratuito",
+    "annually": "Annualmente",
+    "availableFeatures": "Funzionalità disponibili",
+    "billedAnnually": "Fatturato annualmente",
+    "billedMonthlyOnly": "Fatturato solo mensilmente",
+    "cancelSubscription": "Annulla abbonamento",
+    "cancelSubscriptionAccessUntil": "Puoi continuare a utilizzare le funzionalità di '{{plan}}' fino al {{ date | longDate('it-IT') }}, dopodiché non avrai più accesso.",
+    "cancelSubscriptionNoCharge": "Non ti verrà addebitato alcun costo per questo abbonamento.",
+    "cancelSubscriptionTitle": "Annullare abbonamento {{plan}}?",
+    "cannotSubscribeMonthly": "Non puoi abbonarti a questo piano pagando mensilmente. Per abbonarti a questo piano, devi scegliere di pagare annualmente.",
+    "cannotSubscribeUnrecoverable": "Non puoi abbonarti a questo piano. Il tuo abbonamento esistente è più costoso di questo piano.",
+    "checkout": {
+      "description__paymentSuccessful": "Il pagamento è andato a buon fine.",
+      "description__subscriptionSuccessful": "Il tuo nuovo abbonamento è pronto.",
+      "downgradeNotice": "Manterrai il tuo abbonamento attuale e le sue funzionalità fino alla fine del ciclo di fatturazione, quindi passerai a questo abbonamento.",
+      "emailForm": {
+        "subtitle": "Prima di completare l'acquisto devi aggiungere un indirizzo email a cui verranno inviate le ricevute.",
+        "title": "Aggiungi un indirizzo email"
+      },
+      "lineItems": {
+        "title__paymentMethod": "Metodo di pagamento",
+        "title__statementId": "ID estratto conto",
+        "title__subscriptionBegins": "Inizio abbonamento",
+        "title__totalPaid": "Totale pagato"
+      },
+      "pastDueNotice": "Il tuo precedente abbonamento era scaduto, senza alcun pagamento.",
+      "perMonth": "al mese",
+      "title": "Checkout",
+      "title__paymentSuccessful": "Pagamento riuscito!",
+      "title__subscriptionSuccessful": "Successo!"
+    },
+    "credit": "Credito",
+    "creditRemainder": "Credito per il resto del tuo abbonamento attuale.",
+    "defaultFreePlanActive": "Attualmente sei sul piano Gratuito",
+    "free": "Gratuito",
+    "getStarted": "Inizia",
+    "highlightedPlanBadge": "Popolare",
+    "keepSubscription": "Mantieni abbonamento",
+    "manage": "Gestisci",
+    "manageSubscription": "Gestisci abbonamento",
+    "month": "Mese",
+    "monthly": "Mensile",
+    "pastDue": "Scaduto",
+    "pay": "Paga {{amount}}",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "Pagamento annuale",
+        "monthly": "Pagamento mensile"
+      },
+      "dev": {
+        "anyNumbers": "Qualsiasi numero",
+        "cardNumber": "Numero carta",
+        "cvcZip": "CVC, CAP",
+        "developmentMode": "Modalità sviluppo",
+        "expirationDate": "Data di scadenza",
+        "testCardInfo": "Informazioni carta di prova"
+      }
+    },
+    "paymentMethods__label": "Metodi di pagamento",
+    "pricingTable": {
+      "billingCycle": "Ciclo di fatturazione",
+      "included": "Incluso",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "Riabbonati",
+    "seeAllFeatures": "Vedi tutte le funzionalità",
+    "subscribe": "Abbonati",
+    "subscriptionDetails": {
+      "beginsOn": "Inizia il",
+      "currentBillingCycle": "Ciclo di fatturazione attuale",
+      "endsOn": "Termina il",
+      "nextPaymentAmount": "Importo prossimo pagamento",
+      "nextPaymentOn": "Prossimo pagamento il",
+      "pastDueAt": "Scaduto il",
+      "renewsAt": "Si rinnova il",
+      "subscribedOn": "Abbonato il",
+      "title": "Abbonamento"
+    },
+    "subtotal": "Subtotale",
+    "switchPlan": "Passa a questo piano",
+    "switchToAnnual": "Passa ad annuale",
+    "switchToAnnualWithAnnualPrice": "Passa ad annuale {{price}} / anno",
+    "switchToMonthly": "Passa a mensile",
+    "switchToMonthlyWithPrice": "Passa a mensile {{price}} / mese",
+    "totalDue": "Totale dovuto",
+    "totalDueToday": "Totale dovuto oggi",
+    "viewFeatures": "Visualizza funzionalità",
+    "year": "Anno"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Contatta l'amministratore della tua organizzazione per ampliare i tuoi permessi.",
+      "title": "Non hai il permesso di gestire il Single Sign-On (SSO)"
+    },
+    "navbar": { "title": "Configura Single Sign-On (SSO)" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Non verificato",
+        "badge__verified": "Verificato",
+        "txtRecord": {
+          "hostLabel": "Host / Nome",
+          "instructions": "Aggiungi questo record TXT al tuo provider DNS. Verificheremo automaticamente non appena il record sarà attivo.",
+          "typeLabel": "Tipo",
+          "valueLabel": "Valore"
+        },
+        "verifiedAtLabel": "Verificato il {{ date | shortDate('it-IT') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "Aggiungi {{domain}}",
+        "messageLabel": "La tua email usa {{domain}}. Vuoi aggiungerlo?"
+      },
+      "formButtonPrimary__add": "Aggiungi",
+      "formFieldInputPlaceholder__domain": "Aggiungi dominio",
+      "formFieldLabel__domain": "Dominio",
+      "removeDomainDialog": {},
+      "subtitle": "Aggiungi e verifica la proprietà dei domini che la tua organizzazione utilizza per accedere.",
+      "title": "Aggiungi domini SSO"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Provider SAML personalizzato",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Seleziona il provider per cui configurerai l'SSO.",
+      "title": "Seleziona provider",
+      "warning": "Una volta selezionato un provider non potrai cambiarlo fino al termine della configurazione"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Crea organizzazione",
+    "invitePage": { "formButtonReset": "Salta" },
+    "title": "Crea organizzazione"
+  },
+  "dates": {
+    "lastDay": "Ieri alle {{ date | timeString('it-IT') }}",
+    "next6Days": "{{ date | weekday('it-IT','long') }} alle {{ date | timeString('it-IT') }}",
+    "nextDay": "Domani alle {{ date | timeString('it-IT') }}",
+    "numeric": "{{ date | numeric('it-IT') }}",
+    "previous6Days": "{{ date | weekday('it-IT','long') }} alle {{ date | timeString('it-IT') }}",
+    "sameDay": "Oggi alle {{ date | timeString('it-IT') }}"
+  },
+  "dividerText": "oppure",
+  "footerActionLink__alternativePhoneCodeProvider": "Alrimenti invia codice tramite SMS",
+  "footerActionLink__useAnotherMethod": "Utilizzo un altro metodo",
+  "footerPageLink__help": "Aiuto",
+  "footerPageLink__privacy": "Privacy",
+  "footerPageLink__terms": "Termini",
+  "formButtonPrimary": "Continua",
+  "formButtonPrimary__verify": "Verifica",
+  "formFieldAction__forgotPassword": "Password dimenticata?",
+  "formFieldError__matchingPasswords": "Le password coincidono.",
+  "formFieldError__notMatchingPasswords": "Le password non coincidono.",
+  "formFieldError__verificationLinkExpired": "Il link di verifica è scaduto. Per favore richiedi un nuovo link.",
+  "formFieldHintText__optional": "Opzionale",
+  "formFieldHintText__slug": "Uno slug è un identificativo leggibile dall’uomo che deve essere univoco. Spesso viene usato negli URL.",
+  "formFieldInputPlaceholder__apiKeyDescription": "Spiega come mai stai generando questa chiave API",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "Seleziona una data",
+  "formFieldInputPlaceholder__apiKeyName": "Inserisci il nome della tua chiave segreta",
+  "formFieldInputPlaceholder__backupCode": "Inserisci il codice di backup",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Elimina Account",
+  "formFieldInputPlaceholder__emailAddress": "Inserisci l'indirizzo email",
+  "formFieldInputPlaceholder__emailAddress_username": "Inserisci l'indirizzo email o il nome utente",
+  "formFieldInputPlaceholder__emailAddresses": "esempio@email.com, esempio2@email.com",
+  "formFieldInputPlaceholder__firstName": "Inserisci il tuo nome",
+  "formFieldInputPlaceholder__lastName": "Inserisci il tuo cognome",
+  "formFieldInputPlaceholder__organizationDomain": "Inserisci il dominio dell'organizzazione",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "Inserisci l'indirizzo email del dominio dell'organizzazione",
+  "formFieldInputPlaceholder__organizationName": "Inserisci il nome dell'organizzazione",
+  "formFieldInputPlaceholder__organizationSlug": "Inserisci lo slug dell'organizzazione",
+  "formFieldInputPlaceholder__password": "Inserisci la tua password",
+  "formFieldInputPlaceholder__phoneNumber": "Inserisci il numero di telefono",
+  "formFieldInputPlaceholder__username": "Inserisci il nome utente",
+  "formFieldLabel__apiKey": "Chiave API",
+  "formFieldLabel__apiKeyDescription": "Descrizione",
+  "formFieldLabel__apiKeyExpiration": "Scadenza",
+  "formFieldLabel__apiKeyName": "Nome chiave segreta",
+  "formFieldLabel__automaticInvitations": "Abilita inviti automatici per questo dominio",
+  "formFieldLabel__backupCode": "Codice di backup",
+  "formFieldLabel__confirmDeletion": "Conferma",
+  "formFieldLabel__confirmPassword": "Conferma password",
+  "formFieldLabel__currentPassword": "Password corrente",
+  "formFieldLabel__emailAddress": "Indirizzo email",
+  "formFieldLabel__emailAddress_username": "Indirizzo email o nome utente",
+  "formFieldLabel__emailAddresses": "Indirizzi email",
+  "formFieldLabel__firstName": "Nome",
+  "formFieldLabel__lastName": "Cognome",
+  "formFieldLabel__newPassword": "Nuova password",
+  "formFieldLabel__organizationDomain": "Dominio",
+  "formFieldLabel__organizationDomainDeletePending": "Elimina inviti e suggerimenti pendenti",
+  "formFieldLabel__organizationDomainEmailAddress": "Indirizzo email di verifica",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Inserisci un indirizzo email sotto questo dominio per ricevere un codice e verificare questo dominio.",
+  "formFieldLabel__organizationName": "Nome organizzazione",
+  "formFieldLabel__organizationSlug": "Slug",
+  "formFieldLabel__passkeyName": "Nome della passkey",
+  "formFieldLabel__password": "Password",
+  "formFieldLabel__phoneNumber": "Numero di telefono",
+  "formFieldLabel__role": "Ruolo",
+  "formFieldLabel__signOutOfOtherSessions": "Disconnetti tutti gli altri dispositivi",
+  "formFieldLabel__username": "Nome utente",
+  "impersonationFab": {
+    "action__signOut": "Disconnetti",
+    "title": "Accesso tramite {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Ultimo utilizzo",
+  "maintenanceMode": "Modalità di manutenzione",
+  "membershipRole__admin": "Amministratore",
+  "membershipRole__basicMember": "Utente",
+  "membershipRole__guestMember": "Ospite",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Crea organizzazione",
+    "action__invitationAccept": "Unisciti",
+    "action__suggestionsAccept": "Richiedi di unirti",
+    "createOrganization": "Crea organizzazione",
+    "invitationAcceptedLabel": "Unito",
+    "subtitle": "per continuare a {{applicationName}}",
+    "suggestionsAcceptedLabel": "In attesa di approvazione",
+    "title": "Scegli un account",
+    "titleWithoutPersonal": "Scegli un’organizzazione"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "Chiavi API" },
+    "badge__automaticInvitation": "Inviti automatici",
+    "badge__automaticSuggestion": "Suggerimenti automatici",
+    "badge__manualInvitation": "Nessuna iscrizione automatica",
+    "badge__unverified": "Non verificato",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Nessuno storico pagamenti",
+        "notFound": "Tentativo di pagamento non trovato",
+        "tableHeader__amount": "Importo",
+        "tableHeader__date": "Data",
+        "tableHeader__status": "Stato"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Imposta come predefinito",
+        "actionLabel__remove": "Rimuovi",
+        "add": "Aggiungi nuovo metodo di pagamento",
+        "addSubtitle": "Aggiungi un nuovo metodo di pagamento al tuo account.",
+        "cancelButton": "Annulla",
+        "formButtonPrimary__add": "Aggiungi metodo di pagamento",
+        "formButtonPrimary__pay": "Paga {{amount}}",
+        "payWithTestCardButton": "Paga con carta di prova",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} verrà rimosso da questo account.",
+          "messageLine2": "Non potrai più utilizzare questo metodo di pagamento e gli abbonamenti ricorrenti che dipendono da esso non funzioneranno più.",
+          "successMessage": "{{paymentMethod}} è stato rimosso dal tuo account.",
+          "title": "Rimuovi metodo di pagamento"
+        },
+        "title": "Metodi di pagamento"
+      },
+      "start": {
+        "headerTitle__payments": "Pagamenti",
+        "headerTitle__plans": "Piani",
+        "headerTitle__statements": "Estratti conto",
+        "headerTitle__subscriptions": "Abbonamento"
+      },
+      "statementsSection": {
+        "empty": "Nessun estratto conto da visualizzare",
+        "itemCaption__paidForPlan": "Pagato per il piano {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Credito proporzionale per l'utilizzo parziale dell'abbonamento precedente",
+        "itemCaption__subscribedAndPaidForPlan": "Abbonato e pagato per il piano {{plan}} {{period}}",
+        "notFound": "Estratto conto non trovato",
+        "tableHeader__amount": "Importo",
+        "tableHeader__date": "Data",
+        "title": "Estratti conto",
+        "totalPaid": "Totale pagato"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__newSubscription": "Abbonati a un piano",
+        "actionLabel__switchPlan": "Cambia piano",
+        "tableHeader__edit": "Modifica",
+        "tableHeader__plan": "Piano",
+        "tableHeader__startDate": "Data inizio",
+        "title": "Abbonamento"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gestisci" },
+      "switchPlansSection": { "title": "Cambia piani" },
+      "title": "Fatturazione"
+    },
+    "createDomainPage": {
+      "subtitle": "Aggiungi il dominio da verificare. Gli utenti con indirizzi email in questo dominio possono unirsi all’organizzazione automaticamente o richiedere di unirsi.",
+      "title": "Aggiungi dominio"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "L'invito non puó essere inviato. Correggi i seguenti e riprova:",
+      "formButtonPrimary__continue": "Invia inviti",
+      "selectDropdown__role": "Seleziona ruolo",
+      "subtitle": "Invita un nuovo membro in questa organizzazione",
+      "successMessage": "Invito inviato con successo",
+      "title": "Invita membri"
+    },
+    "membersPage": {
+      "action__invite": "Invita",
+      "action__search": "Cerca",
+      "activeMembersTab": {
+        "menuAction__remove": "Rimuovi membro",
+        "tableHeader__actions": "Azioni",
+        "tableHeader__joined": "Iscritto",
+        "tableHeader__role": "Ruolo",
+        "tableHeader__user": "Utente"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Stiamo aggiornando i ruoli disponibili. Una volta completato, potrai aggiornare nuovamente i ruoli.",
+          "title": "I ruoli sono temporaneamente bloccati"
+        }
+      },
+      "detailsTitle__emptyRow": "Nessun membro da visualizzare",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Invita utenti collegando un dominio email con la tua organizzazione. Chiunque si iscriva con un dominio email corrispondente potrà unirsi all’organizzazione in qualsiasi momento.",
+          "headerTitle": "Inviti automatici",
+          "primaryButton": "Gestisci domini verificati"
+        },
+        "table__emptyRow": "Nessun invito da visualizzare"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Revoca invito",
+        "tableHeader__invited": "Invitato"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Gli utenti che si iscrivono con un dominio email corrispondente, potranno vedere un suggerimento di richiesta di unirsi alla tua organizzazione.",
+          "headerTitle": "Suggerimenti automatici",
+          "primaryButton": "Gestisci domini verificati"
+        },
+        "menuAction__approve": "Approva",
+        "menuAction__reject": "Rifiuta",
+        "tableHeader__requested": "Richiesta accesso",
+        "table__emptyRow": "Nessuna richiesta da visualizzare"
+      },
+      "start": {
+        "headerTitle__invitations": "Inviti",
+        "headerTitle__members": "Membri",
+        "headerTitle__requests": "Richieste"
+      }
+    },
+    "navbar": {
+      "apiKeys": "Chiavi API",
+      "billing": "Fatturazione",
+      "description": "Gestisci la tua organizzazione.",
+      "general": "Generale",
+      "members": "Membri",
+      "title": "Organizzazione"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "Non hai i permessi per gestire la fatturazione di questa organizzazione"
+      },
+      "title": "Piani"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Scrivi \"{{organizationName}}\" qui sotto per continuare.",
+          "messageLine1": "Sei sicuro di voler eliminare questa organizzazione?",
+          "messageLine2": "Questa azione è permanente e irreversibile.",
+          "successMessage": "Hai eliminato l’organizzazione.",
+          "title": "Elimina organizzazione"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Scrivi \"{{organizationName}}\" qui sotto per continuare.",
+          "messageLine1": "Sei sicuro di voler lasciare questa organizzazione? Perderai accesso a questa organizzazione e le sue applicazioni.",
+          "messageLine2": "Questa azione è permanente ed irreversibile.",
+          "successMessage": "Hai lasciato l'organizzazione.",
+          "title": "Lascia organizzazione"
+        },
+        "title": "Pericolo"
+      },
+      "domainSection": {
+        "menuAction__manage": "Gestisci",
+        "menuAction__remove": "Elimina",
+        "menuAction__verify": "Verifica",
+        "primaryButton": "Aggiungi dominio",
+        "subtitle": "Consenti agli utenti di unirsi automaticamente all'organizzazione oppure di richiedere di unirsi in base a un dominio email verificato.",
+        "title": "Domini verificati"
+      },
+      "successMessage": "L'organizzazione è stata aggiornata.",
+      "title": "Profilo dell'organizzazione"
+    },
+    "removeDomainPage": {
+      "messageLine1": "Il dominio email {{domain}} verrà rimosso.",
+      "messageLine2": "Gli utenti non potranno più unirsi automaticamente all'organizzazione dopo questo.",
+      "successMessage": "{{domain}} è stato rimosso.",
+      "title": "Rimuovi dominio"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "Generale",
+      "headerTitle__members": "Membri",
+      "profileSection": {
+        "primaryButton": "Modifica profilo",
+        "title": "Profilo dell'organizzazione",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "Rimuovere questo dominio influirà sugli utenti invitati.",
+        "removeDomainActionLabel__remove": "Rimuovi dominio",
+        "removeDomainSubtitle": "Rimuovi questo dominio dai tuoi domini verificati",
+        "removeDomainTitle": "Rimuovi dominio"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Gli utenti sono automaticamente invitati a unirsi all'organizzazione quando si registrano e possono unirsi in qualsiasi momento.",
+        "automaticInvitationOption__label": "Inviti automatici",
+        "automaticSuggestionOption__description": "Gli utenti ricevono un suggerimento per richiedere di unirsi, ma devono essere approvati da un amministratore prima di poter accedere all'organizzazione.",
+        "automaticSuggestionOption__label": "Suggerimenti automatici",
+        "calloutInfoLabel": "La modifica della modalità di iscrizione influenzerà solo i nuovi utenti.",
+        "calloutInvitationCountLabel": "Inviti in sospeso inviati agli utenti: {{count}}",
+        "calloutSuggestionCountLabel": "Suggerimenti in sospeso inviati agli utenti: {{count}}",
+        "manualInvitationOption__description": "Gli utenti possono essere invitati manualmente solo all'organizzazione.",
+        "manualInvitationOption__label": "Nessuna iscrizione automatica",
+        "subtitle": "Scegli come gli utenti di questo dominio possono unirsi all'organizzazione."
+      },
+      "start": {
+        "headerTitle__danger": "Pericolo",
+        "headerTitle__enrollment": "Opzioni di iscrizione"
+      },
+      "subtitle": "Il dominio {{domain}} è ora verificato. Continua selezionando la modalità di iscrizione.",
+      "title": "Aggiorna {{domain}}"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Inserisci il codice di verifica inviato al tuo indirizzo email",
+      "formTitle": "Codice di verifica",
+      "resendButton": "Non hai ricevuto un codice? Reinvia",
+      "subtitle": "Il dominio {{domainName}} deve essere verificato tramite email.",
+      "subtitleVerificationCodeScreen": "È stato inviato un codice di verifica a {{emailAddress}}. Inserisci il codice per continuare.",
+      "title": "Verifica dominio"
+    }
+  },
+  "organizationSwitcher": {
+    "action__createOrganization": "Crea Organizzazione",
+    "action__invitationAccept": "Unisciti",
+    "action__manageOrganization": "Gestisci Organizzazione",
+    "action__suggestionsAccept": "Richiedi di unirti",
+    "notSelected": "Nessuna organizzazione selezionata",
+    "personalWorkspace": "Spazio di lavoro personale",
+    "suggestionsAcceptedLabel": "In attesa di approvazione"
+  },
+  "paginationButton__next": "Prossimo",
+  "paginationButton__previous": "Precedente",
+  "paginationRowText__displaying": "Visualizzando",
+  "paginationRowText__of": "di",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Clicca qui per utilizzare un metodo alternativo",
+      "actionText": "Usa un metodo di verifica alternativo",
+      "blockButton__backupCode": "Verifica con il codice di backup",
+      "blockButton__emailCode": "Verifica con il codice via email",
+      "blockButton__password": "Verifica con la password",
+      "blockButton__phoneCode": "Verifica con il codice SMS",
+      "blockButton__totp": "Verifica con il TOTP",
+      "getHelp": {
+        "blockButton__emailSupport": "Contatta il supporto via email",
+        "content": "Se hai bisogno di assistenza, contatta il nostro supporto.",
+        "title": "Ottieni aiuto"
+      },
+      "subtitle": "Scegli un metodo per verificarti",
+      "title": "Verifica necessaria"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Usa il codice di backup che ti è stato fornito al momento della registrazione.",
+      "title": "Verifica con il codice di backup"
+    },
+    "emailCode": {
+      "formTitle": "Inserisci il codice che ti è stato inviato via email.",
+      "resendButton": "Invia di nuovo il codice",
+      "subtitle": "Controlla la tua email per il codice di verifica.",
+      "title": "Verifica con il codice email"
+    },
+    "noAvailableMethods": {
+      "message": "Non sono disponibili metodi di verifica.",
+      "subtitle": "Contatta il supporto per assistenza.",
+      "title": "Nessun metodo disponibile"
+    },
+    "passkey": {},
+    "password": {
+      "actionLink": "Reimposta la password",
+      "subtitle": "Inserisci la tua password per continuare.",
+      "title": "Verifica con la password"
+    },
+    "phoneCode": {
+      "formTitle": "Inserisci il codice che ti è stato inviato via SMS.",
+      "resendButton": "Invia di nuovo il codice",
+      "subtitle": "Controlla il tuo SMS per il codice di verifica.",
+      "title": "Verifica con il codice SMS"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Inserisci il codice che ti abbiamo inviato via SMS.",
+      "resendButton": "Invia di nuovo il codice",
+      "subtitle": "Controlla il tuo SMS per il codice di verifica.",
+      "title": "Verifica SMS (MFA)"
+    },
+    "totpMfa": {
+      "formTitle": "Inserisci il codice dalla tua app di autenticazione.",
+      "subtitle": "Usa l’app di autenticazione che hai configurato.",
+      "title": "Verifica TOTP (MFA)"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Aggiungi account",
+      "action__signOutAll": "Disconnettiti da tutti gli account",
+      "subtitle": "Seleziona l'account con cui desideri continuare.",
+      "title": "Scegli un account"
+    },
+    "alternativeMethods": {
+      "actionLink": "Richiedi aiuto",
+      "actionText": "Non ne possiedi nessuno?",
+      "blockButton__backupCode": "Usa un codice di backup",
+      "blockButton__emailCode": "Invia codice a {{identifier}}",
+      "blockButton__emailLink": "Invia link a {{identifier}}",
+      "blockButton__passkey": "Usa una passkey",
+      "blockButton__password": "Accedi con la tua password",
+      "blockButton__phoneCode": "Invia codice a {{identifier}}",
+      "blockButton__totp": "Usa la tua app di autenticazione",
+      "getHelp": {
+        "blockButton__emailSupport": "Supporto email",
+        "content": "Se stai incontrando delle difficoltà ad accedere al tuo account, inviaci una email e ti aiuteremo a ripristinare il tuo account il prima possibile.",
+        "title": "Richiedi aiuto"
+      },
+      "subtitle": "Problemi di accesso? Puoi usare uno di questi metodi per accedere.",
+      "title": "Usa un altro metodo"
+    },
+    "alternativePhoneCodeProvider": {},
+    "backupCodeMfa": {
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Inserisci un codice di backup"
+    },
+    "emailCode": {
+      "formTitle": "Codice di verifica",
+      "resendButton": "Rinvia codice",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Controlla la tua email"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Controlla la tua email",
+      "resendButton": "Non hai ricevuto un codice? Reinvia",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Controlla la tua email"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Il client utilizzato non corrisponde al tipo di account associato.",
+        "title": "Errore di mismatch del client"
+      },
+      "expired": {
+        "subtitle": "Ritorna alla scheda originaria per continuare",
+        "title": "Questo link di verifica è scaduto"
+      },
+      "failed": {
+        "subtitle": "Ritorna alla scheda originaria per continuare",
+        "title": "Questo link di verifica non è valido"
+      },
+      "formSubtitle": "Usa il link di verifica inviato al tuo indirizzo email",
+      "formTitle": "Link di verifica",
+      "loading": {
+        "subtitle": "Verrai presto reindirizzato",
+        "title": "Accesso in corso..."
+      },
+      "resendButton": "Rinvia link",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Controlla la tua email",
+      "unusedTab": { "title": "Puoi chiudere questa scheda" },
+      "verified": {
+        "subtitle": "Verrai presto reindirizzato",
+        "title": "Accesso avvenuto con successo"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Ritorna alla scheda originaria per continuare",
+        "subtitleNewTab": "Ritorna sulla nuova scheda aperta per continuare",
+        "titleNewTab": "Accedi da un'altra scheda"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Usa il link di verifica inviato alla tua email",
+      "resendButton": "Non hai ricevuto il link? Reinvia",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Controlla la tua email"
+    },
+    "enterpriseConnections": {},
+    "forgotPassword": {
+      "formTitle": "Codice di reset della password",
+      "resendButton": "Non hai ricevuto un codice? Reinvia",
+      "subtitle": "per resettare la tua password",
+      "subtitle_email": "Per prima cosa, inserisci il codice inviato al tuo ID email",
+      "subtitle_phone": "Per prima cosa, inserisci il codice inviato al tuo telefono",
+      "title": "Resetta la password"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Resetta la tua password",
+      "label__alternativeMethods": "Oppure, accedi con un altro metodo",
+      "title": "Hai dimenticato la password?"
+    },
+    "newDeviceVerificationNotice": "Stai effettuando l'accesso da un nuovo dispositivo. Richiediamo la verifica per mantenere il tuo account sicuro.",
+    "noAvailableMethods": {
+      "message": "Impossibile procedere con l'accesso. Non ci sono strumenti di autenticazione disponibili.",
+      "subtitle": "Si è verificato un errore",
+      "title": "Impossibile accedere"
+    },
+    "passkey": {
+      "subtitle": "Usa una passkey per un accesso più sicuro e rapido.",
+      "title": "Autenticazione tramite passkey"
+    },
+    "password": {
+      "actionLink": "Usa un altro metodo",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Inserisci la tua password"
+    },
+    "passwordCompromised": {},
+    "passwordPwned": {
+      "title": "La tua password è stata trovata in un data breach."
+    },
+    "passwordUntrusted": {},
+    "phoneCode": {
+      "formTitle": "Codice di verifica",
+      "resendButton": "Rinvia il codice",
+      "subtitle": "per accedere a {{applicationName}}",
+      "title": "Controlla il tuo telefono"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Codice di verifica",
+      "resendButton": "Rinvia il codice",
+      "subtitle": "per accedere a {{applicationName}}",
+      "title": "Controlla il tuo telefono"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Resetta la password",
+      "requiredMessage": "Per motivi di sicurezza, è richiesto di resettare la tua password.",
+      "successMessage": "La tua password è stata cambiata con successo. Ti stiamo collegando, attendi un momento.",
+      "title": "Imposta nuova password"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Dobbiamo verificare la tua identità prima di resettare la tua password."
+    },
+    "start": {
+      "actionLink": "Registrati",
+      "actionLink__join_waitlist": "Unisciti alla lista d'attesa",
+      "actionLink__use_email": "Usa email",
+      "actionLink__use_email_username": "Usa email o username",
+      "actionLink__use_passkey": "Usa passkey",
+      "actionLink__use_phone": "Usa telefono",
+      "actionLink__use_username": "Usa username",
+      "actionText": "Non hai un account?",
+      "actionText__join_waitlist": "Unisciti alla lista d'attesa",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Accedi"
+    },
+    "totpMfa": {
+      "formTitle": "Codice di verifica",
+      "subtitle": "Inserisci il codice di verifica dalla tua app di autenticazione.",
+      "title": "Verifica in due passaggi"
+    },
+    "web3Solana": {
+      "subtitle": "Seleziona un wallet qui sotto per accedere",
+      "title": "Accedi con Solana"
+    }
+  },
+  "signInEnterPasswordTitle": "Inserisci la tua password",
+  "signUp": {
+    "alternativePhoneCodeProvider": {},
+    "continue": {
+      "actionLink": "Accedi",
+      "actionText": "Hai un account?",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Compila i campi mancanti"
+    },
+    "emailCode": {
+      "formSubtitle": "Inserisci il codice di verifica inviato alla tua email",
+      "formTitle": "Codice di verifica",
+      "resendButton": "Rinvia codice",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Verifica la tua email"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Il client che stai utilizzando non corrisponde a quello previsto per il tuo account.",
+        "title": "Errore di incompatibilità del client"
+      },
+      "formSubtitle": "Usa il link di verifica inviato al tuo indirizzo email",
+      "formTitle": "Link di verifica",
+      "loading": { "title": "Registrando..." },
+      "resendButton": "Rinvia link",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Verifica la tua email",
+      "verified": { "title": "Registrato con successo" },
+      "verifiedSwitchTab": {
+        "subtitle": "Ritorna alla nuova tab aperta per continuare",
+        "subtitleNewTab": "Ritorna alla tab precedente per continuare",
+        "title": "Email verificata con successo"
+      }
+    },
+    "enterpriseConnections": {},
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "Accetto la Politica sulla Privacy",
+        "label__onlyTermsOfService": "Accetto i Termini di Servizio",
+        "label__termsOfServiceAndPrivacyPolicy": "Accetto i {{ termsOfServiceLink || link(\"Termini di Servizio\") }} e la {{ privacyPolicyLink || link(\"Politica sulla Privacy\") }}"
+      },
+      "continue": {
+        "subtitle": "Per completare la registrazione, accetta i termini e la privacy policy.",
+        "title": "Continua"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Inserisci il codice di verifica inviato al tuo numero di telefono",
+      "formTitle": "Codice di verifica",
+      "resendButton": "Rinvia codice",
+      "subtitle": "per continuare su {{applicationName}}",
+      "title": "Verifica il tuo numero di telefono"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Contatta il supporto",
+      "actionText": "Hai bisogno di aiuto?",
+      "blockButton__emailSupport": "Email al supporto",
+      "blockButton__joinWaitlist": "Unisciti alla lista d'attesa",
+      "subtitle": "L'accesso è limitato per il momento. Ti invitiamo a contattare il supporto per ulteriori informazioni.",
+      "subtitleWaitlist": "Puoi unirti alla lista d'attesa e ti avviseremo quando l'accesso sarà disponibile.",
+      "title": "Accesso limitato"
+    },
+    "start": {
+      "actionLink": "Accedi",
+      "actionLink__use_email": "Usa email",
+      "actionLink__use_phone": "Usa telefono",
+      "actionText": "Hai già un account?",
+      "alternativePhoneCodeProvider": {},
+      "subtitle": "per continuare su {{applicationName}}",
+      "subtitleCombined": "per continuare su {{applicationName}}",
+      "title": "Crea il tuo account",
+      "titleCombined": "Crea il tuo account"
+    },
+    "web3Solana": {
+      "subtitle": "Seleziona un wallet qui sotto per registrarti",
+      "title": "Registrati con Solana"
+    }
+  },
+  "socialButtonsBlockButton": "Continua con {{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "Un'organizzazione esiste già per il nome dell'azienda rilevato ({{organizationName}}) e {{organizationDomain}}. Unisciti tramite invito."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "Crea nuova organizzazione",
+      "action__invitationAccept": "Unisciti",
+      "action__suggestionsAccept": "Richiedi di unirti",
+      "subtitle": "Unisciti a un'organizzazione esistente o creane una nuova",
+      "subtitle__createOrganizationDisabled": "Unisciti a un'organizzazione esistente",
+      "suggestionsAcceptedLabel": "In attesa di approvazione",
+      "title": "Scegli un'organizzazione"
+    },
+    "createOrganization": {
+      "formButtonReset": "Annulla",
+      "formButtonSubmit": "Continua",
+      "formFieldInputPlaceholder__name": "La mia organizzazione",
+      "formFieldInputPlaceholder__slug": "la-mia-organizzazione",
+      "formFieldLabel__name": "Nome",
+      "formFieldLabel__slug": "Slug",
+      "subtitle": "Inserisci i dettagli della tua organizzazione per continuare",
+      "title": "Configura la tua organizzazione"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Contatta l'amministratore della tua organizzazione per un invito.",
+      "title": "Devi appartenere a un'organizzazione"
+    },
+    "signOut": {
+      "actionLink": "Esci",
+      "actionText": "Accesso effettuato come {{identifier}}"
+    }
+  },
+  "taskResetPassword": { "signOut": {} },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "Sei già un membro di questa organizzazione.",
+    "avatar_file_size_exceeded": "La dimensione del file supera il limite massimo di 10 MB. Scegli un file più piccolo.",
+    "avatar_file_type_invalid": "Tipo di file non supportato. Carica un'immagine JPG, PNG, GIF o WEBP.",
+    "captcha_invalid": "Registrazione non riuscita a causa di fallite convalide di sicurezza. Per favore, ricarica la pagina e riprova o contatta il supporto per ulteriore assistenza.",
+    "captcha_unavailable": "Registrazione non riuscita a causa della convalida del bot non riuscita. Per favore, ricarica la pagina e riprova o contatta il supporto per ulteriore assistenza.",
+    "form_code_incorrect": "Il codice inserito non è corretto. Riprova.",
+    "form_email_address_blocked": "I servizi di posta elettronica temporanea non sono supportati. Si prega di utilizzare il proprio indirizzo email normale per creare un account.",
+    "form_identifier_exists__email_address": "Questa email è già registrata.",
+    "form_identifier_exists__phone_number": "Questo numero di telefono è già registrato.",
+    "form_identifier_exists__username": "Questo username è già in uso.",
+    "form_identifier_not_found": "Non abbiamo trovato nessun account con queste informazioni.",
+    "form_param_format_invalid": "Formato non valido.",
+    "form_param_format_invalid__email_address": "L'indirizzo email deve essere un indirizzo email valido.",
+    "form_param_format_invalid__phone_number": "Il numero di telefono deve essere in un formato internazionale valido.",
+    "form_param_max_length_exceeded__first_name": "Il nome non deve superare i 256 caratteri.",
+    "form_param_max_length_exceeded__last_name": "Il cognome non deve superare i 256 caratteri.",
+    "form_param_max_length_exceeded__name": "Il nome non deve superare i 256 caratteri.",
+    "form_param_nil": "Questo campo è obbligatorio.",
+    "form_param_value_invalid": "Valore non valido.",
+    "form_password_incorrect": "Password errata.",
+    "form_password_length_too_short": "La password deve avere almeno 8 caratteri.",
+    "form_password_not_strong_enough": "La tua password non è abbastanza forte.",
+    "form_password_or_identifier_incorrect": "La password o l'indirizzo email è errato. Riprova o usa un altro metodo.",
+    "form_password_pwned": "Questa password è stata trovata in una violazione dei dati. Scegli una password diversa.",
+    "form_password_pwned__sign_in": "Questa password è stata trovata in una violazione dei dati. Non può essere utilizzata. Reimposta la tua password.",
+    "form_password_size_in_bytes_exceeded": "La tua password ha superato il numero massimo di byte consentiti, per favore accorciala o rimuovi alcuni caratteri speciali.",
+    "form_password_validation_failed": "Password errata.",
+    "form_username_invalid_character": "Il nome utente contiene caratteri non validi.",
+    "form_username_invalid_length": "Il nome utente deve avere una lunghezza compresa tra 3 e 32 caratteri.",
+    "form_username_needs_non_number_char": "Il tuo nome utente deve contenere almeno un carattere non numerico.",
+    "identification_deletion_failed": "Non puoi eliminare la tua ultima identificazione.",
+    "not_allowed_access": "L'indirizzo email o il numero di telefono non è autorizzato per la registrazione. Questo può essere dovuto all'uso di '+', '=', '#' o '.' nell'indirizzo email, l'uso di un dominio collegato a un servizio email temporaneo o l'esclusione esplicita. Se ritieni che si tratti di un errore, contattaci.",
+    "organization_domain_blocked": "Il dominio dell'organizzazione è stato bloccato.",
+    "organization_domain_common": "Questo dominio è troppo comune per essere utilizzato.",
+    "organization_membership_quota_exceeded": "Hai raggiunto il limite massimo di membri nell'organizzazione.",
+    "organization_minimum_permissions_needed": "Non hai i permessi minimi necessari per completare questa operazione.",
+    "passwordComplexity": {},
+    "phone_number_exists": "Questo numero di telefono è già in uso. Per favore, prova con un altro.",
+    "session_exists": "Sei già loggato.",
+    "web3_signature_request_rejected": "Hai rifiutato la richiesta di firma. Riprova per continuare.",
+    "web3_solana_signature_generation_failed": "Si è verificato un errore durante la generazione della firma. Riprova per continuare.",
+    "zxcvbn": { "suggestions": {}, "warnings": {} }
+  },
+  "userButton": {
+    "action__addAccount": "Aggiungi account",
+    "action__closeUserMenu": "Chiudi menu utente",
+    "action__manageAccount": "Gestisci account",
+    "action__openUserMenu": "Apri menu utente",
+    "action__signOut": "Disconnetti",
+    "action__signOutAll": "Disconnetti da tutti gli accounts",
+    "label__accountActions": "Azioni account",
+    "label__activeSessions": "Sessioni attive",
+    "label__userButtonPopover": "Pannello account"
+  },
+  "userProfile": {
+    "apiKeysPage": {},
+    "backupCodePage": {
+      "actionLabel__copied": "Copiati!",
+      "actionLabel__copy": "Copia tutti",
+      "actionLabel__download": "Scarica .txt",
+      "actionLabel__print": "Stampa",
+      "infoText1": "I codici di backup saranno abilitati per questo account.",
+      "infoText2": "Tieni segreti i codici di backup e salvali in maniera sicura. Potrai generare altri codici di backup se pensi che possano essere compromessi.",
+      "subtitle__codelist": "Salvali in maniera sicura e tienili segreti.",
+      "successMessage": "I codici di backup sono ora abilitati. Puoi ora utilizzare questi codici di backup per accedere al tuo account, nel caso di perdita del proprio strumento di autenticazione. Ogni codice potrà essere utilizzato una sola volta.",
+      "successSubtitle": "Puoi ora utilizzare questi codici di backup per accedere al tuo account, nel caso di perdita del proprio strumento di autenticazione.",
+      "title": "Aggiungi verifica codici backup",
+      "title__codelist": "Codici di backup"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Nessuno storico pagamenti",
+        "notFound": "Tentativo di pagamento non trovato",
+        "tableHeader__amount": "Importo",
+        "tableHeader__date": "Data",
+        "tableHeader__status": "Stato"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Imposta come predefinito",
+        "actionLabel__remove": "Rimuovi",
+        "add": "Aggiungi nuovo metodo di pagamento",
+        "addSubtitle": "Aggiungi un nuovo metodo di pagamento al tuo account.",
+        "cancelButton": "Annulla",
+        "formButtonPrimary__add": "Aggiungi metodo di pagamento",
+        "formButtonPrimary__pay": "Paga {{amount}}",
+        "payWithTestCardButton": "Paga con carta di prova",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} verrà rimosso da questo account.",
+          "messageLine2": "Non potrai più utilizzare questo metodo di pagamento e gli abbonamenti ricorrenti che dipendono da esso non funzioneranno più.",
+          "successMessage": "{{paymentMethod}} è stato rimosso dal tuo account.",
+          "title": "Rimuovi metodo di pagamento"
+        },
+        "title": "Metodi di pagamento"
+      },
+      "start": {
+        "headerTitle__payments": "Pagamenti",
+        "headerTitle__plans": "Piani",
+        "headerTitle__statements": "Estratti conto",
+        "headerTitle__subscriptions": "Abbonamento"
+      },
+      "statementsSection": {
+        "empty": "Nessun estratto conto da visualizzare",
+        "itemCaption__paidForPlan": "Pagato per il piano {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Credito proporzionale per l'utilizzo parziale dell'abbonamento precedente",
+        "itemCaption__subscribedAndPaidForPlan": "Abbonato e pagato per il piano {{plan}} {{period}}",
+        "notFound": "Estratto conto non trovato",
+        "tableHeader__amount": "Importo",
+        "tableHeader__date": "Data",
+        "title": "Estratti conto",
+        "totalPaid": "Totale pagato"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__newSubscription": "Abbonati a un piano",
+        "actionLabel__switchPlan": "Cambia piano",
+        "tableHeader__edit": "Modifica",
+        "tableHeader__plan": "Piano",
+        "tableHeader__startDate": "Data inizio",
+        "title": "Abbonamento"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gestisci" },
+      "switchPlansSection": { "title": "Cambia piani" },
+      "title": "Fatturazione"
+    },
+    "connectedAccountPage": {
+      "formHint": "Seleziona un provider per collegare il tuo account.",
+      "formHint__noAccounts": "Non ci sono provider esterni disponibili.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} sarà rimosso dal tuo account.",
+        "messageLine2": "Non sarai piú in grado di accedere utilizzando questo account e le funzionalità collegate smetteranno di funzionare.",
+        "successMessage": "{{connectedAccount}} è stato rimosso dal tuo account.",
+        "title": "Rimuovi account collegato"
+      },
+      "socialButtonsBlockButton": "Collega {{provider|titleize}} account",
+      "successMessage": "Il provider è stato aggiunto al tuo account",
+      "title": "Aggiungi account collegato"
+    },
+    "deletePage": {
+      "actionDescription": "Digita \"Elimina account\" qui sotto per continuare.",
+      "confirm": "Elimina account",
+      "messageLine1": "Sei sicuro di voler eliminare il tuo account? Alcuni dati associati potrebbero essere conservati. Per richiedere la cancellazione completa dei dati, contatta l'assistenza.",
+      "messageLine2": "Questa azione è permanente e irreversibile.",
+      "title": "Elimina account"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "Una email contenente un codice di verifica è stata inviata a questo indirizzo email.",
+        "formSubtitle": "Inserisci il codice di verifica inviato a {{identifier}}",
+        "formTitle": "Codice di verifica",
+        "resendButton": "Rinvia codice",
+        "successMessage": "L'indirizzo email {{identifier}} è stato aggiunto al tuo account."
+      },
+      "emailLink": {
+        "formHint": "Una email contenente un link di verifica sarà inviata a questo indirizzo email.",
+        "formSubtitle": "Clicca sul link di verifica nella email inviata a {{identifier}}",
+        "formTitle": "Link di verifica",
+        "resendButton": "Rinvia link",
+        "successMessage": "L'indirizzo email {{identifier}} è stato aggiunto al tuo account."
+      },
+      "enterpriseSSOLink": {},
+      "removeResource": {
+        "messageLine1": "{{identifier}} sarà rimosso dal tuo account.",
+        "messageLine2": "Non sarai piú in grado di accedere utilizzando questo indirizzo email.",
+        "successMessage": "{{emailAddress}} è stato rimosso dal tuo account.",
+        "title": "Rimuovi indirizzo email"
+      },
+      "title": "Aggiungi un indirizzo email",
+      "verifyTitle": "Verifica indirizzo email"
+    },
+    "formButtonPrimary__add": "Aggiungi",
+    "formButtonPrimary__continue": "Continua",
+    "formButtonPrimary__finish": "Concludi",
+    "formButtonPrimary__remove": "Rimuovi",
+    "formButtonPrimary__save": "Salva",
+    "formButtonReset": "Cancella",
+    "mfaPage": {
+      "formHint": "Seleziona un metodo da aggiungere.",
+      "title": "Aggiungi verifica in 2 passaggi"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "Usa numero esistente",
+      "primaryButton__addPhoneNumber": "Aggiungi un numero di telefono",
+      "removeResource": {
+        "messageLine1": "{{identifier}} non riceverà piú i codici di verifica all'accesso.",
+        "messageLine2": "Il tuo account potrebbe essere non sicuro. Sei sicuro di voler continuare?",
+        "successMessage": "La verifica in 2 passaggi tramite SMS è stata rimossa per {{mfaPhoneCode}}",
+        "title": "Rimuovi verifica in 2 passaggi"
+      },
+      "subtitle__availablePhoneNumbers": "Seleziona un numero di telefono da registrare per la verifica in 2 passaggi tramite SMS.",
+      "subtitle__unavailablePhoneNumbers": "Non ci sono numeri di telefono da registrare per la verifica in 2 passaggi tramite SMS.",
+      "successMessage1": "Quando accedi, dovrai inserire un codice di verifica inviato a questo numero di telefono come passaggio aggiuntivo.",
+      "successMessage2": "Salva questi codici di backup e conservali in un luogo sicuro. Se perdi l'accesso al tuo dispositivo di autenticazione, puoi utilizzare i codici di backup per accedere.",
+      "successTitle": "Verifica codice SMS abilitata",
+      "title": "Aggiungi verifica tramite SMS"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "Scansiona il codice QR",
+        "buttonUnableToScan__nonPrimary": "Non è possibile scansionare il codice QR?",
+        "infoText__ableToScan": "Aggiungi un nuovo metodo di accesso nella tua app di autenticazione e scansione il seguente codice QR per associarla a questo account.",
+        "infoText__unableToScan": "Aggiungi un nuovo metodo di accesso nella tua app di autenticazione ed aggiungi la chiave di sicurezza generata sotto.",
+        "inputLabel__unableToScan1": "Assicurarsi che le password Time-based oppure One-time siano abilitate, poi continua il collegamento al tuo account.",
+        "inputLabel__unableToScan2": "Alternativamente, se il tuo autenticatore supporta TOTP URIs, puoi anche copiare l'intera URI."
+      },
+      "removeResource": {
+        "messageLine1": "I codici di verifica di questo autenticatore non saranno piú richiesti all'accesso.",
+        "messageLine2": "Il tuo account potrebbe essere non sicuro. Sei sicuro di voler continuare?",
+        "successMessage": "La verifica in 2 passaggi tramite autenticatore è stata rimossa.",
+        "title": "Rimuovi verifica in 2 passaggi"
+      },
+      "successMessage": "Verifica in 2 passaggi attivata. All'accesso sarà richiesto di inserire un codice di verifica generato dall'app di autenticazione come ulteriore passaggio.",
+      "title": "Aggiungi app di autenticazione",
+      "verifySubtitle": "Inserisci il codice di verifica generato dalla tua app di autenticazione",
+      "verifyTitle": "Codice di verifica"
+    },
+    "mobileButton__menu": "Menu",
+    "navbar": {
+      "account": "Profilo",
+      "description": "Gestisci il tuo account.",
+      "security": "Sicurezza",
+      "title": "Account"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "Sei sicuro di voler rimuovere questa chiave di accesso dal tuo account?",
+        "title": "Rimuovi chiave di accesso"
+      },
+      "subtitle__rename": "Modifica il nome della tua chiave di accesso",
+      "title__rename": "Rinomina chiave di accesso"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "È consigliabile disconnettersi da tutti gli altri dispositivi che potrebbero aver utilizzato la tua vecchia password.",
+      "readonly": "La tua password corrente non può essere modificata perché puoi accedere solo tramite la connessione aziendale.",
+      "successMessage__set": "La tua password è stata impostata.",
+      "successMessage__signOutOfOtherSessions": "Tutti gli altri dispositivi sono stati disconnessi.",
+      "successMessage__update": "La tua password è stata aggiornata.",
+      "title__set": "Imposta password",
+      "title__update": "Cambia password"
+    },
+    "phoneNumberPage": {
+      "infoText": "Un SMS contenente un link di verifica è stato inviato a questo numero di telefono.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} sarà rimosso dal tuo account.",
+        "messageLine2": "Non sarai piú in grado di accedere utilizzando questo numero di telefono.",
+        "successMessage": "{{phoneNumber}} è stato rimosso dal tuo account.",
+        "title": "Rimuovi numero di telefono"
+      },
+      "successMessage": "{{identifier}} è stato aggiunto al tuo account.",
+      "title": "Aggiungi numero di telefono",
+      "verifySubtitle": "Inserisci il codice di verifica inviato a {{identifier}}",
+      "verifyTitle": "Verifica numero di telefono"
+    },
+    "plansPage": {},
+    "profilePage": {
+      "fileDropAreaHint": "Carica una immagine piú piccola di 10MB di tipo JPG, PNG, GIF, oppure WEBP",
+      "imageFormDestructiveActionSubtitle": "Rimuovi immagine",
+      "imageFormSubtitle": "Carica immagine",
+      "imageFormTitle": "Immagine di profilo",
+      "readonly": "Le informazioni del tuo profilo sono state fornite dalla connessione aziendale e non possono essere modificate.",
+      "successMessage": "Il tuo profile è stato aggiornato.",
+      "title": "Aggiorna profilo"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "Disconnetti dal dispositivo",
+        "title": "Dispositivi attivi"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "Riprova",
+        "actionLabel__reauthorize": "Autorizza ora",
+        "destructiveActionTitle": "Rimuovi",
+        "primaryButton": "Collega account",
+        "subtitle__disconnected": "Il tuo account è disconnesso. Per favore, riconnetti il tuo account per continuare.",
+        "subtitle__reauthorize": "Gli ambiti richiesti sono stati aggiornati e potresti riscontrare funzionalità limitate. Per favore, ri-autorizza questa applicazione per evitare problemi.",
+        "title": "Account collegati"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "Elimina account",
+        "title": "Terminazione account"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "Rimuovi indirizzo email",
+        "detailsAction__nonPrimary": "Imposta come principale",
+        "detailsAction__primary": "Completa la verifica",
+        "detailsAction__unverified": "Completa la verifica",
+        "primaryButton": "Aggiungi un indirizzo email",
+        "title": "Indirizzi email"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "Collega account",
+        "title": "Account aziendali"
+      },
+      "headerTitle__account": "Dettagli profilo",
+      "headerTitle__security": "Sicurezza",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "Rigenera codici",
+          "headerTitle": "Codice di backup",
+          "subtitle__regenerate": "Ottieni una nuova lista di codici di sicurezza di backup. I codici di sicurezza di backup precedentemente generati saranno eliminati e non saranno utilizzabili.",
+          "title__regenerate": "Rigenera codici di backup"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "Imposta come predefinito",
+          "destructiveActionLabel": "Rimuovi numero di telefono"
+        },
+        "primaryButton": "Aggiungi verifica in 2 passaggi",
+        "title": "Verifica in 2 passaggi",
+        "totp": {
+          "destructiveActionTitle": "Rimuovi",
+          "headerTitle": "Applicazione di autenticazione"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "Rimuovi chiave di accesso",
+        "menuAction__rename": "Rinomina chiave di accesso",
+        "title": "Gestisci le tue chiavi di accesso"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "Imposta password",
+        "primaryButton__updatePassword": "Cambia password",
+        "title": "Password"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "Rimuovi numero di telefono",
+        "detailsAction__nonPrimary": "Imposta come principale",
+        "detailsAction__primary": "Completa la verifica",
+        "detailsAction__unverified": "Completa la verifica",
+        "primaryButton": "Aggiungi un numero di telefono",
+        "title": "Numeri di telefono"
+      },
+      "profileSection": {
+        "primaryButton": "Salva modifiche",
+        "title": "Profilo"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "Imposta username",
+        "primaryButton__updateUsername": "Cambia username",
+        "title": "Username"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "Rimuovi wallet",
+        "primaryButton": "Web3 wallets",
+        "title": "Web3 wallets",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Seleziona un wallet Solana da collegare al tuo account.",
+          "title": "Aggiungi un wallet Solana"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "Il tuo username è stato aggiornato.",
+      "title__set": "Aggiorna username",
+      "title__update": "Aggiorna username"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} sarà rimosso dal tuo account.",
+        "messageLine2": "Non sarai piú in grado di accedere utilizzando questo web3 wallet.",
+        "successMessage": "{{web3Wallet}} è stato rimosso dal tuo account.",
+        "title": "Rimuovi web3 wallet"
+      },
+      "subtitle__availableWallets": "Seleziona un web3 wallet da collegare al tuo account.",
+      "subtitle__unavailableWallets": "Non ci sono web3 wallets disponibili.",
+      "successMessage": "Il wallet è stato aggiunto al tuo account.",
+      "title": "Aggiungi web3 wallet",
+      "web3WalletButtonsBlockButton": "Continua con il tuo portafoglio Web3"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "Accedi",
+      "actionText": "Hai già accesso?",
+      "formButton": "Unisciti alla lista d'attesa",
+      "subtitle": "Inserisci il tuo indirizzo email e ti avviseremo quando il tuo posto sarà pronto",
+      "title": "Unisciti alla lista d'attesa"
+    },
+    "success": {
+      "message": "Verrai reindirizzato a breve...",
+      "subtitle": "Ti contatteremo quando il tuo posto sarà pronto",
+      "title": "Grazie per esserti unito alla lista d'attesa!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Connetti con {{walletName}}",
+    "continue": "Continua con {{walletName}}",
+    "noneAvailable": "Nessun wallet Solana Web3 rilevato. Installa un {{ solanaWalletsLink || link(\"wallet extension\") }} compatibile con Web3."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/ja-JP.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/ja-JP.json
@@ -1,0 +1,1524 @@
+{
+  "locale": "ja-JP",
+  "apiKeys": {
+    "action__add": "新しいキーを追加",
+    "action__search": "キーを検索",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "コピーして閉じる",
+      "formHint": "セキュリティ上の理由により、後で再度表示することはできません。",
+      "formTitle": "APIキー \"{{name}}\" を今すぐコピー"
+    },
+    "createdAndExpirationStatus__expiresOn": "{{ createdDate | shortDate('ja-JP') }}に作成 • {{ expiresDate | longDate('ja-JP') }}に失効",
+    "createdAndExpirationStatus__never": "{{ createdDate | shortDate('ja-JP') }}に作成 • 有効期限なし",
+    "detailsTitle__emptyRow": "APIキーが見つかりません",
+    "formButtonPrimary__add": "キーを作成",
+    "formFieldCaption__expiration__expiresOn": "{{ date }} に失効",
+    "formFieldCaption__expiration__never": "このキーは有効期限がありません",
+    "formFieldOption__expiration__180d": "180日",
+    "formFieldOption__expiration__1d": "1日",
+    "formFieldOption__expiration__1y": "1年",
+    "formFieldOption__expiration__30d": "30日",
+    "formFieldOption__expiration__60d": "60日",
+    "formFieldOption__expiration__7d": "7日",
+    "formFieldOption__expiration__90d": "90日",
+    "formFieldOption__expiration__never": "期限なし",
+    "formHint": "名前を指定して新しいキーを生成します。後からいつでも取り消すことができます。",
+    "formTitle": "新しいAPIキーを追加",
+    "lastUsed__days": "{{days}}日前",
+    "lastUsed__hours": "{{hours}}時間前",
+    "lastUsed__minutes": "{{minutes}}分前",
+    "lastUsed__months": "{{months}}か月前",
+    "lastUsed__seconds": "{{seconds}}秒前",
+    "lastUsed__years": "{{years}}年前",
+    "menuAction__revoke": "キーを取り消す",
+    "revokeConfirmation": {
+      "confirmationText": "取り消す",
+      "formButtonPrimary__revoke": "キーを取り消す",
+      "formHint": "このシークレットキーを削除してもよろしいですか？",
+      "formTitle": "シークレットキー \"{{apiKeyName}}\" を取り消しますか？"
+    }
+  },
+  "backButton": "戻る",
+  "badge__activePlan": "有効",
+  "badge__canceledEndsAt": "キャンセル済み • {{ date | shortDate('ja-JP') }}に終了",
+  "badge__currentPlan": "現在のプラン",
+  "badge__default": "デフォルト",
+  "badge__endsAt": "{{ date | shortDate('ja-JP') }}に終了",
+  "badge__expired": "期限切れ",
+  "badge__freeTrial": "無料トライアル",
+  "badge__otherImpersonatorDevice": "別の代理ログイン中のデバイス",
+  "badge__pastDueAt": "{{ date | shortDate('ja-JP') }}に支払い期限切れ",
+  "badge__pastDuePlan": "支払い遅延",
+  "badge__primary": "プライマリ",
+  "badge__renewsAt": "{{ date | shortDate('ja-JP') }}に更新",
+  "badge__requiresAction": "アクションが必要",
+  "badge__startsAt": "{{ date | shortDate('ja-JP') }}に開始",
+  "badge__thisDevice": "このデバイス",
+  "badge__trialEndsAt": "トライアルは {{ date | shortDate('ja-JP') }} に終了",
+  "badge__unverified": "未確認",
+  "badge__upcomingPlan": "今後のプラン",
+  "badge__userDevice": "ユーザーデバイス",
+  "badge__you": "あなた",
+  "billing": {
+    "accountCredit": "アカウントクレジット",
+    "addPaymentMethod__label": "支払い方法を追加",
+    "alwaysFree": "常に無料",
+    "annually": "年払い",
+    "availableFeatures": "利用可能な機能",
+    "billedAnnually": "年ごとに請求",
+    "billedAnnuallyOnly": "年払いのみ",
+    "billedMonthlyOnly": "月単位でのみ請求",
+    "cancelFreeTrial": "無料トライアルをキャンセル",
+    "cancelFreeTrialAccessUntil": "{{ date | longDate('ja-JP') }}まではトライアルが有効です。その後はトライアル機能へのアクセスができなくなります。料金が請求されることはありません。",
+    "cancelFreeTrialTitle": "{{plan}}プランの無料トライアルをキャンセルしますか？",
+    "cancelSubscription": "サブスクリプションをキャンセル",
+    "cancelSubscriptionAccessUntil": "{{ date | longDate('ja-JP') }}までは '{{plan}}' の機能を利用できますが、その後はアクセスできなくなります。",
+    "cancelSubscriptionNoCharge": "このサブスクリプションの料金は請求されません。",
+    "cancelSubscriptionPastDue": "サブスクリプションは直ちに終了し、全てのプラン機能へのアクセスが失われます。次回のサブスクリプションで未払い分のお支払いをお願いする場合があります。",
+    "cancelSubscriptionTitle": "{{plan}} のサブスクリプションをキャンセルしますか？",
+    "cannotSubscribeMonthly": "このプランは月払いで契約できません。このプランを契約するには、年払いを選択する必要があります。",
+    "cannotSubscribeUnrecoverable": "このプランを契約することはできません。現在のサブスクリプションの方がこのプランより高額です。",
+    "checkout": {
+      "description__paymentSuccessful": "支払いが完了しました。",
+      "description__subscriptionSuccessful": "新しいサブスクリプションの設定が完了しました。",
+      "downgradeNotice": "現在の請求期間が終了するまでは既存のサブスクリプションとその機能を利用でき、その後このサブスクリプションに切り替わります。",
+      "emailForm": {
+        "subtitle": "購入を完了する前に、領収書送付先となるメールアドレスを追加してください。",
+        "title": "メールアドレスを追加"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "トライアル終了日",
+        "title__paymentMethod": "支払い方法",
+        "title__statementId": "明細ID",
+        "title__subscriptionBegins": "サブスクリプション開始日",
+        "title__totalPaid": "支払い合計"
+      },
+      "pastDueNotice": "前回のサブスクリプションには未払い分が残っています。",
+      "perMonth": "月あたり",
+      "title": "チェックアウト",
+      "title__paymentSuccessful": "支払いが完了しました！",
+      "title__subscriptionSuccessful": "成功しました！",
+      "title__trialSuccess": "トライアルを開始しました！",
+      "totalDueAfterTrial": "トライアル終了まで{{days}}日後に支払う合計金額"
+    },
+    "credit": "クレジット",
+    "creditRemainder": "現在のサブスクリプションの残り期間に対するクレジット。",
+    "defaultFreePlanActive": "現在は無料プランをご利用中です",
+    "free": "無料",
+    "getStarted": "はじめる",
+    "highlightedPlanBadge": "人気",
+    "keepFreeTrial": "無料トライアルを続ける",
+    "keepSubscription": "サブスクリプションを継続",
+    "manage": "管理",
+    "manageSubscription": "サブスクリプションを管理",
+    "month": "月",
+    "monthly": "月払い",
+    "pastDue": "支払い遅延",
+    "pay": "{{amount}}を支払う",
+    "payerCreditRemainder": "アカウント残高からのクレジット。",
+    "paymentMethod": {
+      "applePayDescription": { "annual": "年払い", "monthly": "月払い" },
+      "dev": {
+        "anyNumbers": "任意の数字",
+        "cardNumber": "カード番号",
+        "cvcZip": "CVC / 郵便番号",
+        "developmentMode": "開発モード",
+        "expirationDate": "有効期限",
+        "testCardInfo": "テストカード情報"
+      }
+    },
+    "paymentMethods__label": "支払い方法",
+    "pricingTable": {
+      "billingCycle": "請求サイクル",
+      "included": "含まれる内容",
+      "seatCost": { "tooltip": {} }
+    },
+    "prorationCredit": "按分クレジット",
+    "reSubscribe": "再契約する",
+    "seeAllFeatures": "全ての機能を見る",
+    "startFreeTrial": "無料トライアルを開始",
+    "startFreeTrial__days": "{{days}}日間の無料トライアルを開始",
+    "subscribe": "契約する",
+    "subscriptionDetails": {
+      "beginsOn": "開始日",
+      "currentBillingCycle": "現在の請求サイクル",
+      "endsOn": "終了日",
+      "firstPaymentAmount": "初回支払額",
+      "firstPaymentOn": "初回支払日",
+      "nextPaymentAmount": "次回支払額",
+      "nextPaymentOn": "次回支払日",
+      "pastDueAt": "支払い期限切れ日",
+      "renewsAt": "更新日",
+      "subscribedOn": "契約日",
+      "title": "サブスクリプション",
+      "trialEndsOn": "トライアル終了日",
+      "trialStartedOn": "トライアル開始日"
+    },
+    "subtotal": "小計",
+    "switchPlan": "このプランに切り替える",
+    "switchToAnnual": "年払いに切り替える",
+    "switchToAnnualWithAnnualPrice": "年払い {{price}} / 年 に切り替える",
+    "switchToMonthly": "月払いに切り替える",
+    "switchToMonthlyWithPrice": "月払い {{price}} / 月 に切り替える",
+    "totalDue": "支払い合計",
+    "totalDueToday": "本日のお支払合計",
+    "viewFeatures": "機能を見る",
+    "viewPayment": "支払いを表示",
+    "year": "年"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "権限をアップグレードするには、組織の管理者にお問い合わせください。",
+      "title": "シングルサインオン（SSO）を管理する権限がありません"
+    },
+    "navbar": { "title": "シングルサインオン（SSO）を設定" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "未確認",
+        "badge__verified": "確認済み",
+        "txtRecord": {
+          "hostLabel": "ホスト / 名前",
+          "instructions": "この TXT レコードを DNS プロバイダーに追加してください。レコードが有効になると自動的に確認します。",
+          "typeLabel": "タイプ",
+          "valueLabel": "値"
+        },
+        "verifiedAtLabel": "{{ date | shortDate('ja-JP') }} に確認"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "{{domain}} を追加",
+        "messageLabel": "あなたのメールは {{domain}} を使用しています。追加しますか？"
+      },
+      "formButtonPrimary__add": "追加",
+      "formFieldInputPlaceholder__domain": "ドメインを追加",
+      "formFieldLabel__domain": "ドメイン",
+      "removeDomainDialog": {},
+      "subtitle": "組織がサインインに使用するドメインを追加し、所有権を確認します。",
+      "title": "SSO ドメインを追加"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "カスタムSAMLプロバイダー",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "SSOを設定するプロバイダーを選択してください。",
+      "title": "プロバイダーを選択",
+      "warning": "プロバイダーを選択すると、設定が完了するまで変更できません"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "組織を作成する",
+    "invitePage": { "formButtonReset": "スキップ" },
+    "title": "組織の作成"
+  },
+  "dates": {
+    "lastDay": "昨日の{{ date | timeString('ja-JP') }}に",
+    "next6Days": "{{ date | weekday('ja-JP','long') }}の{{ date | timeString('ja-JP') }}に",
+    "nextDay": "明日の{{ date | timeString('ja-JP') }}に",
+    "numeric": "{{ date | numeric('ja-JP') }}に",
+    "previous6Days": "{{ date | weekday('ja-JP','long') }}の{{ date | timeString('ja-JP') }}に",
+    "sameDay": "今日の{{ date | timeString('ja-JP') }}に"
+  },
+  "dividerText": "または",
+  "footerActionLink__alternativePhoneCodeProvider": "代わりにSMSでコードを送信",
+  "footerActionLink__useAnotherMethod": "別の方法を使用する",
+  "footerPageLink__help": "ヘルプ",
+  "footerPageLink__privacy": "プライバシー",
+  "footerPageLink__terms": "利用規約",
+  "formButtonPrimary": "続ける",
+  "formButtonPrimary__verify": "確認する",
+  "formFieldAction__forgotPassword": "パスワードをお忘れですか？",
+  "formFieldError__matchingPasswords": "パスワードが一致します。",
+  "formFieldError__notMatchingPasswords": "パスワードが一致しません。",
+  "formFieldError__verificationLinkExpired": "検証リンクの有効期限が切れています。新しいリンクをリクエストしてください。",
+  "formFieldHintText__optional": "任意",
+  "formFieldHintText__slug": "Slugは人間が読める一意なIDで、URLでよく使われます。",
+  "formFieldInputPlaceholder__apiKeyDescription": "このキーを生成する理由を記入してください",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "日付を選択",
+  "formFieldInputPlaceholder__apiKeyName": "シークレットキー名を入力",
+  "formFieldInputPlaceholder__backupCode": "バックアップコードを入力",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "アカウント削除",
+  "formFieldInputPlaceholder__emailAddress": "メールアドレスを入力",
+  "formFieldInputPlaceholder__emailAddress_username": "メールアドレスまたはユーザー名",
+  "formFieldInputPlaceholder__emailAddresses": "example@email.com, example2@email.com",
+  "formFieldInputPlaceholder__firstName": "名",
+  "formFieldInputPlaceholder__lastName": "姓",
+  "formFieldInputPlaceholder__organizationDomain": "example.com",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "you@example.com",
+  "formFieldInputPlaceholder__organizationName": "組織名",
+  "formFieldInputPlaceholder__organizationSlug": "my-org",
+  "formFieldInputPlaceholder__password": "パスワードを入力",
+  "formFieldInputPlaceholder__phoneNumber": "電話番号を入力",
+  "formFieldInputPlaceholder__username": "ユーザー名を入力",
+  "formFieldInput__emailAddress_format": "例: name@example.com",
+  "formFieldLabel__apiKey": "APIキー",
+  "formFieldLabel__apiKeyDescription": "説明",
+  "formFieldLabel__apiKeyExpiration": "有効期限",
+  "formFieldLabel__apiKeyName": "シークレットキー名",
+  "formFieldLabel__automaticInvitations": "このドメインの自動招待を有効にする",
+  "formFieldLabel__backupCode": "バックアップコード",
+  "formFieldLabel__confirmDeletion": "削除の確認",
+  "formFieldLabel__confirmPassword": "パスワードの確認",
+  "formFieldLabel__currentPassword": "現在のパスワード",
+  "formFieldLabel__emailAddress": "メールアドレス",
+  "formFieldLabel__emailAddress_username": "メールアドレスまたはユーザー名",
+  "formFieldLabel__emailAddresses": "メールアドレス",
+  "formFieldLabel__firstName": "名",
+  "formFieldLabel__lastName": "姓",
+  "formFieldLabel__newPassword": "新しいパスワード",
+  "formFieldLabel__organizationDomain": "ドメイン",
+  "formFieldLabel__organizationDomainDeletePending": "保留中の招待と提案を削除",
+  "formFieldLabel__organizationDomainEmailAddress": "確認用のメールアドレス",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "このドメインを確認するためのコードを受け取るメールアドレスを入力してください。",
+  "formFieldLabel__organizationName": "組織名",
+  "formFieldLabel__organizationSlug": "Slug",
+  "formFieldLabel__passkeyName": "パスキー名",
+  "formFieldLabel__password": "パスワード",
+  "formFieldLabel__phoneNumber": "電話番号",
+  "formFieldLabel__role": "役割",
+  "formFieldLabel__signOutOfOtherSessions": "他の全てのデバイスからサインアウト",
+  "formFieldLabel__username": "ユーザー名",
+  "impersonationFab": {
+    "action__signOut": "サインアウト",
+    "title": "{{identifier}} としてサインイン中"
+  },
+  "lastAuthenticationStrategy": "最後に使用したもの",
+  "maintenanceMode": "現在メンテナンス中です。数分程度で完了する予定ですので、そのままお待ちください。",
+  "membershipRole__admin": "管理者",
+  "membershipRole__basicMember": "メンバー",
+  "membershipRole__guestMember": "ゲスト",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "組織を作成する",
+    "action__invitationAccept": "参加する",
+    "action__suggestionsAccept": "参加をリクエストする",
+    "createOrganization": "組織を作成",
+    "invitationAcceptedLabel": "参加しました",
+    "subtitle": "{{applicationName}} へ進む",
+    "suggestionsAcceptedLabel": "承認待ち",
+    "title": "アカウントを選択",
+    "titleWithoutPersonal": "組織を選択"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "APIキー" },
+    "badge__automaticInvitation": "自動招待",
+    "badge__automaticSuggestion": "自動提案",
+    "badge__manualInvitation": "自動登録なし",
+    "badge__unverified": "未確認",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "支払い履歴はありません",
+        "notFound": "該当する支払いが見つかりません",
+        "tableHeader__amount": "金額",
+        "tableHeader__date": "日付",
+        "tableHeader__status": "ステータス"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "デフォルトに設定",
+        "actionLabel__remove": "削除",
+        "add": "新しい支払い方法を追加",
+        "addSubtitle": "アカウントに新しい支払い方法を追加します。",
+        "cancelButton": "キャンセル",
+        "formButtonPrimary__add": "支払い方法を追加",
+        "formButtonPrimary__pay": "{{amount}}を支払う",
+        "payWithTestCardButton": "テストカードで支払う",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} はこのアカウントから削除されます。",
+          "messageLine2": "この支払い方法は使用できなくなり、この支払い方法に依存する定期サブスクリプションも動作しなくなります。",
+          "successMessage": "{{paymentMethod}} はアカウントから削除されました。",
+          "title": "支払い方法の削除"
+        },
+        "title": "支払い方法"
+      },
+      "start": {
+        "headerTitle__payments": "支払い",
+        "headerTitle__plans": "プラン",
+        "headerTitle__statements": "明細",
+        "headerTitle__subscriptions": "サブスクリプション"
+      },
+      "statementsSection": {
+        "empty": "表示する明細はありません",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} プランの支払い",
+        "itemCaption__payerCredit": "アカウント残高からのクレジット",
+        "itemCaption__proratedCredit": "前のサブスクリプションの未使用分に対する按分クレジット",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} プランの契約と支払いが完了しました",
+        "notFound": "明細が見つかりません",
+        "tableHeader__amount": "金額",
+        "tableHeader__date": "日付",
+        "title": "明細",
+        "totalPaid": "支払い合計"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "管理",
+        "actionLabel__newSubscription": "プランに申し込む",
+        "actionLabel__switchPlan": "プランを切り替える",
+        "tableHeader__edit": "編集",
+        "tableHeader__plan": "プラン",
+        "tableHeader__startDate": "開始日",
+        "title": "サブスクリプション"
+      },
+      "subscriptionsSection": { "actionLabel__default": "管理" },
+      "switchPlansSection": { "title": "プランを切り替える" },
+      "title": "請求"
+    },
+    "createDomainPage": {
+      "subtitle": "ドメインを追加して検証します。このドメインのメールアドレスを持つユーザーは、自動的に組織に参加するか、参加をリクエストすることができます。",
+      "title": "ドメインを追加"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "招待状を送信できませんでした。以下のメールアドレスには既に保留中の招待があります: {{email_addresses}}",
+      "formButtonPrimary__continue": "招待状を送信する",
+      "selectDropdown__role": "役割を選択",
+      "subtitle": "1つ以上のメールアドレスを入力または貼り付けてください（スペースまたはカンマで区切る）",
+      "successMessage": "招待状が正常に送信されました",
+      "title": "メンバーを招待"
+    },
+    "membersPage": {
+      "action__invite": "招待",
+      "action__search": "検索",
+      "activeMembersTab": {
+        "menuAction__remove": "メンバーの削除",
+        "tableHeader__actions": "アクション",
+        "tableHeader__joined": "参加日時",
+        "tableHeader__role": "役割",
+        "tableHeader__user": "ユーザー"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "利用可能なロールを更新しています。完了次第、ロールを再度更新できるようになります。",
+          "title": "ロールは一時的にロックされています"
+        }
+      },
+      "detailsTitle__emptyRow": "表示するメンバーはありません",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "メールドメインを組織に接続することでユーザーを招待します。一致するメールドメインを持つユーザーは、いつでも組織に参加することができます。",
+          "headerTitle": "自動招待",
+          "primaryButton": "検証済みドメインを管理"
+        },
+        "table__emptyRow": "表示する招待はありません"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "招待を取り消す",
+        "tableHeader__invited": "招待済み"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "一致するメールドメインを持つユーザーは、組織への参加をリクエストする提案を受け取ることができます。",
+          "headerTitle": "自動提案",
+          "primaryButton": "検証済みドメインを管理"
+        },
+        "menuAction__approve": "承認",
+        "menuAction__reject": "拒否",
+        "tableHeader__requested": "アクセスをリクエストしました",
+        "table__emptyRow": "表示するリクエストはありません"
+      },
+      "start": {
+        "headerTitle__invitations": "招待",
+        "headerTitle__members": "メンバー",
+        "headerTitle__requests": "リクエスト"
+      }
+    },
+    "navbar": {
+      "apiKeys": "APIキー",
+      "billing": "請求",
+      "description": "組織を管理します。",
+      "general": "一般",
+      "members": "メンバー",
+      "title": "組織"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "この組織の請求を管理する権限がありません。"
+      },
+      "title": "プラン"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "続行するには \"{{organizationName}}\" と入力してください。",
+          "messageLine1": "この組織を削除してもよろしいですか？",
+          "messageLine2": "この操作は永久的で取り消すことはできません。",
+          "successMessage": "組織が削除されました。",
+          "title": "組織の削除"
+        },
+        "leaveOrganization": {
+          "actionDescription": "続行するには \"{{organizationName}}\" と入力してください。",
+          "messageLine1": "この組織から脱退してもよろしいですか？この組織とそのアプリケーションへのアクセスが失われます。",
+          "messageLine2": "この操作は永久的で取り消すことはできません。",
+          "successMessage": "組織から脱退しました。",
+          "title": "組織を脱退"
+        },
+        "title": "注意"
+      },
+      "domainSection": {
+        "menuAction__manage": "管理",
+        "menuAction__remove": "削除",
+        "menuAction__verify": "検証",
+        "primaryButton": "ドメインを追加",
+        "subtitle": "検証済みのメールドメインに基づいて、ユーザーが自動的に組織に参加するか、参加をリクエストすることを許可します。",
+        "title": "検証済みドメイン"
+      },
+      "successMessage": "組織が更新されました。",
+      "title": "プロフィールの更新"
+    },
+    "removeDomainPage": {
+      "messageLine1": "メールドメイン {{domain}} が削除されます。",
+      "messageLine2": "この後、ユーザーは自動的に組織に参加することができなくなります。",
+      "successMessage": "{{domain}} が削除されました。",
+      "title": "ドメインの削除"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "一般",
+      "headerTitle__members": "メンバー",
+      "profileSection": {
+        "primaryButton": "プロフィールを更新",
+        "title": "組織プロフィール",
+        "uploadAction__title": "ロゴ"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "このドメインを削除すると、招待されたユーザーに影響が出ます。",
+        "removeDomainActionLabel__remove": "ドメインを削除",
+        "removeDomainSubtitle": "検証済みドメインからこのドメインを削除します",
+        "removeDomainTitle": "ドメインの削除"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "サインアップ時にユーザーは自動的に組織に招待され、いつでも参加することができます。",
+        "automaticInvitationOption__label": "自動招待",
+        "automaticSuggestionOption__description": "ユーザーは組織への参加をリクエストする提案を受け取りますが、参加する前に管理者の承認が必要です。",
+        "automaticSuggestionOption__label": "自動提案",
+        "calloutInfoLabel": "新しいユーザーにのみ登録モードの変更が影響します。",
+        "calloutInvitationCountLabel": "ユーザーに送信された保留中の招待状: {{count}}",
+        "calloutSuggestionCountLabel": "ユーザーに送信された保留中の提案: {{count}}",
+        "manualInvitationOption__description": "ユーザーは組織に手動で招待されることのみが可能です。",
+        "manualInvitationOption__label": "自動登録なし",
+        "subtitle": "このドメインのユーザーが組織に参加する方法を選択してください。"
+      },
+      "start": {
+        "headerTitle__danger": "危険",
+        "headerTitle__enrollment": "登録オプション"
+      },
+      "subtitle": "ドメイン {{domain}} が検証されました。登録モードを選択して続行してください。",
+      "title": "{{domain}} の更新"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "メールアドレスに送信された検証コードを入力してください",
+      "formTitle": "検証コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "ドメイン {{domainName}} はメールで検証する必要があります。",
+      "subtitleVerificationCodeScreen": "{{emailAddress}} に検証コードが送信されました。コードを入力して続行してください。",
+      "title": "ドメインを検証"
+    }
+  },
+  "organizationSwitcher": {
+    "action__closeOrganizationSwitcher": "組織スイッチャーを閉じる",
+    "action__createOrganization": "組織の作成",
+    "action__invitationAccept": "参加する",
+    "action__manageOrganization": "組織の管理",
+    "action__openOrganizationSwitcher": "組織スイッチャーを開く",
+    "action__suggestionsAccept": "参加をリクエストする",
+    "notSelected": "組織が選択されていません",
+    "personalWorkspace": "個人ワークスペース",
+    "suggestionsAcceptedLabel": "承認待ち"
+  },
+  "paginationButton__next": "次へ",
+  "paginationButton__previous": "前へ",
+  "paginationRowText__displaying": "表示中",
+  "paginationRowText__of": "全",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "ヘルプを取得",
+      "actionText": "これらのいずれもお持ちでないですか？",
+      "blockButton__backupCode": "バックアップコードを使用する",
+      "blockButton__emailCode": "{{identifier}} にメールコードを送信",
+      "blockButton__passkey": "パスキーを使用する",
+      "blockButton__password": "パスワードで続行",
+      "blockButton__phoneCode": "{{identifier}} にSMSコードを送信",
+      "blockButton__totp": "認証アプリを使用する",
+      "getHelp": {
+        "blockButton__emailSupport": "メールサポート",
+        "content": "アカウントの確認に問題がある場合は、メールでお問い合わせいただければ、できるだけ早くアクセスを回復できるよう対応いたします。",
+        "title": "ヘルプを取得"
+      },
+      "subtitle": "問題が発生していますか？これらの方法のいずれかを使用して本人確認を行うことができます。",
+      "title": "別の方法を使用"
+    },
+    "backupCodeMfa": {
+      "subtitle": "二段階認証の設定時に受け取ったバックアップコードを入力してください",
+      "title": "バックアップコードを入力"
+    },
+    "emailCode": {
+      "formTitle": "検証コード",
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "続行するには、メールに送信されたコードを入力してください",
+      "title": "確認が必要です"
+    },
+    "noAvailableMethods": {
+      "message": "確認を続行できません。利用可能な認証要素が設定されていません。",
+      "subtitle": "エラーが発生しました",
+      "title": "アカウントを確認できません"
+    },
+    "passkey": {
+      "blockButton__passkey": "パスキーを使用する",
+      "subtitle": "パスキーを使用すると、ご本人であることを確認できます。デバイスから指紋認証、顔認証、または画面ロックの解除を求められる場合があります。",
+      "title": "パスキーを使用する"
+    },
+    "password": {
+      "actionLink": "別の方法を使用",
+      "subtitle": "続行するには現在のパスワードを入力してください",
+      "title": "確認が必要です"
+    },
+    "phoneCode": {
+      "formTitle": "検証コード",
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "続行するには、電話に送信されたコードを入力してください",
+      "title": "確認が必要です"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "検証コード",
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "続行するには、電話に送信されたコードを入力してください",
+      "title": "確認が必要です"
+    },
+    "totpMfa": {
+      "formTitle": "検証コード",
+      "subtitle": "続行するには、認証アプリで生成されたコードを入力してください",
+      "title": "確認が必要です"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "アカウントを追加",
+      "action__signOutAll": "全てのアカウントからサインアウト",
+      "subtitle": "続行するアカウントを選択してください。",
+      "title": "アカウントを選択"
+    },
+    "alternativeMethods": {
+      "actionLink": "ヘルプを取得",
+      "actionText": "これらのいずれも持っていませんか？",
+      "blockButton__backupCode": "バックアップコードを使用する",
+      "blockButton__emailCode": "{{identifier}}にメールコードを送信",
+      "blockButton__emailLink": "{{identifier}}にメールリンクを送信",
+      "blockButton__passkey": "パスキーでサインインする",
+      "blockButton__password": "パスワードでサインインする",
+      "blockButton__phoneCode": "{{identifier}}にSMSコードを送信",
+      "blockButton__totp": "認証アプリを使用する",
+      "getHelp": {
+        "blockButton__emailSupport": "メールサポート",
+        "content": "アカウントにサインインできない場合は、メールでお問い合わせいただければ、できるだけ早くアクセスを回復するためにお手伝いいたします。",
+        "title": "ヘルプを取得"
+      },
+      "subtitle": "問題が発生していますか？これらの方法を使用してサインインすることができます。",
+      "title": "別の方法を使用"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "検証コード",
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "{{provider}} を確認してください"
+    },
+    "backupCodeMfa": {
+      "subtitle": "バックアップコードは、二段階認証の設定時に受け取ったものです",
+      "title": "バックアップコードを入力"
+    },
+    "emailCode": {
+      "formTitle": "検証コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "メールを確認"
+    },
+    "emailCodeMfa": {
+      "formTitle": "メールを確認",
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "メールを確認"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "続行するには、サインインを開始したデバイスとブラウザで検証リンクを開いてください",
+        "title": "このデバイスでは検証リンクが無効です"
+      },
+      "expired": {
+        "subtitle": "元のタブに戻って続行してください。",
+        "title": "この検証リンクは期限切れです"
+      },
+      "failed": {
+        "subtitle": "元のタブに戻って続行してください。",
+        "title": "この検証リンクは無効です"
+      },
+      "formSubtitle": "メールに送信された検証リンクを使用してください",
+      "formTitle": "検証リンク",
+      "loading": {
+        "subtitle": "まもなくリダイレクトされます",
+        "title": "サインイン中..."
+      },
+      "resendButton": "リンクを再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "メールを確認",
+      "unusedTab": { "title": "このタブを閉じてもかまいません" },
+      "verified": {
+        "subtitle": "まもなくリダイレクトされます",
+        "title": "サインインが完了しました"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "続行するには元のタブに戻ってください",
+        "subtitleNewTab": "新しく開いたタブに戻って続行してください",
+        "titleNewTab": "他のタブでサインイン済み"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "メールに送信された確認リンクを使用してください",
+      "resendButton": "リンクが届いていませんか？再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "メールを確認してください"
+    },
+    "enterpriseConnections": {
+      "subtitle": "続行するエンタープライズアカウントを選択してください。",
+      "title": "エンタープライズアカウントを選択"
+    },
+    "forgotPassword": {
+      "formTitle": "パスワードリセットコード",
+      "resendButton": "コードを再送信",
+      "subtitle": "パスワードをリセットするために",
+      "subtitle_email": "まず、メールアドレスに送信されたコードを入力してください",
+      "subtitle_phone": "まず、電話に送信されたコードを入力してください",
+      "title": "パスワードをリセット"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "パスワードをリセット",
+      "label__alternativeMethods": "または、別の方法でサインインしてください。",
+      "title": "パスワードをお忘れですか？"
+    },
+    "newDeviceVerificationNotice": "新しいデバイスからサインインしています。アカウントのセキュリティを保つため、確認をお願いしています。",
+    "noAvailableMethods": {
+      "message": "サインインできません。利用可能な認証方法がありません。",
+      "subtitle": "エラーが発生しました",
+      "title": "サインインできません"
+    },
+    "passkey": {
+      "subtitle": "パスキーを使用すると、ご本人であることを確認できます。デバイスから指紋認証、顔認証、または画面ロックの解除を求められる場合があります。",
+      "title": "パスキーを使用する"
+    },
+    "password": {
+      "actionLink": "別の方法を使用",
+      "subtitle": "アカウントに関連付けられたパスワードを入力してください",
+      "title": "パスワードを入力"
+    },
+    "passwordCompromised": { "title": "漏洩したパスワード" },
+    "passwordPwned": { "title": "漏洩したパスワード" },
+    "passwordUntrusted": { "title": "信頼できないパスワード" },
+    "phoneCode": {
+      "formTitle": "検証コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "電話を確認してください"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "検証コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "続行するには、電話に送信された検証コードを入力してください",
+      "title": "電話を確認してください"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "パスワードをリセット",
+      "requiredMessage": "セキュリティ上の理由から、パスワードのリセットが必要です。",
+      "successMessage": "パスワードが正常に変更されました。お待ちください、サインインしています。",
+      "title": "パスワードをリセット"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "パスワードをリセットする前に、身元を確認する必要があります。"
+    },
+    "start": {
+      "actionLink": "サインアップ",
+      "actionLink__join_waitlist": "ウェイトリストに登録",
+      "actionLink__use_email": "メールアドレスを使用",
+      "actionLink__use_email_username": "メールアドレスまたはユーザー名を使用",
+      "actionLink__use_passkey": "代わりにパスキーを使用",
+      "actionLink__use_phone": "電話番号を使用",
+      "actionLink__use_username": "ユーザー名を使用",
+      "actionText": "アカウントをお持ちでないですか？",
+      "actionText__join_waitlist": "先行体験にご興味ありますか？",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "別の方法を使用",
+        "label": "{{provider}} の電話番号",
+        "subtitle": "{{provider}} で検証コードを受け取るための電話番号を入力してください。",
+        "title": "{{provider}} を使って {{applicationName}} にサインイン"
+      },
+      "subtitle": "お帰りなさい！続行するにはサインインしてください",
+      "subtitleCombined": "お帰りなさい！続行するにはサインインしてください",
+      "title": "{{applicationName}} にサインイン",
+      "titleCombined": "{{applicationName}} へ進む"
+    },
+    "totpMfa": {
+      "formTitle": "検証コード",
+      "subtitle": "続行するには、認証アプリで生成された検証コードを入力してください",
+      "title": "二段階認証"
+    },
+    "web3Solana": {
+      "subtitle": "サインインするには下のウォレットを選択してください",
+      "title": "Solana でサインイン"
+    }
+  },
+  "signInEnterPasswordTitle": "パスワードを入力してください",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "コードが届いていませんか？再送信",
+      "subtitle": "{{provider}} に送信された確認コードを入力してください",
+      "title": "{{provider}} を確認してください"
+    },
+    "continue": {
+      "actionLink": "サインイン",
+      "actionText": "アカウントをお持ちですか？",
+      "subtitle": "続行するには残りの詳細を入力してください",
+      "title": "未入力のフィールドを入力"
+    },
+    "emailCode": {
+      "formSubtitle": "メールアドレスに送信された確認コードを入力してください",
+      "formTitle": "確認コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "メールに送信された確認コードを入力してください",
+      "title": "メールアドレスを確認"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "続行するには、サインアップを開始したデバイスとブラウザで検証リンクを開いてください",
+        "title": "このデバイスでは検証リンクが無効です"
+      },
+      "formSubtitle": "メールアドレスに送信された確認リンクを使用してください",
+      "formTitle": "確認リンク",
+      "loading": { "title": "登録中..." },
+      "resendButton": "リンクを再送信",
+      "subtitle": "{{applicationName}} へ進む",
+      "title": "メールアドレスを確認",
+      "verified": { "title": "登録が完了しました" },
+      "verifiedSwitchTab": {
+        "subtitle": "続行するために新しく開いたタブに戻ってください",
+        "subtitleNewTab": "続行するために前のタブに戻ってください",
+        "title": "メールアドレスが正常に確認されました"
+      }
+    },
+    "enterpriseConnections": {
+      "subtitle": "続行するエンタープライズアカウントを選択してください。",
+      "title": "エンタープライズアカウントを選択"
+    },
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "{{privacyPolicyLink || link(\"個人情報保護方針\")}}に同意します",
+        "label__onlyTermsOfService": "{{termsOfServiceLink || link(\"利用規約\")}}に同意します",
+        "label__termsOfServiceAndPrivacyPolicy": "{{termsOfServiceLink || link(\"利用規約\")}}と{{privacyPolicyLink || link(\"個人情報保護方針\")}}に同意します"
+      },
+      "continue": {
+        "subtitle": "続行する前に、利用条件を読み同意してください",
+        "title": "法的同意"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "電話番号に送信された確認コードを入力してください",
+      "formTitle": "確認コード",
+      "resendButton": "コードを再送信",
+      "subtitle": "電話に送信された確認コードを入力してください",
+      "title": "電話番号を確認"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "サインイン",
+      "actionText": "既にアカウントをお持ちですか？",
+      "blockButton__emailSupport": "サポートに連絡",
+      "blockButton__joinWaitlist": "待機リストに参加",
+      "subtitle": "現在サインアップは無効になっています。アクセス権限があると思われる場合は、サポートまでご連絡ください。",
+      "subtitleWaitlist": "現在サインアップは無効になっています。リリース時に最初に通知を受け取るには、待機リストにご参加ください。",
+      "title": "アクセス制限"
+    },
+    "start": {
+      "actionLink": "サインイン",
+      "actionLink__use_email": "代わりにメールアドレスを使用",
+      "actionLink__use_phone": "代わりに電話番号を使用",
+      "actionText": "アカウントをお持ちですか？",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "別の方法を使用",
+        "label": "{{provider}} の電話番号",
+        "subtitle": "{{provider}} で検証コードを受け取るための電話番号を入力してください。",
+        "title": "{{provider}} を使って {{applicationName}} にサインアップ"
+      },
+      "subtitle": "ようこそ！始めるには詳細を入力してください",
+      "subtitleCombined": "ようこそ！始めるには詳細を入力してください",
+      "title": "アカウントを作成",
+      "titleCombined": "アカウントを作成"
+    },
+    "web3Solana": {
+      "subtitle": "サインアップするには下のウォレットを選択してください",
+      "title": "Solana でサインアップ"
+    }
+  },
+  "socialButtonsBlockButton": "{{provider|titleize}}で続ける",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "検出された会社名 ({{organizationName}}) と {{organizationDomain}} に対応する組織は既に存在します。招待を受けて参加してください。"
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "新しい組織を作成",
+      "action__invitationAccept": "参加する",
+      "action__suggestionsAccept": "参加をリクエストする",
+      "subtitle": "既存の組織に参加するか、新しい組織を作成します",
+      "subtitle__createOrganizationDisabled": "既存の組織に参加する",
+      "suggestionsAcceptedLabel": "承認待ち",
+      "title": "組織を選択"
+    },
+    "createOrganization": {
+      "formButtonReset": "キャンセル",
+      "formButtonSubmit": "続行",
+      "formFieldInputPlaceholder__name": "私の組織",
+      "formFieldInputPlaceholder__slug": "my-organization",
+      "formFieldLabel__name": "名前",
+      "formFieldLabel__slug": "Slug",
+      "subtitle": "続行するには組織の詳細を入力してください",
+      "title": "組織をセットアップ"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "招待を受けるには組織の管理者にお問い合わせください。",
+      "title": "組織に所属する必要があります"
+    },
+    "signOut": {
+      "actionLink": "サインアウト",
+      "actionText": "{{identifier}} としてサインイン中"
+    }
+  },
+  "taskResetPassword": {
+    "formButtonPrimary": "パスワードをリセット",
+    "signOut": {
+      "actionLink": "サインアウト",
+      "actionText": "{{identifier}} としてサインイン中"
+    },
+    "subtitle": "続行するには、アカウントの新しいパスワードを設定する必要があります",
+    "title": "パスワードをリセット"
+  },
+  "taskSetupMfa": {
+    "badge": "二段階認証の設定",
+    "signOut": {
+      "actionLink": "サインアウト",
+      "actionText": "{{identifier}} としてサインイン中"
+    },
+    "smsCode": {
+      "addPhone": {
+        "formButtonPrimary": "続行",
+        "infoText": "この電話番号に確認コードを含むSMSが送信されます。通信料がかかる場合があります。"
+      },
+      "addPhoneNumber": "電話番号を追加",
+      "cancel": "キャンセル",
+      "subtitle": "SMSコードによる二段階認証に使用する電話番号を選択してください",
+      "success": {
+        "finishButton": "続行",
+        "message1": "二段階認証が有効になりました。サインイン時に、この電話番号に送信される確認コードを追加の手順として入力する必要があります。",
+        "message2": "これらのバックアップコードを保存し、安全な場所に保管してください。認証デバイスにアクセスできなくなった場合は、バックアップコードを使ってサインインできます。",
+        "title": "SMSコード認証が有効になりました"
+      },
+      "title": "SMSコード認証を追加",
+      "verifyPhone": {
+        "formButtonPrimary": "続行",
+        "formTitle": "検証コード",
+        "resendButton": "コードを再送信",
+        "subtitle": "次の宛先に送信された確認コードを入力してください",
+        "title": "電話番号を確認"
+      }
+    },
+    "start": {
+      "methodSelection": { "phoneCode": "SMSコード", "totp": "認証アプリ" },
+      "subtitle": "追加のセキュリティでアカウントを保護するために、希望する方法を選択してください",
+      "title": "二段階認証を設定"
+    },
+    "totpCode": {
+      "addAuthenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "代わりにQRコードをスキャン",
+        "buttonUnableToScan__nonPrimary": "QRコードをスキャンできませんか？",
+        "formButtonPrimary": "続行",
+        "formButtonReset": "キャンセル",
+        "infoText__ableToScan": "認証アプリで新しいサインイン方法を設定し、次のQRコードをスキャンしてアカウントにリンクしてください。",
+        "infoText__unableToScan": "認証アプリで新しいサインイン方法を設定し、以下のキーを入力してください。",
+        "inputLabel__unableToScan1": "時間ベースまたはワンタイムパスワードが有効になっていることを確認してから、アカウントのリンクを完了してください。"
+      },
+      "success": {
+        "finishButton": "続行",
+        "message1": "二段階認証が有効になりました。サインイン時に、この認証アプリの確認コードを追加の手順として入力する必要があります。",
+        "message2": "これらのバックアップコードを保存し、安全な場所に保管してください。認証デバイスにアクセスできなくなった場合は、バックアップコードを使ってサインインできます。",
+        "title": "認証アプリ認証が有効になりました"
+      },
+      "title": "認証アプリを追加",
+      "verifyTotp": {
+        "formButtonPrimary": "続行",
+        "formButtonReset": "キャンセル",
+        "formTitle": "検証コード",
+        "subtitle": "認証アプリで生成された確認コードを入力してください",
+        "title": "認証アプリを追加"
+      }
+    }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}} は既にこの組織のメンバーです。",
+    "avatar_file_size_exceeded": "ファイルサイズが10MBの上限を超えています。より小さいファイルを選択してください。",
+    "avatar_file_type_invalid": "サポートされていないファイル形式です。JPG、PNG、GIF、またはWEBP画像をアップロードしてください。",
+    "captcha_invalid": "セキュリティ検証に失敗しました。もう一度お試しください。",
+    "captcha_unavailable": "ボット検証に失敗したため、サインアップに失敗しました。ページを更新して再試行するか、サポートに連絡してさらに支援を受けてください。",
+    "form_code_incorrect": "入力されたコードが正しくありません。",
+    "form_email_address_blocked": "一時的なメールサービスはサポートされていません。アカウントを作成するには、通常のメールアドレスを使用してください。",
+    "form_identifier_exists__email_address": "このメールアドレスは既に使用されています。別のものをお試しください。",
+    "form_identifier_exists__phone_number": "この電話番号は既に使用されています。別のものをお試しください。",
+    "form_identifier_exists__username": "このユーザー名は既に使用されています。別のものをお試しください。",
+    "form_identifier_not_found": "その情報に一致するアカウントが見つかりませんでした。",
+    "form_new_password_matches_current": "新しいパスワードを現在のパスワードと同じにすることはできません。",
+    "form_param_format_invalid": "入力された値の形式が正しくありません。確認して修正してください。",
+    "form_param_format_invalid__email_address": "メールアドレスの形式が正しくありません。",
+    "form_param_format_invalid__phone_number": "電話番号は有効な国際形式で入力してください。",
+    "form_param_max_length_exceeded__first_name": "名は256文字以内で入力してください。",
+    "form_param_max_length_exceeded__last_name": "姓は256文字以内で入力してください。",
+    "form_param_max_length_exceeded__name": "名前は256文字以内で入力してください。",
+    "form_param_nil": "この項目は必須です。空欄にはできません。",
+    "form_param_type_invalid": "入力された値の型が正しくありません。",
+    "form_param_type_invalid__email_address": "メールアドレスは有効な文字列である必要があります。",
+    "form_param_type_invalid__phone_number": "電話番号は有効な文字列である必要があります。",
+    "form_param_value_invalid": "入力された値が無効です。修正してください。",
+    "form_password_compromised__sign_in": "このパスワードは侵害された可能性があります。アカウントを保護するため、別のサインイン方法を使用してください。サインイン後にパスワードのリセットが必要になります。",
+    "form_password_incorrect": "入力されたパスワードが正しくありません。もう一度お試しください。",
+    "form_password_length_too_short": "パスワードが短すぎます。8文字以上である必要があります。",
+    "form_password_not_strong_enough": "パスワードの強度が不十分です。",
+    "form_password_or_identifier_incorrect": "パスワードまたはメールアドレスが正しくありません。もう一度お試しいただくか、別の方法をご利用ください。",
+    "form_password_pwned": "このパスワードは侵害の一部として見つかったため使用できません。別のパスワードを試してください。",
+    "form_password_pwned__sign_in": "このパスワードは侵害の一部として見つかったため使用できません。パスワードをリセットしてください。",
+    "form_password_size_in_bytes_exceeded": "パスワードのバイト数が上限を超えています。短くするか、一部の特殊文字を削除してください。",
+    "form_password_untrusted__sign_in": "このパスワードは安全でない可能性があります。アカウントを保護するため、別のサインイン方法を使用してください。サインイン後にパスワードのリセットが必要になります。",
+    "form_password_validation_failed": "パスワードが間違っています",
+    "form_username_invalid_character": "ユーザー名に無効な文字が含まれています。",
+    "form_username_invalid_length": "ユーザー名は{{min_length}}文字以上{{max_length}}文字以下である必要があります。",
+    "form_username_needs_non_number_char": "ユーザー名には少なくとも1つの数字以外の文字が含まれている必要があります。",
+    "identification_deletion_failed": "最後の識別情報は削除できません。",
+    "not_allowed_access": "メールアドレスまたは電話番号は登録に使用できません。これは、'+', '=', '#' または '.' がメールアドレスに使用されているか、一時的な電子メールサービスに接続されたドメインが使用されているか、明示的な除外が行われているためです。エラーが発生した場合は、サポートに連絡してください。",
+    "organization_domain_blocked": "このメールプロバイダーのドメインはブロックされています。別のものを使用してください。",
+    "organization_domain_common": "これは一般的なメールプロバイダーのドメインです。別のものを使用してください。",
+    "organization_domain_exists_for_enterprise_connection": "このドメインは組織の SSO で既に使用されています。",
+    "organization_membership_quota_exceeded": "保留中の招待を含め、組織のメンバー数の上限に達しました。",
+    "organization_minimum_permissions_needed": "必要な最小権限を持つ組織メンバーが少なくとも1人必要です。",
+    "organization_not_found_or_unauthorized": "この組織のメンバーではなくなりました。別の組織を選択するか、新しく作成してください。",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "この組織のメンバーではなくなりました。別の組織を選択してください。",
+    "passkey_already_exists": "このデバイスには既にパスキーが登録されています。",
+    "passkey_not_supported": "このデバイスではパスキーはサポートされていません。",
+    "passkey_pa_not_supported": "登録にはプラットフォーム認証器が必要ですが、このデバイスは対応していません。",
+    "passkey_registration_cancelled": "パスキーの登録はキャンセルされたか、タイムアウトしました。",
+    "passkey_retrieval_cancelled": "パスキーの確認はキャンセルされたか、タイムアウトしました。",
+    "passwordComplexity": {
+      "maximumLength": "{{length}}文字未満",
+      "minimumLength": "{{length}}文字以上",
+      "requireLowercase": "小文字を含む",
+      "requireNumbers": "数字を含む",
+      "requireSpecialCharacter": "特殊文字を含む",
+      "requireUppercase": "大文字を含む",
+      "sentencePrefix": "パスワードは次の条件を満たす必要があります："
+    },
+    "phone_number_exists": "この電話番号は既に使用されています。別のものをお試しください。",
+    "session_exists": "既にサインインしています。",
+    "web3_missing_identifier": "Web3ウォレット拡張機能が見つかりません。続行するにはインストールしてください。",
+    "web3_signature_request_rejected": "署名リクエストを拒否しました。続行するにはもう一度お試しください。",
+    "web3_solana_signature_generation_failed": "署名の生成中にエラーが発生しました。続行するにはもう一度お試しください。",
+    "zxcvbn": {
+      "couldBeStronger": "パスワードは有効ですが、もう少し強化できます。文字を追加してみてください。",
+      "goodPassword": "パスワードは全ての要件を満たしています。",
+      "notEnough": "パスワードの強度が十分ではありません。",
+      "suggestions": {
+        "allUppercase": "全ての文字を大文字にするのではなく、一部の文字を大文字にしてください。",
+        "anotherWord": "より一般的でない単語を追加してください。",
+        "associatedYears": "自分に関連する年号は避けてください。",
+        "capitalization": "最初の文字以外も大文字にしてください。",
+        "dates": "自分に関連する日付や年号は避けてください。",
+        "l33t": "予測可能な文字の代替（例：'@' で 'a' を置き換える）を避けてください。",
+        "longerKeyboardPattern": "長いキーボードパターンを使用し、タイピングの方向を複数回変えてください。",
+        "noNeed": "シンボル、数字、大文字の使用なしでも強力なパスワードを作成できます。",
+        "pwned": "他の場所でこのパスワードを使用している場合は、変更する必要があります。",
+        "recentYears": "最近の年号は避けてください。",
+        "repeated": "繰り返される単語や文字を避けてください。",
+        "reverseWords": "一般的な単語の逆さ読みは避けてください。",
+        "sequences": "一般的な文字の並びを避けてください。",
+        "useWords": "複数の単語を使用してくださいが、一般的なフレーズは避けてください。"
+      },
+      "warnings": {
+        "common": "これは一般的に使われるパスワードです。",
+        "commonNames": "一般的な名前や姓は推測しやすいです。",
+        "dates": "日付は推測しやすいです。",
+        "extendedRepeat": "\"abcabcabc\" といった繰り返しパターンは推測しやすいです。",
+        "keyPattern": "短いキーボードパターンは推測しやすいです。",
+        "namesByThemselves": "単体の名前や姓は推測しやすいです。",
+        "pwned": "このパスワードはインターネット上のデータ侵害によって公開されています。",
+        "recentYears": "最近の年号は推測しやすいです。",
+        "sequences": "\"abc\" といった一般的な文字の並びは推測しやすいです。",
+        "similarToCommon": "これは一般的に使われるパスワードに類似しています。",
+        "simpleRepeat": "\"aaa\" といった繰り返し文字は推測しやすいです。",
+        "straightRow": "キーボード上の連続した行は推測しやすいです。",
+        "topHundred": "これは頻繁に使われるパスワードです。",
+        "topTen": "これはよく使われるパスワードです。",
+        "userInputs": "個人情報やページに関連するデータは含まれていないはずです。",
+        "wordByItself": "単語単体では推測しやすいです。"
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "アカウントの追加",
+    "action__closeUserMenu": "ユーザーメニューを閉じる",
+    "action__manageAccount": "アカウントの管理",
+    "action__openUserMenu": "ユーザーメニューを開く",
+    "action__signOut": "サインアウト",
+    "action__signOutAll": "全てのアカウントからサインアウト",
+    "label__accountActions": "アカウント操作",
+    "label__activeSessions": "アクティブセッション",
+    "label__userButtonPopover": "アカウントパネル"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "APIキー" },
+    "backupCodePage": {
+      "actionLabel__copied": "コピー済み！",
+      "actionLabel__copy": "全てコピー",
+      "actionLabel__download": ".txtでダウンロード",
+      "actionLabel__print": "印刷",
+      "infoText1": "このアカウントではバックアップコードが有効になります。",
+      "infoText2": "バックアップコードは秘密に保管し、安全に保存してください。疑わしい場合はバックアップコードを再生成することができます。",
+      "subtitle__codelist": "バックアップコードを安全に保管し、秘密にしてください。",
+      "successMessage": "バックアップコードが有効になりました。認証デバイスにアクセスできない場合、これらのいずれかを使用してアカウントにサインインできます。各コードは一度しか使用できません。",
+      "successSubtitle": "認証デバイスにアクセスできない場合、これらのいずれかを使用してアカウントにサインインできます。",
+      "title": "バックアップコードの追加",
+      "title__codelist": "バックアップコード"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "支払い履歴はありません",
+        "notFound": "該当する支払いが見つかりません",
+        "tableHeader__amount": "金額",
+        "tableHeader__date": "日付",
+        "tableHeader__status": "ステータス"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "デフォルトに設定",
+        "actionLabel__remove": "削除",
+        "add": "新しい支払い方法を追加",
+        "addSubtitle": "アカウントに新しい支払い方法を追加します。",
+        "cancelButton": "キャンセル",
+        "formButtonPrimary__add": "支払い方法を追加",
+        "formButtonPrimary__pay": "{{amount}}を支払う",
+        "payWithTestCardButton": "テストカードで支払う",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} はこのアカウントから削除されます。",
+          "messageLine2": "この支払い元は使用できなくなり、この支払い元に依存する定期サブスクリプションも動作しなくなります。",
+          "successMessage": "{{paymentMethod}} はアカウントから削除されました。",
+          "title": "支払い方法の削除"
+        },
+        "title": "支払い方法"
+      },
+      "start": {
+        "headerTitle__payments": "支払い",
+        "headerTitle__plans": "プラン",
+        "headerTitle__statements": "明細",
+        "headerTitle__subscriptions": "サブスクリプション"
+      },
+      "statementsSection": {
+        "empty": "表示する明細はありません",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} プランの支払い",
+        "itemCaption__payerCredit": "アカウント残高からのクレジット",
+        "itemCaption__proratedCredit": "前のサブスクリプションの未使用分に対する按分クレジット",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} プランの契約と支払いが完了しました",
+        "notFound": "明細が見つかりません",
+        "tableHeader__amount": "金額",
+        "tableHeader__date": "日付",
+        "title": "明細",
+        "totalPaid": "支払い合計"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "管理",
+        "actionLabel__newSubscription": "プランに申し込む",
+        "actionLabel__switchPlan": "プランを切り替える",
+        "tableHeader__edit": "編集",
+        "tableHeader__plan": "プラン",
+        "tableHeader__startDate": "開始日",
+        "title": "サブスクリプション"
+      },
+      "subscriptionsSection": { "actionLabel__default": "管理" },
+      "switchPlansSection": { "title": "プランを切り替える" },
+      "title": "請求"
+    },
+    "connectedAccountPage": {
+      "formHint": "アカウントを連携するプロバイダを選択してください。",
+      "formHint__noAccounts": "利用可能な外部アカウントプロバイダはありません。",
+      "removeResource": {
+        "messageLine1": "{{identifier}}はこのアカウントから削除されます。",
+        "messageLine2": "この連携アカウントを使用することはできなくなり、関連する機能も使用できなくなります。",
+        "successMessage": "{{connectedAccount}}がアカウントから削除されました。",
+        "title": "連携アカウントの削除"
+      },
+      "socialButtonsBlockButton": "{{provider|titleize}}",
+      "successMessage": "プロバイダがアカウントに追加されました",
+      "title": "連携アカウントの追加"
+    },
+    "deletePage": {
+      "actionDescription": "続行するには下記に \"アカウント削除\" と入力してください。",
+      "confirm": "アカウント削除",
+      "messageLine1": "アカウントを削除してもよろしいですか？一部の関連データが保持される場合があります。完全なデータ削除をリクエストするには、サポートにお問い合わせください。",
+      "messageLine2": "この操作は永久的で取り消すことはできません。",
+      "title": "アカウントの削除"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "このメールアドレスには検証コードが含まれたメールが送信されます。",
+        "formSubtitle": "{{identifier}}に送信された検証コードを入力してください。",
+        "formTitle": "検証コード",
+        "resendButton": "コードを再送信",
+        "successMessage": "メールアドレス{{identifier}}がアカウントに追加されました。"
+      },
+      "emailLink": {
+        "formHint": "このメールアドレスには検証リンクが含まれたメールが送信されます。",
+        "formSubtitle": "{{identifier}}に送信されたメールの検証リンクをクリックしてください。",
+        "formTitle": "検証リンク",
+        "resendButton": "リンクを再送信",
+        "successMessage": "メールアドレス{{identifier}}がアカウントに追加されました。"
+      },
+      "enterpriseSSOLink": {
+        "formButton": "クリックしてサインイン",
+        "formSubtitle": "{{identifier}} でサインインを完了してください"
+      },
+      "formHint": "このメールアドレスをアカウントに追加する前に、確認する必要があります。",
+      "removeResource": {
+        "messageLine1": "{{identifier}}はこのアカウントから削除されます。",
+        "messageLine2": "このメールアドレスを使用してのサインインはできなくなります。",
+        "successMessage": "{{emailAddress}}がアカウントから削除されました。",
+        "title": "メールアドレスの削除"
+      },
+      "title": "メールアドレスの追加",
+      "verifyTitle": "メールアドレスの確認"
+    },
+    "formButtonPrimary__add": "追加",
+    "formButtonPrimary__continue": "続行",
+    "formButtonPrimary__finish": "完了",
+    "formButtonPrimary__remove": "削除",
+    "formButtonPrimary__save": "保存",
+    "formButtonReset": "キャンセル",
+    "mfaPage": {
+      "formHint": "追加する方法を選択してください。",
+      "title": "二段階認証の追加"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "既存の番号を使用",
+      "primaryButton__addPhoneNumber": "電話番号を追加",
+      "removeResource": {
+        "messageLine1": "{{identifier}}はサインイン時に認証コードを受け取らなくなります。",
+        "messageLine2": "アカウントのセキュリティが低下する可能性があります。本当に削除しますか？",
+        "successMessage": "{{mfaPhoneCode}}のSMSコード二段階認証が削除されました。",
+        "title": "二段階認証の削除"
+      },
+      "subtitle__availablePhoneNumbers": "SMSコード二段階認証のために登録する電話番号を選択してください。",
+      "subtitle__unavailablePhoneNumbers": "SMSコード二段階認証のために利用可能な電話番号はありません。",
+      "successMessage1": "サインイン時には、追加のステップとしてこの電話番号に送信された検証コードを入力する必要があります。",
+      "successMessage2": "これらのバックアップコードを保存し、安全な場所に保管してください。認証デバイスへのアクセスを失った場合、バックアップコードを使用してサインインできます。",
+      "successTitle": "SMSコード認証が有効になりました",
+      "title": "SMSコード認証の追加"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "代わりにQRコードをスキャンする",
+        "buttonUnableToScan__nonPrimary": "QRコードをスキャンできませんか？",
+        "infoText__ableToScan": "認証アプリで新しいサインイン方法を設定し、以下のQRコードをスキャンしてアカウントとリンクさせます。",
+        "infoText__unableToScan": "認証アプリで新しいサインイン方法を設定し、以下のキーを入力してください。",
+        "inputLabel__unableToScan1": "タイムベースまたはワンタイムパスワードが有効になっていることを確認し、アカウントのリンクを完了してください。",
+        "inputLabel__unableToScan2": "また、認証アプリがTOTP URIをサポートしている場合は、完全なURIをコピーすることもできます。"
+      },
+      "removeResource": {
+        "messageLine1": "この認証アプリからの検証コードは、サインイン時には不要になります。",
+        "messageLine2": "アカウントのセキュリティが低下する可能性があります。本当に削除しますか？",
+        "successMessage": "認証アプリを使用した二段階認証が削除されました。",
+        "title": "二段階認証の削除"
+      },
+      "successMessage": "二段階認証が有効になりました。サインイン時には、この認証アプリからの検証コードを追加のステップとして入力する必要があります。",
+      "title": "認証アプリの追加",
+      "verifySubtitle": "認証アプリで生成された検証コードを入力してください。",
+      "verifyTitle": "検証コード"
+    },
+    "mobileButton__menu": "メニュー",
+    "navbar": {
+      "account": "プロフィール",
+      "apiKeys": "APIキー",
+      "billing": "請求",
+      "description": "アカウント情報管理",
+      "security": "セキュリティ",
+      "title": "アカウント"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "{{name}} はこのアカウントから削除されます。",
+        "title": "パスキーの削除"
+      },
+      "subtitle__rename": "見つけやすくするために、パスキー名を変更できます。",
+      "title__rename": "パスキー名の変更"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "古いパスワードを使用している可能性のある全てのデバイスからサインアウトすることをお勧めします。",
+      "readonly": "現在、エンタープライズ接続のみでサインインしているため、パスワードは編集できません。",
+      "successMessage__set": "パスワードが設定されました。",
+      "successMessage__signOutOfOtherSessions": "他の全てのデバイスからサインアウトされました。",
+      "successMessage__update": "パスワードが更新されました。",
+      "title__set": "パスワードの設定",
+      "title__update": "パスワードの更新"
+    },
+    "phoneNumberPage": {
+      "infoText": "この電話番号には検証コードが含まれたテキストメッセージが送信されます。メッセージおよびデータ料金が発生する場合があります。",
+      "removeResource": {
+        "messageLine1": "{{identifier}}はこのアカウントから削除されます。",
+        "messageLine2": "この電話番号を使用してのサインインはできなくなります。",
+        "successMessage": "{{phoneNumber}}がアカウントから削除されました。",
+        "title": "電話番号の削除"
+      },
+      "successMessage": "{{identifier}}がアカウントに追加されました。",
+      "title": "電話番号の追加",
+      "verifySubtitle": "{{identifier}}に送信された検証コードを入力してください",
+      "verifyTitle": "電話番号の確認"
+    },
+    "plansPage": { "title": "プラン" },
+    "profilePage": {
+      "fileDropAreaHint": "推奨サイズ 1:1、最大 10MB",
+      "imageFormDestructiveActionSubtitle": "削除",
+      "imageFormSubtitle": "アップロード",
+      "imageFormTitle": "プロフィール画像",
+      "readonly": "プロフィール情報はエンタープライズ接続によって提供されており、編集できません。",
+      "successMessage": "プロフィールが更新されました。",
+      "title": "プロフィールの更新"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "デバイスからサインアウト",
+        "title": "アクティブなデバイス"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "再接続",
+        "actionLabel__reauthorize": "今すぐ認証",
+        "destructiveActionTitle": "削除",
+        "primaryButton": "アカウントを連携する",
+        "subtitle__disconnected": "このアカウントは切断されています。",
+        "subtitle__reauthorize": "必要なスコープが更新され、機能が制限されている可能性があります。問題を避けるために、このアプリケーションを再認証してください。",
+        "title": "連携アカウント"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "アカウントの削除",
+        "title": "アカウントの削除"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "メールアドレスの削除",
+        "detailsAction__nonPrimary": "プライマリに設定する",
+        "detailsAction__primary": "確認を完了する",
+        "detailsAction__unverified": "確認する",
+        "primaryButton": "メールアドレスの追加",
+        "title": "メールアドレス"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "アカウントを連携する",
+        "title": "エンタープライズアカウント"
+      },
+      "headerTitle__account": "プロフィール詳細",
+      "headerTitle__security": "セキュリティ",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "コードを再生成",
+          "headerTitle": "バックアップコード",
+          "subtitle__regenerate": "安全な新しいバックアップコードを取得します。以前のバックアップコードは削除され、使用することはできません。",
+          "title__regenerate": "バックアップコードの再生成"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "デフォルトに設定",
+          "destructiveActionLabel": "削除"
+        },
+        "primaryButton": "二段階認証を追加する",
+        "title": "二段階認証",
+        "totp": {
+          "destructiveActionTitle": "削除",
+          "headerTitle": "認証アプリケーション"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "削除",
+        "menuAction__rename": "名前を変更",
+        "primaryButton": "パスキーを追加",
+        "title": "パスキー"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "パスワードを設定する",
+        "primaryButton__updatePassword": "パスワードを変更する",
+        "title": "パスワード"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "電話番号の削除",
+        "detailsAction__nonPrimary": "プライマリに設定する",
+        "detailsAction__primary": "確認を完了する",
+        "detailsAction__unverified": "電話番号を確認する",
+        "primaryButton": "電話番号の追加",
+        "title": "電話番号"
+      },
+      "profileSection": {
+        "primaryButton": "プロフィールを更新",
+        "title": "プロフィール"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "ユーザー名の設定",
+        "primaryButton__updateUsername": "ユーザー名の変更",
+        "title": "ユーザー名"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "ウォレットの削除",
+        "detailsAction__nonPrimary": "プライマリに設定する",
+        "primaryButton": "ウォレットを接続",
+        "title": "Web3ウォレット",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "アカウントに接続する Solana ウォレットを選択してください。",
+          "title": "Solana ウォレットを追加"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "ユーザー名が更新されました。",
+      "title__set": "ユーザー名の設定",
+      "title__update": "ユーザー名の更新"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}}はこのアカウントから削除されます。",
+        "messageLine2": "このWeb3ウォレットを使用してのサインインはできなくなります。",
+        "successMessage": "{{web3Wallet}}がアカウントから削除されました。",
+        "title": "Web3ウォレットの削除"
+      },
+      "subtitle__availableWallets": "アカウントに接続するWeb3ウォレットを選択してください。",
+      "subtitle__unavailableWallets": "利用可能なWeb3ウォレットはありません。",
+      "successMessage": "ウォレットがアカウントに追加されました。",
+      "title": "Web3ウォレットの追加",
+      "web3WalletButtonsBlockButton": "{{provider|titleize}}"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "サインイン",
+      "actionText": "既にアクセス権をお持ちですか？",
+      "formButton": "待機リストに参加",
+      "subtitle": "メールアドレスを入力していただければ、準備が整い次第お知らせいたします",
+      "title": "待機リストに参加"
+    },
+    "success": {
+      "message": "間もなくリダイレクトされます...",
+      "subtitle": "準備が整い次第ご連絡いたします",
+      "title": "待機リストへの参加ありがとうございます！"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "{{walletName}} で接続",
+    "continue": "{{walletName}} で続行",
+    "noneAvailable": "Solana Web3 ウォレットが検出されませんでした。Web3 に対応した {{ solanaWalletsLink || link(\"ウォレット拡張機能\") }} をインストールしてください。"
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/ko-KR.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/ko-KR.json
@@ -1,0 +1,1435 @@
+{
+  "locale": "ko-KR",
+  "apiKeys": {
+    "action__add": "새 키 만들기",
+    "action__search": "키 검색",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "복사하고 닫기",
+      "formHint": "보안상 나중에 다시 볼 수 없어요.",
+      "formTitle": "지금 \"{{name}}\" API 키를 복사해 주세요"
+    },
+    "createdAndExpirationStatus__expiresOn": "생성 {{ createdDate | shortDate('ko-KR') }} • 만료 {{ expiresDate | longDate('ko-KR') }}",
+    "createdAndExpirationStatus__never": "생성 {{ createdDate | shortDate('ko-KR') }} • 만료 없음",
+    "detailsTitle__emptyRow": "API 키가 없어요",
+    "formButtonPrimary__add": "키 만들기",
+    "formFieldCaption__expiration__expiresOn": "{{ date }}에 만료돼요",
+    "formFieldCaption__expiration__never": "이 키는 만료되지 않아요",
+    "formFieldOption__expiration__180d": "180일",
+    "formFieldOption__expiration__1d": "1일",
+    "formFieldOption__expiration__1y": "1년",
+    "formFieldOption__expiration__30d": "30일",
+    "formFieldOption__expiration__60d": "60일",
+    "formFieldOption__expiration__7d": "7일",
+    "formFieldOption__expiration__90d": "90일",
+    "formFieldOption__expiration__never": "만료 없음",
+    "formHint": "이름을 입력해 새 키를 만들어요. 필요하면 언제든지 폐기할 수 있어요.",
+    "formTitle": "새 API 키 추가",
+    "lastUsed__days": "{{days}}일 전",
+    "lastUsed__hours": "{{hours}}시간 전",
+    "lastUsed__minutes": "{{minutes}}분 전",
+    "lastUsed__months": "{{months}}개월 전",
+    "lastUsed__seconds": "{{seconds}}초 전",
+    "lastUsed__years": "{{years}}년 전",
+    "menuAction__revoke": "키 폐기",
+    "revokeConfirmation": {
+      "confirmationText": "폐기",
+      "formButtonPrimary__revoke": "키 폐기",
+      "formHint": "이 시크릿 키를 삭제할까요?",
+      "formTitle": "\"{{apiKeyName}}\" 시크릿 키를 폐기할까요?"
+    },
+    "tableHeader__actions": "동작",
+    "tableHeader__lastUsed": "마지막 사용",
+    "tableHeader__name": "이름"
+  },
+  "backButton": "돌아가기",
+  "badge__activePlan": "활성",
+  "badge__canceledEndsAt": "취소됨 • {{ date | shortDate('ko-KR') }}에 종료",
+  "badge__currentPlan": "현재 플랜",
+  "badge__default": "기본값",
+  "badge__endsAt": "{{ date | shortDate('ko-KR') }}에 종료",
+  "badge__expired": "만료됨",
+  "badge__freeTrial": "무료 체험",
+  "badge__otherImpersonatorDevice": "기타 사칭 장치",
+  "badge__pastDueAt": "{{ date | shortDate('ko-KR') }}에 연체",
+  "badge__pastDuePlan": "연체됨",
+  "badge__primary": "기본",
+  "badge__renewsAt": "{{ date | shortDate('ko-KR') }}에 갱신",
+  "badge__requiresAction": "조치 필요",
+  "badge__startsAt": "{{ date | shortDate('ko-KR') }}에 시작",
+  "badge__thisDevice": "이 장치",
+  "badge__trialEndsAt": "{{ date | shortDate('ko-KR') }}에 체험 종료",
+  "badge__unverified": "미확인",
+  "badge__upcomingPlan": "예정된 플랜",
+  "badge__userDevice": "사용자 장치",
+  "badge__you": "나",
+  "billing": {
+    "addPaymentMethod__label": "결제 수단 추가",
+    "alwaysFree": "항상 무료",
+    "annually": "연간",
+    "availableFeatures": "사용 가능한 기능",
+    "billedAnnually": "연간 결제",
+    "billedMonthlyOnly": "월간 결제만 가능",
+    "cancelFreeTrial": "무료 체험 취소",
+    "cancelFreeTrialAccessUntil": "무료 체험은 {{ date | longDate('ko-KR') }}까지 유지돼요. 이후에는 체험 기능을 사용할 수 없어요. 요금은 청구되지 않아요.",
+    "cancelFreeTrialTitle": "{{plan}} 플랜 무료 체험을 취소할까요?",
+    "cancelSubscription": "구독 취소",
+    "cancelSubscriptionAccessUntil": "{{ date | longDate('ko-KR') }}까지 '{{plan}}' 기능을 사용할 수 있어요. 이후에는 이용할 수 없어요.",
+    "cancelSubscriptionNoCharge": "이 구독에는 요금이 청구되지 않아요.",
+    "cancelSubscriptionPastDue": "구독이 즉시 종료되고 모든 플랜 기능을 사용할 수 없어요. 다음 결제 시 연체 금액을 결제하셔야 해요.",
+    "cancelSubscriptionTitle": "{{plan}} 구독을 취소할까요?",
+    "cannotSubscribeMonthly": "이 플랜은 월간 결제가 불가해요. 연간 결제를 선택해 주세요.",
+    "cannotSubscribeUnrecoverable": "이 플랜으로 구독할 수 없어요. 현재 구독이 더 높은 요금제예요.",
+    "checkout": {
+      "description__paymentSuccessful": "결제가 완료됐어요.",
+      "description__subscriptionSuccessful": "새 구독이 준비됐어요.",
+      "downgradeNotice": "현재 구독은 결제 주기 종료까지 유지되고, 이후 이 구독으로 전환돼요.",
+      "emailForm": {
+        "subtitle": "결제를 완료하려면 영수증을 받을 이메일 주소를 추가해야 해요.",
+        "title": "이메일 주소 추가"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "무료 체험 종료일",
+        "title__paymentMethod": "결제 수단",
+        "title__statementId": "명세서 ID",
+        "title__subscriptionBegins": "구독 시작",
+        "title__totalPaid": "총 결제"
+      },
+      "pastDueNotice": "이전 구독이 연체되어 결제가 되지 않았어요.",
+      "perMonth": "월",
+      "title": "결제",
+      "title__paymentSuccessful": "결제가 완료됐어요!",
+      "title__subscriptionSuccessful": "성공!",
+      "title__trialSuccess": "무료 체험이 시작됐어요!",
+      "totalDueAfterTrial": "{{days}}일 후 무료 체험이 끝나면 결제할 금액"
+    },
+    "credit": "크레딧",
+    "creditRemainder": "현재 구독 남은 기간에 대한 크레딧",
+    "defaultFreePlanActive": "현재 무료 플랜을 사용 중이에요",
+    "free": "무료",
+    "getStarted": "시작하기",
+    "highlightedPlanBadge": "인기",
+    "keepFreeTrial": "무료 체험 유지",
+    "keepSubscription": "구독 유지",
+    "manage": "관리",
+    "manageSubscription": "구독 관리",
+    "month": "월",
+    "monthly": "월간",
+    "pastDue": "연체",
+    "pay": "{{amount}} 결제",
+    "paymentMethod": {
+      "applePayDescription": { "annual": "연간 결제", "monthly": "월간 결제" },
+      "dev": {
+        "anyNumbers": "아무 숫자나",
+        "cardNumber": "카드 번호",
+        "cvcZip": "CVC, 우편번호",
+        "developmentMode": "개발 모드",
+        "expirationDate": "만료일",
+        "testCardInfo": "테스트 카드 정보"
+      }
+    },
+    "paymentMethods__label": "결제 수단",
+    "pricingTable": {
+      "billingCycle": "결제 주기",
+      "included": "포함",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "다시 구독",
+    "seeAllFeatures": "전체 기능 보기",
+    "startFreeTrial": "무료 체험 시작",
+    "startFreeTrial__days": "{{days}}일 무료 체험 시작",
+    "subscribe": "구독하기",
+    "subscriptionDetails": {
+      "beginsOn": "시작일",
+      "currentBillingCycle": "현재 결제 주기",
+      "endsOn": "종료일",
+      "firstPaymentAmount": "첫 결제 금액",
+      "firstPaymentOn": "첫 결제일",
+      "nextPaymentAmount": "다음 결제 금액",
+      "nextPaymentOn": "다음 결제일",
+      "pastDueAt": "연체일",
+      "renewsAt": "갱신일",
+      "subscribedOn": "구독 시작일",
+      "title": "구독",
+      "trialEndsOn": "체험 종료일",
+      "trialStartedOn": "체험 시작일"
+    },
+    "subtotal": "소계",
+    "switchPlan": "이 플랜으로 전환",
+    "switchToAnnual": "연간 결제로 변경",
+    "switchToAnnualWithAnnualPrice": "연간 {{price}} / 년으로 변경",
+    "switchToMonthly": "월간 결제로 변경",
+    "switchToMonthlyWithPrice": "월간 {{price}} / 월로 변경",
+    "totalDue": "총 결제 금액",
+    "totalDueToday": "오늘 결제 금액",
+    "viewFeatures": "기능 보기",
+    "viewPayment": "결제 보기",
+    "year": "년"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "권한을 업그레이드하려면 조직 관리자에게 문의하세요.",
+      "title": "싱글 사인온(SSO)을 관리할 권한이 없습니다"
+    },
+    "navbar": { "title": "싱글 사인온(SSO) 구성" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "미확인",
+        "badge__verified": "확인됨",
+        "txtRecord": {
+          "hostLabel": "호스트 / 이름",
+          "instructions": "이 TXT 레코드를 DNS 공급자에 추가하세요. 레코드가 활성화되면 자동으로 확인합니다.",
+          "typeLabel": "유형",
+          "valueLabel": "값"
+        },
+        "verifiedAtLabel": "{{ date | shortDate('ko-KR') }}에 확인됨"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "{{domain}} 추가",
+        "messageLabel": "이메일이 {{domain}}을(를) 사용합니다. 추가하시겠습니까?"
+      },
+      "formButtonPrimary__add": "추가",
+      "formFieldInputPlaceholder__domain": "도메인 추가",
+      "formFieldLabel__domain": "도메인",
+      "removeDomainDialog": {},
+      "subtitle": "조직에서 로그인에 사용하는 도메인의 소유권을 추가하고 확인하세요.",
+      "title": "SSO 도메인 추가"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "사용자 지정 SAML 공급자",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "SSO를 설정할 공급자를 선택하세요.",
+      "title": "공급자 선택",
+      "warning": "공급자를 선택하면 구성이 완료될 때까지 다시 변경할 수 없습니다"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "조직 만들기",
+    "invitePage": { "formButtonReset": "넘기기" },
+    "title": "조직 만들기"
+  },
+  "dates": {
+    "lastDay": "어제 {{ date | timeString('ko-KR') }}",
+    "next6Days": "다음 {{ date | weekday('ko-KR','long') }} {{ date | timeString('ko-KR') }}",
+    "nextDay": "내일 {{ date | timeString('ko-KR') }}",
+    "numeric": "{{ date | numeric('ko-KR') }}",
+    "previous6Days": "지난 {{ date | weekday('ko-KR','long') }} {{ date | timeString('ko-KR') }}",
+    "sameDay": "오늘 {{ date | timeString('ko-KR') }}"
+  },
+  "dividerText": "또는",
+  "footerActionLink__alternativePhoneCodeProvider": "대신 SMS로 코드 받기",
+  "footerActionLink__useAnotherMethod": "다른 방법 사용하기",
+  "footerPageLink__help": "도움",
+  "footerPageLink__privacy": "개인정보처리방침",
+  "footerPageLink__terms": "약관",
+  "formButtonPrimary": "계속",
+  "formButtonPrimary__verify": "확인하기",
+  "formFieldAction__forgotPassword": "비밀번호를 잊으셨나요?",
+  "formFieldError__matchingPasswords": "비밀번호가 일치해요.",
+  "formFieldError__notMatchingPasswords": "비밀번호가 일치하지 않아요.",
+  "formFieldError__verificationLinkExpired": "인증 링크가 만료됐어요. 새 링크를 요청해 주세요.",
+  "formFieldHintText__optional": "선택사항",
+  "formFieldHintText__slug": "슬러그는 사람이 읽기 쉬운 고유 ID예요. 보통 URL에 사용돼요.",
+  "formFieldInputPlaceholder__apiKeyDescription": "이 키를 만드는 이유를 적어주세요",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "날짜를 선택하세요",
+  "formFieldInputPlaceholder__apiKeyName": "시크릿 키 이름을 입력하세요",
+  "formFieldInputPlaceholder__backupCode": "백업 코드를 입력하세요",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "계정 삭제",
+  "formFieldInputPlaceholder__emailAddress": "이메일 주소를 입력하세요",
+  "formFieldInputPlaceholder__emailAddress_username": "이메일 주소 또는 아이디를 입력하세요",
+  "formFieldInputPlaceholder__emailAddresses": "이메일 주소를 공백이나 쉼표로 구분해 입력하거나 붙여넣어 주세요",
+  "formFieldInputPlaceholder__firstName": "이름",
+  "formFieldInputPlaceholder__lastName": "성",
+  "formFieldInputPlaceholder__organizationDomain": "example.com",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "you@example.com",
+  "formFieldInputPlaceholder__organizationName": "조직 이름",
+  "formFieldInputPlaceholder__organizationSlug": "my-org",
+  "formFieldInputPlaceholder__password": "비밀번호를 입력하세요",
+  "formFieldInputPlaceholder__phoneNumber": "휴대폰 번호를 입력하세요",
+  "formFieldInput__emailAddress_format": "예시: name@example.com",
+  "formFieldLabel__apiKey": "API 키",
+  "formFieldLabel__apiKeyDescription": "설명",
+  "formFieldLabel__apiKeyExpiration": "만료",
+  "formFieldLabel__apiKeyName": "시크릿 키 이름",
+  "formFieldLabel__automaticInvitations": "이 도메인에 자동 초대 사용",
+  "formFieldLabel__backupCode": "백업 코드",
+  "formFieldLabel__confirmDeletion": "확인",
+  "formFieldLabel__confirmPassword": "비밀번호 확인",
+  "formFieldLabel__currentPassword": "현재 비밀번호",
+  "formFieldLabel__emailAddress": "이메일 주소",
+  "formFieldLabel__emailAddress_username": "이메일 주소 혹은 아이디",
+  "formFieldLabel__emailAddresses": "이메일 주소",
+  "formFieldLabel__firstName": "이름",
+  "formFieldLabel__lastName": "성",
+  "formFieldLabel__newPassword": "새 비밀번호",
+  "formFieldLabel__organizationDomain": "도메인",
+  "formFieldLabel__organizationDomainDeletePending": "대기 중인 초대와 제안 삭제",
+  "formFieldLabel__organizationDomainEmailAddress": "인증 이메일 주소",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "이 도메인의 이메일 주소를 입력하면 코드를 받아 도메인을 인증할 수 있어요.",
+  "formFieldLabel__organizationName": "이름",
+  "formFieldLabel__organizationSlug": "슬러그",
+  "formFieldLabel__passkeyName": "패스키 이름",
+  "formFieldLabel__password": "비밀번호",
+  "formFieldLabel__phoneNumber": "휴대폰 번호",
+  "formFieldLabel__role": "역할",
+  "formFieldLabel__signOutOfOtherSessions": "다른 모든 기기에서 로그아웃",
+  "formFieldLabel__username": "아이디",
+  "impersonationFab": {
+    "action__signOut": "로그아웃",
+    "title": "{{identifier}}로 로그인했어요"
+  },
+  "lastAuthenticationStrategy": "최근 사용",
+  "maintenanceMode": "지금 점검 중이에요. 걱정 마세요, 몇 분이면 끝날 거예요.",
+  "membershipRole__admin": "관리자",
+  "membershipRole__basicMember": "멤버",
+  "membershipRole__guestMember": "게스트",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "조직 만들기",
+    "action__invitationAccept": "참여",
+    "action__suggestionsAccept": "참여 요청",
+    "createOrganization": "조직 만들기",
+    "invitationAcceptedLabel": "참여함",
+    "subtitle": "{{applicationName}}로 계속하려면",
+    "suggestionsAcceptedLabel": "승인 대기",
+    "title": "계정 선택",
+    "titleWithoutPersonal": "조직 선택"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "API 키" },
+    "badge__automaticInvitation": "자동 초대",
+    "badge__automaticSuggestion": "자동 제안",
+    "badge__manualInvitation": "자동 등록 없음",
+    "badge__unverified": "미인증",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "결제 내역이 없어요",
+        "notFound": "결제 시도를 찾을 수 없어요",
+        "tableHeader__amount": "금액",
+        "tableHeader__date": "날짜",
+        "tableHeader__status": "상태"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "기본으로 설정",
+        "actionLabel__remove": "삭제",
+        "add": "새 결제 수단 추가",
+        "addSubtitle": "계정에 새 결제 수단을 추가하세요.",
+        "cancelButton": "취소",
+        "formButtonPrimary__add": "결제 수단 추가",
+        "formButtonPrimary__pay": "{{amount}} 결제",
+        "payWithTestCardButton": "테스트 카드로 결제",
+        "removeMethod": {
+          "messageLine1": "{{identifier}}가 이 계정에서 삭제돼요.",
+          "messageLine2": "이 결제 수단은 더 이상 사용할 수 없고, 연결된 구독도 작동하지 않아요.",
+          "successMessage": "{{paymentMethod}}이(가) 계정에서 삭제됐어요.",
+          "title": "결제 수단 삭제"
+        },
+        "title": "결제 수단"
+      },
+      "start": {
+        "headerTitle__payments": "결제",
+        "headerTitle__plans": "플랜",
+        "headerTitle__statements": "명세서",
+        "headerTitle__subscriptions": "구독"
+      },
+      "statementsSection": {
+        "empty": "표시할 명세서가 없어요",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} 플랜 결제",
+        "itemCaption__proratedCredit": "이전 구독 일부 사용에 대한 비례 크레딧",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} 플랜을 구독하고 결제했어요",
+        "notFound": "명세서를 찾을 수 없어요",
+        "tableHeader__amount": "금액",
+        "tableHeader__date": "날짜",
+        "title": "명세서",
+        "totalPaid": "총 결제"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "관리",
+        "actionLabel__newSubscription": "플랜 구독하기",
+        "actionLabel__switchPlan": "플랜 변경",
+        "tableHeader__edit": "편집",
+        "tableHeader__plan": "플랜",
+        "tableHeader__startDate": "시작일",
+        "title": "구독"
+      },
+      "subscriptionsSection": { "actionLabel__default": "관리" },
+      "switchPlansSection": { "title": "플랜 변경" },
+      "title": "결제"
+    },
+    "createDomainPage": {
+      "subtitle": "도메인을 추가해 인증하세요. 이 도메인의 이메일을 가진 사용자는 조직에 자동으로 참여하거나 참여 요청을 할 수 있어요.",
+      "title": "도메인 추가"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "초대를 보낼 수 없어요. 다음 이메일 주소에는 이미 대기 중인 초대가 있어요: {{email_addresses}}.",
+      "formButtonPrimary__continue": "초대 보내기",
+      "selectDropdown__role": "역할 선택",
+      "subtitle": "공백이나 쉼표로 구분해 이메일 주소를 입력하거나 붙여넣어 주세요.",
+      "successMessage": "초대가 성공적으로 전송됐어요",
+      "title": "새 멤버 초대"
+    },
+    "membersPage": {
+      "action__invite": "초대",
+      "action__search": "검색",
+      "activeMembersTab": {
+        "menuAction__remove": "회원 제거",
+        "tableHeader__actions": "작업",
+        "tableHeader__joined": "가입됨",
+        "tableHeader__role": "역할",
+        "tableHeader__user": "사용자"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "사용 가능한 역할을 업데이트하고 있어요. 끝나면 다시 역할을 바꿀 수 있어요.",
+          "title": "역할이 잠시 잠겼어요"
+        }
+      },
+      "detailsTitle__emptyRow": "표시할 멤버 없음",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "이메일 도메인을 조직과 연결해 사용자를 초대하세요. 해당 도메인으로 가입한 사용자는 언제든 조직에 참여할 수 있어요.",
+          "headerTitle": "자동 초대",
+          "primaryButton": "인증된 도메인 관리"
+        },
+        "table__emptyRow": "표시할 초대가 없어요"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "초대 취소",
+        "tableHeader__invited": "초대됨"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "해당 도메인으로 가입한 사용자는 조직 참여 요청을 제안받을 수 있어요.",
+          "headerTitle": "자동 제안",
+          "primaryButton": "인증된 도메인 관리"
+        },
+        "menuAction__approve": "승인",
+        "menuAction__reject": "거절",
+        "tableHeader__requested": "요청됨",
+        "table__emptyRow": "요청이 없어요"
+      },
+      "start": {
+        "headerTitle__invitations": "초대",
+        "headerTitle__members": "멤버",
+        "headerTitle__requests": "요청"
+      }
+    },
+    "navbar": {
+      "apiKeys": "API 키",
+      "billing": "결제",
+      "description": "조직을 관리하세요.",
+      "general": "일반",
+      "members": "멤버",
+      "title": "조직"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "이 조직의 결제를 관리할 권한이 없어요."
+      },
+      "title": "플랜"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "계속하려면 아래에 {{organizationName}}을(를) 입력하세요.",
+          "messageLine1": "이 조직을 삭제할까요?",
+          "messageLine2": "이 작업은 되돌릴 수 없어요.",
+          "successMessage": "조직을 삭제했어요.",
+          "title": "조직 삭제"
+        },
+        "leaveOrganization": {
+          "actionDescription": "계속하려면 아래에 \"{{organizationName}}\"을(를) 입력하세요.",
+          "messageLine1": "이 조직을 탈퇴할까요? 조직과 관련 앱에 대한 접근 권한을 잃게 돼요.",
+          "messageLine2": "이 작업은 되돌릴 수 없어요.",
+          "successMessage": "조직을 탈퇴했어요.",
+          "title": "조직 떠나기"
+        },
+        "title": "위험"
+      },
+      "domainSection": {
+        "menuAction__manage": "관리",
+        "menuAction__remove": "삭제",
+        "menuAction__verify": "인증",
+        "primaryButton": "도메인 추가",
+        "subtitle": "인증된 이메일 도메인을 기준으로 사용자가 자동 참여하거나 참여 요청을 할 수 있게 해요.",
+        "title": "인증된 도메인"
+      },
+      "successMessage": "조직이 업데이트됐어요.",
+      "title": "프로필 업데이트"
+    },
+    "removeDomainPage": {
+      "messageLine1": "이메일 도메인 {{domain}}이(가) 삭제돼요.",
+      "messageLine2": "이후에는 사용자가 조직에 자동으로 참여할 수 없어요.",
+      "successMessage": "{{domain}}이(가) 삭제됐어요.",
+      "title": "도메인 삭제"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "일반",
+      "headerTitle__members": "멤버",
+      "profileSection": {
+        "primaryButton": "프로필 업데이트",
+        "title": "조직 프로필",
+        "uploadAction__title": "로고"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "이 도메인을 삭제하면 초대된 사용자에게 영향이 있어요.",
+        "removeDomainActionLabel__remove": "도메인 삭제",
+        "removeDomainSubtitle": "이 도메인을 인증된 도메인 목록에서 삭제",
+        "removeDomainTitle": "도메인 삭제"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "사용자가 가입하면 자동으로 초대되고 언제든지 조직에 참여할 수 있어요.",
+        "automaticInvitationOption__label": "자동 초대",
+        "automaticSuggestionOption__description": "사용자는 참여 요청 제안을 받지만, 관리자가 승인해야 조직에 참여할 수 있어요.",
+        "automaticSuggestionOption__label": "자동 제안",
+        "calloutInfoLabel": "등록 방식 변경은 새 사용자에게만 적용돼요.",
+        "calloutInvitationCountLabel": "대기 중인 초대: {{count}}",
+        "calloutSuggestionCountLabel": "대기 중인 제안: {{count}}",
+        "manualInvitationOption__description": "사용자는 수동으로만 조직에 초대할 수 있어요.",
+        "manualInvitationOption__label": "자동 등록 없음",
+        "subtitle": "이 도메인 사용자가 조직에 참여하는 방법을 선택하세요."
+      },
+      "start": {
+        "headerTitle__danger": "위험",
+        "headerTitle__enrollment": "등록 옵션"
+      },
+      "subtitle": "도메인 {{domain}}이(가) 인증됐어요. 등록 방식을 선택해 주세요.",
+      "title": "{{domain}} 업데이트"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "이메일로 전송된 인증 코드를 입력하세요",
+      "formTitle": "인증 코드",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "도메인 {{domainName}}은 이메일로 인증이 필요해요.",
+      "subtitleVerificationCodeScreen": "{{emailAddress}}로 인증 코드가 전송됐어요. 코드를 입력해 주세요.",
+      "title": "도메인 인증"
+    }
+  },
+  "organizationSwitcher": {
+    "action__closeOrganizationSwitcher": "조직 전환기 닫기",
+    "action__createOrganization": "조직 만들기",
+    "action__invitationAccept": "참여",
+    "action__manageOrganization": "조직 관리",
+    "action__openOrganizationSwitcher": "조직 전환기 열기",
+    "action__suggestionsAccept": "참여 요청",
+    "notSelected": "선택한 조직 없음",
+    "personalWorkspace": "개인 워크스페이스",
+    "suggestionsAcceptedLabel": "승인 대기"
+  },
+  "paginationButton__next": "다음",
+  "paginationButton__previous": "이전",
+  "paginationRowText__displaying": "표시중",
+  "paginationRowText__of": "의",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "도움 요청하기",
+      "actionText": "이 방법이 없나요?",
+      "blockButton__backupCode": "백업 코드 사용",
+      "blockButton__emailCode": "{{identifier}}로 이메일 코드 보내기",
+      "blockButton__passkey": "패스키 사용하기",
+      "blockButton__password": "비밀번호로 계속",
+      "blockButton__phoneCode": "{{identifier}}로 SMS 코드 보내기",
+      "blockButton__totp": "인증 앱 사용하기",
+      "getHelp": {
+        "blockButton__emailSupport": "이메일 지원",
+        "content": "계정 인증에 문제가 있다면 이메일로 문의해 주세요. 최대한 빠르게 도와드릴게요.",
+        "title": "도움 요청하기"
+      },
+      "subtitle": "문제가 있나요? 다른 방법으로 인증할 수 있어요.",
+      "title": "다른 방법 사용하기"
+    },
+    "backupCodeMfa": {
+      "subtitle": "2단계 인증 설정 때 받은 백업 코드를 입력하세요",
+      "title": "백업 코드 입력"
+    },
+    "emailCode": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "이메일로 전송된 코드를 입력해 주세요",
+      "title": "인증이 필요해요"
+    },
+    "noAvailableMethods": {
+      "message": "인증을 진행할 수 없어요. 설정된 인증 수단이 없어요.",
+      "subtitle": "오류가 발생했어요",
+      "title": "계정을 확인할 수 없어요"
+    },
+    "passkey": {
+      "blockButton__passkey": "패스키 사용하기",
+      "subtitle": "패스키로 신원을 확인해요. 기기에서 지문, 얼굴 또는 화면 잠금을 요청할 수 있어요.",
+      "title": "패스키 사용"
+    },
+    "password": {
+      "actionLink": "다른 방법 사용하기",
+      "subtitle": "계속하려면 현재 비밀번호를 입력하세요",
+      "title": "인증이 필요해요"
+    },
+    "phoneCode": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "휴대폰으로 전송된 코드를 입력해 주세요",
+      "title": "인증이 필요해요"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "휴대폰으로 전송된 코드를 입력해 주세요",
+      "title": "인증이 필요해요"
+    },
+    "totpMfa": {
+      "formTitle": "인증 코드",
+      "subtitle": "인증 앱에서 생성된 코드를 입력해 주세요",
+      "title": "인증이 필요해요"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "계정 추가",
+      "action__signOutAll": "모든 계정 로그아웃",
+      "subtitle": "계속할 계정을 선택해 주세요.",
+      "title": "계정 선택"
+    },
+    "alternativeMethods": {
+      "actionLink": "도움 요청하기",
+      "actionText": "이 방법이 없나요?",
+      "blockButton__backupCode": "백업 코드 사용하기",
+      "blockButton__emailCode": "{{identifier}}로 이메일 코드 보내기",
+      "blockButton__emailLink": "{{identifier}}로 이메일 링크 보내기",
+      "blockButton__passkey": "패스키로 로그인",
+      "blockButton__password": "비밀번호로 로그인",
+      "blockButton__phoneCode": "{{identifier}}로 SMS 코드 보내기",
+      "blockButton__totp": "인증 앱 사용하기",
+      "getHelp": {
+        "blockButton__emailSupport": "이메일 지원",
+        "content": "계정 로그인에 문제가 있다면 이메일로 알려 주세요. 최대한 빠르게 접근을 복구해 드릴게요.",
+        "title": "도움 요청하기"
+      },
+      "subtitle": "문제가 있나요? 다른 방법으로 로그인할 수 있어요.",
+      "title": "다른 방법 사용하기"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "{{provider}} 확인"
+    },
+    "backupCodeMfa": {
+      "subtitle": "백업 코드는 2단계 인증을 설정할 때 받은 코드예요",
+      "title": "백업 코드 입력"
+    },
+    "emailCode": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드 재전송",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "이메일을 확인하세요"
+    },
+    "emailCodeMfa": {
+      "formTitle": "이메일을 확인하세요",
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "이메일을 확인하세요"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "계속하려면 로그인 시작한 기기와 브라우저에서 링크를 열어 주세요.",
+        "title": "이 기기에서는 인증 링크를 사용할 수 없어요"
+      },
+      "expired": {
+        "subtitle": "계속하려면 원래 탭으로 돌아가세요.",
+        "title": "이 인증 링크는 만료됐어요"
+      },
+      "failed": {
+        "subtitle": "계속하려면 원래 탭으로 돌아가세요.",
+        "title": "이 인증 링크는 유효하지 않아요"
+      },
+      "formSubtitle": "이메일로 전송된 인증 링크를 사용하세요",
+      "formTitle": "인증 링크",
+      "loading": { "subtitle": "곧 이동돼요", "title": "로그인 중..." },
+      "resendButton": "링크 재전송",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "이메일을 확인하세요",
+      "unusedTab": { "title": "이 탭은 닫아도 돼요" },
+      "verified": { "subtitle": "곧 이동돼요", "title": "로그인이 완료됐어요" },
+      "verifiedSwitchTab": {
+        "subtitle": "계속하려면 원래 탭으로 돌아가세요",
+        "subtitleNewTab": "계속하려면 새로 연 탭으로 돌아가세요",
+        "titleNewTab": "다른 탭에서 로그인"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "이메일로 전송된 확인 링크를 사용하세요",
+      "resendButton": "링크를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "{{applicationName}}(으)로 계속",
+      "title": "이메일을 확인하세요"
+    },
+    "enterpriseConnections": {
+      "subtitle": "계속할 기업 계정을 선택해 주세요.",
+      "title": "기업 계정 선택"
+    },
+    "forgotPassword": {
+      "formTitle": "비밀번호 재설정 코드",
+      "resendButton": "코드 재전송",
+      "subtitle": "비밀번호를 재설정하려면",
+      "subtitle_email": "먼저 이메일로 전송된 코드를 입력하세요",
+      "subtitle_phone": "먼저 휴대폰으로 전송된 코드를 입력하세요",
+      "title": "비밀번호 재설정"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "비밀번호 재설정",
+      "label__alternativeMethods": "또는 다른 방법으로 로그인",
+      "title": "비밀번호를 잊으셨나요?"
+    },
+    "newDeviceVerificationNotice": "새로운 기기에서 로그인 중이에요. 계정 보안을 위해 확인을 요청하고 있어요.",
+    "noAvailableMethods": {
+      "message": "로그인을 계속할 수 없어요. 사용할 수 있는 인증 방법이 없어요.",
+      "subtitle": "오류가 발생했어요",
+      "title": "로그인할 수 없어요"
+    },
+    "passkey": {
+      "subtitle": "패스키로 로그인하면 본인 확인이 돼요. 기기에서 지문, 얼굴 또는 화면 잠금을 요청할 수 있어요.",
+      "title": "패스키 사용"
+    },
+    "password": {
+      "actionLink": "다른 방법 사용하기",
+      "subtitle": "계정에 등록된 비밀번호를 입력해 주세요",
+      "title": "비밀번호를 입력하세요"
+    },
+    "passwordCompromised": { "title": "비밀번호가 유출됐을 수 있어요" },
+    "passwordPwned": { "title": "유출된 비밀번호예요" },
+    "passwordUntrusted": { "title": "신뢰할 수 없는 비밀번호예요" },
+    "phoneCode": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드 다시 보내기",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "휴대폰 확인"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "인증 코드",
+      "resendButton": "코드 다시 보내기",
+      "subtitle": "계속하려면 휴대폰으로 전송된 인증 코드를 입력하세요",
+      "title": "휴대폰 확인"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "비밀번호 재설정",
+      "requiredMessage": "보안을 위해 비밀번호를 재설정해야 해요.",
+      "successMessage": "비밀번호가 변경됐어요. 로그인 중이에요. 잠시만 기다려 주세요.",
+      "title": "비밀번호 재설정"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "비밀번호를 재설정하기 전에 신원을 확인해야 해요."
+    },
+    "start": {
+      "actionLink": "회원가입",
+      "actionLink__join_waitlist": "대기 목록 참여",
+      "actionLink__use_email": "이메일 사용하기",
+      "actionLink__use_email_username": "이메일 또는 아이디 사용하기",
+      "actionLink__use_passkey": "패스키 사용하기",
+      "actionLink__use_phone": "휴대폰 번호 사용하기",
+      "actionLink__use_username": "아이디 사용하기",
+      "actionText": "계정이 없으신가요?",
+      "actionText__join_waitlist": "미리 사용해 보고 싶으신가요?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "다른 방법 사용하기",
+        "label": "{{provider}} 휴대폰 번호",
+        "subtitle": "{{provider}}로 인증 코드를 받을 휴대폰 번호를 입력하세요.",
+        "title": "{{provider}}로 {{applicationName}}에 로그인"
+      },
+      "subtitle": "환영해요! 계속하려면 로그인해 주세요",
+      "title": "{{applicationName}}에 로그인",
+      "titleCombined": "{{applicationName}}로 계속"
+    },
+    "totpMfa": {
+      "formTitle": "인증 코드",
+      "subtitle": "계속하려면 인증 앱에서 생성된 인증 코드를 입력하세요",
+      "title": "2단계 인증"
+    },
+    "web3Solana": {
+      "subtitle": "로그인하려면 아래에서 지갑을 선택하세요",
+      "title": "Solana로 로그인"
+    }
+  },
+  "signInEnterPasswordTitle": "비밀번호를 입력하세요",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "코드를 받지 못하셨나요? 다시 보내기",
+      "subtitle": "{{provider}}로 전송된 인증 코드를 입력하세요",
+      "title": "{{provider}} 인증"
+    },
+    "continue": {
+      "actionLink": "로그인",
+      "actionText": "계정이 있으신가요?",
+      "subtitle": "계속하려면 누락된 필드에 값을 입력하세요",
+      "title": "누락된 필드를 입력하세요"
+    },
+    "emailCode": {
+      "formSubtitle": "이메일 주소로 전송된 인증 코드를 입력하세요",
+      "formTitle": "인증 코드",
+      "resendButton": "코드 재전송",
+      "subtitle": "이메일로 전송된 인증 코드를 입력하세요",
+      "title": "이메일 인증"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "계속하려면 가입을 시작한 기기와 브라우저에서 링크를 열어 주세요.",
+        "title": "이 기기에서는 인증 링크를 사용할 수 없어요"
+      },
+      "formSubtitle": "이메일로 받은 인증 링크를 사용해 주세요.",
+      "formTitle": "인증 링크",
+      "loading": { "title": "가입 중..." },
+      "resendButton": "링크 재전송",
+      "subtitle": "{{applicationName}}로 계속하려면",
+      "title": "이메일 인증하기",
+      "verified": { "title": "가입이 완료됐어요" },
+      "verifiedSwitchTab": {
+        "subtitle": "계속하려면 새로 연 탭으로 돌아가기",
+        "subtitleNewTab": "계속하려면 이전 탭으로 돌아가기",
+        "title": "이메일 인증 성공"
+      }
+    },
+    "enterpriseConnections": {
+      "subtitle": "계속할 기업 계정을 선택해 주세요.",
+      "title": "기업 계정 선택"
+    },
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "{{ privacyPolicyLink || link(\"개인정보처리방침\") }}에 동의해요",
+        "label__onlyTermsOfService": "{{ termsOfServiceLink || link(\"서비스 약관\") }}에 동의해요",
+        "label__termsOfServiceAndPrivacyPolicy": "{{ termsOfServiceLink || link(\"서비스 약관\") }}과 {{ privacyPolicyLink || link(\"개인정보처리방침\") }}에 동의해요"
+      },
+      "continue": {
+        "subtitle": "계속하려면 약관에 동의해 주세요",
+        "title": "약관 동의"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "휴대폰 번호로 전송된 인증 코드를 입력하세요.",
+      "formTitle": "인증 코드",
+      "resendButton": "코드 재전송",
+      "subtitle": "휴대폰으로 전송된 인증 코드를 입력하세요",
+      "title": "휴대폰 번호 인증"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "로그인",
+      "actionText": "이미 계정이 있나요?",
+      "blockButton__emailSupport": "이메일 지원",
+      "blockButton__joinWaitlist": "대기 목록 참여",
+      "subtitle": "현재 회원가입이 중단돼 있어요. 접근 권한이 필요하다면 지원팀에 문의해 주세요.",
+      "subtitleWaitlist": "회원가입이 중단돼 있어요. 출시 소식을 가장 먼저 받으려면 대기 목록에 참여해 주세요.",
+      "title": "접근 제한"
+    },
+    "start": {
+      "actionLink": "로그인하기",
+      "actionLink__use_email": "이메일로 가입",
+      "actionLink__use_phone": "휴대폰으로 가입",
+      "actionText": "계정이 있으신가요?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "다른 방법 사용하기",
+        "label": "{{provider}} 휴대폰 번호",
+        "subtitle": "{{provider}}로 인증 코드를 받을 휴대폰 번호를 입력하세요.",
+        "title": "{{provider}}로 {{applicationName}}에 가입"
+      },
+      "subtitle": "환영해요! 아래 정보를 입력해 주세요.",
+      "subtitleCombined": "환영해요! 아래 정보를 입력해 주세요.",
+      "title": "계정 만들기",
+      "titleCombined": "계정 만들기"
+    },
+    "web3Solana": {
+      "subtitle": "가입하려면 아래에서 지갑을 선택하세요",
+      "title": "Solana로 가입"
+    }
+  },
+  "socialButtonsBlockButton": "{{provider|titleize}}로 계속하기",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "감지된 회사 이름({{organizationName}})과 {{organizationDomain}}에 해당하는 조직이 이미 있어요. 초대로 참여해 주세요."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "새 조직 만들기",
+      "action__invitationAccept": "참여",
+      "action__suggestionsAccept": "참여 요청",
+      "subtitle": "기존 조직에 참여하거나 새 조직을 만드세요",
+      "subtitle__createOrganizationDisabled": "기존 조직에 참여하세요",
+      "suggestionsAcceptedLabel": "승인 대기 중",
+      "title": "조직 선택"
+    },
+    "createOrganization": {
+      "formButtonReset": "취소",
+      "formButtonSubmit": "계속",
+      "formFieldInputPlaceholder__name": "내 조직",
+      "formFieldInputPlaceholder__slug": "nae-jigug",
+      "formFieldLabel__name": "이름",
+      "formFieldLabel__slug": "슬러그",
+      "subtitle": "조직 정보를 입력해 계속하세요",
+      "title": "조직 설정"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "초대가 필요하면 조직 관리자에게 문의해 주세요.",
+      "title": "조직에 소속돼야 해요"
+    },
+    "signOut": {
+      "actionLink": "로그아웃",
+      "actionText": "{{identifier}}로 로그인됨"
+    }
+  },
+  "taskResetPassword": {
+    "formButtonPrimary": "비밀번호 재설정",
+    "signOut": {
+      "actionLink": "로그아웃",
+      "actionText": "{{identifier}}로 로그인됨"
+    },
+    "subtitle": "계속하려면 비밀번호를 새로 설정해야 해요",
+    "title": "비밀번호 재설정"
+  },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}}은(는) 이미 이 조직의 멤버예요.",
+    "avatar_file_size_exceeded": "파일 크기가 최대 10MB 제한을 초과해요. 더 작은 파일을 선택해 주세요.",
+    "avatar_file_type_invalid": "지원되지 않는 파일 형식이에요. JPG, PNG, GIF 또는 WEBP 이미지를 업로드해 주세요.",
+    "captcha_invalid": "보안 검증에 실패해 회원가입을 완료할 수 없어요. 페이지를 새로고침한 뒤 다시 시도하거나 지원팀에 문의해 주세요.",
+    "captcha_unavailable": "봇 검증에 실패해 회원가입을 완료할 수 없어요. 페이지를 새로고침한 뒤 다시 시도하거나 지원팀에 문의해 주세요.",
+    "form_email_address_blocked": "임시 이메일 서비스는 지원되지 않아요. 계정을 만들려면 일반 이메일 주소를 사용해 주세요.",
+    "form_identifier_not_found": "이 정보와 일치하는 계정을 찾을 수 없어요.",
+    "form_new_password_matches_current": "새 비밀번호는 현재 비밀번호와 같을 수 없어요.",
+    "form_param_format_invalid__email_address": "이메일 주소 형식이 올바르지 않아요.",
+    "form_param_format_invalid__phone_number": "전화번호는 올바른 국제 형식이어야 해요.",
+    "form_param_max_length_exceeded__first_name": "이름은 256자를 넘을 수 없어요.",
+    "form_param_max_length_exceeded__last_name": "성은 256자를 넘을 수 없어요.",
+    "form_param_max_length_exceeded__name": "이름은 256자를 넘을 수 없어요.",
+    "form_password_length_too_short": "비밀번호가 너무 짧아요. 최소 8자 이상이어야 해요.",
+    "form_password_not_strong_enough": "비밀번호가 충분히 안전하지 않아요.",
+    "form_password_or_identifier_incorrect": "비밀번호 또는 이메일 주소가 올바르지 않아요. 다시 시도하거나 다른 방법을 사용해 보세요.",
+    "form_password_pwned": "이 비밀번호는 유출된 기록이 있어 사용할 수 없어요. 다른 비밀번호를 사용해 주세요.",
+    "form_password_pwned__sign_in": "이 비밀번호는 유출된 비밀번호예요. 비밀번호를 재설정해 주세요.",
+    "form_password_size_in_bytes_exceeded": "비밀번호가 허용되는 최대 바이트 수를 초과했어요. 비밀번호를 줄이거나 일부 특수 문자를 제거해 주세요.",
+    "form_password_untrusted__sign_in": "비밀번호가 유출됐을 수 있어요. 계정을 보호하기 위해 다른 방법으로 로그인해 주세요. 로그인 후 비밀번호를 재설정해야 해요.",
+    "form_password_validation_failed": "잘못된 비밀번호",
+    "form_username_invalid_length": "아이디는 {{min_length}}~{{max_length}}자여야 해요.",
+    "form_username_needs_non_number_char": "아이디에는 숫자가 아닌 문자가 하나 이상 포함돼야 해요.",
+    "identification_deletion_failed": "마지막 식별 정보는 삭제할 수 없어요.",
+    "not_allowed_access": "이메일 주소 또는 전화번호는 가입에 사용할 수 없어요. 이메일 주소에 '+', '=', '#' 또는 '.'이 포함됐거나 임시 이메일 서비스 도메인이거나, 명시적으로 제외된 경우예요. 이 오류가 계속되면 지원에 문의해 주세요.",
+    "organization_not_found_or_unauthorized": "이 조직의 멤버가 아니에요. 다른 조직을 선택하거나 새로 만들어 주세요.",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "이 조직의 멤버가 아니에요. 다른 조직을 선택해 주세요.",
+    "passkey_already_exists": "이 기기에 이미 패스키가 등록되어 있어요.",
+    "passkey_not_supported": "이 기기에서는 패스키를 지원하지 않아요.",
+    "passkey_pa_not_supported": "등록을 위해 플랫폼 인증기가 필요하지만, 이 기기는 지원하지 않아요.",
+    "passkey_registration_cancelled": "패스키 등록이 취소되었거나 시간이 초과됐어요.",
+    "passkey_retrieval_cancelled": "패스키 인증이 취소되었거나 시간이 초과됐어요.",
+    "passwordComplexity": {
+      "maximumLength": "{{length}} 보다 짧은 문자열",
+      "minimumLength": "{{length}} 또는 그 이상의 문자열",
+      "requireLowercase": "소문자",
+      "requireNumbers": "숫자",
+      "requireSpecialCharacter": "특수문자",
+      "requireUppercase": "대문자",
+      "sentencePrefix": "비밀번호에는 다음이 꼭 포함돼야 해요"
+    },
+    "phone_number_exists": "이 전화번호는 이미 사용 중이에요. 다른 번호를 시도해 주세요.",
+    "session_exists": "이미 로그인 중이에요.",
+    "web3_missing_identifier": "Web3 지갑 확장 프로그램을 찾을 수 없어요. 계속하려면 설치해 주세요.",
+    "web3_signature_request_rejected": "서명 요청을 거부했어요. 계속하려면 다시 시도해 주세요.",
+    "web3_solana_signature_generation_failed": "서명을 생성하는 동안 오류가 발생했어요. 계속하려면 다시 시도해 주세요.",
+    "zxcvbn": {
+      "couldBeStronger": "비밀번호는 괜찮지만 더 강하게 만들 수 있어요. 문자를 더 추가해 보세요.",
+      "goodPassword": "좋아요! 훌륭한 비밀번호예요.",
+      "notEnough": "비밀번호가 충분히 안전하지 않아요.",
+      "suggestions": {
+        "allUppercase": "모든 글자가 아닌 일부 글자만 대문자로 바꿔 보세요.",
+        "anotherWord": "덜 흔한 단어를 더 추가해 보세요.",
+        "associatedYears": "나와 관련된 연도는 피하는 게 좋아요.",
+        "capitalization": "첫 글자 외에도 대문자를 섞어 보세요.",
+        "dates": "나와 관련된 날짜나 연도는 피하는 게 좋아요.",
+        "l33t": "'a'에서 '@'와 같이 예측 가능한 문자 대체를 피하세요.",
+        "longerKeyboardPattern": "더 긴 키보드 패턴을 쓰고 입력 방향을 바꿔 보세요.",
+        "noNeed": "기호, 숫자, 대문자 없이도 강한 비밀번호를 만들 수 있어요.",
+        "pwned": "이 비밀번호를 다른 곳에서도 쓴다면 변경해 주세요.",
+        "recentYears": "최근 연도는 피하세요.",
+        "repeated": "반복되는 단어나 문자는 피하세요.",
+        "reverseWords": "익숙한 단어를 거꾸로 쓰지 마세요.",
+        "sequences": "흔한 문자 순서는 피하세요.",
+        "useWords": "여러 단어를 쓰되 흔한 문구는 피하세요."
+      },
+      "warnings": {
+        "common": "자주 쓰는 비밀번호예요.",
+        "commonNames": "흔한 이름이나 성은 추측하기 쉬워요.",
+        "dates": "날짜는 쉽게 추측돼요.",
+        "extendedRepeat": "\"abcabcabc\" 같은 반복 패턴은 쉽게 추측돼요.",
+        "keyPattern": "짧은 키보드 패턴은 추측하기 쉬워요.",
+        "namesByThemselves": "단일 이름이나 성은 추측하기 쉬워요.",
+        "pwned": "인터넷 유출로 비밀번호가 노출됐어요.",
+        "recentYears": "최근 연도는 추측하기 쉬워요.",
+        "sequences": "\"abc\" 같은 흔한 문자 순서는 추측하기 쉬워요.",
+        "similarToCommon": "자주 쓰는 비밀번호와 비슷해요.",
+        "simpleRepeat": "\"aaa\" 같은 반복 문자는 추측하기 쉬워요.",
+        "straightRow": "키보드 한 줄 패턴은 추측하기 쉬워요.",
+        "topHundred": "자주 쓰는 비밀번호예요.",
+        "topTen": "아주 많이 쓰는 비밀번호예요.",
+        "userInputs": "개인 정보나 페이지 관련 데이터는 피하는 게 좋아요.",
+        "wordByItself": "한 단어만 쓰면 추측하기 쉬워요."
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "계정 추가",
+    "action__closeUserMenu": "사용자 메뉴 닫기",
+    "action__manageAccount": "계정 관리",
+    "action__openUserMenu": "사용자 메뉴 열기",
+    "action__signOut": "로그아웃",
+    "action__signOutAll": "모든 계정에서 로그아웃",
+    "label__accountActions": "계정 작업",
+    "label__activeSessions": "활성 세션",
+    "label__userButtonPopover": "계정 패널"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "API 키" },
+    "backupCodePage": {
+      "actionLabel__copied": "복사 완료!",
+      "actionLabel__copy": "전체 복사",
+      "actionLabel__download": ".txt 다운로드",
+      "actionLabel__print": "인쇄",
+      "infoText1": "이 계정에 백업 코드가 활성화돼요.",
+      "infoText2": "백업 코드는 비밀로 보관해 주세요. 노출이 의심되면 다시 생성할 수 있어요.",
+      "subtitle__codelist": "안전하게 저장하고 비밀로 유지하세요.",
+      "successMessage": "이제 백업 코드가 활성화됐어요. 인증 장치에 접근할 수 없을 때 이 중 하나로 로그인할 수 있어요. 각 코드는 한 번만 사용할 수 있어요.",
+      "successSubtitle": "인증 장치에 접근할 수 없을 때 이 중 하나로 로그인할 수 있어요.",
+      "title": "백업 코드 인증 추가",
+      "title__codelist": "백업 코드"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "결제 내역이 없어요",
+        "notFound": "결제 시도를 찾을 수 없어요",
+        "tableHeader__amount": "금액",
+        "tableHeader__date": "날짜",
+        "tableHeader__status": "상태"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "기본으로 설정",
+        "actionLabel__remove": "삭제",
+        "add": "새 결제 수단 추가",
+        "addSubtitle": "계정에 새 결제 수단을 추가하세요.",
+        "cancelButton": "취소",
+        "formButtonPrimary__add": "결제 수단 추가",
+        "formButtonPrimary__pay": "{{amount}} 결제",
+        "payWithTestCardButton": "테스트 카드로 결제",
+        "removeMethod": {
+          "messageLine1": "{{identifier}}가 이 계정에서 삭제돼요.",
+          "messageLine2": "이 결제 수단은 더 이상 사용할 수 없고, 연결된 구독도 작동하지 않아요.",
+          "successMessage": "{{paymentMethod}}이(가) 계정에서 삭제됐어요.",
+          "title": "결제 수단 삭제"
+        },
+        "title": "결제 수단"
+      },
+      "start": {
+        "headerTitle__payments": "결제",
+        "headerTitle__plans": "플랜",
+        "headerTitle__statements": "명세서",
+        "headerTitle__subscriptions": "구독"
+      },
+      "statementsSection": {
+        "empty": "표시할 명세서가 없어요",
+        "itemCaption__paidForPlan": "{{plan}} {{period}} 플랜 결제",
+        "itemCaption__proratedCredit": "이전 구독 일부 사용에 대한 비례 크레딧",
+        "itemCaption__subscribedAndPaidForPlan": "{{plan}} {{period}} 플랜을 구독하고 결제했어요",
+        "notFound": "명세서를 찾을 수 없어요",
+        "tableHeader__amount": "금액",
+        "tableHeader__date": "날짜",
+        "title": "명세서",
+        "totalPaid": "총 결제"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "관리",
+        "actionLabel__newSubscription": "플랜 구독하기",
+        "actionLabel__switchPlan": "플랜 변경",
+        "tableHeader__edit": "편집",
+        "tableHeader__plan": "플랜",
+        "tableHeader__startDate": "시작일",
+        "title": "구독"
+      },
+      "subscriptionsSection": { "actionLabel__default": "관리" },
+      "switchPlansSection": { "title": "플랜 변경" },
+      "title": "결제"
+    },
+    "connectedAccountPage": {
+      "formHint": "계정을 연결할 제공자를 선택하세요",
+      "formHint__noAccounts": "사용 가능한 외부 계정 제공자가 없어요.",
+      "removeResource": {
+        "messageLine1": "{{identifier}}가 이 계정에서 제거될 예정이에요.",
+        "messageLine2": "이 연결된 계정은 더 이상 사용할 수 없고, 관련 기능도 작동하지 않아요.",
+        "successMessage": "{{connectedAccount}}가 계정에서 삭제됐어요.",
+        "title": "연결된 계정 제거"
+      },
+      "socialButtonsBlockButton": "{{provider|titleize}} 계정 연결",
+      "successMessage": "이 제공자가 계정에 추가됐어요.",
+      "title": "연결된 계정 추가하기"
+    },
+    "deletePage": {
+      "actionDescription": "계속하려면 아래에 계정 삭제를 입력하세요.",
+      "confirm": "계정 삭제",
+      "messageLine1": "계정을 삭제할까요? 일부 관련 데이터는 보관될 수 있어요. 전체 데이터 삭제를 요청하려면 고객 지원에 문의해 주세요.",
+      "messageLine2": "이 작업은 되돌릴 수 없어요.",
+      "title": "계정 삭제"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "이 이메일 주소로 인증 코드가 포함된 이메일이 전송돼요.",
+        "formSubtitle": "{{identifier}}에게 전송된 인증 코드를 입력해 주세요",
+        "formTitle": "인증 코드",
+        "resendButton": "코드 재전송",
+        "successMessage": "{{identifier}} 이메일이 계정에 추가됐어요."
+      },
+      "emailLink": {
+        "formHint": "인증 링크가 포함된 이메일이 이 이메일 주소로 전송돼요.",
+        "formSubtitle": "{{identifier}}에게 전송된 이메일의 링크를 클릭해 주세요.",
+        "formTitle": "인증 링크",
+        "resendButton": "링크 재전송",
+        "successMessage": "{{identifier}} 이메일이 계정에 추가됐어요."
+      },
+      "enterpriseSSOLink": {
+        "formButton": "로그인 계속하기",
+        "formSubtitle": "{{identifier}}로 로그인 완료"
+      },
+      "formHint": "이 이메일 주소를 추가하려면 먼저 인증해야 해요.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} 이메일이 이 계정에서 제거될 예정이에요.",
+        "messageLine2": "더 이상 이 이메일 주소로 로그인할 수 없어요.",
+        "successMessage": "{{emailAddress}} 이메일이 계정에서 삭제됐어요.",
+        "title": "이메일 제거"
+      },
+      "title": "이메일 주소 추가",
+      "verifyTitle": "이메일 주소 인증"
+    },
+    "formButtonPrimary__add": "추가",
+    "formButtonPrimary__continue": "계속",
+    "formButtonPrimary__finish": "완료",
+    "formButtonPrimary__remove": "삭제",
+    "formButtonPrimary__save": "저장",
+    "formButtonReset": "취소",
+    "mfaPage": {
+      "formHint": "추가할 방법을 선택해 주세요.",
+      "title": "2단계 인증 추가"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "기존 번호 사용",
+      "primaryButton__addPhoneNumber": "휴대폰 번호 추가",
+      "removeResource": {
+        "messageLine1": "{{identifier}}는 로그인할 때 더 이상 인증 코드를 받지 않아요.",
+        "messageLine2": "계정이 안전하지 않을 수 있어요. 계속할까요?",
+        "successMessage": "{{mfaPhoneCode}}에 대한 SMS 코드 2단계 인증이 제거됐어요.",
+        "title": "2단계 인증 제거"
+      },
+      "subtitle__availablePhoneNumbers": "SMS 코드 2단계 인증을 위해 등록할 휴대폰 번호를 선택하세요.",
+      "subtitle__unavailablePhoneNumbers": "SMS 코드 2단계 인증에 등록할 수 있는 휴대폰 번호가 없어요.",
+      "successMessage1": "로그인할 때 이 휴대폰 번호로 전송된 인증 코드를 추가로 입력해야 해요.",
+      "successMessage2": "백업 코드를 안전한 곳에 보관해 주세요. 인증 기기에 접근할 수 없게 되면 백업 코드로 로그인할 수 있어요.",
+      "successTitle": "SMS 코드 인증이 활성화됐어요",
+      "title": "SMS 코드 인증 추가"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "대신 QR 코드 스캔 하세요",
+        "buttonUnableToScan__nonPrimary": "QR 코드를 스캔할 수 없나요?",
+        "infoText__ableToScan": "인증 앱에서 새 로그인 방법을 만들고 QR 코드를 스캔해 계정에 연결해 주세요.",
+        "infoText__unableToScan": "인증 장치에서 새 로그인 방법을 만든 다음 아래 키를 입력해 주세요.",
+        "inputLabel__unableToScan1": "시간 기반 또는 일회용 비밀번호가 켜져 있는지 확인한 뒤 계정 연결을 완료해 주세요.",
+        "inputLabel__unableToScan2": "인증 앱이 TOTP URI를 지원한다면 전체 URI를 복사해도 돼요."
+      },
+      "removeResource": {
+        "messageLine1": "로그인할 때 더 이상 이 인증자의 인증 코드가 필요하지 않아요.",
+        "messageLine2": "계정이 안전하지 않을 수 있어요. 계속할까요?",
+        "successMessage": "인증 앱을 통한 2단계 인증이 제거됐어요.",
+        "title": "2단계 인증 제거"
+      },
+      "successMessage": "이제 2단계 인증이 활성화됐어요. 로그인할 때 추가 단계로 이 인증자의 인증 코드를 입력해야 해요.",
+      "title": "인증 애플리케이션 추가",
+      "verifySubtitle": "인증 앱이 생성한 인증 코드를 입력해 주세요",
+      "verifyTitle": "인증 코드"
+    },
+    "mobileButton__menu": "메뉴",
+    "navbar": {
+      "account": "프로필",
+      "apiKeys": "API 키",
+      "billing": "결제",
+      "description": "계정 정보를 관리하세요.",
+      "security": "보안",
+      "title": "계정"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "{{name}}이(가) 이 계정에서 삭제돼요.",
+        "title": "패스키 삭제"
+      },
+      "subtitle__rename": "패스키 이름을 바꾸면 더 쉽게 찾을 수 있어요.",
+      "title__rename": "패스키 이름 변경"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "이전 비밀번호를 사용했을 수 있는 다른 기기에서 로그아웃하는 것을 권장해요.",
+      "readonly": "기업 연결로만 로그인할 수 있어 비밀번호를 변경할 수 없어요.",
+      "successMessage__set": "비밀번호가 설정됐어요.",
+      "successMessage__signOutOfOtherSessions": "다른 모든 기기는 로그아웃됐어요.",
+      "successMessage__update": "비밀번호가 업데이트됐어요.",
+      "title__set": "비밀번호 설정",
+      "title__update": "비밀번호 변경"
+    },
+    "phoneNumberPage": {
+      "infoText": "인증 코드가 포함된 문자 메시지가 이 휴대폰 번호로 전송돼요. 통신사 요금이 부과될 수 있어요.",
+      "removeResource": {
+        "messageLine1": "{{identifier}}가 계정에서 제거될 예정이에요.",
+        "messageLine2": "더 이상 이 휴대폰 번호로 로그인할 수 없어요.",
+        "successMessage": "{{phoneNumber}}가 계정에서 제거됐어요.",
+        "title": "휴대폰 번호 제거"
+      },
+      "successMessage": "{{identifier}}가 계정에 추가됐어요.",
+      "title": "휴대폰 번호 추가",
+      "verifySubtitle": "{{identifier}}로 전송된 인증 코드를 입력하세요",
+      "verifyTitle": "휴대폰 번호 인증"
+    },
+    "plansPage": { "title": "플랜" },
+    "profilePage": {
+      "fileDropAreaHint": "10MB보다 작은 JPG, PNG, GIF, WEBP 이미지를 업로드해 주세요.",
+      "imageFormDestructiveActionSubtitle": "이미지 제거",
+      "imageFormSubtitle": "이미지 업로드",
+      "imageFormTitle": "프로필 이미지",
+      "readonly": "기업 연결에서 제공된 프로필 정보라 수정할 수 없어요.",
+      "successMessage": "프로필이 업데이트됐어요.",
+      "title": "프로필 업데이트"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "이 장치에서 로그아웃",
+        "title": "활성화된 장치"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "재시도",
+        "actionLabel__reauthorize": "지금 인증하기",
+        "destructiveActionTitle": "제거",
+        "primaryButton": "계정 연결하기",
+        "subtitle__disconnected": "이 계정은 연결이 해제됐어요.",
+        "subtitle__reauthorize": "필요한 권한 범위가 업데이트되어 일부 기능이 제한될 수 있어요. 문제를 피하려면 이 애플리케이션을 다시 인증해 주세요.",
+        "title": "연결된 계정"
+      },
+      "dangerSection": { "deleteAccountButton": "계정 삭제", "title": "위험" },
+      "emailAddressesSection": {
+        "destructiveAction": "이메일 주소 제거",
+        "detailsAction__nonPrimary": "기본으로 설정",
+        "detailsAction__primary": "인증 완료",
+        "detailsAction__unverified": "인증 완료",
+        "primaryButton": "이메일 주소 추가",
+        "title": "이메일 주소"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "계정 연결하기",
+        "title": "기업 계정"
+      },
+      "headerTitle__account": "프로필",
+      "headerTitle__security": "보안",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "코드 재생성",
+          "headerTitle": "백업 코드",
+          "subtitle__regenerate": "새로운 보안 백업 코드 세트를 받아 보세요. 이전 백업 코드는 삭제돼 사용할 수 없어요.",
+          "title__regenerate": "백업 코드 재생성"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "기본으로 설정",
+          "destructiveActionLabel": "휴대폰 번호 제거"
+        },
+        "primaryButton": "2단계 인증 추가",
+        "title": "2단계 인증",
+        "totp": {
+          "destructiveActionTitle": "제거",
+          "headerTitle": "인증 애플리케이션"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "삭제",
+        "menuAction__rename": "이름 변경",
+        "primaryButton": "패스키 추가",
+        "title": "패스키"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "비밀번호 설정",
+        "primaryButton__updatePassword": "비밀번호 변경",
+        "title": "비밀번호"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "휴대폰 번호 제거",
+        "detailsAction__nonPrimary": "기본으로 설정",
+        "detailsAction__primary": "인증 완료",
+        "detailsAction__unverified": "인증 완료",
+        "primaryButton": "휴대폰 번호 추가",
+        "title": "휴대폰 번호"
+      },
+      "profileSection": { "primaryButton": "프로필 수정", "title": "프로필" },
+      "usernameSection": {
+        "primaryButton__setUsername": "아이디 설정",
+        "primaryButton__updateUsername": "아이디 변경",
+        "title": "아이디"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "지갑 제거",
+        "detailsAction__nonPrimary": "기본으로 설정",
+        "primaryButton": "지갑 연결하기",
+        "title": "Web3 지갑",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "계정에 연결할 Solana 지갑을 선택하세요.",
+          "title": "Solana 지갑 추가"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "아이디가 업데이트됐어요.",
+      "title__set": "아이디 업데이트",
+      "title__update": "아이디 업데이트"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}}가 이 계정에서 제거될 예정이에요.",
+        "messageLine2": "더 이상 이 Web3 지갑으로 로그인할 수 없어요.",
+        "successMessage": "{{web3Wallet}}가 계정에서 제거됐어요.",
+        "title": "web3 지갑 제거"
+      },
+      "subtitle__availableWallets": "계정에 연결할 web3 지갑을 선택하세요.",
+      "subtitle__unavailableWallets": "사용 가능한 Web3 지갑이 없어요.",
+      "successMessage": "지갑이 계정에 추가됐어요.",
+      "title": "web3 지갑 추가",
+      "web3WalletButtonsBlockButton": "{{provider|titleize}}"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "로그인",
+      "actionText": "이미 액세스 권한이 있으신가요?",
+      "formButton": "대기 목록에 가입",
+      "subtitle": "이메일 주소를 입력하면 준비되는 대로 알려드릴게요",
+      "title": "대기 목록에 가입"
+    },
+    "success": {
+      "message": "곧 이동돼요...",
+      "subtitle": "준비되는 대로 연락드릴게요",
+      "title": "대기 목록에 함께해 주셔서 고마워요!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "{{walletName}}(으)로 연결",
+    "continue": "{{walletName}}(으)로 계속",
+    "noneAvailable": "Solana Web3 지갑을 찾을 수 없어요. Web3를 지원하는 {{ solanaWalletsLink || link(\"wallet extension\") }}을(를) 설치해 주세요."
+  }
+}

--- a/turbo/apps/platform/src/i18n/clerk-localizations/pt-BR.json
+++ b/turbo/apps/platform/src/i18n/clerk-localizations/pt-BR.json
@@ -1,0 +1,1466 @@
+{
+  "locale": "pt-BR",
+  "apiKeys": {
+    "action__add": "Adicionar nova chave",
+    "action__search": "Pesquisar chaves",
+    "copySecret": {
+      "formButtonPrimary__copyAndClose": "Copiar e fechar",
+      "formHint": "Por razões de segurança, não permitiremos que você visualize novamente mais tarde.",
+      "formTitle": "Copie sua chave API \"{{name}}\" agora"
+    },
+    "createdAndExpirationStatus__expiresOn": "Criada {{ createdDate | shortDate('pt-BR') }} • Expira {{ expiresDate | longDate('pt-BR') }}",
+    "createdAndExpirationStatus__never": "Criada {{ createdDate | shortDate('pt-BR') }} • Nunca expira",
+    "detailsTitle__emptyRow": "Nenhuma chave de API encontrada",
+    "formButtonPrimary__add": "Criar chave",
+    "formFieldCaption__expiration__expiresOn": "Expira em {{ date }}",
+    "formFieldCaption__expiration__never": "Esta chave nunca expirará",
+    "formFieldOption__expiration__180d": "180 Dias",
+    "formFieldOption__expiration__1d": "1 Dia",
+    "formFieldOption__expiration__1y": "1 Ano",
+    "formFieldOption__expiration__30d": "30 Dias",
+    "formFieldOption__expiration__60d": "60 Dias",
+    "formFieldOption__expiration__7d": "7 Dias",
+    "formFieldOption__expiration__90d": "90 Dias",
+    "formFieldOption__expiration__never": "Nunca",
+    "formHint": "Forneça um nome para gerar uma nova chave. Você poderá revogá-la a qualquer momento.",
+    "formTitle": "Adicionar nova chave de API",
+    "lastUsed__days": "{{days}}d atrás",
+    "lastUsed__hours": "{{hours}}h atrás",
+    "lastUsed__minutes": "{{minutes}}min atrás",
+    "lastUsed__months": "{{months}}mês(es) atrás",
+    "lastUsed__seconds": "{{seconds}}s atrás",
+    "lastUsed__years": "{{years}}a atrás",
+    "menuAction__revoke": "Revogar chave",
+    "revokeConfirmation": {
+      "confirmationText": "Revogar",
+      "formButtonPrimary__revoke": "Revogar chave",
+      "formHint": "Tem certeza de que deseja excluir esta chave de API?",
+      "formTitle": "Revogar chave de API \"{{apiKeyName}}\"?"
+    }
+  },
+  "backButton": "Voltar",
+  "badge__activePlan": "Ativo",
+  "badge__canceledEndsAt": "Cancelado • Termina {{ date | shortDate('pt-BR') }}",
+  "badge__currentPlan": "Plano atual",
+  "badge__default": "Padrão",
+  "badge__endsAt": "Termina {{ date | shortDate('pt-BR') }}",
+  "badge__expired": "Expirado",
+  "badge__freeTrial": "Teste gratuito",
+  "badge__otherImpersonatorDevice": "Personificar outro dispositivo",
+  "badge__pastDueAt": "Vencido em {{ date | shortDate('pt-BR') }}",
+  "badge__pastDuePlan": "Vencido",
+  "badge__primary": "Principal",
+  "badge__renewsAt": "Renova {{ date | shortDate('pt-BR') }}",
+  "badge__requiresAction": "Requer ação",
+  "badge__startsAt": "Inicia {{ date | shortDate('pt-BR') }}",
+  "badge__thisDevice": "Este dispositivo",
+  "badge__trialEndsAt": "Teste termina em {{ date | shortDate('pt-BR') }}",
+  "badge__unverified": "Não verificado",
+  "badge__upcomingPlan": "Próximo plano",
+  "badge__userDevice": "Dispositivo do usuário",
+  "badge__you": "Você",
+  "billing": {
+    "addPaymentMethod__label": "Adicionar método de pagamento",
+    "alwaysFree": "Gratuito",
+    "annually": "Anualmente",
+    "availableFeatures": "Recursos disponíveis",
+    "billedAnnually": "Cobrança anual",
+    "billedMonthlyOnly": "Apenas cobrança mensal",
+    "cancelFreeTrial": "Cancelar teste gratuito",
+    "cancelFreeTrialAccessUntil": "Cancelar acesso ao teste gratuito até {{ date | longDate('pt-BR') }}",
+    "cancelFreeTrialTitle": "Cancelar teste gratuito?",
+    "cancelSubscription": "Cancelar assinatura",
+    "cancelSubscriptionAccessUntil": "Você pode continuar usando os recursos de {{plan}} até {{ date | longDate('pt-BR') }}, após o qual você não terá mais acesso.",
+    "cancelSubscriptionNoCharge": "Você não será cobrado por esta assinatura.",
+    "cancelSubscriptionPastDue": "Cancelar assinatura em atraso",
+    "cancelSubscriptionTitle": "Cancelar assinatura do plano {{plan}}?",
+    "cannotSubscribeMonthly": "Você não pode assinar este plano pagando mensalmente. Para assinar este plano, você precisa escolher pagar anualmente.",
+    "cannotSubscribeUnrecoverable": "Você não pode assinar este plano. Sua assinatura existente é mais cara que este plano.",
+    "checkout": {
+      "description__paymentSuccessful": "Seu pagamento foi realizado com sucesso.",
+      "description__subscriptionSuccessful": "Sua nova assinatura está pronta.",
+      "downgradeNotice": "Você manterá sua assinatura atual e seus recursos até o final do ciclo de faturamento, após o qual você será transferido para este plano.",
+      "emailForm": {
+        "subtitle": "Antes de concluir sua compra, você deve adicionar um endereço de e-mail para o qual os recibos serão enviados.",
+        "title": "Adicionar endereço de e-mail"
+      },
+      "lineItems": {
+        "title__freeTrialEndsAt": "Teste gratuito termina em",
+        "title__paymentMethod": "Método de pagamento",
+        "title__statementId": "ID da declaração",
+        "title__subscriptionBegins": "Assinatura começa",
+        "title__totalPaid": "Total pago"
+      },
+      "pastDueNotice": "Sua assinatura anterior estava em atraso, sem pagamento.",
+      "perMonth": "por mês",
+      "title": "Checkout",
+      "title__paymentSuccessful": "Pagamento realizado com sucesso!",
+      "title__subscriptionSuccessful": "Sucesso!",
+      "title__trialSuccess": "Teste gratuito ativado com sucesso!",
+      "totalDueAfterTrial": "Total devido após o teste"
+    },
+    "credit": "Crédito",
+    "creditRemainder": "Crédito para o restante da sua assinatura atual.",
+    "defaultFreePlanActive": "Você está atualmente no plano Gratuito",
+    "free": "Gratuito",
+    "getStarted": "Começar",
+    "highlightedPlanBadge": "Popular",
+    "keepFreeTrial": "Manter teste gratuito",
+    "keepSubscription": "Manter assinatura",
+    "manage": "Gerenciar",
+    "manageSubscription": "Gerenciar assinatura",
+    "month": "Mês",
+    "monthly": "Mensal",
+    "pastDue": "Atrasado",
+    "pay": "Pagar {{amount}}",
+    "paymentMethod": {
+      "applePayDescription": {
+        "annual": "Pagamento anual",
+        "monthly": "Pagamento mensal"
+      },
+      "dev": {
+        "anyNumbers": "Qualquer número",
+        "cardNumber": "Número do cartão",
+        "cvcZip": "CVC, CEP",
+        "developmentMode": "Modo de desenvolvimento",
+        "expirationDate": "Data de validade",
+        "testCardInfo": "Informações do cartão de teste"
+      }
+    },
+    "paymentMethods__label": "Métodos de pagamento",
+    "pricingTable": {
+      "billingCycle": "Ciclo de faturamento",
+      "included": "Incluso",
+      "seatCost": { "tooltip": {} }
+    },
+    "reSubscribe": "Assinar novamente",
+    "seeAllFeatures": "Ver todos os recursos",
+    "startFreeTrial": "Iniciar teste gratuito",
+    "startFreeTrial__days": "Iniciar teste gratuito de {{days}} dias",
+    "subscribe": "Assinar",
+    "subscriptionDetails": {
+      "beginsOn": "Inicia em",
+      "currentBillingCycle": "Ciclo de faturamento atual",
+      "endsOn": "Termina em",
+      "firstPaymentAmount": "Valor do primeiro pagamento",
+      "firstPaymentOn": "Primeiro pagamento em",
+      "nextPaymentAmount": "Valor do próximo pagamento",
+      "nextPaymentOn": "Próximo pagamento em",
+      "pastDueAt": "Vencido em",
+      "renewsAt": "Renova em",
+      "subscribedOn": "Assinado em",
+      "title": "Assinatura",
+      "trialEndsOn": "Teste termina em",
+      "trialStartedOn": "Teste iniciado em"
+    },
+    "subtotal": "Subtotal",
+    "switchPlan": "Mudar de plano",
+    "switchToAnnual": "Mudar para anual",
+    "switchToAnnualWithAnnualPrice": "Mudar para anual {{price}} / ano",
+    "switchToMonthly": "Mudar para mensal",
+    "switchToMonthlyWithPrice": "Mudar para mensal {{price}} / mês",
+    "totalDue": "Total devido",
+    "totalDueToday": "Total devido hoje",
+    "viewFeatures": "Ver recursos",
+    "viewPayment": "Ver pagamento",
+    "year": "Ano"
+  },
+  "configureSSO": {
+    "activate": {},
+    "changeProviderDialog": {},
+    "configureStep": {
+      "activeConnectionWarning": {},
+      "attributeMappingTable": { "badges": {} },
+      "samlCustom": {
+        "assignUsersStep": {},
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "createAppInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      },
+      "samlGoogle": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "configureUserAccess": { "assignUsersInstructions": {} },
+        "createAppStep": { "createAppInstructions": {} },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataFile": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "nameIdInstructions": {},
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlMicrosoft": {
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "assignUsersInstructions": {},
+          "createAppInstructions": { "step4": { "subSteps": {} } }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        },
+        "serviceProviderStep": {
+          "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+        }
+      },
+      "samlOkta": {
+        "assignUsersStep": { "assignUsersInstructions": {} },
+        "attributeMappingStep": {
+          "attributeMappingTable": {
+            "columns": {},
+            "rows": { "email": {}, "firstName": {}, "lastName": {} }
+          }
+        },
+        "createAppStep": {
+          "completeSamlIntegrationInstructions": {},
+          "createAppInstructions": {},
+          "serviceProviderInstructions": {
+            "serviceProviderFields": { "acsUrl": {}, "spEntityId": {} }
+          }
+        },
+        "identityProviderMetadataStep": {
+          "manual": { "issuer": {}, "signOnUrl": {}, "signingCertificate": {} },
+          "metadataUrl": {},
+          "modes": {}
+        }
+      }
+    },
+    "missingManageEnterpriseConnectionsPermission": {
+      "subtitle": "Entre em contato com o administrador da sua organização para ampliar suas permissões.",
+      "title": "Você não tem permissão para gerenciar o logon único (SSO)"
+    },
+    "navbar": { "title": "Configurar logon único (SSO)" },
+    "organizationDomainsStep": {
+      "domainCard": {
+        "badge__unverified": "Não verificado",
+        "badge__verified": "Verificado",
+        "txtRecord": {
+          "hostLabel": "Host / Nome",
+          "instructions": "Adicione este registro TXT ao seu provedor de DNS. Verificaremos automaticamente assim que o registro estiver ativo.",
+          "typeLabel": "Tipo",
+          "valueLabel": "Valor"
+        },
+        "verifiedAtLabel": "Verificado em {{ date | shortDate('pt-BR') }}"
+      },
+      "domainSuggestion": {
+        "formButtonPrimary__add": "Adicionar {{domain}}",
+        "messageLabel": "Seu e-mail usa {{domain}}. Deseja adicioná-lo?"
+      },
+      "formButtonPrimary__add": "Adicionar",
+      "formFieldInputPlaceholder__domain": "Adicionar domínio",
+      "formFieldLabel__domain": "Domínio",
+      "removeDomainDialog": {},
+      "subtitle": "Adicione e verifique a propriedade dos domínios que sua organização usa para fazer login.",
+      "title": "Adicionar domínios de SSO"
+    },
+    "resetConnectionDialog": {},
+    "selectProviderStep": {
+      "saml": {
+        "customSaml": "Provedor SAML personalizado",
+        "groupLabel": "SAML",
+        "okta": "Okta Workforce"
+      },
+      "subtitle": "Selecione o provedor para o qual você vai configurar o SSO.",
+      "title": "Selecionar provedor",
+      "warning": "Depois que um provedor for selecionado, você não poderá alterá-lo até que a configuração seja concluída"
+    },
+    "testConfigurationStep": {
+      "testResults": { "empty": {} },
+      "testRunDetails": {
+        "howToFix": {
+          "oauth_access_denied": {},
+          "oauth_fetch_user_error": {},
+          "oauth_token_exchange_error": {},
+          "saml_email_address_domain_mismatch": {},
+          "saml_response_relaystate_missing": {},
+          "saml_user_attribute_missing": {}
+        },
+        "parsedUserInfo": {},
+        "runDetails": {}
+      },
+      "testUrl": {}
+    }
+  },
+  "createOrganization": {
+    "formButtonSubmit": "Criar organização",
+    "invitePage": { "formButtonReset": "Pular" },
+    "title": "Criar organização"
+  },
+  "dates": {
+    "lastDay": "Ontem às {{ date | timeString('pt-BR') }}",
+    "next6Days": "{{ date | weekday('pt-BR','long') }} às {{ date | timeString('pt-BR') }}",
+    "nextDay": "Amanhã às {{ date | timeString('pt-BR') }}",
+    "numeric": "{{ date | numeric('pt-BR') }}",
+    "previous6Days": "Último {{ date | weekday('pt-BR','long') }} às {{ date | timeString('pt-BR') }}",
+    "sameDay": "Hoje às {{ date | timeString('pt-BR') }}"
+  },
+  "dividerText": "ou",
+  "footerActionLink__alternativePhoneCodeProvider": "Enviar código via SMS",
+  "footerActionLink__useAnotherMethod": "Utilize outro método",
+  "footerPageLink__help": "Ajuda",
+  "footerPageLink__privacy": "Privacidade",
+  "footerPageLink__terms": "Termos de uso",
+  "formButtonPrimary": "Continuar",
+  "formButtonPrimary__verify": "Verificar",
+  "formFieldAction__forgotPassword": "Esqueceu a senha?",
+  "formFieldError__matchingPasswords": "Senhas conferem.",
+  "formFieldError__notMatchingPasswords": "Senhas não conferem.",
+  "formFieldError__verificationLinkExpired": "O link de verificação expirou. Por favor solicite um novo link.",
+  "formFieldHintText__optional": "Opcional",
+  "formFieldHintText__slug": "Um rótulo é um identificador legível por humanos que deve ser único. É comumente usado em URLs.",
+  "formFieldInputPlaceholder__apiKeyDescription": "Explique por que você está gerando esta chave",
+  "formFieldInputPlaceholder__apiKeyExpirationDate": "Selecionar data",
+  "formFieldInputPlaceholder__apiKeyName": "Digite o nome da sua chave secreta",
+  "formFieldInputPlaceholder__backupCode": "Insira o código de backup",
+  "formFieldInputPlaceholder__confirmDeletionUserAccount": "Excluir conta",
+  "formFieldInputPlaceholder__emailAddress": "Digite o endereço de e-mail",
+  "formFieldInputPlaceholder__emailAddress_username": "Digite seu e-mail ou nome de usuário",
+  "formFieldInputPlaceholder__emailAddresses": "Insira um ou mais endereços de e-mail separados por espaços ou vírgulas",
+  "formFieldInputPlaceholder__firstName": "Digite seu primeiro nome",
+  "formFieldInputPlaceholder__lastName": "Digite seu sobrenome",
+  "formFieldInputPlaceholder__organizationDomain": "Digite o domínio da organização",
+  "formFieldInputPlaceholder__organizationDomainEmailAddress": "Digite o e-mail associado ao domínio da organização",
+  "formFieldInputPlaceholder__organizationName": "Digite o nome da organização",
+  "formFieldInputPlaceholder__organizationSlug": "minha-org",
+  "formFieldInputPlaceholder__password": "Digite sua senha",
+  "formFieldInputPlaceholder__phoneNumber": "Digite seu número de telefone",
+  "formFieldInputPlaceholder__username": "Digite seu nome de usuário",
+  "formFieldInput__emailAddress_format": "Formato de exemplo: nome@exemplo.com",
+  "formFieldLabel__apiKey": "Chave API",
+  "formFieldLabel__apiKeyDescription": "Descrição",
+  "formFieldLabel__apiKeyExpiration": "Expiração",
+  "formFieldLabel__apiKeyName": "Nome da chave de API",
+  "formFieldLabel__automaticInvitations": "Ativar convites automáticos para este domínio",
+  "formFieldLabel__backupCode": "Código de backup",
+  "formFieldLabel__confirmDeletion": "Confirmar exclusão",
+  "formFieldLabel__confirmPassword": "Confirmar senha",
+  "formFieldLabel__currentPassword": "Senha atual",
+  "formFieldLabel__emailAddress": "Seu e-mail",
+  "formFieldLabel__emailAddress_username": "E-mail ou nome de usuário",
+  "formFieldLabel__emailAddresses": "Endereços de e-mail",
+  "formFieldLabel__firstName": "Nome",
+  "formFieldLabel__lastName": "Sobrenome",
+  "formFieldLabel__newPassword": "Nova senha",
+  "formFieldLabel__organizationDomain": "Domínio",
+  "formFieldLabel__organizationDomainDeletePending": "Excluir convites e sugestões pendentes",
+  "formFieldLabel__organizationDomainEmailAddress": "Endereço de e-mail de verificação",
+  "formFieldLabel__organizationDomainEmailAddressDescription": "Endereço de e-mail para receber um código e verificar este domínio",
+  "formFieldLabel__organizationName": "Nome da organização",
+  "formFieldLabel__organizationSlug": "Rótulo do URL",
+  "formFieldLabel__passkeyName": "Nome da chave de acesso",
+  "formFieldLabel__password": "Senha",
+  "formFieldLabel__phoneNumber": "Telefone",
+  "formFieldLabel__role": "Função",
+  "formFieldLabel__signOutOfOtherSessions": "Desconectar de todos os outros dispositivos",
+  "formFieldLabel__username": "Nome de usuário",
+  "impersonationFab": {
+    "action__signOut": "Sair",
+    "title": "Logado como {{identifier}}"
+  },
+  "lastAuthenticationStrategy": "Último uso",
+  "maintenanceMode": "Estamos em manutenção, mas não se preocupe, não deve levar mais do que alguns minutos",
+  "membershipRole__admin": "Administrador",
+  "membershipRole__basicMember": "Membro",
+  "membershipRole__guestMember": "Convidado",
+  "oauthConsent": { "redirectUriModal": {}, "scopeList": {} },
+  "organizationList": {
+    "action__createOrganization": "Criar organização",
+    "action__invitationAccept": "Participar",
+    "action__suggestionsAccept": "Solicitar participação",
+    "createOrganization": "Criar organização",
+    "invitationAcceptedLabel": "Participando",
+    "subtitle": "para continuar no {{applicationName}}",
+    "suggestionsAcceptedLabel": "Aprovação pendente",
+    "title": "Selecione uma conta",
+    "titleWithoutPersonal": "Selecione uma organização"
+  },
+  "organizationProfile": {
+    "apiKeysPage": { "title": "Chaves de API" },
+    "badge__automaticInvitation": "Convites automáticos",
+    "badge__automaticSuggestion": "Sugestões automáticas",
+    "badge__manualInvitation": "Sem inscrição automática",
+    "badge__unverified": "Não verificado",
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Nenhum histórico de pagamento",
+        "notFound": "Pagamento não encontrado",
+        "tableHeader__amount": "Valor",
+        "tableHeader__date": "Data",
+        "tableHeader__status": "Status"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Tornar padrão",
+        "actionLabel__remove": "Remover",
+        "add": "Adicionar novo método de pagamento",
+        "addSubtitle": "Adicione um novo método de pagamento à sua conta.",
+        "cancelButton": "Cancelar",
+        "formButtonPrimary__add": "Adicionar Método de Pagamento",
+        "formButtonPrimary__pay": "Pagar {{amount}}",
+        "payWithTestCardButton": "Pagar com cartão de teste",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} será removido desta conta.",
+          "messageLine2": "Você não poderá mais usar esta forma de pagamento e quaisquer assinaturas recorrentes dependentes dela deixarão de funcionar.",
+          "successMessage": "{{paymentMethod}} foi removido da sua conta.",
+          "title": "Remover método de pagamento"
+        },
+        "title": "Métodos de pagamento"
+      },
+      "start": {
+        "headerTitle__payments": "Pagamentos",
+        "headerTitle__plans": "Planos",
+        "headerTitle__statements": "Extratos",
+        "headerTitle__subscriptions": "Assinaturas"
+      },
+      "statementsSection": {
+        "empty": "Nenhum extrato para exibir",
+        "itemCaption__paidForPlan": "Pago para plano {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédito proporcional para uso parcial do plano anterior",
+        "itemCaption__subscribedAndPaidForPlan": "Assinado e pago para plano {{plan}} {{period}}",
+        "notFound": "Extrato não encontrado",
+        "tableHeader__amount": "Valor",
+        "tableHeader__date": "Data",
+        "title": "Extratos",
+        "totalPaid": "Total pago"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gerenciar assinatura",
+        "actionLabel__newSubscription": "Assinar um plano",
+        "actionLabel__switchPlan": "Mudar de plano",
+        "tableHeader__edit": "Editar",
+        "tableHeader__plan": "Plano",
+        "tableHeader__startDate": "Data de início",
+        "title": "Assinatura"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gerenciar" },
+      "switchPlansSection": { "title": "Mudar de plano" },
+      "title": "Faturamento"
+    },
+    "createDomainPage": {
+      "subtitle": "Adicione o domínio para verificar. Usuários com endereços de e-mail neste domínio podem se juntar à organização automaticamente ou solicitar participação.",
+      "title": "Adicionar domínio"
+    },
+    "invitePage": {
+      "detailsTitle__inviteFailed": "Os convites não puderam ser enviados. Já existem convites pendentes para os seguintes endereços de e-mail: {{email_addresses}}.",
+      "formButtonPrimary__continue": "Enviar convites",
+      "selectDropdown__role": "Selecione a função",
+      "subtitle": "Insira ou cole um ou mais endereços de e-mail, separados por espaços ou vírgulas.",
+      "successMessage": "Convites enviados com sucesso",
+      "title": "Convidar membros"
+    },
+    "membersPage": {
+      "action__invite": "Convidar",
+      "action__search": "Pesquisar",
+      "activeMembersTab": {
+        "menuAction__remove": "Remover membro",
+        "tableHeader__actions": "Ações",
+        "tableHeader__joined": "Entrou",
+        "tableHeader__role": "Função",
+        "tableHeader__user": "Usuário"
+      },
+      "alerts": {
+        "roleSetMigrationInProgress": {
+          "subtitle": "Estamos atualizando as funções disponíveis. Assim que isso for concluído, você poderá atualizar as funções novamente.",
+          "title": "As funções estão temporariamente bloqueadas"
+        }
+      },
+      "detailsTitle__emptyRow": "Nenhum membro para exibir",
+      "invitationsTab": {
+        "autoInvitations": {
+          "headerSubtitle": "Convide usuários conectando um domínio de e-mail com sua organização. Qualquer pessoa que se inscrever com um domínio de e-mail correspondente poderá se juntar à organização a qualquer momento.",
+          "headerTitle": "Convites automáticos",
+          "primaryButton": "Gerenciar domínios verificados"
+        },
+        "table__emptyRow": "Nenhum convite para exibir"
+      },
+      "invitedMembersTab": {
+        "menuAction__revoke": "Cancelar convite",
+        "tableHeader__invited": "Convidado"
+      },
+      "requestsTab": {
+        "autoSuggestions": {
+          "headerSubtitle": "Usuários que se inscrevem com um domínio de e-mail correspondente podem ver uma sugestão para solicitar participação em sua organização.",
+          "headerTitle": "Sugestões automáticas",
+          "primaryButton": "Gerenciar domínios verificados"
+        },
+        "menuAction__approve": "Aprovar",
+        "menuAction__reject": "Rejeitar",
+        "tableHeader__requested": "Acesso solicitado",
+        "table__emptyRow": "Nenhuma solicitação para exibir"
+      },
+      "start": {
+        "headerTitle__invitations": "Convites",
+        "headerTitle__members": "Membros",
+        "headerTitle__requests": "Solicitações"
+      }
+    },
+    "navbar": {
+      "apiKeys": "Chaves de API",
+      "billing": "Faturamento",
+      "description": "Gerencie sua organização.",
+      "general": "Geral",
+      "members": "Membros",
+      "title": "Organização"
+    },
+    "plansPage": {
+      "alerts": {
+        "noPermissionsToManageBilling": "Você não tem permissões para gerenciar o faturamento desta organização."
+      },
+      "title": "Planos"
+    },
+    "profilePage": {
+      "dangerSection": {
+        "deleteOrganization": {
+          "actionDescription": "Digite {{organizationName}} abaixo para continuar.",
+          "messageLine1": "Tem certeza de que deseja excluir esta organização?",
+          "messageLine2": "Esta ação é permanente e irreversível.",
+          "successMessage": "Você excluiu a organização.",
+          "title": "Excluir organização"
+        },
+        "leaveOrganization": {
+          "actionDescription": "Digite {{organizationName}} abaixo para continuar.",
+          "messageLine1": "Tem certeza de que deseja sair desta organização? Você perderá o acesso a esta organização e suas aplicações.",
+          "messageLine2": "Esta ação é permanente e não pode ser desfeita.",
+          "successMessage": "Você saiu da organização.",
+          "title": "Sair da organização"
+        },
+        "title": "Perigo"
+      },
+      "domainSection": {
+        "menuAction__manage": "Gerenciar",
+        "menuAction__remove": "Excluir",
+        "menuAction__verify": "Verificar",
+        "primaryButton": "Adicionar domínio",
+        "subtitle": "Permita que os usuários se juntem à organização automaticamente ou solicitem participação com base em um domínio de e-mail verificado.",
+        "title": "Domínios verificados"
+      },
+      "successMessage": "A organização foi atualizada.",
+      "title": "Perfil da organização"
+    },
+    "removeDomainPage": {
+      "messageLine1": "O domínio de e-mail {{domain}} será removido.",
+      "messageLine2": "Os usuários não poderão mais se juntar à organização automaticamente após isso.",
+      "successMessage": "{{domain}} foi removido.",
+      "title": "Excluir domínio"
+    },
+    "securityPage": { "removeDialog": {}, "ssoSection": {} },
+    "start": {
+      "headerTitle__general": "Geral",
+      "headerTitle__members": "Membros",
+      "profileSection": {
+        "primaryButton": "Atualizar perfil",
+        "title": "Perfil da Organização",
+        "uploadAction__title": "Logo"
+      }
+    },
+    "verifiedDomainPage": {
+      "dangerTab": {
+        "calloutInfoLabel": "A exclusão deste domínio afetará os usuários convidados.",
+        "removeDomainActionLabel__remove": "Excluir domínio",
+        "removeDomainSubtitle": "Remova este domínio de seus domínios verificados",
+        "removeDomainTitle": "Excluir domínio"
+      },
+      "enrollmentTab": {
+        "automaticInvitationOption__description": "Os usuários são convidados automaticamente a se juntar à organização quando se inscrevem e podem se juntar a qualquer momento.",
+        "automaticInvitationOption__label": "Convites automáticos",
+        "automaticSuggestionOption__description": "Os usuários recebem uma sugestão para solicitar participação, mas devem ser aprovados por um administrador antes de poderem se juntar à organização.",
+        "automaticSuggestionOption__label": "Sugestões automáticas",
+        "calloutInfoLabel": "Alterar o modo de inscrição afetará apenas os novos usuários.",
+        "calloutInvitationCountLabel": "Convites pendentes enviados aos usuários: {{count}}",
+        "calloutSuggestionCountLabel": "Sugestões pendentes enviadas aos usuários: {{count}}",
+        "manualInvitationOption__description": "Os usuários só podem ser convidados manualmente para a organização.",
+        "manualInvitationOption__label": "Sem inscrição automática",
+        "subtitle": "Escolha como os usuários deste domínio podem se juntar à organização."
+      },
+      "start": {
+        "headerTitle__danger": "Perigo",
+        "headerTitle__enrollment": "Opções de inscrição"
+      },
+      "subtitle": "O domínio {{domain}} agora está verificado. Continue selecionando o modo de inscrição.",
+      "title": "Atualizar {{domain}}"
+    },
+    "verifyDomainPage": {
+      "formSubtitle": "Insira o código de verificação enviado para o seu endereço de e-mail",
+      "formTitle": "Código de verificação",
+      "resendButton": "Não recebeu um código? Reenviar",
+      "subtitle": "O domínio {{domainName}} precisa ser verificado por e-mail.",
+      "subtitleVerificationCodeScreen": "Um código de verificação foi enviado para {{emailAddress}}. Insira o código para continuar.",
+      "title": "Verificar domínio"
+    }
+  },
+  "organizationSwitcher": {
+    "action__closeOrganizationSwitcher": "Fechar seletor de organização",
+    "action__createOrganization": "Criar organização",
+    "action__invitationAccept": "Participar",
+    "action__manageOrganization": "Gerenciar organização",
+    "action__openOrganizationSwitcher": "Abrir seletor de organização",
+    "action__suggestionsAccept": "Solicitar participação",
+    "notSelected": "Nenhuma organização selecionada",
+    "personalWorkspace": "Conta pessoal",
+    "suggestionsAcceptedLabel": "Aprovação pendente"
+  },
+  "paginationButton__next": "Próximo",
+  "paginationButton__previous": "Anterior",
+  "paginationRowText__displaying": "Exibindo",
+  "paginationRowText__of": "de",
+  "reverification": {
+    "alternativeMethods": {
+      "actionLink": "Solicitar ajuda",
+      "actionText": "Não tem nenhum dos métodos? Tente outra forma.",
+      "blockButton__backupCode": "Usar código de backup",
+      "blockButton__emailCode": "Enviar código para {{identifier}}",
+      "blockButton__passkey": "Usar sua chave de acesso",
+      "blockButton__password": "Usar senha",
+      "blockButton__phoneCode": "Enviar código de telefone",
+      "blockButton__totp": "Usar autenticação TOTP",
+      "getHelp": {
+        "blockButton__emailSupport": "Entrar em contato com o suporte",
+        "content": "Se você não tem nenhum dos métodos listados, entre em contato com nosso suporte.",
+        "title": "Solicitar ajuda"
+      },
+      "subtitle": "Escolha um dos métodos alternativos para verificar sua identidade.",
+      "title": "Métodos alternativos de verificação"
+    },
+    "backupCodeMfa": {
+      "subtitle": "Digite seu código de backup para continuar.",
+      "title": "Verificação com código de backup"
+    },
+    "emailCode": {
+      "formTitle": "Código enviado para seu e-mail",
+      "resendButton": "Reenviar código",
+      "subtitle": "Verifique seu e-mail e insira o código para continuar.",
+      "title": "Verifique seu e-mail"
+    },
+    "noAvailableMethods": {
+      "message": "Nenhum método de verificação disponível. Entre em contato com o suporte.",
+      "subtitle": "Não há métodos de verificação disponíveis no momento.",
+      "title": "Métodos de verificação indisponíveis"
+    },
+    "passkey": {
+      "blockButton__passkey": "Usar sua chave de acesso",
+      "subtitle": "Usar sua chave de acesso confirma a sua identidade. Seu dispositivo pode solicitar sua impressão digital, reconhecimento facial ou PIN.",
+      "title": "Use sua chave de acesso."
+    },
+    "password": {
+      "actionLink": "Usar outro método",
+      "subtitle": "Digite sua senha para continuar.",
+      "title": "Digite sua senha"
+    },
+    "phoneCode": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "Verifique seu celular para o código de verificação.",
+      "title": "Verifique seu celular"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "Verifique seu celular para o código de verificação.",
+      "title": "Verifique seu celular"
+    },
+    "totpMfa": {
+      "formTitle": "Código de verificação TOTP",
+      "subtitle": "Digite o código de verificação gerado pelo seu aplicativo de autenticação.",
+      "title": "Autenticação TOTP"
+    }
+  },
+  "searchInput": {},
+  "signIn": {
+    "accountSwitcher": {
+      "action__addAccount": "Adicionar conta",
+      "action__signOutAll": "Sair de todas as contas",
+      "subtitle": "Selecione a conta com a qual gostaria de continuar.",
+      "title": "Escolha uma conta."
+    },
+    "alternativeMethods": {
+      "actionLink": "Ajuda",
+      "actionText": "Não tem nenhum destes?",
+      "blockButton__backupCode": "Utilize um código de backup",
+      "blockButton__emailCode": "Enviar código para {{identifier}}",
+      "blockButton__emailLink": "Enviar link para {{identifier}}",
+      "blockButton__passkey": "Acessar com sua chave de acesso",
+      "blockButton__password": "Acessar com sua senha",
+      "blockButton__phoneCode": "Enviar código para {{identifier}}",
+      "blockButton__totp": "Utilize seu aplicativo autenticador",
+      "getHelp": {
+        "blockButton__emailSupport": "E-mail de suporte",
+        "content": "Se estiver com dificuldades para entrar em sua conta, envie um e-mail para nós que iremos te ajudar a restaurar seu acesso o mais rápido possível.",
+        "title": "Ajuda"
+      },
+      "subtitle": "Encontrando dificuldades? Você pode utilizar qualquer um destes métodos para acessar.",
+      "title": "Utilize outro método"
+    },
+    "alternativePhoneCodeProvider": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "Verifique seu celular para o código de verificação.",
+      "title": "Verifique seu celular"
+    },
+    "backupCodeMfa": {
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Insira um código de backup"
+    },
+    "emailCode": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu e-mail"
+    },
+    "emailCodeMfa": {
+      "formTitle": "Verifique seu e-mail",
+      "resendButton": "Não recebeu um código? Reenviar",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu e-mail"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Para continuar, abra o link de verificação no mesmo dispositivo e navegador em que iniciou o login",
+        "title": "Link de verificação é inválido para este dispositivo"
+      },
+      "expired": {
+        "subtitle": "Retorne para a aba original para continuar",
+        "title": "Este link de verificação expirou"
+      },
+      "failed": {
+        "subtitle": "Retorne para a aba original para continuar",
+        "title": "Este link de verificação é inválido"
+      },
+      "formSubtitle": "Utilize o link enviado no seu e-mail",
+      "formTitle": "Link de verificação",
+      "loading": {
+        "subtitle": "Você será redirecionado em breve",
+        "title": "Conectando..."
+      },
+      "resendButton": "Não recebeu um link? Reenviar",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu e-mail",
+      "unusedTab": { "title": "Você pode fechar esta aba" },
+      "verified": {
+        "subtitle": "Você será redirecionado em breve",
+        "title": "Login realizado com sucesso"
+      },
+      "verifiedSwitchTab": {
+        "subtitle": "Retorne para a aba original para continuar",
+        "subtitleNewTab": "Retorne para a nova aba que foi aberta para continuar",
+        "titleNewTab": "Conectado em outra aba"
+      }
+    },
+    "emailLinkMfa": {
+      "formSubtitle": "Use o link de verificação enviado para o seu e-mail",
+      "resendButton": "Não recebeu o link? Reenviar",
+      "subtitle": "para continuar para {{applicationName}}",
+      "title": "Verifique seu e-mail"
+    },
+    "enterpriseConnections": {
+      "subtitle": "Selecione a conta corporativa com a qual deseja continuar.",
+      "title": "Escolha sua conta corporativa"
+    },
+    "forgotPassword": {
+      "formTitle": "Código de redefinição de senha",
+      "resendButton": "Não recebeu um código? Reenviar",
+      "subtitle": "para redefinir sua senha",
+      "subtitle_email": "Primeiro, digite o código enviado para seu e-mail",
+      "subtitle_phone": "Primeiro, digite o código enviado para seu telefone",
+      "title": "Redefinir senha"
+    },
+    "forgotPasswordAlternativeMethods": {
+      "blockButton__resetPassword": "Redefinir sua senha",
+      "label__alternativeMethods": "Ou, faça login com outro método.",
+      "title": "Esqueceu a senha?"
+    },
+    "newDeviceVerificationNotice": "Você está entrando de um novo dispositivo. Estamos solicitando verificação para manter sua conta segura.",
+    "noAvailableMethods": {
+      "message": "Não foi possível fazer login. Não há nenhum método de autenticação disponível.",
+      "subtitle": "Aconteceu um erro",
+      "title": "Não foi possível fazer login"
+    },
+    "passkey": {
+      "subtitle": "Usar sua chave de acesso confirma a sua identidade. Seu dispositivo pode solicitar sua impressão digital, reconhecimento facial ou PIN.",
+      "title": "Use sua chave de acesso."
+    },
+    "password": {
+      "actionLink": "Utilize outro método",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Insira sua senha"
+    },
+    "passwordCompromised": { "title": "Senha comprometida" },
+    "passwordPwned": { "title": "Senha comprometida" },
+    "passwordUntrusted": { "title": "Senha não confiável" },
+    "phoneCode": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu telefone"
+    },
+    "phoneCodeMfa": {
+      "formTitle": "Código de verificação",
+      "resendButton": "Reenviar código",
+      "subtitle": "Para continuar, insira o código enviado para o seu telefone.",
+      "title": "Verifique seu telefone"
+    },
+    "protectCheck": {},
+    "resetPassword": {
+      "formButtonPrimary": "Redefinir Senha",
+      "requiredMessage": "Por razões de segurança, é necessário redefinir sua senha.",
+      "successMessage": "Sua senha foi alterada com sucesso. Entrando, por favor aguarde um momento.",
+      "title": "Redefinir Senha"
+    },
+    "resetPasswordMfa": {
+      "detailsLabel": "Precisamos verificar sua identidade antes de redefinir sua senha."
+    },
+    "start": {
+      "actionLink": "Registre-se",
+      "actionLink__join_waitlist": "Entrar na lista de espera",
+      "actionLink__use_email": "Usar e-mail",
+      "actionLink__use_email_username": "Usar e-mail ou nome de usuário",
+      "actionLink__use_passkey": "Ou use sua chave de acesso",
+      "actionLink__use_phone": "Usar telefone",
+      "actionLink__use_username": "Usar nome de usuário",
+      "actionText": "Não possui uma conta?",
+      "actionText__join_waitlist": "Quer ser notificado quando estivermos prontos?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Usar outro método",
+        "label": "{{provider}} telefone",
+        "subtitle": "Insira seu número de telefone para receber um código de verificação em {{provider}}.",
+        "title": "Entrar no {{applicationName}} com {{provider}}"
+      },
+      "subtitle": "para continuar em {{applicationName}}",
+      "subtitleCombined": "Bem-vindo de volta! Por favor, faça login para continuar",
+      "title": "Entrar",
+      "titleCombined": "Continuar em {{applicationName}}"
+    },
+    "totpMfa": {
+      "formTitle": "Código de verificação",
+      "subtitle": "Para continuar, insira o código gerado pelo seu aplicativo autenticador.",
+      "title": "Verificação em duas etapas"
+    },
+    "web3Solana": {
+      "subtitle": "Selecione uma carteira abaixo para entrar",
+      "title": "Entrar com Solana"
+    }
+  },
+  "signInEnterPasswordTitle": "Insira sua senha",
+  "signUp": {
+    "alternativePhoneCodeProvider": {
+      "resendButton": "Não recebeu um código? Reenviar",
+      "subtitle": "Insira o código de verificação enviado para seu {{provider}}",
+      "title": "Verifique seu {{provider}}"
+    },
+    "continue": {
+      "actionLink": "Entrar",
+      "actionText": "Possui uma conta?",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Preencha os campos ausentes"
+    },
+    "emailCode": {
+      "formSubtitle": "Insira o código enviado para seu e-mail",
+      "formTitle": "Código de verificação",
+      "resendButton": "Não recebeu o código? Reenviar",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu e-mail"
+    },
+    "emailLink": {
+      "clientMismatch": {
+        "subtitle": "Para continuar, abra o link de verificação no mesmo dispositivo e navegador em que iniciou o cadastro",
+        "title": "Link de verificação é inválido para este dispositivo"
+      },
+      "formSubtitle": "Utilize o link enviado no seu e-mail",
+      "formTitle": "Link de verificação",
+      "loading": { "title": "Conectando..." },
+      "resendButton": "Reenviar link",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu e-mail",
+      "verified": { "title": "Cadastro realizado com sucesso" },
+      "verifiedSwitchTab": {
+        "subtitle": "Retorne para a nova aba que foi aberta para continuar",
+        "subtitleNewTab": "Retorne para a aba anterior para continuar",
+        "title": "E-mail verificado com sucesso"
+      }
+    },
+    "enterpriseConnections": {
+      "subtitle": "Selecione a conta corporativa com a qual deseja continuar.",
+      "title": "Escolha sua conta corporativa"
+    },
+    "legalConsent": {
+      "checkbox": {
+        "label__onlyPrivacyPolicy": "Eu concordo com a {{privacyPolicyLink || link(\"Política de Privacidade\")}}",
+        "label__onlyTermsOfService": "Eu concordo com os {{termsOfServiceLink || link(\"Termos de Uso\")}}",
+        "label__termsOfServiceAndPrivacyPolicy": "Eu concordo com os {{termsOfServiceLink || link(\"Termos de Uso\")}} e com a {{ privacyPolicyLink || link(\"Política de Privacidade\") }}"
+      },
+      "continue": {
+        "subtitle": "Por favor leia e aceite os termos para continuar",
+        "title": "Continuar"
+      }
+    },
+    "phoneCode": {
+      "formSubtitle": "Insira o código enviado para seu telefone",
+      "formTitle": "Código de verificação",
+      "resendButton": "Não recebeu o código? Reenviar",
+      "subtitle": "para continuar em {{applicationName}}",
+      "title": "Verifique seu telefone"
+    },
+    "protectCheck": {},
+    "restrictedAccess": {
+      "actionLink": "Entrar",
+      "actionText": "Já possui uma conta?",
+      "blockButton__emailSupport": "Suporte por e-mail",
+      "blockButton__joinWaitlist": "Entre na lista de espera",
+      "subtitle": "Cadastros estão desabilitados no momento. Se você deveria ter acesso, por favor entre em contato com o suporte.",
+      "subtitleWaitlist": "Cadastros estão desabilitados no momento. Para ser um dos primeiros a saber quando lançarmos, entre na lista de espera.",
+      "title": "Acesso restrito"
+    },
+    "start": {
+      "actionLink": "Entrar",
+      "actionLink__use_email": "Ou use e-mail",
+      "actionLink__use_phone": "Ou use telefone",
+      "actionText": "Possui uma conta?",
+      "alternativePhoneCodeProvider": {
+        "actionLink": "Usar outro método",
+        "label": "{{provider}} telefone",
+        "subtitle": "Insira seu número de telefone para receber um código de verificação em {{provider}}.",
+        "title": "Entrar no {{applicationName}} com {{provider}}"
+      },
+      "subtitle": "para continuar em {{applicationName}}",
+      "subtitleCombined": "para continuar em {{applicationName}}",
+      "title": "Criar sua conta",
+      "titleCombined": "Criar sua conta"
+    },
+    "web3Solana": {
+      "subtitle": "Selecione uma carteira abaixo para se cadastrar",
+      "title": "Cadastrar-se com Solana"
+    }
+  },
+  "socialButtonsBlockButton": "Continuar com {{provider|titleize}}",
+  "socialButtonsBlockButtonManyInView": "{{provider|titleize}}",
+  "taskChooseOrganization": {
+    "alerts": {
+      "organizationAlreadyExists": "Uma organização já existe para o nome da empresa detectado ({{organizationName}}) e {{organizationDomain}}. Entre por convite."
+    },
+    "chooseOrganization": {
+      "action__createOrganization": "Criar nova organização",
+      "action__invitationAccept": "Participar",
+      "action__suggestionsAccept": "Solicitar participação",
+      "subtitle": "Junte-se a uma organização existente ou crie uma nova",
+      "subtitle__createOrganizationDisabled": "Junte-se a uma organização existente",
+      "suggestionsAcceptedLabel": "Aprovação pendente",
+      "title": "Escolha uma organização"
+    },
+    "createOrganization": {
+      "formButtonReset": "Cancelar",
+      "formButtonSubmit": "Criar nova organização",
+      "formFieldInputPlaceholder__name": "Minha organização",
+      "formFieldInputPlaceholder__slug": "minha-organizacao",
+      "formFieldLabel__name": "Nome",
+      "formFieldLabel__slug": "Rótulo do URL",
+      "subtitle": "Conte-nos um pouco sobre sua organização",
+      "title": "Configure sua conta"
+    },
+    "organizationCreationDisabled": {
+      "subtitle": "Entre em contato com o administrador da sua organização para obter um convite.",
+      "title": "Você deve pertencer a uma organização"
+    },
+    "signOut": {
+      "actionLink": "Sair",
+      "actionText": "Conectado como {{identifier}}"
+    }
+  },
+  "taskResetPassword": {
+    "formButtonPrimary": "Resetar Senha",
+    "signOut": {
+      "actionLink": "Sair",
+      "actionText": "Conectado como {{identifier}}"
+    },
+    "subtitle": "Sua conta requer uma nova senha antes de continuar",
+    "title": "Resetar senha"
+  },
+  "taskSetupMfa": {
+    "signOut": {},
+    "smsCode": { "addPhone": {}, "success": {}, "verifyPhone": {} },
+    "start": { "methodSelection": {} },
+    "totpCode": { "addAuthenticatorApp": {}, "success": {}, "verifyTotp": {} }
+  },
+  "unstable__errors": {
+    "already_a_member_in_organization": "{{email}} já é membro da organização.",
+    "avatar_file_size_exceeded": "O tamanho do arquivo excede o limite máximo de 10 MB. Por favor, escolha um arquivo menor.",
+    "avatar_file_type_invalid": "Tipo de arquivo não suportado. Por favor, envie uma imagem JPG, PNG, GIF ou WEBP.",
+    "captcha_invalid": "Não foi possível se inscrever devido a falhas nas validações de segurança. Por favor, atualize a página para tentar novamente ou entre em contato com o suporte para obter mais ajuda.",
+    "captcha_unavailable": "Não foi possível se inscrever devido à indisponibilidade do captcha. Por favor atualize a página para tentar novamente ou entre em contato com o suporte para obter mais ajuda.",
+    "form_code_incorrect": "Código incorreto.",
+    "form_email_address_blocked": "Serviços de e-mail temporários não são suportados. Por favor, use seu endereço de e-mail regular para criar uma conta.",
+    "form_identifier_exists__email_address": "E-mail já está em uso. Por favor, tente outro.",
+    "form_identifier_exists__phone_number": "Telefone já está em uso. Por favor, tente outro.",
+    "form_identifier_exists__username": "Nome de usuário já está em uso. Por favor, tente outro.",
+    "form_identifier_not_found": "Não foi possível encontrar o usuário.",
+    "form_new_password_matches_current": "A nova senha não pode ser igual à senha atual.",
+    "form_param_format_invalid": "Formato inválido.",
+    "form_param_format_invalid__email_address": "O endereço de e-mail deve ser um endereço de e-mail válido.",
+    "form_param_format_invalid__phone_number": "Número de telefone precisa estar num formato internacional válido.",
+    "form_param_max_length_exceeded__first_name": "O primeiro nome não deve exceder 256 caracteres.",
+    "form_param_max_length_exceeded__last_name": "O sobrenome não deve exceder 256 caracteres.",
+    "form_param_max_length_exceeded__name": "O nome não deve exceder 256 caracteres.",
+    "form_param_nil": "Campo obrigatório.",
+    "form_param_type_invalid": "Tipo de parâmetro inválido.",
+    "form_param_type_invalid__email_address": "Endereço de e-mail inválido.",
+    "form_param_type_invalid__phone_number": "Número de telefone inválido.",
+    "form_param_value_invalid": "Valor inválido.",
+    "form_password_incorrect": "Senha incorreta.",
+    "form_password_length_too_short": "Sua senha é muito curta. Por favor, tente novamente.",
+    "form_password_not_strong_enough": "Sua senha não é forte o suficiente.",
+    "form_password_or_identifier_incorrect": "A senha ou o endereço de e-mail está incorreto. Tente novamente ou use outro método.",
+    "form_password_pwned": "Esta senha foi comprometida e não pode ser usada, por favor, tente outra senha.",
+    "form_password_pwned__sign_in": "Esta senha foi comprometida, por favor redefina sua senha.",
+    "form_password_size_in_bytes_exceeded": "Sua senha excedeu o número máximo de bytes permitidos, por favor, encurte-a ou remova alguns caracteres especiais.",
+    "form_password_untrusted__sign_in": "Sua senha pode estar comprometida. Para proteger sua conta, continue com um método de login alternativo. Você precisará redefinir sua senha após o login.",
+    "form_password_validation_failed": "Senha incorreta",
+    "form_username_invalid_character": "Nome de usuário contém caracteres inválidos. Por favor, tente outro.",
+    "form_username_invalid_length": "Nome de usuário deve ter entre 3 e 256 caracteres.",
+    "form_username_needs_non_number_char": "Nome de usuário deve conter pelo menos um caractere não número.",
+    "identification_deletion_failed": "Você não pode excluir sua última identificação.",
+    "not_allowed_access": "O endereço de e-mail ou número de telefone não é permitido para registro. Isso pode ser devido ao uso de '+', '=', '#' ou '.' no endereço de e-mail, o uso de um domínio associado a um serviço de e-mail temporário ou uma exclusão explícita.",
+    "organization_domain_blocked": "Este é um provedor de domínio de e-mail bloqueado. Por favor, use um diferente.",
+    "organization_domain_common": "Este é um provedor de domínio de e-mail comum. Por favor, use um diferente.",
+    "organization_domain_exists_for_enterprise_connection": "Este domínio já existe para uma conexão empresarial.",
+    "organization_membership_quota_exceeded": "Você chegou ao seu limite de membros da organização, incluindo convites pendentes.",
+    "organization_minimum_permissions_needed": "É necessário que haja pelo menos um membro da organização com as permissões mínimas necessárias.",
+    "organization_not_found_or_unauthorized": "Organização não encontrada ou não autorizada",
+    "organization_not_found_or_unauthorized_with_create_organization_disabled": "Organização não encontrada ou não autorizada, a criação de organizações está desabilitada",
+    "passkey_already_exists": "Uma chave de acesso já está registrada neste dispositivo.",
+    "passkey_not_supported": "Chaves de acesso não são suportadas neste dispositivo.",
+    "passkey_pa_not_supported": "Registro precisa de chave de acesso mas dispositivo não a suporta.",
+    "passkey_registration_cancelled": "Registro de chave de acesso cancelado ou expirado.",
+    "passkey_retrieval_cancelled": "Verificação de chave de acesso cancelada ou expirada.",
+    "passwordComplexity": {
+      "maximumLength": "menos de {{length}} caracteres",
+      "minimumLength": "{{length}} ou mais caracteres",
+      "requireLowercase": "uma letra minúscula",
+      "requireNumbers": "um número",
+      "requireSpecialCharacter": "um caractere especial",
+      "requireUppercase": "uma letra maiúscula",
+      "sentencePrefix": "Sua senha deve conter"
+    },
+    "phone_number_exists": "Este número de telefone já está em uso. Por favor, tente outro.",
+    "session_exists": "Você já está conectado.",
+    "web3_missing_identifier": "Uma extensão de carteira Web3 não pode ser encontrada. Por favor, instale uma para continuar.",
+    "web3_signature_request_rejected": "Você rejeitou a solicitação de assinatura. Tente novamente para continuar.",
+    "web3_solana_signature_generation_failed": "Ocorreu um erro ao gerar a assinatura. Tente novamente para continuar.",
+    "zxcvbn": {
+      "couldBeStronger": "Sua senha funciona, mas poderia ser mais forte. Tente adicionar mais caracteres.",
+      "goodPassword": "Sua senha atende a todos os requisitos necessários.",
+      "notEnough": "Sua senha não é forte o suficiente.",
+      "suggestions": {
+        "allUppercase": "Utilize apenas algumas letras maiúsculas, não todas.",
+        "anotherWord": "Adicione mais palavras que são menos comuns.",
+        "associatedYears": "Evite anos associados a você.",
+        "capitalization": "Utilize outras letras maiúsculas, além do que primeira.",
+        "dates": "Evite datas e anos associados a você.",
+        "l33t": "Evite substituições previsíveis de letras, como '@' por 'a'.",
+        "longerKeyboardPattern": "Use padrões de teclado mais longos e mude a direção da digitação várias vezes.",
+        "noNeed": "Você pode criar senhas fortes sem usar símbolos, números ou letras maiúsculas.",
+        "pwned": "Se você usar esta senha em outro lugar, você deve mudá-la.",
+        "recentYears": "Evite anos recentes.",
+        "repeated": "Evite palavras e caracteres repetidos.",
+        "reverseWords": "Evite utilizar palavras comuns escritas de \"trás para frente\".",
+        "sequences": "Evite sequências comuns de caracteres.",
+        "useWords": "Use várias palavras, mas evite frases comuns."
+      },
+      "warnings": {
+        "common": "Esta é uma senha comumente usada.",
+        "commonNames": "Nomes e sobrenomes comuns são fáceis de adivinhar.",
+        "dates": "Datas são fáceis de adivinhar.",
+        "extendedRepeat": "Padrões de caracteres repetidos, como \"abcabcabc\" são fáceis de adivinhar.",
+        "keyPattern": "Padrões curtos de teclado são fáceis de adivinhar.",
+        "namesByThemselves": "Nomes ou sobrenomes são fáceis de adivinhar.",
+        "pwned": "Sua senha foi exposta por uma violação de dados na Internet.",
+        "recentYears": "Anos recentes são fáceis de adivinhar.",
+        "sequences": "Sequências comuns de caracteres, como \"abc\" são fáceis de adivinhar.",
+        "similarToCommon": "Esta é semelhante a uma senha comumente usada.",
+        "simpleRepeat": "Caracteres repetidos, como \"aaa\" são fáceis de adivinhar.",
+        "straightRow": "Letras que vêm em sequência teclado são fáceis de adivinhar.",
+        "topHundred": "Esta é uma senha usada frequentemente.",
+        "topTen": "Esta é uma senha muito usada.",
+        "userInputs": "Não deve haver nenhum dado pessoal ou relacionado à página.",
+        "wordByItself": "Palavras simples são fáceis de adivinhar."
+      }
+    }
+  },
+  "userButton": {
+    "action__addAccount": "Adicionar conta",
+    "action__closeUserMenu": "Fechar menu do usuário",
+    "action__manageAccount": "Gerenciar conta",
+    "action__openUserMenu": "Abrir menu do usuário",
+    "action__signOut": "Sair",
+    "action__signOutAll": "Sair de todas as contas",
+    "label__accountActions": "Ações da conta",
+    "label__activeSessions": "Sessões ativas",
+    "label__userButtonPopover": "Painel da conta"
+  },
+  "userProfile": {
+    "apiKeysPage": { "title": "Chaves de API" },
+    "backupCodePage": {
+      "actionLabel__copied": "Copiado!",
+      "actionLabel__copy": "Copiar tudo",
+      "actionLabel__download": "Download .txt",
+      "actionLabel__print": "Imprimir",
+      "infoText1": "Códigos de backup serão ativados para esta conta.",
+      "infoText2": "Guarde-os em segurança e mantenha-os em sigilo. Você pode gerar novos códigos de backup se suspeitar que eles tenham sido comprometidos.",
+      "subtitle__codelist": "Guarde-os em segurança e mantenha-os em sigilo.",
+      "successMessage": "Códigos de backup foram ativados para esta conta. Você pode usar um deles para fazer login na sua conta caso perca o acesso ao seu dispositivo de autenticação. Cada código poderá ser utilizado apenas uma vez.",
+      "successSubtitle": "Você pode usar um deles para fazer login na sua conta caso perca o acesso ao seu dispositivo de autenticação.",
+      "title": "Adicionar código de backup para verificação",
+      "title__codelist": "Códigos de backup"
+    },
+    "billingPage": {
+      "accountCreditsSection": {},
+      "creditHistoryPage": {},
+      "paymentHistorySection": {
+        "empty": "Nenhum histórico de pagamento",
+        "notFound": "Pagamento não encontrado",
+        "tableHeader__amount": "Valor",
+        "tableHeader__date": "Data",
+        "tableHeader__status": "Status"
+      },
+      "paymentMethodsSection": {
+        "actionLabel__default": "Tornar padrão",
+        "actionLabel__remove": "Remover",
+        "add": "Adicionar novo método de pagamento",
+        "addSubtitle": "Adicione um novo método de pagamento à sua conta.",
+        "cancelButton": "Cancelar",
+        "formButtonPrimary__add": "Adicionar Método de Pagamento",
+        "formButtonPrimary__pay": "Pagar {{amount}}",
+        "payWithTestCardButton": "Pagar com cartão de teste",
+        "removeMethod": {
+          "messageLine1": "{{identifier}} será removido desta conta.",
+          "messageLine2": "Você não poderá mais usar esta forma de pagamento e quaisquer assinaturas recorrentes dependentes dela deixarão de funcionar.",
+          "successMessage": "{{paymentMethod}} foi removido da sua conta.",
+          "title": "Remover método de pagamento"
+        },
+        "title": "Métodos de pagamento"
+      },
+      "start": {
+        "headerTitle__payments": "Pagamentos",
+        "headerTitle__plans": "Planos",
+        "headerTitle__statements": "Extratos",
+        "headerTitle__subscriptions": "Assinaturas"
+      },
+      "statementsSection": {
+        "empty": "Nenhum extrato para exibir",
+        "itemCaption__paidForPlan": "Pago para plano {{plan}} {{period}}",
+        "itemCaption__proratedCredit": "Crédito proporcional para uso parcial do plano anterior",
+        "itemCaption__subscribedAndPaidForPlan": "Assinado e pago para plano {{plan}} {{period}}",
+        "notFound": "Extrato não encontrado",
+        "tableHeader__amount": "Valor",
+        "tableHeader__date": "Data",
+        "title": "Extratos",
+        "totalPaid": "Total pago"
+      },
+      "subscriptionsListSection": {
+        "actionLabel__manageSubscription": "Gerenciar assinatura",
+        "actionLabel__newSubscription": "Assinar um plano",
+        "actionLabel__switchPlan": "Mudar de plano",
+        "tableHeader__edit": "Editar",
+        "tableHeader__plan": "Plano",
+        "tableHeader__startDate": "Data de início",
+        "title": "Assinatura"
+      },
+      "subscriptionsSection": { "actionLabel__default": "Gerenciar" },
+      "switchPlansSection": { "title": "Mudar de plano" },
+      "title": "Faturamento"
+    },
+    "connectedAccountPage": {
+      "formHint": "Selecione um provedor para conectar à sua conta.",
+      "formHint__noAccounts": "Não há provedores de conta externos disponíveis.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} será removido desta conta.",
+        "messageLine2": "Você não conseguirá mais usar esta conta e quaisquer recursos dependentes dela deixarão de funcionar.",
+        "successMessage": "{{connectedAccount}} foi removido da sua conta.",
+        "title": "Remover conta conectada"
+      },
+      "socialButtonsBlockButton": "Conectar conta {{provider|titleize}}",
+      "successMessage": "O provedor foi adicionado à sua conta",
+      "title": "Conecte uma conta"
+    },
+    "deletePage": {
+      "actionDescription": "Digite Excluir conta abaixo para continuar.",
+      "confirm": "Excluir conta",
+      "messageLine1": "Tem certeza de que deseja excluir sua conta? Alguns dados associados podem ser mantidos. Para solicitar a exclusão completa de dados, entre em contato com o suporte.",
+      "messageLine2": "Esta ação é permanente e irreversível.",
+      "title": "Excluir conta"
+    },
+    "emailAddressPage": {
+      "emailCode": {
+        "formHint": "Um e-mail contendo um código de verificação será enviado para este endereço de e-mail.",
+        "formSubtitle": "Insira o código de verificação enviado para {{identifier}}",
+        "formTitle": "Código de verificação",
+        "resendButton": "Não recebeu um código? Reenviar",
+        "successMessage": "O e-mail {{identifier}} foi adicionado na sua conta."
+      },
+      "emailLink": {
+        "formHint": "Um e-mail contendo um link de verificação será enviado para este endereço de e-mail.",
+        "formSubtitle": "Clique no link de verificação enviado para {{identifier}}",
+        "formTitle": "Link de verificação",
+        "resendButton": "Não recebeu um código? Reenviar",
+        "successMessage": "O e-mail {{identifier}} foi adicionado na sua conta."
+      },
+      "enterpriseSSOLink": {
+        "formButton": "Clique para autenticar",
+        "formSubtitle": "Complete a autenticação com {{identifier}}"
+      },
+      "formHint": "Você precisará verificar este endereço de email antes de poder adicioná-lo à sua conta.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} será removido desta conta.",
+        "messageLine2": "Você não conseguirá fazer login novamente com este endereço de e-mail.",
+        "successMessage": "{{emailAddress}} foi removido da sua conta.",
+        "title": "Remover e-mail"
+      },
+      "title": "Adicionar e-mail",
+      "verifyTitle": "Verificar endereço de e-mail"
+    },
+    "formButtonPrimary__add": "Add",
+    "formButtonPrimary__continue": "Continuar",
+    "formButtonPrimary__finish": "Finalizar",
+    "formButtonPrimary__remove": "Excluir",
+    "formButtonPrimary__save": "Salvar",
+    "formButtonReset": "Cancelar",
+    "mfaPage": {
+      "formHint": "Selecione um método para adicionar.",
+      "title": "Adicione verificação em duas etapas"
+    },
+    "mfaPhoneCodePage": {
+      "backButton": "Usar número existente",
+      "primaryButton__addPhoneNumber": "Adicione um número de telefone",
+      "removeResource": {
+        "messageLine1": "{{identifier}} não receberá mais códigos de verificação ao realizar o login.",
+        "messageLine2": "Sua conta pode ficar menos segura. Tem certeza que deseja continuar?",
+        "successMessage": "Código SMS de verificação em duas etapas foi removido para {{mfaPhoneCode}}",
+        "title": "Remover verificação em duas etapas"
+      },
+      "subtitle__availablePhoneNumbers": "Selecione um número de telefone para registrar a verificação em duas etapas por código SMS.",
+      "subtitle__unavailablePhoneNumbers": "Não há números de telefone disponíveis para registrar a verificação em duas etapas por código SMS.",
+      "successMessage1": "Ao acessar, será necessário o passo adicional de digitar o código de verificação enviado a este telefone.",
+      "successMessage2": "Salve estes códigos de backup e os armazene em um lugar seguro. Se você perder acesso ao seu dispositivo de autenticação, você pode utilizá-los para acessar o sistema.",
+      "successTitle": "Verificação por SMS habilitada",
+      "title": "Adicionar verificação por SMS"
+    },
+    "mfaTOTPPage": {
+      "authenticatorApp": {
+        "buttonAbleToScan__nonPrimary": "Escanear código QR em vez disso",
+        "buttonUnableToScan__nonPrimary": "Não pode escanear o código QR?",
+        "infoText__ableToScan": "Configure um novo método de login no seu aplicativo autenticador e escaneie o seguinte código QR para vinculá-lo à sua conta.",
+        "infoText__unableToScan": "Configure um novo método de login no seu aplicativo autenticador e insira a chave informada abaixo.",
+        "inputLabel__unableToScan1": "Certifique-se de que o 'One-time passwords' está habilitado, em seguida, conclua a vinculação de sua conta.",
+        "inputLabel__unableToScan2": "Alternativamente, se seu autenticador suportar URIs TOTP, você também pode copiar a URI completa."
+      },
+      "removeResource": {
+        "messageLine1": "Os códigos de verificação deste aplicativo autenticador não serão mais necessários ao fazer login.",
+        "messageLine2": "Sua conta pode ficar menos segura. Tem certeza que deseja continuar?",
+        "successMessage": "A verificação em duas etapas via aplicativo autenticador foi removida.",
+        "title": "Remover verificação em duas etapas"
+      },
+      "successMessage": "A verificação em duas etapas está ativa agora. Ao fazer login, você precisará inserir um código de verificação deste aplicativo autenticador como uma etapa adicional.",
+      "title": "Adicionar um aplicativo autenticador",
+      "verifySubtitle": "Insira o código de verificação gerado pelo seu aplicativo autenticador",
+      "verifyTitle": "Código de verificação"
+    },
+    "mobileButton__menu": "Menu",
+    "navbar": {
+      "account": "Perfil",
+      "apiKeys": "Chaves de API",
+      "billing": "Faturamento",
+      "description": "Gerencie seus dados de perfil.",
+      "security": "Segurança",
+      "title": "Conta"
+    },
+    "passkeyScreen": {
+      "removeResource": {
+        "messageLine1": "{{name}} será removido desta conta.",
+        "title": "Remover chave de acesso"
+      },
+      "subtitle__rename": "Você pode renomear a chave de acesso para que seja mais fácil encontrá-la.",
+      "title__rename": "Renomear chave de acesso"
+    },
+    "passwordPage": {
+      "checkboxInfoText__signOutOfOtherSessions": "É recomendado sair de todos os demais dispositivos que podem ter utilizado sua senha antiga.",
+      "readonly": "Sua senha atualmente não pode ser editada porque você só pode fazer login por meio da conexão da empresa.",
+      "successMessage__set": "Sua senha foi salva.",
+      "successMessage__signOutOfOtherSessions": "Todos os outros dispositivos foram desconectados.",
+      "successMessage__update": "Sua senha foi atualizada.",
+      "title__set": "Defina a senha",
+      "title__update": "Trocar senha"
+    },
+    "phoneNumberPage": {
+      "infoText": "Um SMS contendo um link de verificação será enviado para este telefone.",
+      "removeResource": {
+        "messageLine1": "{{identifier}} será removido desta conta.",
+        "messageLine2": "Você não conseguirá fazer login novamente utilizando este número de telefone.",
+        "successMessage": "{{phoneNumber}} foi removido da sua conta.",
+        "title": "Remover telefone"
+      },
+      "successMessage": "{{identifier}} foi adicionado na sua conta.",
+      "title": "Adicionar telefone",
+      "verifySubtitle": "Insira o código de verificação enviado para {{identifier}}",
+      "verifyTitle": "Verificar número de telefone"
+    },
+    "plansPage": { "title": "Planos" },
+    "profilePage": {
+      "fileDropAreaHint": "Carregue uma imagem JPG, PNG, GIF ou WEBP menor que 10 MB",
+      "imageFormDestructiveActionSubtitle": "Remover imagem",
+      "imageFormSubtitle": "Carregar imagem",
+      "imageFormTitle": "Imagem do perfil",
+      "readonly": "As informações do seu perfil foram fornecidas pela conexão corporativa e não podem ser editadas.",
+      "successMessage": "Seu perfil foi atualizado.",
+      "title": "Atualizar perfil"
+    },
+    "start": {
+      "activeDevicesSection": {
+        "destructiveAction": "Sair do dispositivo",
+        "title": "Dispositivos ativos"
+      },
+      "connectedAccountsSection": {
+        "actionLabel__connectionFailed": "Tentar novamente",
+        "actionLabel__reauthorize": "Reautorizar agora",
+        "destructiveActionTitle": "Remover",
+        "primaryButton": "Conectar conta",
+        "subtitle__disconnected": "Esta conta foi desconectada",
+        "subtitle__reauthorize": "Os escopos necessários foram atualizados, e você pode estar experimentado funcionalidades limitadas. Por favor, reautorize esta aplicação para evitar outros problemas",
+        "title": "Contas conectadas"
+      },
+      "dangerSection": {
+        "deleteAccountButton": "Excluir Conta",
+        "title": "Perigo"
+      },
+      "emailAddressesSection": {
+        "destructiveAction": "Remover e-mail",
+        "detailsAction__nonPrimary": "Definir como principal",
+        "detailsAction__primary": "Completar verificação",
+        "detailsAction__unverified": "Completar verificação",
+        "primaryButton": "Adicionar um e-mail",
+        "title": "Endereços de e-mail"
+      },
+      "enterpriseAccountsSection": {
+        "primaryButton": "Conectar conta",
+        "title": "Contas corporativas"
+      },
+      "headerTitle__account": "Conta",
+      "headerTitle__security": "Segurança",
+      "mfaSection": {
+        "backupCodes": {
+          "actionLabel__regenerate": "Gerar códigos novamente",
+          "headerTitle": "Códigos de backup",
+          "subtitle__regenerate": "Obtenha um novo conjunto de códigos de backup seguros. Os códigos de backup anteriores serão excluídos e não poderão ser usados.",
+          "title__regenerate": "Gerar códigos de backup novamente"
+        },
+        "phoneCode": {
+          "actionLabel__setDefault": "Definir como principal",
+          "destructiveActionLabel": "Remover telefone"
+        },
+        "primaryButton": "Adicione verificação",
+        "title": "Verificação em duas etapas",
+        "totp": {
+          "destructiveActionTitle": "Remover",
+          "headerTitle": "Aplicativo autenticador"
+        }
+      },
+      "passkeysSection": {
+        "menuAction__destructive": "Remover",
+        "menuAction__rename": "Renomear",
+        "primaryButton": "Adicionar chave de acesso",
+        "title": "Chaves de acesso"
+      },
+      "passwordSection": {
+        "primaryButton__setPassword": "Defina a senha",
+        "primaryButton__updatePassword": "Trocar a senha",
+        "title": "Senha"
+      },
+      "phoneNumbersSection": {
+        "destructiveAction": "Remover telefone",
+        "detailsAction__nonPrimary": "Definir como principal",
+        "detailsAction__primary": "Completar verificação",
+        "detailsAction__unverified": "Completar verificação",
+        "primaryButton": "Adicione um telefone",
+        "title": "Números de telefone"
+      },
+      "profileSection": {
+        "primaryButton": "Atualizar perfil",
+        "title": "Perfil"
+      },
+      "usernameSection": {
+        "primaryButton__setUsername": "Definir nome de usuário",
+        "primaryButton__updateUsername": "Trocar nome de usuário",
+        "title": "Nome de usuário"
+      },
+      "web3WalletsSection": {
+        "destructiveAction": "Remover carteira",
+        "detailsAction__nonPrimary": "Definir como principal",
+        "primaryButton": "Carteiras Web3",
+        "title": "Carteiras Web3",
+        "web3SelectSolanaWalletScreen": {
+          "subtitle": "Selecione uma carteira Solana para conectar à sua conta.",
+          "title": "Adicionar uma carteira Solana"
+        }
+      }
+    },
+    "usernamePage": {
+      "successMessage": "Seu nome de usuário foi atualizado.",
+      "title__set": "Atualizar nome de usuário",
+      "title__update": "Atualizar nome de usuário"
+    },
+    "web3WalletPage": {
+      "removeResource": {
+        "messageLine1": "{{identifier}} será removido desta conta.",
+        "messageLine2": "Você não poderá mais usar esta carteira Web3 para entrar na sua conta.",
+        "successMessage": "{{Web3Wallet}} foi removido da sua conta.",
+        "title": "Remover carteira Web3"
+      },
+      "subtitle__availableWallets": "Selecione uma carteira Web3 para conectar à sua conta.",
+      "subtitle__unavailableWallets": "Não há carteiras Web3 disponíveis.",
+      "successMessage": "A carteira foi adicionada à sua conta.",
+      "title": "Adicionar carteira Web3",
+      "web3WalletButtonsBlockButton": "Conectar carteira Web3"
+    }
+  },
+  "waitlist": {
+    "start": {
+      "actionLink": "Entrar",
+      "actionText": "Já possui acesso?",
+      "formButton": "Entrar na lista de espera",
+      "subtitle": "Entre com seu e-mail e entraremos em contato quando seu lugar estiver disponível",
+      "title": "Entre na lista de espera"
+    },
+    "success": {
+      "message": "Te redirecionando em breve...",
+      "subtitle": "Entraremos em contato quando seu lugar estiver disponível",
+      "title": "Obrigado por entrar na lista de espera!"
+    }
+  },
+  "web3SolanaWalletButtons": {
+    "connect": "Conectar com {{walletName}}",
+    "continue": "Continuar com {{walletName}}",
+    "noneAvailable": "Nenhuma carteira Solana Web3 foi detectada. Instale uma {{ solanaWalletsLink || link(\"wallet extension\") }} compatível com Web3."
+  }
+}

--- a/turbo/apps/platform/src/i18n/index.ts
+++ b/turbo/apps/platform/src/i18n/index.ts
@@ -24,12 +24,12 @@ export function currentLocale(): string {
   return i18n.resolvedLanguage ?? i18n.language;
 }
 
-interface InitialLocaleResources {
+export interface InitialLocaleResources {
   readonly locale: SupportedLocale;
   readonly resources: Resource;
 }
 
-async function loadInitialLocaleResources(
+export async function loadInitialLocaleResources(
   locale: SupportedLocale,
   signal?: AbortSignal,
 ): Promise<InitialLocaleResources> {
@@ -71,8 +71,15 @@ export async function initializeI18n(
   locale: SupportedLocale = DEFAULT_LOCALE,
   signal?: AbortSignal,
 ): Promise<SupportedLocale> {
-  const hostname = location.hostname;
   const initial = await loadInitialLocaleResources(locale, signal);
+  return initializeI18nWithResources(initial, signal);
+}
+
+export async function initializeI18nWithResources(
+  initial: InitialLocaleResources,
+  signal?: AbortSignal,
+): Promise<SupportedLocale> {
+  const hostname = location.hostname;
   signal?.throwIfAborted();
   await i18n.init({
     defaultNS: DEFAULT_NAMESPACE,
@@ -90,6 +97,7 @@ export async function initializeI18n(
     returnNull: false,
     supportedLngs: SUPPORTED_LOCALES,
   });
+  signal?.throwIfAborted();
   return initial.locale;
 }
 
@@ -101,20 +109,33 @@ function addLocaleResources(
   i18n.addResourceBundle(locale, "common", resources.common, true, true);
 }
 
+export function loadI18nLanguageResources(
+  locale: SupportedLocale,
+  signal?: AbortSignal,
+): Promise<LocaleResources | undefined> {
+  return !i18n.hasResourceBundle(locale, "agents") ||
+    !i18n.hasResourceBundle(locale, "common")
+    ? loadLocaleResources(locale, signal)
+    : Promise.resolve(undefined);
+}
+
 export async function changeI18nLanguage(
   locale: SupportedLocale,
   signal?: AbortSignal,
 ): Promise<void> {
-  let resources: LocaleResources | undefined;
-  if (
-    !i18n.hasResourceBundle(locale, "agents") ||
-    !i18n.hasResourceBundle(locale, "common")
-  ) {
-    resources = await loadLocaleResources(locale, signal);
-  }
+  const resources = await loadI18nLanguageResources(locale, signal);
+  await changeI18nLanguageWithResources(locale, resources, signal);
+}
+
+export async function changeI18nLanguageWithResources(
+  locale: SupportedLocale,
+  resources: LocaleResources | undefined,
+  signal?: AbortSignal,
+): Promise<void> {
   signal?.throwIfAborted();
   if (resources) {
     addLocaleResources(locale, resources);
   }
   await i18n.changeLanguage(locale);
+  signal?.throwIfAborted();
 }

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -1,5 +1,5 @@
 import { command, state } from "ccstate";
-import { posthog, type CaptureResult } from "posthog-js";
+import { posthog, type CaptureResult } from "posthog-js/dist/module.slim";
 import { isStandalonePwa } from "./keyboard-dismiss-gesture.ts";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 

--- a/turbo/apps/platform/src/mocks/handlers/clerk-localizations.ts
+++ b/turbo/apps/platform/src/mocks/handlers/clerk-localizations.ts
@@ -1,0 +1,40 @@
+import { http, HttpResponse } from "msw";
+
+import deDE from "../../i18n/clerk-localizations/de-DE.json";
+import deDEUrl from "../../i18n/clerk-localizations/de-DE.json?url";
+import esES from "../../i18n/clerk-localizations/es-ES.json";
+import esESUrl from "../../i18n/clerk-localizations/es-ES.json?url";
+import frFR from "../../i18n/clerk-localizations/fr-FR.json";
+import frFRUrl from "../../i18n/clerk-localizations/fr-FR.json?url";
+import hiIN from "../../i18n/clerk-localizations/hi-IN.json";
+import hiINUrl from "../../i18n/clerk-localizations/hi-IN.json?url";
+import idID from "../../i18n/clerk-localizations/id-ID.json";
+import idIDUrl from "../../i18n/clerk-localizations/id-ID.json?url";
+import itIT from "../../i18n/clerk-localizations/it-IT.json";
+import itITUrl from "../../i18n/clerk-localizations/it-IT.json?url";
+import jaJP from "../../i18n/clerk-localizations/ja-JP.json";
+import jaJPUrl from "../../i18n/clerk-localizations/ja-JP.json?url";
+import koKR from "../../i18n/clerk-localizations/ko-KR.json";
+import koKRUrl from "../../i18n/clerk-localizations/ko-KR.json?url";
+import ptBR from "../../i18n/clerk-localizations/pt-BR.json";
+import ptBRUrl from "../../i18n/clerk-localizations/pt-BR.json?url";
+
+const clerkLocalizationFixtures = [
+  { localization: deDE, url: deDEUrl },
+  { localization: esES, url: esESUrl },
+  { localization: frFR, url: frFRUrl },
+  { localization: hiIN, url: hiINUrl },
+  { localization: idID, url: idIDUrl },
+  { localization: itIT, url: itITUrl },
+  { localization: jaJP, url: jaJPUrl },
+  { localization: koKR, url: koKRUrl },
+  { localization: ptBR, url: ptBRUrl },
+] as const;
+
+export const clerkLocalizationHandlers = clerkLocalizationFixtures.map(
+  ({ localization, url }) => {
+    return http.get(url, () => {
+      return HttpResponse.json(localization);
+    });
+  },
+);

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -96,8 +96,10 @@ import { apiVoiceIoHandlers } from "./api-voice-io.ts";
 import { apiBuildInfoHandlers } from "./api-build-info.ts";
 import { apiWebFilesHandlers } from "./api-web-files.ts";
 import { localeResourceHandlers } from "./locale-resources.ts";
+import { clerkLocalizationHandlers } from "./clerk-localizations.ts";
 
 export const handlers = [
+  ...clerkLocalizationHandlers,
   ...localeResourceHandlers,
   ...apiBuildInfoHandlers,
   ...apiConnectorsHandlers,

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -4,20 +4,31 @@ import { describe, expect, it, vi } from "vitest";
 import indexHtml from "../../../index.html?raw";
 import { setupPage } from "../../__tests__/page-helper.ts";
 import { formatAppNumber } from "../../i18n/format.ts";
+import frFRClerk from "../../i18n/clerk-localizations/fr-FR.json";
+import frFRClerkUrl from "../../i18n/clerk-localizations/fr-FR.json?url";
+import itITClerk from "../../i18n/clerk-localizations/it-IT.json";
+import itITClerkUrl from "../../i18n/clerk-localizations/it-IT.json?url";
+import ptBRClerkUrl from "../../i18n/clerk-localizations/pt-BR.json?url";
+import {
+  clerkLocalizationForLocale,
+  clerkLocalizations$,
+} from "../../i18n/clerk-localization.ts";
 import frFRCommonUrl from "../../i18n/locales/fr-FR/common.json?url";
 import hiINAgents from "../../i18n/locales/hi-IN/agents.json";
 import hiINCommon from "../../i18n/locales/hi-IN/common.json";
 import idIDAgents from "../../i18n/locales/id-ID/agents.json";
 import itITCommon from "../../i18n/locales/it-IT/common.json";
+import itITCommonUrl from "../../i18n/locales/it-IT/common.json?url";
 import {
   CHAT_ATTACHMENT_HEADINGS,
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
+  type SupportedLocale,
 } from "../../i18n/resources.ts";
 import { changeI18nLanguage, i18n, initializeI18n } from "../../i18n/index.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";
-import { locale$, setLocale$ } from "../locale.ts";
+import { initLocale$, locale$, setLocale$ } from "../locale.ts";
 import { resetSignal } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
 
@@ -26,6 +37,13 @@ const TEST_ORG_ID = "org_inline_locale";
 const TEST_LOCALE_STORAGE_KEY = `vm0:locale:${TEST_ORG_ID}`;
 const testLocaleStorage = localStorageSignals(TEST_LOCALE_STORAGE_KEY);
 const activeOrgIdStorage = sessionStorageSignals(ACTIVE_ORG_STORAGE_KEY);
+
+function loadedClerkLocalization(locale: SupportedLocale) {
+  return clerkLocalizationForLocale(
+    context.store.get(clerkLocalizations$),
+    locale,
+  );
+}
 
 type LocaleEntrypointScript = (
   windowObject: Window,
@@ -129,6 +147,120 @@ describe("bootstrap locale", () => {
     expect(i18n.language).toBe(DEFAULT_LOCALE);
     expect(i18n.hasResourceBundle(DEFAULT_LOCALE, "common")).toBeTruthy();
     expect(i18n.hasResourceBundle(DEFAULT_LOCALE, "agents")).toBeTruthy();
+  });
+
+  it("loads only the selected Clerk localization and reuses its cache", async () => {
+    const clerkLocalizationRequests: string[] = [];
+    context.mocks.http.get(
+      /\/clerk-localizations\/[^/]+\.json$/,
+      ({ request }) => {
+        clerkLocalizationRequests.push(new URL(request.url).pathname);
+        return HttpResponse.json(frFRClerk);
+      },
+    );
+    context.mocks.browser.language("fr-FR");
+    executeLocaleEntrypoint();
+
+    await setupPage({ context, path: "/error", withoutRender: true });
+
+    expect(clerkLocalizationRequests).toStrictEqual([
+      new URL(frFRClerkUrl, location.href).pathname,
+    ]);
+    expect(loadedClerkLocalization("fr-FR").signIn?.start?.actionLink).toBe(
+      "S'inscrire",
+    );
+
+    await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
+    await context.store.set(setLocale$, "fr-FR", context.signal);
+
+    expect(clerkLocalizationRequests).toHaveLength(1);
+  });
+
+  it("uses English Clerk fallback when a selected localization fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    context.mocks.http.get(ptBRClerkUrl, () => {
+      return new HttpResponse(null, { status: 503 });
+    });
+    await initializeI18n(DEFAULT_LOCALE, context.signal);
+
+    await context.store.set(setLocale$, "pt-BR", context.signal);
+
+    expect(context.store.get(locale$)).toBe("pt-BR");
+    expect(i18n.language).toBe("pt-BR");
+    expect(document.documentElement.lang).toBe("pt-BR");
+    expect(context.store.get(clerkLocalizations$).has("pt-BR")).toBeFalsy();
+    expect(loadedClerkLocalization("pt-BR").locale).toBe(DEFAULT_LOCALE);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[E][ClerkLocalization]",
+      `Failed to load pt-BR Clerk localization; falling back to ${DEFAULT_LOCALE}`,
+      expect.any(Error),
+    );
+  });
+
+  it("does not cache or apply a runtime Clerk localization after abort", async () => {
+    await initializeI18n(DEFAULT_LOCALE, context.signal);
+    const requestStarted = context.mocks.deferred<void>();
+    context.mocks.http.get(itITClerkUrl, ({ never }) => {
+      requestStarted.resolve(undefined);
+      return never();
+    });
+    const resetLocaleSwitchSignal$ = resetSignal();
+    const localeSwitchSignal = context.store.set(
+      resetLocaleSwitchSignal$,
+      context.signal,
+    );
+
+    const switching = context.store.set(
+      setLocale$,
+      "it-IT",
+      localeSwitchSignal,
+    );
+    await requestStarted.promise;
+    context.store.set(resetLocaleSwitchSignal$, context.signal);
+
+    await expect(switching).rejects.toMatchObject({ name: "AbortError" });
+    expect(context.store.get(locale$)).toBe(DEFAULT_LOCALE);
+    expect(i18n.language).toBe(DEFAULT_LOCALE);
+    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
+    expect(context.store.get(clerkLocalizations$).has("it-IT")).toBeFalsy();
+    expect(loadedClerkLocalization("it-IT").locale).toBe(DEFAULT_LOCALE);
+  });
+
+  it("does not initialize or cache a selected Clerk locale after abort", async () => {
+    document.documentElement.lang = "it-IT";
+    const appRequestStarted = context.mocks.deferred<void>();
+    const clerkLocalizationLoaded = context.mocks.deferred<void>();
+    context.mocks.http.get(itITCommonUrl, ({ never }) => {
+      appRequestStarted.resolve(undefined);
+      return never();
+    });
+    context.mocks.http.get(itITClerkUrl, () => {
+      clerkLocalizationLoaded.resolve(undefined);
+      return HttpResponse.json(itITClerk);
+    });
+    const resetLocaleInitializationSignal$ = resetSignal();
+    const localeInitializationSignal = context.store.set(
+      resetLocaleInitializationSignal$,
+      context.signal,
+    );
+
+    const initializing = context.store.set(
+      initLocale$,
+      localeInitializationSignal,
+    );
+    await Promise.all([
+      appRequestStarted.promise,
+      clerkLocalizationLoaded.promise,
+    ]);
+    context.store.set(resetLocaleInitializationSignal$, context.signal);
+
+    await expect(initializing).rejects.toMatchObject({ name: "AbortError" });
+    expect(context.store.get(locale$)).toBe(DEFAULT_LOCALE);
+    expect(i18n.language).toBe(DEFAULT_LOCALE);
+    expect(document.documentElement.lang).toBe("it-IT");
+    expect(context.store.get(clerkLocalizations$).has("it-IT")).toBeFalsy();
   });
 
   it("loads resources for every supported locale", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -7,12 +7,6 @@ import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
   BOOTSTRAP_PHASE_TIMING_EVENT,
   type BootstrapThreadMetadataSource,
-  captureTaskCompletedSuccessfully,
-  clearPostHogUser,
-  initPostHog,
-  registerPostHogAttribution,
-  setPostHogOrganization,
-  setPostHogUser,
 } from "../../lib/posthog.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -110,45 +104,6 @@ function mockEmptyThreadMetadata(): void {
 }
 
 describe("bootstrap phase telemetry", () => {
-  it("keeps every configured slim analytics call wired", () => {
-    initPostHog();
-    setPostHogUser({
-      email: "test@example.com",
-      id: "user_analytics",
-      name: "Analytics Test",
-    });
-    registerPostHogAttribution({ utm_source: "test" });
-    setPostHogOrganization("org_analytics");
-    setPostHogOrganization(undefined);
-    captureTaskCompletedSuccessfully();
-    clearPostHogUser();
-
-    expect(posthog.init).toHaveBeenCalledWith(
-      "phc_bootstrap_phase_telemetry_test",
-      expect.objectContaining({
-        autocapture: false,
-        capture_pageview: false,
-        disable_session_recording: true,
-      }),
-    );
-    expect(posthog.identify).toHaveBeenCalledWith("user_analytics", {
-      email: "test@example.com",
-      name: "Analytics Test",
-    });
-    expect(posthog.register).toHaveBeenNthCalledWith(1, {
-      utm_source: "test",
-    });
-    expect(posthog.register).toHaveBeenNthCalledWith(2, {
-      org_id: "org_analytics",
-    });
-    expect(posthog.unregister).toHaveBeenCalledWith("org_id");
-    expect(posthog.capture).toHaveBeenCalledWith(
-      "task_completed_successfully",
-      { surface: "chat_thread" },
-    );
-    expect(posthog.reset).toHaveBeenCalledOnce();
-  });
-
   it("captures bounded bootstrap and cold thread metadata phases", async () => {
     mockEmptyThreadMetadata();
 

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -7,6 +7,12 @@ import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
   BOOTSTRAP_PHASE_TIMING_EVENT,
   type BootstrapThreadMetadataSource,
+  captureTaskCompletedSuccessfully,
+  clearPostHogUser,
+  initPostHog,
+  registerPostHogAttribution,
+  setPostHogOrganization,
+  setPostHogUser,
 } from "../../lib/posthog.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -46,7 +52,7 @@ const { apiOriginMarker, posthog } = vi.hoisted(() => {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return { posthog };
 });
 
@@ -104,6 +110,45 @@ function mockEmptyThreadMetadata(): void {
 }
 
 describe("bootstrap phase telemetry", () => {
+  it("keeps every configured slim analytics call wired", () => {
+    initPostHog();
+    setPostHogUser({
+      email: "test@example.com",
+      id: "user_analytics",
+      name: "Analytics Test",
+    });
+    registerPostHogAttribution({ utm_source: "test" });
+    setPostHogOrganization("org_analytics");
+    setPostHogOrganization(undefined);
+    captureTaskCompletedSuccessfully();
+    clearPostHogUser();
+
+    expect(posthog.init).toHaveBeenCalledWith(
+      "phc_bootstrap_phase_telemetry_test",
+      expect.objectContaining({
+        autocapture: false,
+        capture_pageview: false,
+        disable_session_recording: true,
+      }),
+    );
+    expect(posthog.identify).toHaveBeenCalledWith("user_analytics", {
+      email: "test@example.com",
+      name: "Analytics Test",
+    });
+    expect(posthog.register).toHaveBeenNthCalledWith(1, {
+      utm_source: "test",
+    });
+    expect(posthog.register).toHaveBeenNthCalledWith(2, {
+      org_id: "org_analytics",
+    });
+    expect(posthog.unregister).toHaveBeenCalledWith("org_id");
+    expect(posthog.capture).toHaveBeenCalledWith(
+      "task_completed_successfully",
+      { surface: "chat_thread" },
+    );
+    expect(posthog.reset).toHaveBeenCalledOnce();
+  });
+
   it("captures bounded bootstrap and cold thread metadata phases", async () => {
     mockEmptyThreadMetadata();
 
@@ -145,6 +190,14 @@ describe("bootstrap phase telemetry", () => {
     context.store.set(hideAppSkeleton$, context.signal);
 
     expect(timingEvents()).toHaveLength(1);
+    expect(
+      posthog.capture.mock.calls.flatMap(([eventName]) => {
+        return eventName === "app_first_skeleton_hide" ||
+          eventName === BOOTSTRAP_PHASE_TIMING_EVENT
+          ? [eventName]
+          : [];
+      }),
+    ).toStrictEqual(["app_first_skeleton_hide", BOOTSTRAP_PHASE_TIMING_EVENT]);
   });
 
   it("discards thread timing from an aborted navigation", async () => {

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.test.ts
@@ -58,7 +58,7 @@ const { apiOriginMarker, posthog, posthogKey } = vi.hoisted(() => {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return { posthog };
 });
 

--- a/turbo/apps/platform/src/signals/locale.ts
+++ b/turbo/apps/platform/src/signals/locale.ts
@@ -1,5 +1,14 @@
 import { command, computed, state } from "ccstate";
-import { changeI18nLanguage, initializeI18n } from "../i18n/index.ts";
+import {
+  cacheClerkLocalization$,
+  loadClerkLocalization$,
+} from "../i18n/clerk-localization.ts";
+import {
+  changeI18nLanguageWithResources,
+  initializeI18nWithResources,
+  loadI18nLanguageResources,
+  loadInitialLocaleResources,
+} from "../i18n/index.ts";
 import { DEFAULT_LOCALE, type SupportedLocale } from "../i18n/resources.ts";
 import {
   localeStorageKey,
@@ -36,8 +45,14 @@ export const availableLocalePreferences$ = computed(async (get) => {
 export const initLocale$ = command(
   async ({ set }, signal: AbortSignal): Promise<SupportedLocale | null> => {
     const requestedLocale = resolveDocumentLocale();
-    const locale = await initializeI18n(requestedLocale, signal);
+    const [initial, clerkLocalization] = await Promise.all([
+      loadInitialLocaleResources(requestedLocale, signal),
+      set(loadClerkLocalization$, requestedLocale, signal),
+    ]);
     signal.throwIfAborted();
+    const locale = await initializeI18nWithResources(initial, signal);
+    signal.throwIfAborted();
+    set(cacheClerkLocalization$, requestedLocale, clerkLocalization);
     applyDocumentLocaleCopy();
     set(internalLocale$, locale);
     document.documentElement.lang = locale;
@@ -47,8 +62,14 @@ export const initLocale$ = command(
 
 export const setLocale$ = command(
   async ({ set }, locale: SupportedLocale, signal: AbortSignal) => {
-    await changeI18nLanguage(locale, signal);
+    const [resources, clerkLocalization] = await Promise.all([
+      loadI18nLanguageResources(locale, signal),
+      set(loadClerkLocalization$, locale, signal),
+    ]);
     signal.throwIfAborted();
+    await changeI18nLanguageWithResources(locale, resources, signal);
+    signal.throwIfAborted();
+    set(cacheClerkLocalization$, locale, clerkLocalization);
     applyDocumentLocaleCopy();
     set(internalLocale$, locale);
     document.documentElement.lang = locale;

--- a/turbo/apps/platform/src/test/mocks/clerk-react.ts
+++ b/turbo/apps/platform/src/test/mocks/clerk-react.ts
@@ -43,9 +43,12 @@ interface ClerkProviderProps {
   localization?: {
     signIn?: {
       emailCode?: { subtitle?: string };
-      start?: { title?: string };
+      start?: { actionLink?: string; title?: string };
     };
-    unstable__errors?: { user_banned?: string };
+    unstable__errors?: {
+      not_allowed_access?: string;
+      user_banned?: string;
+    };
   };
   signInFallbackRedirectUrl?: string;
   signInUrl?: string;
@@ -65,7 +68,11 @@ export function ClerkProvider({
     createElement("span", {
       "data-clerk-sign-in-email-code-subtitle":
         localization?.signIn?.emailCode?.subtitle,
+      "data-clerk-sign-in-start-action-link":
+        localization?.signIn?.start?.actionLink,
       "data-clerk-sign-in-start-title": localization?.signIn?.start?.title,
+      "data-clerk-access-not-allowed-error":
+        localization?.unstable__errors?.not_allowed_access,
       "data-clerk-user-banned-error":
         localization?.unstable__errors?.user_banned,
       "data-clerk-touch-session":

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-i18n.test.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-i18n.test.ts
@@ -166,8 +166,8 @@ describe("auth v2 platform localization ownership", () => {
     }
 
     const v1Localization = Object.values(v1LocalizationSources).join("\n");
-    expect(v1Localization).toContain("@clerk/localizations");
     expect(v1Localization).toContain("getClerkLocalization");
+    expect(v1Localization).toContain("clerkLocalizationForLocale");
 
     const v1Provider = Object.values(v1ProviderSources).join("\n");
     expect(v1Provider).toContain('from "../auth/clerk-localization.ts"');

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-diagnostics.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-diagnostics.test.tsx
@@ -38,7 +38,7 @@ const { apiOriginMarker, posthog } = vi.hoisted(() => {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return { posthog };
 });
 

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -13,9 +13,8 @@ import { PRESENTATION_ONBOARDING_URL } from "../../../__tests__/presentation-onb
 import type { SupportedLocale } from "../../../i18n/resources.ts";
 import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setLocale$ } from "../../../signals/locale.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { i18n } from "../../../i18n/index.ts";
-import { getClerkLocalization } from "../clerk-localization.ts";
 
 const context = testContext();
 
@@ -210,15 +209,12 @@ describe("app auth pages", () => {
       expect(screen.getByLabelText(localeCase.toggleTheme)).toBeInTheDocument();
       expect(document.title).toBe(localeCase.documentTitle);
 
-      const localization = getClerkLocalization(
-        "VM0",
-        localeCase.locale,
-        i18n.t,
-      );
-      expect(localization.signIn?.start?.actionLink).toBe(
+      expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+        "data-clerk-sign-in-start-action-link",
         localeCase.actionLink,
       );
-      expect(localization.unstable__errors?.not_allowed_access).toBe(
+      expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+        "data-clerk-access-not-allowed-error",
         localeCase.accessNotAllowed,
       );
 
@@ -241,9 +237,12 @@ describe("app auth pages", () => {
     expect(screen.getByLabelText("テーマの切り替え")).toBeInTheDocument();
     expect(document.title).toBe("サインアップ | VM0");
 
-    const localization = getClerkLocalization("VM0", "ja-JP", i18n.t);
-    expect(localization.signIn?.start?.actionLink).toBe("サインアップ");
-    expect(localization.unstable__errors?.not_allowed_access).toBe(
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-action-link",
+      "サインアップ",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-access-not-allowed-error",
       "アクセスは許可されていません。",
     );
 
@@ -263,9 +262,12 @@ describe("app auth pages", () => {
     expect(screen.getByLabelText("테마 전환")).toBeInTheDocument();
     expect(document.title).toBe("회원가입 | VM0");
 
-    const localization = getClerkLocalization("VM0", "ko-KR", i18n.t);
-    expect(localization.signIn?.start?.actionLink).toBe("회원가입");
-    expect(localization.unstable__errors?.not_allowed_access).toBe(
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-action-link",
+      "회원가입",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-access-not-allowed-error",
       "접근이 허용되지 않습니다.",
     );
 
@@ -287,9 +289,12 @@ describe("app auth pages", () => {
     expect(screen.getByLabelText("Design wechseln")).toBeInTheDocument();
     expect(document.title).toBe("Registrieren | VM0");
 
-    const localization = getClerkLocalization("VM0", "de-DE", i18n.t);
-    expect(localization.signIn?.start?.actionLink).toBe("Registrieren");
-    expect(localization.unstable__errors?.not_allowed_access).toBe(
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-action-link",
+      "Registrieren",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-access-not-allowed-error",
       "Zugriff nicht gestattet.",
     );
 
@@ -311,9 +316,12 @@ describe("app auth pages", () => {
     expect(screen.getByLabelText("Cambiar tema")).toBeInTheDocument();
     expect(document.title).toBe("Crear una cuenta | VM0");
 
-    const localization = getClerkLocalization("VM0", "es-ES", i18n.t);
-    expect(localization.signIn?.start?.actionLink).toBe("Regístrese");
-    expect(localization.unstable__errors?.not_allowed_access).toBe(
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-action-link",
+      "Regístrese",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-access-not-allowed-error",
       "Acceso no permitido.",
     );
 
@@ -322,10 +330,40 @@ describe("app auth pages", () => {
     });
   });
 
-  it("uses Italian Clerk resources", () => {
-    const localization = getClerkLocalization("VM0", "it-IT", i18n.t);
+  it("uses Italian Clerk resources", async () => {
+    useLocale("it-IT");
+    setBrowserUrl("https://app.vm0.ai/sign-up");
 
-    expect(localization.signIn?.start?.actionLink).toBe("Registrati");
+    detachedSetupPage({ context, path: "/sign-up" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+        "data-clerk-sign-in-start-action-link",
+        "Registrati",
+      );
+    });
+  });
+
+  it("updates the rendered Clerk provider after a runtime locale switch", async () => {
+    setBrowserUrl("https://app.vm0.ai/sign-up");
+    detachedSetupPage({ context, path: "/sign-up" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+        "data-clerk-sign-in-start-action-link",
+        "Sign up",
+      );
+    });
+
+    await act(async () => {
+      await context.store.set(setLocale$, "fr-FR", context.signal);
+    });
+
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-action-link",
+      "S'inscrire",
+    );
+    expect(document.documentElement.lang).toBe("fr-FR");
   });
 
   it("mounts the Clerk sign-up route before Clerk finishes loading", async () => {

--- a/turbo/apps/platform/src/views/auth/clerk-localization.ts
+++ b/turbo/apps/platform/src/views/auth/clerk-localization.ts
@@ -1,17 +1,9 @@
-import {
-  deDE,
-  enUS,
-  esES,
-  frFR,
-  hiIN,
-  idID,
-  itIT,
-  jaJP,
-  koKR,
-  ptBR,
-} from "@clerk/localizations";
 import { publicBrandPresentation } from "@okouai/core/public-brand";
 import type { TFunction } from "i18next";
+import {
+  clerkLocalizationForLocale,
+  type ClerkLocalizationCache,
+} from "../../i18n/clerk-localization.ts";
 import type { SupportedLocale } from "../../i18n/resources.ts";
 import type { BrandName } from "../../signals/branding.ts";
 
@@ -39,31 +31,13 @@ function replaceClerkApplicationName<T>(value: T, brandName: BrandName): T {
 export function getClerkLocalization(
   brandName: BrandName,
   locale: SupportedLocale,
+  clerkLocalizations: ClerkLocalizationCache,
   t: TFunction<"common">,
 ) {
   const supportEmail = publicBrandPresentation(
     brandName === "Okou" ? "okou" : "vm0",
   ).supportEmail;
-  const localization =
-    locale === "pt-BR"
-      ? ptBR
-      : locale === "ja-JP"
-        ? jaJP
-        : locale === "ko-KR"
-          ? koKR
-          : locale === "id-ID"
-            ? idID
-            : locale === "de-DE"
-              ? deDE
-              : locale === "es-ES"
-                ? esES
-                : locale === "it-IT"
-                  ? itIT
-                  : locale === "fr-FR"
-                    ? frFR
-                    : locale === "hi-IN"
-                      ? hiIN
-                      : enUS;
+  const localization = clerkLocalizationForLocale(clerkLocalizations, locale);
   const brandedLocalization =
     brandName === "Okou"
       ? replaceClerkApplicationName(localization, brandName)

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -5,6 +5,7 @@ import {
 import { useGet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { clerkLocalizations$ } from "../../i18n/clerk-localization.ts";
 import { resolvePlatformRuntimeConfig } from "../../lib/platform-host.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { locale$ } from "../../signals/locale.ts";
@@ -30,6 +31,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const clerkInstance = useGet(clerkInstance$);
   const clerkUi = useGet(clerkUi$);
   const domainBrandName = useGet(brandName$);
+  const clerkLocalizations = useGet(clerkLocalizations$);
   const locale = useGet(locale$);
   const isAuthPage =
     location.pathname === ROUTES.signIn ||
@@ -54,7 +56,12 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     afterSignOutUrl: resolveAppAuthUrl("/sign-in"),
     allowedRedirectOrigins,
     appearance: getClerkAppearance(),
-    localization: getClerkLocalization(clerkBrandName, locale, t),
+    localization: getClerkLocalization(
+      clerkBrandName,
+      locale,
+      clerkLocalizations,
+      t,
+    ),
     publishableKey,
     signInFallbackRedirectUrl: appUrl,
     signInUrl: resolveAppAuthUrl("/sign-in"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-metadata-readiness.test.tsx
@@ -47,7 +47,7 @@ const { apiOriginMarker, posthog } = vi.hoisted(() => {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return { posthog };
 });
 

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx
@@ -44,7 +44,7 @@ const { apiOriginMarker, posthog } = vi.hoisted(() => {
   };
 });
 
-vi.mock("posthog-js", () => {
+vi.mock("posthog-js/dist/module.slim", () => {
   return { posthog };
 });
 


### PR DESCRIPTION
## Summary

- replace the eager import of all supported Clerk localizations with English plus one validated, selected-locale JSON asset
- coordinate app and Clerk locale preparation before committing a language change, with a finite ccstate cache, English fallback, and abort-safe initialization/runtime switching
- use the installed PostHog `dist/module.slim` ESM entry after verifying that version 1.414.0 exports every configured API (`init`, `identify`, `register`, `unregister`, `reset`, and `capture`)
- preserve the existing locale JSON loading from #29597 and the startup telemetry capture path

Refs #29576.

## Bundle evidence

Measured from production Vite builds at base `58656533202285c048d5d86b60923d6f225fd182` and this branch. Compressed sizes are the sum of each eager JS response using Node `gzipSync` and Brotli quality 11.

| Eager JS graph | `origin/main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Raw | 12,444,147 B | 11,673,445 B | -770,702 B (-6.19%) |
| Gzip | 3,037,944 B | 2,854,611 B | -183,333 B (-6.03%) |
| Brotli | 2,370,283 B | 2,254,409 B | -115,874 B (-4.89%) |

The eager graph remains 37 JS assets; no route splitting or chunking configuration changed. The nine non-English Clerk JSON assets are emitted but are not preloaded.

For the main platform chunk alone:

| Main JS | `origin/main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Raw | 11,017,789 B | 10,247,087 B | -770,702 B (-7.00%) |
| Gzip | 2,730,777 B | 2,547,438 B | -183,339 B (-6.71%) |
| Brotli | 2,105,786 B | 1,989,897 B | -115,889 B (-5.50%) |

## Behavior preserved

- English remains immediately available as the Clerk fallback.
- Initial app and Clerk locale resources load concurrently; neither the active locale nor the Clerk cache is committed after an aborted initialization.
- Runtime locale changes update i18n, `document.documentElement.lang`, and the rendered Clerk provider together.
- Clerk localization load/validation failures retain the requested app locale while rendering Clerk's English fallback and logging the failure.
- `app_first_skeleton_hide` remains captured before `app_bootstrap_phase_timing`, and repeated skeleton hides do not duplicate either bootstrap report.
- PostHog startup and product calls remain synchronous and retain the existing configuration that disables autocapture, automatic pageviews, and session recording.

## Fallbacks

- `turbo/apps/platform/src/i18n/clerk-localization.ts:loadClerkLocalization$` / `clerkLocalizationForLocale` — when a selected non-English Clerk asset fails HTTP, JSON, or shape validation, the app keeps the requested app locale and renders Clerk's English localization. Surface: platform app UI and static localization loading; this is not cross-version rollout compatibility. It is a permanent presentational default, so no removal condition or follow-up is planned.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged non-API, platform, and API type-check commands from `commit-check`
- focused Vitest coverage across nine files, each run separately
- `pnpm --filter @okouai/app build`
- generated Clerk JSON snapshots verified against installed `@clerk/localizations` 4.13.8
- `git diff --check`

## Residual risk

- The app-owned Clerk JSON snapshots must be refreshed when `@clerk/localizations` changes. Runtime shape/locale validation and English fallback contain stale or invalid asset failures.
- The PostHog slim entry deliberately omits extensions disabled by current configuration. Enabling autocapture, automatic pageviews, or session recording later requires revisiting this import.
