### PR TITLE
test(runner): stabilize agent-ready cache benchmark

### DIFF
--- a/.github/scripts/runner-behavior-agent-ready-benchmark-remote.sh
+++ b/.github/scripts/runner-behavior-agent-ready-benchmark-remote.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR=$1
+GROUP=$2
+INVOCATION_ID=$3
+AGENT_READY_BENCHMARK_SAMPLES=$4
+MAX_WORKSPACE_PROMOTION_RETRIES=3
+AGENT_READY_BENCHMARK_RAW=""
+AGENT_READY_LAST_RUN_ID=""
+AGENT_READY_SAMPLE_ERROR=""
+AGENT_READY_SUBMIT_ERROR=""
+AGENT_READY_SUBMIT_RUN_ID=""
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+case "$AGENT_READY_BENCHMARK_SAMPLES" in
+  ''|*[!0-9]*) fail "Agent-ready benchmark sample count must be an integer" ;;
+esac
+if [ "$AGENT_READY_BENCHMARK_SAMPLES" -lt 1 ] \
+  || [ "$AGENT_READY_BENCHMARK_SAMPLES" -gt 100 ]; then
+  fail "Agent-ready benchmark sample count must be between 1 and 100"
+fi
+
+cleanup() {
+  if [ -n "$AGENT_READY_BENCHMARK_RAW" ]; then
+    rm -f "$AGENT_READY_BENCHMARK_RAW"
+  fi
+}
+trap cleanup EXIT
+
+AGENT_READY_BENCHMARK_RAW=$(mktemp)
+
+record_agent_ready_benchmark_failure() {
+  local path=$1
+  local run_id=$2
+  local error=$3
+  error=$(printf '%s' "$error" | tail -c 512)
+  AGENT_READY_SAMPLE_ERROR=$error
+  jq -cn \
+    --arg path "$path" \
+    --arg run_id "$run_id" \
+    --arg error "$error" \
+    '{path: $path, success: false, run_id: $run_id, error: $error}' \
+    >> "$AGENT_READY_BENCHMARK_RAW"
+}
+
+agent_ready_log_field() {
+  local line=$1
+  local field=$2
+  sed -n "s/.*${field}=\\([^ ]*\\).*/\\1/p" <<<"$line"
+}
+
+read_agent_ready_log() {
+  local run_id=$1
+  local line=""
+  for _ in $(seq 1 50); do
+    line=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1 \
+      | grep -F "run_id=$run_id" \
+      | grep -F 'agent startup timing' \
+      | tail -n 1) || true
+    if [ -n "$line" ]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+submit_agent_ready_benchmark_run() {
+  local chat_thread_id=$1
+  local session_id=$2
+  local result=""
+  local result_json=""
+
+  AGENT_READY_SUBMIT_ERROR=""
+  AGENT_READY_SUBMIT_RUN_ID=""
+  if ! result=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --chat-thread-id "$chat_thread_id" \
+    --session-id "$session_id" \
+    --feature-flag sandboxReuse=true \
+    --prompt 'true' 2>&1); then
+    AGENT_READY_SUBMIT_ERROR="local submit failed: $result"
+    return 1
+  fi
+  result_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$result")
+  AGENT_READY_SUBMIT_RUN_ID=$(jq -r '.run_id // empty' <<<"$result_json" 2>/dev/null) \
+    || true
+  if [ -z "$AGENT_READY_SUBMIT_RUN_ID" ]; then
+    AGENT_READY_SUBMIT_ERROR="local submit omitted run ID"
+    return 1
+  fi
+}
+
+record_agent_ready_benchmark_sample() {
+  local path=$1
+  local expected_sandbox_reuse=$2
+  local expected_workspace_reuse=$3
+  local chat_thread_id=$4
+  local session_id=$5
+  local run_id=""
+  local ready_log=""
+  local sandbox_reuse=""
+  local workspace_reuse=""
+  local shell_spawn_ms=""
+  local agent_ready_ms=""
+  local containment_create_us=""
+  local placement_broker_setup_us=""
+  local shell_spawn_component_us=""
+  local bootstrap_ready_wait_us=""
+
+  AGENT_READY_LAST_RUN_ID=""
+  AGENT_READY_SAMPLE_ERROR=""
+  if ! submit_agent_ready_benchmark_run "$chat_thread_id" "$session_id"; then
+    record_agent_ready_benchmark_failure "$path" "" "$AGENT_READY_SUBMIT_ERROR"
+    return 1
+  fi
+  run_id=$AGENT_READY_SUBMIT_RUN_ID
+  AGENT_READY_LAST_RUN_ID=$run_id
+  if ! ready_log=$(read_agent_ready_log "$run_id"); then
+    record_agent_ready_benchmark_failure "$path" "$run_id" "Agent-ready log was not found"
+    return 1
+  fi
+
+  sandbox_reuse=$(agent_ready_log_field "$ready_log" sandbox_reuse)
+  workspace_reuse=$(agent_ready_log_field "$ready_log" workspace_reuse)
+  if [ "$sandbox_reuse" != "$expected_sandbox_reuse" ]; then
+    record_agent_ready_benchmark_failure "$path" "$run_id" \
+      "expected sandbox_reuse=$expected_sandbox_reuse, observed $sandbox_reuse"
+    return 1
+  fi
+  if [ -n "$expected_workspace_reuse" ] \
+    && [ "$workspace_reuse" != "$expected_workspace_reuse" ]; then
+    record_agent_ready_benchmark_failure "$path" "$run_id" \
+      "expected workspace_reuse=$expected_workspace_reuse, observed $workspace_reuse"
+    return 1
+  fi
+
+  shell_spawn_ms=$(agent_ready_log_field "$ready_log" shell_spawn_ms)
+  agent_ready_ms=$(agent_ready_log_field "$ready_log" agent_ready_ms)
+  containment_create_us=$(agent_ready_log_field "$ready_log" containment_create_us)
+  placement_broker_setup_us=$(agent_ready_log_field "$ready_log" placement_broker_setup_us)
+  shell_spawn_component_us=$(agent_ready_log_field "$ready_log" shell_spawn_component_us)
+  bootstrap_ready_wait_us=$(agent_ready_log_field "$ready_log" bootstrap_ready_wait_us)
+  for value in \
+    "$shell_spawn_ms" \
+    "$agent_ready_ms" \
+    "$containment_create_us" \
+    "$placement_broker_setup_us" \
+    "$shell_spawn_component_us" \
+    "$bootstrap_ready_wait_us"; do
+    case "$value" in
+      ''|*[!0-9]*)
+        record_agent_ready_benchmark_failure "$path" "$run_id" \
+          "Agent-ready log contained a missing or invalid duration"
+        return 1
+        ;;
+    esac
+  done
+
+  jq -cn \
+    --arg path "$path" \
+    --arg run_id "$run_id" \
+    --arg sandbox_reuse "$sandbox_reuse" \
+    --arg workspace_reuse "$workspace_reuse" \
+    --argjson shell_spawn_ms "$shell_spawn_ms" \
+    --argjson agent_ready_ms "$agent_ready_ms" \
+    --argjson containment_create_us "$containment_create_us" \
+    --argjson placement_broker_setup_us "$placement_broker_setup_us" \
+    --argjson shell_spawn_component_us "$shell_spawn_component_us" \
+    --argjson bootstrap_ready_wait_us "$bootstrap_ready_wait_us" \
+    '{
+      path: $path,
+      success: true,
+      run_id: $run_id,
+      sandbox_reuse: $sandbox_reuse,
+      workspace_reuse: $workspace_reuse,
+      shell_spawn_ms: $shell_spawn_ms,
+      agent_ready_ms: $agent_ready_ms,
+      containment_create_us: $containment_create_us,
+      placement_broker_setup_us: $placement_broker_setup_us,
+      shell_spawn_component_us: $shell_spawn_component_us,
+      bootstrap_ready_wait_us: $bootstrap_ready_wait_us
+    }' >> "$AGENT_READY_BENCHMARK_RAW"
+}
+
+read_workspace_promotion_log() {
+  local run_id=$1
+  local line=""
+  for _ in $(seq 1 50); do
+    line=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1 \
+      | grep -F "run_id=$run_id" \
+      | grep -E 'workspace image cache (promoted|promotion skipped)' \
+      | tail -n 1) || true
+    if [ -n "$line" ]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+print_workspace_promotion_diagnostics() {
+  local run_id=$1
+  local logs=""
+  local lines=""
+  echo "--- Workspace cache promotion logs for run ${run_id} ---" >&2
+  logs=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+    || true
+  lines=$(printf '%s\n' "$logs" \
+    | grep -F "run_id=$run_id" \
+    | grep -F 'workspace image cache') || true
+  if [ -n "$lines" ]; then
+    printf '%s\n' "$lines" >&2
+  else
+    echo "No workspace image cache logs found" >&2
+  fi
+}
+
+for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  thread_id=$(cat /proc/sys/kernel/random/uuid)
+  record_agent_ready_benchmark_sample \
+    fresh PoolMiss CacheMiss "$thread_id" "agent-ready-fresh-$index" \
+    || true
+done
+
+WORKSPACE_BENCHMARK_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+if ! submit_agent_ready_benchmark_run \
+  "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace; then
+  fail "workspace-cache Agent-ready benchmark warmup failed: $AGENT_READY_SUBMIT_ERROR"
+fi
+WORKSPACE_BENCHMARK_RUN_ID=$AGENT_READY_SUBMIT_RUN_ID
+WORKSPACE_BENCHMARK_SUCCESSFUL_SAMPLES=0
+WORKSPACE_BENCHMARK_PROMOTION_ATTEMPTS=0
+WORKSPACE_BENCHMARK_MAX_PROMOTION_ATTEMPTS=$((
+  AGENT_READY_BENCHMARK_SAMPLES + MAX_WORKSPACE_PROMOTION_RETRIES
+))
+
+while [ "$WORKSPACE_BENCHMARK_SUCCESSFUL_SAMPLES" -lt "$AGENT_READY_BENCHMARK_SAMPLES" ]; do
+  WORKSPACE_BENCHMARK_PROMOTION_ATTEMPTS=$((WORKSPACE_BENCHMARK_PROMOTION_ATTEMPTS + 1))
+  if ! submit_agent_ready_benchmark_run \
+    "$WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID" agent-ready-workspace-evictor; then
+    fail "workspace-cache Agent-ready benchmark eviction failed: $AGENT_READY_SUBMIT_ERROR"
+  fi
+
+  if ! promotion_log=$(read_workspace_promotion_log "$WORKSPACE_BENCHMARK_RUN_ID"); then
+    print_workspace_promotion_diagnostics "$WORKSPACE_BENCHMARK_RUN_ID"
+    fail "workspace-cache promotion outcome was not found for run $WORKSPACE_BENCHMARK_RUN_ID"
+  fi
+
+  if grep -F 'workspace image cache promotion skipped: capacity lock busy' \
+    <<<"$promotion_log" >/dev/null; then
+    if [ "$WORKSPACE_BENCHMARK_PROMOTION_ATTEMPTS" \
+      -ge "$WORKSPACE_BENCHMARK_MAX_PROMOTION_ATTEMPTS" ]; then
+      print_workspace_promotion_diagnostics "$WORKSPACE_BENCHMARK_RUN_ID"
+      fail "workspace-cache promotion capacity lock remained busy after ${WORKSPACE_BENCHMARK_PROMOTION_ATTEMPTS} attempts"
+    fi
+    echo "RETRY: workspace-cache promotion capacity lock was busy for run ${WORKSPACE_BENCHMARK_RUN_ID}"
+    if ! submit_agent_ready_benchmark_run \
+      "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace; then
+      fail "workspace-cache Agent-ready benchmark re-prime failed: $AGENT_READY_SUBMIT_ERROR"
+    fi
+    WORKSPACE_BENCHMARK_RUN_ID=$AGENT_READY_SUBMIT_RUN_ID
+    continue
+  fi
+
+  if ! grep -F 'workspace image cache promoted' <<<"$promotion_log" >/dev/null; then
+    print_workspace_promotion_diagnostics "$WORKSPACE_BENCHMARK_RUN_ID"
+    fail "unexpected workspace-cache promotion outcome for run $WORKSPACE_BENCHMARK_RUN_ID"
+  fi
+
+  if ! record_agent_ready_benchmark_sample \
+    workspace-cache PoolMiss Reused \
+    "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace; then
+    fail "workspace-cache sample failed after confirmed promotion: $AGENT_READY_SAMPLE_ERROR"
+  fi
+  WORKSPACE_BENCHMARK_RUN_ID=$AGENT_READY_LAST_RUN_ID
+  WORKSPACE_BENCHMARK_SUCCESSFUL_SAMPLES=$((WORKSPACE_BENCHMARK_SUCCESSFUL_SAMPLES + 1))
+done
+
+EXACT_REUSE_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+if ! submit_agent_ready_benchmark_run \
+  "$EXACT_REUSE_THREAD_ID" agent-ready-exact-reuse; then
+  fail "exact-reuse Agent-ready benchmark warmup failed: $AGENT_READY_SUBMIT_ERROR"
+fi
+for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
+  record_agent_ready_benchmark_sample \
+    exact-reuse Reused SandboxReused \
+    "$EXACT_REUSE_THREAD_ID" agent-ready-exact-reuse \
+    || true
+done
+
+echo "AGENT_READY_BENCHMARK_RAW_BEGIN"
+cat "$AGENT_READY_BENCHMARK_RAW"
+echo "AGENT_READY_BENCHMARK_RAW_END"
+jq -s '
+  def percentile($values; $ratio):
+    ($values | sort) as $ordered
+    | if ($ordered | length) == 0 then null
+      else $ordered[((($ordered | length) * $ratio | ceil) - 1)]
+      end;
+  def metric_summary($rows; $field):
+    [$rows[] | select(.success) | .[$field]] as $values
+    | {
+        p50: percentile($values; 0.50),
+        p90: percentile($values; 0.90),
+        p95: percentile($values; 0.95),
+        p99: percentile($values; 0.99)
+      };
+  . as $records
+  | ["fresh", "workspace-cache", "exact-reuse"]
+  | map(
+      . as $path
+      | [$records[] | select(.path == $path)] as $rows
+      | {
+          path: $path,
+          sample_count: ($rows | length),
+          failures: ([$rows[] | select(.success | not)] | length),
+          metrics: {
+            shell_spawn_ms: metric_summary($rows; "shell_spawn_ms"),
+            agent_ready_ms: metric_summary($rows; "agent_ready_ms"),
+            containment_create_us: metric_summary($rows; "containment_create_us"),
+            placement_broker_setup_us: metric_summary($rows; "placement_broker_setup_us"),
+            shell_spawn_component_us: metric_summary($rows; "shell_spawn_component_us"),
+            bootstrap_ready_wait_us: metric_summary($rows; "bootstrap_ready_wait_us")
+          }
+        }
+    )
+' "$AGENT_READY_BENCHMARK_RAW"
+
+AGENT_READY_BENCHMARK_FAILURES=$(jq -s '[.[] | select(.success | not)] | length' \
+  "$AGENT_READY_BENCHMARK_RAW")
+[ "$AGENT_READY_BENCHMARK_FAILURES" -eq 0 ] \
+  || fail "Agent-ready benchmark recorded $AGENT_READY_BENCHMARK_FAILURES failures"

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+AGENT_READY_BENCHMARK_SOURCE="${SCRIPT_DIR}/runner-behavior-agent-ready-benchmark-remote.sh"
 REMOTE="${METAL_USER}@${HOST}"
 SVC="${JOB_REF}-process-containment"
 GROUP="vm0/process-containment-${JOB_REF}"
 RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
 GROUP_DIR="/var/lib/vm0-runner/groups/vm0/process-containment-${JOB_REF}"
