### PR TITLE
fix(billing): reconcile paid checkout on return

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -78,6 +78,13 @@ fi
 if [[ "$(grep -Fc 'upgradeToPro: false' "$RUNNER_TOKEN")" -ne 1 ]]; then
   fail "the default mock runner account must remain on limited-free"
 fi
+grep -Fq 'for (const target of targets)' "$RUNNER_TOKEN" ||
+  fail "runner credential provisioning must serialize live Checkout sessions"
+if grep -Fq 'RUNNER_CREDENTIAL_CONCURRENCY' "$RUNNER_TOKEN"; then
+  fail "runner credential provisioning must not retain concurrent Checkout batches"
+fi
+grep -Fq 'during ${stage}' "$RUNNER_TOKEN" ||
+  fail "runner credential provisioning failures must identify their stage"
 
 ruby -ryaml -ropen3 -rtempfile - "$WORKFLOW" "$RUNNER_MOCK_CLAUDE_BOOTSTRAP" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
@@ -311,15 +318,14 @@ unless prepare_step.fetch("run").end_with?("runner-account.ts prepare")
   raise "runner E2E account preparation must use the shared lifecycle entry point"
 end
 
-unless %w[prepare deploy-api deploy-app deploy-stripe-listener].all? do |job_name|
+unless %w[prepare deploy-api deploy-app].all? do |job_name|
     Array(account_prepare["needs"]).include?(job_name)
   end
-  raise "runner E2E account preparation must wait for previews and Stripe forwarding"
+  raise "runner E2E account preparation must wait for API and app previews"
 end
-unless account_prepare.fetch("if").include?(
-    "github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success'"
-  )
-  raise "runner E2E account preparation must use staging or preview Stripe forwarding"
+if Array(account_prepare["needs"]).include?("deploy-stripe-listener") ||
+    account_prepare.fetch("if").include?("needs.deploy-stripe-listener")
+  raise "runner E2E account preparation must reconcile Checkout without Stripe forwarding"
 end
 
 expected_organization_outputs = {

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2463,15 +2463,14 @@ jobs:
     concurrency:
       group: cli-e2e-03-runner-prepare-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-api, deploy-app, deploy-stripe-listener]
+    needs: [prepare, deploy-api, deploy-app]
     if: |
       always() &&
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true' &&
       needs.deploy-api.result == 'success' &&
