### PR TITLE
fix(browser): use Browser Use Cloud V4

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -51,7 +51,7 @@ const TEST_APP_ROUTES = Object.freeze([
 
 const context = testContext();
 const computerUse = createComputerUseBddApi(context);
-const BROWSER_USE_API_URL = "https://api.browser-use.com/api/v3";
+const BROWSER_USE_API_URL = "https://api.browser-use.com/api/v4";
 const STARTED_AT_MS = Date.parse("2026-07-24T10:00:00.000Z");
 const MINUTE_MS = 60_000;
 const DAY_MS = 24 * 60 * MINUTE_MS;

--- a/turbo/apps/api/src/signals/services/browser-use.service.ts
+++ b/turbo/apps/api/src/signals/services/browser-use.service.ts
@@ -14,7 +14,7 @@ import {
   settle,
 } from "../utils";
 
-const BROWSER_USE_API_BASE_URL = "https://api.browser-use.com/api/v3";
+const BROWSER_USE_API_BASE_URL = "https://api.browser-use.com/api/v4";
 const BROWSER_USE_REQUEST_TIMEOUT_MS = 30_000;
 const BROWSER_USE_CDP_REQUEST_TIMEOUT_MS = 15_000;
 const MAX_BROWSER_USE_RESPONSE_BYTES = 512 * 1024;


### PR DESCRIPTION
## What

- move VM0's Browser Use provider from `/api/v3` to `/api/v4`
- update the browser integration-test mock to enforce the V4 route

## Why

VM0 already uses the profile and standalone browser endpoints supported by V4. This keeps its managed browser provider on Browser Use's current API without changing payloads or lifecycle behavior.

## Validation

- 15 focused browser integration tests
- full API type-check
- full API lint
- workspace-scoped Knip
- Prettier and diff checks
- live V4 OpenAPI contract check for profile and browser create/get/stop

No credentials or live Browser Use sessions were used.