+AGENT_READY_BENCHMARK_WORKER="${RUNNER_DIR}/agent-ready-benchmark.sh"
 
 echo "=== Cleaning stale process-containment runner state ==="
 ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
@@ -39,25 +42,31 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --api-url https://not-a-real-server.test \
   --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
+echo "=== Staging Agent-ready benchmark worker ==="
+# shellcheck disable=SC2029
+ssh "$REMOTE" "sudo tee '${AGENT_READY_BENCHMARK_WORKER}' >/dev/null \
+  && sudo chmod 0755 '${AGENT_READY_BENCHMARK_WORKER}'" \
+  < "$AGENT_READY_BENCHMARK_SOURCE"
+
 echo "=== Running process-containment test ==="
-ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GROUP_DIR}" "${AGENT_READY_BENCHMARK_SAMPLES:-3}" <<'REMOTE_SCRIPT'
+ssh "$REMOTE" bash -s -- \
+  "${BIN_DIR}" \
+  "${SVC}" \
+  "${GROUP}" \
+  "${RUNNER_DIR}" \
+  "${GROUP_DIR}" \
+  "${AGENT_READY_BENCHMARK_WORKER}" \
+  "${AGENT_READY_BENCHMARK_SAMPLES:-3}" <<'REMOTE_SCRIPT'
 set -euo pipefail
-BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5; AGENT_READY_BENCHMARK_SAMPLES=$6
+BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
+AGENT_READY_BENCHMARK_WORKER=$6; AGENT_READY_BENCHMARK_SAMPLES=$7
 UNIT="vm0-runner-${SVC}.service"
 SESSION_ID="e2e-process-containment-session"
 CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 PRESSURE_SUBMIT_PID=""
 PRESSURE_SUBMIT_OUTPUT=""
-AGENT_READY_BENCHMARK_RAW=""
 
 fail() { echo "FAIL: $1"; exit 1; }
-
-case "$AGENT_READY_BENCHMARK_SAMPLES" in
-  ''|*[!0-9]*) fail "Agent-ready benchmark sample count must be an integer" ;;
-esac
-[ "$AGENT_READY_BENCHMARK_SAMPLES" -ge 1 ] \
-  && [ "$AGENT_READY_BENCHMARK_SAMPLES" -le 100 ] \
-  || fail "Agent-ready benchmark sample count must be between 1 and 100"
 
 wait_for_unit_inactive() {
   for _ in $(seq 1 30); do
@@ -77,9 +86,6 @@ cleanup() {
   fi
   if [ -n "$PRESSURE_SUBMIT_OUTPUT" ]; then
     rm -f "$PRESSURE_SUBMIT_OUTPUT"
-  fi
-  if [ -n "$AGENT_READY_BENCHMARK_RAW" ]; then
-    rm -f "$AGENT_READY_BENCHMARK_RAW"
   fi
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   wait_for_unit_inactive
@@ -982,231 +988,11 @@ if grep -F 'process control latency exceeded calibrated bound' <<<"$LOGS" >/dev/
 fi
 
 echo "--- Benchmark: Guest Agent ready boundary ---"
-AGENT_READY_BENCHMARK_RAW=$(mktemp)
-
-record_agent_ready_benchmark_failure() {
-  local path=$1
-  local run_id=$2
-  local error=$3
-  error=$(printf '%s' "$error" | tail -c 512)
-  jq -cn \
-    --arg path "$path" \
-    --arg run_id "$run_id" \
-    --arg error "$error" \
-    '{path: $path, success: false, run_id: $run_id, error: $error}' \
-    >> "$AGENT_READY_BENCHMARK_RAW"
-}
-
-agent_ready_log_field() {
-  local line=$1
-  local field=$2
-  sed -n "s/.*${field}=\\([^ ]*\\).*/\\1/p" <<<"$line"
-}
-
-read_agent_ready_log() {
-  local run_id=$1
-  local line=""
-  for _ in $(seq 1 50); do
-    line=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1 \
-      | grep -F "run_id=$run_id" \
-      | grep -F 'agent startup timing' \
-      | tail -n 1) || true
-    if [ -n "$line" ]; then
-      printf '%s\n' "$line"
-      return 0
-    fi
-    sleep 0.1
-  done
-  return 1
-}
-
-record_agent_ready_benchmark_sample() {
-  local path=$1
-  local expected_sandbox_reuse=$2
-  local expected_workspace_reuse=$3
-  local chat_thread_id=$4
-  local session_id=$5
-  local result=""
-  local result_json=""
-  local run_id=""
-  local ready_log=""
-  local sandbox_reuse=""
-  local workspace_reuse=""
-  local shell_spawn_ms=""
-  local agent_ready_ms=""
-  local containment_create_us=""
-  local placement_broker_setup_us=""
-  local shell_spawn_component_us=""
-  local bootstrap_ready_wait_us=""
-
-  if ! result=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-    --chat-thread-id "$chat_thread_id" \
-    --session-id "$session_id" \
-    --feature-flag sandboxReuse=true \
-    --prompt 'true' 2>&1); then
-    record_agent_ready_benchmark_failure "$path" "" "local submit failed: $result"
-    return
-  fi
-  result_json=$(awk '/^\{/{line=$0} END{print line}' <<<"$result")
-  run_id=$(jq -r '.run_id // empty' <<<"$result_json" 2>/dev/null) || true
-  if [ -z "$run_id" ]; then
-    record_agent_ready_benchmark_failure "$path" "" "local submit omitted run ID"
-    return
-  fi
-  if ! ready_log=$(read_agent_ready_log "$run_id"); then
-    record_agent_ready_benchmark_failure "$path" "$run_id" "Agent-ready log was not found"
-    return
-  fi
-
-  sandbox_reuse=$(agent_ready_log_field "$ready_log" sandbox_reuse)
-  workspace_reuse=$(agent_ready_log_field "$ready_log" workspace_reuse)
-  if [ "$sandbox_reuse" != "$expected_sandbox_reuse" ]; then
-    record_agent_ready_benchmark_failure "$path" "$run_id" \
-      "expected sandbox_reuse=$expected_sandbox_reuse, observed $sandbox_reuse"
-    return
-  fi
-  if [ -n "$expected_workspace_reuse" ] \
-    && [ "$workspace_reuse" != "$expected_workspace_reuse" ]; then
-    record_agent_ready_benchmark_failure "$path" "$run_id" \
-      "expected workspace_reuse=$expected_workspace_reuse, observed $workspace_reuse"
-    return
-  fi
-
-  shell_spawn_ms=$(agent_ready_log_field "$ready_log" shell_spawn_ms)
-  agent_ready_ms=$(agent_ready_log_field "$ready_log" agent_ready_ms)
-  containment_create_us=$(agent_ready_log_field "$ready_log" containment_create_us)
-  placement_broker_setup_us=$(agent_ready_log_field "$ready_log" placement_broker_setup_us)
-  shell_spawn_component_us=$(agent_ready_log_field "$ready_log" shell_spawn_component_us)
-  bootstrap_ready_wait_us=$(agent_ready_log_field "$ready_log" bootstrap_ready_wait_us)
-  for value in \
-    "$shell_spawn_ms" \
-    "$agent_ready_ms" \
-    "$containment_create_us" \
-    "$placement_broker_setup_us" \
-    "$shell_spawn_component_us" \
-    "$bootstrap_ready_wait_us"; do
-    case "$value" in
-      ''|*[!0-9]*)
-        record_agent_ready_benchmark_failure "$path" "$run_id" \
-          "Agent-ready log contained a missing or invalid duration"
-        return
-        ;;
-    esac
-  done
-
-  jq -cn \
-    --arg path "$path" \
-    --arg run_id "$run_id" \
-    --arg sandbox_reuse "$sandbox_reuse" \
-    --arg workspace_reuse "$workspace_reuse" \
-    --argjson shell_spawn_ms "$shell_spawn_ms" \
-    --argjson agent_ready_ms "$agent_ready_ms" \
-    --argjson containment_create_us "$containment_create_us" \
-    --argjson placement_broker_setup_us "$placement_broker_setup_us" \
-    --argjson shell_spawn_component_us "$shell_spawn_component_us" \
-    --argjson bootstrap_ready_wait_us "$bootstrap_ready_wait_us" \
-    '{
-      path: $path,
-      success: true,
-      run_id: $run_id,
-      sandbox_reuse: $sandbox_reuse,
-      workspace_reuse: $workspace_reuse,
-      shell_spawn_ms: $shell_spawn_ms,
-      agent_ready_ms: $agent_ready_ms,
-      containment_create_us: $containment_create_us,
-      placement_broker_setup_us: $placement_broker_setup_us,
-      shell_spawn_component_us: $shell_spawn_component_us,
-      bootstrap_ready_wait_us: $bootstrap_ready_wait_us
-    }' >> "$AGENT_READY_BENCHMARK_RAW"
-}
-
-for index in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  thread_id=$(cat /proc/sys/kernel/random/uuid)
-  record_agent_ready_benchmark_sample \
-    fresh PoolMiss CacheMiss "$thread_id" "agent-ready-fresh-$index"
-done
-
-WORKSPACE_BENCHMARK_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
-WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --chat-thread-id "$WORKSPACE_BENCHMARK_THREAD_ID" \
-  --session-id agent-ready-workspace \
-  --feature-flag sandboxReuse=true \
-  --prompt 'true' >/dev/null \
-  || fail "workspace-cache Agent-ready benchmark warmup failed"
-
-for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  # Pool-pressure eviction promotes the measured workspace. Alternate with a
-  # second key so every sample checks out that promoted image instead of taking
-  # the exact sandbox-reuse path or relying on service-stop promotion.
-  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-    --chat-thread-id "$WORKSPACE_BENCHMARK_EVICTOR_THREAD_ID" \
-    --session-id agent-ready-workspace-evictor \
-    --feature-flag sandboxReuse=true \
-    --prompt 'true' >/dev/null \
-    || fail "workspace-cache Agent-ready benchmark eviction failed"
-  record_agent_ready_benchmark_sample \
-    workspace-cache PoolMiss Reused \
-    "$WORKSPACE_BENCHMARK_THREAD_ID" agent-ready-workspace
-done
-
-EXACT_REUSE_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --chat-thread-id "$EXACT_REUSE_THREAD_ID" \
-  --session-id agent-ready-exact-reuse \
-  --feature-flag sandboxReuse=true \
-  --prompt 'true' >/dev/null \
-  || fail "exact-reuse Agent-ready benchmark warmup failed"
-for _ in $(seq 1 "$AGENT_READY_BENCHMARK_SAMPLES"); do
-  record_agent_ready_benchmark_sample \
-    exact-reuse Reused SandboxReused \
-    "$EXACT_REUSE_THREAD_ID" agent-ready-exact-reuse
-done
-
-echo "AGENT_READY_BENCHMARK_RAW_BEGIN"
-cat "$AGENT_READY_BENCHMARK_RAW"
-echo "AGENT_READY_BENCHMARK_RAW_END"
-jq -s '
-  def percentile($values; $ratio):
-    ($values | sort) as $ordered
-    | if ($ordered | length) == 0 then null
-      else $ordered[((($ordered | length) * $ratio | ceil) - 1)]
-      end;
-  def metric_summary($rows; $field):
-    [$rows[] | select(.success) | .[$field]] as $values
-    | {
-        p50: percentile($values; 0.50),
-        p90: percentile($values; 0.90),
-        p95: percentile($values; 0.95),
-        p99: percentile($values; 0.99)
-      };
-  . as $records
-  | ["fresh", "workspace-cache", "exact-reuse"]
-  | map(
-      . as $path
-      | [$records[] | select(.path == $path)] as $rows
-      | {
-          path: $path,
-          sample_count: ($rows | length),
-          failures: ([$rows[] | select(.success | not)] | length),
-          metrics: {
-            shell_spawn_ms: metric_summary($rows; "shell_spawn_ms"),
-            agent_ready_ms: metric_summary($rows; "agent_ready_ms"),
-            containment_create_us: metric_summary($rows; "containment_create_us"),
-            placement_broker_setup_us: metric_summary($rows; "placement_broker_setup_us"),
-            shell_spawn_component_us: metric_summary($rows; "shell_spawn_component_us"),
-            bootstrap_ready_wait_us: metric_summary($rows; "bootstrap_ready_wait_us")
-          }
-        }
-    )
-' "$AGENT_READY_BENCHMARK_RAW"
-
-AGENT_READY_BENCHMARK_FAILURES=$(jq -s '[.[] | select(.success | not)] | length' \
-  "$AGENT_READY_BENCHMARK_RAW")
-[ "$AGENT_READY_BENCHMARK_FAILURES" -eq 0 ] \
-  || fail "Agent-ready benchmark recorded $AGENT_READY_BENCHMARK_FAILURES failures"
-rm -f "$AGENT_READY_BENCHMARK_RAW"
-AGENT_READY_BENCHMARK_RAW=""
+sudo "$AGENT_READY_BENCHMARK_WORKER" \
+  "$BIN_DIR" \
+  "$GROUP" \
+  "$INVOCATION_ID" \
+  "$AGENT_READY_BENCHMARK_SAMPLES"
 
 echo "PASS: detached user/root descendants were reclaimed"
 echo "PASS: mixed-identity leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"

