### PR TITLE
test(guest-agent): clear inherited canonical api url

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_env_isolation.rs
+++ b/crates/guest-agent/tests/codex_app_server_env_isolation.rs
@@ -1,0 +1,41 @@
+//! Codex app-server setup must replace inherited API URL aliases.
+//!
+//! This test lives in its own binary to isolate process environment and working
+//! directory mutations performed by `setup_codex_app_server_env`.
+
+mod common;
+
+const INHERITED_CANONICAL_API_URL: &str = "https://inherited.example.invalid";
+
+#[test]
+fn codex_app_server_setup_clears_inherited_canonical_api_url()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            INHERITED_CANONICAL_API_URL,
+        );
+        common::setup_codex_app_server_env(
+            &tmp.path().join("unused-mock-codex"),
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-env-isolation-test",
+                prompt: "verify isolated app-server setup",
+                scenario: None,
+                resume_session_id: None,
+            },
+        )?;
+    }
+
+    assert!(
+        std::env::var_os(guest_contracts::env::CANONICAL_API_URL_ENV).is_none(),
+        "Codex app-server setup retained the inherited canonical API URL"
+    );
+    let installed_api_url = std::env::var(guest_contracts::env::API_URL_ENV)?;
+    let runtime = common::guest_runtime_from_process_env()?;
+    assert_eq!(runtime.config.api_url, installed_api_url);
+    assert_ne!(runtime.config.api_url, INHERITED_CANONICAL_API_URL);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1045,6 +1045,7 @@ pub struct CodexAppServerEnvConfig<'a> {
 pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
     for key in [
         guest_contracts::env::API_URL_ENV,
+        guest_contracts::env::CANONICAL_API_URL_ENV,
         guest_contracts::env::RUN_ID_ENV,
         guest_contracts::env::API_TOKEN_ENV,
         guest_contracts::env::CANONICAL_API_TOKEN_ENV,


### PR DESCRIPTION
## Summary

- clear both API URL aliases before guest-agent integration tests install their owned environment
- add a process-isolated Codex setup regression that starts with a conflicting inherited canonical URL
- verify production `GuestRuntime` capture resolves the setup-owned legacy URL

## Scope

- test-only changes in the guest-agent shared integration setup and a focused integration binary
- no production alias resolver, precedence, telemetry, API, protocol, persistence, migration, or deployment changes
- existing fail-closed conflict behavior remains covered by `api_url_env_aliases`

## Validation

- `cargo test -p guest-agent --test codex_app_server_env_isolation`
- `cargo test -p guest-agent --test api_url_env_aliases`
- `cargo test -p guest-agent`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps`
- `git diff --check`
- `lefthook run pre-commit`
- commit-message validation through the repository hook

No tests were skipped.

Closes #29782
