### PR TITLE
feat(platform): make non-settings connector mutations account-explicit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -658,9 +658,14 @@ describe("GET /api/connector-catalog", () => {
 
   it("returns connected manual grant status from public API-created state", async () => {
     const actor = bdd.user();
-    await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
-      apiKey: "sk-public-status",
-    });
+    const connection = await connectorsApi.connectManualGrant(
+      actor,
+      "openai",
+      "api-token",
+      {
+        apiKey: "sk-public-status",
+      },
+    );
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
@@ -684,6 +689,7 @@ describe("GET /api/connector-catalog", () => {
       tokenExpiresAt: null,
     });
     expect(openai?.connection).toStrictEqual({
+      id: connection.id,
       authMethod: "api-token",
       externalUsername: null,
       externalEmail: null,
@@ -848,9 +854,14 @@ describe("GET /api/connector-catalog", () => {
 
   it("returns exact connector metadata with the current connection status", async () => {
     const actor = bdd.user();
-    await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
-      apiKey: "sk-public-detail-status",
-    });
+    const connection = await connectorsApi.connectManualGrant(
+      actor,
+      "openai",
+      "api-token",
+      {
+        apiKey: "sk-public-detail-status",
+      },
+    );
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
@@ -870,6 +881,7 @@ describe("GET /api/connector-catalog", () => {
       connected: true,
       connectionStatus: "connected",
       connection: {
+        id: connection.id,
         authMethod: "api-token",
         externalUsername: null,
         externalEmail: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2048,7 +2048,11 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     });
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
-    ).resolves.toMatchObject({ connected: true });
+    ).resolves.toMatchObject({
+      connected: true,
+      connectedAccountId: connected.connectedAccountId,
+      connectedAccountUpdatedAt: expect.any(String),
+    });
 
     const parent = await readCustomConnectorCredentialStorageParent(context, {
       orgId: admin.orgId ?? "",

--- a/turbo/apps/api/src/signals/routes/custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-create.ts
@@ -46,7 +46,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     body: serialiseCustomConnector({
       row: result,
       valueMarkers: [],
-      connectedConnection: false,
+      connectedAccountId: null,
     }),
   };
 });

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -821,6 +821,7 @@ function connectionForCatalogStatus(
     return null;
   }
   return {
+    id: connector.id,
     authMethod: connector.authMethod,
     externalUsername: connector.externalUsername,
     externalEmail: connector.externalEmail,

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -88,6 +88,11 @@ interface ConnectedCustomConnectorConnection {
   readonly storageVersion: number;
 }
 
+interface ConnectedCustomConnectorAccount {
+  readonly id: string;
+  readonly updatedAt: Date;
+}
+
 export type CustomConnectorCredentialAccess =
   | { readonly kind: "absent" }
   | {
@@ -633,30 +638,18 @@ export async function loadConnectedCustomConnectorConnections(
   return connectedConnections;
 }
 
-export function customConnectorDefinitionConnectedAccountId(args: {
+export function customConnectorDefinitionConnectedAccount(args: {
   readonly connectedConnections: ReadonlyMap<
     string,
     ConnectedCustomConnectorConnection
   >;
   readonly definition: CustomConnectorCredentialDefinition;
-}): string | null {
+}): ConnectedCustomConnectorAccount | null {
   const connection = args.connectedConnections.get(args.definition.id);
   const current =
     connection?.authMode === args.definition.authMode &&
     connection.storageVersion === args.definition.storageVersion;
-  return current ? connection.id : null;
-}
-
-export function customConnectorDefinitionConnectedAccountUpdatedAt(args: {
-  readonly connectedConnections: ReadonlyMap<
-    string,
-    ConnectedCustomConnectorConnection
-  >;
-  readonly definition: CustomConnectorCredentialDefinition;
-}): Date | null {
-  const connection = args.connectedConnections.get(args.definition.id);
-  const current =
-    connection?.authMode === args.definition.authMode &&
-    connection.storageVersion === args.definition.storageVersion;
-  return current ? connection.updatedAt : null;
+  return current
+    ? { id: connection.id, updatedAt: connection.updatedAt }
+    : null;
 }

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -69,6 +69,7 @@ interface CustomConnectorCredentialDefinition {
 
 interface CustomConnectorStoredConnection {
   readonly id: string;
+  readonly updatedAt: Date;
   readonly customConnectorId: string;
   readonly storedAuthMethod: string;
   readonly storedStorageVersion: number;
@@ -81,6 +82,8 @@ interface CustomConnectorStoredConnection {
 }
 
 interface ConnectedCustomConnectorConnection {
+  readonly id: string;
+  readonly updatedAt: Date;
   readonly authMode: OrgCustomConnectorAuthMode;
   readonly storageVersion: number;
 }
@@ -129,6 +132,7 @@ function customConnectorStoredConnectionsQuery(
       id: sql`${connectors.id}`
         .mapWith(connectors.id)
         .as("member_connector_id"),
+      updatedAt: connectors.updatedAt,
       customConnectorId: sql`${orgCustomConnectors.id}`
         .mapWith(orgCustomConnectors.id)
         .as("custom_connector_id"),
@@ -573,6 +577,7 @@ export async function loadCurrentCustomConnectorStoredValues(
     .with(storedConnections, storedValues)
     .select({
       id: storedConnections.id,
+      updatedAt: storedConnections.updatedAt,
       customConnectorId: storedConnections.customConnectorId,
       storedAuthMethod: storedConnections.storedAuthMethod,
       storedStorageVersion: storedConnections.storedStorageVersion,
@@ -618,6 +623,8 @@ export async function loadConnectedCustomConnectorConnections(
   for (const row of rows) {
     if (customConnectorStoredConnectionIsConnected(row, now)) {
       connectedConnections.set(row.customConnectorId, {
+        id: row.id,
+        updatedAt: row.updatedAt,
         authMode: row.definitionAuthMethod,
         storageVersion: row.definitionStorageVersion,
       });
@@ -626,16 +633,30 @@ export async function loadConnectedCustomConnectorConnections(
   return connectedConnections;
 }
 
-export function customConnectorDefinitionHasConnectedConnection(args: {
+export function customConnectorDefinitionConnectedAccountId(args: {
   readonly connectedConnections: ReadonlyMap<
     string,
     ConnectedCustomConnectorConnection
   >;
   readonly definition: CustomConnectorCredentialDefinition;
-}): boolean {
+}): string | null {
   const connection = args.connectedConnections.get(args.definition.id);
-  return (
+  const current =
     connection?.authMode === args.definition.authMode &&
-    connection.storageVersion === args.definition.storageVersion
-  );
+    connection.storageVersion === args.definition.storageVersion;
+  return current ? connection.id : null;
+}
+
+export function customConnectorDefinitionConnectedAccountUpdatedAt(args: {
+  readonly connectedConnections: ReadonlyMap<
+    string,
+    ConnectedCustomConnectorConnection
+  >;
+  readonly definition: CustomConnectorCredentialDefinition;
+}): Date | null {
+  const connection = args.connectedConnections.get(args.definition.id);
+  const current =
+    connection?.authMode === args.definition.authMode &&
+    connection.storageVersion === args.definition.storageVersion;
+  return current ? connection.updatedAt : null;
 }

--- a/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
@@ -11,7 +11,8 @@ import {
 } from "./custom-connector.service";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionHasConnectedConnection,
+  customConnectorDefinitionConnectedAccountId,
+  customConnectorDefinitionConnectedAccountUpdatedAt,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
@@ -48,10 +49,15 @@ export function customConnectorList(args: {
       return serialiseCustomConnector({
         row: normaliseCustomConnectorRow(row.connector, row.oauthConfig),
         valueMarkers: markers,
-        connectedConnection: customConnectorDefinitionHasConnectedConnection({
+        connectedAccountId: customConnectorDefinitionConnectedAccountId({
           connectedConnections,
           definition: row.connector,
         }),
+        connectedAccountUpdatedAt:
+          customConnectorDefinitionConnectedAccountUpdatedAt({
+            connectedConnections,
+            definition: row.connector,
+          }),
       });
     });
   });

--- a/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
@@ -11,8 +11,7 @@ import {
 } from "./custom-connector.service";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionConnectedAccountId,
-  customConnectorDefinitionConnectedAccountUpdatedAt,
+  customConnectorDefinitionConnectedAccount,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
@@ -46,18 +45,15 @@ export function customConnectorList(args: {
       loadConnectedCustomConnectorConnections(db, args),
     ]);
     return connectorRows.map((row) => {
+      const connectedAccount = customConnectorDefinitionConnectedAccount({
+        connectedConnections,
+        definition: row.connector,
+      });
       return serialiseCustomConnector({
         row: normaliseCustomConnectorRow(row.connector, row.oauthConfig),
         valueMarkers: markers,
-        connectedAccountId: customConnectorDefinitionConnectedAccountId({
-          connectedConnections,
-          definition: row.connector,
-        }),
-        connectedAccountUpdatedAt:
-          customConnectorDefinitionConnectedAccountUpdatedAt({
-            connectedConnections,
-            definition: row.connector,
-          }),
+        connectedAccountId: connectedAccount?.id ?? null,
+        connectedAccountUpdatedAt: connectedAccount?.updatedAt,
       });
     });
   });

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -60,7 +60,8 @@ import {
 import { deleteConnectorSelectionsForCustomConnectorDefinition } from "./connector-credential-storage-write.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
-  customConnectorDefinitionHasConnectedConnection,
+  customConnectorDefinitionConnectedAccountId,
+  customConnectorDefinitionConnectedAccountUpdatedAt,
   loadCurrentCustomConnectorStoredValues,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
@@ -731,7 +732,8 @@ function effectivePermissionBundleRef(
 export function serialiseCustomConnector(args: {
   readonly row: CustomConnectorRow;
   readonly valueMarkers: readonly CustomConnectorCredentialValueMarker[];
-  readonly connectedConnection: boolean;
+  readonly connectedAccountId: string | null;
+  readonly connectedAccountUpdatedAt?: Date | null;
 }): CustomConnectorResponse {
   const connectorMarkers = args.valueMarkers.filter((marker) => {
     return (
@@ -752,12 +754,12 @@ export function serialiseCustomConnector(args: {
     args.row.authMode !== "manual" ||
     customConnectorManualAuthReferencesMemberField(args.row);
   const connected =
-    args.connectedConnection &&
+    args.connectedAccountId !== null &&
     validManualAuth &&
     missingRequiredFields.length === 0;
   const responseMissingRequiredFields = [
     ...missingRequiredFields,
-    ...(args.row.authMode === "oauth" && !args.connectedConnection
+    ...(args.row.authMode === "oauth" && args.connectedAccountId === null
       ? ["oauth"]
       : []),
   ];
@@ -775,6 +777,17 @@ export function serialiseCustomConnector(args: {
     skillMarkdown: args.row.skillMarkdown,
     storageVersion: args.row.storageVersion,
     connected,
+    ...(connected && args.connectedAccountId
+      ? {
+          connectedAccountId: args.connectedAccountId,
+          ...(args.connectedAccountUpdatedAt
+            ? {
+                connectedAccountUpdatedAt:
+                  args.connectedAccountUpdatedAt.toISOString(),
+              }
+            : {}),
+        }
+      : {}),
     missingRequiredFields: [...responseMissingRequiredFields],
     configuredFieldKeys: [...configured],
     createdAt: args.row.createdAt.toISOString(),
@@ -2492,10 +2505,15 @@ export function getCustomConnectorResponse(args: {
     return serialiseCustomConnector({
       row: connector,
       valueMarkers: markers,
-      connectedConnection: customConnectorDefinitionHasConnectedConnection({
+      connectedAccountId: customConnectorDefinitionConnectedAccountId({
         connectedConnections,
         definition: connector,
       }),
+      connectedAccountUpdatedAt:
+        customConnectorDefinitionConnectedAccountUpdatedAt({
+          connectedConnections,
+          definition: connector,
+        }),
     });
   });
 }
@@ -2964,7 +2982,7 @@ export const setCustomConnectorValues$ = command(
       ...serialiseCustomConnector({
         row: writeResult.connector,
         valueMarkers: markers,
-        connectedConnection: writeResult.connectedConnection,
+        connectedAccountId: writeResult.connectedAccountId,
       }),
       connectedAccountId: writeResult.connectedAccountId,
     };

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -60,8 +60,7 @@ import {
 import { deleteConnectorSelectionsForCustomConnectorDefinition } from "./connector-credential-storage-write.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
-  customConnectorDefinitionConnectedAccountId,
-  customConnectorDefinitionConnectedAccountUpdatedAt,
+  customConnectorDefinitionConnectedAccount,
   loadCurrentCustomConnectorStoredValues,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
@@ -2502,18 +2501,15 @@ export function getCustomConnectorResponse(args: {
         userId: args.userId,
       }),
     ]);
+    const connectedAccount = customConnectorDefinitionConnectedAccount({
+      connectedConnections,
+      definition: connector,
+    });
     return serialiseCustomConnector({
       row: connector,
       valueMarkers: markers,
-      connectedAccountId: customConnectorDefinitionConnectedAccountId({
-        connectedConnections,
-        definition: connector,
-      }),
-      connectedAccountUpdatedAt:
-        customConnectorDefinitionConnectedAccountUpdatedAt({
-          connectedConnections,
-          definition: connector,
-        }),
+      connectedAccountId: connectedAccount?.id ?? null,
+      connectedAccountUpdatedAt: connectedAccount?.updatedAt,
     });
   });
 }

--- a/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
@@ -11,7 +11,8 @@ import { and, eq } from "drizzle-orm";
 import { db$ } from "../external/db";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionHasConnectedConnection,
+  customConnectorDefinitionConnectedAccountId,
+  customConnectorDefinitionConnectedAccountUpdatedAt,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
@@ -84,10 +85,15 @@ export function runMcpConnectorList(args: {
       const response = serialiseCustomConnector({
         row: normaliseCustomConnectorRow(connector),
         valueMarkers,
-        connectedConnection: customConnectorDefinitionHasConnectedConnection({
+        connectedAccountId: customConnectorDefinitionConnectedAccountId({
           connectedConnections,
           definition: connector,
         }),
+        connectedAccountUpdatedAt:
+          customConnectorDefinitionConnectedAccountUpdatedAt({
+            connectedConnections,
+            definition: connector,
+          }),
       });
       if (response.kind !== "mcp") {
         throw new Error("Run MCP connector query returned a non-MCP connector");

--- a/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
@@ -11,8 +11,7 @@ import { and, eq } from "drizzle-orm";
 import { db$ } from "../external/db";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionConnectedAccountId,
-  customConnectorDefinitionConnectedAccountUpdatedAt,
+  customConnectorDefinitionConnectedAccount,
   loadCurrentCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
@@ -82,18 +81,15 @@ export function runMcpConnectorList(args: {
     ]);
 
     return rows.map(({ connector }) => {
+      const connectedAccount = customConnectorDefinitionConnectedAccount({
+        connectedConnections,
+        definition: connector,
+      });
       const response = serialiseCustomConnector({
         row: normaliseCustomConnectorRow(connector),
         valueMarkers,
-        connectedAccountId: customConnectorDefinitionConnectedAccountId({
-          connectedConnections,
-          definition: connector,
-        }),
-        connectedAccountUpdatedAt:
-          customConnectorDefinitionConnectedAccountUpdatedAt({
-            connectedConnections,
-            definition: connector,
-          }),
+        connectedAccountId: connectedAccount?.id ?? null,
+        connectedAccountUpdatedAt: connectedAccount?.updatedAt,
       });
       if (response.kind !== "mcp") {
         throw new Error("Run MCP connector query returned a non-MCP connector");

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -25,10 +25,7 @@ import {
 import { resolvePlatformOriginForTarget } from "../api-base.ts";
 import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-slug.ts";
 import { isAgentConnectorAuthorized } from "../okou-page/agent-connector-authorizations.ts";
-import {
-  connectorAccountOptionsFor,
-  defaultBuiltinConnectorAccountMode,
-} from "../okou-page/settings/connector-account-dialogs.ts";
+import { defaultBuiltinConnectorAccountOptions } from "../okou-page/settings/connector-account-dialogs.ts";
 import {
   chatActionCallbackFromUrl,
   runChatActionCallback$,
@@ -231,8 +228,8 @@ function createCatalogConnectorActivation(
     if (!connector) {
       return;
     }
-    const accountMode = defaultBuiltinConnectorAccountMode(connector);
-    if (!accountMode) {
+    const accountOptions = defaultBuiltinConnectorAccountOptions(connector);
+    if (!accountOptions) {
       return;
     }
 
@@ -250,7 +247,7 @@ function createCatalogConnectorActivation(
       connectorLabel: connector.label,
       connectorIcon: connector.icon,
       agentId: descriptor.agentId,
-      ...connectorAccountOptionsFor(accountMode),
+      ...accountOptions,
     };
     const connectionCompleted =
       directConnectMethod.kind === "browser-auth"

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -26,6 +26,10 @@ import { resolvePlatformOriginForTarget } from "../api-base.ts";
 import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-slug.ts";
 import { isAgentConnectorAuthorized } from "../okou-page/agent-connector-authorizations.ts";
 import {
+  connectorAccountOptionsFor,
+  defaultBuiltinConnectorAccountMode,
+} from "../okou-page/settings/connector-account-dialogs.ts";
+import {
   chatActionCallbackFromUrl,
   runChatActionCallback$,
   type ChatActionCallback,
@@ -227,6 +231,10 @@ function createCatalogConnectorActivation(
     if (!connector) {
       return;
     }
+    const accountMode = defaultBuiltinConnectorAccountMode(connector);
+    if (!accountMode) {
+      return;
+    }
 
     const directConnectMethod =
       getConnectorStatusDirectConnectMethod(connector);
@@ -242,6 +250,7 @@ function createCatalogConnectorActivation(
       connectorLabel: connector.label,
       connectorIcon: connector.icon,
       agentId: descriptor.agentId,
+      ...connectorAccountOptionsFor(accountMode),
     };
     const connectionCompleted =
       directConnectMethod.kind === "browser-auth"

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import type { ConnectorAuthMethodId } from "@okouai/api-contracts/contracts/connector-identity";
 import type {
   ConnectorAccountConnection,
   ConnectorAccountMutationIntent,
@@ -15,10 +16,15 @@ import {
 } from "./connector-accounts.ts";
 
 export type ConnectorAccountConnectMode =
-  | { readonly kind: "add" }
+  | {
+      readonly kind: "add";
+      readonly completionSource?: "default-projection";
+    }
   | {
       readonly kind: "reconnect";
-      readonly account: ConnectorAccountConnection;
+      readonly connectionId: string;
+      readonly authMethod?: ConnectorAuthMethodId;
+      readonly completionSource?: "default-projection";
     };
 
 export function connectorAccountMutationFor(
@@ -28,9 +34,69 @@ export function connectorAccountMutationFor(
     return undefined;
   }
   if (mode.kind === "reconnect") {
-    return { intent: "reconnect", connectionId: mode.account.id };
+    return { intent: "reconnect", connectionId: mode.connectionId };
   }
   return { intent: "add" };
+}
+
+export function connectorAccountOptionsFor(
+  mode: ConnectorAccountConnectMode | undefined,
+):
+  | Record<string, never>
+  | {
+      readonly account: ConnectorAccountMutationIntent;
+      readonly useDefaultConnectorProjection?: true;
+    } {
+  const account = connectorAccountMutationFor(mode);
+  if (!account) {
+    return {};
+  }
+  return {
+    account,
+    ...(mode?.completionSource === "default-projection"
+      ? { useDefaultConnectorProjection: true as const }
+      : {}),
+  };
+}
+
+export function defaultBuiltinConnectorAccountMode(
+  connector: PlatformConnectorCatalogStatusItem | undefined,
+): ConnectorAccountConnectMode | null {
+  if (!connector) {
+    return null;
+  }
+  const connection = connector.connection;
+  if (!connection) {
+    return connector.connected
+      ? null
+      : { kind: "add", completionSource: "default-projection" };
+  }
+  return connection.id
+    ? {
+        kind: "reconnect",
+        connectionId: connection.id,
+        authMethod: connection.authMethod,
+        completionSource: "default-projection",
+      }
+    : null;
+}
+
+export function defaultCustomConnectorAccountMode(
+  connector: CustomConnectorResponse | undefined,
+): ConnectorAccountConnectMode | null {
+  if (!connector) {
+    return null;
+  }
+  if (!connector.connected) {
+    return { kind: "add", completionSource: "default-projection" };
+  }
+  return connector.connectedAccountId
+    ? {
+        kind: "reconnect",
+        connectionId: connector.connectedAccountId,
+        completionSource: "default-projection",
+      }
+    : null;
 }
 
 interface BuiltinAccountConnectDialog {

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -16,15 +16,11 @@ import {
 } from "./connector-accounts.ts";
 
 export type ConnectorAccountConnectMode =
-  | {
-      readonly kind: "add";
-      readonly completionSource?: "default-projection";
-    }
+  | { readonly kind: "add" }
   | {
       readonly kind: "reconnect";
       readonly connectionId: string;
       readonly authMethod?: ConnectorAuthMethodId;
-      readonly completionSource?: "default-projection";
     };
 
 export interface ConnectorAccountMutationOptions {
@@ -56,12 +52,7 @@ export function connectorAccountOptionsFor(
   if (!account) {
     return {};
   }
-  return {
-    account,
-    ...(mode?.completionSource === "default-projection"
-      ? { useDefaultConnectorProjection: true as const }
-      : {}),
-  };
+  return { account };
 }
 
 export function defaultBuiltinConnectorAccountOptions(

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -27,6 +27,16 @@ export type ConnectorAccountConnectMode =
       readonly completionSource?: "default-projection";
     };
 
+export interface ConnectorAccountMutationOptions {
+  readonly account?: ConnectorAccountMutationIntent;
+  readonly useDefaultConnectorProjection?: true;
+}
+
+export interface DefaultConnectorAccountMutationOptions {
+  readonly account: ConnectorAccountMutationIntent;
+  readonly useDefaultConnectorProjection: true;
+}
+
 export function connectorAccountMutationFor(
   mode: ConnectorAccountConnectMode | undefined,
 ): ConnectorAccountMutationIntent | undefined {
@@ -41,12 +51,7 @@ export function connectorAccountMutationFor(
 
 export function connectorAccountOptionsFor(
   mode: ConnectorAccountConnectMode | undefined,
-):
-  | Record<string, never>
-  | {
-      readonly account: ConnectorAccountMutationIntent;
-      readonly useDefaultConnectorProjection?: true;
-    } {
+): ConnectorAccountMutationOptions {
   const account = connectorAccountMutationFor(mode);
   if (!account) {
     return {};
@@ -59,9 +64,9 @@ export function connectorAccountOptionsFor(
   };
 }
 
-export function defaultBuiltinConnectorAccountMode(
+export function defaultBuiltinConnectorAccountOptions(
   connector: PlatformConnectorCatalogStatusItem | undefined,
-): ConnectorAccountConnectMode | null {
+): DefaultConnectorAccountMutationOptions | null {
   if (!connector) {
     return null;
   }
@@ -69,32 +74,38 @@ export function defaultBuiltinConnectorAccountMode(
   if (!connection) {
     return connector.connected
       ? null
-      : { kind: "add", completionSource: "default-projection" };
+      : {
+          account: { intent: "add" },
+          useDefaultConnectorProjection: true,
+        };
   }
   return connection.id
     ? {
-        kind: "reconnect",
-        connectionId: connection.id,
-        authMethod: connection.authMethod,
-        completionSource: "default-projection",
+        account: { intent: "reconnect", connectionId: connection.id },
+        useDefaultConnectorProjection: true,
       }
     : null;
 }
 
-export function defaultCustomConnectorAccountMode(
+export function defaultCustomConnectorAccountOptions(
   connector: CustomConnectorResponse | undefined,
-): ConnectorAccountConnectMode | null {
+): DefaultConnectorAccountMutationOptions | null {
   if (!connector) {
     return null;
   }
   if (!connector.connected) {
-    return { kind: "add", completionSource: "default-projection" };
+    return {
+      account: { intent: "add" },
+      useDefaultConnectorProjection: true,
+    };
   }
   return connector.connectedAccountId
     ? {
-        kind: "reconnect",
-        connectionId: connector.connectedAccountId,
-        completionSource: "default-projection",
+        account: {
+          intent: "reconnect",
+          connectionId: connector.connectedAccountId,
+        },
+        useDefaultConnectorProjection: true,
       }
     : null;
 }

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -86,6 +86,7 @@ type PostConnectOptions = {
   readonly connectorLabel?: string;
   readonly agentId?: string;
   readonly account?: ConnectorAccountMutationIntent;
+  readonly useDefaultConnectorProjection?: boolean;
 };
 type BrowserAuthPostConnectOptions = PostConnectOptions & {
   readonly connectorIcon: PublicConnectorCatalogIcon;
@@ -2098,6 +2099,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
   authMethod: ConnectorAuthMethodId,
   agentId: string | undefined,
   account: ConnectorAccountMutationIntent,
+  useDefaultConnectorProjection: boolean,
 ) {
   // Snapshot taken on the first body invocation: `null` marks "no connector
   // yet" and an `updatedAt` value marks "reconnect scenario — wait for it to
@@ -2107,7 +2109,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
   let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
 
   return command(async ({ get }, sig: AbortSignal): Promise<boolean> => {
-    if (account.intent !== "single-account") {
+    if (!useDefaultConnectorProjection && account.intent !== "single-account") {
       const currentVersion = await readConnectorAccountMutationVersion(
         get(apiClient$),
         { kind: "builtin", connectorSlug },
@@ -2338,7 +2340,10 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
     } = args;
     const { authWindow, connectionId: expectedConnectionId } = oauthStart;
     const expectedConnectionAvailable$ = command(
-      async ({ get }, sig: AbortSignal): Promise<boolean> => {
+      async ({ get, set }, sig: AbortSignal): Promise<boolean> => {
+        if (options.useDefaultConnectorProjection) {
+          return await set(onConnectorChanged$, sig);
+        }
         return expectedConnectionId
           ? await connectorAccountConnectionExists(
               get(apiClient$),
@@ -2402,7 +2407,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       if (!connectedAfterClose) {
         return false;
       }
-      if (!expectedConnected) {
+      if (!expectedConnected && !expectedConnectionId) {
         completedConnectionId = null;
       }
     } else if (!expectedConnectionId) {
@@ -2412,7 +2417,8 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
 
     set(reloadConnectors$);
     const isConnected =
-      account.intent !== "single-account" ||
+      (!options.useDefaultConnectorProjection &&
+        account.intent !== "single-account") ||
       (await set(
         defaultConnectorProjectionMatchesAuthMethod$,
         connectorSlug,
@@ -2472,6 +2478,7 @@ export const connectConnectorOAuthAuthCode$ = command(
           method.id,
           options.agentId,
           account,
+          options.useDefaultConnectorProjection ?? false,
         );
         const oauthStart = await set(
           openConnectorOAuthAuthCodeWindow$,

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -2189,6 +2189,44 @@ const defaultConnectorProjectionMatchesAuthMethod$ = command(
   },
 );
 
+function getDefaultConnectorProjectionConnectionId(
+  account: ConnectorAccountMutationIntent,
+  expectedConnectionId: string | null,
+  useDefaultConnectorProjection: boolean,
+): string | null {
+  if (!useDefaultConnectorProjection) {
+    return null;
+  }
+  return account.intent === "reconnect"
+    ? account.connectionId
+    : expectedConnectionId;
+}
+
+function createExpectedConnectorConnectionAvailableCommand(
+  connectorSlug: ConnectorSlug,
+  expectedConnectionId: string | null,
+  useDefaultConnectorProjection: boolean,
+  onConnectorChanged$: ReturnType<
+    typeof createConnectorOAuthAuthCodeChangedCommand
+  >,
+) {
+  return command(
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+      if (useDefaultConnectorProjection) {
+        return await set(onConnectorChanged$, signal);
+      }
+      return expectedConnectionId
+        ? await connectorAccountConnectionExists(
+            get(apiClient$),
+            { kind: "builtin", connectorSlug },
+            expectedConnectionId,
+            signal,
+          )
+        : false;
+    },
+  );
+}
+
 const openConnectorOAuthAuthCodeWindow$ = command(
   async (
     { get, set },
@@ -2349,21 +2387,13 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       oauthStart,
     } = args;
     const { authWindow, connectionId: expectedConnectionId } = oauthStart;
-    const expectedConnectionAvailable$ = command(
-      async ({ get, set }, sig: AbortSignal): Promise<boolean> => {
-        if (options.useDefaultConnectorProjection) {
-          return await set(onConnectorChanged$, sig);
-        }
-        return expectedConnectionId
-          ? await connectorAccountConnectionExists(
-              get(apiClient$),
-              { kind: "builtin", connectorSlug },
-              expectedConnectionId,
-              sig,
-            )
-          : false;
-      },
-    );
+    const expectedConnectionAvailable$ =
+      createExpectedConnectorConnectionAvailableCommand(
+        connectorSlug,
+        expectedConnectionId,
+        options.useDefaultConnectorProjection ?? false,
+        onConnectorChanged$,
+      );
     const waitSignal = set(resetOAuthAuthCodeWaitSignal$, signal);
     const onMatchingConnectorChanged$ = command(
       async ({ set }, payload: unknown, sig: AbortSignal): Promise<boolean> => {
@@ -2433,11 +2463,11 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
         defaultConnectorProjectionMatchesAuthMethod$,
         connectorSlug,
         method.id,
-        options.useDefaultConnectorProjection
-          ? account.intent === "reconnect"
-            ? account.connectionId
-            : expectedConnectionId
-          : null,
+        getDefaultConnectorProjectionConnectionId(
+          account,
+          expectedConnectionId,
+          options.useDefaultConnectorProjection ?? false,
+        ),
         signal,
       ));
     if (isConnected) {

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -2141,6 +2141,12 @@ function createConnectorOAuthAuthCodeChangedCommand(
       return false;
     }
     if (current) {
+      if (
+        account.intent === "reconnect" &&
+        current.id !== account.connectionId
+      ) {
+        return false;
+      }
       // initialUpdatedAt === null means the connector didn't exist on the first
       // fetch; any subsequent appearance signals completion.
       const connectionChanged =
@@ -2169,12 +2175,16 @@ const defaultConnectorProjectionMatchesAuthMethod$ = command(
     { get },
     connectorSlug: ConnectorSlug,
     authMethod: ConnectorAuthMethodId,
+    connectionId: string | null,
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { connectors } = await get(connectors$);
     signal.throwIfAborted();
     return connectors.some((connector) => {
-      return connectorMatchesAuthMethod(connector, connectorSlug, authMethod);
+      return (
+        connectorMatchesAuthMethod(connector, connectorSlug, authMethod) &&
+        (connectionId === null || connector.id === connectionId)
+      );
     });
   },
 );
@@ -2423,6 +2433,11 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
         defaultConnectorProjectionMatchesAuthMethod$,
         connectorSlug,
         method.id,
+        options.useDefaultConnectorProjection
+          ? account.intent === "reconnect"
+            ? account.connectionId
+            : expectedConnectionId
+          : null,
         signal,
       ));
     if (isConnected) {

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -584,10 +584,14 @@ function defaultCustomConnectorOAuthCompletion(args: {
     args.account?.intent === "reconnect"
       ? args.account.connectionId
       : args.expectedConnectionId;
+  const projectedAccountMatches =
+    args.connector?.connectedAccountId === connectionId ||
+    (args.account?.intent === "add" &&
+      args.connector?.connectedAccountId === undefined);
   const completed =
     connectionId !== null &&
     args.connector?.connected === true &&
-    args.connector.connectedAccountId === connectionId &&
+    projectedAccountMatches &&
     (args.account?.intent === "add"
       ? args.initialUpdatedAt === null
       : args.initialUpdatedAt !== undefined &&

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -455,6 +455,7 @@ export const setCustomConnectorValues$ = command(
     args: {
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
+      readonly account?: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -476,6 +477,7 @@ export const setCustomConnectorValuesForAgent$ = command(
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
       readonly agentId: string;
+      readonly account?: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -484,6 +486,7 @@ export const setCustomConnectorValuesForAgent$ = command(
       {
         id: args.id,
         values: args.values,
+        ...(args.account ? { account: args.account } : {}),
         authorizationTarget: { kind: "agent", agentId: args.agentId },
       },
       signal,
@@ -558,15 +561,127 @@ async function customConnectorAccountMutationCompleted(
   );
 }
 
+interface CustomConnectorOAuthTargetArgs {
+  readonly id: string;
+  readonly authorizationTarget: CustomConnectorAuthorizationTarget;
+  readonly account?: ConnectorAccountMutationIntent;
+  readonly authorizeTarget?: boolean;
+  readonly useDefaultConnectorProjection?: boolean;
+}
+
+interface CustomConnectorOAuthCompletion {
+  readonly completed: boolean;
+  readonly connectionId: string | null;
+}
+
+function defaultCustomConnectorOAuthCompletion(args: {
+  readonly connector: CustomConnectorResponse | undefined;
+  readonly account: ConnectorAccountMutationIntent | undefined;
+  readonly expectedConnectionId: string | null;
+  readonly initialUpdatedAt: string | null | undefined;
+}): CustomConnectorOAuthCompletion {
+  const connectionId =
+    args.expectedConnectionId ??
+    (args.account?.intent === "reconnect" ? args.account.connectionId : null);
+  const completed =
+    connectionId !== null &&
+    args.connector?.connected === true &&
+    args.connector.connectedAccountId === connectionId &&
+    (args.account?.intent === "add"
+      ? args.initialUpdatedAt === null
+      : args.initialUpdatedAt !== undefined &&
+        args.connector.connectedAccountUpdatedAt !== undefined &&
+        args.connector.connectedAccountUpdatedAt !== args.initialUpdatedAt);
+  return {
+    completed,
+    connectionId: completed ? connectionId : null,
+  };
+}
+
+async function customConnectorOAuthCompletion(
+  args: {
+    readonly createClient: ApiClientFactory;
+    readonly connector: CustomConnectorResponse | undefined;
+    readonly target: CustomConnectorOAuthTargetArgs;
+    readonly expectedConnectionId: string | null;
+    readonly initialAccountVersion: ConnectorAccountMutationVersion | undefined;
+    readonly initialDefaultUpdatedAt: string | null | undefined;
+  },
+  signal: AbortSignal,
+): Promise<CustomConnectorOAuthCompletion> {
+  if (args.target.useDefaultConnectorProjection) {
+    return defaultCustomConnectorOAuthCompletion({
+      connector: args.connector,
+      account: args.target.account,
+      expectedConnectionId: args.expectedConnectionId,
+      initialUpdatedAt: args.initialDefaultUpdatedAt,
+    });
+  }
+  const exactAccountCompleted = args.expectedConnectionId
+    ? await connectorAccountConnectionExists(
+        args.createClient,
+        { kind: "custom", customConnectorId: args.target.id },
+        args.expectedConnectionId,
+        signal,
+      )
+    : false;
+  if (exactAccountCompleted) {
+    return { completed: true, connectionId: args.expectedConnectionId };
+  }
+  // Older API responses omit the exact ID. Remove this bounded account
+  // mutation fallback with the final rollout contraction in #28571.
+  const completed = await customConnectorAccountMutationCompleted(
+    args.createClient,
+    args.target.id,
+    args.target.account,
+    args.initialAccountVersion,
+    signal,
+  );
+  return {
+    completed,
+    connectionId:
+      completed && args.target.account?.intent === "reconnect"
+        ? args.target.account.connectionId
+        : null,
+  };
+}
+
+const authorizeCompletedCustomConnectorTarget$ = command(
+  async (
+    { set },
+    args: {
+      readonly connector: CustomConnectorResponse | undefined;
+      readonly target: CustomConnectorAuthorizationTarget;
+      readonly authorizeTarget: boolean;
+    },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (!args.connector?.connected || !args.authorizeTarget) {
+      return false;
+    }
+    if (!args.connector.permissionBundleRef) {
+      await set(
+        authorizeCustomConnectorForTarget$,
+        {
+          connectorId: args.connector.id,
+          target: args.target,
+        },
+        signal,
+      );
+      return true;
+    }
+    return await set(
+      isCustomConnectorAuthorizedForTarget$,
+      { connectorId: args.connector.id, target: args.target },
+      signal,
+    );
+  },
+);
+
 const connectCustomConnectorOAuth2ForTarget$ = command(
   async (
     { get, set },
-    args: {
-      readonly id: string;
-      readonly authorizationTarget: CustomConnectorAuthorizationTarget;
-      readonly account?: ConnectorAccountMutationIntent;
-      readonly authorizeTarget?: boolean;
-    },
+    args: CustomConnectorOAuthTargetArgs,
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
     const authWindow = window.open(
@@ -580,18 +695,27 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
     authWindow.opener = null;
     let navigated = false;
     let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
+    let initialDefaultUpdatedAt: string | null | undefined;
     let expectedConnectionId: string | null = null;
     await withCleanup(
       (async () => {
         const createClient = get(apiClient$);
-        initialAccountVersion = args.account
-          ? await readConnectorAccountMutationVersion(
-              createClient,
-              { kind: "custom", customConnectorId: args.id },
-              args.account,
-              signal,
-            )
-          : undefined;
+        if (args.useDefaultConnectorProjection) {
+          const connectors = await get(customConnectors$);
+          initialDefaultUpdatedAt =
+            connectors.find((connector) => {
+              return connector.id === args.id;
+            })?.connectedAccountUpdatedAt ?? null;
+        }
+        initialAccountVersion =
+          args.account && !args.useDefaultConnectorProjection
+            ? await readConnectorAccountMutationVersion(
+                createClient,
+                { kind: "custom", customConnectorId: args.id },
+                args.account,
+                signal,
+              )
+            : undefined;
         const client = createClient(customConnectorOAuth2Contract, {
           apiBase: "api",
         });
@@ -623,66 +747,43 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
       signal,
     );
     signal.throwIfAborted();
-    const exactAccountCompleted = expectedConnectionId
-      ? await connectorAccountConnectionExists(
-          get(apiClient$),
-          { kind: "custom", customConnectorId: args.id },
-          expectedConnectionId,
-          signal,
-        )
-      : false;
-    const accountCompleted = exactAccountCompleted
-      ? true
-      : // Older API responses omit the exact ID. Remove this bounded account
-        // mutation fallback with the final rollout contraction in #28571.
-        await customConnectorAccountMutationCompleted(
-          get(apiClient$),
-          args.id,
-          args.account,
-          initialAccountVersion,
-          signal,
-        );
-    if (!accountCompleted) {
-      return {
-        connected: false,
-        targetAuthorized: false,
-        connectionId: null,
-      };
-    }
     set(bumpReload$);
     const connectors = await get(customConnectors$);
     signal.throwIfAborted();
     const connector = connectors.find((candidate) => {
       return candidate.id === args.id;
     });
-    let targetAuthorized = false;
-    if (connector?.connected && args.authorizeTarget !== false) {
-      if (!connector.permissionBundleRef) {
-        await set(
-          authorizeCustomConnectorForTarget$,
-          {
-            connectorId: args.id,
-            target: args.authorizationTarget,
-          },
-          signal,
-        );
-        targetAuthorized = true;
-      } else {
-        targetAuthorized = await set(
-          isCustomConnectorAuthorizedForTarget$,
-          { connectorId: connector.id, target: args.authorizationTarget },
-          signal,
-        );
-      }
+    const completion = await customConnectorOAuthCompletion(
+      {
+        createClient: get(apiClient$),
+        connector,
+        target: args,
+        expectedConnectionId,
+        initialAccountVersion,
+        initialDefaultUpdatedAt,
+      },
+      signal,
+    );
+    if (!completion.completed) {
+      return {
+        connected: false,
+        targetAuthorized: false,
+        connectionId: null,
+      };
     }
+    const targetAuthorized = await set(
+      authorizeCompletedCustomConnectorTarget$,
+      {
+        connector,
+        target: args.authorizationTarget,
+        authorizeTarget: args.authorizeTarget !== false,
+      },
+      signal,
+    );
     return {
       connected: connector?.connected ?? false,
       targetAuthorized,
-      connectionId: exactAccountCompleted
-        ? expectedConnectionId
-        : args.account?.intent === "reconnect"
-          ? args.account.connectionId
-          : null,
+      connectionId: completion.connectionId,
     };
   },
 );
@@ -690,13 +791,17 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
 export const connectCustomConnectorOAuth2$ = command(
   async (
     { set },
-    id: string,
+    args: {
+      readonly id: string;
+      readonly account?: ConnectorAccountMutationIntent;
+      readonly useDefaultConnectorProjection?: boolean;
+    },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       connectCustomConnectorOAuth2ForTarget$,
       {
-        id,
+        ...args,
         authorizationTarget: { kind: "visible-agents" },
       },
       signal,
@@ -707,13 +812,22 @@ export const connectCustomConnectorOAuth2$ = command(
 export const connectCustomConnectorOAuth2ForAgent$ = command(
   async (
     { set },
-    args: { readonly id: string; readonly agentId: string },
+    args: {
+      readonly id: string;
+      readonly agentId: string;
+      readonly account?: ConnectorAccountMutationIntent;
+      readonly useDefaultConnectorProjection?: boolean;
+    },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       connectCustomConnectorOAuth2ForTarget$,
       {
         id: args.id,
+        ...(args.account ? { account: args.account } : {}),
+        ...(args.useDefaultConnectorProjection
+          ? { useDefaultConnectorProjection: true as const }
+          : {}),
         authorizationTarget: { kind: "agent", agentId: args.agentId },
       },
       signal,

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -581,8 +581,9 @@ function defaultCustomConnectorOAuthCompletion(args: {
   readonly initialUpdatedAt: string | null | undefined;
 }): CustomConnectorOAuthCompletion {
   const connectionId =
-    args.expectedConnectionId ??
-    (args.account?.intent === "reconnect" ? args.account.connectionId : null);
+    args.account?.intent === "reconnect"
+      ? args.account.connectionId
+      : args.expectedConnectionId;
   const completed =
     connectionId !== null &&
     args.connector?.connected === true &&

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -1227,7 +1227,7 @@ describe("chat composer connector connection", () => {
       ({ body, params, respond }) => {
         expect(params.id).toBe(connector.id);
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           values: [{ key: "secret", kind: "secret", value: "acme-secret" }],
         });
         connected = true;
@@ -1342,7 +1342,11 @@ describe("chat composer connector connection", () => {
       connectorOauthStartContract.start,
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("google-analytics");
-        expect(body.agentId).toBe(AGENT_ID);
+        expect(body).toMatchObject({
+          account: { intent: "add" },
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+        });
         return respond(200, {
           authorizationUrl: "https://accounts.google.test/analytics/authorize",
         });
@@ -1395,7 +1399,7 @@ describe("chat composer connector connection", () => {
         connectCount += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -10,6 +10,7 @@ import {
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
   connectorOauthStartContract,
+  connectorsMainContract,
 } from "@okouai/api-contracts/contracts/connectors";
 import {
   browserContract,
@@ -1696,16 +1697,26 @@ describe("chat event action cards", () => {
     context.mocks.browser.open(authWindow);
     let reconnectRequired = true;
     const gmailConnectionId = crypto.randomUUID();
+    const siblingConnectionId = crypto.randomUUID();
+    const siblingProjectionRead = context.mocks.deferred<void>();
+    let projectedConnector = connectedConnector({
+      id: gmailConnectionId,
+      slug: "gmail",
+      authMethod: "oauth",
+      connectionStatus: "reconnect-required",
+      reconnectReason: "authorization_expired_or_revoked",
+    });
 
-    context.mocks.data.connectors([
-      connectedConnector({
-        id: gmailConnectionId,
-        slug: "gmail",
-        authMethod: "oauth",
-        connectionStatus: "reconnect-required",
-        reconnectReason: "authorization_expired_or_revoked",
-      }),
-    ]);
+    context.mocks.data.connectors([projectedConnector]);
+    context.mocks.api(connectorsMainContract.list, ({ respond }) => {
+      if (projectedConnector.id === siblingConnectionId) {
+        siblingProjectionRead.resolve();
+      }
+      return respond(200, {
+        connectors: [projectedConnector],
+        connectorProvidedBindings: [],
+      });
+    });
     context.mocks.api(connectorCatalogContract.get, ({ respond }) => {
       return respond(200, {
         connector: publicConnectorStatusItem({
@@ -1753,18 +1764,16 @@ describe("chat event action cards", () => {
           authorizeAgent: true,
           callbackTarget: "app",
         });
-        reconnectRequired = false;
-        context.mocks.data.connectors([
-          connectedConnector({
-            id: gmailConnectionId,
-            slug: "gmail",
-            authMethod: "oauth",
-            externalEmail: "sender@example.com",
-            updatedAt: "2026-01-01T00:00:01Z",
-          }),
-        ]);
+        projectedConnector = connectedConnector({
+          id: siblingConnectionId,
+          slug: "gmail",
+          authMethod: "oauth",
+          externalEmail: "sibling@example.com",
+          updatedAt: "2026-01-01T00:00:01Z",
+        });
         return respond(200, {
           authorizationUrl: "https://accounts.google.test/oauth",
+          connectionId: siblingConnectionId,
         });
       },
     );
@@ -1806,6 +1815,21 @@ describe("chat event action cards", () => {
       connectorCard,
     );
     await user.click(reconnectButton);
+
+    await siblingProjectionRead.promise;
+    expect(sentPrompts).toStrictEqual([]);
+
+    reconnectRequired = false;
+    projectedConnector = connectedConnector({
+      id: gmailConnectionId,
+      slug: "gmail",
+      authMethod: "oauth",
+      externalEmail: "sender@example.com",
+      updatedAt: "2026-01-01T00:00:02Z",
+    });
+    context.mocks.ably.trigger("connector:changed", {
+      connectorSlug: "gmail",
+    });
 
     await waitFor(() => {
       expect(authWindow.location.href).toBe(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -1695,9 +1695,11 @@ describe("chat event action cards", () => {
     });
     context.mocks.browser.open(authWindow);
     let reconnectRequired = true;
+    const gmailConnectionId = crypto.randomUUID();
 
     context.mocks.data.connectors([
       connectedConnector({
+        id: gmailConnectionId,
         slug: "gmail",
         authMethod: "oauth",
         connectionStatus: "reconnect-required",
@@ -1714,6 +1716,7 @@ describe("chat event action cards", () => {
             ? "reconnect-required"
             : "connected",
           connection: {
+            id: gmailConnectionId,
             authMethod: "oauth",
             externalUsername: null,
             externalEmail: "sender@example.com",
@@ -1741,7 +1744,10 @@ describe("chat event action cards", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("gmail");
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: {
+            intent: "reconnect",
+            connectionId: gmailConnectionId,
+          },
           authMethod: "oauth",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -1750,6 +1756,7 @@ describe("chat event action cards", () => {
         reconnectRequired = false;
         context.mocks.data.connectors([
           connectedConnector({
+            id: gmailConnectionId,
             slug: "gmail",
             authMethod: "oauth",
             externalEmail: "sender@example.com",
@@ -1863,7 +1870,7 @@ describe("chat event action cards", () => {
       connectorOauthStartContract.start,
       ({ body, respond }) => {
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           authMethod: "oauth",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -1969,7 +1976,7 @@ describe("chat event action cards", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,
@@ -2922,7 +2929,7 @@ describe("chat event action cards", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("future-connector");
         expect(body.agentId).toBe(AGENT_ID);
-        expect(body.account).toStrictEqual({ intent: "single-account" });
+        expect(body.account).toStrictEqual({ intent: "add" });
         expect(body.authorizeAgent).toBeTruthy();
         connected = true;
         authorized = true;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
@@ -120,7 +120,7 @@ function mockConnectorOauthStart(): { readonly authWindow: Window } {
     connectorOauthStartContract.start,
     ({ body, params, respond }) => {
       expect(body).toStrictEqual({
-        account: { intent: "single-account" },
+        account: { intent: "add" },
         authMethod: "oauth",
         agentId: AGENT_ID,
         authorizeAgent: true,
@@ -149,7 +149,7 @@ function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
     connectorOpenIdStartContract.start,
     ({ body, params, respond }) => {
       expect(body).toStrictEqual({
-        account: { intent: "single-account" },
+        account: { intent: "add" },
         authMethod: "openid",
         agentId: AGENT_ID,
         authorizeAgent: true,
@@ -528,7 +528,7 @@ describe("directed connector authorize page", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -701,7 +701,7 @@ describe("directed connector connect page", () => {
     });
   });
 
-  it("starts permissioned OAuth before checking the target grant", async () => {
+  it("completes add against an older permissioned OAuth projection", async () => {
     let connected = false;
     const connectionId = crypto.randomUUID();
     let authorizationUpdates = 0;
@@ -733,18 +733,7 @@ describe("directed connector connect page", () => {
     });
     context.mocks.api(customConnectorsContract.list, ({ respond }) => {
       return respond(200, {
-        connectors: [
-          {
-            ...connector,
-            connected,
-            ...(connected
-              ? {
-                  connectedAccountId: connectionId,
-                  connectedAccountUpdatedAt: "2026-01-01T00:00:01Z",
-                }
-              : {}),
-          },
-        ],
+        connectors: [{ ...connector, connected }],
       });
     });
     context.mocks.api(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -372,8 +372,8 @@ function mockConnectorOpenIdStart(args?: {
   return { authWindow };
 }
 
-function getButtonByText(text: string): HTMLElement {
-  const button = queryAllByRoleFast("button").find((element) => {
+function getButtonByText(text: string, container?: ParentNode): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((element) => {
     return element.textContent?.trim() === text;
   });
   if (!button) {
@@ -450,6 +450,72 @@ describe("directed connector connect page", () => {
         { customConnectorId: connector.id, permissionNames: [] },
       ]);
       expect(screen.getByText("DeepWiki connected")).toBeInTheDocument();
+    });
+  });
+
+  it("reconnects exact manual custom account without changing field status", async () => {
+    const connectionId = crypto.randomUUID();
+    const connector = customConnector({
+      displayName: "Acme Configured API",
+      connected: true,
+      connectedAccountId: connectionId,
+      connectedAccountUpdatedAt: "2026-01-01T00:00:00Z",
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+    });
+    let submittedValues: readonly {
+      readonly key: string;
+      readonly kind: "secret" | "variable";
+      readonly value: string;
+    }[] = [];
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(
+      customConnectorValuesContract.set,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(connector.id);
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId,
+        });
+        submittedValues = body.values;
+        return respond(200, {
+          ...connector,
+          connectedAccountUpdatedAt: "2026-01-01T00:00:01Z",
+        });
+      },
+    );
+    context.mocks.api(
+      agentCustomConnectorsContract.update,
+      ({ body, respond }) => {
+        return respond(200, { grants: body.grants });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Acme Configured API connected");
+    click(getButtonByText("Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Connect Acme Configured API",
+    });
+    const secretInput = within(dialog).getByLabelText("Secret");
+    expect(secretInput).toHaveAccessibleDescription("Required · Configured");
+    await fill(secretInput, "replacement-secret");
+    click(getButtonByText("Save"));
+
+    await waitFor(() => {
+      expect(submittedValues).toStrictEqual([
+        {
+          key: "secret",
+          kind: "secret",
+          value: "replacement-secret",
+        },
+      ]);
     });
   });
 
@@ -839,6 +905,7 @@ describe("directed connector connect page", () => {
       }),
     );
     let connectCalls = 0;
+    let visibleAgentAuthorizationUpdates = 0;
     const threadId = "00000000-0000-4000-a000-000000000101";
     const callbackPrompt = "Re-check Stripe, then continue";
     let continuationPrompt: string | null = null;
@@ -878,6 +945,12 @@ describe("directed connector connect page", () => {
         threadId,
       });
     });
+    context.mocks.api(userConnectorsContract.update, ({ body, respond }) => {
+      visibleAgentAuthorizationUpdates += 1;
+      return respond(200, {
+        enabledConnectorSlugs: [...body.enabledConnectorSlugs],
+      });
+    });
     detachedSetupPage({
       context,
       path: `/connectors/stripe/connect?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`,
@@ -895,6 +968,7 @@ describe("directed connector connect page", () => {
       expect(screen.getByText("Public Stripe connected")).toBeInTheDocument();
       expect(continuationPrompt).toBe(callbackPrompt);
     });
+    expect(visibleAgentAuthorizationUpdates).toBe(0);
     expect(
       screen.queryByRole("dialog", { name: "Public Stripe" }),
     ).not.toBeInTheDocument();
@@ -986,6 +1060,102 @@ describe("directed connector connect page", () => {
         screen.getByText("Zero needs Public GitHub to proceed"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows exact-account reconnect semantics without hiding account status", async () => {
+    const connectionId = crypto.randomUUID();
+    const connector = publicOAuthConnectorStatus({
+      slug: "github",
+      label: "Public GitHub",
+      singleAuthCodeAuthMethodId: null,
+    });
+    mockPublicConnectorStatus({
+      ...connector,
+      connected: true,
+      connectionStatus: "reconnect-required",
+      connection: {
+        id: connectionId,
+        authMethod: "oauth",
+        externalUsername: "mock-connected-account",
+        externalEmail: null,
+        reconnectReason: "authorization_expired_or_revoked",
+      },
+      authMethods: [
+        ...connector.authMethods,
+        {
+          id: "api-token",
+          label: "Alternate API token",
+          description: null,
+          grantKind: "manual",
+          manualFields: [
+            {
+              id: "apiToken",
+              label: "Alternate API token",
+              required: true,
+              placeholder: "alternate-token",
+              inputType: "password",
+            },
+          ],
+          startOptions: [],
+        },
+      ],
+    });
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    let oauthStarted = false;
+    let startedConnectorSlug: string | null = null;
+    let startedAccountIntent: string | null = null;
+    let startedAuthMethod: string | null = null;
+    let startedAgentId: string | null = null;
+    let startedAuthorizeAgent = false;
+    let startedConnectionId: string | null = null;
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        oauthStarted = true;
+        startedConnectorSlug = params.connectorSlug;
+        startedAccountIntent = body.account.intent;
+        startedAuthMethod = body.authMethod;
+        startedAgentId = body.agentId ?? null;
+        startedAuthorizeAgent = body.authorizeAgent === true;
+        if (body.account.intent === "reconnect") {
+          startedConnectionId = body.account.connectionId;
+        }
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/github/reconnect",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/connect?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Public GitHub connected");
+    click(getButtonByText("Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Public GitHub",
+    });
+    expect(within(dialog).getByText("Connection expired")).toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText("Alternate API token"),
+    ).not.toBeInTheDocument();
+    click(getButtonByText("Reconnect", dialog));
+
+    await waitFor(() => {
+      expect(oauthStarted).toBeTruthy();
+    });
+    expect(startedConnectorSlug).toBe("github");
+    expect(startedAccountIntent).toBe("reconnect");
+    expect(startedAuthMethod).toBe("oauth");
+    expect(startedAgentId).toBe(AGENT_ID);
+    expect(startedAuthorizeAgent).toBeTruthy();
+    expect(startedConnectionId).toBe(connectionId);
   });
 
   it("asks the server to connect and authorize a manual grant", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -455,6 +455,7 @@ describe("directed connector connect page", () => {
 
   it("starts OAuth and authorizes an OAuth custom connector", async () => {
     let connected = false;
+    const connectionId = crypto.randomUUID();
     let grants: AgentCustomConnectorGrant[] = [];
     const connector = customConnector({
       slug: "_acme-oauth",
@@ -481,16 +482,29 @@ describe("directed connector connect page", () => {
     });
     context.mocks.api(customConnectorsContract.list, ({ respond }) => {
       return respond(200, {
-        connectors: [{ ...connector, connected }],
+        connectors: [
+          {
+            ...connector,
+            connected,
+            ...(connected
+              ? {
+                  connectedAccountId: connectionId,
+                  connectedAccountUpdatedAt: "2026-01-01T00:00:01Z",
+                }
+              : {}),
+          },
+        ],
       });
     });
     context.mocks.api(
       customConnectorOAuth2Contract.start,
-      ({ params, respond }) => {
+      ({ body, params, respond }) => {
         expect(params.id).toBe(connector.id);
+        expect(body.account).toStrictEqual({ intent: "add" });
         connected = true;
         return respond(200, {
           authorizationUrl: "https://acme.test/oauth/authorize",
+          connectionId,
         });
       },
     );
@@ -532,8 +546,96 @@ describe("directed connector connect page", () => {
     });
   });
 
+  it("reconnects the exact default OAuth custom connector account", async () => {
+    const connectionId = crypto.randomUUID();
+    let connectedAccountUpdatedAt = "2026-01-01T00:00:00Z";
+    let grants: AgentCustomConnectorGrant[] = [];
+    const connector = customConnector({
+      slug: "_acme-oauth-reconnect",
+      displayName: "Acme OAuth Reconnect",
+      authMode: "oauth",
+      connected: true,
+      connectedAccountId: connectionId,
+      connectedAccountUpdatedAt,
+      fields: [],
+      missingRequiredFields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "client-id",
+        authorizationUrl: "https://acme.test/oauth/reconnect",
+        tokenUrl: "https://acme.test/oauth/token",
+        tokenEndpointAuthMethod: "client_secret_post",
+        pkceMethod: "S256",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    });
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, {
+        connectors: [{ ...connector, connectedAccountUpdatedAt }],
+      });
+    });
+    context.mocks.api(
+      customConnectorOAuth2Contract.start,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(connector.id);
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId,
+        });
+        connectedAccountUpdatedAt = "2026-01-01T00:00:01Z";
+        return respond(200, {
+          authorizationUrl: "https://acme.test/oauth/reconnect",
+        });
+      },
+    );
+    context.mocks.api(
+      agentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        grants = body.grants;
+        return respond(200, { grants });
+      },
+    );
+    const authWindow = context.mocks.browser.authWindow();
+    authWindow.closed = true;
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Acme OAuth Reconnect connected");
+    click(getButtonByText("Reconnect"));
+    await screen.findByRole("dialog", {
+      name: "Connect Acme OAuth Reconnect",
+    });
+    click(getButtonByText("Continue"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://acme.test/oauth/reconnect",
+      );
+      expect(grants).toStrictEqual([
+        { customConnectorId: connector.id, permissionNames: [] },
+      ]);
+    });
+  });
+
   it("starts permissioned OAuth before checking the target grant", async () => {
     let connected = false;
+    const connectionId = crypto.randomUUID();
     let authorizationUpdates = 0;
     const authorizationRequested = context.mocks.deferred<void>();
     const releaseAuthorization = context.mocks.deferred<void>();
@@ -563,16 +665,29 @@ describe("directed connector connect page", () => {
     });
     context.mocks.api(customConnectorsContract.list, ({ respond }) => {
       return respond(200, {
-        connectors: [{ ...connector, connected }],
+        connectors: [
+          {
+            ...connector,
+            connected,
+            ...(connected
+              ? {
+                  connectedAccountId: connectionId,
+                  connectedAccountUpdatedAt: "2026-01-01T00:00:01Z",
+                }
+              : {}),
+          },
+        ],
       });
     });
     context.mocks.api(
       customConnectorOAuth2Contract.start,
-      ({ params, respond }) => {
+      ({ body, params, respond }) => {
         expect(params.id).toBe(connector.id);
+        expect(body.account).toStrictEqual({ intent: "add" });
         connected = true;
         return respond(200, {
           authorizationUrl: "https://acme.test/oauth/authorize",
+          connectionId,
         });
       },
     );
@@ -731,7 +846,7 @@ describe("directed connector connect page", () => {
         connectCalls += 1;
         expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           authMethod: "api",
           agentId: AGENT_ID,
           authorizeAgent: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -548,6 +548,7 @@ describe("directed connector connect page", () => {
 
   it("reconnects the exact default OAuth custom connector account", async () => {
     const connectionId = crypto.randomUUID();
+    const siblingConnectionId = crypto.randomUUID();
     let connectedAccountUpdatedAt = "2026-01-01T00:00:00Z";
     let grants: AgentCustomConnectorGrant[] = [];
     const connector = customConnector({
@@ -592,6 +593,7 @@ describe("directed connector connect page", () => {
         connectedAccountUpdatedAt = "2026-01-01T00:00:01Z";
         return respond(200, {
           authorizationUrl: "https://acme.test/oauth/reconnect",
+          connectionId: siblingConnectionId,
         });
       },
     );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -134,7 +134,9 @@ function threadArtifactFile(
   };
 }
 
-function googleDriveConnector(): ConnectorResponse {
+function googleDriveConnector(
+  overrides: Partial<ConnectorResponse> = {},
+): ConnectorResponse {
   return {
     id: "11111111-1111-4111-8111-111111111111",
     slug: "google-drive",
@@ -148,10 +150,13 @@ function googleDriveConnector(): ConnectorResponse {
     tokenExpiresAt: null,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
   };
 }
 
-function googleDriveCatalogStatus(): PublicConnectorCatalogStatusItem {
+function googleDriveCatalogStatus(
+  overrides: Partial<PublicConnectorCatalogStatusItem> = {},
+): PublicConnectorCatalogStatusItem {
   return {
     slug: "google-drive",
     label: "Google Drive",
@@ -187,6 +192,7 @@ function googleDriveCatalogStatus(): PublicConnectorCatalogStatusItem {
     tokenExpiresAt: null,
     singleAuthCodeAuthMethodId: "oauth",
     connectNotice: null,
+    ...overrides,
   };
 }
 
@@ -657,137 +663,173 @@ describe("thread-owned utility sidebar", () => {
     });
   });
 
-  it("connects Google Drive from an artifact with explicit compact account intent", async () => {
-    const user = userEvent.setup({ delay: null });
-    const markdownUrl =
-      "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-connect-notes.md";
-    const summary = catalogArtifact({ title: "drive-connect-notes.md" });
-    const artifactFiles = [
-      threadArtifactFile(markdownUrl, {
-        id: "artifact-drive-connect-notes",
-        filename: "drive-connect-notes.md",
-        googleDriveSync: { status: "disconnected" },
+  it.each([
+    {
+      intent: "add",
+      initialConnector: null,
+      catalogStatus: googleDriveCatalogStatus(),
+      account: { intent: "add" as const },
+    },
+    {
+      intent: "reconnect",
+      initialConnector: googleDriveConnector({
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
       }),
-    ];
-
-    setupArtifactCatalog(
-      [summary],
-      new Map([
-        [
-          summary.id,
-          catalogFileDetail({
-            contentType: "text/markdown",
-            filename: "drive-connect-notes.md",
-            fileId: "f0000000-0000-4000-a000-000000000004",
-            summary,
-            url: markdownUrl,
-          }),
-        ],
-      ]),
-    );
-    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
-      return respond(200, { connectors: [googleDriveCatalogStatus()] });
-    });
-    context.mocks.http.get(markdownUrl, () => {
-      return new Response("# Connect notes\n\nReady for Drive.", {
-        headers: { "Content-Type": "text/plain" },
-      });
-    });
-
-    let connectorConnected = false;
-    let agentAuthorized = false;
-    let oauthStarted = false;
-    let artifactSynced = false;
-    context.mocks.api(connectorsMainContract.list, ({ respond }) => {
-      return respond(200, {
-        connectors: connectorConnected ? [googleDriveConnector()] : [],
-        connectorProvidedBindings: [],
-      });
-    });
-    context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
-      expect(params.id).toBe(AGENT_ID);
-      return respond(200, {
-        enabledConnectorSlugs: agentAuthorized ? ["google-drive"] : [],
-      });
-    });
-    context.mocks.api(userConnectorsContract.update, ({ never }) => {
-      return never();
-    });
-    const authWindow = context.mocks.browser.authWindow();
-    Object.defineProperty(authWindow, "location", {
-      value: { href: "" },
-      configurable: true,
-    });
-    context.mocks.browser.open(authWindow);
-    context.mocks.api(
-      connectorOauthStartContract.start,
-      ({ body, params, respond }) => {
-        expect(params.connectorSlug).toBe("google-drive");
-        expect(body).toStrictEqual({
-          account: { intent: "single-account" },
+      catalogStatus: googleDriveCatalogStatus({
+        connected: true,
+        connectionStatus: "reconnect-required",
+        connection: {
+          id: googleDriveConnector().id,
           authMethod: "oauth",
-          agentId: AGENT_ID,
-          authorizeAgent: true,
-          callbackTarget: "app",
-        });
-        oauthStarted = true;
-        connectorConnected = true;
-        agentAuthorized = true;
-        authWindow.close();
-        return respond(200, {
-          authorizationUrl: "https://accounts.google.test/drive/authorize",
-        });
+          externalUsername: "drive-user",
+          externalEmail: "drive-user@example.com",
+          reconnectReason: "authorization_expired_or_revoked",
+        },
+      }),
+      account: {
+        intent: "reconnect" as const,
+        connectionId: googleDriveConnector().id,
       },
-    );
-    context.mocks.api(
-      chatThreadArtifactsContract.syncGoogleDrive,
-      ({ body, respond }) => {
-        expect(connectorConnected).toBeTruthy();
-        expect(agentAuthorized).toBeTruthy();
-        expect(body).toStrictEqual({
-          runId: "run-sidebar",
-          fileId: "artifact-drive-connect-notes",
+    },
+  ])(
+    "connects Google Drive from an artifact with explicit $intent intent",
+    async ({ initialConnector, catalogStatus, account }) => {
+      const user = userEvent.setup({ delay: null });
+      const markdownUrl =
+        "https://cdn.vm7.io/artifacts/test/run-sidebar/drive-connect-notes.md";
+      const summary = catalogArtifact({ title: "drive-connect-notes.md" });
+      const artifactFiles = [
+        threadArtifactFile(markdownUrl, {
+          id: "artifact-drive-connect-notes",
+          filename: "drive-connect-notes.md",
+          googleDriveSync: { status: "disconnected" },
+        }),
+      ];
+
+      setupArtifactCatalog(
+        [summary],
+        new Map([
+          [
+            summary.id,
+            catalogFileDetail({
+              contentType: "text/markdown",
+              filename: "drive-connect-notes.md",
+              fileId: "f0000000-0000-4000-a000-000000000004",
+              summary,
+              url: markdownUrl,
+            }),
+          ],
+        ]),
+      );
+      context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+        return respond(200, { connectors: [catalogStatus] });
+      });
+      context.mocks.http.get(markdownUrl, () => {
+        return new Response("# Connect notes\n\nReady for Drive.", {
+          headers: { "Content-Type": "text/plain" },
         });
-        artifactFiles[0] = {
-          ...artifactFiles[0]!,
-          googleDriveSync: {
-            status: "synced",
+      });
+
+      let connectorConnected = false;
+      let agentAuthorized = false;
+      let oauthStarted = false;
+      let artifactSynced = false;
+      context.mocks.api(connectorsMainContract.list, ({ respond }) => {
+        return respond(200, {
+          connectors: connectorConnected
+            ? [googleDriveConnector()]
+            : initialConnector
+              ? [initialConnector]
+              : [],
+          connectorProvidedBindings: [],
+        });
+      });
+      context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        return respond(200, {
+          enabledConnectorSlugs: agentAuthorized ? ["google-drive"] : [],
+        });
+      });
+      context.mocks.api(userConnectorsContract.update, ({ never }) => {
+        return never();
+      });
+      const authWindow = context.mocks.browser.authWindow();
+      Object.defineProperty(authWindow, "location", {
+        value: { href: "" },
+        configurable: true,
+      });
+      context.mocks.browser.open(authWindow);
+      context.mocks.api(
+        connectorOauthStartContract.start,
+        ({ body, params, respond }) => {
+          expect(params.connectorSlug).toBe("google-drive");
+          expect(body).toStrictEqual({
+            account,
+            authMethod: "oauth",
+            agentId: AGENT_ID,
+            authorizeAgent: true,
+            callbackTarget: "app",
+          });
+          oauthStarted = true;
+          connectorConnected = true;
+          agentAuthorized = true;
+          authWindow.close();
+          return respond(200, {
+            authorizationUrl: "https://accounts.google.test/drive/authorize",
+          });
+        },
+      );
+      context.mocks.api(
+        chatThreadArtifactsContract.syncGoogleDrive,
+        ({ body, respond }) => {
+          expect(connectorConnected).toBeTruthy();
+          expect(agentAuthorized).toBeTruthy();
+          expect(body).toStrictEqual({
+            runId: "run-sidebar",
+            fileId: "artifact-drive-connect-notes",
+          });
+          artifactFiles[0] = {
+            ...artifactFiles[0]!,
+            googleDriveSync: {
+              status: "synced",
+              id: "drive-file-connect-notes",
+              name: "drive-connect-notes.md",
+              webViewLink: "https://drive.test/drive-connect-notes",
+            },
+          };
+          artifactSynced = true;
+          return respond(200, {
             id: "drive-file-connect-notes",
             name: "drive-connect-notes.md",
             webViewLink: "https://drive.test/drive-connect-notes",
-          },
-        };
-        artifactSynced = true;
-        return respond(200, {
-          id: "drive-file-connect-notes",
-          name: "drive-connect-notes.md",
-          webViewLink: "https://drive.test/drive-connect-notes",
-        });
-      },
-    );
+          });
+        },
+      );
 
-    setupChatThread({ artifactFiles });
-    await openCatalogArtifact("drive-connect-notes.md");
-    await screen.findByText("Ready for Drive.");
+      setupChatThread({ artifactFiles });
+      await openCatalogArtifact("drive-connect-notes.md");
+      await screen.findByText("Ready for Drive.");
 
-    await user.click(screen.getByLabelText("Download artifact"));
-    await waitFor(() => {
-      expect(menuItemByText("Connect Google Drive")).toBeEnabled();
-    });
-    await user.click(menuItemByText("Connect Google Drive"));
+      await user.click(screen.getByLabelText("Download artifact"));
+      await waitFor(() => {
+        expect(menuItemByText("Connect Google Drive")).toBeEnabled();
+      });
+      await user.click(menuItemByText("Connect Google Drive"));
 
-    await waitFor(() => {
-      expect(oauthStarted).toBeTruthy();
-    });
-    context.mocks.ably.trigger("connector:changed", {
-      connectorSlug: "google-drive",
-    });
+      await waitFor(() => {
+        expect(oauthStarted).toBeTruthy();
+      });
+      context.mocks.ably.trigger("connector:changed", {
+        connectorSlug: "google-drive",
+      });
 
-    await waitFor(() => {
-      expect(artifactSynced).toBeTruthy();
-      expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
-    });
-  });
+      await waitFor(() => {
+        expect(artifactSynced).toBeTruthy();
+        expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
+      });
+    },
+  );
 
   it("shows empty and unavailable CSV states from catalog details", async () => {
     const emptyCsvUrl =

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -51,10 +51,11 @@ import {
   getOnlyAvailableCatalogBrowserAuthMethodDetail,
   type ConnectorCatalogBrowserAuthMethodDetail,
 } from "../../signals/okou-page/settings/connectors.ts";
+import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import {
-  singleAccountConnectorMutation,
-  type PlatformConnectorCatalogStatusItem,
-} from "../../signals/connector-domain.ts";
+  connectorAccountMutationFor,
+  defaultBuiltinConnectorAccountMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import {
   copyAttachmentLinkToClipboard,
   publicAttachmentUrl,
@@ -185,6 +186,14 @@ function startGoogleDriveConnectAndRun(
     return;
   }
   const agentId = params.agentId;
+  const accountMode = defaultBuiltinConnectorAccountMode(params.connector);
+  if (!accountMode) {
+    return;
+  }
+  const account = connectorAccountMutationFor(accountMode);
+  if (!account) {
+    return;
+  }
   const authWindow = window.open(
     "about:blank",
     "_blank",
@@ -203,7 +212,7 @@ function startGoogleDriveConnectAndRun(
       const request = {
         params: { connectorSlug: params.connector.slug },
         body: {
-          account: singleAccountConnectorMutation,
+          account,
           authMethod: params.authMethod.id,
           agentId,
           authorizeAgent: true as const,

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -52,10 +52,7 @@ import {
   type ConnectorCatalogBrowserAuthMethodDetail,
 } from "../../signals/okou-page/settings/connectors.ts";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
-import {
-  connectorAccountMutationFor,
-  defaultBuiltinConnectorAccountMode,
-} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
+import { defaultBuiltinConnectorAccountOptions } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import {
   copyAttachmentLinkToClipboard,
   publicAttachmentUrl,
@@ -186,11 +183,9 @@ function startGoogleDriveConnectAndRun(
     return;
   }
   const agentId = params.agentId;
-  const accountMode = defaultBuiltinConnectorAccountMode(params.connector);
-  if (!accountMode) {
-    return;
-  }
-  const account = connectorAccountMutationFor(accountMode);
+  const account = defaultBuiltinConnectorAccountOptions(
+    params.connector,
+  )?.account;
   if (!account) {
     return;
   }

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -177,10 +177,9 @@ import { CustomConnectorConnectDialog } from "./components/settings/custom-conne
 import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
-  connectorAccountOptionsFor,
-  defaultBuiltinConnectorAccountMode,
-  defaultCustomConnectorAccountMode,
-  type ConnectorAccountConnectMode,
+  defaultBuiltinConnectorAccountOptions,
+  defaultCustomConnectorAccountOptions,
+  type DefaultConnectorAccountMutationOptions,
 } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import {
   connectConnectorNoAuth$,
@@ -10699,18 +10698,18 @@ function ComposerAttachments({ signals }: { signals: ComposerSignals }) {
 
 function ComposerConnectorConnectDialogs({
   selectedConnector,
-  selectedConnectorAccountMode,
+  selectedConnectorAccountOptions,
   selectedCustomConnector,
-  selectedCustomConnectorAccountMode,
+  selectedCustomConnectorAccountOptions,
   agentId,
   onBuiltinClose,
   onBuiltinSuccess,
   onCustomClose,
 }: {
   readonly selectedConnector: PlatformConnectorCatalogStatusItem | undefined;
-  readonly selectedConnectorAccountMode: ConnectorAccountConnectMode | null;
+  readonly selectedConnectorAccountOptions: DefaultConnectorAccountMutationOptions | null;
   readonly selectedCustomConnector: CustomConnectorResponse | undefined;
-  readonly selectedCustomConnectorAccountMode: ConnectorAccountConnectMode | null;
+  readonly selectedCustomConnectorAccountOptions: DefaultConnectorAccountMutationOptions | null;
   readonly agentId: string;
   readonly onBuiltinClose: () => void;
   readonly onBuiltinSuccess: () => Promise<void>;
@@ -10718,20 +10717,20 @@ function ComposerConnectorConnectDialogs({
 }) {
   return (
     <>
-      {selectedConnector && selectedConnectorAccountMode ? (
+      {selectedConnector && selectedConnectorAccountOptions ? (
         <ConnectModal
           item={selectedConnector}
           agentId={agentId}
-          accountMode={selectedConnectorAccountMode}
+          accountOptions={selectedConnectorAccountOptions}
           onClose={onBuiltinClose}
           onSuccess={onBuiltinSuccess}
         />
       ) : null}
-      {selectedCustomConnector && selectedCustomConnectorAccountMode ? (
+      {selectedCustomConnector && selectedCustomConnectorAccountOptions ? (
         <CustomConnectorConnectDialog
           connector={selectedCustomConnector}
           agentId={agentId}
-          accountMode={selectedCustomConnectorAccountMode}
+          accountOptions={selectedCustomConnectorAccountOptions}
           onClose={onCustomClose}
         />
       ) : null}
@@ -10850,11 +10849,10 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const selectedConnector = selectedConnectorSlug
     ? connectorMap.get(selectedConnectorSlug)
     : undefined;
-  const selectedConnectorAccountMode =
-    defaultBuiltinConnectorAccountMode(selectedConnector);
-  const selectedCustomConnectorAccountMode = defaultCustomConnectorAccountMode(
-    selectedCustomConnector,
-  );
+  const selectedConnectorAccountOptions =
+    defaultBuiltinConnectorAccountOptions(selectedConnector);
+  const selectedCustomConnectorAccountOptions =
+    defaultCustomConnectorAccountOptions(selectedCustomConnector);
 
   const handleConnectSuccess = async (connectorSlug: ConnectorSlug) => {
     const label = connectorMap.get(connectorSlug)?.label ?? connectorSlug;
@@ -10924,7 +10922,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     connector: PlatformConnectorCatalogStatusItem,
   ): ConnectorConnectHandlers => {
     const connectorSlug = connector.slug;
-    const accountMode = defaultBuiltinConnectorAccountMode(connector);
+    const accountOptions = defaultBuiltinConnectorAccountOptions(connector);
     return {
       openModal: () => {
         updateConnectorUi({
@@ -10933,7 +10931,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         });
       },
       connectBrowserAuth: async (authMethod) => {
-        if (!accountMode) {
+        if (!accountOptions) {
           return false;
         }
         updateConnectorUi({ pendingConnectorSlug: connectorSlug });
@@ -10944,7 +10942,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
             connectorLabel: connector.label,
             connectorIcon: connector.icon,
             agentId: agentRecordId,
-            ...connectorAccountOptionsFor(accountMode),
+            ...accountOptions,
           },
           pageSignal,
         );
@@ -10956,7 +10954,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         return connected;
       },
       connectNoAuth: async (authMethod) => {
-        if (!accountMode) {
+        if (!accountOptions) {
           return false;
         }
         updateConnectorUi({ pendingConnectorSlug: connectorSlug });
@@ -10967,7 +10965,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
             options: {
               connectorLabel: connector.label,
               agentId: agentRecordId,
-              ...connectorAccountOptionsFor(accountMode),
+              ...accountOptions,
             },
           },
           pageSignal,
@@ -11039,9 +11037,11 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
       />
       <ComposerConnectorConnectDialogs
         selectedConnector={selectedConnector}
-        selectedConnectorAccountMode={selectedConnectorAccountMode}
+        selectedConnectorAccountOptions={selectedConnectorAccountOptions}
         selectedCustomConnector={selectedCustomConnector}
-        selectedCustomConnectorAccountMode={selectedCustomConnectorAccountMode}
+        selectedCustomConnectorAccountOptions={
+          selectedCustomConnectorAccountOptions
+        }
         agentId={agentRecordId}
         onBuiltinClose={() => {
           updateConnectorUi({ selectedConnectorSlug: null });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -177,6 +177,12 @@ import { CustomConnectorConnectDialog } from "./components/settings/custom-conne
 import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
+  connectorAccountOptionsFor,
+  defaultBuiltinConnectorAccountMode,
+  defaultCustomConnectorAccountMode,
+  type ConnectorAccountConnectMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
+import {
   connectConnectorNoAuth$,
   connectConnectorOAuthAuthCode$,
   connectFlowConnectorSlug$,
@@ -10691,6 +10697,48 @@ function ComposerAttachments({ signals }: { signals: ComposerSignals }) {
   );
 }
 
+function ComposerConnectorConnectDialogs({
+  selectedConnector,
+  selectedConnectorAccountMode,
+  selectedCustomConnector,
+  selectedCustomConnectorAccountMode,
+  agentId,
+  onBuiltinClose,
+  onBuiltinSuccess,
+  onCustomClose,
+}: {
+  readonly selectedConnector: PlatformConnectorCatalogStatusItem | undefined;
+  readonly selectedConnectorAccountMode: ConnectorAccountConnectMode | null;
+  readonly selectedCustomConnector: CustomConnectorResponse | undefined;
+  readonly selectedCustomConnectorAccountMode: ConnectorAccountConnectMode | null;
+  readonly agentId: string;
+  readonly onBuiltinClose: () => void;
+  readonly onBuiltinSuccess: () => Promise<void>;
+  readonly onCustomClose: () => void;
+}) {
+  return (
+    <>
+      {selectedConnector && selectedConnectorAccountMode ? (
+        <ConnectModal
+          item={selectedConnector}
+          agentId={agentId}
+          accountMode={selectedConnectorAccountMode}
+          onClose={onBuiltinClose}
+          onSuccess={onBuiltinSuccess}
+        />
+      ) : null}
+      {selectedCustomConnector && selectedCustomConnectorAccountMode ? (
+        <CustomConnectorConnectDialog
+          connector={selectedCustomConnector}
+          agentId={agentId}
+          accountMode={selectedCustomConnectorAccountMode}
+          onClose={onCustomClose}
+        />
+      ) : null}
+    </>
+  );
+}
+
 function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
   const mcpEnabled = useGet(customConnectorMcpEnabled$);
@@ -10802,6 +10850,11 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const selectedConnector = selectedConnectorSlug
     ? connectorMap.get(selectedConnectorSlug)
     : undefined;
+  const selectedConnectorAccountMode =
+    defaultBuiltinConnectorAccountMode(selectedConnector);
+  const selectedCustomConnectorAccountMode = defaultCustomConnectorAccountMode(
+    selectedCustomConnector,
+  );
 
   const handleConnectSuccess = async (connectorSlug: ConnectorSlug) => {
     const label = connectorMap.get(connectorSlug)?.label ?? connectorSlug;
@@ -10871,6 +10924,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     connector: PlatformConnectorCatalogStatusItem,
   ): ConnectorConnectHandlers => {
     const connectorSlug = connector.slug;
+    const accountMode = defaultBuiltinConnectorAccountMode(connector);
     return {
       openModal: () => {
         updateConnectorUi({
@@ -10879,6 +10933,9 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         });
       },
       connectBrowserAuth: async (authMethod) => {
+        if (!accountMode) {
+          return false;
+        }
         updateConnectorUi({ pendingConnectorSlug: connectorSlug });
         const connected = await connectBrowserAuth(
           connectorSlug,
@@ -10887,6 +10944,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
             connectorLabel: connector.label,
             connectorIcon: connector.icon,
             agentId: agentRecordId,
+            ...connectorAccountOptionsFor(accountMode),
           },
           pageSignal,
         );
@@ -10898,6 +10956,9 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         return connected;
       },
       connectNoAuth: async (authMethod) => {
+        if (!accountMode) {
+          return false;
+        }
         updateConnectorUi({ pendingConnectorSlug: connectorSlug });
         const connected = await connectNoAuth(
           {
@@ -10906,6 +10967,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
             options: {
               connectorLabel: connector.label,
               agentId: agentRecordId,
+              ...connectorAccountOptionsFor(accountMode),
             },
           },
           pageSignal,
@@ -10975,30 +11037,25 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         onToggle={handleToggle}
         onToggleCustom={handleCustomToggle}
       />
-      {selectedConnector && (
-        <ConnectModal
-          item={selectedConnector}
-          agentId={agentRecordId}
-          onClose={() => {
-            return updateConnectorUi({ selectedConnectorSlug: null });
-          }}
-          onSuccess={async () => {
-            const connectorSlug = pendingConnectorSlug ?? selectedConnectorSlug;
-            if (connectorSlug) {
-              await completeConnectorAddition(connectorSlug);
-            }
-          }}
-        />
-      )}
-      {selectedCustomConnector && agentRecordId && (
-        <CustomConnectorConnectDialog
-          connector={selectedCustomConnector}
-          agentId={agentRecordId}
-          onClose={() => {
-            updateConnectorUi({ selectedCustomConnectorId: null });
-          }}
-        />
-      )}
+      <ComposerConnectorConnectDialogs
+        selectedConnector={selectedConnector}
+        selectedConnectorAccountMode={selectedConnectorAccountMode}
+        selectedCustomConnector={selectedCustomConnector}
+        selectedCustomConnectorAccountMode={selectedCustomConnectorAccountMode}
+        agentId={agentRecordId}
+        onBuiltinClose={() => {
+          updateConnectorUi({ selectedConnectorSlug: null });
+        }}
+        onBuiltinSuccess={async () => {
+          const connectorSlug = pendingConnectorSlug ?? selectedConnectorSlug;
+          if (connectorSlug) {
+            await completeConnectorAddition(connectorSlug);
+          }
+        }}
+        onCustomClose={() => {
+          updateConnectorUi({ selectedCustomConnectorId: null });
+        }}
+      />
       {connectorUi.showAddDialog && (
         <AddConnectorsDialog
           signals={signals}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -175,6 +175,10 @@ import {
 } from "../../signals/chat-page/chat-goal.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
+import {
+  defaultBuiltinConnectorAccountMode,
+  defaultCustomConnectorAccountMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import { customConnectors$ } from "../../signals/okou-page/settings/custom-connectors.ts";
 import {
   openImageLightbox$ as openAttachmentImageLightbox$,
@@ -5564,20 +5568,30 @@ function ChatConnectorActionConnectModal() {
         (candidate.kind === "http" || mcpEnabled)
       );
     });
-    return connector ? (
+    const accountMode = connector
+      ? defaultCustomConnectorAccountMode(connector)
+      : null;
+    return connector && accountMode ? (
       <CustomConnectorConnectDialog
         connector={connector}
         agentId={active.agentId}
+        accountMode={accountMode}
         onClose={close}
         onSuccess={onSuccess}
       />
     ) : null;
   }
 
+  const accountMode = defaultBuiltinConnectorAccountMode(active.catalogItem);
+  if (!accountMode) {
+    return null;
+  }
+
   return (
     <ConnectModal
       item={active.catalogItem}
       agentId={active.agentId}
+      accountMode={accountMode}
       onClose={close}
       onSuccess={onSuccess}
     />

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -176,8 +176,8 @@ import {
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
 import {
-  defaultBuiltinConnectorAccountMode,
-  defaultCustomConnectorAccountMode,
+  defaultBuiltinConnectorAccountOptions,
+  defaultCustomConnectorAccountOptions,
 } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import { customConnectors$ } from "../../signals/okou-page/settings/custom-connectors.ts";
 import {
@@ -5568,30 +5568,37 @@ function ChatConnectorActionConnectModal() {
         (candidate.kind === "http" || mcpEnabled)
       );
     });
-    const accountMode = connector
-      ? defaultCustomConnectorAccountMode(connector)
+    const accountOptions = connector
+      ? defaultCustomConnectorAccountOptions(connector)
       : null;
-    return connector && accountMode ? (
+    return connector && accountOptions ? (
       <CustomConnectorConnectDialog
         connector={connector}
         agentId={active.agentId}
-        accountMode={accountMode}
+        accountOptions={accountOptions}
         onClose={close}
         onSuccess={onSuccess}
       />
     ) : null;
   }
 
-  const accountMode = defaultBuiltinConnectorAccountMode(active.catalogItem);
-  if (!accountMode) {
+  const accountOptions = defaultBuiltinConnectorAccountOptions(
+    active.catalogItem,
+  );
+  if (!accountOptions) {
     return null;
   }
+  const reconnectAuthMethod =
+    accountOptions.account.intent === "reconnect"
+      ? active.catalogItem.connection?.authMethod
+      : undefined;
 
   return (
     <ConnectModal
       item={active.catalogItem}
       agentId={active.agentId}
-      accountMode={accountMode}
+      accountOptions={accountOptions}
+      reconnectAuthMethod={reconnectAuthMethod}
       onClose={close}
       onSuccess={onSuccess}
     />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -68,6 +68,7 @@ import { i18n } from "../../../../i18n/index.ts";
 import {
   connectorAccountOptionsFor,
   type ConnectorAccountConnectMode,
+  type ConnectorAccountMutationOptions,
 } from "../../../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,7 @@ type PostConnectOptions = {
   readonly connectorLabel?: string;
   readonly agentId?: string;
   readonly account?: ConnectorAccountMutationIntent;
+  readonly useDefaultConnectorProjection?: boolean;
 };
 type BrowserAuthPostConnectOptions = PostConnectOptions & {
   readonly connectorIcon: PlatformConnectorCatalogStatusItem["icon"];
@@ -184,7 +186,9 @@ type ConnectModalContentProps = {
   agentId?: string;
   onSuccess: (connectionId: string | null) => void | Promise<void>;
   authorizeVisibleAgentsOnConnect: boolean;
+  accountOptions: ConnectorAccountMutationOptions;
   accountMode?: ConnectorAccountConnectMode;
+  reconnectAuthMethod?: ConnectorAuthMethodId;
 };
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
@@ -272,7 +276,7 @@ function ManualGrantForm({
   onSuccess,
   authorizeVisibleAgentsOnConnect,
   agentId,
-  accountMode,
+  accountOptions,
   submit,
   submitting,
 }: {
@@ -283,7 +287,7 @@ function ManualGrantForm({
   onSuccess: (connectionId: string | null) => void | Promise<void>;
   authorizeVisibleAgentsOnConnect: boolean;
   agentId?: string;
-  accountMode?: ConnectorAccountConnectMode;
+  accountOptions: ConnectorAccountMutationOptions;
   submit: SubmitManualGrantFn;
   submitting: boolean;
 }) {
@@ -312,7 +316,7 @@ function ManualGrantForm({
           authorizeVisibleAgents: authorizeVisibleAgentsOnConnect,
           connectorLabel,
           ...(agentId ? { agentId } : {}),
-          ...connectorAccountOptionsFor(accountMode),
+          ...accountOptions,
         },
         pageSignal,
       );
@@ -420,7 +424,9 @@ function OAuthAuthCodeConnectButton({
   onSuccess,
   authorizeVisibleAgentsOnConnect,
   agentId,
+  accountOptions,
   accountMode,
+  reconnectAuthMethod,
   connectOAuthAuthCodeAndSettle,
 }: ConnectModalContentProps & {
   method: PublicConnectorCatalogAuthMethodDetail;
@@ -442,7 +448,7 @@ function OAuthAuthCodeConnectButton({
               connectorLabel: item.label,
               connectorIcon: item.icon,
               ...(agentId ? { agentId } : {}),
-              ...connectorAccountOptionsFor(accountMode),
+              ...accountOptions,
             },
             signal,
           ),
@@ -451,7 +457,7 @@ function OAuthAuthCodeConnectButton({
       }}
       className="w-full"
     >
-      {accountMode?.kind === "reconnect"
+      {accountMode?.kind === "reconnect" || reconnectAuthMethod !== undefined
         ? t(($) => {
             return $.connectors.actions.reconnect;
           })
@@ -472,8 +478,11 @@ function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
       item={props.item}
       method={props.method}
       onSuccess={props.onSuccess}
+      agentId={props.agentId}
       authorizeVisibleAgentsOnConnect={props.authorizeVisibleAgentsOnConnect}
+      accountOptions={props.accountOptions}
       accountMode={props.accountMode}
+      reconnectAuthMethod={props.reconnectAuthMethod}
       connectOAuthAuthCodeAndSettle={props.connectOAuthAuthCodeAndSettle}
     />
   );
@@ -805,7 +814,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...connectorAccountOptionsFor(props.accountMode),
+          ...props.accountOptions,
         },
         startOptions: selectedDeviceAuthStartOptions(
           startOptions,
@@ -1040,7 +1049,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
         connectorSlug: props.item.slug,
         authMethod: props.authMethod,
         ...(props.agentId ? { agentId: props.agentId } : {}),
-        ...connectorAccountOptionsFor(props.accountMode),
+        ...props.accountOptions,
         authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
       },
       signal,
@@ -1058,7 +1067,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...connectorAccountOptionsFor(props.accountMode),
+          ...props.accountOptions,
         },
       },
       signal,
@@ -1121,7 +1130,7 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
       onSuccess={props.onSuccess}
       authorizeVisibleAgentsOnConnect={props.authorizeVisibleAgentsOnConnect}
       agentId={props.agentId}
-      accountMode={props.accountMode}
+      accountOptions={props.accountOptions}
       submit={props.submitManualGrant}
       submitting={props.manualGrantSubmitting}
     />
@@ -1141,7 +1150,7 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...connectorAccountOptionsFor(props.accountMode),
+          ...props.accountOptions,
         },
       },
       signal,
@@ -1203,16 +1212,17 @@ function getConnectMethodContentComponent(
   }
 }
 
-function getConnectMethodContentEntries(
+function getConnectEntries(
   item: PlatformConnectorCatalogStatusItem,
   accountMode: ConnectorAccountConnectMode | undefined,
+  reconnectAuthMethod: ConnectorAuthMethodId | undefined,
 ): ConnectMethodContentEntry[] {
+  const requiredAuthMethod =
+    accountMode?.kind === "reconnect"
+      ? accountMode.authMethod
+      : reconnectAuthMethod;
   return item.authMethods.flatMap((method) => {
-    if (
-      accountMode?.kind === "reconnect" &&
-      accountMode.authMethod !== undefined &&
-      method.id !== accountMode.authMethod
-    ) {
+    if (requiredAuthMethod !== undefined && method.id !== requiredAuthMethod) {
       return [];
     }
     const authMethod = method.id;
@@ -1303,7 +1313,9 @@ function StandardConnectMethodsContent({
   agentId,
   onSuccess,
   authorizeVisibleAgentsOnConnect,
+  accountOptions,
   accountMode,
+  reconnectAuthMethod,
   connectOAuthAuthCodeAndSettle,
   connectOAuthDeviceAuthAndSettle,
   connectExternalCode,
@@ -1336,7 +1348,9 @@ function StandardConnectMethodsContent({
           agentId,
           onSuccess,
           authorizeVisibleAgentsOnConnect,
+          accountOptions,
           accountMode,
+          reconnectAuthMethod,
           connectOAuthAuthCodeAndSettle,
           connectOAuthDeviceAuthAndSettle,
           connectExternalCode,
@@ -1357,7 +1371,9 @@ function ConnectModalContent({
   agentId,
   onSuccess,
   authorizeVisibleAgentsOnConnect,
+  accountOptions,
   accountMode,
+  reconnectAuthMethod,
 }: ConnectModalContentProps) {
   const [settleLoadable, connectOAuthAuthCodeAndSettleCommand] = useLoadableSet(
     connectConnectorOAuthAuthCodeAndSettle$,
@@ -1396,7 +1412,7 @@ function ConnectModalContent({
   const manualGrantSubmitting = manualGrantLoadable.state === "loading";
   const noAuthSubmitting = noAuthLoadable.state === "loading";
   const isPolling = pollingConnectorSlug === item.slug;
-  const entries = getConnectMethodContentEntries(item, accountMode);
+  const entries = getConnectEntries(item, accountMode, reconnectAuthMethod);
   const onConnectSuccess = async (connectionId: string | null) => {
     await runConnectSuccess(item.slug, onSuccess, connectionId, pageSignal);
   };
@@ -1462,7 +1478,9 @@ function ConnectModalContent({
       agentId={agentId}
       onSuccess={onConnectSuccess}
       authorizeVisibleAgentsOnConnect={authorizeVisibleAgentsOnConnect}
+      accountOptions={accountOptions}
       accountMode={accountMode}
+      reconnectAuthMethod={reconnectAuthMethod}
       connectOAuthAuthCodeAndSettle={connectOAuthAuthCodeAndSettle}
       connectOAuthDeviceAuthAndSettle={connectOAuthDeviceAuthAndSettleCommandFn}
       connectExternalCode={connectExternalCode}
@@ -1487,14 +1505,18 @@ export function ConnectModal({
   onSuccess,
   authorizeVisibleAgentsOnConnect = false,
   agentId,
+  accountOptions,
   accountMode,
+  reconnectAuthMethod,
 }: {
   item: PlatformConnectorCatalogStatusItem;
   onClose: () => void;
   onSuccess?: (connectionId: string | null) => void | Promise<void>;
   authorizeVisibleAgentsOnConnect?: boolean;
   agentId?: string;
+  accountOptions?: ConnectorAccountMutationOptions;
   accountMode?: ConnectorAccountConnectMode;
+  reconnectAuthMethod?: ConnectorAuthMethodId;
 }) {
   const clearConnectorOAuthDeviceAuth = useSet(clearConnectorOAuthDeviceAuth$);
   const clearConnectorExternalCode = useSet(clearConnectorExternalCode$);
@@ -1556,7 +1578,11 @@ export function ConnectModal({
           item={item}
           agentId={agentId}
           authorizeVisibleAgentsOnConnect={authorizeVisibleAgentsOnConnect}
+          accountOptions={
+            accountOptions ?? connectorAccountOptionsFor(accountMode)
+          }
           accountMode={accountMode}
+          reconnectAuthMethod={reconnectAuthMethod}
           onSuccess={async (connectionId) => {
             await onSuccess?.(connectionId);
             clearConnectorOAuthDeviceAuth();

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -66,7 +66,7 @@ import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 import { i18n } from "../../../../i18n/index.ts";
 import {
-  connectorAccountMutationFor,
+  connectorAccountOptionsFor,
   type ConnectorAccountConnectMode,
 } from "../../../../signals/okou-page/settings/connector-account-dialogs.ts";
 
@@ -312,11 +312,7 @@ function ManualGrantForm({
           authorizeVisibleAgents: authorizeVisibleAgentsOnConnect,
           connectorLabel,
           ...(agentId ? { agentId } : {}),
-          ...(accountMode
-            ? {
-                account: connectorAccountMutationFor(accountMode),
-              }
-            : {}),
+          ...connectorAccountOptionsFor(accountMode),
         },
         pageSignal,
       );
@@ -446,11 +442,7 @@ function OAuthAuthCodeConnectButton({
               connectorLabel: item.label,
               connectorIcon: item.icon,
               ...(agentId ? { agentId } : {}),
-              ...(accountMode
-                ? {
-                    account: connectorAccountMutationFor(accountMode),
-                  }
-                : {}),
+              ...connectorAccountOptionsFor(accountMode),
             },
             signal,
           ),
@@ -813,11 +805,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...(props.accountMode
-            ? {
-                account: connectorAccountMutationFor(props.accountMode),
-              }
-            : {}),
+          ...connectorAccountOptionsFor(props.accountMode),
         },
         startOptions: selectedDeviceAuthStartOptions(
           startOptions,
@@ -1052,12 +1040,8 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
         connectorSlug: props.item.slug,
         authMethod: props.authMethod,
         ...(props.agentId ? { agentId: props.agentId } : {}),
-        ...(props.accountMode
-          ? {
-              account: connectorAccountMutationFor(props.accountMode),
-              authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
-            }
-          : {}),
+        ...connectorAccountOptionsFor(props.accountMode),
+        authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
       },
       signal,
     );
@@ -1074,11 +1058,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...(props.accountMode
-            ? {
-                account: connectorAccountMutationFor(props.accountMode),
-              }
-            : {}),
+          ...connectorAccountOptionsFor(props.accountMode),
         },
       },
       signal,
@@ -1161,11 +1141,7 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
           authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
-          ...(props.accountMode
-            ? {
-                account: connectorAccountMutationFor(props.accountMode),
-              }
-            : {}),
+          ...connectorAccountOptionsFor(props.accountMode),
         },
       },
       signal,
@@ -1234,7 +1210,8 @@ function getConnectMethodContentEntries(
   return item.authMethods.flatMap((method) => {
     if (
       accountMode?.kind === "reconnect" &&
-      method.id !== accountMode.account.authMethod
+      accountMode.authMethod !== undefined &&
+      method.id !== accountMode.authMethod
     ) {
       return [];
     }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -4,7 +4,6 @@ import type {
   CustomConnectorResponse,
   CustomConnectorValueInput,
 } from "@okouai/api-contracts/contracts/custom-connectors";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   Button,
   Dialog,
@@ -148,7 +147,10 @@ function CredentialFields({
   });
 }
 
-function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
+function useCustomConnectorConnectionSubmitters(
+  agentId: string | undefined,
+  accountMode: ConnectorAccountConnectMode | undefined,
+) {
   const [valuesLoadable, submitValues] = useLoadableSet(
     setCustomConnectorValues$,
   );
@@ -167,38 +169,62 @@ function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
   const [accountOAuthLoadable, submitAccountOAuth2] = useLoadableSet(
     connectCustomConnectorAccountOAuth2$,
   );
+  const account = accountMutationFor(accountMode);
+  const usesDefaultProjection =
+    accountMode?.completionSource === "default-projection";
+  const managesAccount = account !== undefined && !usesDefaultProjection;
 
   const submitDeclaredValues = async (
     args: {
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
-      readonly account?: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (args.account) {
-      return await submitAccountValues(
-        { id: args.id, values: args.values, account: args.account },
+    if (managesAccount && account) {
+      return await submitAccountValues({ ...args, account }, signal);
+    }
+    if (agentId) {
+      return await submitAgentValues(
+        { ...args, agentId, ...(account ? { account } : {}) },
         signal,
       );
     }
-    if (agentId) {
-      return await submitAgentValues({ ...args, agentId }, signal);
-    }
-    return await submitValues(args, signal);
+    return await submitValues(
+      { ...args, ...(account ? { account } : {}) },
+      signal,
+    );
   };
   const submitOAuth = async (
     connectorId: string,
-    account: ConnectorAccountMutationIntent | undefined,
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (account) {
+    if (managesAccount && account) {
       return await submitAccountOAuth2({ id: connectorId, account }, signal);
     }
     if (agentId) {
-      return await submitAgentOAuth2({ id: connectorId, agentId }, signal);
+      return await submitAgentOAuth2(
+        {
+          id: connectorId,
+          agentId,
+          ...(account ? { account } : {}),
+          ...(usesDefaultProjection
+            ? { useDefaultConnectorProjection: true as const }
+            : {}),
+        },
+        signal,
+      );
     }
-    return await submitOAuth2(connectorId, signal);
+    return await submitOAuth2(
+      {
+        id: connectorId,
+        ...(account ? { account } : {}),
+        ...(usesDefaultProjection
+          ? { useDefaultConnectorProjection: true as const }
+          : {}),
+      },
+      signal,
+    );
   };
 
   return {
@@ -331,9 +357,8 @@ export function CustomConnectorConnectDialog({
   const resetForm = useSet(resetCustomConnectorConnectInput$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
   const { submitting, submitDeclaredValues, submitOAuth } =
-    useCustomConnectorConnectionSubmitters(agentId);
+    useCustomConnectorConnectionSubmitters(agentId, accountMode);
   const signal = useGet(pageSignal$);
-  const accountMutation = accountMutationFor(accountMode);
   const oauth = connector.authMode === "oauth";
   const values = declaredValuesFromForm(connector, form.values);
   const submittedKeys = new Set(
@@ -374,11 +399,8 @@ export function CustomConnectorConnectDialog({
     detach(
       (async () => {
         const result = oauth
-          ? await submitOAuth(connector.id, accountMutation, signal)
-          : await submitDeclaredValues(
-              { id: connector.id, values, account: accountMutation },
-              signal,
-            );
+          ? await submitOAuth(connector.id, signal)
+          : await submitDeclaredValues({ id: connector.id, values }, signal);
         if (!result.connected) {
           return;
         }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -34,8 +34,9 @@ import { sanitizeTokenInputRecord } from "../../../../signals/okou-page/settings
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
 import {
-  connectorAccountMutationFor as accountMutationFor,
+  connectorAccountOptionsFor,
   type ConnectorAccountConnectMode,
+  type ConnectorAccountMutationOptions,
 } from "../../../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 interface CustomConnectorConnectionSubmission {
@@ -149,7 +150,7 @@ function CredentialFields({
 
 function useCustomConnectorConnectionSubmitters(
   agentId: string | undefined,
-  accountMode: ConnectorAccountConnectMode | undefined,
+  accountOptions: ConnectorAccountMutationOptions,
 ) {
   const [valuesLoadable, submitValues] = useLoadableSet(
     setCustomConnectorValues$,
@@ -169,9 +170,9 @@ function useCustomConnectorConnectionSubmitters(
   const [accountOAuthLoadable, submitAccountOAuth2] = useLoadableSet(
     connectCustomConnectorAccountOAuth2$,
   );
-  const account = accountMutationFor(accountMode);
+  const account = accountOptions.account;
   const usesDefaultProjection =
-    accountMode?.completionSource === "default-projection";
+    accountOptions.useDefaultConnectorProjection === true;
   const managesAccount = account !== undefined && !usesDefaultProjection;
 
   const submitDeclaredValues = async (
@@ -291,6 +292,7 @@ interface CustomConnectorConnectDialogProps {
   readonly agentId?: string;
   readonly onClose?: () => void;
   readonly onSuccess?: (connectionId: string | null) => void | Promise<void>;
+  readonly accountOptions?: ConnectorAccountMutationOptions;
   readonly accountMode?: ConnectorAccountConnectMode;
 }
 
@@ -349,6 +351,7 @@ export function CustomConnectorConnectDialog({
   agentId,
   onClose,
   onSuccess,
+  accountOptions,
   accountMode,
 }: CustomConnectorConnectDialogProps) {
   const { t } = useTranslation();
@@ -356,8 +359,10 @@ export function CustomConnectorConnectDialog({
   const setField = useSet(setCustomConnectorConnectField$);
   const resetForm = useSet(resetCustomConnectorConnectInput$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
+  const resolvedAccountOptions =
+    accountOptions ?? connectorAccountOptionsFor(accountMode);
   const { submitting, submitDeclaredValues, submitOAuth } =
-    useCustomConnectorConnectionSubmitters(agentId, accountMode);
+    useCustomConnectorConnectionSubmitters(agentId, resolvedAccountOptions);
   const signal = useGet(pageSignal$);
   const oauth = connector.authMode === "oauth";
   const values = declaredValuesFromForm(connector, form.values);

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -606,7 +606,7 @@ function CustomConnectorGrid({
       return;
     }
     if (connectsDirectlyWithOAuth(connector)) {
-      detach(connectOAuth2(connector.id, signal), Reason.DomCallback);
+      detach(connectOAuth2({ id: connector.id }, signal), Reason.DomCallback);
       return;
     }
     openConnect(connector);
@@ -736,7 +736,7 @@ function CustomAccountDialogs({
           onReconnect={(account) => {
             openAccountConnect(managedAccounts, {
               kind: "reconnect",
-              account,
+              connectionId: account.id,
             });
           }}
         />

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -1364,7 +1364,8 @@ export function ConnectorsPage() {
           onReconnect={(account) => {
             openAccountConnect(managedAccountConnector, {
               kind: "reconnect",
-              account,
+              connectionId: account.id,
+              authMethod: account.authMethod,
             });
           }}
         />

--- a/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
@@ -44,10 +44,7 @@ import { ProductBrandMarkLink } from "./directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { useTranslation } from "react-i18next";
 import { assistantName$ } from "../../signals/branding.ts";
-import {
-  connectorAccountOptionsFor,
-  defaultBuiltinConnectorAccountMode,
-} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
+import { defaultBuiltinConnectorAccountOptions } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 // ---------------------------------------------------------------------------
 // Action button / authorized badge
@@ -338,13 +335,12 @@ function runDirectedAuthorize(
     );
     return;
   }
-  const accountMode = params.item
-    ? defaultBuiltinConnectorAccountMode(params.item)
+  const accountOptions = params.item
+    ? defaultBuiltinConnectorAccountOptions(params.item)
     : null;
-  if (!accountMode) {
+  if (!accountOptions) {
     return;
   }
-  const accountOptions = connectorAccountOptionsFor(accountMode);
   const launchMode = params.item
     ? getConnectorStatusConnectLaunchMode(params.item)
     : "modal";
@@ -418,8 +414,8 @@ function DirectedAuthorizeConnectModal({
   if (!open || !item) {
     return null;
   }
-  const accountMode = defaultBuiltinConnectorAccountMode(item);
-  if (!accountMode) {
+  const accountOptions = defaultBuiltinConnectorAccountOptions(item);
+  if (!accountOptions) {
     return null;
   }
 
@@ -427,7 +423,7 @@ function DirectedAuthorizeConnectModal({
     <ConnectModal
       item={item}
       agentId={agentId}
-      accountMode={accountMode}
+      accountOptions={accountOptions}
       onSuccess={async () => {
         reloadAuthorization();
         await handleAuthorizeSuccess();

--- a/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
@@ -6,6 +6,7 @@ import {
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -43,6 +44,10 @@ import { ProductBrandMarkLink } from "./directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { useTranslation } from "react-i18next";
 import { assistantName$ } from "../../signals/branding.ts";
+import {
+  connectorAccountOptionsFor,
+  defaultBuiltinConnectorAccountMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 // ---------------------------------------------------------------------------
 // Action button / authorized badge
@@ -296,6 +301,8 @@ function runDirectedAuthorize(
         readonly connectorLabel?: string;
         readonly connectorIcon: PlatformConnectorCatalogStatusItem["icon"];
         readonly agentId?: string;
+        readonly account?: ConnectorAccountMutationIntent;
+        readonly useDefaultConnectorProjection?: boolean;
       },
       signal: AbortSignal,
     ) => Promise<ConnectorConnectionResult | false>;
@@ -306,6 +313,8 @@ function runDirectedAuthorize(
         readonly options: {
           readonly connectorLabel?: string;
           readonly agentId?: string;
+          readonly account?: ConnectorAccountMutationIntent;
+          readonly useDefaultConnectorProjection?: boolean;
         };
       },
       signal: AbortSignal,
@@ -329,6 +338,13 @@ function runDirectedAuthorize(
     );
     return;
   }
+  const accountMode = params.item
+    ? defaultBuiltinConnectorAccountMode(params.item)
+    : null;
+  if (!accountMode) {
+    return;
+  }
+  const accountOptions = connectorAccountOptionsFor(accountMode);
   const launchMode = params.item
     ? getConnectorStatusConnectLaunchMode(params.item)
     : "modal";
@@ -350,6 +366,7 @@ function runDirectedAuthorize(
               connectorLabel: params.connectorLabel,
               connectorIcon: params.item.icon,
               agentId: params.agentId,
+              ...accountOptions,
             },
             signal,
           );
@@ -361,6 +378,7 @@ function runDirectedAuthorize(
               options: {
                 connectorLabel: params.connectorLabel,
                 agentId: params.agentId,
+                ...accountOptions,
               },
             },
             signal,
@@ -400,11 +418,16 @@ function DirectedAuthorizeConnectModal({
   if (!open || !item) {
     return null;
   }
+  const accountMode = defaultBuiltinConnectorAccountMode(item);
+  if (!accountMode) {
+    return null;
+  }
 
   return (
     <ConnectModal
       item={item}
       agentId={agentId}
+      accountMode={accountMode}
       onSuccess={async () => {
         reloadAuthorization();
         await handleAuthorizeSuccess();

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -6,6 +6,7 @@ import {
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   CustomConnectorResponse,
   CustomConnectorSlug,
@@ -81,6 +82,12 @@ import { CustomConnectorIcon } from "./components/settings/custom-connector-icon
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
 import { customConnectorTarget } from "./components/settings/custom-connector-display.ts";
 import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switch.ts";
+import {
+  connectorAccountOptionsFor,
+  defaultBuiltinConnectorAccountMode,
+  defaultCustomConnectorAccountMode,
+  type ConnectorAccountConnectMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 function runDirectedConnect(
   params: {
@@ -94,6 +101,9 @@ function runDirectedConnect(
         readonly connectorLabel?: string;
         readonly connectorIcon: PlatformConnectorCatalogStatusItem["icon"];
         readonly agentId?: string;
+        readonly account?: ConnectorAccountMutationIntent;
+        readonly useDefaultConnectorProjection?: boolean;
+        readonly authorizeVisibleAgents?: boolean;
       },
       signal: AbortSignal,
     ) => Promise<ConnectorConnectionResult | false>;
@@ -104,6 +114,9 @@ function runDirectedConnect(
         readonly options: {
           readonly connectorLabel?: string;
           readonly agentId?: string;
+          readonly account?: ConnectorAccountMutationIntent;
+          readonly useDefaultConnectorProjection?: boolean;
+          readonly authorizeVisibleAgents?: boolean;
         };
       },
       signal: AbortSignal,
@@ -114,6 +127,11 @@ function runDirectedConnect(
   },
   signal: AbortSignal,
 ): void {
+  const accountMode = defaultBuiltinConnectorAccountMode(params.item);
+  if (!accountMode) {
+    return;
+  }
+  const accountOptions = connectorAccountOptionsFor(accountMode);
   const launchMode = getConnectorStatusConnectLaunchMode(params.item);
   if (
     launchMode === "modal" &&
@@ -155,6 +173,8 @@ function runDirectedConnect(
             connectorLabel: params.item.label,
             connectorIcon: params.item.icon,
             ...(params.agentId ? { agentId: params.agentId } : {}),
+            authorizeVisibleAgents: true,
+            ...accountOptions,
           },
           signal,
         );
@@ -174,6 +194,8 @@ function runDirectedConnect(
             options: {
               connectorLabel: params.item.label,
               ...(params.agentId ? { agentId: params.agentId } : {}),
+              authorizeVisibleAgents: true,
+              ...accountOptions,
             },
           },
           signal,
@@ -192,12 +214,14 @@ function ManualGrantForm({
   agentId,
   connectorLabel,
   manualGrantMethod,
+  accountMode,
   onSuccess,
 }: {
   connectorSlug: ConnectorSlug;
   agentId: string | null;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail;
+  accountMode: ConnectorAccountConnectMode;
   onSuccess: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
@@ -236,6 +260,8 @@ function ManualGrantForm({
                 options: {
                   connectorLabel,
                   ...(agentId ? { agentId } : {}),
+                  authorizeVisibleAgents: true,
+                  ...connectorAccountOptionsFor(accountMode),
                 },
               },
               pageSignal,
@@ -307,6 +333,7 @@ function ManualGrantDialog({
   icon,
   connectorLabel,
   manualGrantMethod,
+  accountMode,
   open,
   onOpenChange,
   onSuccess,
@@ -316,11 +343,12 @@ function ManualGrantDialog({
   icon: PlatformConnectorCatalogStatusItem["icon"] | undefined;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
+  accountMode: ConnectorAccountConnectMode | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void | Promise<void>;
 }) {
-  if (!manualGrantMethod) {
+  if (!manualGrantMethod || !accountMode) {
     return null;
   }
   return (
@@ -337,6 +365,7 @@ function ManualGrantDialog({
           agentId={agentId}
           connectorLabel={connectorLabel}
           manualGrantMethod={manualGrantMethod}
+          accountMode={accountMode}
           onSuccess={async () => {
             await onSuccess();
             onOpenChange(false);
@@ -423,10 +452,16 @@ function DirectedConnectModal({
   if (!open || !item) {
     return null;
   }
+  const accountMode = defaultBuiltinConnectorAccountMode(item);
+  if (!accountMode) {
+    return null;
+  }
   return (
     <ConnectModal
       item={item}
       {...(agentId ? { agentId } : {})}
+      accountMode={accountMode}
+      authorizeVisibleAgentsOnConnect
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -458,6 +493,7 @@ function DirectedConnectDialogs({
   readonly setConnectModalOpen: (open: boolean) => void;
   readonly onSuccess: () => void | Promise<void>;
 }) {
+  const accountMode = item ? defaultBuiltinConnectorAccountMode(item) : null;
   return (
     <>
       <ManualGrantDialog
@@ -466,6 +502,7 @@ function DirectedConnectDialogs({
         icon={icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
+        accountMode={accountMode}
         open={manualGrantDialogOpen}
         onOpenChange={setManualGrantDialogOpen}
         onSuccess={onSuccess}
@@ -657,10 +694,11 @@ function DirectedConnectCard() {
     return null;
   }
   const authMethods = item?.authMethods ?? [];
+  const accountMode = item ? defaultBuiltinConnectorAccountMode(item) : null;
   const manualGrantMethod = item
     ? getOnlyManualConnectorStatusAuthMethod(item)
     : null;
-  const canConnect = authMethods.length > 0;
+  const canConnect = authMethods.length > 0 && accountMode !== null;
   const connectorLabel = item?.label ?? connectorSlug;
   const connectorDescription = item?.description ?? "";
   const handleConnectSuccess = async () => {
@@ -758,6 +796,45 @@ function customConnectorForSlug(
   });
 }
 
+interface CustomConnectorConnection {
+  readonly connector: CustomConnectorResponse;
+  readonly accountMode: ConnectorAccountConnectMode;
+}
+
+function customConnectorConnection(
+  connector: CustomConnectorResponse | undefined,
+): CustomConnectorConnection | null {
+  const accountMode = defaultCustomConnectorAccountMode(connector);
+  return connector && accountMode ? { connector, accountMode } : null;
+}
+
+function CustomDirectedConnectorDialog({
+  connection,
+  open,
+  agentId,
+  onClose,
+  onSuccess,
+}: {
+  readonly connection: CustomConnectorConnection | null;
+  readonly open: boolean;
+  readonly agentId: string | null;
+  readonly onClose: () => void;
+  readonly onSuccess: () => Promise<void>;
+}) {
+  if (!connection || !open) {
+    return null;
+  }
+  return (
+    <CustomConnectorConnectDialog
+      connector={connection.connector}
+      {...(agentId ? { agentId } : {})}
+      accountMode={connection.accountMode}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />
+  );
+}
+
 function CustomDirectedConnectCard({
   connectorSlug,
 }: {
@@ -781,6 +858,7 @@ function CustomDirectedConnectCard({
     connectorSlug,
     mcpEnabled,
   );
+  const connection = customConnectorConnection(connector);
   const dialogOpen =
     dialogKey?.connectorSlug === connectorSlug &&
     dialogKey.agentId === agentId &&
@@ -830,25 +908,24 @@ function CustomDirectedConnectCard({
         isLoading={connectorsLoadable.state === "loading"}
         isConnected={connector?.connected ?? false}
         isConnecting={false}
-        canConnect={connector !== undefined}
+        canConnect={connection !== null}
         onConnect={() => {
-          if (!connector) {
+          if (!connection) {
             return;
           }
           resetConnectInput();
           setDialogOpen(true);
         }}
       />
-      {connector && dialogOpen ? (
-        <CustomConnectorConnectDialog
-          connector={connector}
-          {...(agentId ? { agentId } : {})}
-          onClose={() => {
-            setDialogOpen(false);
-          }}
-          onSuccess={handleConnectSuccess}
-        />
-      ) : null}
+      <CustomDirectedConnectorDialog
+        connection={connection}
+        open={dialogOpen}
+        agentId={agentId}
+        onClose={() => {
+          setDialogOpen(false);
+        }}
+        onSuccess={handleConnectSuccess}
+      />
     </>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -83,10 +83,9 @@ import { CustomConnectorConnectDialog } from "./components/settings/custom-conne
 import { customConnectorTarget } from "./components/settings/custom-connector-display.ts";
 import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
-  connectorAccountOptionsFor,
-  defaultBuiltinConnectorAccountMode,
-  defaultCustomConnectorAccountMode,
-  type ConnectorAccountConnectMode,
+  defaultBuiltinConnectorAccountOptions,
+  defaultCustomConnectorAccountOptions,
+  type DefaultConnectorAccountMutationOptions,
 } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 function runDirectedConnect(
@@ -127,11 +126,10 @@ function runDirectedConnect(
   },
   signal: AbortSignal,
 ): void {
-  const accountMode = defaultBuiltinConnectorAccountMode(params.item);
-  if (!accountMode) {
+  const accountOptions = defaultBuiltinConnectorAccountOptions(params.item);
+  if (!accountOptions) {
     return;
   }
-  const accountOptions = connectorAccountOptionsFor(accountMode);
   const launchMode = getConnectorStatusConnectLaunchMode(params.item);
   if (
     launchMode === "modal" &&
@@ -172,8 +170,9 @@ function runDirectedConnect(
           {
             connectorLabel: params.item.label,
             connectorIcon: params.item.icon,
-            ...(params.agentId ? { agentId: params.agentId } : {}),
-            authorizeVisibleAgents: true,
+            ...(params.agentId
+              ? { agentId: params.agentId }
+              : { authorizeVisibleAgents: true }),
             ...accountOptions,
           },
           signal,
@@ -193,8 +192,9 @@ function runDirectedConnect(
             authMethod,
             options: {
               connectorLabel: params.item.label,
-              ...(params.agentId ? { agentId: params.agentId } : {}),
-              authorizeVisibleAgents: true,
+              ...(params.agentId
+                ? { agentId: params.agentId }
+                : { authorizeVisibleAgents: true }),
               ...accountOptions,
             },
           },
@@ -214,14 +214,14 @@ function ManualGrantForm({
   agentId,
   connectorLabel,
   manualGrantMethod,
-  accountMode,
+  accountOptions,
   onSuccess,
 }: {
   connectorSlug: ConnectorSlug;
   agentId: string | null;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail;
-  accountMode: ConnectorAccountConnectMode;
+  accountOptions: DefaultConnectorAccountMutationOptions;
   onSuccess: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
@@ -259,9 +259,8 @@ function ManualGrantForm({
                 ),
                 options: {
                   connectorLabel,
-                  ...(agentId ? { agentId } : {}),
-                  authorizeVisibleAgents: true,
-                  ...connectorAccountOptionsFor(accountMode),
+                  ...(agentId ? { agentId } : { authorizeVisibleAgents: true }),
+                  ...accountOptions,
                 },
               },
               pageSignal,
@@ -333,7 +332,7 @@ function ManualGrantDialog({
   icon,
   connectorLabel,
   manualGrantMethod,
-  accountMode,
+  accountOptions,
   open,
   onOpenChange,
   onSuccess,
@@ -343,12 +342,12 @@ function ManualGrantDialog({
   icon: PlatformConnectorCatalogStatusItem["icon"] | undefined;
   connectorLabel: string;
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
-  accountMode: ConnectorAccountConnectMode | null;
+  accountOptions: DefaultConnectorAccountMutationOptions | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void | Promise<void>;
 }) {
-  if (!manualGrantMethod || !accountMode) {
+  if (!manualGrantMethod || !accountOptions) {
     return null;
   }
   return (
@@ -365,7 +364,7 @@ function ManualGrantDialog({
           agentId={agentId}
           connectorLabel={connectorLabel}
           manualGrantMethod={manualGrantMethod}
-          accountMode={accountMode}
+          accountOptions={accountOptions}
           onSuccess={async () => {
             await onSuccess();
             onOpenChange(false);
@@ -452,16 +451,21 @@ function DirectedConnectModal({
   if (!open || !item) {
     return null;
   }
-  const accountMode = defaultBuiltinConnectorAccountMode(item);
-  if (!accountMode) {
+  const accountOptions = defaultBuiltinConnectorAccountOptions(item);
+  if (!accountOptions) {
     return null;
   }
+  const reconnectAuthMethod =
+    accountOptions.account.intent === "reconnect"
+      ? item.connection?.authMethod
+      : undefined;
   return (
     <ConnectModal
       item={item}
       {...(agentId ? { agentId } : {})}
-      accountMode={accountMode}
-      authorizeVisibleAgentsOnConnect
+      accountOptions={accountOptions}
+      reconnectAuthMethod={reconnectAuthMethod}
+      authorizeVisibleAgentsOnConnect={!agentId}
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -493,7 +497,9 @@ function DirectedConnectDialogs({
   readonly setConnectModalOpen: (open: boolean) => void;
   readonly onSuccess: () => void | Promise<void>;
 }) {
-  const accountMode = item ? defaultBuiltinConnectorAccountMode(item) : null;
+  const accountOptions = item
+    ? defaultBuiltinConnectorAccountOptions(item)
+    : null;
   return (
     <>
       <ManualGrantDialog
@@ -502,7 +508,7 @@ function DirectedConnectDialogs({
         icon={icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
-        accountMode={accountMode}
+        accountOptions={accountOptions}
         open={manualGrantDialogOpen}
         onOpenChange={setManualGrantDialogOpen}
         onSuccess={onSuccess}
@@ -694,11 +700,13 @@ function DirectedConnectCard() {
     return null;
   }
   const authMethods = item?.authMethods ?? [];
-  const accountMode = item ? defaultBuiltinConnectorAccountMode(item) : null;
+  const accountOptions = item
+    ? defaultBuiltinConnectorAccountOptions(item)
+    : null;
   const manualGrantMethod = item
     ? getOnlyManualConnectorStatusAuthMethod(item)
     : null;
-  const canConnect = authMethods.length > 0 && accountMode !== null;
+  const canConnect = authMethods.length > 0 && accountOptions !== null;
   const connectorLabel = item?.label ?? connectorSlug;
   const connectorDescription = item?.description ?? "";
   const handleConnectSuccess = async () => {
@@ -798,14 +806,14 @@ function customConnectorForSlug(
 
 interface CustomConnectorConnection {
   readonly connector: CustomConnectorResponse;
-  readonly accountMode: ConnectorAccountConnectMode;
+  readonly accountOptions: DefaultConnectorAccountMutationOptions;
 }
 
 function customConnectorConnection(
   connector: CustomConnectorResponse | undefined,
 ): CustomConnectorConnection | null {
-  const accountMode = defaultCustomConnectorAccountMode(connector);
-  return connector && accountMode ? { connector, accountMode } : null;
+  const accountOptions = defaultCustomConnectorAccountOptions(connector);
+  return connector && accountOptions ? { connector, accountOptions } : null;
 }
 
 function CustomDirectedConnectorDialog({
@@ -828,7 +836,7 @@ function CustomDirectedConnectorDialog({
     <CustomConnectorConnectDialog
       connector={connection.connector}
       {...(agentId ? { agentId } : {})}
-      accountMode={connection.accountMode}
+      accountOptions={connection.accountOptions}
       onClose={onClose}
       onSuccess={onSuccess}
     />

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -1015,7 +1015,7 @@ describe("onboarding flow", () => {
       ({ body, params, respond }) => {
         expect(params.connectorSlug).toBe("ahrefs");
         expect(body.authMethod).toBe("api-token");
-        expect(body.account).toStrictEqual({ intent: "single-account" });
+        expect(body.account).toStrictEqual({ intent: "add" });
         expect(body.authorizeAgent).toBeTruthy();
         expect(body.agentId).toBeUndefined();
         return respond(200, {

--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -16,15 +16,10 @@ import {
   setSelectedConnectorSlug$,
 } from "../../signals/okou-page/settings/connectors.ts";
 import { connectorCatalogStatus$ } from "../../signals/external/connectors.ts";
-import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "../okou-page/components/settings/add-connection-dialog.tsx";
 import { ConnectorCard } from "../okou-page/components/settings/connector-card.tsx";
-import type { ConnectorConnectHandlers } from "../okou-page/components/settings/launch-connector-connect.ts";
-import {
-  connectorAccountOptionsFor,
-  defaultBuiltinConnectorAccountMode,
-} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
+import { defaultBuiltinConnectorAccountOptions } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 type ConnectorSetupVariant = "workflow" | "prompt";
 
@@ -33,79 +28,6 @@ function parseConnectorSlugs(values: readonly string[]): ConnectorSlug[] {
     const parsed = connectorSlugSchema.safeParse(value);
     return parsed.success ? [parsed.data] : [];
   });
-}
-
-function OnboardingConnectorCard({
-  connectorSlug,
-  item,
-  connected,
-  connecting,
-  loading,
-  layout,
-  required,
-}: {
-  readonly connectorSlug: ConnectorSlug;
-  readonly item: PlatformConnectorCatalogStatusItem | undefined;
-  readonly connected: boolean;
-  readonly connecting: boolean;
-  readonly loading: boolean;
-  readonly layout: ConnectorSetupVariant;
-  readonly required: boolean;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const connect = useSet(connectConnectorOAuthAuthCode$);
-  const connectNoAuth = useSet(connectConnectorNoAuth$);
-  const setSelectedConnectorSlug = useSet(setSelectedConnectorSlug$);
-  const accountMode = defaultBuiltinConnectorAccountMode(item);
-  const connectHandlers: ConnectorConnectHandlers | undefined =
-    item && accountMode
-      ? {
-          openModal: () => {
-            setSelectedConnectorSlug(connectorSlug);
-          },
-          connectBrowserAuth: (authMethod) => {
-            return connect(
-              connectorSlug,
-              authMethod,
-              {
-                connectorLabel: item.label,
-                connectorIcon: item.icon,
-                authorizeVisibleAgents: true,
-                ...connectorAccountOptionsFor(accountMode),
-              },
-              pageSignal,
-            );
-          },
-          connectNoAuth: (authMethod) => {
-            return connectNoAuth(
-              {
-                connectorSlug,
-                authMethod,
-                options: {
-                  connectorLabel: item.label,
-                  authorizeVisibleAgents: true,
-                  ...connectorAccountOptionsFor(accountMode),
-                },
-              },
-              pageSignal,
-            );
-          },
-        }
-      : undefined;
-
-  return (
-    <ConnectorCard
-      variant="onboarding"
-      connectorSlug={connectorSlug}
-      connector={item}
-      connected={connected}
-      busy={connecting}
-      loading={loading}
-      layout={layout}
-      required={required}
-      connect={connectHandlers}
-    />
-  );
 }
 
 export function OnboardingConnectorSetup({
@@ -123,9 +45,12 @@ export function OnboardingConnectorSetup({
   const requiredSet = new Set(
     parseConnectorSlugs(requiredConnectorSlugs ?? []),
   );
+  const pageSignal = useGet(pageSignal$);
   const connectorCatalogItemsLoadable = useLastLoadable(
     connectorCatalogStatus$,
   );
+  const connect = useSet(connectConnectorOAuthAuthCode$);
+  const connectNoAuth = useSet(connectConnectorNoAuth$);
   const selectedConnectorSlug = useGet(selectedConnectorSlug$);
   const setSelectedConnectorSlug = useSet(setSelectedConnectorSlug$);
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
@@ -146,8 +71,8 @@ export function OnboardingConnectorSetup({
         return connector.slug === selectedConnectorSlug;
       })
     : undefined;
-  const selectedAccountMode =
-    defaultBuiltinConnectorAccountMode(selectedConnector);
+  const selectedAccountOptions =
+    defaultBuiltinConnectorAccountOptions(selectedConnector);
   const loading = connectorCatalogItemsLoadable.state === "loading";
 
   return (
@@ -169,26 +94,64 @@ export function OnboardingConnectorSetup({
             connectFlowSlug === connectorSlug ||
             pollingAuthCodeSlug === connectorSlug ||
             pollingDeviceAuthSlug === connectorSlug;
+          const accountOptions = defaultBuiltinConnectorAccountOptions(item);
 
           return (
-            <OnboardingConnectorCard
+            <ConnectorCard
               key={connectorSlug}
+              variant="onboarding"
               connectorSlug={connectorSlug}
-              item={item}
+              connector={item}
               connected={connected}
-              connecting={connecting}
+              busy={connecting}
               loading={loading}
               layout={variant}
               required={requiredSet.has(connectorSlug)}
+              connect={
+                item && accountOptions
+                  ? {
+                      openModal: () => {
+                        setSelectedConnectorSlug(connectorSlug);
+                      },
+                      connectBrowserAuth: (authMethod) => {
+                        return connect(
+                          connectorSlug,
+                          authMethod,
+                          {
+                            connectorLabel: item.label,
+                            connectorIcon: item.icon,
+                            authorizeVisibleAgents: true,
+                            ...accountOptions,
+                          },
+                          pageSignal,
+                        );
+                      },
+                      connectNoAuth: (authMethod) => {
+                        return connectNoAuth(
+                          {
+                            connectorSlug,
+                            authMethod,
+                            options: {
+                              connectorLabel: item.label,
+                              authorizeVisibleAgents: true,
+                              ...accountOptions,
+                            },
+                          },
+                          pageSignal,
+                        );
+                      },
+                    }
+                  : undefined
+              }
             />
           );
         })}
         {children}
       </section>
-      {selectedConnector && selectedAccountMode ? (
+      {selectedConnector && selectedAccountOptions ? (
         <ConnectModal
           item={selectedConnector}
-          accountMode={selectedAccountMode}
+          accountOptions={selectedAccountOptions}
           authorizeVisibleAgentsOnConnect
           onClose={() => {
             setSelectedConnectorSlug(null);

--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -16,9 +16,15 @@ import {
   setSelectedConnectorSlug$,
 } from "../../signals/okou-page/settings/connectors.ts";
 import { connectorCatalogStatus$ } from "../../signals/external/connectors.ts";
+import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "../okou-page/components/settings/add-connection-dialog.tsx";
 import { ConnectorCard } from "../okou-page/components/settings/connector-card.tsx";
+import type { ConnectorConnectHandlers } from "../okou-page/components/settings/launch-connector-connect.ts";
+import {
+  connectorAccountOptionsFor,
+  defaultBuiltinConnectorAccountMode,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 type ConnectorSetupVariant = "workflow" | "prompt";
 
@@ -27,6 +33,79 @@ function parseConnectorSlugs(values: readonly string[]): ConnectorSlug[] {
     const parsed = connectorSlugSchema.safeParse(value);
     return parsed.success ? [parsed.data] : [];
   });
+}
+
+function OnboardingConnectorCard({
+  connectorSlug,
+  item,
+  connected,
+  connecting,
+  loading,
+  layout,
+  required,
+}: {
+  readonly connectorSlug: ConnectorSlug;
+  readonly item: PlatformConnectorCatalogStatusItem | undefined;
+  readonly connected: boolean;
+  readonly connecting: boolean;
+  readonly loading: boolean;
+  readonly layout: ConnectorSetupVariant;
+  readonly required: boolean;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
+  const connectNoAuth = useSet(connectConnectorNoAuth$);
+  const setSelectedConnectorSlug = useSet(setSelectedConnectorSlug$);
+  const accountMode = defaultBuiltinConnectorAccountMode(item);
+  const connectHandlers: ConnectorConnectHandlers | undefined =
+    item && accountMode
+      ? {
+          openModal: () => {
+            setSelectedConnectorSlug(connectorSlug);
+          },
+          connectBrowserAuth: (authMethod) => {
+            return connect(
+              connectorSlug,
+              authMethod,
+              {
+                connectorLabel: item.label,
+                connectorIcon: item.icon,
+                authorizeVisibleAgents: true,
+                ...connectorAccountOptionsFor(accountMode),
+              },
+              pageSignal,
+            );
+          },
+          connectNoAuth: (authMethod) => {
+            return connectNoAuth(
+              {
+                connectorSlug,
+                authMethod,
+                options: {
+                  connectorLabel: item.label,
+                  authorizeVisibleAgents: true,
+                  ...connectorAccountOptionsFor(accountMode),
+                },
+              },
+              pageSignal,
+            );
+          },
+        }
+      : undefined;
+
+  return (
+    <ConnectorCard
+      variant="onboarding"
+      connectorSlug={connectorSlug}
+      connector={item}
+      connected={connected}
+      busy={connecting}
+      loading={loading}
+      layout={layout}
+      required={required}
+      connect={connectHandlers}
+    />
+  );
 }
 
 export function OnboardingConnectorSetup({
@@ -44,12 +123,9 @@ export function OnboardingConnectorSetup({
   const requiredSet = new Set(
     parseConnectorSlugs(requiredConnectorSlugs ?? []),
   );
-  const pageSignal = useGet(pageSignal$);
   const connectorCatalogItemsLoadable = useLastLoadable(
     connectorCatalogStatus$,
   );
-  const connect = useSet(connectConnectorOAuthAuthCode$);
-  const connectNoAuth = useSet(connectConnectorNoAuth$);
   const selectedConnectorSlug = useGet(selectedConnectorSlug$);
   const setSelectedConnectorSlug = useSet(setSelectedConnectorSlug$);
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
@@ -70,6 +146,8 @@ export function OnboardingConnectorSetup({
         return connector.slug === selectedConnectorSlug;
       })
     : undefined;
+  const selectedAccountMode =
+    defaultBuiltinConnectorAccountMode(selectedConnector);
   const loading = connectorCatalogItemsLoadable.state === "loading";
 
   return (
@@ -93,54 +171,25 @@ export function OnboardingConnectorSetup({
             pollingDeviceAuthSlug === connectorSlug;
 
           return (
-            <ConnectorCard
+            <OnboardingConnectorCard
               key={connectorSlug}
-              variant="onboarding"
               connectorSlug={connectorSlug}
-              connector={item}
+              item={item}
               connected={connected}
-              busy={connecting}
+              connecting={connecting}
               loading={loading}
               layout={variant}
               required={requiredSet.has(connectorSlug)}
-              connect={
-                item
-                  ? {
-                      openModal: () => {
-                        setSelectedConnectorSlug(connectorSlug);
-                      },
-                      connectBrowserAuth: (authMethod) => {
-                        return connect(
-                          connectorSlug,
-                          authMethod,
-                          {
-                            connectorLabel: item.label,
-                            connectorIcon: item.icon,
-                          },
-                          pageSignal,
-                        );
-                      },
-                      connectNoAuth: (authMethod) => {
-                        return connectNoAuth(
-                          {
-                            connectorSlug,
-                            authMethod,
-                            options: { connectorLabel: item.label },
-                          },
-                          pageSignal,
-                        );
-                      },
-                    }
-                  : undefined
-              }
             />
           );
         })}
         {children}
       </section>
-      {selectedConnector ? (
+      {selectedConnector && selectedAccountMode ? (
         <ConnectModal
           item={selectedConnector}
+          accountMode={selectedAccountMode}
+          authorizeVisibleAgentsOnConnect
           onClose={() => {
             setSelectedConnectorSlug(null);
           }}

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
@@ -117,6 +117,7 @@ const publicConnectorCatalogConnectionStatusSchema = z.enum([
 ]);
 
 const publicConnectorCatalogConnectionSchema = z.object({
+  id: z.uuid().optional(),
   authMethod: connectorAuthMethodIdSchema,
   externalUsername: z.string().nullable(),
   externalEmail: z.string().nullable(),

--- a/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
@@ -156,6 +156,8 @@ const customConnectorResponseBaseSchema = z.object({
   skillMarkdown: customConnectorSkillMarkdownSchema.nullable().optional(),
   storageVersion: z.number().int().positive(),
   connected: z.boolean(),
+  connectedAccountId: z.uuid().optional(),
+  connectedAccountUpdatedAt: z.string().optional(),
   missingRequiredFields: z.array(z.string()),
   configuredFieldKeys: z.array(z.string()),
   createdAt: z.string(),


### PR DESCRIPTION
## Summary

- expose exact built-in and custom default-account identities in connector projections
- send explicit `add` or exact-ID `reconnect` mutations from every supported non-Settings connector flow
- verify OAuth completion against the mutated default account while preserving agent authorization behavior
- fail closed when a mixed-version API omits the account identity required for a reconnect

## UX and interaction boundary

- Keep internal account mutation options separate from Settings-oriented UI presentation mode.
- Preserve the existing add/authorize entry points and user flow in Chat composer, onboarding, and directed authorize.
- Allow UI changes that accurately communicate a real exact-account reconnect, such as `Reconnect` wording, the existing account status, or retaining that account's auth method.
- Do not let mutation plumbing alone hide connected/configured state, change form requirements or success callbacks, or suppress normal-path actions.
- Keep the current deterministic-default behavior; this PR does not add an account picker.
- Missing exact IDs during mixed-version overlap must fail closed without falling back to `single-account` or treating a connected target as a new account.

## Scope

This PR intentionally leaves the compact Settings compatibility paths on `single-account`. Removing that final boundary remains parent issue work in #28571.

## Validation

Current pushed-head validation:

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm check-types`
- `pnpm knip`
- focused Platform connector integration tests: 7 files, 267 tests passed
- focused API connector catalog/custom connector integration tests: 2 files, 108 tests passed
- focused API contracts connector client tests: 9 tests passed
- isolated App files that timed out under the full four-worker run: 4 files, 75 tests passed
- isolated CLI connector check with the local overriding API URL cleared: 72 tests passed

The full local four-worker Vitest run completed 10,004 tests successfully but exited nonzero because the synced local `OKOU_API_BACKEND_URL` overrode a CLI test's MSW origin and four unrelated App tests hit their 5-second timeout under contention. Both groups passed in the isolated runs above without skipping tests or changing timeouts.

Closes #29769

Parent: #28571
