### PR TITLE
feat(platform): improve shared conversation handoff

### DIFF
--- a/turbo/apps/api/src/signals/services/default-agent-profile.ts
+++ b/turbo/apps/api/src/signals/services/default-agent-profile.ts
@@ -1,4 +1,6 @@
+import { DEFAULT_AGENT_AVATAR_URL as CORE_DEFAULT_AGENT_AVATAR_URL } from "@okouai/core/agent-avatar";
+
 export const DEFAULT_AGENT_NAME = "default-agent";
 export const DEFAULT_AGENT_DISPLAY_NAME = "Zero";
 export const DEFAULT_AGENT_SOUND = "professional";
-export const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+export const DEFAULT_AGENT_AVATAR_URL = CORE_DEFAULT_AGENT_AVATAR_URL;

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5366,13 +5366,11 @@
     "handoffDescription": "{{assistantName}} übernimmt den Kontext in einen neuen Chat",
     "handoffPrompt": "Setze diese geteilte Unterhaltung mit mir fort: {{url}}",
     "makeConversationYours": "Mach diese Unterhaltung zu deiner",
-    "notFoundDescription": "Diese geteilte Unterhaltung existiert nicht.",
     "notFoundTitle": "Geteilte Unterhaltung nicht gefunden",
     "share": "Teilen",
     "signIn": "Anmelden",
     "signUp": "Registrieren",
-    "tryItYourself": "Selbst ausprobieren",
-    "yourWorkspace": "Dein Workspace"
+    "tryItYourself": "Selbst ausprobieren"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5363,10 +5363,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} übernimmt den Kontext in einen neuen Chat",
+    "handoffPrompt": "Setze diese geteilte Unterhaltung mit mir fort: {{url}}",
+    "makeConversationYours": "Mach diese Unterhaltung zu deiner",
     "notFoundDescription": "Diese geteilte Unterhaltung existiert nicht.",
     "notFoundTitle": "Geteilte Unterhaltung nicht gefunden",
-    "tryOkou": "{{assistantName}} ausprobieren"
+    "share": "Teilen",
+    "signIn": "Anmelden",
+    "signUp": "Registrieren",
+    "tryItYourself": "Selbst ausprobieren",
+    "yourWorkspace": "Dein Workspace"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5355,10 +5355,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} carries the context into a new chat",
+    "handoffPrompt": "Continue this shared conversation with me: {{url}}",
+    "makeConversationYours": "Make this conversation yours",
     "notFoundDescription": "This shared conversation does not exist.",
     "notFoundTitle": "Shared conversation not found",
-    "tryOkou": "Try {{assistantName}}"
+    "share": "Share",
+    "signIn": "Sign in",
+    "signUp": "Sign up",
+    "tryItYourself": "Try it yourself",
+    "yourWorkspace": "Your workspace"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5358,13 +5358,11 @@
     "handoffDescription": "{{assistantName}} carries the context into a new chat",
     "handoffPrompt": "Continue this shared conversation with me: {{url}}",
     "makeConversationYours": "Make this conversation yours",
-    "notFoundDescription": "This shared conversation does not exist.",
     "notFoundTitle": "Shared conversation not found",
     "share": "Share",
     "signIn": "Sign in",
     "signUp": "Sign up",
-    "tryItYourself": "Try it yourself",
-    "yourWorkspace": "Your workspace"
+    "tryItYourself": "Try it yourself"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5425,13 +5425,11 @@
     "handoffDescription": "{{assistantName}} lleva el contexto a un chat nuevo",
     "handoffPrompt": "Continúa esta conversación compartida conmigo: {{url}}",
     "makeConversationYours": "Haz tuya esta conversación",
-    "notFoundDescription": "Esta conversación compartida no existe.",
     "notFoundTitle": "Conversación compartida no encontrada",
     "share": "Compartir",
     "signIn": "Iniciar sesión",
     "signUp": "Registrarse",
-    "tryItYourself": "Pruébalo tú",
-    "yourWorkspace": "Tu espacio de trabajo"
+    "tryItYourself": "Pruébalo tú"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5422,10 +5422,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} lleva el contexto a un chat nuevo",
+    "handoffPrompt": "Continúa esta conversación compartida conmigo: {{url}}",
+    "makeConversationYours": "Haz tuya esta conversación",
     "notFoundDescription": "Esta conversación compartida no existe.",
     "notFoundTitle": "Conversación compartida no encontrada",
-    "tryOkou": "Probar {{assistantName}}"
+    "share": "Compartir",
+    "signIn": "Iniciar sesión",
+    "signUp": "Registrarse",
+    "tryItYourself": "Pruébalo tú",
+    "yourWorkspace": "Tu espacio de trabajo"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5422,10 +5422,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} transfère le contexte vers une nouvelle conversation",
+    "handoffPrompt": "Poursuis cette conversation partagée avec moi : {{url}}",
+    "makeConversationYours": "Faites de cette conversation la vôtre",
     "notFoundDescription": "Cette conversation partagée n’existe pas.",
     "notFoundTitle": "Conversation partagée introuvable",
-    "tryOkou": "Essayer {{assistantName}}"
+    "share": "Partager",
+    "signIn": "Se connecter",
+    "signUp": "S’inscrire",
+    "tryItYourself": "Essayez par vous-même",
+    "yourWorkspace": "Votre espace de travail"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5425,13 +5425,11 @@
     "handoffDescription": "{{assistantName}} transfère le contexte vers une nouvelle conversation",
     "handoffPrompt": "Poursuis cette conversation partagée avec moi : {{url}}",
     "makeConversationYours": "Faites de cette conversation la vôtre",
-    "notFoundDescription": "Cette conversation partagée n’existe pas.",
     "notFoundTitle": "Conversation partagée introuvable",
     "share": "Partager",
     "signIn": "Se connecter",
     "signUp": "S’inscrire",
-    "tryItYourself": "Essayez par vous-même",
-    "yourWorkspace": "Votre espace de travail"
+    "tryItYourself": "Essayez par vous-même"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5366,13 +5366,11 @@
     "handoffDescription": "{{assistantName}} संदर्भ को एक नई चैट में ले जाता है",
     "handoffPrompt": "इस साझा बातचीत को मेरे साथ जारी रखें: {{url}}",
     "makeConversationYours": "इस बातचीत को अपना बनाएं",
-    "notFoundDescription": "यह साझा बातचीत मौजूद नहीं है।",
     "notFoundTitle": "साझा बातचीत नहीं मिली",
     "share": "साझा करें",
     "signIn": "साइन इन करें",
     "signUp": "साइन अप करें",
-    "tryItYourself": "खुद आज़माएं",
-    "yourWorkspace": "आपका वर्कस्पेस"
+    "tryItYourself": "खुद आज़माएं"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5363,10 +5363,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} संदर्भ को एक नई चैट में ले जाता है",
+    "handoffPrompt": "इस साझा बातचीत को मेरे साथ जारी रखें: {{url}}",
+    "makeConversationYours": "इस बातचीत को अपना बनाएं",
     "notFoundDescription": "यह साझा बातचीत मौजूद नहीं है।",
     "notFoundTitle": "साझा बातचीत नहीं मिली",
-    "tryOkou": "{{assistantName}} आज़माएँ"
+    "share": "साझा करें",
+    "signIn": "साइन इन करें",
+    "signUp": "साइन अप करें",
+    "tryItYourself": "खुद आज़माएं",
+    "yourWorkspace": "आपका वर्कस्पेस"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5355,10 +5355,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} membawa konteks ke percakapan baru",
+    "handoffPrompt": "Lanjutkan percakapan yang dibagikan ini dengan saya: {{url}}",
+    "makeConversationYours": "Jadikan percakapan ini milik Anda",
     "notFoundDescription": "Percakapan yang dibagikan ini tidak ada.",
     "notFoundTitle": "Percakapan yang dibagikan tidak ditemukan",
-    "tryOkou": "Coba {{assistantName}}"
+    "share": "Bagikan",
+    "signIn": "Masuk",
+    "signUp": "Daftar",
+    "tryItYourself": "Coba sendiri",
+    "yourWorkspace": "Ruang kerja Anda"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5358,13 +5358,11 @@
     "handoffDescription": "{{assistantName}} membawa konteks ke percakapan baru",
     "handoffPrompt": "Lanjutkan percakapan yang dibagikan ini dengan saya: {{url}}",
     "makeConversationYours": "Jadikan percakapan ini milik Anda",
-    "notFoundDescription": "Percakapan yang dibagikan ini tidak ada.",
     "notFoundTitle": "Percakapan yang dibagikan tidak ditemukan",
     "share": "Bagikan",
     "signIn": "Masuk",
     "signUp": "Daftar",
-    "tryItYourself": "Coba sendiri",
-    "yourWorkspace": "Ruang kerja Anda"
+    "tryItYourself": "Coba sendiri"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5422,10 +5422,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} porta il contesto in una nuova chat",
+    "handoffPrompt": "Continua questa conversazione condivisa con me: {{url}}",
+    "makeConversationYours": "Fai tua questa conversazione",
     "notFoundDescription": "Questa conversazione condivisa non esiste.",
     "notFoundTitle": "Conversazione condivisa non trovata",
