### PR TITLE
docs(rust): document guest-mock-codex home resolution

### DIFF
--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -1,7 +1,10 @@
 //! Reusable mock Codex app-server contract used by the binary and tests.
 //!
 //! The mock speaks Codex app-server newline-delimited JSON-RPC over stdio and
-//! persists JSONL session artifacts under `$CODEX_HOME`.
+//! persists JSONL session artifacts under the resolved Codex home. The artifact
+//! root is resolved as follows: a non-empty `$CODEX_HOME` takes precedence; an
+//! empty `$CODEX_HOME` is treated as unset, so `$HOME/.codex` is used, falling
+//! back to `/home/user/.codex` when `$HOME` is unavailable.
 
 mod app_server;
 mod session;

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -1,7 +1,10 @@
 //! Mock Codex app-server for testing.
 //!
 //! The binary speaks newline-delimited JSON-RPC over stdio and persists mock
-//! session artifacts under `$CODEX_HOME`. Behavior is selected with
+//! session artifacts under the resolved Codex home. The artifact root is
+//! resolved as follows: a non-empty `$CODEX_HOME` takes precedence; an empty
+//! `$CODEX_HOME` is treated as unset, so `$HOME/.codex` is used, falling back to
+//! `/home/user/.codex` when `$HOME` is unavailable. Behavior is selected with
 //! `MOCK_CODEX_APP_SERVER_SCENARIO`.
 
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
## Summary

- Document the resolved Codex home used by `guest-mock-codex` session artifacts.
- Clarify the non-empty `CODEX_HOME`, empty-variable, `HOME/.codex`, and
  `/home/user/.codex` fallback behavior in both public entry-point docs.

## Scope

This PR updates documentation comments only in
`crates/guest-mock-codex/src/lib.rs` and `crates/guest-mock-codex/src/main.rs`.
The resolver, app-server persistence, initialize response, tests, and runtime
behavior are unchanged.

Closes #29764

## Validation

- `git diff --check`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-mock-codex --all-features --no-deps`
