### PR TITLE
fix(mail): enforce operation-specific gmail scopes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -576,6 +576,7 @@ interface GmailConnectorOAuthOptions {
   readonly refreshToken?: string;
   readonly subject?: string;
   readonly email?: string;
+  readonly scopes?: readonly string[];
 }
 
 export function mockGmailConnectorOAuth(
@@ -603,7 +604,9 @@ export function mockGmailConnectorOAuth(
         refresh_token: options.refreshToken ?? "gmail-refresh-token",
         expires_in: 3600,
         token_type: "Bearer",
-        scope: "https://www.googleapis.com/auth/gmail.modify",
+        scope: (
+          options.scopes ?? ["https://www.googleapis.com/auth/gmail.modify"]
+        ).join(" "),
       });
     }),
     http.get(GOOGLE_OPENID_USERINFO_URL, () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -29,6 +29,7 @@ import {
   seedCustomThreadConnectorSelection,
   setConnectorDefaultState,
   setConnectorCredentialStorageState,
+  setLegacyBuiltinOAuthScopes,
   setConnectorSecretOwner,
 } from "./helpers/connector-credential-storage-state";
 import { mailRoutes } from "../mail";
@@ -45,6 +46,9 @@ const GMAIL_THREAD_ID = "gmail-thread-id";
 const GMAIL_MESSAGE_ID = "gmail-draft-message-id";
 const GMAIL_SENT_MESSAGE_ID = "gmail-sent-message-id";
 const GMAIL_IMAGE_ATTACHMENT_ID = "attachment-image";
+const GMAIL_MODIFY_SCOPE = "https://www.googleapis.com/auth/gmail.modify";
+const GMAIL_SETTINGS_SCOPE =
+  "https://www.googleapis.com/auth/gmail.settings.basic";
 const GMAIL_IMAGE_BYTES = Buffer.from("mail draft image");
 const GMAIL_PDF_BYTES = Buffer.from("mail draft pdf");
 const GMAIL_TEXT_BYTES = Buffer.from("mail draft decision");
@@ -250,7 +254,9 @@ function mockGmailDraftApi(options?: {
   return state;
 }
 
-async function seedGmailMailCardFixture() {
+async function seedGmailMailCardFixture(options?: {
+  readonly grantedScopes?: readonly string[];
+}) {
   const actor = bdd.user();
   if (!actor.orgId) {
     throw new Error("Expected an org-scoped actor");
@@ -268,6 +274,9 @@ async function seedGmailMailCardFixture() {
   mockGmailConnectorOAuth({
     accessToken: "gmail-mail-card-token",
     email: "sender@example.com",
+    ...(options?.grantedScopes === undefined
+      ? {}
+      : { scopes: options.grantedScopes }),
   });
   const start = await connectors.startOauth(actor, "gmail", "oauth");
   const state = new URL(start.authorizationUrl).searchParams.get("state");
@@ -315,6 +324,43 @@ async function linkDraft(
 }
 
 describe("POST /api/mail/drafts/link", () => {
+  it("uses the authoritative Gmail grant instead of the requested scope snapshot", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    await setLegacyBuiltinOAuthScopes(context, {
+      orgId: fixture.actor.orgId ?? "",
+      userId: fixture.actor.userId,
+      connectorSlug: "gmail",
+      oauthScopes: [GMAIL_MODIFY_SCOPE, GMAIL_SETTINGS_SCOPE],
+    });
+    const gmail = mockGmailDraftApi();
+
+    await linkDraft(fixture);
+
+    expect(gmail.draftReadCount).toBe(1);
+  });
+
+  it("rejects a Gmail draft operation when its required grant is missing", async () => {
+    const fixture = await seedGmailMailCardFixture({ grantedScopes: [] });
+    const gmail = mockGmailDraftApi();
+
+    const response = await accept(
+      client().linkDraft({
+        headers: authHeaders(),
+        body: {
+          threadId: fixture.thread.id,
+          agentId: fixture.agent.agentId,
+          gmailDraftId: GMAIL_DRAFT_ID,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Gmail access does not include permission to manage mail drafts",
+    );
+    expect(gmail.draftReadCount).toBe(0);
+  });
+
   it("uses the default for new drafts while preserving and deleting an exact pinned account", async () => {
     const fixture = await seedGmailMailCardFixture();
     mockGmailDraftApi();

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -361,6 +361,39 @@ describe("POST /api/mail/drafts/link", () => {
     expect(gmail.draftReadCount).toBe(0);
   });
 
+  it("reports a missing Gmail grant without marking a linked draft for reconnect", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const gmail = mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+    mockGmailConnectorOAuth({
+      accessToken: "gmail-mail-card-token",
+      email: "sender@example.com",
+      scopes: [],
+    });
+    const start = await connectors.startOauth(fixture.actor, "gmail", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Gmail OAuth state");
+    }
+    await connectors.completeOauthCallback("gmail", {
+      code: "zero-mail-partial-grant-code",
+      state,
+    });
+
+    const response = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Gmail access does not include permission to manage mail drafts",
+    );
+    expect(gmail.draftReadCount).toBe(1);
+  });
+
   it("uses the default for new drafts while preserving and deleting an exact pinned account", async () => {
     const fixture = await seedGmailMailCardFixture();
     mockGmailDraftApi();

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -10,7 +10,6 @@ import {
   type MailDraftStatus,
   type MailInlineImage,
 } from "@okouai/api-contracts/contracts/mail";
-import { connectorAuthMethodHasRequiredScopes } from "@okouai/connectors/connector-auth-method";
 import { agents } from "@okouai/db/schema/agent";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { connectors } from "@okouai/db/schema/connector";
@@ -42,6 +41,11 @@ const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS = 60 * 60 * 1000;
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 const GMAIL_ACCESS_TOKEN_ENV = "GMAIL_TOKEN";
+const REQUIRED_GMAIL_MAIL_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.modify",
+] as const;
+const GMAIL_MAIL_PERMISSION_ERROR =
+  "Gmail access does not include permission to manage mail drafts";
 const oauthScopesSchema = z.array(z.string());
 
 interface GmailMessagePart {
@@ -106,7 +110,6 @@ interface MailConnection extends ConnectorCredentialConnection {
   readonly connectorSlug: "gmail";
   readonly externalEmail: string;
   readonly externalUsername: string | null;
-  readonly scopesReady: boolean;
 }
 
 interface MailDraftResult {
@@ -332,10 +335,6 @@ async function loadMailConnections(args: {
         oauthScopes,
         stateRevision: row.stateRevision,
         storageVersion: access.storageVersion,
-        scopesReady: connectorAuthMethodHasRequiredScopes(
-          runtimeMethod.method,
-          oauthScopes,
-        ),
         tokenExpiresAt: row.tokenExpiresAt,
       },
     ];
@@ -456,8 +455,16 @@ async function resolveMailAccessToken(
   },
   signal: AbortSignal,
 ): Promise<MailAccessTokenResult> {
-  if (args.connection.needsReconnect || !args.connection.scopesReady) {
+  if (args.connection.needsReconnect) {
     return { kind: "error", message: "Reconnect Gmail before continuing" };
+  }
+  const grantedScopes = new Set(args.connection.oauthScopes ?? []);
+  if (
+    REQUIRED_GMAIL_MAIL_SCOPES.some((scope) => {
+      return !grantedScopes.has(scope);
+    })
+  ) {
+    return { kind: "error", message: GMAIL_MAIL_PERMISSION_ERROR };
   }
   const accessTokenValueRef = connectorCredentialRuntimeValueRef(
     args.connection,
@@ -1502,7 +1509,7 @@ export const linkMailDraft$ = command(
         agentId: threadAgentId,
       })
     ).filter((connection) => {
-      return !connection.needsReconnect && connection.scopesReady;
+      return !connection.needsReconnect;
     });
     signal.throwIfAborted();
     const connection = connections.length === 1 ? connections[0] : undefined;

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -194,6 +194,7 @@ interface MailAccessTokenSuccess {
 interface MailAccessTokenFailure {
   readonly kind: "error";
   readonly message: string;
+  readonly reason: "permission" | "unavailable";
 }
 
 type MailAccessTokenResult = MailAccessTokenSuccess | MailAccessTokenFailure;
@@ -238,6 +239,11 @@ interface MailAccess {
   readonly kind: "ok";
   readonly accessToken: string;
   readonly connection: MailConnection;
+}
+
+interface MailAccessFailure extends MailDraftErrorResult {
+  readonly kind: "conflict";
+  readonly reason: "permission" | "unavailable";
 }
 
 function linkResult(mailDraftId: string): MailDraftLinkResult {
@@ -456,7 +462,11 @@ async function resolveMailAccessToken(
   signal: AbortSignal,
 ): Promise<MailAccessTokenResult> {
   if (args.connection.needsReconnect) {
-    return { kind: "error", message: "Reconnect Gmail before continuing" };
+    return {
+      kind: "error",
+      message: "Reconnect Gmail before continuing",
+      reason: "unavailable",
+    };
   }
   const grantedScopes = new Set(args.connection.oauthScopes ?? []);
   if (
@@ -464,14 +474,22 @@ async function resolveMailAccessToken(
       return !grantedScopes.has(scope);
     })
   ) {
-    return { kind: "error", message: GMAIL_MAIL_PERMISSION_ERROR };
+    return {
+      kind: "error",
+      message: GMAIL_MAIL_PERMISSION_ERROR,
+      reason: "permission",
+    };
   }
   const accessTokenValueRef = connectorCredentialRuntimeValueRef(
     args.connection,
     GMAIL_ACCESS_TOKEN_ENV,
   );
   if (accessTokenValueRef === null) {
-    return { kind: "error", message: "Reconnect Gmail before continuing" };
+    return {
+      kind: "error",
+      message: "Reconnect Gmail before continuing",
+      reason: "unavailable",
+    };
   }
   const values = await loadConnectorCredentialValues({
     connection: args.connection,
@@ -501,11 +519,19 @@ async function resolveMailAccessToken(
     signal,
   );
   if (refreshed.kind === "configuration-unavailable") {
-    return { kind: "error", message: "Gmail OAuth is not configured" };
+    return {
+      kind: "error",
+      message: "Gmail OAuth is not configured",
+      reason: "unavailable",
+    };
   }
   return refreshed.kind === "ok"
     ? { kind: "ok", accessToken: refreshed.accessToken }
-    : { kind: "error", message: "Reconnect Gmail before continuing" };
+    : {
+        kind: "error",
+        message: "Reconnect Gmail before continuing",
+        reason: "unavailable",
+      };
 }
 
 function decodeHeader(value: string): string {
@@ -1041,6 +1067,13 @@ function reconnectDraftResult(row: MailDraftRow): MailDraftResult {
   );
 }
 
+function mailDraftAccessFailureResult(
+  row: MailDraftRow,
+  failure: MailAccessFailure,
+): MailDraftMutationResult {
+  return failure.reason === "permission" ? failure : reconnectDraftResult(row);
+}
+
 async function connectionForRow(args: {
   readonly db: ReadonlyDb;
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -1080,10 +1113,14 @@ async function accessForRow(
     readonly row: MailDraftRow;
   },
   signal: AbortSignal,
-): Promise<MailAccess | MailDraftErrorResult> {
+): Promise<MailAccess | MailAccessFailure> {
   const connection = await connectionForRow(args);
   if (!connection) {
-    return { kind: "conflict", message: "Reconnect Gmail before continuing" };
+    return {
+      kind: "conflict",
+      message: "Reconnect Gmail before continuing",
+      reason: "unavailable",
+    };
   }
   const access = await resolveMailAccessToken(
     {
@@ -1097,7 +1134,7 @@ async function accessForRow(
   );
   return access.kind === "ok"
     ? { ...access, connection }
-    : { kind: "conflict", message: access.message };
+    : { kind: "conflict", message: access.message, reason: access.reason };
 }
 
 async function persistLinkedDraft(args: {
@@ -1223,8 +1260,11 @@ async function getMailDraft(
       args.row.id,
       responseDraft({ row: args.row, details: null, detailAvailable: false }),
     );
-    if (access.kind !== "ok" || !sentGmailMessageId) {
-      return access.kind === "ok" ? stored : reconnectDraftResult(args.row);
+    if (access.kind !== "ok") {
+      return mailDraftAccessFailureResult(args.row, access);
+    }
+    if (!sentGmailMessageId) {
+      return stored;
     }
     let sent: GmailSentValue | null = null;
     const sentResult = await runGmailOperation(
@@ -1272,7 +1312,7 @@ async function getMailDraft(
       : stored;
   }
   if (access.kind !== "ok") {
-    return reconnectDraftResult(args.row);
+    return mailDraftAccessFailureResult(args.row, access);
   }
   const gmailResult = await runGmailOperation(
     {


### PR DESCRIPTION
## Summary

- replace Gmail mail-draft connector-wide scope readiness with an explicit `gmail.modify` operation requirement
- keep reconnect and credential failures separate from missing mail permissions, returning a draft-specific permission error before Gmail or credential I/O
- preserve permission failures when reading linked drafts instead of incorrectly presenting them as reconnect-required
- cover authoritative granted scopes, divergent requested scopes, and missing operation grants through the mail route integration suite

## Behavior

The original fail-closed scope guard remains in place. A healthy Gmail connection is now selected independently of connector-wide requested scopes, then the mail service checks its effective granted-scope snapshot for the permission required by mail-draft operations. Existing `oauthGrantedScopes ?? oauthScopes` rollout compatibility remains unchanged. Connection or credential unavailability still produces reconnect behavior; an insufficient grant remains an explicit operation permission error.

## Exclusions

- no connector health, schema, frontend, runner, or public contract changes
- no X image-sharing behavior changes; its operation scopes were audited and are already explicit
- no broader OAuth fixture audit, which remains tracked by #29469

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/mail.test.ts --silent=passed-only` — 16 passed
- `pnpm knip`
- pre-commit repository type checks — 14 packages passed
- `git diff --check`

Closes #29467

Parent context: #29462
