### PR TITLE
docs(guest-agent): document ignored secretmasker input entries

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -28,17 +28,25 @@ pub struct SecretMasker {
 }
 
 impl SecretMasker {
-    /// Build a masker from an owned guest-agent config.
+    /// Build a masker from a guest-agent config.
+    ///
+    /// The config's `secret_values` field is parsed with [`Self::from_raw`], so
+    /// the same input format and silent omission rules apply.
     pub fn from_config(config: &env::GuestConfig) -> Self {
         Self::from_raw(&config.secret_values)
     }
 
-    /// Build a masker from a raw comma-separated base64-encoded secret string.
+    /// Build a masker from a raw, comma-separated string of Base64-encoded secrets.
     ///
-    /// For each secret of at least five UTF-8 bytes, the normal matcher stores
-    /// plain, base64-encoded, and percent-encoded variants. Diagnostic-only
-    /// multiline variants, including individual lines, use the same byte
-    /// threshold for bounded stderr masking.
+    /// Each component is trimmed before processing. Empty components, invalid
+    /// Base64, decoded values that are not valid UTF-8, decoded empty values,
+    /// and decoded values shorter than five UTF-8 bytes are ignored. These
+    /// omissions are silent: this constructor returns a masker without an
+    /// error or diagnostic, and only successfully decoded values of at least
+    /// five UTF-8 bytes are masked. For each eligible secret, the normal
+    /// matcher stores plain, Base64-encoded, and percent-encoded variants.
+    /// Diagnostic-only multiline variants, including individual lines, use the
+    /// same byte threshold for bounded stderr masking.
     pub fn from_raw(raw: &str) -> Self {
         if raw.is_empty() {
             return Self::empty();


### PR DESCRIPTION
## Summary

- Document the silent filtering contract for `SecretMasker::from_raw`.
- Link `SecretMasker::from_config` to the canonical constructor contract.

## Behavior Changed

The public Rustdoc now states that `from_raw` trims comma-separated Base64 components and silently ignores empty components, invalid Base64, decoded non-UTF-8 values, decoded empty values, and values shorter than five UTF-8 bytes. It also states that only successfully decoded eligible values are masked and that omissions produce no error or diagnostic.

## Explicit Exclusions

- No parser, matcher, masking, configuration-format, or public API behavior changed.
- No runtime tests were changed; existing `from_raw` tests remain the behavior regression coverage.

## Validation

- `cd crates && cargo fmt --all -- --check` — passed.
- `cd crates && cargo doc -p guest-agent --all-features --no-deps` — passed; Rustdoc generated successfully.
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib masker::tests::from_raw` — passed; 5 tests passed.
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent` — attempted, but the full test build could not link one integration-test binary after the workspace filesystem reached 100% capacity; the generated Cargo target was cleaned and the scoped masker tests passed under constrained resources.
- `git diff --check` — passed.

Closes #29742
