### PR TITLE
refactor(runner): decouple local identity from config name

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -24,7 +24,7 @@ pub struct ConfigArgs {
     #[arg(long, required = true)]
     snapshot_hash: Vec<String>,
 
-    /// Runner logical name
+    /// Legacy release-shaped Runner name retained for compatibility
     #[arg(long)]
     name: String,
     /// Canonical physical hostname used for diagnostic attribution
@@ -138,7 +138,7 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
 
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);
     let runner_config = RunnerConfig {
-        name: args.name,
+        name: Some(args.name),
         hostname: args.hostname,
         group: args.group,
         base_dir: runner_dir.clone(),
@@ -463,6 +463,7 @@ mod tests {
         assert_eq!(profile.snapshot_hash, snapshot_hash);
         assert_eq!(profile.rootfs_disk_mb, 12288);
         assert_eq!(profile.workspace_disk_mb, 16384);
+        assert_eq!(runner_config.name.as_deref(), Some("test"));
         assert_eq!(runner_config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
     }
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -8,7 +8,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use crate::config::RunnerConfig;
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::live_runner_instances::LiveRunnerInstance;
 use crate::paths::HomePaths;
 use crate::process;
@@ -25,7 +25,7 @@ use reqwest::Client;
 /// CLI arguments for the `doctor` subcommand.
 #[derive(Args)]
 pub struct DoctorArgs {
-    /// Only check the runner with this name (matches config `name` field)
+    /// Only check the Runner service with this systemd unit suffix
     #[arg(long)]
     name: Option<String>,
 }
@@ -342,7 +342,6 @@ fn firecracker_found_for_sandbox(
 
 struct RunnerReport {
     live_runner: LiveRunnerInstance,
-    name: Option<String>,
     base_dir: Option<PathBuf>,
     pid: u32,
     config_path: PathBuf,
@@ -432,6 +431,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     // Phase 1: Discover running processes (single /proc scan)
     let discovered = process::discover_all().await;
     let home = HomePaths::new()?;
+    let config_path_filter = resolve_service_config_path(args.name.as_deref()).await?;
 
     // Phase 2: Discover installed services
     let installed_services = find_installed_services().await;
@@ -441,7 +441,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     let api_client = build_api_client();
     let mut reports = build_runner_reports(
         &live_runners,
-        args.name.as_deref(),
+        config_path_filter.as_deref(),
         api_client.as_ref(),
         &discovered,
         &installed_services,
@@ -449,7 +449,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     .await;
 
     // Phase 4: Find stopped services (installed but no matching running process)
-    // Skip when filtering by name — other runners' stopped services are irrelevant
+    // Skip when filtering by service — other runners' stopped services are irrelevant.
     let stopped = if args.name.is_none() {
         find_stopped_services(&installed_services, &reports)
     } else {
@@ -458,23 +458,20 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
 
     // Phase 5: Global orphan detection
     // When --name is set, run orphan firecracker detection scoped to that
-    // runner. Orphan mitmproxy and namespace are skipped (no
+    // service's selected Runner. Orphan mitmproxy and namespace are skipped (no
     // runner-identifying info on orphaned processes).
     let mut global_warnings: Vec<Warning> = if args.name.is_none() {
         detect_global_orphans(&reports, &discovered.firecrackers, &discovered.mitmdumps).await
     } else {
-        // Scoped detection: orphan firecracker for the named runner.
+        // Scoped detection: orphan firecracker for the selected service.
         // Orphan mitmproxy, namespace, and NBD devices are skipped because
         // they lack per-runner attribution — report them only in global mode
         // (no --name) so they don't cause unrelated runners to fail.
         let mut warnings = Vec::new();
 
         // Orphan firecracker: scope by base_dir match.
-        let named_base_dir = reports
-            .iter()
-            .find(|r| r.name.as_deref() == args.name.as_deref())
-            .and_then(|r| r.base_dir.clone());
-        if let Some(base_dir) = named_base_dir {
+        let selected_base_dir = reports.first().and_then(|r| r.base_dir.clone());
+        if let Some(base_dir) = selected_base_dir {
             let runner_pids: Vec<u32> = live_runners.iter().map(|runner| runner.pid).collect();
             warnings.extend(
                 detect_orphan_firecrackers(&discovered.firecrackers, &runner_pids, Some(&base_dir))
@@ -624,16 +621,14 @@ async fn recheck_current_runner_warnings(
 
 async fn build_runner_reports(
     live_runners: &[LiveRunnerInstance],
-    name_filter: Option<&str>,
+    config_path_filter: Option<&Path>,
     api_client: Option<&Client>,
     discovered: &process::DiscoveredProcesses,
     installed: &[InstalledService],
 ) -> Vec<RunnerReport> {
-    stream::iter(
-        live_runners
-            .iter()
-            .filter(|runner| name_filter.is_none_or(|name| runner.runner_name == name)),
-    )
+    stream::iter(live_runners.iter().filter(|runner| {
+        config_path_filter.is_none_or(|config_path| runner.config_path == config_path)
+    }))
     .map(|runner| {
         build_runner_report(
             runner,
@@ -665,7 +660,6 @@ async fn build_runner_report(
 
     // Load config (best-effort)
     let config = load_config_lenient(&runner.config_path).await;
-    let name = Some(runner.runner_name.clone());
 
     // Detect service type
     let service_type = detect_service_type(runner.pid, installed).await;
@@ -695,7 +689,6 @@ async fn build_runner_report(
 
     let mut report = RunnerReport {
         live_runner: runner.clone(),
-        name,
         base_dir: Some(runner.base_dir.clone()),
         pid: runner.pid,
         config_path: runner.config_path.clone(),
@@ -724,6 +717,22 @@ async fn build_runner_report(
     }
 
     report
+}
+
+async fn resolve_service_config_path(name: Option<&str>) -> RunnerResult<Option<PathBuf>> {
+    let Some(name) = name else {
+        return Ok(None);
+    };
+    let unit = super::service::RunnerServiceUnit::from_suffix(name)?;
+    let config_path = super::service::read_unit_config_path(&unit)
+        .await?
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "{} does not select a runner --config path",
+                unit.unit_name()
+            ))
+        })?;
+    Ok(Some(config_path))
 }
 
 fn build_status_diagnostics(
@@ -2474,7 +2483,6 @@ mod tests {
                 PathBuf::from("/data/active.yaml"),
                 PathBuf::from("/data/active"),
             ),
-            name: None,
             base_dir: None,
             pid: 1,
             config_path: PathBuf::from("/data/active.yaml"),
@@ -2493,17 +2501,13 @@ mod tests {
         assert_eq!(stopped[0].config_info, "/data/stopped.yaml");
     }
 
-    fn make_report(name: Option<&str>) -> RunnerReport {
+    fn make_report(label: &str) -> RunnerReport {
+        let config_path = PathBuf::from(format!("/data/{label}.yaml"));
         RunnerReport {
-            live_runner: live_runner_instance(
-                1,
-                PathBuf::from("/data/test.yaml"),
-                PathBuf::from("/data/test"),
-            ),
-            name: name.map(String::from),
+            live_runner: live_runner_instance(1, config_path.clone(), PathBuf::from("/data/test")),
             base_dir: None,
             pid: 1,
-            config_path: PathBuf::from("/data/test.yaml"),
+            config_path,
             subcommand: "start".into(),
             service_type: ServiceType::Bare,
             status: None,
@@ -2699,21 +2703,21 @@ mod tests {
         config_path: PathBuf,
         base_dir: PathBuf,
     ) -> LiveRunnerInstance {
-        live_runner_instance_named(pid, config_path, base_dir, "test-runner")
+        live_runner_instance_named(pid, config_path, base_dir, Some("test-runner"))
     }
 
     fn live_runner_instance_named(
         pid: u32,
         config_path: PathBuf,
         base_dir: PathBuf,
-        runner_name: &str,
+        runner_name: Option<&str>,
     ) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid,
             starttime: 0,
             config_path,
             base_dir,
-            runner_name: runner_name.into(),
+            runner_name: runner_name.map(String::from),
             runner_group: "vm0/test".into(),
             subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
@@ -2940,7 +2944,6 @@ mod tests {
         );
         let mut reports = vec![RunnerReport {
             live_runner: runner.clone(),
-            name: Some(runner.runner_name.clone()),
             base_dir: Some(base_dir.clone()),
             pid: runner.pid,
             config_path: runner.config_path.clone(),
@@ -2982,7 +2985,7 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("runner.yaml"),
                 base_dir: base_dir.clone(),
-                runner_name: "test-runner".into(),
+                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },
@@ -2997,7 +3000,6 @@ mod tests {
             .unwrap();
         let mut reports = vec![RunnerReport {
             live_runner: runner.clone(),
-            name: Some(runner.runner_name.clone()),
             base_dir: Some(base_dir.clone()),
             pid: runner.pid,
             config_path: runner.config_path.clone(),
@@ -3031,7 +3033,7 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("runner.yaml"),
                 base_dir: base_dir.clone(),
-                runner_name: "test-runner".into(),
+                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },
@@ -3052,7 +3054,6 @@ mod tests {
         .unwrap();
         let mut reports = vec![RunnerReport {
             live_runner: runner.clone(),
-            name: Some(runner.runner_name.clone()),
             base_dir: Some(base_dir.clone()),
             pid: runner.pid,
             config_path: runner.config_path.clone(),
@@ -3106,7 +3107,6 @@ mod tests {
 
         let report = build_runner_report(&runner, None, &[], &[], &[], &[]).await;
 
-        assert_eq!(report.name.as_deref(), Some("test-runner"));
         assert_eq!(report.base_dir.as_deref(), Some(base_dir.as_path()));
         assert_eq!(report.config_path, dir.path().join("missing-runner.yaml"));
         assert_eq!(report.pid, std::process::id());
@@ -3254,25 +3254,25 @@ mod tests {
                 u32::MAX - 3,
                 slow_fixture.config_path.clone(),
                 slow_fixture.base_dir.clone(),
-                "runner-a",
+                Some("runner-a"),
             ),
             live_runner_instance_named(
                 u32::MAX - 2,
                 fast_a_fixture.config_path.clone(),
                 fast_a_fixture.base_dir.clone(),
-                "runner-b",
+                Some("runner-b"),
             ),
             live_runner_instance_named(
                 u32::MAX - 1,
                 fast_b_fixture.config_path.clone(),
                 fast_b_fixture.base_dir.clone(),
-                "runner-c",
+                Some("runner-c"),
             ),
             live_runner_instance_named(
                 u32::MAX,
                 fast_c_fixture.config_path.clone(),
                 fast_c_fixture.base_dir.clone(),
-                "runner-d",
+                Some("runner-d"),
             ),
         ];
         let client = build_api_client();
@@ -3287,9 +3287,14 @@ mod tests {
         assert_eq!(
             reports
                 .iter()
-                .map(|report| report.name.as_deref().unwrap())
+                .map(|report| report.config_path.as_path())
                 .collect::<Vec<_>>(),
-            vec!["runner-a", "runner-b", "runner-c", "runner-d"]
+            vec![
+                slow_fixture.config_path.as_path(),
+                fast_a_fixture.config_path.as_path(),
+                fast_b_fixture.config_path.as_path(),
+                fast_c_fixture.config_path.as_path(),
+            ]
         );
         assert!(reports.iter().all(|report| report.api_ok == Some(true)));
         slow.assert_calls_async(1).await;
@@ -3299,7 +3304,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_runner_reports_filters_non_target_before_api_check() {
+    async fn build_runner_reports_filters_non_target_config_path_before_api_check() {
         let server = MockServer::start_async().await;
         let target_api = server
             .mock_async(|when, then| {
@@ -3322,6 +3327,19 @@ mod tests {
             None,
             Some((&target_url, "target-token")),
         );
+        let mut target_config: serde_yaml_ng::Value =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&target_fixture.config_path).unwrap())
+                .unwrap();
+        target_config
+            .as_mapping_mut()
+            .unwrap()
+            .remove(serde_yaml_ng::Value::String("name".into()))
+            .unwrap();
+        std::fs::write(
+            &target_fixture.config_path,
+            serde_yaml_ng::to_string(&target_config).unwrap(),
+        )
+        .unwrap();
         let other_fixture = doctor_report_fixture_for_runner(
             "other-runner",
             "running",
@@ -3334,20 +3352,20 @@ mod tests {
                 u32::MAX - 1,
                 other_fixture.config_path.clone(),
                 other_fixture.base_dir.clone(),
-                "other-runner",
+                Some("shared-legacy-name"),
             ),
             live_runner_instance_named(
                 u32::MAX,
                 target_fixture.config_path.clone(),
                 target_fixture.base_dir.clone(),
-                "target-runner",
+                None,
             ),
         ];
         let client = build_api_client();
 
         let reports = build_runner_reports(
             &runners,
-            Some("target-runner"),
+            Some(&target_fixture.config_path),
             client.as_ref(),
             &empty_discovered(),
             &[],
@@ -3355,7 +3373,7 @@ mod tests {
         .await;
 
         assert_eq!(reports.len(), 1);
-        assert_eq!(reports[0].name.as_deref(), Some("target-runner"));
+        assert_eq!(reports[0].config_path, target_fixture.config_path);
         target_api.assert_calls_async(1).await;
         other_api.assert_calls_async(0).await;
     }
@@ -3388,10 +3406,10 @@ mod tests {
             })
             .await;
         let mut reports = [
-            make_report(Some("runner-a")),
-            make_report(Some("runner-b")),
-            make_report(Some("runner-c")),
-            make_report(Some("runner-d")),
+            make_report("runner-a"),
+            make_report("runner-b"),
+            make_report("runner-c"),
+            make_report("runner-d"),
         ];
         for (report, path) in reports.iter_mut().zip(["/a", "/b", "/c", "/d"]) {
             report.warnings.push(Warning::ApiUnreachable {
@@ -3411,9 +3429,14 @@ mod tests {
         assert_eq!(
             reports
                 .iter()
-                .map(|report| report.name.as_deref().unwrap())
+                .map(|report| report.config_path.as_path())
                 .collect::<Vec<_>>(),
-            vec!["runner-a", "runner-b", "runner-c", "runner-d"]
+            vec![
+                Path::new("/data/runner-a.yaml"),
+                Path::new("/data/runner-b.yaml"),
+                Path::new("/data/runner-c.yaml"),
+                Path::new("/data/runner-d.yaml"),
+            ]
         );
         assert!(reports.iter().all(|report| report.warnings.is_empty()));
         api_a.assert_calls_async(1).await;

--- a/crates/runner/src/cmd/kill/target.rs
+++ b/crates/runner/src/cmd/kill/target.rs
@@ -369,7 +369,7 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("benchmark.yaml"),
                 base_dir: dir.path().join("benchmark-base"),
-                runner_name: "bench-runner".into(),
+                runner_name: Some("bench-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "benchmark".into(),
             },

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -572,11 +572,12 @@ async fn uninstall_with_ops(
 
 fn readiness_base_dir_from_live_instances(
     unit: &RunnerServiceUnit,
+    config_path: &Path,
     instances: &[LiveRunnerInstance],
 ) -> RunnerResult<Option<PathBuf>> {
     let matches = instances
         .iter()
-        .filter(|instance| instance.runner_name == unit.suffix() && instance.subcommand == "start")
+        .filter(|instance| instance.config_path == config_path && instance.subcommand == "start")
         .collect::<Vec<_>>();
 
     match matches.as_slice() {
@@ -591,10 +592,11 @@ fn readiness_base_dir_from_live_instances(
 
 async fn readiness_base_dir(
     unit: &RunnerServiceUnit,
+    config_path: &Path,
     home: &HomePaths,
 ) -> RunnerResult<Option<PathBuf>> {
     let instances = live_runner_instances::try_list(home).await?;
-    readiness_base_dir_from_live_instances(unit, &instances)
+    readiness_base_dir_from_live_instances(unit, config_path, &instances)
 }
 
 async fn wait_running(args: ServiceWaitRunningArgs) -> RunnerResult<()> {
@@ -605,6 +607,12 @@ async fn wait_running(args: ServiceWaitRunningArgs) -> RunnerResult<()> {
     }
 
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
+    let config_path = read_unit_config_path(&unit).await?.ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not select a runner --config path",
+            unit.unit_name()
+        ))
+    })?;
     let home = HomePaths::new()?;
     let deadline = TokioInstant::now() + TokioDuration::from_secs(args.timeout_secs);
     let mut last_observation = "not checked".to_string();
@@ -618,7 +626,7 @@ async fn wait_running(args: ServiceWaitRunningArgs) -> RunnerResult<()> {
             )));
         }
 
-        match readiness_base_dir(&unit, &home).await? {
+        match readiness_base_dir(&unit, &config_path, &home).await? {
             Some(base_dir) => match status_file::read_as::<StatusForReadiness>(&base_dir).await {
                 Ok(Some(status)) => match status.mode.as_str() {
                     "running" => {
@@ -1001,13 +1009,17 @@ profiles:
         }
     }
 
-    fn live_runner_instance(runner_name: &str, base_dir: PathBuf) -> LiveRunnerInstance {
+    fn live_runner_instance(
+        runner_name: Option<&str>,
+        config_path: PathBuf,
+        base_dir: PathBuf,
+    ) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid: 123,
             starttime: 456,
-            config_path: base_dir.join("runner.yaml"),
+            config_path,
             base_dir,
-            runner_name: runner_name.to_string(),
+            runner_name: runner_name.map(String::from),
             runner_group: "test/group".to_string(),
             subcommand: "start".to_string(),
             started_at: "2026-01-01T00:00:00.000Z".to_string(),
@@ -1075,18 +1087,28 @@ profiles:
     fn readiness_base_dir_waits_without_live_record() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
 
-        let base_dir = readiness_base_dir_from_live_instances(&unit, &[]).unwrap();
+        let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
+        let base_dir = readiness_base_dir_from_live_instances(&unit, &config_path, &[]).unwrap();
 
         assert_eq!(base_dir, None);
     }
 
     #[test]
-    fn readiness_base_dir_uses_live_record_for_nonstandard_runner_dirname() {
+    fn readiness_base_dir_uses_exact_config_path_during_release_overlap() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
         let actual_base_dir = PathBuf::from("/vm0-runner/runners/pr-123");
-        let instances = vec![live_runner_instance("pr-123-1", actual_base_dir.clone())];
+        let config_path = actual_base_dir.join("runner.yaml");
+        let instances = vec![
+            live_runner_instance(None, config_path.clone(), actual_base_dir.clone()),
+            live_runner_instance(
+                Some("pr-123-1"),
+                PathBuf::from("/vm0-runner/runners/other/runner.yaml"),
+                PathBuf::from("/vm0-runner/runners/other"),
+            ),
+        ];
 
-        let base_dir = readiness_base_dir_from_live_instances(&unit, &instances).unwrap();
+        let base_dir =
+            readiness_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap();
 
         assert_eq!(base_dir, Some(actual_base_dir));
     }
@@ -1094,12 +1116,22 @@ profiles:
     #[test]
     fn readiness_base_dir_rejects_duplicate_live_records() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
+        let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
         let instances = vec![
-            live_runner_instance("pr-123-1", PathBuf::from("/vm0-runner/runners/pr-123")),
-            live_runner_instance("pr-123-1", PathBuf::from("/vm0-runner/runners/other")),
+            live_runner_instance(
+                Some("legacy-a"),
+                config_path.clone(),
+                PathBuf::from("/vm0-runner/runners/pr-123"),
+            ),
+            live_runner_instance(
+                Some("legacy-b"),
+                config_path.clone(),
+                PathBuf::from("/vm0-runner/runners/other"),
+            ),
         ];
 
-        let error = readiness_base_dir_from_live_instances(&unit, &instances).unwrap_err();
+        let error =
+            readiness_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap_err();
 
         assert!(
             error.to_string().contains("multiple live runner instance"),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -487,7 +487,7 @@ async fn run_start_with_home(
     let runner_identity = load_runner_process_identity(&runner_config.base_dir).await?;
     info!(
         runner_id = %runner_identity.runner_id(),
-        runner_name = %runner_config.name,
+        runner_release = crate::RUNNER_RELEASE,
         "runner identity"
     );
 
@@ -518,7 +518,7 @@ async fn run_start_with_home(
         client_session_id: runner_client_session_id.clone(),
     })?;
     let background_fill = crate::storage_cache::StorageCacheBackgroundFillCoordinator::new()?;
-    let name = runner_config.name;
+    let legacy_name = runner_config.name;
     let hostname = runner_config.hostname;
     let group = runner_config.group;
     let cancel_tokens = RunCancellationRegistry::new();
@@ -831,7 +831,7 @@ async fn run_start_with_home(
     let live_runner_instance_metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: registry_config_path,
         base_dir: base_dir_canonical.clone(),
-        runner_name: name.clone(),
+        runner_name: legacy_name,
         runner_group: group_name.clone(),
         subcommand: "start".into(),
     };
@@ -857,7 +857,6 @@ async fn run_start_with_home(
     let config = RunConfig {
         runner: RunnerInfo {
             identity: runner_identity,
-            name,
             group: group_name,
             profiles: runner_config.profiles,
         },
@@ -942,7 +941,6 @@ struct RunConfig {
 
 struct RunnerInfo {
     identity: RunnerProcessIdentity,
-    name: String,
     group: String,
     profiles: BTreeMap<String, ProfileConfig>,
 }
@@ -1631,7 +1629,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     if startup_mode == RunnerMode::Running {
         info!(
-            name = %runner.name,
+            runner_release = crate::RUNNER_RELEASE,
             group = %runner.group,
             effective_vcpu = capacity.budget.effective_vcpu(),
             effective_memory_mb = capacity.budget.effective_memory_mb(),
@@ -1640,7 +1638,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         );
     } else {
         info!(
-            name = %runner.name,
+            runner_release = crate::RUNNER_RELEASE,
             group = %runner.group,
             mode = ?startup_mode,
             "runner startup completed after lifecycle signal"

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -220,7 +220,7 @@ done
     let metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: dir.path().join("runner.yaml"),
         base_dir: dir.path().join("base"),
-        runner_name: "test-runner".into(),
+        runner_name: Some("test-runner".into()),
         runner_group: "vm0/test".into(),
         subcommand: "start".into(),
     };
@@ -488,7 +488,7 @@ async fn factory_startup_failure_stops_status_and_cleans_startup_resources() {
 }
 
 #[tokio::test]
-async fn local_provider_setup_failure_does_not_create_runtime() {
+async fn nameless_config_reaches_local_provider_setup_before_runtime() {
     const ROOTFS_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const SNAPSHOT_HASH: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
@@ -531,7 +531,6 @@ async fn local_provider_setup_failure_does_not_create_runtime() {
         &config_path,
         format!(
             r#"
-name: test
 group: test/group
 base_dir: {base_dir}
 ca_dir: {ca_dir}

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -208,7 +208,6 @@ fn build_mock_run_config_with_runtime(
     let config = RunConfig {
         runner: RunnerInfo {
             identity: test_runner_identity(),
-            name: "test".into(),
             group: "test-group".into(),
             profiles,
         },

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -72,9 +72,10 @@ pub(crate) const DIAGNOSTIC_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 /// are resolved against the YAML file's parent directory during [`load`].
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunnerConfig {
-    /// Human-readable identifier for this runner instance, surfaced in logs
-    /// and reported to the control plane alongside `group`.
-    pub name: String,
+    /// Legacy release-shaped identifier retained during the local identity
+    /// compatibility window. Current runtime selection must not depend on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     /// Canonical physical host identity used only for diagnostic attribution.
     /// The raw configured value is preserved and never used for scheduling,
     /// authorization, targeting, or ownership.

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -331,7 +331,7 @@ server:
     );
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
-    assert_eq!(config.name, "test-runner");
+    assert_eq!(config.name.as_deref(), Some("test-runner"));
     assert_eq!(config.hostname, None);
     assert_eq!(config.profiles.len(), 1);
     let default = &config.profiles["vm0/default"];
@@ -353,6 +353,19 @@ async fn load_preserves_optional_hostname() {
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
 
+    assert_eq!(config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
+}
+
+#[tokio::test]
+async fn load_accepts_missing_legacy_name() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture
+        .yaml_with_default_profile("hostname: prod-1.aws.vm3.ai\n")
+        .replacen("name: test\n", "", 1);
+
+    let config = fixture.load_config(&yaml, true).await.unwrap();
+
+    assert_eq!(config.name, None);
     assert_eq!(config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
 }
 
@@ -1139,7 +1152,7 @@ async fn generate_then_load_round_trip() {
     let fixture = ConfigFixture::new().await;
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
-        name: "test-runner".into(),
+        name: Some("test-runner".into()),
         hostname: Some("prod-1.aws.vm3.ai".into()),
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
@@ -1199,7 +1212,7 @@ async fn generate_tightens_existing_runner_dir_and_config_file() {
     std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
     let config = RunnerConfig {
-        name: "test-runner".into(),
+        name: Some("test-runner".into()),
         hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
@@ -1278,7 +1291,7 @@ fn factory_config_resolves_paths() {
     let home = HomePaths::with_root(dir.path().to_path_buf());
 
     let config = RunnerConfig {
-        name: "test".into(),
+        name: Some("test".into()),
         hostname: None,
         group: "test/group".into(),
         base_dir: dir.path().join("runner"),
@@ -1311,7 +1324,7 @@ async fn idle_pool_config_round_trip() {
     let fixture = ConfigFixture::new().await;
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
-        name: "test-runner".into(),
+        name: Some("test-runner".into()),
         hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -16,7 +16,8 @@ const LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES: u64 = 64 * 1024;
 pub(crate) struct LiveRunnerInstanceMetadata {
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
-    pub runner_name: String,
+    /// Legacy release-shaped compatibility metadata.
+    pub runner_name: Option<String>,
     pub runner_group: String,
     pub subcommand: String,
 }
@@ -33,7 +34,8 @@ pub(crate) struct LiveRunnerInstance {
     pub starttime: u64,
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
-    pub runner_name: String,
+    /// Legacy release-shaped compatibility metadata.
+    pub runner_name: Option<String>,
     pub runner_group: String,
     pub subcommand: String,
     pub started_at: String,
@@ -88,7 +90,8 @@ struct LiveRunnerInstanceRecord {
     euid: u32,
     config_path: PathBuf,
     base_dir: PathBuf,
-    runner_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    runner_name: Option<String>,
     runner_group: String,
     subcommand: String,
     started_at: String,
@@ -217,10 +220,10 @@ async fn try_list_with_liveness(
     }
 
     instances.sort_by(|left, right| {
-        left.runner_name
-            .cmp(&right.runner_name)
+        left.config_path
+            .cmp(&right.config_path)
             .then_with(|| left.pid.cmp(&right.pid))
-            .then_with(|| left.config_path.cmp(&right.config_path))
+            .then_with(|| left.starttime.cmp(&right.starttime))
     });
     Ok(instances)
 }
@@ -274,7 +277,6 @@ pub(crate) async fn is_current(
     };
     Ok(record.config_path == instance.config_path
         && record.base_dir == instance.base_dir
-        && record.runner_name == instance.runner_name
         && record.runner_group == instance.runner_group
         && record.subcommand == instance.subcommand
         && record.started_at == instance.started_at)
@@ -851,7 +853,7 @@ mod tests {
             LiveRunnerInstanceMetadata {
                 config_path: self.root().join("runner.yaml"),
                 base_dir: self.root().join("base"),
-                runner_name: "test-runner".into(),
+                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             }
@@ -874,7 +876,7 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("stale-runner.yaml"),
                 base_dir: self.root().join("stale-base"),
-                runner_name: "stale-runner".into(),
+                runner_name: Some("stale-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -893,7 +895,7 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("other-runner.yaml"),
                 base_dir: self.root().join("other-base"),
-                runner_name: "other-runner".into(),
+                runner_name: Some("other-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -908,7 +910,7 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("procfs-runner.yaml"),
                 base_dir: self.root().join("procfs-base"),
-                runner_name: "procfs-runner".into(),
+                runner_name: Some("procfs-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -954,6 +956,16 @@ mod tests {
         serde_json::to_vec_pretty(&value).unwrap()
     }
 
+    fn serialize_record_without_runner_name(record: &LiveRunnerInstanceRecord) -> Vec<u8> {
+        let mut value = serde_json::to_value(record).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("runner_name")
+            .unwrap();
+        serde_json::to_vec_pretty(&value).unwrap()
+    }
+
     #[tokio::test]
     async fn publish_writes_private_record_without_secret_fields() {
         let registry = TestRegistry::new();
@@ -968,6 +980,13 @@ mod tests {
         assert_eq!(record.pid, std::process::id());
         assert_eq!(record.euid, current_euid());
         assert_eq!(record.base_dir, registry.root().join("base"));
+
+        #[derive(Deserialize)]
+        struct LegacyRecord {
+            runner_name: String,
+        }
+        let legacy_record: LegacyRecord = serde_json::from_str(&content).unwrap();
+        assert_eq!(legacy_record.runner_name, "test-runner");
 
         #[cfg(unix)]
         {
@@ -1047,10 +1066,42 @@ mod tests {
         assert_eq!(instance.starttime, handle.identity.starttime);
         assert_eq!(instance.config_path, registry.root().join("runner.yaml"));
         assert_eq!(instance.base_dir, registry.root().join("base"));
-        assert_eq!(instance.runner_name, "test-runner");
+        assert_eq!(instance.runner_name.as_deref(), Some("test-runner"));
         assert_eq!(instance.runner_group, "vm0/test");
         assert_eq!(instance.subcommand, "start");
         assert!(!instance.started_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn try_list_accepts_record_without_legacy_runner_name() {
+        let registry = TestRegistry::new();
+        let handle = publish(&registry.home, registry.metadata()).await.unwrap();
+        let record = read_valid_record(&handle.path).await.unwrap();
+        crate::state_file::write_private_atomic(
+            &handle.path,
+            &serialize_record_without_runner_name(&record),
+        )
+        .await
+        .unwrap();
+
+        let instances = try_list(&registry.home).await.unwrap();
+
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].runner_name, None);
+    }
+
+    #[tokio::test]
+    async fn publish_omits_absent_legacy_runner_name() {
+        let registry = TestRegistry::new();
+        let mut metadata = registry.metadata();
+        metadata.runner_name = None;
+
+        let handle = publish(&registry.home, metadata).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&handle.path).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(value.get("runner_name").is_none());
+        assert_eq!(try_list(&registry.home).await.unwrap()[0].runner_name, None);
     }
 
     #[cfg(unix)]
@@ -1070,9 +1121,12 @@ mod tests {
         assert_eq!(
             instances
                 .iter()
-                .map(|instance| instance.runner_name.as_str())
+                .map(|instance| instance.config_path.clone())
                 .collect::<Vec<_>>(),
-            ["other-runner", "test-runner"]
+            [
+                registry.root().join("other-runner.yaml"),
+                registry.root().join("runner.yaml"),
+            ]
         );
     }
 
@@ -1228,6 +1282,12 @@ mod tests {
             .into_iter()
             .next()
             .unwrap();
+
+        assert!(is_current(&registry.home, &instance).await.unwrap());
+
+        let mut record = read_valid_record(&handle.path).await.unwrap();
+        record.runner_name = None;
+        write_record(&handle.path, &record).await;
 
         assert!(is_current(&registry.home, &instance).await.unwrap());
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -164,38 +164,7 @@ enum Command {
     Local(cmd::LocalArgs),
 }
 
-/// Extract the runner `name` field from a runner config YAML.
-///
-/// Called before tracing is initialized, so warnings go to stderr directly.
-/// The returned value is sanitized to contain only `[a-zA-Z0-9_-]` characters
-/// so it is safe for use as a log file prefix.
-fn runner_name_from_config(path: &Path) -> String {
-    #[derive(serde::Deserialize)]
-    struct Partial {
-        name: String,
-    }
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!(
-                "warn: could not read config for runner name: {}: {e}",
-                path.display()
-            );
-            return "default".into();
-        }
-    };
-    let raw = match serde_yaml_ng::from_str::<Partial>(&content) {
-        Ok(p) => p.name,
-        Err(e) => {
-            eprintln!(
-                "warn: could not parse runner name from {}: {e}",
-                path.display()
-            );
-            return "default".into();
-        }
-    };
-    sanitize_name(&raw)
-}
+const RUNNER_RELEASE: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 
 /// Read the optional canonical hostname before tracing starts.
 ///
@@ -216,24 +185,8 @@ fn runner_hostname_from_config(path: &Path) -> Option<String> {
     Some(hostname)
 }
 
-/// Replace non-`[a-zA-Z0-9_-]` characters with `-`.
-/// Returns `"default"` if the result is empty.
-fn sanitize_name(raw: &str) -> String {
-    let sanitized: String = raw
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    if sanitized.is_empty() {
-        "default".into()
-    } else {
-        sanitized
-    }
+fn runner_log_prefix(release: &str) -> String {
+    format!("runner-{release}")
 }
 
 /// Initialize tracing with a tee writer (stderr + rolling log file) plus an
@@ -242,15 +195,13 @@ fn sanitize_name(raw: &str) -> String {
 /// Returns the [`tracing_appender::non_blocking::WorkerGuard`] that must be
 /// held alive until the process exits so buffered logs are flushed.
 fn init_tracing_with_file(
-    config_path: &Path,
     axiom_layer: Option<axiom_layer::AxiomLayer>,
 ) -> Result<tracing_appender::non_blocking::WorkerGuard, Box<dyn std::error::Error>> {
     let home = paths::HomePaths::new()?;
     let log_dir = home.logs_dir();
     log_file::ensure_log_dir(&log_dir).map_err(|e| format!("create {}: {e}", log_dir.display()))?;
 
-    let name = runner_name_from_config(config_path);
-    let prefix = format!("runner-{name}");
+    let prefix = runner_log_prefix(RUNNER_RELEASE);
 
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -326,7 +277,7 @@ async fn main() -> ExitCode {
 
     let was_enabled = axiom_layer.is_some();
     let (_guard, axiom_installed) = match &cli.command {
-        Command::Start(args) => match init_tracing_with_file(&args.config, axiom_layer) {
+        Command::Start(_) => match init_tracing_with_file(axiom_layer) {
             Ok(guard) => (Some(guard), was_enabled),
             Err(e) => {
                 // The failed `init_tracing_with_file` already consumed `axiom_layer`,
@@ -593,36 +544,9 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_name_passthrough() {
-        assert_eq!(sanitize_name("my-runner_01"), "my-runner_01");
-    }
-
-    #[test]
-    fn sanitize_name_replaces_slashes() {
-        assert_eq!(sanitize_name("foo/bar"), "foo-bar");
-    }
-
-    #[test]
-    fn sanitize_name_replaces_path_traversal() {
-        assert_eq!(sanitize_name("../../etc/passwd"), "------etc-passwd");
-    }
-
-    #[test]
-    fn sanitize_name_replaces_non_ascii() {
-        assert_eq!(sanitize_name("runner-日本語"), "runner----");
-    }
-
-    #[test]
-    fn sanitize_name_empty_returns_default() {
-        assert_eq!(sanitize_name(""), "default");
-    }
-
-    #[test]
-    fn runner_name_missing_file_returns_default() {
-        assert_eq!(
-            runner_name_from_config(Path::new("/nonexistent.yaml")),
-            "default"
-        );
+    fn runner_log_prefix_uses_explicit_release_identity() {
+        assert_eq!(runner_log_prefix("v1.2.3"), "runner-v1.2.3");
+        assert_ne!(runner_log_prefix("v1.2.3"), runner_log_prefix("v1.2.4"));
     }
 
     #[test]

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -172,7 +172,7 @@ mod tests {
             starttime: 1,
             config_path: base_dir.join("runner.yaml"),
             base_dir: base_dir.to_path_buf(),
-            runner_name: "test-runner".into(),
+            runner_name: Some("test-runner".into()),
             runner_group: "vm0/test".into(),
             subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
@@ -373,7 +373,7 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: base.join("runner.yaml"),
                 base_dir: base,
-                runner_name: "test-runner".into(),
+                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -13,13 +13,21 @@ the raw value. Existing configuration files without `hostname` continue to
 load and omit the canonical hostname fields.
 
 Hostname does not select a service, directory, release, or rollback target.
-Those lifecycle identities continue to use the version-shaped `name`, such as
-`v0.174.0`. Current Runner binaries send optional canonical `runnerHostname`
-from configuration and canonical `runnerVersion` compiled into the binary. They
-no longer send legacy `runnerName` in heartbeats or sandbox telemetry. Current
-API revisions no longer declare, persist, or map that field. During deployment
-overlap, an extra `runnerName` from an older Runner payload is tolerated but
-discarded before request handling.
+Systemd suffixes and versioned binary/Runner directories remain explicit
+release lifecycle identities. Live processes are selected by their exact
+config path and process identity, and rolling log files use the release
+compiled into the Runner binary. Current Runner binaries send optional
+canonical `runnerHostname` from configuration and canonical `runnerVersion`
+compiled into the binary. They no longer send legacy `runnerName` in
+heartbeats or sandbox telemetry. Current API revisions no longer declare,
+persist, or map that field. During deployment overlap, an extra `runnerName`
+from an older Runner payload is tolerated but discarded before request
+handling.
+
+The version-shaped YAML `name` remains an optional local compatibility field
+while retained Runner binaries and operator automation still require it.
+Current production configuration continues writing it, but current runtime,
+readiness, and doctor selection do not use it as process identity.
 
 Operational queries and alerts should use `runner_hostname` and
 `runner_version`. A bounded historical fallback may use `runner_name` only for


### PR DESCRIPTION
## Summary

- make the Runner config `name` an optional legacy compatibility field while keeping current config generation unchanged
- select live Runner processes for service readiness and scoped doctor checks by the exact config path selected by systemd
- name rolling logs from the release compiled into the Runner binary and keep live-record reads compatible with records that include or omit `runner_name`

## Explicit exclusions

- do not remove `runner config --name` or stop production automation from writing version-shaped names; that cleanup remains in #29772
- do not change the Ansible version-shaped build, promote, or rollback lifecycle

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p runner --no-deps`
- `cd crates && cargo test -p runner --quiet`
- `.github/scripts/tests/runner-attribution-ansible-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`
- `git diff --check`
- verified `git diff --quiet -- ansible`

Closes #29534

Parent delivery issue: #29497

Follow-up cleanup: #29772
