### PR TITLE
test(api): isolate destructive connector catalog fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -67,7 +67,6 @@ import {
   deleteApiTestConnectorCatalogRuntimeProjectionRow,
   expireApiTestConnectorCatalogRuntimeProjectionAuthority,
   installApiTestConnectorCatalog,
-  mockApiTestConnectorProviderConfiguration,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogFilteredAuthMethods,
@@ -9263,6 +9262,11 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   it("uses exact runtime projections and authoritative fallback for builtin sync", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-runtime-sync-projection-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog();
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await connectors.updateFeatureSwitches(actor, {
@@ -9294,10 +9298,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     }
     expect(larkTarget.sourceId).toBe(connected.id);
 
-    onTestFinished(async () => {
-      mockApiTestConnectorProviderConfiguration();
-      await installApiTestConnectorCatalog();
-    });
     await installApiTestConnectorCatalog({
       catalogVersion: `api-test-runtime-sync-projection-${randomUUID()}`,
       runtimeProjection: true,


### PR DESCRIPTION
## Summary

- isolate the destructive runtime-projection test behind a UUID-scoped connector catalog source
- initialize the private source before connector and run setup
- remove completion-time restoration that could not prevent parallel readers from observing the invalid snapshot

## Why

API test files share PostgreSQL while running in parallel. This test intentionally writes an invalid gzip payload into the active connector catalog snapshot, but previously targeted the default source used by every file. Permission-grant tests could read that snapshot during the corruption window and return an unexpected `500`.

The private source preserves real database, decoding, projection, and fallback behavior without serializing tests or changing production error handling.

## Scope

- test fixture isolation only
- no production behavior changes
- no retries, sleeps, locks, or test serialization

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "uses exact runtime projections and authoritative fallback for builtin sync" --reporter=dot`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/user-permission-grants.test.ts -t "filters expired grants and folds active grants into legacy policies" --reporter=dot`
- focused two-file concurrent invocation repeated sequentially three times: 3/3 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/user-permission-grants.test.ts --reporter=dot` (189 passed)
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks, including full Turbo type checking and full Knip

Closes #29806
