### PR TITLE
feat(cli): make connector account intent explicit

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -19,9 +19,16 @@ import {
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
 
-function connectorResponse(connectorSlug: string, authMethod = "api-token") {
+const DEFAULT_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+const SIBLING_CONNECTION_ID = "22222222-2222-4222-8222-222222222222";
+
+function connectorResponse(
+  connectorSlug: string,
+  authMethod = "api-token",
+  id = "00000000-0000-4000-8000-000000000001",
+) {
   return {
-    id: "00000000-0000-4000-8000-000000000001",
+    id,
     slug: connectorSlug,
     authMethod,
     externalId: null,
@@ -47,6 +54,12 @@ describe("okou connector connect command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    connectCommand.setOptionValue("accountName", undefined);
+    connectCommand.setOptionValue("add", undefined);
+    connectCommand.setOptionValue("authMethod", undefined);
+    connectCommand.setOptionValue("json", undefined);
+    connectCommand.setOptionValue("reconnect", undefined);
+    connectCommand.setOptionValue("value", []);
   });
 
   afterEach(() => {
@@ -56,9 +69,17 @@ describe("okou connector connect command", () => {
     vi.unstubAllEnvs();
   });
 
-  it("connects a connector with repeated value flags", async () => {
+  it("preserves first-connect syntax and sends explicit add", async () => {
     let receivedBody: unknown;
     server.use(
+      http.get("http://localhost:3000/api/connectors/:connectorSlug", () => {
+        return HttpResponse.json(
+          {
+            error: { message: "Connector not found", code: "NOT_FOUND" },
+          },
+          { status: 404 },
+        );
+      }),
       http.post(
         "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
         async ({ params, request }) => {
@@ -83,7 +104,7 @@ describe("okou connector connect command", () => {
     ]);
 
     expect(receivedBody).toStrictEqual({
-      account: { intent: "single-account" },
+      account: { intent: "add" },
       authMethod: "api-token",
       values: {
         apiToken: "secret-token",
@@ -95,6 +116,94 @@ describe("okou connector connect command", () => {
     expect(output).toContain("Zendesk connected");
     expect(output).toContain("okou connector status zendesk");
     expect(output).not.toContain("secret-token");
+  });
+
+  it("preserves reconnect syntax and resolves the current default exactly", async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.get(
+        "http://localhost:3000/api/connectors/:connectorSlug",
+        ({ params }) => {
+          return HttpResponse.json(
+            connectorResponse(
+              String(params.connectorSlug),
+              "api-token",
+              DEFAULT_CONNECTION_ID,
+            ),
+          );
+        },
+      ),
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        async ({ params, request }) => {
+          receivedBody = await request.json();
+          return HttpResponse.json(
+            connectorResponse(
+              String(params.connectorSlug),
+              "api-token",
+              DEFAULT_CONNECTION_ID,
+            ),
+          );
+        },
+      ),
+    );
+
+    await connectCommand.parseAsync([
+      "node",
+      "cli",
+      "openai",
+      "--value",
+      "apiKey=sk-updated",
+    ]);
+
+    expect(receivedBody).toStrictEqual({
+      account: {
+        intent: "reconnect",
+        connectionId: DEFAULT_CONNECTION_ID,
+      },
+      authMethod: "api-token",
+      values: { apiKey: "sk-updated" },
+    });
+  });
+
+  it("reconnects one explicitly selected sibling without resolving the default", async () => {
+    let defaultReadCount = 0;
+    let receivedBody: unknown;
+    server.use(
+      http.get("http://localhost:3000/api/connectors/:connectorSlug", () => {
+        defaultReadCount += 1;
+        return HttpResponse.json(connectorResponse("openai"));
+      }),
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        async ({ request }) => {
+          receivedBody = await request.json();
+          return HttpResponse.json(
+            connectorResponse("openai", "api-token", SIBLING_CONNECTION_ID),
+          );
+        },
+      ),
+    );
+
+    await connectCommand.parseAsync([
+      "node",
+      "cli",
+      "openai",
+      "--reconnect",
+      SIBLING_CONNECTION_ID,
+      "--value",
+      "apiKey=sk-sibling",
+    ]);
+
+    expect(defaultReadCount).toBe(0);
+    expect(receivedBody).toStrictEqual({
+      account: {
+        intent: "reconnect",
+        connectionId: SIBLING_CONNECTION_ID,
+      },
+      authMethod: "api-token",
+      values: { apiKey: "sk-sibling" },
+    });
   });
 
   it("connects with an explicit manual grant auth method", async () => {
@@ -115,6 +224,9 @@ describe("okou connector connect command", () => {
       "node",
       "cli",
       "openai",
+      "--add",
+      "--account-name",
+      " Work ",
       "--auth-method",
       "api-token",
       "--value",
@@ -122,7 +234,7 @@ describe("okou connector connect command", () => {
     ]);
 
     expect(receivedBody).toStrictEqual({
-      account: { intent: "single-account" },
+      account: { intent: "add", displayName: "Work" },
       authMethod: "api-token",
       values: {
         apiKey: "sk-test",
@@ -159,13 +271,14 @@ describe("okou connector connect command", () => {
       "node",
       "cli",
       connectorSlug,
+      "--add",
       "--value",
       "apiKey=secret-token",
     ]);
 
     expect(receivedType).toBe(connectorSlug);
     expect(receivedBody).toStrictEqual({
-      account: { intent: "single-account" },
+      account: { intent: "add" },
       authMethod,
       values: { apiKey: "secret-token" },
     });
@@ -187,6 +300,7 @@ describe("okou connector connect command", () => {
       "node",
       "cli",
       "openai",
+      "--add",
       "--value",
       "apiKey=sk-test",
       "--json",
@@ -201,7 +315,7 @@ describe("okou connector connect command", () => {
 
   it("fails with usage guidance when no values are provided", async () => {
     await expect(
-      connectCommand.parseAsync(["node", "cli", "openai"]),
+      connectCommand.parseAsync(["node", "cli", "openai", "--add"]),
     ).rejects.toThrow("process.exit called");
 
     const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
@@ -224,13 +338,105 @@ describe("okou connector connect command", () => {
     );
 
     await expect(
-      connectCommand.parseAsync(["node", "cli", "openai", "--value", "apiKey"]),
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--add",
+        "--value",
+        "apiKey",
+      ]),
     ).rejects.toThrow("process.exit called");
 
     expect(requestCalled).toBeFalsy();
     const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorOutput).toContain("Invalid --value format");
     expect(errorOutput).toContain("Use --value NAME=VALUE");
+  });
+
+  it("rejects account names without an explicit add", async () => {
+    let requestCalled = false;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCalled = true;
+          return HttpResponse.json(connectorResponse("openai"));
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--account-name",
+        "Work",
+        "--value",
+        "apiKey=sk-test",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCalled).toBeFalsy();
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "--account-name requires --add",
+    );
+  });
+
+  it("rejects conflicting add and reconnect choices", async () => {
+    let requestCalled = false;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCalled = true;
+          return HttpResponse.json(connectorResponse("openai"));
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--add",
+        "--reconnect",
+        DEFAULT_CONNECTION_ID,
+        "--value",
+        "apiKey=sk-test",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCalled).toBeFalsy();
+  });
+
+  it("rejects malformed reconnect IDs before requests", async () => {
+    let requestCalled = false;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCalled = true;
+          return HttpResponse.json(connectorResponse("openai"));
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--reconnect",
+        "not-a-uuid",
+        "--value",
+        "apiKey=sk-test",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCalled).toBeFalsy();
   });
 
   it("fails before the request when the selected auth method is not configured", async () => {
@@ -250,6 +456,7 @@ describe("okou connector connect command", () => {
         "node",
         "cli",
         "github",
+        "--add",
         "--auth-method",
         "api-token",
         "--value",
@@ -282,6 +489,7 @@ describe("okou connector connect command", () => {
         "node",
         "cli",
         "stripe",
+        "--add",
         "--auth-method",
         "oauth",
         "--value",
@@ -320,6 +528,7 @@ describe("okou connector connect command", () => {
         "node",
         "cli",
         "zendesk",
+        "--add",
         "--value",
         "apiToken=secret-token",
       ]),
@@ -353,6 +562,7 @@ describe("okou connector connect command", () => {
         "node",
         "cli",
         "zendesk",
+        "--add",
         "--value",
         "apiToken=secret-token",
       ]),
@@ -388,6 +598,7 @@ describe("okou connector connect command", () => {
         "node",
         "cli",
         "zendesk",
+        "--add",
         "--value",
         "apiToken=secret-token",
       ]),
@@ -398,6 +609,44 @@ describe("okou connector connect command", () => {
     expect(errorOutput).toContain(
       "409: Multiple connector accounts require an exact choice",
     );
+    expect(errorOutput).not.toContain("secret-token");
+  });
+
+  it("surfaces missing exact reconnects without retrying or printing secrets", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCount += 1;
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Connector account not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--reconnect",
+        SIBLING_CONNECTION_ID,
+        "--value",
+        "apiKey=secret-token",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCount).toBe(1);
+    const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorOutput).toContain("404: Connector account not found");
     expect(errorOutput).not.toContain("secret-token");
   });
 });

--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -384,6 +384,34 @@ describe("okou connector connect command", () => {
     );
   });
 
+  it("rejects invalid account names before requests", async () => {
+    let requestCalled = false;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+        () => {
+          requestCalled = true;
+          return HttpResponse.json(connectorResponse("openai"));
+        },
+      ),
+    );
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "cli",
+        "openai",
+        "--add",
+        "--account-name",
+        "",
+        "--value",
+        "apiKey=sk-test",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requestCalled).toBeFalsy();
+  });
+
   it("rejects conflicting add and reconnect choices", async () => {
     let requestCalled = false;
     server.use(

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -1,8 +1,14 @@
-import { Command } from "commander";
+import {
+  connectorAccountDisplayNameSchema,
+  connectorAccountSelectionSchema,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { Command, InvalidArgumentError, Option } from "commander";
 import chalk from "chalk";
 import {
   connectConnectorManualGrant,
+  getConnector,
   listConnectorCatalogStatus,
+  type ConnectorManualGrantAccountMutation,
 } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
@@ -12,13 +18,57 @@ import {
 } from "./public-catalog";
 
 interface ConnectOptions {
+  readonly accountName?: string;
+  readonly add?: boolean;
   readonly authMethod?: string;
-  readonly value?: readonly string[];
   readonly json?: boolean;
+  readonly reconnect?: string;
+  readonly value?: readonly string[];
 }
 
 function collectValue(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function parseAccountName(value: string): string {
+  const result = connectorAccountDisplayNameSchema.safeParse(value);
+  if (result.success) {
+    return result.data;
+  }
+  throw new InvalidArgumentError(
+    result.error.issues[0]?.message ?? "account name is invalid",
+  );
+}
+
+function parseReconnectConnectionId(value: string): string {
+  const result =
+    connectorAccountSelectionSchema.shape.connectionId.safeParse(value);
+  if (result.success) {
+    return result.data;
+  }
+  throw new InvalidArgumentError(
+    result.error.issues[0]?.message ?? "connection ID is invalid",
+  );
+}
+
+function resolveAccountMutation(
+  options: ConnectOptions,
+): ConnectorManualGrantAccountMutation | null {
+  if (options.accountName !== undefined && !options.add) {
+    throw new Error("--account-name requires --add");
+  }
+  if (options.add) {
+    return {
+      intent: "add",
+      ...(options.accountName === undefined
+        ? {}
+        : { displayName: options.accountName }),
+    };
+  }
+  if (options.reconnect !== undefined) {
+    return { intent: "reconnect", connectionId: options.reconnect };
+  }
+  return null;
 }
 
 function parseConnectorValues(rawValues: readonly string[] | undefined) {
@@ -56,6 +106,24 @@ export const connectCommand = new Command()
   .name("connect")
   .description("Connect a connector with manual grant values")
   .argument("<slug>", "Connector slug (e.g., zendesk)")
+  .addOption(
+    new Option("--add", "Create a new connector account").conflicts(
+      "reconnect",
+    ),
+  )
+  .addOption(
+    new Option(
+      "--reconnect <connection-id>",
+      "Reconnect one exact account ID from connector account list",
+    )
+      .conflicts("add")
+      .argParser(parseReconnectConnectionId),
+  )
+  .addOption(
+    new Option("--account-name <name>", "Name the account created with --add")
+      .conflicts("reconnect")
+      .argParser(parseAccountName),
+  )
   .option("--auth-method <method>", "Connector auth method to use")
   .option(
     "--value <name=value>",
@@ -64,8 +132,20 @@ export const connectCommand = new Command()
     [],
   )
   .option("--json", "Print the connector response as JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  okou connector connect openai --value apiKey=...
+  okou connector connect openai --add --account-name Work --value apiKey=...
+  okou connector connect openai --reconnect <connection-id> --value apiKey=...
+
+Find connection IDs:
+  okou connector account list openai`,
+  )
   .action(
     withErrorHandler(async (connectorSlug: string, options: ConnectOptions) => {
+      const requestedAccount = resolveAccountMutation(options);
       const values = parseConnectorValues(options.value);
       const catalog = await listConnectorCatalogStatus();
       const connectorMetadata = findConnectorStatusItem(
@@ -84,9 +164,21 @@ export const connectCommand = new Command()
         connectorMetadata,
         options.authMethod,
       );
+      const existingConnector = requestedAccount
+        ? null
+        : await getConnector(connectorMetadata.slug);
+      const account: ConnectorManualGrantAccountMutation =
+        requestedAccount ??
+        (existingConnector
+          ? {
+              intent: "reconnect",
+              connectionId: existingConnector.id,
+            }
+          : { intent: "add" });
       const connector = await connectConnectorManualGrant(
         connectorMetadata.slug,
         authMethod.id,
+        account,
         values,
       );
 

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -114,7 +114,7 @@ export const connectCommand = new Command()
   .addOption(
     new Option(
       "--reconnect <connection-id>",
-      "Reconnect one exact account ID from connector account list",
+      "Reconnect the account with this connection ID",
     )
       .conflicts("add")
       .argParser(parseReconnectConnectionId),

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -6,6 +6,7 @@ import type {
 import {
   CONNECTOR_ACCOUNT_LIST_MAX_LIMIT,
   connectorAccountsContract,
+  type ConnectorAccountMutationIntent,
   type ConnectorAccountConnection,
   type ConnectorAccountInspectionResult,
   type ConnectorAccountSelection,
@@ -64,6 +65,11 @@ type ConnectorAccountConnectionsResult =
       readonly connections: readonly ConnectorAccountConnection[];
     }
   | { readonly state: "unavailable" };
+
+export type ConnectorManualGrantAccountMutation = Extract<
+  ConnectorAccountMutationIntent,
+  { intent: "add" | "reconnect" }
+>;
 
 export async function listConnectorAccountConnections(
   target: ConnectorAccountTarget,
@@ -248,6 +254,7 @@ export async function getConnector(
 export async function connectConnectorManualGrant(
   connectorSlug: ConnectorSlug,
   authMethod: ConnectorAuthMethodId,
+  account: ConnectorManualGrantAccountMutation,
   values: Record<string, string>,
 ): Promise<Connector> {
   const config = await getClientConfig();
@@ -256,7 +263,7 @@ export async function connectConnectorManualGrant(
   const result = await client.connect({
     params: { connectorSlug },
     body: {
-      account: { intent: "single-account" },
+      account,
       authMethod,
       values,
     },

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -126,10 +126,24 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("keeps account intent optional for installed CLI manual grants", () => {
+  it("accepts replacement and installed CLI manual grant requests", () => {
     expect(
       connectorManualGrantContract.connect.body.safeParse({
         authMethod: "api-token",
+        values: { apiKey: "test" },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorManualGrantContract.connect.body.safeParse({
+        authMethod: "api-token",
+        account: { intent: "add", displayName: "Work" },
+        values: { apiKey: "test" },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorManualGrantContract.connect.body.safeParse({
+        authMethod: "api-token",
+        account: { intent: "reconnect", connectionId },
         values: { apiKey: "test" },
       }).success,
     ).toBe(true);


### PR DESCRIPTION
## Summary

- keep the existing `okou connector connect <slug> --value ...` flow while translating its deterministic default into explicit `add` or exact `reconnect`
- add optional `--add`, `--account-name`, and `--reconnect <connection-id>` controls for multiple connector accounts
- require replacement CLI manual-grant requests to carry an `add | reconnect` account mutation while preserving the server contract for older CLI builds

## Scope

- no Platform UI changes
- no removal of legacy server-side singleton or omitted-intent compatibility
- no App floor changes or migration of other producers

## Validation

- `pnpm exec prettier --write apps/cli/src/commands/connector/connect.ts apps/cli/src/lib/api/domains/connectors.ts apps/cli/src/commands/connector/__tests__/connect.test.ts packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts`
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm knip --workspace @okouai/cli --workspace @okouai/api-contracts`
- `env -u OKOU_API_BACKEND_URL -u VM0_API_BACKEND_URL pnpm -F @okouai/cli exec vitest run --maxWorkers=4 --silent=passed-only` (1044 passed, 1 skipped on the implementation head)
- `pnpm -F @okouai/api-contracts test` (637 passed)
- current-head connector CLI coverage run (18 passed) and API-contract integration test (12 passed)
- `pnpm -F @okouai/cli build`
- pre-commit hook on the current head: full Knip and repository typecheck (14 tasks passed)

Closes #29771
Parent context: #28571
