### PR TITLE
perf(python): retry only pending provider timing states

### DIFF
--- a/crates/runner/mitm-addon/src/provider_timing_store.py
+++ b/crates/runner/mitm-addon/src/provider_timing_store.py
@@ -11,6 +11,8 @@ is acquired for incomplete context. Once a buffered-report lease is acquired, sa
 admission keeps the operations, context, and lease together for retry. Successful webhook admission
 transfers delivery ownership to ``usage.webhook``. The store then clears its pending state and
 releases the buffered lease.
+Retry-eligible run IDs are indexed in the pending subset of current LRU order so global retries do
+not visit completed or incomplete-context state.
 Eviction, explicit discard, and reset release any lease that remains locally retained.
 
 See ``codex_output_timing.py`` and ``claude_output_timing.py`` for provider usage, and
@@ -57,7 +59,8 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
     State creation and access maintain the run map's LRU order. Retained operations stay local until
     a complete reporting context and bounded webhook admission are available; queue saturation
     leaves the state and its buffered lease retained, while successful admission hands delivery to
-    ``usage.webhook``.
+    ``usage.webhook``. A bounded ordered index mirrors the retry-eligible subset of the run map, so
+    global retry cost and ordering depend only on current retryable work.
     """
 
     def __init__(
@@ -71,6 +74,7 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         self._log_type = log_type
         self._max_tracked_runs = max_tracked_runs
         self._run_states: OrderedDict[str, StateT] = OrderedDict()
+        self._retryable_run_ids: OrderedDict[str, None] = OrderedDict()
         self._lock = threading.Lock()
 
     @contextmanager
@@ -106,7 +110,8 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
             state = self._state_factory()
             self._run_states[run_id] = state
             if len(self._run_states) > self._max_tracked_runs:
-                _, evicted = self._run_states.popitem(last=False)
+                evicted_run_id, evicted = self._run_states.popitem(last=False)
+                self._retryable_run_ids.pop(evicted_run_id, None)
                 self._release_buffered_report_locked(evicted)
             return state
 
@@ -120,6 +125,8 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         alter pending operations, reporting context, or lease ownership.
         """
         self._run_states.move_to_end(run_id)
+        if run_id in self._retryable_run_ids:
+            self._retryable_run_ids.move_to_end(run_id)
 
     def discard_locked(self, run_id: str) -> None:
         """Discard a tracked run and release any retained buffered-report lease.
@@ -128,6 +135,7 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         discarded with its state; no delivery retry remains after this terminal removal.
         """
         state = self._run_states.pop(run_id)
