### PR TITLE
docs(python): document shared model json inspection contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -163,8 +163,8 @@ class ModelJsonResponseInspector:
         """Feed the next content-decoded JSON bytes for this response.
 
         Call this method repeatedly as response chunks arrive, before :meth:`finish`. If
-            :meth:`accepts_more_input` returns ``False``, the bounded parser has recorded a
-            permanent parse or configured-bound error and later chunks cannot recover it.
+        :meth:`accepts_more_input` returns ``False``, the bounded parser has recorded a
+        permanent parse or configured-bound error and later chunks cannot recover it.
         """
         self._extractor.feed(chunk)
 

--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -93,13 +93,43 @@ _OPENAI_RESPONSES_REGISTRATION = _ModelJsonUsageRegistration(
 
 @dataclass(frozen=True)
 class ModelJsonResponseInspection:
+    """Combined usage and failure projections from one model JSON response.
+
+    The projections are produced by the same bounded, response-scoped parser. Their consumers
+    are independent: disabling one projection does not change the result contract of the other.
+
+    Attributes:
+        usage: Protocol-specific normalized usage data, or ``None`` when usage inspection is
+            disabled, no usage is present, or usage extraction did not complete. When usage
+            extraction does not complete, ``usage_error`` contains the parser diagnostic.
+        usage_error: The usage parser diagnostic when extraction did not complete. This is
+            ``None`` when usage inspection is disabled, no usage is present in complete JSON, or
+            usage was extracted successfully.
+        failure: Bounded :class:`ModelHttpFailureEvidence` for the same JSON document. When
+            failure inspection is disabled, this is the default, intentionally invalid evidence.
+            When it is enabled, callers must check ``failure.is_valid`` before interpreting the
+            projection as provider outcome evidence. Failure-sensitive overflow can invalidate
+            this projection while leaving ``usage`` available when both consumers are enabled.
+    """
+
     usage: dict | None
     usage_error: str | None
     failure: ModelHttpFailureEvidence
 
 
 class ModelJsonResponseInspector:
-    """One bounded JSON extractor shared by active model HTTP consumers."""
+    """Incrementally inspect one content-decoded model JSON response.
+
+    One bounded :class:`JsonSelectiveExtractor` is shared by the active usage and failure
+    consumers. It selects the union of their fields and is limited to 65,536 work units. When
+    both consumers are enabled, failure-only strings may be discarded at their bound so that
+    usage extraction can remain available; the resulting failure evidence is then invalid and
+    must not be classified without checking ``is_valid``.
+
+    Feed chunks from one response with :meth:`feed`, use :meth:`accepts_more_input` to determine
+    whether the parser can accept another chunk, and call :meth:`finish` exactly once after all
+    input has been supplied.
+    """
 
     def __init__(
         self,
@@ -129,12 +159,36 @@ class ModelJsonResponseInspector:
         )
 
     def feed(self, chunk: bytes) -> None:
+        """Feed the next content-decoded JSON bytes for this response.
+
+        Call this method repeatedly as response chunks arrive, before :meth:`finish`. If
+        :meth:`accepts_more_input` returns ``False``, the bounded parser has recorded a permanent
+        parse or work-limit error and later chunks cannot recover it.
+        """
         self._extractor.feed(chunk)
 
     def accepts_more_input(self) -> bool:
+        """Return whether the bounded parser can accept another response chunk.
+
+        A completed root remains eligible for input so trailing JSON data can still be validated.
+        A ``False`` result means that a permanent parse or configured-bound error has stopped
+        further parsing; it is not a successful inspection result. Call :meth:`finish` after the
+        final accepted chunk.
+        """
         return self._extractor.accepts_more_input()
 
     def finish(self) -> ModelJsonResponseInspection:
+        """Finalize the response and return the combined inspection.
+
+        Call once after all response chunks have been fed. The returned ``usage`` and
+        ``usage_error`` follow the selected protocol's usage contract. If usage inspection is
+        disabled, both usage fields are ``None``. If failure inspection is disabled, ``failure``
+        is a default :class:`ModelHttpFailureEvidence` with ``is_valid=False``. When failure
+        inspection is enabled, callers must check ``failure.is_valid`` before using it; incomplete
+        parsing or failure-sensitive overflow produces invalid evidence. With both consumers
+        enabled, failure-only overflow can invalidate ``failure`` without discarding available
+        usage data.
+        """
         result = self._extractor.finish()
         usage, usage_error = (
             self._registration.usage_from_result(result) if self._include_usage else (None, None)
@@ -153,6 +207,25 @@ def create_model_json_response_inspector(
     include_usage: bool,
     include_failure: bool,
 ) -> ModelJsonResponseInspector:
+    """Create a shared bounded inspector for one model JSON response.
+
+    Args:
+        protocol: Model JSON protocol to inspect: ``"anthropic_messages"``,
+            ``"openai_chat_completions"``, or ``"openai_responses"``.
+        include_usage: Whether to derive protocol-specific normalized usage and a usage parsing
+            diagnostic. When false, the returned inspection uses ``(None, None)`` for these
+            fields.
+        include_failure: Whether to derive bounded :class:`ModelHttpFailureEvidence`. When
+            false, the returned inspection contains the default invalid evidence instance.
+
+    Returns:
+        A response-scoped :class:`ModelJsonResponseInspector`. Feed content-decoded JSON chunks
+        with ``feed()``, consult ``accepts_more_input()`` before supplying another chunk, and
+        call ``finish()`` exactly once after the response is complete. Usage and failure are
+        collected by one selective parser, bounded to 65,536 work units. If both consumers are
+        enabled, failure-only string overflow can invalidate the failure projection while
+        preserving usage extraction; check ``failure.is_valid`` before interpreting it.
+    """
     return ModelJsonResponseInspector(
         protocol,
         include_usage=include_usage,

--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -96,7 +96,8 @@ class ModelJsonResponseInspection:
     """Combined usage and failure projections from one model JSON response.
 
     The projections are produced by the same bounded, response-scoped parser. Their consumers
-    are independent: disabling one projection does not change the result contract of the other.
+    are independently enabled: disabling one produces its documented disabled value without
+    suppressing the other projection.
 
     Attributes:
         usage: Protocol-specific normalized usage data, or ``None`` when usage inspection is
@@ -162,8 +163,8 @@ class ModelJsonResponseInspector:
         """Feed the next content-decoded JSON bytes for this response.
 
         Call this method repeatedly as response chunks arrive, before :meth:`finish`. If
-        :meth:`accepts_more_input` returns ``False``, the bounded parser has recorded a permanent
-        parse or work-limit error and later chunks cannot recover it.
+            :meth:`accepts_more_input` returns ``False``, the bounded parser has recorded a
+            permanent parse or configured-bound error and later chunks cannot recover it.
         """
         self._extractor.feed(chunk)
 


### PR DESCRIPTION
## Summary

- Document the public `ModelJsonResponseInspection` result fields and failure-evidence validity contract.
- Document the shared incremental inspector lifecycle, supported protocols, consumer flags, and bounded one-parser behavior.
- Clarify that combined usage/failure inspection can preserve usage when failure-sensitive fields overflow while invalidating the failure projection.

## Scope

This is a documentation-only change in `crates/runner/mitm-addon/src/usage/model_json.py`. Runtime behavior, public type shapes, tests, dependencies, and response parsing are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6673 passed, 59 warnings

Closes #29789
