### PR TITLE
refactor(api): stop legacy runner name handling

### DIFF
--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -16,9 +16,10 @@ Hostname does not select a service, directory, release, or rollback target.
 Those lifecycle identities continue to use the version-shaped `name`, such as
 `v0.174.0`. Current Runner binaries send optional canonical `runnerHostname`
 from configuration and canonical `runnerVersion` compiled into the binary. They
-no longer send legacy `runnerName` in heartbeats or sandbox telemetry. During
-the compatibility window, the API still accepts `runnerName` from draining
-older Runner binaries and preserves its version-shaped value as `runner_name`.
+no longer send legacy `runnerName` in heartbeats or sandbox telemetry. Current
+API revisions no longer declare, persist, or map that field. During deployment
+overlap, an extra `runnerName` from an older Runner payload is tolerated but
+discarded before request handling.
 
 Operational queries and alerts should use `runner_hostname` and
 `runner_version`. A bounded historical fallback may use `runner_name` only for
@@ -26,11 +27,13 @@ records that lack the canonical dimensions from before the cutover. Never
 interpret `runner_name` as a hostname.
 
 Runner Axiom warning/error events similarly include optional
-`runner_hostname` and required `runner_version`. Deploy the API and nullable
-heartbeat storage before deploying a Runner that omits the legacy name. Canary
-the Runner and verify claim snapshots, telemetry/Axiom dimensions, distinct
-hostnames on two hosts running one version, and retained-version rollback
-before removing the legacy receiver or historical query fallback.
+`runner_hostname` and required `runner_version`. The rollout order is compatible
+API and nullable heartbeat storage, Runner producer cutover, then logical API
+receiver removal. Retain the nullable physical column until all serving and
+rollback API revisions that reference it have retired. Canary each transition
+and verify claim snapshots, telemetry/Axiom dimensions, distinct hostnames on
+two hosts running one version, and retained-version rollback. Remove any
+historical query fallback only after its bounded observation window expires.
 
 The runner reads host-local overrides from `/etc/vm0-runner/host.env` once
 during startup. A missing file is equivalent to an empty file: the runner uses

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -239,7 +239,6 @@ function runnerHeartbeatBody(
 ): RunnerHeartbeatBody {
   return {
     runnerId: args.runnerId ?? randomUUID(),
-    runnerName: "bdd-runner",
     group: args.group ?? "vm0/test",
     snapshotGeneration: args.snapshotGeneration ?? 1,
     snapshotSequence: args.snapshotSequence ?? 1,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5302,15 +5302,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expectApiError(missingSandboxStatesHeartbeat.body);
 
-    const canonicalHeartbeat = await api.requestRawHeartbeatRunner(
+    const overlapHeartbeat = await api.requestRawHeartbeatRunner(
       true,
       [200],
       rawHeartbeatBody({
+        runnerName: "v0.168.14",
         admittableProfiles: ["vm0/default"],
         heldSandboxStates: [],
       }),
     );
-    expect(canonicalHeartbeat.body).toStrictEqual({
+    expect(overlapHeartbeat.body).toStrictEqual({
       ok: true,
     });
     const invalidWorkspaceVersionHeartbeat =

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2077,13 +2077,13 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     ).toBeFalsy();
   });
 
-  it("attributes sandbox operations to stable legacy and canonical runner dimensions", async () => {
+  it("attributes sandbox operations to canonical runner dimensions across overlap", async () => {
     const { runId, headers } = await createEventWebhookRun(
       `runner-name telemetry ${randomUUID()}`,
     );
 
     context.mocks.axiom.sdkIngest.mockClear();
-    await api.requestAgentTelemetry(
+    await api.requestAgentTelemetryUnchecked(
       {
         runId,
         runnerName: "v0.168.14",
@@ -2092,7 +2092,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
         sandboxOperations: [
           {
             ts: nowDate().toISOString(),
-            action_type: "runner_name_attribution",
+            action_type: "runner_attribution_overlap",
             duration_ms: 12,
             success: true,
             runner_pre_spawn_concurrency_bucket: "3_4",
@@ -2109,14 +2109,19 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
       [
         expect.objectContaining({
           run_id: runId,
-          op_type: "runner_name_attribution",
-          runner_name: "v0.168.14",
+          op_type: "runner_attribution_overlap",
           runner_hostname: "prod-1.aws.vm3.ai",
           runner_version: "0.168.14",
           runner_pre_spawn_concurrency_bucket: "3_4",
         }),
       ],
     );
+    const overlapEvents: unknown =
+      context.mocks.axiom.sdkIngest.mock.calls[0]?.[1];
+    if (!Array.isArray(overlapEvents) || !isUnknownRecord(overlapEvents[0])) {
+      throw new Error("Expected one overlap runner telemetry event");
+    }
+    expect(overlapEvents[0]).not.toHaveProperty("runner_name");
 
     context.mocks.axiom.sdkIngest.mockClear();
     await api.requestAgentTelemetry(
@@ -2158,43 +2163,6 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     }
     const canonicalEvent = canonicalEvents[0];
     expect(canonicalEvent).not.toHaveProperty("runner_name");
-
-    context.mocks.axiom.sdkIngest.mockClear();
-    await api.requestAgentTelemetry(
-      {
-        runId,
-        runnerName: "v0.168.16",
-        sandboxOperations: [
-          {
-            ts: nowDate().toISOString(),
-            action_type: "legacy_runner_name_attribution",
-            duration_ms: 6,
-            success: true,
-          },
-        ],
-      },
-      headers,
-      [200],
-    );
-    await flushWaitUntilForTest();
-
-    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
-      "vm0-sandbox-op-log-dev",
-      [
-        expect.objectContaining({
-          op_type: "legacy_runner_name_attribution",
-          runner_name: "v0.168.16",
-        }),
-      ],
-    );
-    const legacyEvents: unknown =
-      context.mocks.axiom.sdkIngest.mock.calls[0]?.[1];
-    if (!Array.isArray(legacyEvents) || !isUnknownRecord(legacyEvents[0])) {
-      throw new Error("Expected one legacy runner telemetry event");
-    }
-    const legacyEvent = legacyEvents[0];
-    expect(legacyEvent).not.toHaveProperty("runner_hostname");
-    expect(legacyEvent).not.toHaveProperty("runner_version");
   });
 
   it("rejects malformed, unauthenticated, mismatched, and missing-run sandbox reports", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -515,7 +515,6 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .insert(runnerState)
     .values({
       runnerId: body.data.runnerId,
-      runnerName: body.data.runnerName ?? null,
       runnerGroup: body.data.group,
       heartbeatGeneration: snapshotOrder.generation,
       heartbeatSequence: snapshotOrder.sequence,
@@ -534,7 +533,6 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .onConflictDoUpdate({
       target: runnerState.runnerId,
       set: {
-        runnerName: body.data.runnerName ?? null,
         runnerGroup: body.data.group,
         heartbeatGeneration: snapshotOrder.generation,
         heartbeatSequence: snapshotOrder.sequence,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -66,7 +66,6 @@ interface SandboxOperationDimensionInput {
 }
 
 interface SandboxRunnerDimensionInput {
-  readonly runnerName?: string;
   readonly runnerHostname?: string;
   readonly runnerVersion?: string;
 }
@@ -77,7 +76,6 @@ function sandboxOperationDimensions(
 ): Record<string, string> {
   return {
     source: "sandbox",
-    ...(runner.runnerName ? { runner_name: runner.runnerName } : {}),
     ...(runner.runnerHostname
       ? { runner_hostname: runner.runnerHostname }
       : {}),
@@ -442,7 +440,6 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
         runId: body.runId,
         timestamp: op.ts,
         dimensions: sandboxOperationDimensions(op, {
-          runnerName: body.runnerName,
           runnerHostname: body.runnerHostname,
           runnerVersion: body.runnerVersion,
         }),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -1253,7 +1253,6 @@ describe("runner resume session contract", () => {
   it("accepts ordered heartbeat snapshots", () => {
     const heartbeat = {
       runnerId: "33333333-3333-4333-8333-333333333333",
-      runnerName: "runner-contract-test",
       group: "vm0/test",
       snapshotGeneration: 1,
       snapshotSequence: 1,
@@ -1281,12 +1280,6 @@ describe("runner resume session contract", () => {
             reusableSandbox: { profile: "vm0/default" },
           },
         ],
-      }).success,
-    ).toBe(true);
-    expect(
-      heartbeatBodySchema.safeParse({
-        ...heartbeat,
-        runnerName: undefined,
       }).success,
     ).toBe(true);
     expect(
@@ -1323,7 +1316,6 @@ describe("runner resume session contract", () => {
   it("requires canonical heartbeat state", () => {
     const heartbeat = {
       runnerId: "33333333-3333-4333-8333-333333333333",
-      runnerName: "runner-contract-test",
       group: "vm0/test",
       snapshotGeneration: 1,
       snapshotSequence: 1,
@@ -1363,7 +1355,6 @@ describe("runner resume session contract", () => {
   it("bounds profile-qualified workspace cache heartbeat state", () => {
     const heartbeat = {
       runnerId: "33333333-3333-4333-8333-333333333333",
-      runnerName: "runner-contract-test",
       group: "vm0/test",
       snapshotGeneration: 1,
       snapshotSequence: 1,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -233,32 +233,23 @@ describe("agent completion active input receipts", () => {
 });
 
 describe("webhook telemetry contract", () => {
-  it("accepts optional bounded legacy and canonical runner dimensions", () => {
+  it("accepts optional bounded canonical runner dimensions", () => {
     const runId = "00000000-0000-4000-8000-000000000000";
-    const previousPayload = webhookTelemetryContract.send.body.parse({ runId });
-    expect(previousPayload).not.toHaveProperty("runnerName");
-    expect(previousPayload).not.toHaveProperty("runnerHostname");
-    expect(previousPayload).not.toHaveProperty("runnerVersion");
+    const minimalPayload = webhookTelemetryContract.send.body.parse({ runId });
+    expect(minimalPayload).not.toHaveProperty("runnerHostname");
+    expect(minimalPayload).not.toHaveProperty("runnerVersion");
 
     expect(
       webhookTelemetryContract.send.body.parse({
         runId,
-        runnerName: "v0.168.14",
         runnerHostname: "prod-1.aws.vm3.ai",
         runnerVersion: "0.168.14",
       }),
     ).toMatchObject({
-      runnerName: "v0.168.14",
       runnerHostname: "prod-1.aws.vm3.ai",
       runnerVersion: "0.168.14",
     });
 
-    for (const runnerName of ["", "x".repeat(129)]) {
-      expect(
-        webhookTelemetryContract.send.body.safeParse({ runId, runnerName })
-          .success,
-      ).toBe(false);
-    }
     for (const runnerHostname of ["", "x".repeat(256)]) {
       expect(
         webhookTelemetryContract.send.body.safeParse({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1320,7 +1320,6 @@ export const runnersBuiltinFirewallsResolveContract = c.router({
 export const heartbeatBodySchema = z
   .object({
     runnerId: z.uuid(),
-    runnerName: z.string().optional(),
     group: runnerGroupSchema,
     snapshotGeneration: runnerHeartbeatGenerationSchema,
     snapshotSequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -893,8 +893,6 @@ const sandboxOperationSchema = z.object({
   session_history_download_source: sandboxOperationDownloadSourceSchema,
 });
 
-const telemetryRunnerNameSchema = z.string().min(1).max(128);
-
 /**
  * Webhook telemetry contract for /api/webhooks/agent/telemetry
  */
@@ -909,7 +907,6 @@ export const webhookTelemetryContract = c.router({
     headers: authHeadersSchema,
     body: z.object({
       runId: z.string().min(1, "runId is required"),
-      runnerName: telemetryRunnerNameSchema.optional(),
       runnerHostname: runnerHostnameSchema.optional(),
       runnerVersion: runnerVersionSchema.optional(),
       systemLog: z.string().optional(),


### PR DESCRIPTION
## Summary

- remove legacy `runnerName` from heartbeat and sandbox telemetry contracts
- stop writing legacy Runner name state and emitting new Axiom `runner_name` dimensions
- tolerate the removed property from older payloads through request parsing while preserving canonical hostname/version, scheduling, and reuse behavior
- document the logical cutover and retain the nullable database column for the later deployment-gated physical cleanup

## Compatibility

- old payloads may still include `runnerName`; the new receiver strips the extra property before handling
- `runner_state.runner_name` remains in the Drizzle schema and database so serving and rollback API revisions remain compatible
- GitHub Actions workflow runner-name handling is unchanged

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @okouai/api-contracts`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts src/contracts/__tests__/webhooks.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- pre-commit hook: repository Knip and TypeScript checks

Closes #29532

Parent context: #29497