+        self._retryable_run_ids.pop(run_id, None)
         self._release_buffered_report_locked(state)
 
     def admit_pending_locked(
@@ -154,6 +162,7 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         state.pending_context = context
         if state.buffered_report is None:
             state.buffered_report = usage.admit_buffered_report()
+        self._retryable_run_ids[run_id] = None
         self._admit_retained_locked(run_id, state)
 
     def retry_pending(self, flow: http.HTTPFlow, run_id: str) -> None:
@@ -173,12 +182,16 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
     def retry_all_pending(self) -> None:
         """Retry retained reports in current LRU order until admission is saturated.
 
-        This entry point acquires the store lock internally. Each successful admission clears that
-        run's retained operations, context, and buffered lease; the first rejected admission leaves
-        that run and all later runs for a future retry. This sweep does not touch LRU order.
+        This entry point acquires the store lock internally and visits only the ordered retryable
+        subset of retained run state. Each successful admission clears that run's retained
+        operations, context, buffered lease, and index membership; the first rejected admission
+        leaves that run first and all later runs for a future retry. This sweep does not touch LRU
+        order.
         """
         with self._lock:
-            for run_id, state in self._run_states.items():
+            while self._retryable_run_ids:
+                run_id = next(iter(self._retryable_run_ids))
+                state = self._run_states[run_id]
                 if not self._admit_retained_locked(run_id, state):
                     return
 
@@ -193,17 +206,22 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
             for state in self._run_states.values():
                 self._release_buffered_report_locked(state)
             self._run_states.clear()
+            self._retryable_run_ids.clear()
 
     def _admit_retained_locked(self, run_id: str, state: StateT) -> bool:
         """Admit retained state while the caller holds ``locked()``.
 
         Return ``False`` when bounded webhook admission is saturated and leave the retained state
-        unchanged. On success, clear the pending operations and context and release the buffered
-        lease after delivery ownership transfers to ``usage.webhook``.
+        and retry index unchanged. On success, clear retry membership, pending operations, and
+        context, then release the buffered lease after delivery ownership transfers to
+        ``usage.webhook``.
         """
         context = state.pending_context
         if not state.pending_operations or context is None:
-            return True
+            raise RuntimeError("retryable provider timing report had incomplete state")
+        lease = state.buffered_report
+        if lease is None:
+            raise RuntimeError("retryable provider timing report had no buffered owner")
         operations = [
             {
                 "ts": observed_at,
@@ -226,9 +244,7 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         ):
             return False
 
-        lease = state.buffered_report
-        if lease is None:
-            raise RuntimeError("admitted provider timing report had no buffered owner")
+        del self._retryable_run_ids[run_id]
         state.pending_operations.clear()
         state.pending_context = None
         state.buffered_report = None

--- a/crates/runner/mitm-addon/tests/test_provider_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_provider_output_timing.py
@@ -1,9 +1,10 @@
 """Cross-provider integration tests for provider-output timing stores."""
 
+import sys
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
-from types import TracebackType
+from types import FrameType, TracebackType
 from typing import Self
 from unittest.mock import patch
 
@@ -374,6 +375,122 @@ def test_provider_stores_keep_independent_lru_capacity(
         ("claude_output_timing", "run-claude-recent"),
         ("codex_output_timing", "run-shared"),
     ]
+
+
+def test_retry_all_pending_visits_only_retryable_runs_in_current_lru_order(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+) -> None:
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    delivery_available = True
+    admission_results: list[bool] = []
+    attempted_run_ids: list[str] = []
+    admitted_run_ids: list[str] = []
+
+    def enqueue_timing_delivery(
+        _url: str,
+        _sandbox_token: str,
+        payload: dict[str, object],
+        _proxy_log_path: str,
+        _log_type: str,
+    ) -> bool:
+        run_id = payload["runId"]
+        assert isinstance(run_id, str)
+        attempted_run_ids.append(run_id)
+        admitted = admission_results.pop(0) if admission_results else delivery_available
+        if admitted:
+            admitted_run_ids.append(run_id)
+        return admitted
+
+    def codex_flow(run_id: str) -> http.HTTPFlow:
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        flow.metadata[metadata_keys.SANDBOX_RUN_ID] = run_id
+        return flow
+
+    def observe_generated_response(flow: http.HTTPFlow) -> None:
+        codex_output_timing.observe_server_event(flow, "response.created")
+        codex_output_timing.observe_server_event(flow, "response.output_item.added")
+
+    admission_code = type(codex_output_timing._store)._admit_retained_locked.__code__
+
+    def retry_and_capture_visits() -> list[str]:
+        visited_run_ids: list[str] = []
+
+        def capture_visit(frame: FrameType, event: str, _arg: object) -> None:
+            if event != "call" or frame.f_code is not admission_code:
+                return
+            run_id = frame.f_locals.get("run_id")
+            assert isinstance(run_id, str)
+            visited_run_ids.append(run_id)
+
+        previous_profile = sys.getprofile()
+        sys.setprofile(capture_visit)
+        try:
+            codex_output_timing.retry_all_pending()
+        finally:
+            sys.setprofile(previous_profile)
+        return visited_run_ids
+
+    with (
+        mitm_ctx(api_url="https://api.test"),
+        patch.object(
+            usage.webhook,
+            "enqueue_webhook_delivery",
+            side_effect=enqueue_timing_delivery,
+        ),
+    ):
+        for index in range(128):
+            observe_generated_response(codex_flow(f"run-completed-{index}"))
+
+        delivery_available = False
+        older_pending_flow = codex_flow("run-pending-older")
+        newer_pending_flow = codex_flow("run-pending-newer")
+        observe_generated_response(older_pending_flow)
+        observe_generated_response(newer_pending_flow)
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=2,
+            reports=0,
+            flush_request_id="before-pending-touch",
+        )
+
+        codex_output_timing.observe_server_event(older_pending_flow, "response.completed")
+
+        attempted_run_ids.clear()
+        admitted_run_ids.clear()
+        admission_results.extend((True, False))
+        assert retry_and_capture_visits() == ["run-pending-newer", "run-pending-older"]
+        assert attempted_run_ids == ["run-pending-newer", "run-pending-older"]
+        assert admitted_run_ids == ["run-pending-newer"]
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=0,
+            flush_request_id="after-saturated-retry",
+        )
+
+        attempted_run_ids.clear()
+        admission_results.append(True)
+        assert retry_and_capture_visits() == ["run-pending-older"]
+        assert attempted_run_ids == ["run-pending-older"]
+        assert admitted_run_ids == ["run-pending-newer", "run-pending-older"]
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-final-retry",
+        )
+
+        attempted_run_ids.clear()
+        assert retry_and_capture_visits() == []
+        assert attempted_run_ids == []
+        assert admitted_run_ids == ["run-pending-newer", "run-pending-older"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- index retry-eligible provider timing run IDs separately from retained LRU state
- preserve current LRU-derived retry order, stop-on-saturation behavior, and buffered-report lease ownership
- cover sparse pending retries across many completed runs, including recency changes, repeated retries, and duplicate prevention

## Scope

- no API, runner protocol, persisted state, database, configuration, or deployment-order changes
- completed provider timing state remains retained for first-milestone semantics

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6,674 passed)

Closes #29788