--- a/.github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh
+++ b/.github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh
@@ -79,6 +79,12 @@ write_agent_log() {
 }
 
 if [ "$1" = "journalctl" ]; then
+  if [ "$#" -ne 3 ] \
+    || [ "$2" != "--no-pager" ] \
+    || [ "$3" != "_SYSTEMD_INVOCATION_ID=invocation-id" ]; then
+    echo "journal read was not scoped to the expected invocation: $*" >&2
+    exit 2
+  fi
   cat "$TEST_STATE_DIR/journal"
   exit 0
 fi
@@ -129,6 +135,9 @@ case "$session_id" in
     if [ "$promotion" = busy ]; then
       printf '%s\n' \
         "run_id=${workspace_run_id} workspace image cache promotion skipped: capacity lock busy" \
+        >> "$TEST_STATE_DIR/journal"
+      printf '%s\n' \
+        'run_id=unrelated-run workspace image cache promoted' \
         >> "$TEST_STATE_DIR/journal"
     else
       printf '%s\n' \

--- a/.github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh
+++ b/.github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+WORKER="$REPO_ROOT/.github/scripts/runner-behavior-agent-ready-benchmark-remote.sh"
+
+assert_contains() {
+  local file=$1
+  local expected=$2
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "expected ${file} to contain: ${expected}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_count() {
+  local file=$1
+  local expected=$2
+  local value=$3
+  local actual=""
+
+  actual=$(grep -Fc -- "$value" "$file" || true)
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${file} to contain ${value} ${expected} time(s); got ${actual}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_value() {
+  local file=$1
+  local expected=$2
+  local actual=""
+
+  actual=$(<"$file")
+  if [ "$actual" != "$expected" ]; then
+    echo "expected ${file} to contain ${expected}; got ${actual}" >&2
+    exit 1
+  fi
+}
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/sudo" <<'FAKE_SUDO'
+#!/usr/bin/env bash
+set -euo pipefail
+
+increment() {
+  local name=$1
+  local file="$TEST_STATE_DIR/$name"
+  local value=0
+
+  if [ -f "$file" ]; then
+    value=$(<"$file")
+  fi
+  value=$((value + 1))
+  printf '%s\n' "$value" > "$file"
+  printf '%s\n' "$value"
+}
+
+write_agent_log() {
+  local run_id=$1
+  local sandbox_reuse=$2
+  local workspace_reuse=$3
+
+  printf '%s\n' \
+    "run_id=${run_id} agent startup timing sandbox_reuse=${sandbox_reuse} workspace_reuse=${workspace_reuse} shell_spawn_ms=1 agent_ready_ms=2 containment_create_us=3 placement_broker_setup_us=4 shell_spawn_component_us=5 bootstrap_ready_wait_us=6" \
+    >> "$TEST_STATE_DIR/journal"
+}
+
+if [ "$1" = "journalctl" ]; then
+  cat "$TEST_STATE_DIR/journal"
+  exit 0
+fi
+
+if [ "$1" != "/fake/bin/runner" ] || [ "$2" != "local" ] || [ "$3" != "submit" ]; then
+  echo "unexpected sudo invocation: $*" >&2
+  exit 2
+fi
+
+session_id=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--session-id" ]; then
+    session_id=$2
+    break
+  fi
+  shift
+done
+[ -n "$session_id" ] || { echo "local submit omitted session ID" >&2; exit 2; }
+
+submit_count=$(increment submit-count)
+run_id="run-${submit_count}"
+
+case "$session_id" in
+  agent-ready-fresh-*)
+    write_agent_log "$run_id" PoolMiss CacheMiss
+    ;;
+  agent-ready-workspace)
+    workspace_reuse=CacheMiss
+    if [ -f "$TEST_STATE_DIR/last-promotion" ] \
+      && [ "$(<"$TEST_STATE_DIR/last-promotion")" = promoted ]; then
+      workspace_reuse=Reused
+      if [ "$TEST_SCENARIO" = confirmed-miss ]; then
+        workspace_reuse=CacheMiss
+      fi
+    fi
+    write_agent_log "$run_id" PoolMiss "$workspace_reuse"
+    printf '%s\n' "$run_id" > "$TEST_STATE_DIR/workspace-run-id"
+    ;;
+  agent-ready-workspace-evictor)
+    evict_count=$(increment evict-count)
+    workspace_run_id=$(<"$TEST_STATE_DIR/workspace-run-id")
+    promotion=promoted
+    if [ "$TEST_SCENARIO" = persistent-contention ] \
+      || { [ "$TEST_SCENARIO" = transient-contention ] && [ "$evict_count" -eq 1 ]; }; then
+      promotion=busy
+    fi
+    printf '%s\n' "$promotion" > "$TEST_STATE_DIR/last-promotion"
+    if [ "$promotion" = busy ]; then
+      printf '%s\n' \
+        "run_id=${workspace_run_id} workspace image cache promotion skipped: capacity lock busy" \
+        >> "$TEST_STATE_DIR/journal"
+    else
+      printf '%s\n' \
+        "run_id=${workspace_run_id} workspace image cache promoted" \
+        >> "$TEST_STATE_DIR/journal"
+    fi
+    ;;
+  agent-ready-exact-reuse)
+    exact_count=$(increment exact-count)
+    if [ "$exact_count" -eq 1 ]; then
+      write_agent_log "$run_id" PoolMiss CacheMiss
+    else
+      write_agent_log "$run_id" Reused SandboxReused
+    fi
+    ;;
+  *)
+    echo "unexpected session ID: $session_id" >&2
+    exit 2
+    ;;
+esac
+
+printf '{"run_id":"%s"}\n' "$run_id"
+FAKE_SUDO
+chmod +x "$fake_bin/sudo"
+
+LAST_CASE_DIR=""
+
+run_case() {
+  local name=$1
+  local scenario=$2
+  local expected_status=$3
+  local sample_count=$4
+  local case_dir="$tmp/$name"
+  local status=0
+
+  mkdir -p "$case_dir"
+  : > "$case_dir/journal"
+  set +e
+  TEST_SCENARIO="$scenario" \
+    TEST_STATE_DIR="$case_dir" \
+    PATH="$fake_bin:$PATH" \
+    bash "$WORKER" /fake/bin vm0/test invocation-id "$sample_count" \
+    > "$case_dir/output" 2>&1
+  status=$?
+  set -e
+  if [ "$status" -ne "$expected_status" ]; then
+    echo "expected ${name} status ${expected_status}; got ${status}" >&2
+    cat "$case_dir/output" >&2
+    exit 1
+  fi
+  LAST_CASE_DIR=$case_dir
+}
+
+run_case direct-success direct-success 0 2
+assert_count "$LAST_CASE_DIR/output" 2 '"path":"fresh","success":true'
+assert_count "$LAST_CASE_DIR/output" 2 '"path":"workspace-cache","success":true'
+assert_count "$LAST_CASE_DIR/output" 2 '"path":"exact-reuse","success":true'
+assert_value "$LAST_CASE_DIR/submit-count" 10
+
+run_case transient-contention transient-contention 0 1
+assert_contains "$LAST_CASE_DIR/output" \
+  'RETRY: workspace-cache promotion capacity lock was busy for run run-2'
+assert_count "$LAST_CASE_DIR/output" 1 '"path":"workspace-cache","success":true'
+assert_value "$LAST_CASE_DIR/submit-count" 8
+
+run_case persistent-contention persistent-contention 1 1
+assert_contains "$LAST_CASE_DIR/output" \
+  'workspace-cache promotion capacity lock remained busy after 4 attempts'
+assert_count "$LAST_CASE_DIR/output" 3 \
+  'RETRY: workspace-cache promotion capacity lock was busy'
+assert_value "$LAST_CASE_DIR/submit-count" 9
+
+run_case confirmed-miss confirmed-miss 1 1
+assert_contains "$LAST_CASE_DIR/output" \
+  'workspace-cache sample failed after confirmed promotion: expected workspace_reuse=Reused, observed CacheMiss'
+assert_value "$LAST_CASE_DIR/submit-count" 4
+
+echo "PASS: Agent-ready benchmark handles workspace-cache promotion contention"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -306,6 +306,7 @@ jobs:
             .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \
             .github/scripts/tests/semgrep-results-test.sh \
+            .github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh \
             .github/scripts/tests/runner-behavior-durable-test.sh \
             .github/scripts/tests/validate-desktop-migration-policy-test.sh \
             e2e/scripts/ensure-stripe-cli.sh \


### PR DESCRIPTION
## Summary

- extract the Agent-ready timing benchmark into a staged remote worker
- wait for the exact workspace run's promotion outcome and re-prime only after explicit capacity-lock contention
- bound retries while preserving hard failures after confirmed promotion and exact configured sample counts
- cover success, transient contention, retry exhaustion, and unexpected cache misses through the worker entry point

Production workspace-cache locking and promotion behavior are unchanged.

## Validation

- `bash -n .github/actions/report-memory-peak/*.sh .github/scripts/*.sh .github/scripts/tests/*.sh`
- `shellcheck .github/scripts/runner-behavior-process-containment.sh .github/scripts/runner-behavior-agent-ready-benchmark-remote.sh .github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh`
- `bash .github/scripts/tests/runner-behavior-agent-ready-benchmark-test.sh`
- `git diff --check`
- `scripts/check-file-size.sh` through the pre-commit hook

The workflow-shell compatibility test could not run locally because this container does not provide `yq`; PR CI runs it with the complete workflow-lint toolchain.

Closes #29807