-    "tryOkou": "Prova {{assistantName}}"
+    "share": "Condividi",
+    "signIn": "Accedi",
+    "signUp": "Registrati",
+    "tryItYourself": "Provalo tu",
+    "yourWorkspace": "Il tuo spazio di lavoro"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5425,13 +5425,11 @@
     "handoffDescription": "{{assistantName}} porta il contesto in una nuova chat",
     "handoffPrompt": "Continua questa conversazione condivisa con me: {{url}}",
     "makeConversationYours": "Fai tua questa conversazione",
-    "notFoundDescription": "Questa conversazione condivisa non esiste.",
     "notFoundTitle": "Conversazione condivisa non trovata",
     "share": "Condividi",
     "signIn": "Accedi",
     "signUp": "Registrati",
-    "tryItYourself": "Provalo tu",
-    "yourWorkspace": "Il tuo spazio di lavoro"
+    "tryItYourself": "Provalo tu"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5358,13 +5358,11 @@
     "handoffDescription": "{{assistantName}} がコンテキストを新しいチャットに引き継ぎます",
     "handoffPrompt": "この共有された会話を私と続けてください: {{url}}",
     "makeConversationYours": "この会話を自分のものに",
-    "notFoundDescription": "この共有された会話は存在しません。",
     "notFoundTitle": "共有された会話が見つかりません",
     "share": "共有",
     "signIn": "ログイン",
     "signUp": "新規登録",
-    "tryItYourself": "自分で試す",
-    "yourWorkspace": "あなたのワークスペース"
+    "tryItYourself": "自分で試す"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5355,10 +5355,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} がコンテキストを新しいチャットに引き継ぎます",
+    "handoffPrompt": "この共有された会話を私と続けてください: {{url}}",
+    "makeConversationYours": "この会話を自分のものに",
     "notFoundDescription": "この共有された会話は存在しません。",
     "notFoundTitle": "共有された会話が見つかりません",
-    "tryOkou": "{{assistantName}}を試す"
+    "share": "共有",
+    "signIn": "ログイン",
+    "signUp": "新規登録",
+    "tryItYourself": "自分で試す",
+    "yourWorkspace": "あなたのワークスペース"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5358,13 +5358,11 @@
     "handoffDescription": "{{assistantName}}가 컨텍스트를 새 채팅으로 가져갑니다",
     "handoffPrompt": "이 공유 대화를 저와 계속하세요: {{url}}",
     "makeConversationYours": "이 대화를 내 것으로",
-    "notFoundDescription": "이 공유된 대화는 존재하지 않습니다.",
     "notFoundTitle": "공유된 대화를 찾을 수 없습니다",
     "share": "공유",
     "signIn": "로그인",
     "signUp": "회원가입",
-    "tryItYourself": "직접 사용해 보기",
-    "yourWorkspace": "내 워크스페이스"
+    "tryItYourself": "직접 사용해 보기"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5355,10 +5355,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}}가 컨텍스트를 새 채팅으로 가져갑니다",
+    "handoffPrompt": "이 공유 대화를 저와 계속하세요: {{url}}",
+    "makeConversationYours": "이 대화를 내 것으로",
     "notFoundDescription": "이 공유된 대화는 존재하지 않습니다.",
     "notFoundTitle": "공유된 대화를 찾을 수 없습니다",
