### PR TITLE
perf(guest-session-prune): avoid duplicate codex buffers

### DIFF
--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -133,44 +133,26 @@ enum RolloutRecord<'a> {
 
 struct TurnState {
     id: String,
-    bytes: Vec<u8>,
+    start_offset: usize,
     saw_user_message: bool,
     saw_compatible_context: bool,
     invalid: Option<CodexHistoryIneligibleReason>,
 }
 
 impl TurnState {
-    fn new(id: &str, raw_record: &[u8], body_max_bytes: usize) -> Self {
-        let mut state = Self {
+    fn new(id: &str, start_offset: usize) -> Self {
+        Self {
             id: id.to_string(),
-            bytes: Vec::new(),
+            start_offset,
             saw_user_message: false,
             saw_compatible_context: false,
             invalid: None,
-        };
-        state.push(raw_record, body_max_bytes);
-        state
-    }
-
-    fn push(&mut self, raw_record: &[u8], body_max_bytes: usize) {
-        if self.invalid.is_some() {
-            return;
         }
-        let Some(next_size) = self.bytes.len().checked_add(raw_record.len()) else {
-            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
-            return;
-        };
-        if next_size > body_max_bytes {
-            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
-            return;
-        }
-        self.bytes.extend_from_slice(raw_record);
     }
 
     fn invalidate(&mut self, reason: CodexHistoryIneligibleReason) {
         if self.invalid.is_none() {
             self.invalid = Some(reason);
-            self.bytes.clear();
         }
     }
 
@@ -189,7 +171,6 @@ impl TurnState {
 }
 
 struct CandidateState {
-    bytes: Vec<u8>,
     selected_turn_id: String,
     selected_turn_delimited: bool,
     invalid: Option<CodexHistoryIneligibleReason>,
@@ -202,32 +183,15 @@ impl CandidateState {
     ) -> Self {
         let invalid = turn.invalid.or_else(|| compact_validation.err());
         Self {
-            bytes: turn.bytes.clone(),
             selected_turn_id: turn.id.clone(),
             selected_turn_delimited: false,
             invalid,
         }
     }
 
-    fn push(&mut self, raw_record: &[u8], body_max_bytes: usize) {
-        if self.invalid.is_some() {
-            return;
-        }
-        let Some(next_size) = self.bytes.len().checked_add(raw_record.len()) else {
-            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
-            return;
-        };
-        if next_size > body_max_bytes {
-            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
-            return;
-        }
-        self.bytes.extend_from_slice(raw_record);
-    }
-
     fn invalidate(&mut self, reason: CodexHistoryIneligibleReason) {
         if self.invalid.is_none() {
             self.invalid = Some(reason);
-            self.bytes.clear();
         }
     }
 }
@@ -294,6 +258,22 @@ fn select_with_limits_and_hook(
     expected_thread_id: &str,
     limits: SelectionLimits,
     before_final_check: impl FnOnce(),
+) -> io::Result<CodexHistorySelection> {
+    select_with_limits_and_observer(
+        source,
+        expected_thread_id,
+        limits,
+        before_final_check,
+        |_| {},
+    )
+}
+
+fn select_with_limits_and_observer(
+    source: &mut File,
+    expected_thread_id: &str,
+    limits: SelectionLimits,
+    before_final_check: impl FnOnce(),
+    mut observe_retained_bytes: impl FnMut(usize),
 ) -> io::Result<CodexHistorySelection> {
     let source_size = source.metadata()?.len();
     if source_size <= limits.candidate_max_bytes {
@@ -371,6 +351,9 @@ fn select_with_limits_and_hook(
         }
     }
 
+    let canonical_record_len = canonical_record.len();
+    let mut retained_bytes = canonical_record;
+    observe_retained_bytes(retained_bytes.len());
     let mut current_turn: Option<TurnState> = None;
     let mut candidate: Option<CandidateState> = None;
     loop {
@@ -394,8 +377,11 @@ fn select_with_limits_and_hook(
                 process_record(
                     &raw_record,
                     body_max_bytes,
+                    canonical_record_len,
+                    &mut retained_bytes,
                     &mut current_turn,
                     &mut candidate,
+                    &mut observe_retained_bytes,
                 );
             }
         }
@@ -425,21 +411,19 @@ fn select_with_limits_and_hook(
         return Ok(CodexHistorySelection::Ineligible(reason));
     }
 
-    let mut bytes = canonical_record;
-    bytes.extend_from_slice(&candidate.bytes);
-    if bytes.len() as u64 > limits.candidate_max_bytes {
+    if retained_bytes.len() as u64 > limits.candidate_max_bytes {
         return Ok(CodexHistorySelection::Ineligible(
             CodexHistoryIneligibleReason::CandidateTooLarge,
         ));
     }
-    if bytes.len() as u64 >= source_size {
+    if retained_bytes.len() as u64 >= source_size {
         return Ok(CodexHistorySelection::Ineligible(
             CodexHistoryIneligibleReason::NoCompactBoundary,
         ));
     }
 
     Ok(CodexHistorySelection::Candidate(CodexHistoryCandidate {
-        bytes,
+        bytes: retained_bytes,
         source_size,
     }))
 }
@@ -447,8 +431,11 @@ fn select_with_limits_and_hook(
 fn process_record(
     raw_record: &[u8],
     body_max_bytes: usize,
+    canonical_record_len: usize,
+    retained_bytes: &mut Vec<u8>,
     current_turn: &mut Option<TurnState>,
     candidate: &mut Option<CandidateState>,
+    observe_retained_bytes: &mut impl FnMut(usize),
 ) {
     let parsed = serde_json::from_slice::<Value>(strip_jsonl_line_ending(raw_record))
         .map_err(|_| CodexHistoryIneligibleReason::InvalidRecord)
@@ -459,7 +446,15 @@ fn process_record(
     let value = match parsed {
         Ok(value) => value,
         Err(reason) => {
-            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            append_to_retained_state(
+                raw_record,
+                body_max_bytes,
+                canonical_record_len,
+                retained_bytes,
+                current_turn,
+                candidate,
+                observe_retained_bytes,
+            );
             invalidate_retained_state(current_turn, candidate, reason);
             return;
         }
@@ -467,7 +462,15 @@ fn process_record(
     let record = match classify_rollout_record(&value) {
         Ok(record) => record,
         Err(reason) => {
-            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            append_to_retained_state(
+                raw_record,
+                body_max_bytes,
+                canonical_record_len,
+                retained_bytes,
+                current_turn,
+                candidate,
+                observe_retained_bytes,
+            );
             invalidate_retained_state(current_turn, candidate, reason);
             return;
         }
@@ -475,27 +478,44 @@ fn process_record(
 
     match record {
         RolloutRecord::Event(EventRecord::TurnStarted(turn_id)) => {
-            finish_current_turn(current_turn, candidate);
-            if let Some(existing) = candidate.as_mut() {
-                existing.push(raw_record, body_max_bytes);
-            }
-            *current_turn = Some(TurnState::new(turn_id, raw_record, body_max_bytes));
+            finish_current_turn(
+                current_turn,
+                candidate,
+                retained_bytes,
+                canonical_record_len,
+                observe_retained_bytes,
+            );
+            *current_turn = Some(TurnState::new(turn_id, retained_bytes.len()));
+            append_to_retained_state(
+                raw_record,
+                body_max_bytes,
+                canonical_record_len,
+                retained_bytes,
+                current_turn,
+                candidate,
+                observe_retained_bytes,
+            );
         }
         record => {
-            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            append_to_retained_state(
+                raw_record,
+                body_max_bytes,
+                canonical_record_len,
+                retained_bytes,
+                current_turn,
+                candidate,
+                observe_retained_bytes,
+            );
             match record {
                 RolloutRecord::Compacted(validation) => {
-                    *candidate = current_turn
-                        .as_ref()
-                        .map(|turn| CandidateState::from_compacting_turn(turn, validation))
-                        .or_else(|| {
-                            Some(CandidateState {
-                                bytes: Vec::new(),
-                                selected_turn_id: String::new(),
-                                selected_turn_delimited: false,
-                                invalid: Some(CodexHistoryIneligibleReason::InvalidTurn),
-                            })
-                        });
+                    select_compacting_turn(
+                        validation,
+                        canonical_record_len,
+                        retained_bytes,
+                        current_turn,
+                        candidate,
+                        observe_retained_bytes,
+                    );
                 }
                 RolloutRecord::Event(EventRecord::UserMessage) => {
                     if let Some(turn) = current_turn.as_mut() {
@@ -516,13 +536,26 @@ fn process_record(
                     }
                 }
                 RolloutRecord::Event(EventRecord::TurnComplete(turn_id)) => {
-                    complete_turn(turn_id, current_turn, candidate);
+                    complete_turn(
+                        turn_id,
+                        current_turn,
+                        candidate,
+                        retained_bytes,
+                        canonical_record_len,
+                        observe_retained_bytes,
+                    );
                 }
                 RolloutRecord::Event(EventRecord::TurnAborted) => {
                     if let Some(existing) = candidate.as_mut() {
                         existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
                     }
                     *current_turn = None;
+                    truncate_unselected_bytes(
+                        retained_bytes,
+                        canonical_record_len,
+                        candidate,
+                        observe_retained_bytes,
+                    );
                 }
                 RolloutRecord::Event(EventRecord::ThreadRolledBack) => {
                     if let Some(existing) = candidate.as_mut() {
@@ -542,15 +575,72 @@ fn process_record(
 fn append_to_retained_state(
     raw_record: &[u8],
     body_max_bytes: usize,
+    canonical_record_len: usize,
+    retained_bytes: &mut Vec<u8>,
     current_turn: &mut Option<TurnState>,
     candidate: &mut Option<CandidateState>,
+    observe_retained_bytes: &mut impl FnMut(usize),
 ) {
-    if let Some(turn) = current_turn.as_mut() {
-        turn.push(raw_record, body_max_bytes);
+    let current_turn_retains = current_turn
+        .as_ref()
+        .is_some_and(|turn| turn.invalid.is_none());
+    let candidate_retains = candidate
+        .as_ref()
+        .is_some_and(|candidate| candidate.invalid.is_none());
+    if !current_turn_retains && !candidate_retains {
+        return;
     }
-    if let Some(existing) = candidate.as_mut() {
-        existing.push(raw_record, body_max_bytes);
+    let Some(next_body_size) = retained_bytes
+        .len()
+        .checked_sub(canonical_record_len)
+        .and_then(|size| size.checked_add(raw_record.len()))
+    else {
+        invalidate_retained_state(
+            current_turn,
+            candidate,
+            CodexHistoryIneligibleReason::CandidateTooLarge,
+        );
+        return;
+    };
+    if next_body_size > body_max_bytes {
+        invalidate_retained_state(
+            current_turn,
+            candidate,
+            CodexHistoryIneligibleReason::CandidateTooLarge,
+        );
+        return;
     }
+    retained_bytes.extend_from_slice(raw_record);
+    observe_retained_bytes(retained_bytes.len());
+}
+
+fn select_compacting_turn(
+    compact_validation: Result<(), CodexHistoryIneligibleReason>,
+    canonical_record_len: usize,
+    retained_bytes: &mut Vec<u8>,
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+    observe_retained_bytes: &mut impl FnMut(usize),
+) {
+    let Some(turn) = current_turn.as_mut() else {
+        *candidate = Some(CandidateState {
+            selected_turn_id: String::new(),
+            selected_turn_delimited: false,
+            invalid: Some(CodexHistoryIneligibleReason::InvalidTurn),
+        });
+        return;
+    };
+    if candidate.is_some() && turn.start_offset > canonical_record_len {
+        let turn_len = retained_bytes.len() - turn.start_offset;
+        retained_bytes.copy_within(turn.start_offset.., canonical_record_len);
+        retained_bytes.truncate(canonical_record_len + turn_len);
+        turn.start_offset = canonical_record_len;
+        observe_retained_bytes(retained_bytes.len());
+    }
+    *candidate = Some(CandidateState::from_compacting_turn(
+        turn,
+        compact_validation,
+    ));
 }
 
 fn invalidate_retained_state(
@@ -570,6 +660,9 @@ fn complete_turn(
     turn_id: &str,
     current_turn: &mut Option<TurnState>,
     candidate: &mut Option<CandidateState>,
+    retained_bytes: &mut Vec<u8>,
+    canonical_record_len: usize,
+    observe_retained_bytes: &mut impl FnMut(usize),
 ) {
     let Some(turn) = current_turn.take() else {
         if let Some(existing) = candidate.as_mut() {
@@ -581,22 +674,49 @@ fn complete_turn(
         if let Some(existing) = candidate.as_mut() {
             existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
         }
+        truncate_unselected_bytes(
+            retained_bytes,
+            canonical_record_len,
+            candidate,
+            observe_retained_bytes,
+        );
         return;
     }
-    finish_turn(turn, candidate);
+    finish_turn(
+        turn,
+        candidate,
+        retained_bytes,
+        canonical_record_len,
+        observe_retained_bytes,
+    );
 }
 
 fn finish_current_turn(
     current_turn: &mut Option<TurnState>,
     candidate: &mut Option<CandidateState>,
+    retained_bytes: &mut Vec<u8>,
+    canonical_record_len: usize,
+    observe_retained_bytes: &mut impl FnMut(usize),
 ) {
     let Some(turn) = current_turn.take() else {
         return;
     };
-    finish_turn(turn, candidate);
+    finish_turn(
+        turn,
+        candidate,
+        retained_bytes,
+        canonical_record_len,
+        observe_retained_bytes,
+    );
 }
 
-fn finish_turn(turn: TurnState, candidate: &mut Option<CandidateState>) {
+fn finish_turn(
+    turn: TurnState,
+    candidate: &mut Option<CandidateState>,
+    retained_bytes: &mut Vec<u8>,
+    canonical_record_len: usize,
+    observe_retained_bytes: &mut impl FnMut(usize),
+) {
     let validation = turn.validate_segment();
     if let Some(existing) = candidate.as_mut() {
         if existing.selected_turn_id == turn.id {
@@ -605,6 +725,24 @@ fn finish_turn(turn: TurnState, candidate: &mut Option<CandidateState>) {
         if let Err(reason) = validation {
             existing.invalidate(reason);
         }
+    }
+    truncate_unselected_bytes(
+        retained_bytes,
+        canonical_record_len,
+        candidate,
+        observe_retained_bytes,
+    );
+}
+
+fn truncate_unselected_bytes(
+    retained_bytes: &mut Vec<u8>,
+    canonical_record_len: usize,
+    candidate: &Option<CandidateState>,
+    observe_retained_bytes: &mut impl FnMut(usize),
+) {
+    if candidate.is_none() {
+        retained_bytes.truncate(canonical_record_len);
+        observe_retained_bytes(retained_bytes.len());
     }
 }
 
@@ -1176,6 +1314,56 @@ mod tests {
         let selected = candidate_bytes(select(&file).unwrap());
 
         assert!(selected.ends_with(&later.concat()));
+    }
+
+    #[test]
+    fn bounds_near_limit_retained_bytes_to_one_candidate_window() {
+        let mut records = complete_generation("older summary");
+        records.push(event("thread_rolled_back", json!({"num_turns": 1})));
+        let mut latest = vec![
+            turn_started("turn-2"),
+            user_message(),
+            turn_context("turn-2"),
+        ];
+        latest.extend((0..5).map(|index| {
+            line(
+                "response_item",
+                json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": format!("chunk-{index}-{}", "x".repeat(900)),
+                    }],
+                }),
+            )
+        }));
+        latest.extend([compacted("newer summary"), turn_complete("turn-2")]);
+        records.extend(latest.clone());
+        let file = source(&records);
+        let mut source = file.reopen().unwrap();
+        let mut peak_retained_bytes = 0;
+
+        let selection = select_with_limits_and_observer(
+            &mut source,
+            THREAD_ID,
+            TEST_LIMITS,
+            || {},
+            |retained_bytes| {
+                peak_retained_bytes = peak_retained_bytes.max(retained_bytes);
+            },
+        )
+        .unwrap();
+        let selected = candidate_bytes(selection);
+        let expected = std::iter::once(canonical(Some("legacy")))
+            .chain(latest)
+            .flatten()
+            .collect::<Vec<_>>();
+        let candidate_limit = TEST_LIMITS.candidate_max_bytes as usize;
+
+        assert_eq!(selected, expected);
+        assert!(selected.len() > candidate_limit * 3 / 4);
+        assert!(peak_retained_bytes <= candidate_limit);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain Codex compact-generation bytes in one canonical-prefixed working buffer
- replace newer compact candidates by moving the selected turn in place instead of cloning or dual-appending
- move the completed buffer directly into the result and cover the one-window invariant with a near-limit regression

## Details

Turn and candidate state now hold offsets and validation metadata rather than their own cumulative byte buffers. Completed pre-candidate turns are truncated, newer compact boundaries discard superseded bytes in the same allocation, and exact raw JSONL output remains unchanged.

This does not change public APIs, protocols, persisted formats, ineligible reasons, or guest-agent fallback behavior. The bounded current-record buffer, JSON parsing allocations, caller-owned staging/compression, and allocator-specific capacity/RSS behavior remain outside this change.

## Validation

- `cargo test -p guest-session-prune`
- `cargo test -p guest-agent --lib session_history`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-session-prune --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-session-prune --no-deps`
- `git diff --check`
- `lefthook run pre-commit`

Closes #29739
