### PR TITLE
docs(mitm-addon): document chat completions benchmark usage

### DIFF
--- a/crates/runner/mitm-addon/scripts/README.md
+++ b/crates/runner/mitm-addon/scripts/README.md
@@ -32,3 +32,30 @@ uv run --no-sync python -m pytest tests/test_update_x_tlds.py
 
 For a local or reproducible source file, pass `--source-file` to the updater instead
 of fetching IANA. The same generated-module and integrity-pin review applies.
+
+# Chat Completions extractor benchmark
+
+The [Chat Completions extractor benchmark](benchmark_openai_chat_completions_usage.py)
+compares the cost of constructing a selective JSON extractor for each event with the cost of
+resetting and reusing one extractor. Run it from the repository root with the addon's locked uv
+environment:
+
+```bash
+cd crates/runner/mitm-addon
+PYTHONPATH=src uv run --no-sync python scripts/benchmark_openai_chat_completions_usage.py
+```
+
+The benchmark uses this representative usage-free Chat Completions delta payload:
+
+```json
+{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"delta":{"content":"x"}}]}
+```
+
+Each fresh cycle constructs an extractor, feeds the payload, and finishes the document. Each reused
+cycle resets the existing extractor before feeding and finishing the same payload. The script runs
+10,000 cycles per repeat for five repeats, reports the median duration for each path, and reports a
+speedup ratio calculated as fresh duration divided by reused duration.
+
+The timings are informational and machine-dependent microbenchmark results, not an end-to-end
+parser benchmark or a fixed CI pass/fail threshold. For before-and-after comparisons, use the same
+Python and dependency environment, hardware, and similar system conditions where possible.


### PR DESCRIPTION
## Summary

- Document how to run the Chat Completions extractor benchmark from the mitm-addon package.
- Explain the representative payload, fresh versus reset-reuse cycles, 10,000-cycle/five-repeat median measurements, and speedup ratio.
- Clarify that timings are machine-dependent informational evidence and should be compared in the same environment rather than against a fixed CI threshold.

## Scope

- Changed: `crates/runner/mitm-addon/scripts/README.md`.
- Excluded: benchmark Python code, runtime behavior, tests, dependency metadata, and generated files.

## Validation

- `git diff --check` — passed.
- Verified the benchmark script, `pyproject.toml`, and `uv.lock` are unchanged.
- Attempted the documented benchmark command from `crates/runner/mitm-addon`; it could not start because `uv` is unavailable in this checkout and no local `.venv` is present.
- The documented uv-based package checks were not run for the same unavailable-toolchain reason.

Closes #29740