-    "tryOkou": "{{assistantName}} 사용해 보기"
+    "share": "공유",
+    "signIn": "로그인",
+    "signUp": "회원가입",
+    "tryItYourself": "직접 사용해 보기",
+    "yourWorkspace": "내 워크스페이스"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5422,10 +5422,16 @@
     }
   },
   "sharedThread": {
-    "brand": "{{brandName}}",
+    "handoffDescription": "{{assistantName}} leva o contexto para uma nova conversa",
+    "handoffPrompt": "Continue esta conversa compartilhada comigo: {{url}}",
+    "makeConversationYours": "Torne esta conversa sua",
     "notFoundDescription": "Esta conversa compartilhada não existe.",
     "notFoundTitle": "Conversa compartilhada não encontrada",
-    "tryOkou": "Experimentar o {{assistantName}}"
+    "share": "Compartilhar",
+    "signIn": "Entrar",
+    "signUp": "Criar conta",
+    "tryItYourself": "Experimente você mesmo",
+    "yourWorkspace": "Seu espaço de trabalho"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5425,13 +5425,11 @@
     "handoffDescription": "{{assistantName}} leva o contexto para uma nova conversa",
     "handoffPrompt": "Continue esta conversa compartilhada comigo: {{url}}",
     "makeConversationYours": "Torne esta conversa sua",
-    "notFoundDescription": "Esta conversa compartilhada não existe.",
     "notFoundTitle": "Conversa compartilhada não encontrada",
     "share": "Compartilhar",
     "signIn": "Entrar",
     "signUp": "Criar conta",
-    "tryItYourself": "Experimente você mesmo",
-    "yourWorkspace": "Seu espaço de trabalho"
+    "tryItYourself": "Experimente você mesmo"
   },
   "usage": {
     "displayNames": {

--- a/turbo/apps/platform/src/views/components/product-brand-mark.tsx
+++ b/turbo/apps/platform/src/views/components/product-brand-mark.tsx
@@ -1,6 +1,6 @@
 import { useGet } from "ccstate-react";
 
-import { brandName$ } from "../../signals/branding.ts";
+import { brandName$, type BrandName } from "../../signals/branding.ts";
 
 type ProductBrandMarkSize = "default" | "compact" | "small";
 
@@ -66,11 +66,14 @@ function Vm0BrandMark({
 }
 
 export function ProductBrandMark({
+  brandName: explicitBrandName,
   size = "default",
 }: {
+  brandName?: BrandName;
   size?: ProductBrandMarkSize;
 }) {
-  const brandName = useGet(brandName$);
+  const hostnameBrandName = useGet(brandName$);
+  const brandName = explicitBrandName ?? hostnameBrandName;
 
   if (brandName === "VM0") {
     return <Vm0BrandMark size={size} label={brandName} />;

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -16,6 +16,12 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
+export const CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS =
+  "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9";
+
+export const CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS =
+  "h-7 w-7 rounded-full object-cover object-top @[900px]:h-9 @[900px]:w-9";
+
 export const CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS =
   "flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150";
 

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -16,6 +16,15 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
+export const CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS =
+  "flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150";
+
+export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS =
+  "@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]";
+
+export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS =
+  "flex items-center justify-between pt-2 pb-1 gap-2 -ml-1";
+
 // Consecutive user messages read as one burst. The copy button already sits
 // `mt-1` below its message, so this pull keeps the gap below it equally tight.
 export const CHAT_THREAD_MESSAGE_STACK_PULL_CLASS = "-mt-5";

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@okouai/ui";
+import type { HTMLAttributes } from "react";
+
+export const CHAT_THREAD_CONTENT_MAIN_CLASS =
+  "items-center py-4 pl-4 pr-4 sm:pl-6 sm:pr-6 @container";
+
+export const CHAT_THREAD_MESSAGE_LIST_CLASS =
+  "w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible";
+
+export const CHAT_THREAD_USER_MESSAGE_ROW_CLASS =
+  "flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
+
+export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
+  "flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300";
+
+export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
+  "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
+
+// Consecutive user messages read as one burst. The copy button already sits
+// `mt-1` below its message, so this pull keeps the gap below it equally tight.
+export const CHAT_THREAD_MESSAGE_STACK_PULL_CLASS = "-mt-5";
+
+export function ChatUserMessageBubble({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ChatAssistantMessageBody({
+  className,
+  compactTop = false,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { readonly compactTop?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "zero-chat-bubble-assistant px-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
+        compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -299,6 +299,8 @@ import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 import {
   ChatAssistantMessageBody,
   ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS,
+  CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
@@ -6204,7 +6206,7 @@ function AssistantBubbleAvatar({ thread }: { thread: ChatPanelSignals }) {
     <Link
       pathname="/agents/:agentId"
       options={{ pathParams: { agentId } }}
-      className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-state-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className={`${CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS} transition-colors duration-150 hover:bg-state-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
       aria-label={t(($) => {
         return $.chat.agentPage.viewAgentProfile;
       })}
@@ -6212,7 +6214,7 @@ function AssistantBubbleAvatar({ thread }: { thread: ChatPanelSignals }) {
       <AgentAvatarImg
         name={agentId}
         alt=""
-        className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-full object-cover object-top"
+        className={CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS}
       />
     </Link>
   );

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -299,11 +299,14 @@ import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 import {
   ChatAssistantMessageBody,
   ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "./chat-message-surface.tsx";
 
@@ -6683,7 +6686,7 @@ function UserMessageActions({
     return null;
   }
   return (
-    <div className="flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+    <div className={CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS}>
       <IconTooltipButton
         type="button"
         onClick={onCopy}
@@ -8128,9 +8131,9 @@ function PagedGroupActions({
   };
 
   return (
-    <div className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
+    <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS}>
       <div className="hidden @[900px]:block" />
-      <div className="flex items-center justify-between pt-2 pb-1 gap-2 -ml-1">
+      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS}>
         <PagedGroupPrimaryActions
           firstRunId={firstRunId}
           hasContent={hasContent}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -296,6 +296,16 @@ import {
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 import { IconTooltipButton } from "../components/icon-tooltip.tsx";
+import {
+  ChatAssistantMessageBody,
+  ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
+  CHAT_THREAD_CONTENT_MAIN_CLASS,
+  CHAT_THREAD_MESSAGE_LIST_CLASS,
+  CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
+} from "./chat-message-surface.tsx";
 
 type RecommendedFollowup = ChatRecommendedFollowup;
 
@@ -2986,8 +2996,6 @@ function resolveSessionError(
   return null;
 }
 
-const CHAT_THREAD_CONTENT_MAIN_CLASS =
-  "items-center py-4 pl-4 pr-4 sm:pl-6 sm:pr-6 @container";
 const CHAT_RENDER_LOAD_MORE_TOP_THRESHOLD_PX = 100;
 
 function renderedChatEventKeys(
@@ -3186,7 +3194,7 @@ function ChatThreadEventsMain({ thread }: { thread: ChatPanelSignals }) {
         ref={scrollContentOnRef}
         data-message-container
         className={cn(
-          "w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible",
+          CHAT_THREAD_MESSAGE_LIST_CLASS,
           sharingPhase !== "idle" && "pr-10 lg:pr-0",
         )}
         style={{ visibility: renderedGroupsReady ? "visible" : "hidden" }}
@@ -4223,12 +4231,6 @@ const RUN_SECTION_LABEL_CLASS =
 const RUN_SECTION_ROW_CLASS =
   "-mt-5 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
-// Consecutive user messages read as one burst, which means an even rhythm: the
-// copy button sits the same distance from the text above it as from the next
-// message. The button already sits `mt-1` under its own message, so this pull
-// cancels the thread's 24px gap down to that same 4px on the other side of it.
-const MESSAGE_STACK_PULL_CLASS = "-mt-5";
-
 function RunSectionDivider({
   label,
   labelPosition = "left",
@@ -4563,7 +4565,12 @@ function ChatThreadSkeletonOverlay({ thread }: { thread: ChatPanelSignals }) {
       className="absolute inset-0 z-10 overflow-hidden pointer-events-none bg-background"
     >
       <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
-        <div className="zero-chat-skeleton-reveal w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4">
+        <div
+          className={cn(
+            "zero-chat-skeleton-reveal",
+            CHAT_THREAD_MESSAGE_LIST_CLASS,
+          )}
+        >
           <ChatSkeleton />
         </div>
       </main>
@@ -7421,14 +7428,6 @@ function isElevatedUserMessagePart(
   );
 }
 
-function UserMessageBubble({ children }: { children: ReactNode }) {
-  return (
-    <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
-      {children}
-    </div>
-  );
-}
-
 function UserMessageContent({
   document,
   attachments,
@@ -7463,14 +7462,14 @@ function UserMessageContent({
         onImageClick={onImageClick}
       />
       {hasBody ? (
-        <UserMessageBubble>
+        <ChatUserMessageBubble>
           <div className="px-4 py-3">
             <UserMessageView
               document={document}
               elevatedFileIds={elevatedFileIds}
             />
           </div>
-        </UserMessageBubble>
+        </ChatUserMessageBubble>
       ) : null}
     </>
   );
@@ -7514,7 +7513,7 @@ function WorkflowUserMessage({
       data-turn-created-at={event.createdAt}
       className="group"
     >
-      <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div className={CHAT_THREAD_USER_MESSAGE_ROW_CLASS}>
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex w-full flex-col items-end">
           <MessageAnnotation renderPart={renderPart} />
@@ -7567,7 +7566,7 @@ function GoalUserMessage({
       data-turn-created-at={event.createdAt}
       className="group"
     >
-      <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div className={CHAT_THREAD_USER_MESSAGE_ROW_CLASS}>
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex w-full flex-col items-end">
           <MessageAnnotation renderPart={renderPart} />
@@ -7697,9 +7696,12 @@ function PagedUserMessage({
       data-role="user"
       data-chat-scroll-anchor-event-id={event.id}
       data-turn-created-at={event.createdAt}
-      className={cn("group", stackedOnPrevious && MESSAGE_STACK_PULL_CLASS)}
+      className={cn(
+        "group",
+        stackedOnPrevious && CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+      )}
     >
-      <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div className={CHAT_THREAD_USER_MESSAGE_ROW_CLASS}>
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex flex-col items-end w-full">
           {annotationPart ? (
@@ -7786,9 +7788,9 @@ function PagedAssistantGroup({
       data-role="assistant"
       data-chat-run-id={runId}
       data-turn-created-at={group.events[0]?.createdAt}
-      className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
+      className={CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS}
     >
-      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex flex-col gap-2">
           {runGroupFolds?.map((fold) => {
@@ -7832,20 +7834,17 @@ function PagedAssistantEventItem({
   const error = chatEventError(event);
   if (error) {
     return (
-      <div
+      <ChatAssistantMessageBody
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
-        className={cn(
-          "zero-chat-bubble-assistant px-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
-          compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
-        )}
+        compactTop={compactTop}
       >
         <AssistantErrorContent
           error={error}
           eventId={event.id}
           thread={thread}
         />
-      </div>
+      </ChatAssistantMessageBody>
     );
   }
 
@@ -7854,18 +7853,15 @@ function PagedAssistantEventItem({
     hasChatEventBodyContent(event)
   ) {
     return (
-      <div
+      <ChatAssistantMessageBody
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
-        className={cn(
-          "zero-chat-bubble-assistant px-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
-          compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
-        )}
+        compactTop={compactTop}
       >
         {event.tree !== undefined ? (
           <MarkdownEventBody tree={event.tree} mediaPreview />
         ) : null}
-      </div>
+      </ChatAssistantMessageBody>
     );
   }
 

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -75,6 +75,9 @@ describe("shared thread page", () => {
     expect(
       document.querySelectorAll("[data-shared-message-copy]"),
     ).toHaveLength(3);
+    expect(
+      document.querySelector("[data-shared-thread-product-logo]"),
+    ).toHaveAttribute("src", "/icons/icon-192.png");
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
     expect(
@@ -175,6 +178,9 @@ describe("shared thread page", () => {
       screen.findByRole("heading", { name: "VM0" }),
     ).resolves.toBeInTheDocument();
     expect(document.title).toBe("VM0");
+    expect(
+      document.querySelector("[data-shared-thread-product-logo]"),
+    ).not.toBeInTheDocument();
   });
 
   it("defaults an ambiguous not-found page to VM0 presentation", async () => {

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -28,6 +28,12 @@ describe("shared thread page", () => {
           },
           {
             messageIndex: 1,
+            role: "user",
+            content: "Keep it concise.",
+            runIndex: 0,
+          },
+          {
+            messageIndex: 2,
             role: "assistant",
             content: "Launch the **public preview**.",
             runIndex: 0,
@@ -46,11 +52,27 @@ describe("shared thread page", () => {
       screen.findByRole("heading", { name: "Public launch plan" }),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("What should we launch?")).toBeInTheDocument();
+    expect(screen.getByText("Keep it concise.")).toBeInTheDocument();
     expect(screen.getByText("public preview").tagName).toBe("STRONG");
-    expect(document.querySelector("[data-role='user']")).toBeInTheDocument();
+    const userMessages = document.querySelectorAll("[data-role='user']");
+    expect(userMessages).toHaveLength(2);
+    expect(userMessages[1]).toHaveClass("-mt-5");
     expect(
       document.querySelector("[data-role='assistant']"),
     ).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Okou" })).toHaveClass(
+      "h-7",
+      "@[900px]:h-9",
+    );
+    expect(
+      document.querySelector("[data-shared-message-actions='user']"),
+    ).toHaveClass("mt-1");
+    expect(
+      document.querySelector("[data-shared-message-actions='assistant']"),
+    ).toHaveClass("pt-2", "pb-1");
+    expect(
+      document.querySelectorAll("[data-shared-message-copy]"),
+    ).toHaveLength(3);
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
     expect(

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -77,11 +77,11 @@ describe("shared thread page", () => {
     ).toHaveLength(3);
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
-    expect(
-      queryAllByRoleFast("button").find((button) => {
-        return button.getAttribute("aria-label") === "Share";
-      }),
-    ).toBeInTheDocument();
+    const shareButton = queryAllByRoleFast("button").find((button) => {
+      return button.getAttribute("aria-label") === "Share";
+    });
+    expect(shareButton).toBeInTheDocument();
+    expect(shareButton?.parentElement).toHaveClass("gap-2");
     expect(
       screen.getByText("Make this conversation yours"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -1,5 +1,6 @@
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -13,6 +14,8 @@ const SHARED_THREAD_ID = "30000000-0000-4000-8000-000000000702";
 
 describe("shared thread page", () => {
   it("renders the immutable public DTO without owner or agent identity", async () => {
+    const user = userEvent.setup({ delay: null });
+    const clipboard = context.mocks.browser.clipboardWriteText();
     context.mocks.api(sharedThreadsContract.get, ({ params, respond }) => {
       expect(params.id).toBe(SHARED_THREAD_ID);
       return respond(200, {
@@ -54,46 +57,60 @@ describe("shared thread page", () => {
     expect(screen.getByText("What should we launch?")).toBeInTheDocument();
     expect(screen.getByText("Keep it concise.")).toBeInTheDocument();
     expect(screen.getByText("public preview").tagName).toBe("STRONG");
-    const userMessages = document.querySelectorAll("[data-role='user']");
-    expect(userMessages).toHaveLength(2);
-    expect(userMessages[1]).toHaveClass("-mt-5");
-    expect(
-      document.querySelector("[data-role='assistant']"),
-    ).toBeInTheDocument();
-    const assistantAvatar = screen.getByRole("img", { name: "Okou" });
-    expect(assistantAvatar).toHaveClass("h-7", "@[900px]:h-9");
-    expect(assistantAvatar.querySelectorAll("img")).toHaveLength(3);
-    expect(
-      document.querySelector("[data-shared-assistant-avatar] svg"),
-    ).not.toBeInTheDocument();
-    expect(
-      document.querySelector("[data-shared-message-actions='user']"),
-    ).toHaveClass("mt-1");
-    expect(
-      document.querySelector("[data-shared-message-actions='assistant']"),
-    ).toHaveClass("pt-2", "pb-1");
-    expect(
-      document.querySelectorAll("[data-shared-message-copy]"),
-    ).toHaveLength(3);
+    const links = queryAllByRoleFast("link");
+    const brandLink = links.find((link) => {
+      return link.getAttribute("aria-label") === "Okou";
+    });
+    expect(brandLink).toBeInTheDocument();
+    expect(brandLink?.textContent).toBe("Okou");
+    expect(screen.getByRole("img", { name: "Okou" })).toBeInTheDocument();
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
-    const shareButton = queryAllByRoleFast("button").find((button) => {
-      return button.getAttribute("aria-label") === "Share";
-    });
-    expect(shareButton).toBeInTheDocument();
-    expect(shareButton?.parentElement).toHaveClass("gap-2");
     expect(
       screen.getByText("Make this conversation yours"),
     ).toBeInTheDocument();
-    expect(document.querySelector("[data-message-container]")).toHaveClass(
-      "max-w-[900px]",
-      "gap-6",
-    );
-    expect(document.querySelector("[data-shared-thread-handoff]")).toHaveClass(
-      "shrink-0",
-    );
 
-    const links = queryAllByRoleFast("link");
+    const shareUrl = `${window.location.origin}/share/threads/${SHARED_THREAD_ID}`;
+    const buttons = queryAllByRoleFast("button");
+    const shareButton = buttons.find((button) => {
+      return button.getAttribute("aria-label") === "Share";
+    });
+    if (shareButton === undefined) {
+      throw new Error("shared thread share button not found");
+    }
+    await user.click(shareButton);
+    await waitFor(() => {
+      expect(clipboard.writes).toStrictEqual([shareUrl]);
+    });
+    await expect(screen.findByText("Link copied")).resolves.toBeInTheDocument();
+
+    const copyButtons = buttons.filter((button) => {
+      return button.getAttribute("aria-label") === "Copy message";
+    });
+    const userCopyButton = copyButtons[0];
+    const assistantCopyButton = copyButtons.at(-1);
+    if (userCopyButton === undefined || assistantCopyButton === undefined) {
+      throw new Error("shared message copy buttons not found");
+    }
+
+    await user.click(userCopyButton);
+    await waitFor(() => {
+      expect(clipboard.writes).toStrictEqual([
+        shareUrl,
+        "What should we launch?",
+      ]);
+    });
+    await expect(screen.findByText("Copied!")).resolves.toBeInTheDocument();
+
+    await user.click(assistantCopyButton);
+    await waitFor(() => {
+      expect(clipboard.writes).toStrictEqual([
+        shareUrl,
+        "What should we launch?",
+        "Launch the **public preview**.",
+      ]);
+    });
+
     const handoffLink = links.find((link) => {
       return link.textContent === "Try it yourself";
     });
@@ -126,33 +143,6 @@ describe("shared thread page", () => {
     expect(signUpUrl.searchParams.get("redirect_url")).toBe(
       handoffUrl.toString(),
     );
-  });
-
-  it("owns its scrolling because the app shell clips overflow", async () => {
-    context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
-      return respond(200, {
-        id: SHARED_THREAD_ID,
-        title: "Long thread",
-        publicBrand: "vm0",
-        messages: [
-          {
-            messageIndex: 0,
-            role: "user",
-            content: "First question",
-            runIndex: 0,
-          },
-        ],
-      });
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/share/threads/${SHARED_THREAD_ID}`,
-      user: null,
-    });
-
-    const scroller = await screen.findByTestId("shared-thread-scroll");
-    expect(scroller).toHaveClass("absolute", "inset-0", "overflow-y-auto");
   });
 
   it("does not repeat a brand-only document title", async () => {

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -60,10 +60,12 @@ describe("shared thread page", () => {
     expect(
       document.querySelector("[data-role='assistant']"),
     ).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Okou" })).toHaveClass(
-      "h-7",
-      "@[900px]:h-9",
-    );
+    const assistantAvatar = screen.getByRole("img", { name: "Okou" });
+    expect(assistantAvatar).toHaveClass("h-7", "@[900px]:h-9");
+    expect(assistantAvatar.querySelectorAll("img")).toHaveLength(3);
+    expect(
+      document.querySelector("[data-shared-assistant-avatar] svg"),
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector("[data-shared-message-actions='user']"),
     ).toHaveClass("mt-1");

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -53,11 +53,49 @@ describe("shared thread page", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
-    const tryOkouLink = queryAllByRoleFast("link").find((link) => {
-      return link.textContent === "Try Okou";
+    expect(
+      queryAllByRoleFast("button").find((button) => {
+        return button.getAttribute("aria-label") === "Share";
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Make this conversation yours"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Your workspace")).toBeInTheDocument();
+
+    const links = queryAllByRoleFast("link");
+    const handoffLink = links.find((link) => {
+      return link.textContent === "Try it yourself";
     });
-    expect(tryOkouLink).toBeInTheDocument();
-    expect(tryOkouLink).toHaveAttribute("href", window.location.origin);
+    expect(handoffLink).toBeInTheDocument();
+    const handoffUrl = new URL(handoffLink?.getAttribute("href") ?? "");
+    expect(handoffUrl.origin).toBe(window.location.origin);
+    expect(handoffUrl.pathname).toBe("/");
+    expect(handoffUrl.searchParams.get("prompt")).toContain(
+      `/share/threads/${SHARED_THREAD_ID}`,
+    );
+
+    const signInLinks = links.filter((link) => {
+      return link.textContent === "Sign in";
+    });
+    expect(signInLinks).toHaveLength(2);
+    for (const signInLink of signInLinks) {
+      const signInUrl = new URL(signInLink.getAttribute("href") ?? "");
+      expect(signInUrl.pathname).toBe("/sign-in");
+      expect(signInUrl.searchParams.get("redirect_url")).toBe(
+        handoffUrl.toString(),
+      );
+    }
+
+    const signUpLink = links.find((link) => {
+      return link.textContent === "Sign up";
+    });
+    expect(signUpLink).toBeInTheDocument();
+    const signUpUrl = new URL(signUpLink?.getAttribute("href") ?? "");
+    expect(signUpUrl.pathname).toBe("/sign-up");
+    expect(signUpUrl.searchParams.get("redirect_url")).toBe(
+      handoffUrl.toString(),
+    );
   });
 
   it("owns its scrolling because the app shell clips overflow", async () => {
@@ -133,7 +171,7 @@ describe("shared thread page", () => {
     ).toBeInTheDocument();
     expect(
       links.find((link) => {
-        return link.textContent === "Try Zero";
+        return link.textContent === "Sign up";
       }),
     ).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -75,9 +75,6 @@ describe("shared thread page", () => {
     expect(
       document.querySelectorAll("[data-shared-message-copy]"),
     ).toHaveLength(3);
-    expect(
-      document.querySelector("[data-shared-thread-product-logo]"),
-    ).toHaveAttribute("src", "/icons/icon-192.png");
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
     expect(
@@ -178,9 +175,6 @@ describe("shared thread page", () => {
       screen.findByRole("heading", { name: "VM0" }),
     ).resolves.toBeInTheDocument();
     expect(document.title).toBe("VM0");
-    expect(
-      document.querySelector("[data-shared-thread-product-logo]"),
-    ).not.toBeInTheDocument();
   });
 
   it("defaults an ambiguous not-found page to VM0 presentation", async () => {

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -61,7 +61,13 @@ describe("shared thread page", () => {
     expect(
       screen.getByText("Make this conversation yours"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Your workspace")).toBeInTheDocument();
+    expect(document.querySelector("[data-message-container]")).toHaveClass(
+      "max-w-[900px]",
+      "gap-6",
+    );
+    expect(document.querySelector("[data-shared-thread-handoff]")).toHaveClass(
+      "shrink-0",
+    );
 
     const links = queryAllByRoleFast("link");
     const handoffLink = links.find((link) => {
@@ -122,7 +128,7 @@ describe("shared thread page", () => {
     });
 
     const scroller = await screen.findByTestId("shared-thread-scroll");
-    expect(scroller).toHaveClass("h-full", "overflow-y-auto");
+    expect(scroller).toHaveClass("absolute", "inset-0", "overflow-y-auto");
   });
 
   it("does not repeat a brand-only document title", async () => {
@@ -166,7 +172,7 @@ describe("shared thread page", () => {
     const links = queryAllByRoleFast("link");
     expect(
       links.find((link) => {
-        return link.textContent === "VM0";
+        return link.getAttribute("aria-label") === "VM0";
       }),
     ).toBeInTheDocument();
     expect(

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -320,8 +320,17 @@ function SharedThreadHeader({
         <a
           href={homeUrl}
           aria-label={brandName}
-          className="shrink-0 text-foreground transition-opacity hover:opacity-70"
+          className="inline-flex shrink-0 items-center gap-1.5 text-foreground transition-opacity hover:opacity-70"
         >
+          {brandName === "Okou" ? (
+            <img
+              data-shared-thread-product-logo=""
+              src="/icons/icon-192.png"
+              alt=""
+              aria-hidden="true"
+              className="h-5 w-5 rounded-md"
+            />
+          ) : null}
           <ProductBrandMark size="small" />
         </a>
         {title !== null ? (

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -2,10 +2,11 @@ import type {
   SharedMessage,
   SharedThreadResponse,
 } from "@okouai/api-contracts/contracts/shared-threads";
+import { DEFAULT_AGENT_AVATAR_URL } from "@okouai/core/agent-avatar";
 import { Button, Card, CardContent, cn } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { Root } from "hast";
-import { Copy, MessageCircle, Share2 } from "lucide-react";
+import { Copy, Share2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   appUrlForPublicBrand,
@@ -20,6 +21,8 @@ import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import {
   ChatAssistantMessageBody,
   ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS,
+  CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
@@ -30,6 +33,7 @@ import {
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "../okou-page/chat-message-surface.tsx";
+import { AvatarFromUrl } from "../okou-page/sidebar-shared.tsx";
 
 /**
  * A shared message with the tree its body parsed into. The page setup command
@@ -96,11 +100,13 @@ function SharedAssistantAvatar({
   return (
     <div
       data-shared-assistant-avatar=""
-      role="img"
-      aria-label={assistantName}
-      className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary text-primary-foreground @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9"
+      className={CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS}
     >
-      <MessageCircle size={17} aria-hidden="true" />
+      <AvatarFromUrl
+        avatarUrl={DEFAULT_AGENT_AVATAR_URL}
+        alt={assistantName}
+        className={CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS}
+      />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -5,7 +5,7 @@ import type {
 import { Button, Card, CardContent, cn } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { Root } from "hast";
-import { Share2 } from "lucide-react";
+import { Copy, MessageCircle, Share2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   appUrlForPublicBrand,
@@ -14,16 +14,20 @@ import {
 
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 import { MarkdownEventBody } from "../components/markdown.tsx";
 import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import {
   ChatAssistantMessageBody,
   ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "../okou-page/chat-message-surface.tsx";
 
@@ -84,6 +88,63 @@ function groupSharedMessages(
   return groups;
 }
 
+function SharedAssistantAvatar({
+  assistantName,
+}: {
+  readonly assistantName: string;
+}) {
+  return (
+    <div
+      data-shared-assistant-avatar=""
+      role="img"
+      aria-label={assistantName}
+      className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary text-primary-foreground @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9"
+    >
+      <MessageCircle size={17} aria-hidden="true" />
+    </div>
+  );
+}
+
+function SharedMessageCopyButton({ content }: { readonly content: string }) {
+  const { t } = useTranslation();
+  const label = t(($) => {
+    return $.chat.actions.copyMessage;
+  });
+
+  return (
+    <IconTooltipButton
+      type="button"
+      data-shared-message-copy=""
+      className="rounded-md p-1 text-muted-foreground/60 transition-colors duration-150 hover:bg-state-hover hover:text-foreground"
+      aria-label={label}
+      onClick={() => {
+        detach(
+          (async () => {
+            const didCopy = await writeToClipboard(content);
+            if (didCopy) {
+              toast.success(
+                t(($) => {
+                  return $.chat.actions.copied;
+                }),
+              );
+              return;
+            }
+            toast.error(
+              t(($) => {
+                return $.chat.sharing.copyFailed;
+              }),
+            );
+          })(),
+          Reason.DomCallback,
+          "copy shared message",
+        );
+      }}
+    >
+      <Copy size={18} />
+    </IconTooltipButton>
+  );
+}
+
 function SharedUserGroup({ group }: { readonly group: SharedMessageGroup }) {
   return (
     <>
@@ -105,6 +166,12 @@ function SharedUserGroup({ group }: { readonly group: SharedMessageGroup }) {
                     {message.content}
                   </div>
                 </ChatUserMessageBubble>
+                <div
+                  data-shared-message-actions="user"
+                  className={CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS}
+                >
+                  <SharedMessageCopyButton content={message.content} />
+                </div>
               </div>
             </div>
           </div>
@@ -115,22 +182,24 @@ function SharedUserGroup({ group }: { readonly group: SharedMessageGroup }) {
 }
 
 function SharedAssistantGroup({
+  assistantName,
   group,
 }: {
+  readonly assistantName: string;
   readonly group: SharedMessageGroup;
 }) {
+  const content = group.messages
+    .map((message) => {
+      return message.content;
+    })
+    .join("\n\n");
   return (
     <div
       data-role="assistant"
       className={CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS}
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
-        {/* Public snapshots omit agent identity, so keep Chat's desktop avatar
-            column without inventing a different public avatar treatment. */}
-        <div
-          aria-hidden="true"
-          className="hidden @[900px]:block @[900px]:h-9 @[900px]:w-9 @[900px]:shrink-0"
-        />
+        <SharedAssistantAvatar assistantName={assistantName} />
         <div className="relative flex min-w-0 flex-col gap-2">
           {group.messages.map((message, index) => {
             return message.tree === undefined ? null : (
@@ -142,6 +211,17 @@ function SharedAssistantGroup({
               </ChatAssistantMessageBody>
             );
           })}
+        </div>
+      </div>
+      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS}>
+        <div className="hidden @[900px]:block" />
+        <div
+          data-shared-message-actions="assistant"
+          className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS}
+        >
+          <div className="flex items-center gap-1">
+            <SharedMessageCopyButton content={content} />
+          </div>
         </div>
       </div>
     </div>
@@ -307,8 +387,10 @@ function SharedThreadHeader({
 }
 
 function SharedThreadTranscript({
+  assistantName,
   groups,
 }: {
+  readonly assistantName: string;
   readonly groups: readonly SharedMessageGroup[];
 }) {
   return (
@@ -327,7 +409,11 @@ function SharedThreadTranscript({
               return group.role === "user" ? (
                 <SharedUserGroup key={group.key} group={group} />
               ) : (
-                <SharedAssistantGroup key={group.key} group={group} />
+                <SharedAssistantGroup
+                  key={group.key}
+                  assistantName={assistantName}
+                  group={group}
+                />
               );
             })}
           </div>
@@ -392,7 +478,10 @@ export function SharedThreadPage({
       />
       {sharedThread ? (
         <>
-          <SharedThreadTranscript groups={groups} />
+          <SharedThreadTranscript
+            assistantName={presentation.assistantName}
+            groups={groups}
+          />
           <SharedThreadHandoff
             assistantName={presentation.assistantName}
             handoffUrl={handoffUrl.toString()}

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -320,17 +320,8 @@ function SharedThreadHeader({
         <a
           href={homeUrl}
           aria-label={brandName}
-          className="inline-flex shrink-0 items-center gap-1.5 text-foreground transition-opacity hover:opacity-70"
+          className="shrink-0 text-foreground transition-opacity hover:opacity-70"
         >
-          {brandName === "Okou" ? (
-            <img
-              data-shared-thread-product-logo=""
-              src="/icons/icon-192.png"
-              alt=""
-              aria-hidden="true"
-              className="h-5 w-5 rounded-md"
-            />
-          ) : null}
           <ProductBrandMark size="small" />
         </a>
         {title !== null ? (

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -2,10 +2,10 @@ import type {
   SharedMessage,
   SharedThreadResponse,
 } from "@okouai/api-contracts/contracts/shared-threads";
-import { Button, Card } from "@okouai/ui";
+import { Button, Card, CardContent, cn } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { Root } from "hast";
-import { ArrowRight, MessageCircle, Share2 } from "lucide-react";
+import { Share2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   appUrlForPublicBrand,
@@ -15,6 +15,17 @@ import {
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { MarkdownEventBody } from "../components/markdown.tsx";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
+import {
+  ChatAssistantMessageBody,
+  ChatUserMessageBubble,
+  CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
+  CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
+  CHAT_THREAD_CONTENT_MAIN_CLASS,
+  CHAT_THREAD_MESSAGE_LIST_CLASS,
+  CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
+} from "../okou-page/chat-message-surface.tsx";
 
 /**
  * A shared message with the tree its body parsed into. The page setup command
@@ -75,76 +86,62 @@ function groupSharedMessages(
 
 function SharedUserGroup({ group }: { readonly group: SharedMessageGroup }) {
   return (
-    <div data-role="user">
-      <div className="flex min-w-0 flex-col items-end @[900px]:-ml-[46px] @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:items-start @[900px]:gap-2.5">
-        <div className="hidden @[900px]:block @[900px]:h-9 @[900px]:w-9 @[900px]:shrink-0" />
-        <div className="flex w-full flex-col items-end gap-2">
-          {group.messages.map((message) => {
-            return (
-              <div
-                key={message.messageIndex}
-                className="zero-chat-bubble-user max-w-[85%] whitespace-pre-wrap rounded-xl px-4 py-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]"
-              >
-                {message.content}
+    <>
+      {group.messages.map((message, index) => {
+        return (
+          <div
+            key={message.messageIndex}
+            data-role="user"
+            className={cn(
+              "group",
+              index > 0 && CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+            )}
+          >
+            <div className={CHAT_THREAD_USER_MESSAGE_ROW_CLASS}>
+              <div className="hidden @[900px]:block @[900px]:h-9 @[900px]:w-9 @[900px]:shrink-0" />
+              <div className="flex w-full flex-col items-end">
+                <ChatUserMessageBubble>
+                  <div className="whitespace-pre-wrap px-4 py-3">
+                    {message.content}
+                  </div>
+                </ChatUserMessageBubble>
               </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function SharedBrandMark({
-  size = "md",
-}: {
-  readonly size?: "sm" | "md" | "avatar";
-}) {
-  return (
-    <span
-      className={
-        size === "sm"
-          ? "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[#ed4e01] text-white"
-          : size === "avatar"
-            ? "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-xl bg-[#ed4e01] text-white @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9"
-            : "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#ed4e01] text-white"
-      }
-      aria-hidden="true"
-    >
-      <MessageCircle size={size === "md" ? 19 : 17} />
-    </span>
+            </div>
+          </div>
+        );
+      })}
+    </>
   );
 }
 
 function SharedAssistantGroup({
   group,
-  assistantName,
 }: {
   readonly group: SharedMessageGroup;
-  readonly assistantName: string;
 }) {
   return (
-    <div data-role="assistant">
-      <div className="flex min-w-0 flex-col gap-2 @[900px]:-ml-[46px] @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:items-start @[900px]:gap-2.5">
-        <SharedBrandMark size="avatar" />
-        <div className="min-w-0">
-          <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-            <span className="text-[#ed4e01]" aria-hidden="true">
-              ✦
-            </span>
-            {assistantName}
-          </div>
-          <div className="zero-chat-bubble-assistant flex min-w-0 flex-col gap-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]">
-            {group.messages.map((message) => {
-              return message.tree === undefined ? null : (
-                <MarkdownEventBody
-                  key={message.messageIndex}
-                  tree={message.tree}
-                  mediaPreview
-                />
-              );
-            })}
-          </div>
+    <div
+      data-role="assistant"
+      className={CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS}
+    >
+      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
+        {/* Public snapshots omit agent identity, so keep Chat's desktop avatar
+            column without inventing a different public avatar treatment. */}
+        <div
+          aria-hidden="true"
+          className="hidden @[900px]:block @[900px]:h-9 @[900px]:w-9 @[900px]:shrink-0"
+        />
+        <div className="relative flex min-w-0 flex-col gap-2">
+          {group.messages.map((message, index) => {
+            return message.tree === undefined ? null : (
+              <ChatAssistantMessageBody
+                key={message.messageIndex}
+                compactTop={index > 0}
+              >
+                <MarkdownEventBody tree={message.tree} mediaPreview />
+              </ChatAssistantMessageBody>
+            );
+          })}
         </div>
       </div>
     </div>
@@ -162,66 +159,56 @@ function SharedThreadHandoff({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-4 pb-[max(1rem,var(--sab))] sm:px-6">
-      <Card className="pointer-events-auto mx-auto w-full max-w-[1040px] overflow-visible rounded-[var(--zero-composer-radius)] border-border/80 bg-background/95 shadow-[var(--zero-card-shadow)] backdrop-blur">
-        <div className="flex items-center gap-3 p-3 sm:gap-4 sm:px-4">
-          <SharedBrandMark />
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold text-foreground">
-              {t(($) => {
-                return $.sharedThread.makeConversationYours;
-              })}
-            </p>
-            <p className="hidden truncate text-xs text-muted-foreground sm:block">
-              {t(
-                ($) => {
-                  return $.sharedThread.handoffDescription;
-                },
-                { assistantName },
-              )}
-            </p>
-          </div>
-
-          <div className="hidden h-12 min-w-[230px] items-center justify-center gap-3 rounded-xl bg-muted/70 px-4 lg:flex">
-            <span className="flex flex-col gap-1.5" aria-hidden="true">
-              <span className="h-2.5 w-7 rounded-full bg-muted-foreground/15" />
-              <span className="h-2.5 w-9 rounded-full border border-muted-foreground/20 bg-background" />
-            </span>
-            <ArrowRight
-              className="text-[#ed4e01]"
-              size={14}
-              aria-hidden="true"
-            />
-            <span className="text-xs font-medium text-muted-foreground">
-              {t(($) => {
-                return $.sharedThread.yourWorkspace;
-              })}
-            </span>
-          </div>
-
-          <div className="flex shrink-0 items-center gap-1 sm:gap-2">
-            <Button variant="quiet" size="sm" asChild>
-              <a href={signInUrl}>
-                {t(($) => {
-                  return $.sharedThread.signIn;
-                })}
-              </a>
-            </Button>
-            <Button
-              size="sm"
-              className="bg-foreground text-background hover:bg-foreground/90 active:bg-foreground/80"
-              asChild
-            >
-              <a href={handoffUrl}>
-                {t(($) => {
-                  return $.sharedThread.tryItYourself;
-                })}
-              </a>
-            </Button>
-          </div>
+    <footer
+      data-shared-thread-handoff=""
+      className="relative shrink-0 bg-[hsl(var(--background))]"
+      style={{
+        paddingBottom: "max(0.5rem - var(--sab), 0px)",
+      }}
+    >
+      <div className="pointer-events-none absolute inset-x-0 -top-5 h-[21px] bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
+      <div className="pb-2 pl-4 pr-4 pt-3 sm:pl-6 sm:pr-6">
+        <div className="mx-auto max-w-[900px]">
+          <Card className="zero-composer relative z-10 overflow-visible">
+            <CardContent className="p-0">
+              <div className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-foreground">
+                    {t(($) => {
+                      return $.sharedThread.makeConversationYours;
+                    })}
+                  </p>
+                  <p className="hidden truncate text-xs text-muted-foreground sm:block">
+                    {t(
+                      ($) => {
+                        return $.sharedThread.handoffDescription;
+                      },
+                      { assistantName },
+                    )}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+                  <Button variant="quiet" size="sm" asChild>
+                    <a href={signInUrl}>
+                      {t(($) => {
+                        return $.sharedThread.signIn;
+                      })}
+                    </a>
+                  </Button>
+                  <Button size="sm" asChild>
+                    <a href={handoffUrl}>
+                      {t(($) => {
+                        return $.sharedThread.tryItYourself;
+                      })}
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
         </div>
-      </Card>
-    </div>
+      </div>
+    </footer>
   );
 }
 
@@ -242,106 +229,124 @@ function SharedThreadHeader({
 }) {
   const { t } = useTranslation();
   return (
-    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
-      <div className="mx-auto grid h-14 w-full max-w-[1200px] grid-cols-[minmax(0,1fr)_minmax(0,2fr)_minmax(0,1fr)] items-center gap-2 px-4 sm:gap-4 sm:px-6">
+    <header className="relative z-10 flex min-h-12 shrink-0 items-center gap-3 border-b border-border/50 bg-background px-3 sm:h-14 sm:border-b-0 sm:px-6">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <a
           href={homeUrl}
           aria-label={brandName}
-          className="inline-flex items-center gap-2 text-sm font-semibold text-foreground"
+          className="shrink-0 text-foreground transition-opacity hover:opacity-70"
         >
-          <SharedBrandMark size="sm" />
-          <span className="hidden sm:inline">{brandName}</span>
+          <ProductBrandMark size="small" />
         </a>
         {title !== null ? (
-          <h1 className="min-w-0 truncate text-center text-sm font-semibold text-foreground">
+          <h1 className="min-w-0 truncate text-sm font-medium text-foreground">
             {title}
           </h1>
-        ) : (
-          <div />
-        )}
-        <div className="flex items-center justify-end gap-1 sm:gap-2">
-          {shareUrl !== null ? (
-            <Button
-              showTooltip
-              type="button"
-              variant="quiet"
-              size="icon-sm"
-              aria-label={t(($) => {
-                return $.sharedThread.share;
-              })}
-              onClick={() => {
-                detach(
-                  (async () => {
-                    const copied = await writeToClipboard(shareUrl);
-                    if (copied) {
-                      toast.success(
-                        t(($) => {
-                          return $.chat.sharing.linkCopied;
-                        }),
-                      );
-                      return;
-                    }
-                    toast.error(
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5">
+        {shareUrl !== null ? (
+          <Button
+            showTooltip
+            type="button"
+            variant="quiet"
+            size="icon-sm"
+            iconSize="md"
+            className="shrink-0 duration-150"
+            aria-label={t(($) => {
+              return $.sharedThread.share;
+            })}
+            onClick={() => {
+              detach(
+                (async () => {
+                  const copied = await writeToClipboard(shareUrl);
+                  if (copied) {
+                    toast.success(
                       t(($) => {
-                        return $.chat.sharing.copyFailed;
+                        return $.chat.sharing.linkCopied;
                       }),
                     );
-                  })(),
-                  Reason.DomCallback,
-                  "copy shared thread link",
-                );
-              }}
-            >
-              <Share2 size={16} />
-            </Button>
-          ) : null}
-          <Button
-            variant="quiet"
-            size="sm"
-            className="hidden sm:inline-flex"
-            asChild
+                    return;
+                  }
+                  toast.error(
+                    t(($) => {
+                      return $.chat.sharing.copyFailed;
+                    }),
+                  );
+                })(),
+                Reason.DomCallback,
+                "copy shared thread link",
+              );
+            }}
           >
-            <a href={signInUrl}>
-              {t(($) => {
-                return $.sharedThread.signIn;
-              })}
-            </a>
+            <Share2 size={18} />
           </Button>
-          <Button
-            size="sm"
-            className="bg-foreground text-background hover:bg-foreground/90 active:bg-foreground/80"
-            asChild
-          >
-            <a href={signUpUrl}>
-              {t(($) => {
-                return $.sharedThread.signUp;
-              })}
-            </a>
-          </Button>
-        </div>
+        ) : null}
+        <Button
+          variant="quiet"
+          size="sm"
+          className="hidden sm:inline-flex"
+          asChild
+        >
+          <a href={signInUrl}>
+            {t(($) => {
+              return $.sharedThread.signIn;
+            })}
+          </a>
+        </Button>
+        <Button size="sm" asChild>
+          <a href={signUpUrl}>
+            {t(($) => {
+              return $.sharedThread.signUp;
+            })}
+          </a>
+        </Button>
       </div>
     </header>
+  );
+}
+
+function SharedThreadTranscript({
+  groups,
+}: {
+  readonly groups: readonly SharedMessageGroup[];
+}) {
+  return (
+    <div className="relative min-h-0 flex-1 isolate">
+      <div
+        data-testid="shared-thread-scroll"
+        tabIndex={-1}
+        className="absolute inset-0 overflow-y-auto focus:outline-none [overflow-anchor:none] [scrollbar-gutter:stable]"
+      >
+        <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
+          <div
+            data-message-container=""
+            className={CHAT_THREAD_MESSAGE_LIST_CLASS}
+          >
+            {groups.map((group) => {
+              return group.role === "user" ? (
+                <SharedUserGroup key={group.key} group={group} />
+              ) : (
+                <SharedAssistantGroup key={group.key} group={group} />
+              );
+            })}
+          </div>
+        </main>
+      </div>
+    </div>
   );
 }
 
 function SharedThreadNotFound() {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-1 items-center justify-center px-6 py-16 text-center">
-      <div>
-        <p className="text-sm font-semibold text-primary">404</p>
-        <h1 className="mt-3 text-2xl font-semibold text-foreground">
-          {t(($) => {
-            return $.sharedThread.notFoundTitle;
-          })}
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t(($) => {
-            return $.sharedThread.notFoundDescription;
-          })}
-        </p>
-      </div>
-    </div>
+    <main className="flex min-h-0 flex-1 items-center justify-center px-6 py-16 text-center">
+      <h1 className="text-lg font-semibold text-foreground">
+        {t(($) => {
+          return $.sharedThread.notFoundTitle;
+        })}
+      </h1>
+    </main>
   );
 }
 
@@ -374,11 +379,9 @@ export function SharedThreadPage({
   signInUrl.searchParams.set("redirect_url", handoffUrl.toString());
   const signUpUrl = new URL("/sign-up", `${homeUrl}/`);
   signUpUrl.searchParams.set("redirect_url", handoffUrl.toString());
+
   return (
-    <main
-      className="zero-app flex h-full flex-col overflow-y-auto bg-background text-foreground"
-      data-testid="shared-thread-scroll"
-    >
+    <div className="zero-app zero-workspace-bg flex h-full min-h-0 flex-col text-foreground">
       <SharedThreadHeader
         brandName={presentation.brandName}
         homeUrl={homeUrl}
@@ -387,33 +390,18 @@ export function SharedThreadPage({
         signUpUrl={signUpUrl.toString()}
         title={sharedThread?.title ?? null}
       />
-
       {sharedThread ? (
-        <section className="@container mx-auto w-full max-w-[948px] px-4 pb-40 pt-6 sm:px-6 sm:pb-36 sm:pt-8">
-          <div className="mx-auto flex w-full max-w-[900px] flex-col gap-6">
-            {groups.map((group) => {
-              return group.role === "user" ? (
-                <SharedUserGroup key={group.key} group={group} />
-              ) : (
-                <SharedAssistantGroup
-                  key={group.key}
-                  group={group}
-                  assistantName={presentation.assistantName}
-                />
-              );
-            })}
-          </div>
-        </section>
+        <>
+          <SharedThreadTranscript groups={groups} />
+          <SharedThreadHandoff
+            assistantName={presentation.assistantName}
+            handoffUrl={handoffUrl.toString()}
+            signInUrl={signInUrl.toString()}
+          />
+        </>
       ) : (
         <SharedThreadNotFound />
       )}
-      {sharedThread ? (
-        <SharedThreadHandoff
-          assistantName={presentation.assistantName}
-          handoffUrl={handoffUrl.toString()}
-          signInUrl={signInUrl.toString()}
-        />
-      ) : null}
-    </main>
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -330,7 +330,7 @@ function SharedThreadHeader({
           </h1>
         ) : null}
       </div>
-      <div className="flex shrink-0 items-center gap-0.5">
+      <div className="flex shrink-0 items-center gap-2">
         {shareUrl !== null ? (
           <Button
             showTooltip

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -13,6 +13,7 @@ import {
   publicBrandPresentation,
 } from "@okouai/core/public-brand";
 
+import type { BrandName } from "../../signals/branding.ts";
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { IconTooltipButton } from "../components/icon-tooltip.tsx";
@@ -306,7 +307,7 @@ function SharedThreadHeader({
   signUpUrl,
   title,
 }: {
-  readonly brandName: string;
+  readonly brandName: BrandName;
   readonly homeUrl: string;
   readonly shareUrl: string | null;
   readonly signInUrl: string;
@@ -322,7 +323,7 @@ function SharedThreadHeader({
           aria-label={brandName}
           className="shrink-0 text-foreground transition-opacity hover:opacity-70"
         >
-          <ProductBrandMark size="small" />
+          <ProductBrandMark brandName={brandName} size="small" />
         </a>
         {title !== null ? (
           <h1 className="min-w-0 truncate text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -2,14 +2,18 @@ import type {
   SharedMessage,
   SharedThreadResponse,
 } from "@okouai/api-contracts/contracts/shared-threads";
+import { Button, Card } from "@okouai/ui";
+import { toast } from "@okouai/ui/components/ui/sonner";
 import type { Root } from "hast";
-import { MessageCircle } from "lucide-react";
+import { ArrowRight, MessageCircle, Share2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   appUrlForPublicBrand,
   publicBrandPresentation,
 } from "@okouai/core/public-brand";
 
+import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { MarkdownEventBody } from "../components/markdown.tsx";
 
 /**
@@ -71,41 +75,252 @@ function groupSharedMessages(
 
 function SharedUserGroup({ group }: { readonly group: SharedMessageGroup }) {
   return (
-    <div className="flex flex-col items-end gap-2" data-role="user">
-      {group.messages.map((message) => {
-        return (
-          <div
-            key={message.messageIndex}
-            className="zero-chat-bubble-user max-w-[85%] whitespace-pre-wrap rounded-xl px-4 py-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]"
-          >
-            {message.content}
-          </div>
-        );
-      })}
+    <div data-role="user">
+      <div className="flex min-w-0 flex-col items-end @[900px]:-ml-[46px] @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:items-start @[900px]:gap-2.5">
+        <div className="hidden @[900px]:block @[900px]:h-9 @[900px]:w-9 @[900px]:shrink-0" />
+        <div className="flex w-full flex-col items-end gap-2">
+          {group.messages.map((message) => {
+            return (
+              <div
+                key={message.messageIndex}
+                className="zero-chat-bubble-user max-w-[85%] whitespace-pre-wrap rounded-xl px-4 py-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]"
+              >
+                {message.content}
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
+  );
+}
+
+function SharedBrandMark({
+  size = "md",
+}: {
+  readonly size?: "sm" | "md" | "avatar";
+}) {
+  return (
+    <span
+      className={
+        size === "sm"
+          ? "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[#ed4e01] text-white"
+          : size === "avatar"
+            ? "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-xl bg-[#ed4e01] text-white @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9"
+            : "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#ed4e01] text-white"
+      }
+      aria-hidden="true"
+    >
+      <MessageCircle size={size === "md" ? 19 : 17} />
+    </span>
   );
 }
 
 function SharedAssistantGroup({
   group,
+  assistantName,
 }: {
   readonly group: SharedMessageGroup;
+  readonly assistantName: string;
 }) {
   return (
-    <div
-      className="flex min-w-0 flex-col gap-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]"
-      data-role="assistant"
-    >
-      {group.messages.map((message) => {
-        return message.tree === undefined ? null : (
-          <MarkdownEventBody
-            key={message.messageIndex}
-            tree={message.tree}
-            mediaPreview
-          />
-        );
-      })}
+    <div data-role="assistant">
+      <div className="flex min-w-0 flex-col gap-2 @[900px]:-ml-[46px] @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:items-start @[900px]:gap-2.5">
+        <SharedBrandMark size="avatar" />
+        <div className="min-w-0">
+          <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <span className="text-[#ed4e01]" aria-hidden="true">
+              ✦
+            </span>
+            {assistantName}
+          </div>
+          <div className="zero-chat-bubble-assistant flex min-w-0 flex-col gap-3 text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere]">
+            {group.messages.map((message) => {
+              return message.tree === undefined ? null : (
+                <MarkdownEventBody
+                  key={message.messageIndex}
+                  tree={message.tree}
+                  mediaPreview
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
+  );
+}
+
+function SharedThreadHandoff({
+  assistantName,
+  handoffUrl,
+  signInUrl,
+}: {
+  readonly assistantName: string;
+  readonly handoffUrl: string;
+  readonly signInUrl: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-4 pb-[max(1rem,var(--sab))] sm:px-6">
+      <Card className="pointer-events-auto mx-auto w-full max-w-[1040px] overflow-visible rounded-[var(--zero-composer-radius)] border-border/80 bg-background/95 shadow-[var(--zero-card-shadow)] backdrop-blur">
+        <div className="flex items-center gap-3 p-3 sm:gap-4 sm:px-4">
+          <SharedBrandMark />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold text-foreground">
+              {t(($) => {
+                return $.sharedThread.makeConversationYours;
+              })}
+            </p>
+            <p className="hidden truncate text-xs text-muted-foreground sm:block">
+              {t(
+                ($) => {
+                  return $.sharedThread.handoffDescription;
+                },
+                { assistantName },
+              )}
+            </p>
+          </div>
+
+          <div className="hidden h-12 min-w-[230px] items-center justify-center gap-3 rounded-xl bg-muted/70 px-4 lg:flex">
+            <span className="flex flex-col gap-1.5" aria-hidden="true">
+              <span className="h-2.5 w-7 rounded-full bg-muted-foreground/15" />
+              <span className="h-2.5 w-9 rounded-full border border-muted-foreground/20 bg-background" />
+            </span>
+            <ArrowRight
+              className="text-[#ed4e01]"
+              size={14}
+              aria-hidden="true"
+            />
+            <span className="text-xs font-medium text-muted-foreground">
+              {t(($) => {
+                return $.sharedThread.yourWorkspace;
+              })}
+            </span>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+            <Button variant="quiet" size="sm" asChild>
+              <a href={signInUrl}>
+                {t(($) => {
+                  return $.sharedThread.signIn;
+                })}
+              </a>
+            </Button>
+            <Button
+              size="sm"
+              className="bg-foreground text-background hover:bg-foreground/90 active:bg-foreground/80"
+              asChild
+            >
+              <a href={handoffUrl}>
+                {t(($) => {
+                  return $.sharedThread.tryItYourself;
+                })}
+              </a>
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function SharedThreadHeader({
+  brandName,
+  homeUrl,
+  shareUrl,
+  signInUrl,
+  signUpUrl,
+  title,
+}: {
+  readonly brandName: string;
+  readonly homeUrl: string;
+  readonly shareUrl: string | null;
+  readonly signInUrl: string;
+  readonly signUpUrl: string;
+  readonly title: string | null;
+}) {
+  const { t } = useTranslation();
+  return (
+    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
+      <div className="mx-auto grid h-14 w-full max-w-[1200px] grid-cols-[minmax(0,1fr)_minmax(0,2fr)_minmax(0,1fr)] items-center gap-2 px-4 sm:gap-4 sm:px-6">
+        <a
+          href={homeUrl}
+          aria-label={brandName}
+          className="inline-flex items-center gap-2 text-sm font-semibold text-foreground"
+        >
+          <SharedBrandMark size="sm" />
+          <span className="hidden sm:inline">{brandName}</span>
+        </a>
+        {title !== null ? (
+          <h1 className="min-w-0 truncate text-center text-sm font-semibold text-foreground">
+            {title}
+          </h1>
+        ) : (
+          <div />
+        )}
+        <div className="flex items-center justify-end gap-1 sm:gap-2">
+          {shareUrl !== null ? (
+            <Button
+              showTooltip
+              type="button"
+              variant="quiet"
+              size="icon-sm"
+              aria-label={t(($) => {
+                return $.sharedThread.share;
+              })}
+              onClick={() => {
+                detach(
+                  (async () => {
+                    const copied = await writeToClipboard(shareUrl);
+                    if (copied) {
+                      toast.success(
+                        t(($) => {
+                          return $.chat.sharing.linkCopied;
+                        }),
+                      );
+                      return;
+                    }
+                    toast.error(
+                      t(($) => {
+                        return $.chat.sharing.copyFailed;
+                      }),
+                    );
+                  })(),
+                  Reason.DomCallback,
+                  "copy shared thread link",
+                );
+              }}
+            >
+              <Share2 size={16} />
+            </Button>
+          ) : null}
+          <Button
+            variant="quiet"
+            size="sm"
+            className="hidden sm:inline-flex"
+            asChild
+          >
+            <a href={signInUrl}>
+              {t(($) => {
+                return $.sharedThread.signIn;
+              })}
+            </a>
+          </Button>
+          <Button
+            size="sm"
+            className="bg-foreground text-background hover:bg-foreground/90 active:bg-foreground/80"
+            asChild
+          >
+            <a href={signUpUrl}>
+              {t(($) => {
+                return $.sharedThread.signUp;
+              })}
+            </a>
+          </Button>
+        </div>
+      </div>
+    </header>
   );
 }
 
@@ -140,46 +355,51 @@ export function SharedThreadPage({
   const publicBrand = sharedThread?.publicBrand ?? "vm0";
   const presentation = publicBrandPresentation(publicBrand);
   const homeUrl = appUrlForPublicBrand(window.location.origin, publicBrand);
+  const shareUrl = sharedThread
+    ? `${window.location.origin}/share/threads/${encodeURIComponent(sharedThread.id)}`
+    : null;
+  const handoffUrl = new URL(homeUrl);
+  if (shareUrl) {
+    handoffUrl.searchParams.set(
+      "prompt",
+      t(
+        ($) => {
+          return $.sharedThread.handoffPrompt;
+        },
+        { url: shareUrl },
+      ),
+    );
+  }
+  const signInUrl = new URL("/sign-in", `${homeUrl}/`);
+  signInUrl.searchParams.set("redirect_url", handoffUrl.toString());
+  const signUpUrl = new URL("/sign-up", `${homeUrl}/`);
+  signUpUrl.searchParams.set("redirect_url", handoffUrl.toString());
   return (
     <main
-      className="flex h-full flex-col overflow-y-auto bg-background text-foreground"
+      className="zero-app flex h-full flex-col overflow-y-auto bg-background text-foreground"
       data-testid="shared-thread-scroll"
     >
-      <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
-        <div className="mx-auto flex h-14 w-full max-w-[948px] items-center justify-between px-4 sm:px-6">
-          <a
-            href={homeUrl}
-            className="inline-flex items-center gap-2 text-sm font-semibold text-foreground"
-          >
-            <span className="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-[#ed4e01] text-white">
-              <MessageCircle size={17} />
-            </span>
-            {t(($) => {
-              return $.sharedThread.brand;
-            }, presentation)}
-          </a>
-          <a
-            href={homeUrl}
-            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary-hover"
-          >
-            {t(($) => {
-              return $.sharedThread.tryOkou;
-            }, presentation)}
-          </a>
-        </div>
-      </header>
+      <SharedThreadHeader
+        brandName={presentation.brandName}
+        homeUrl={homeUrl}
+        shareUrl={shareUrl}
+        signInUrl={signInUrl.toString()}
+        signUpUrl={signUpUrl.toString()}
+        title={sharedThread?.title ?? null}
+      />
 
       {sharedThread ? (
-        <section className="mx-auto w-full max-w-[948px] px-4 py-8 sm:px-6 sm:py-10">
-          <h1 className="mb-8 text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-            {sharedThread.title}
-          </h1>
+        <section className="@container mx-auto w-full max-w-[948px] px-4 pb-40 pt-6 sm:px-6 sm:pb-36 sm:pt-8">
           <div className="mx-auto flex w-full max-w-[900px] flex-col gap-6">
             {groups.map((group) => {
               return group.role === "user" ? (
                 <SharedUserGroup key={group.key} group={group} />
               ) : (
-                <SharedAssistantGroup key={group.key} group={group} />
+                <SharedAssistantGroup
+                  key={group.key}
+                  group={group}
+                  assistantName={presentation.assistantName}
+                />
               );
             })}
           </div>
@@ -187,6 +407,13 @@ export function SharedThreadPage({
       ) : (
         <SharedThreadNotFound />
       )}
+      {sharedThread ? (
+        <SharedThreadHandoff
+          assistantName={presentation.assistantName}
+          handoffUrl={handoffUrl.toString()}
+          signInUrl={signInUrl.toString()}
+        />
+      ) : null}
     </main>
   );
 }

--- a/turbo/packages/core/src/agent-avatar.ts
+++ b/turbo/packages/core/src/agent-avatar.ts
@@ -1,5 +1,8 @@
 export const AVATAR_PRESET_PREFIX = "preset:";
 
+/** Avatar used by the default assistant across branded chat surfaces. */
+export const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+
 /**
  * Number of built-in preset avatars: `preset:0` through `preset:4`.
  * Kept in sync with the render catalog in the platform's `zero-avatars.ts`.


### PR DESCRIPTION
## Summary

- align public shared conversations with the existing Chat transcript layout while keeping the public surface free of workspace navigation and the composer
- add branded header actions for copying the share link, signing in, and signing up
- add a bottom handoff CTA that opens a new chat with the canonical shared URL prefilled and preserves the destination through authentication
- localize the new public-share copy across all supported locales

## Verification

- `npx prettier@3.8.1 --check turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx turbo/apps/platform/src/i18n/locales/*/common.json`
- `pnpm exec oxlint src/views/shared-thread-page/shared-thread-page.tsx src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx`
- `pnpm exec eslint src/views/shared-thread-page/shared-thread-page.tsx src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx --max-warnings 0`
- `pnpm check-types`
- `pnpm exec vitest run src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx` (4 passed)
- `pnpm i18n:check`
- `pnpm lint:localized-ui`

## Notes

- Browser preview verification is deferred to the PR pipeline; no local development server was started.