-      needs.deploy-app.result == 'success' &&
-      (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success')
+      needs.deploy-app.result == 'success'
     outputs:
       runner-organization-id: ${{ steps.account.outputs.runner-organization-id }}
       codex-organization-id: ${{ steps.account.outputs.codex-organization-id }}

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -21,8 +21,6 @@ import {
   fillStripeCheckout,
 } from "./lib/stripe-checkout";
 
-const RUNNER_CREDENTIAL_CONCURRENCY = 2;
-
 interface RunnerCredentialTarget {
   readonly email: string;
   readonly fileName: string;
@@ -88,45 +86,15 @@ async function main(): Promise<void> {
   await clerkSetup();
   const browser = await chromium.launch();
   try {
-    for (
-      let batchStart = 0;
-      batchStart < targets.length;
-      batchStart += RUNNER_CREDENTIAL_CONCURRENCY
-    ) {
-      const batch = targets.slice(
-        batchStart,
-        batchStart + RUNNER_CREDENTIAL_CONCURRENCY,
-      );
-      const results = await Promise.allSettled(
-        batch.map((target) =>
-          provisionRunnerCredential({
-            apiUrl,
-            appUrl,
-            browser,
-            outputDirectory,
-            target,
-            vercelAutomationBypassSecret,
-          }),
-        ),
-      );
-      const failures = results.flatMap((result, index) => {
-        if (result.status === "fulfilled") {
-          return [];
-        }
-        const target = batch[index];
-        return [
-          new Error(
-            `Failed to provision runner E2E credential for ${target.email} (${target.fileName})`,
-            { cause: result.reason },
-          ),
-        ];
+    for (const target of targets) {
+      await provisionRunnerCredential({
+        apiUrl,
+        appUrl,
+        browser,
+        outputDirectory,
+        target,
+        vercelAutomationBypassSecret,
       });
-      if (failures.length > 0) {
-        throw new AggregateError(
-          failures,
-          failures.map((failure) => failure.message).join("; "),
-        );
-      }
     }
   } finally {
     await browser.close();
@@ -144,54 +112,68 @@ async function provisionRunnerCredential(
     target,
     vercelAutomationBypassSecret,
   } = options;
-  await withLoadedClerkTestingPage(
-    browser,
-    {
-      appUrl,
-      contextOptions: {
-        ignoreHTTPSErrors: true,
-        extraHTTPHeaders: vercelAutomationBypassSecret
-          ? {
-              "x-vercel-protection-bypass": vercelAutomationBypassSecret,
-            }
-          : undefined,
-      },
-    },
-    async (page) => {
-      let clerkSessionToken = await signInWithLoadedClerkTestingHelper(
-        page,
-        target.email,
+  let stage = "browser setup";
+  try {
+    await withLoadedClerkTestingPage(
+      browser,
+      {
         appUrl,
-        { activeOrganizationId: target.organizationId },
-      );
-      await ensureRunnerOrganizationReady({
-        apiUrl,
-        clerkSessionToken,
-        vercelAutomationBypassSecret,
-      });
-      if (target.upgradeToPro) {
-        await completePaidOnboarding(page, target, appUrl, outputDirectory);
-        clerkSessionToken = await refreshClerkSessionToken(page, {
-          activeOrganizationId: target.organizationId,
+        contextOptions: {
+          ignoreHTTPSErrors: true,
+          extraHTTPHeaders: vercelAutomationBypassSecret
+            ? {
+                "x-vercel-protection-bypass": vercelAutomationBypassSecret,
+              }
+            : undefined,
+        },
+      },
+      async (page) => {
+        stage = "Clerk sign-in";
+        let clerkSessionToken = await signInWithLoadedClerkTestingHelper(
+          page,
+          target.email,
+          appUrl,
+          { activeOrganizationId: target.organizationId },
+        );
+        stage = "organization bootstrap";
+        await ensureRunnerOrganizationReady({
+          apiUrl,
+          clerkSessionToken,
+          vercelAutomationBypassSecret,
         });
-      }
-      const token = await issueCliToken({
-        apiUrl,
-        clerkSessionToken,
-        vercelAutomationBypassSecret,
-      });
-      const outputFile = join(outputDirectory, target.fileName);
-      await writeFile(
-        outputFile,
-        `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
-        { encoding: "utf8", mode: 0o600 },
-      );
-      console.log("Generated runner E2E API credential", {
-        email: target.email,
-        outputFile,
-      });
-    },
-  );
+        if (target.upgradeToPro) {
+          stage = "paid onboarding";
+          await completePaidOnboarding(page, target, appUrl, outputDirectory);
+          stage = "Clerk session refresh";
+          clerkSessionToken = await refreshClerkSessionToken(page, {
+            activeOrganizationId: target.organizationId,
+          });
+        }
+        stage = "CLI authorization";
+        const token = await issueCliToken({
+          apiUrl,
+          clerkSessionToken,
+          vercelAutomationBypassSecret,
+        });
+        const outputFile = join(outputDirectory, target.fileName);
+        stage = "credential file write";
+        await writeFile(
+          outputFile,
+          `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
+          { encoding: "utf8", mode: 0o600 },
+        );
+        console.log("Generated runner E2E API credential", {
+          email: target.email,
+          outputFile,
+        });
+      },
+    );
+  } catch (cause: unknown) {
+    throw new Error(
+      `Failed to provision runner E2E credential for ${target.email} (${target.fileName}) during ${stage}`,
+      { cause },
+    );
+  }
 }
 
 async function completePaidOnboarding(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -40,6 +40,7 @@ import { server } from "../../../mocks/server";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import {
   mockStripeClient,
+  type StripeInvoice,
   type StripeInvoiceCreatePreviewParams,
 } from "../../external/stripe-client";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -14717,6 +14718,138 @@ describe("POST /api/billing/checkout/complete", () => {
     expect(status.subscriptionStatus).toBe("trialing");
     expect(status.onboardingPaymentPending).toBeTruthy();
     expect(status.currentPeriodEnd).toBeNull();
+  });
+
+  it("reconciles a paid invoice before its webhook arrives", async () => {
+    mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const invoiceId = `in_${randomUUID().slice(0, 8)}`;
+    const periodEnd = currentSecond() + 30 * 86_400;
+    const fixture = await trackedSeed({
+      onboardingPaymentPending: true,
+      stripeCustomerId: customerId,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const paidInvoice: StripeInvoice = {
+      id: invoiceId,
+      customer: customerId,
+      metadata: {},
+      amount_due: 2000,
+      amount_paid: 2000,
+      currency: "usd",
+      status: "paid",
+      parent: {
+        subscription_details: {
+          subscription: subscriptionId,
+          metadata: {},
+        },
+      },
+      lines: {
+        has_more: false,
+        data: [
+          {
+            id: `il_${randomUUID().slice(0, 8)}`,
+            amount: 2000,
+            subtotal: 2000,
+            quantity: 1,
+            price: { id: TEST_PRICE_PRO },
+            period: {
+              start: periodEnd - 30 * 86_400,
+              end: periodEnd,
+            },
+            parent: {
+              type: "subscription_item_details",
+              subscription_item_details: { proration: false },
+            },
+          },
+        ],
+      },
+    };
+    const subscription = {
+      id: subscriptionId,
+      status: "active",
+      customer: customerId,
+      cancel_at_period_end: false,
+      cancel_at: null,
+      schedule: null,
+      trial_end: null,
+      metadata: {},
+      latest_invoice: paidInvoice,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: periodEnd,
+          },
+        ],
+      },
+    };
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: "cs_test_paid_before_webhook",
+      mode: "subscription",
+      status: "complete",
+      customer: customerId,
+      subscription: subscriptionId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(subscription);
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      billingCheckoutContract,
+    );
+    const requests = [
+      client.complete({
+        body: { sessionId: "cs_test_paid_before_webhook" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      client.complete({
+        body: { sessionId: "cs_test_paid_before_webhook" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+    ];
+    const responses = await Promise.all(
+      requests.map(async (request) => {
+        return await accept(request, [200]);
+      }),
+    );
+
+    for (const response of responses) {
+      expect(response.body).toStrictEqual({
+        completed: true,
+        googleAdsConversion: {
+          transactionId: invoiceId,
+          valueUsd: 20,
+        },
+      });
+    }
+    const statusBeforeWebhook = await readBillingStatus(fixture);
+    expect(statusBeforeWebhook).toMatchObject({
+      tier: "pro",
+      credits: 20_000,
+      hasSubscription: true,
+      subscriptionStatus: "active",
+      onboardingPaymentPending: false,
+    });
+
+    const event = {
+      type: "invoice.paid",
+      data: { object: paidInvoice },
+    };
+    context.mocks.stripe.webhooks.constructEvent.mockReturnValueOnce(event);
+    await accept(
+      setupApp({ context, routes: webhooksStripeRoutes })(
+        webhookStripeContract,
+      ).post({
+        body: JSON.stringify(event),
+        extraHeaders: { "stripe-signature": "t=1,v1=checkout-test" },
+      }),
+      [200],
+    );
+
+    await expect(readBillingStatus(fixture)).resolves.toStrictEqual(
+      statusBeforeWebhook,
+    );
   });
 
   it("keeps checkout pending when the subscription is incomplete", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -14721,21 +14721,60 @@ describe("POST /api/billing/checkout/complete", () => {
   });
 
   it("reconciles a paid invoice before its webhook arrives", async () => {
+    setUsagePackPrices();
+    mockUsagePackCatalog();
     mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_${randomUUID().slice(0, 8)}`;
+    const checkoutSessionId = `cs_${randomUUID().slice(0, 8)}`;
     const periodEnd = currentSecond() + 30 * 86_400;
     const fixture = await trackedSeed({
       onboardingPaymentPending: true,
       stripeCustomerId: customerId,
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const seeded = await usagePackStateAction({
+      action: "seed",
+      orgId: fixture.orgId,
+      tier: "pro",
+      stripePlanPriceId: TEST_PRICE_USAGE_PACK_PLAN_PRO,
+      stripeCustomerId: customerId,
+      stripeCheckoutSessionId: checkoutSessionId,
+      allocations: [
+        {
+          userId: fixture.userId,
+          invitationId: null,
+          usagePackUsd: 20,
+          stripePriceId: TEST_PRICE_USAGE_PACK_20,
+        },
+      ],
+    });
+    if (seeded.action !== "seeded") {
+      throw new Error("Failed to seed the usage pack Checkout snapshot");
+    }
+    const usagePackSubscriptionId = seeded.usagePackSubscriptionId;
+    onTestFinished(async () => {
+      await usagePackStateAction({
+        action: "cleanup",
+        orgId: fixture.orgId,
+        usagePackSubscriptionId,
+        deleteGrants: true,
+        deleteOrgMetadata: false,
+      });
+    });
+    const metadata = {
+      orgId: fixture.orgId,
+      tier: "pro",
+      priceId: TEST_PRICE_USAGE_PACK_PLAN_PRO,
+      purpose: "usage_pack_subscription",
+      usagePackSubscriptionId,
+    };
 
     const paidInvoice: StripeInvoice = {
       id: invoiceId,
       customer: customerId,
-      metadata: {},
+      metadata,
       amount_due: 2000,
       amount_paid: 2000,
       currency: "usd",
@@ -14743,7 +14782,7 @@ describe("POST /api/billing/checkout/complete", () => {
       parent: {
         subscription_details: {
           subscription: subscriptionId,
-          metadata: {},
+          metadata,
         },
       },
       lines: {
@@ -14751,10 +14790,25 @@ describe("POST /api/billing/checkout/complete", () => {
         data: [
           {
             id: `il_${randomUUID().slice(0, 8)}`,
+            amount: 0,
+            subtotal: 0,
+            quantity: 1,
+            price: { id: TEST_PRICE_USAGE_PACK_PLAN_PRO },
+            period: {
+              start: periodEnd - 30 * 86_400,
+              end: periodEnd,
+            },
+            parent: {
+              type: "subscription_item_details",
+              subscription_item_details: { proration: false },
+            },
+          },
+          {
+            id: `il_${randomUUID().slice(0, 8)}`,
             amount: 2000,
             subtotal: 2000,
             quantity: 1,
-            price: { id: TEST_PRICE_PRO },
+            price: { id: TEST_PRICE_USAGE_PACK_20 },
             period: {
               start: periodEnd - 30 * 86_400,
               end: periodEnd,
@@ -14775,19 +14829,27 @@ describe("POST /api/billing/checkout/complete", () => {
       cancel_at: null,
       schedule: null,
       trial_end: null,
-      metadata: {},
+      metadata,
       latest_invoice: paidInvoice,
       items: {
         data: [
           {
-            price: { id: TEST_PRICE_PRO },
+            price: { id: TEST_PRICE_USAGE_PACK_PLAN_PRO },
+            quantity: 1,
+            current_period_start: periodEnd - 30 * 86_400,
+            current_period_end: periodEnd,
+          },
+          {
+            price: { id: TEST_PRICE_USAGE_PACK_20 },
+            quantity: 1,
+            current_period_start: periodEnd - 30 * 86_400,
             current_period_end: periodEnd,
           },
         ],
       },
     };
     context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
-      id: "cs_test_paid_before_webhook",
+      id: checkoutSessionId,
       mode: "subscription",
       status: "complete",
       customer: customerId,
@@ -14800,11 +14862,11 @@ describe("POST /api/billing/checkout/complete", () => {
     );
     const requests = [
       client.complete({
-        body: { sessionId: "cs_test_paid_before_webhook" },
+        body: { sessionId: checkoutSessionId },
         headers: { authorization: "Bearer clerk-session" },
       }),
       client.complete({
-        body: { sessionId: "cs_test_paid_before_webhook" },
+        body: { sessionId: checkoutSessionId },
         headers: { authorization: "Bearer clerk-session" },
       }),
     ];
@@ -14823,13 +14885,42 @@ describe("POST /api/billing/checkout/complete", () => {
         },
       });
     }
+    const stateBeforeWebhook = await readUsagePackState(
+      fixture.orgId,
+      usagePackSubscriptionId,
+    );
+    expect(stateBeforeWebhook).toMatchObject({
+      subscription: {
+        stripeCheckoutSessionId: checkoutSessionId,
+        stripeSubscriptionId: subscriptionId,
+        subscriptionStatus: "active",
+      },
+      allocations: [
+        expect.objectContaining({
+          userId: fixture.userId,
+          status: "active",
+        }),
+      ],
+      grants: expect.arrayContaining([
+        expect.objectContaining({
+          userId: fixture.userId,
+          grantType: "purchased",
+          originalAmount: 20_000,
+        }),
+        expect.objectContaining({
+          userId: fixture.userId,
+          grantType: "bonus",
+          originalAmount: 400,
+        }),
+      ]),
+      fulfillmentInvoiceIds: [invoiceId],
+    });
     const statusBeforeWebhook = await readBillingStatus(fixture);
     expect(statusBeforeWebhook).toMatchObject({
       tier: "pro",
-      credits: 20_000,
       hasSubscription: true,
       subscriptionStatus: "active",
-      onboardingPaymentPending: false,
+      memberInviteUsagePackRequired: true,
     });
 
     const event = {
@@ -14847,6 +14938,9 @@ describe("POST /api/billing/checkout/complete", () => {
       [200],
     );
 
+    await expect(
+      readUsagePackState(fixture.orgId, usagePackSubscriptionId),
+    ).resolves.toStrictEqual(stateBeforeWebhook);
     await expect(readBillingStatus(fixture)).resolves.toStrictEqual(
       statusBeforeWebhook,
     );

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -1792,14 +1792,30 @@ const checkoutCompleteAuthed$ = command(
       );
     }
 
+    if (result.status === "paid_invoice_ready") {
+      const reconciledOrgId = await set(
+        reconcilePaidStripeInvoice$,
+        result.paidInvoice,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (reconciledOrgId !== auth.orgId) {
+        throw new Error(
+          `Paid Checkout invoice ${result.paidInvoice.id} did not reconcile to org ${auth.orgId}`,
+        );
+      }
+    }
+
     const conversion =
-      result.status === "completed"
+      result.status === "completed" || result.status === "paid_invoice_ready"
         ? googleAdsPaidConversion(result.paidInvoice)
         : undefined;
     return {
       status: 200 as const,
       body: {
-        completed: result.status === "completed",
+        completed:
+          result.status === "completed" ||
+          result.status === "paid_invoice_ready",
         ...(conversion ? { googleAdsConversion: conversion } : {}),
       },
     };

--- a/turbo/apps/api/src/signals/services/billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-checkout.service.ts
@@ -91,6 +91,10 @@ type CheckoutCompletionResult =
       readonly status: "completed";
       readonly paidInvoice: StripeInvoice | null;
     }
+  | {
+      readonly status: "paid_invoice_ready";
+      readonly paidInvoice: StripeInvoice;
+    }
   | { readonly status: "pending" }
   | { readonly status: "customer_mismatch" }
   | {
@@ -1406,11 +1410,12 @@ export const completeCheckoutSession$ = command(
       );
     signal.throwIfAborted();
 
-    return alreadyPaidSubscription
-      ? {
-          status: "completed",
-          paidInvoice: expandedLatestInvoice(subscription),
-        }
+    const latestInvoice = expandedLatestInvoice(subscription);
+    if (alreadyPaidSubscription) {
+      return { status: "completed", paidInvoice: latestInvoice };
+    }
+    return latestInvoice?.status === "paid"
+      ? { status: "paid_invoice_ready", paidInvoice: latestInvoice }
       : { status: "pending" };
   },
 );


### PR DESCRIPTION
## Summary

- reconcile a completed Checkout Session's paid latest invoice from the public completion route instead of waiting for webhook delivery order
- keep the same invoice projector as Stripe webhooks so repeated, concurrent, and later webhook delivery remains idempotent
- serialize the three paid runner credential checkouts, add target/stage failure context, and remove runner preparation's Stripe-listener dependency

## Scope

- preserves the existing Checkout completion response contract and pending/conflict checks
- preserves the dedicated paid-onboarding Playwright lane and its Stripe-listener coverage
- does not add deployed test endpoints, provider bypasses, database migrations, or timeout increases

## Validation

- `cd turbo && pnpm exec prettier --check apps/api/src/signals/services/billing-checkout.service.ts apps/api/src/signals/routes/billing-checkout.ts apps/api/src/signals/routes/__tests__/billing-checkout.test.ts ../e2e/playwright/runner-token.ts ../.github/workflows/turbo.yml`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm knip --workspace api`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts --maxWorkers=1 --silent=passed-only` (205 tests)
- `cd e2e && pnpm check-types`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- parsed `.github/workflows/turbo.yml` and verified runner preparation no longer needs the listener while the paid-onboarding lane still does
- pre-commit hooks: full Turbo Knip and all-workspace type checks passed

The full runner workflow contract script also requires Ruby, which is unavailable in the local container; CI runs that repository-native check.

Closes #29804
