### PR TITLE
fix(guest-agent): bound pi rpc writes on cancellation

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -484,6 +484,20 @@ async fn write_command(
     Ok(())
 }
 
+async fn write_command_with_cancellation(
+    stdin: &mut tokio::process::ChildStdin,
+    command: &Value,
+    cancellation: &CancellationToken,
+) -> Result<(), AgentError> {
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => Err(AgentError::Execution(
+            "Pi RPC command write was interrupted by cancellation".to_string(),
+        )),
+        result = write_command(stdin, command) => result,
+    }
+}
+
 async fn wait_for_response(
     responses: &mut mpsc::UnboundedReceiver<Value>,
     expected_id: &str,
@@ -527,13 +541,12 @@ async fn abort(
     run_id: &str,
 ) -> Result<(), AgentError> {
     let id = format!("{run_id}:pi:abort");
-    write_command(stdin, &json!({ "id": id, "type": "abort" })).await?;
-    tokio::time::timeout(
-        PI_RPC_ABORT_TIMEOUT,
-        wait_for_response(responses, &id, "abort", true),
-    )
+    tokio::time::timeout(PI_RPC_ABORT_TIMEOUT, async {
+        write_command(stdin, &json!({ "id": id, "type": "abort" })).await?;
+        wait_for_response(responses, &id, "abort", true).await
+    })
     .await
-    .map_err(|_| AgentError::Execution("Pi RPC abort acknowledgement timed out".to_string()))?
+    .map_err(|_| AgentError::Execution("Pi RPC abort timed out".to_string()))?
 }
 
 async fn request_prompt(
@@ -543,13 +556,14 @@ async fn request_prompt(
     message: &str,
     cancellation: &CancellationToken,
 ) -> Result<bool, AgentError> {
-    write_command(
+    write_command_with_cancellation(
         stdin,
         &json!({
             "id": id,
             "type": "prompt",
             "message": message,
         }),
+        cancellation,
     )
     .await?;
     tokio::select! {
@@ -569,13 +583,14 @@ async fn request_steer(
     message: &str,
     cancellation: &CancellationToken,
 ) -> Result<bool, AgentError> {
-    write_command(
+    write_command_with_cancellation(
         stdin,
         &json!({
             "id": id,
             "type": "steer",
             "message": message,
         }),
+        cancellation,
     )
     .await?;
     tokio::select! {
@@ -622,7 +637,12 @@ pub(super) async fn write_commands(
     cancellation: CancellationToken,
 ) -> Result<(), AgentError> {
     let state_id = format!("{run_id}:pi:get-state");
-    write_command(&mut stdin, &json!({ "id": state_id, "type": "get_state" })).await?;
+    write_command_with_cancellation(
+        &mut stdin,
+        &json!({ "id": state_id, "type": "get_state" }),
+        &cancellation,
+    )
+    .await?;
     tokio::select! {
         biased;
         () = cancellation.cancelled() => {

--- a/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
+++ b/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
@@ -1,0 +1,200 @@
+//! Pi user cancellation must interrupt a steer blocked on child stdin.
+
+mod common;
+
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use guest_agent::active_input::ActiveInputControlOutcome;
+use guest_agent::cli::{CliExecutionControls, execute_cli_with_controls_for_config_started_at};
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::CliTerminationReason;
+use tokio_util::sync::CancellationToken;
+
+const RUN_ID: &str = "00000000-0000-4000-8000-000000000145";
+const SESSION_ID: &str = "11111111-1111-4111-8111-111111111145";
+const DELIVERY_ID: &str = "22222222-2222-4222-8222-222222222145";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn pi_cancellation_reaps_child_with_stalled_steer_write()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let child_pid_path = tmp.path().join("pi-child.pid");
+    let steer_started_path = tmp.path().join("pi-steer-started");
+    let npx = bin_dir.join("npx");
+    std::fs::write(
+        &npx,
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$$" > "$PI_CHILD_PID_PATH"
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+IFS= read -r state_command
+case "$state_command" in
+  *'"type":"get_state"'*) ;;
+  *) exit 21 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:get-state\",\"type\":\"response\",\"command\":\"get_state\",\"success\":true,\"data\":{\"sessionId\":\"11111111-1111-4111-8111-111111111145\",\"sessionFile\":\"/home/user/.pi/agent/sessions/--home-user-workspace--/session.jsonl\"}}"
+IFS= read -r prompt_command
+case "$prompt_command" in
+  *'"type":"prompt"'*) ;;
+  *) exit 22 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:initial-prompt\",\"type\":\"response\",\"command\":\"prompt\",\"success\":true}"
+dd bs=1 count=1 of=/dev/null 2>/dev/null
+printf '%s\n' 'steer-started' > "$PI_STEER_STARTED_PATH"
+while :; do
+  sleep 60
+done
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&npx)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&npx, permissions)?;
+
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), RUN_ID)?;
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
+        std::env::set_var(guest_contracts::env::RUN_ID_ENV, RUN_ID);
+        std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::set_var(
+            guest_contracts::env::SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var("HOME", tmp.path());
+        let mut paths = vec![bin_dir];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(paths)?);
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "cancel Pi while steer is blocked on stdin".to_string(),
+                pi_launch_config:
+                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#
+                        .to_string(),
+                pi_model_config: "{}".to_string(),
+                pi_session_id: SESSION_ID.to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
+        common::set_user_env_file_env_for_test(
+            &runtime_dir,
+            &HashMap::from([
+                (
+                    "CLI_PKG_URL".to_string(),
+                    "https://example.invalid/current-okou-cli.tgz".to_string(),
+                ),
+                (
+                    "PI_CHILD_PID_PATH".to_string(),
+                    child_pid_path.to_string_lossy().into_owned(),
+                ),
+                (
+                    "PI_STEER_STARTED_PATH".to_string(),
+                    steer_started_path.to_string_lossy().into_owned(),
+                ),
+            ]),
+        )?;
+    }
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(tmp.path())?;
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let journal_path = guest_contracts::runtime_paths::active_input_receipt_journal_file(
+        runtime.paths.runtime_dir(),
+    );
+    let active_input = common::active_input_runtime(&runtime)?;
+    let controller = active_input.controller();
+    let payload_limit =
+        api_contracts::generated::constants::runners::ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES
+            as usize;
+    let payload = guest_contracts::active_input::encode_active_input(
+        DELIVERY_ID,
+        &"x".repeat(payload_limit - 256),
+    )?;
+    assert!(payload.len() <= payload_limit);
+    assert!(payload.len() > payload_limit - 512);
+    assert_eq!(
+        controller.handle_control_payload(&payload),
+        ActiveInputControlOutcome::Accepted
+    );
+
+    let cancellation = CancellationToken::new();
+    let masker = SecretMasker::from_raw("");
+    let execution = execute_cli_with_controls_for_config_started_at(
+        &masker,
+        common::spawn_dummy_heartbeat(),
+        runtime.http.clone(),
+        CliExecutionControls::new(active_input.into_writer(), cancellation.clone(), None),
+        &runtime.config,
+        &runtime.paths,
+        Instant::now(),
+    );
+    tokio::pin!(execution);
+    tokio::select! {
+        result = &mut execution => {
+            return Err(format!("Pi execution ended before steer stalled: {result:?}").into());
+        }
+        ready = common::wait_for_file_contains(
+            &steer_started_path,
+            "steer-started",
+            Duration::from_secs(5),
+        ) => ready?,
+    }
+
+    let child_pid = std::fs::read_to_string(&child_pid_path)?
+        .trim()
+        .parse::<u32>()?;
+    let child_process_path = PathBuf::from(format!("/proc/{child_pid}"));
+    assert!(
+        child_process_path.exists(),
+        "stalled Pi child must be live before cancellation"
+    );
+
+    cancellation.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(10), execution)
+        .await
+        .expect("Pi cancellation should terminate the stalled child")?;
+
+    assert!(result.active_input_delivery_ids.is_empty());
+    let control_error = result
+        .control_error
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("Pi cancellation omitted its controlled error"))?;
+    assert!(
+        control_error.to_string().contains("Run cancelled by user"),
+        "unexpected cancellation error: {control_error}"
+    );
+    assert_eq!(
+        result
+            .cli_termination
+            .ok_or_else(|| std::io::Error::other("Pi cancellation omitted termination details"))?
+            .reason,
+        CliTerminationReason::UserCancellation
+    );
+    assert!(
+        guest_contracts::active_input_receipts::read_active_input_receipt_journal(
+            &journal_path,
+            RUN_ID,
+        )?
+        .is_empty()
+    );
+    assert!(
+        !child_process_path.exists(),
+        "stalled Pi child must be reaped before execution returns"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- interrupt normal Pi RPC stdin writes when the run is cancelled, without reusing a stream that may contain a partial JSONL command
- bound the complete graceful abort transaction, including the abort write and acknowledgement wait
- add an integration test that fills the active-input payload near its limit, stalls a real child on stdin, cancels the run, and verifies bounded child reaping and cancellation attribution

## Scope

- no API, persisted-state, queue-payload, or Pi protocol changes
- no change to the parent process-group termination policy
- handling a child that acknowledges abort but never exits remains out of scope

## Validation

- `cargo test -p guest-agent --test pi_cli_stalled_stdin_cancellation`
- `env -u OKOU_API_BACKEND_URL -u VM0_API_BACKEND_URL cargo test -p guest-agent`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps`
- `git diff --check`
- `lefthook run pre-commit`

Closes #29745
