### PR TITLE
refactor(github): remove singleton connector mutations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth-account-mutations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth-account-mutations.test.ts
@@ -1,0 +1,381 @@
+import { randomUUID } from "node:crypto";
+
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import {
+  createConnectorBddApi,
+  mockGitHubConnectorOAuth,
+} from "./helpers/api-bdd-connectors";
+import { createGithubBddApi } from "./helpers/api-bdd-github";
+import { setConnectorExternalIdState } from "./helpers/connector-credential-storage-state";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const connectors = createConnectorBddApi(context);
+const github = createGithubBddApi(context);
+
+function requiredOrgId(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped actor");
+  }
+  return actor.orgId;
+}
+
+function oauthState(authorizationUrl: string): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected GitHub OAuth state");
+  }
+  return state;
+}
+
+async function connectGithubAdd(
+  actor: ApiTestUser,
+  args: {
+    readonly code: string;
+    readonly displayName: string;
+    readonly userId: number;
+    readonly login: string;
+  },
+): Promise<void> {
+  mockGitHubConnectorOAuth({ userId: args.userId, login: args.login });
+  const start = await connectors.startOauth(
+    actor,
+    "github",
+    "oauth",
+    undefined,
+    { intent: "add", displayName: args.displayName },
+  );
+  await connectors.completeOauthCallback("github", {
+    code: args.code,
+    state: oauthState(start.authorizationUrl),
+  });
+}
+
+describe("GitHub OAuth account mutation selection", () => {
+  it("adds a new identity and refreshes the exact existing sibling", async () => {
+    await installApiTestConnectorCatalog();
+    const actor = bdd.user();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+
+    await connectGithubAdd(actor, {
+      code: "github-first-add",
+      displayName: "First",
+      userId: 101,
+      login: "github-first",
+    });
+    await connectGithubAdd(actor, {
+      code: "github-second-add",
+      displayName: "Second",
+      userId: 202,
+      login: "github-second",
+    });
+
+    const beforeRefresh = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    expect(beforeRefresh).toHaveLength(2);
+    const secondBefore = beforeRefresh.find((account) => {
+      return account.externalId === "202";
+    });
+    expect(secondBefore).toMatchObject({
+      displayName: "Second",
+      externalUsername: "github-second",
+      isDefault: false,
+    });
+
+    await connectGithubAdd(actor, {
+      code: "github-second-refresh",
+      displayName: "Ignored on refresh",
+      userId: 202,
+      login: "github-second-updated",
+    });
+
+    const afterRefresh = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    expect(afterRefresh).toHaveLength(2);
+    expect(
+      afterRefresh.find((account) => {
+        return account.externalId === "101";
+      }),
+    ).toMatchObject({
+      id: beforeRefresh.find((account) => {
+        return account.externalId === "101";
+      })?.id,
+      displayName: "First",
+      externalUsername: "github-first",
+      isDefault: true,
+    });
+    expect(
+      afterRefresh.find((account) => {
+        return account.externalId === "202";
+      }),
+    ).toMatchObject({
+      id: secondBefore?.id,
+      displayName: "Second",
+      externalUsername: "github-second-updated",
+      isDefault: false,
+    });
+  });
+
+  it("serializes concurrent callbacks for the same new identity", async () => {
+    await installApiTestConnectorCatalog();
+    const actor = bdd.user();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    mockGitHubConnectorOAuth({ userId: 303, login: "github-concurrent" });
+
+    const [first, second] = await Promise.all([
+      connectors.startOauth(actor, "github", "oauth", undefined, {
+        intent: "add",
+        displayName: "Concurrent first",
+      }),
+      connectors.startOauth(actor, "github", "oauth", undefined, {
+        intent: "add",
+        displayName: "Concurrent second",
+      }),
+    ]);
+    await Promise.all([
+      connectors.completeOauthCallback("github", {
+        code: "github-concurrent-first",
+        state: oauthState(first.authorizationUrl),
+      }),
+      connectors.completeOauthCallback("github", {
+        code: "github-concurrent-second",
+        state: oauthState(second.authorizationUrl),
+      }),
+    ]);
+
+    await expect(
+      connectors.listBuiltinConnectorAccounts(actor, "github"),
+    ).resolves.toMatchObject([
+      {
+        externalId: "303",
+        externalUsername: "github-concurrent",
+        isDefault: true,
+      },
+    ]);
+  });
+
+  it("does not match a provider identity owned by another organization", async () => {
+    await installApiTestConnectorCatalog();
+    const firstActor = bdd.user();
+    const secondActor = bdd.user();
+    await connectors.updateFeatureSwitches(firstActor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await connectors.updateFeatureSwitches(secondActor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+
+    await connectGithubAdd(firstActor, {
+      code: "github-first-owner",
+      displayName: "First owner",
+      userId: 304,
+      login: "github-shared-identity",
+    });
+    await connectGithubAdd(secondActor, {
+      code: "github-second-owner",
+      displayName: "Second owner",
+      userId: 304,
+      login: "github-shared-identity",
+    });
+
+    const firstAccounts = await connectors.listBuiltinConnectorAccounts(
+      firstActor,
+      "github",
+    );
+    const secondAccounts = await connectors.listBuiltinConnectorAccounts(
+      secondActor,
+      "github",
+    );
+    expect(firstAccounts).toMatchObject([
+      { externalId: "304", displayName: "First owner", isDefault: true },
+    ]);
+    expect(secondAccounts).toMatchObject([
+      { externalId: "304", displayName: "Second owner", isDefault: true },
+    ]);
+    expect(firstAccounts[0]?.id).not.toBe(secondAccounts[0]?.id);
+  });
+
+  it("fails closed when historical rows duplicate an owned identity", async () => {
+    await installApiTestConnectorCatalog();
+    const actor = bdd.user();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await connectGithubAdd(actor, {
+      code: "github-duplicate-first",
+      displayName: "Duplicate first",
+      userId: 404,
+      login: "github-duplicate-first",
+    });
+    await connectGithubAdd(actor, {
+      code: "github-duplicate-second",
+      displayName: "Duplicate second",
+      userId: 405,
+      login: "github-duplicate-second",
+    });
+    const beforeDuplicate = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    const second = beforeDuplicate.find((account) => {
+      return account.externalId === "405";
+    });
+    if (!second) {
+      throw new Error("Expected the second GitHub connector account");
+    }
+    await setConnectorExternalIdState(context, {
+      orgId: requiredOrgId(actor),
+      userId: actor.userId,
+      connectorId: second.id,
+      externalId: "404",
+    });
+
+    mockGitHubConnectorOAuth({ userId: 404, login: "must-not-be-written" });
+    const start = await connectors.startOauth(
+      actor,
+      "github",
+      "oauth",
+      undefined,
+      { intent: "add" },
+    );
+    const callback = await connectors.completeOauthCallback("github", {
+      code: "github-duplicate-rejected",
+      state: oauthState(start.authorizationUrl),
+    });
+    const location = new URL(callback.headers.get("location") ?? "");
+    expect(location.pathname).toBe("/connector/error");
+    expect(location.searchParams.get("message")).toBe(
+      "Multiple connector accounts require an exact choice",
+    );
+
+    const afterDuplicate = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    expect(afterDuplicate).toHaveLength(2);
+    expect(
+      afterDuplicate.map((account) => {
+        return account.externalUsername;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        "github-duplicate-first",
+        "github-duplicate-second",
+      ]),
+    );
+    expect(afterDuplicate).not.toContainEqual(
+      expect.objectContaining({ externalUsername: "must-not-be-written" }),
+    );
+  });
+
+  it("uses the same exact-identity selection for GitHub App setup", async () => {
+    await installApiTestConnectorCatalog();
+    const actor = bdd.user();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await connectGithubAdd(actor, {
+      code: "github-before-setup-first",
+      displayName: "Before setup first",
+      userId: 501,
+      login: "github-before-setup-first",
+    });
+    await connectGithubAdd(actor, {
+      code: "github-before-setup-second",
+      displayName: "Before setup second",
+      userId: 502,
+      login: "github-before-setup-second",
+    });
+    const beforeRefresh = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    const secondBefore = beforeRefresh.find((account) => {
+      return account.externalId === "502";
+    });
+    const agent = await bdd.createAgent(actor, {
+      displayName: `GitHub account setup ${randomUUID()}`,
+    });
+
+    await github.installGithubApp(actor, agent.agentId, {
+      oauthCode: {
+        code: "github-setup-existing",
+        githubUserId: "502",
+        login: "github-setup-existing-updated",
+      },
+    });
+
+    const afterRefresh = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    expect(afterRefresh).toHaveLength(2);
+    expect(
+      afterRefresh.find((account) => {
+        return account.externalId === "502";
+      }),
+    ).toMatchObject({
+      id: secondBefore?.id,
+      externalUsername: "github-setup-existing-updated",
+      isDefault: false,
+    });
+    await expect(github.readInstallation(actor)).resolves.toMatchObject({
+      connectedGithubUserId: "502",
+      isConnected: true,
+      installation: { status: "active" },
+    });
+
+    const siblingActor = bdd.user();
+    await connectors.updateFeatureSwitches(siblingActor, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
+    });
+    await connectGithubAdd(siblingActor, {
+      code: "github-before-setup-sibling",
+      displayName: "Existing before setup",
+      userId: 601,
+      login: "github-before-setup-sibling",
+    });
+    const siblingAgent = await bdd.createAgent(siblingActor, {
+      displayName: `GitHub sibling setup ${randomUUID()}`,
+    });
+    await github.installGithubApp(siblingActor, siblingAgent.agentId, {
+      oauthCode: {
+        code: "github-setup-new-sibling",
+        githubUserId: "602",
+        login: "github-setup-new-sibling",
+      },
+    });
+
+    const afterSiblingSetup = await connectors.listBuiltinConnectorAccounts(
+      siblingActor,
+      "github",
+    );
+    expect(afterSiblingSetup).toHaveLength(2);
+    expect(
+      afterSiblingSetup.find((account) => {
+        return account.externalId === "602";
+      }),
+    ).toMatchObject({
+      externalUsername: "github-setup-new-sibling",
+      isDefault: false,
+    });
+    await expect(github.readInstallation(siblingActor)).resolves.toMatchObject({
+      connectedGithubUserId: "602",
+      isConnected: true,
+      installation: { status: "active" },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -274,7 +274,11 @@ export function mockCustomConnectorOAuth2Provider(
 }
 
 export function mockGitHubConnectorOAuth(
-  options: { readonly userId?: number } = {},
+  options: {
+    readonly userId?: number;
+    readonly login?: string;
+    readonly email?: string | null;
+  } = {},
 ): void {
   mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
   mockOptionalEnv("GH_OAUTH_CLIENT_ID", "github-client-id");
@@ -292,8 +296,11 @@ export function mockGitHubConnectorOAuth(
     http.get(GITHUB_USER_URL, () => {
       return HttpResponse.json({
         id: options.userId ?? 42,
-        login: "bdd-github-user",
-        email: "bdd-github@example.test",
+        login: options.login ?? "bdd-github-user",
+        email:
+          options.email === undefined
+            ? "bdd-github@example.test"
+            : options.email,
       });
     }),
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -5875,7 +5875,7 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     await expect(
       readConnectorOAuthAccountMutation(context, state),
     ).resolves.toMatchObject({
-      account_mutation: { intent: "single-account" },
+      account_mutation: { intent: "add" },
     });
     expect(response.headers.get("Cache-Control")).toBe("no-store");
 

--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -596,6 +596,9 @@ const completeOAuthCallback$ = command(
         expiresIn: token.expiresIn,
         extraConnectorSecrets: token.extraConnectorSecrets,
         account: args.account,
+        matchExistingExternalIdentity:
+          args.resolvedMethod.connectorSlug === "github" &&
+          args.account.intent === "add",
         insertConnectionId: args.insertConnectionId,
       },
       signal,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -140,6 +140,7 @@ const writeGithubConnectorConnection$ = command(
       readonly oauthRequestedScopes: readonly string[];
       readonly oauthGrantedScopes: readonly string[];
       readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
+      readonly account: { readonly intent: "add" };
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
@@ -155,6 +156,8 @@ const writeGithubConnectorConnection$ = command(
         oauthRequestedScopes: args.oauthRequestedScopes,
         oauthGrantedScopes: args.oauthGrantedScopes,
         extraConnectorSecrets: args.extraConnectorSecrets,
+        account: args.account,
+        matchExistingExternalIdentity: true,
       },
       signal,
     );
@@ -510,6 +513,7 @@ const connectGithubUserAfterSetup$ = command(
           userInfo,
           oauthRequestedScopes,
           oauthGrantedScopes: scopes,
+          account: { intent: "add" },
         },
         signal,
       );

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -184,6 +184,7 @@ export async function resolveConnectorConnectionMutation(
     readonly target: ConnectorAccountTarget;
     readonly mutation: ConnectorAccountMutation;
     readonly allowSiblings: boolean;
+    readonly matchExternalId?: string;
   },
 ): Promise<ConnectorConnectionMutationResolution> {
   await lockConnectorAccountTarget(db, args);
@@ -213,6 +214,37 @@ export async function resolveConnectorConnectionMutation(
       },
       resolution,
     );
+  }
+
+  if (args.mutation.intent === "add" && args.matchExternalId !== undefined) {
+    const existingByExternalId = await db
+      .select(existingConnectorConnectionSelection())
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          targetCondition(args.target),
+          eq(connectors.externalId, args.matchExternalId),
+        ),
+      )
+      .orderBy(connectors.id)
+      .for("update")
+      .limit(2);
+    const [existing, duplicate] = existingByExternalId;
+    if (existing) {
+      const resolution: ConnectorConnectionMutationResolution = duplicate
+        ? { kind: "ambiguous" }
+        : { kind: "ready", mutation: { kind: "update", existing } };
+      return observeConnectorConnectionMutation(
+        {
+          targetKind: args.target.kind,
+          intent: args.mutation.intent,
+          selectedCount: existingByExternalId.length,
+        },
+        resolution,
+      );
+    }
   }
 
   const existing = await db

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -1946,22 +1946,35 @@ async function loadPendingConnectorTokenRevokeForTokenConnect(
   );
 }
 
+function authorizedExternalIdForMutation(args: {
+  readonly mutation: ReturnType<typeof normalizeConnectorAccountMutation>;
+  readonly matchExistingExternalIdentity: boolean | undefined;
+  readonly externalId: string;
+}): string | undefined {
+  return args.matchExistingExternalIdentity && args.mutation.intent === "add"
+    ? args.externalId
+    : undefined;
+}
+
+interface CommitConnectorTokenConnectionArgs {
+  readonly db: Tx;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorTokenState: PreparedConnectorTokenState;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly userInfo: ExternalUserInfo;
+  readonly oauthRequestedScopes: readonly string[];
+  readonly oauthGrantedScopes: readonly string[];
+  readonly tokenExpiresAt: Date | null;
+  readonly account?: ConnectorAccountMutationIntent;
+  readonly matchExistingExternalIdentity?: boolean;
+  readonly insertConnectionId?: string;
+}
+
 async function commitConnectorTokenConnection(
-  args: {
-    readonly db: Tx;
-    readonly orgId: string;
-    readonly userId: string;
-    readonly runtimeMethod: ConnectorRuntimeMethod;
-    readonly snapshot: ConnectorRuntimeSnapshot;
-    readonly connectorTokenState: PreparedConnectorTokenState;
-    readonly featureSwitchContext: FeatureSwitchContext;
-    readonly userInfo: ExternalUserInfo;
-    readonly oauthRequestedScopes: readonly string[];
-    readonly oauthGrantedScopes: readonly string[];
-    readonly tokenExpiresAt: Date | null;
-    readonly account?: ConnectorAccountMutationIntent;
-    readonly insertConnectionId?: string;
-  },
+  args: CommitConnectorTokenConnectionArgs,
   signal: AbortSignal,
 ): Promise<
   | {
@@ -1985,6 +1998,11 @@ async function commitConnectorTokenConnection(
     allowSiblings: connectorAccountSiblingWritesEnabled(
       args.featureSwitchContext,
     ),
+    matchExternalId: authorizedExternalIdForMutation({
+      mutation,
+      matchExistingExternalIdentity: args.matchExistingExternalIdentity,
+      externalId: args.userInfo.id,
+    }),
   });
   signal.throwIfAborted();
   if (resolution.kind !== "ready") {
@@ -2091,6 +2109,7 @@ export const upsertConnectorTokenConnection$ = command(
       readonly expiresIn?: number;
       readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
       readonly account?: ConnectorAccountMutationIntent;
+      readonly matchExistingExternalIdentity?: boolean;
       readonly insertConnectionId?: string;
     },
     signal: AbortSignal,
@@ -2157,6 +2176,7 @@ export const upsertConnectorTokenConnection$ = command(
           oauthGrantedScopes: args.oauthGrantedScopes,
           tokenExpiresAt,
           account: args.account,
+          matchExistingExternalIdentity: args.matchExistingExternalIdentity,
           insertConnectionId: args.insertConnectionId,
         },
         signal,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -536,7 +536,7 @@ export async function buildGithubUserConnectAuthorizationUrl(
     ),
     codeVerifier: authResult.codeVerifier,
     oauthContext: authResult.oauthContext,
-    accountMutation: { intent: "single-account" },
+    accountMutation: { intent: "add" },
     expiresAt: connectorOAuthStateExpiresAt(),
   });
   signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- make both specialized GitHub OAuth producers persist or submit explicit `add` account mutations
- resolve an opted-in GitHub add against the authorized provider identity inside the existing connector target lock
- refresh one exact owned identity, add when none exists, and fail closed on historical duplicates
- add real-route coverage for siblings, exact refresh, concurrency, ownership isolation, duplicate identities, and GitHub App setup

## Compatibility

- preserves existing install/connect entry points, redirects, callback paths, completion destinations, and user steps
- preserves legacy singleton and explicit reconnect completion behavior
- does not change Platform/UI code, public API contracts, database schema, or non-GitHub connector behavior

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/github-oauth-account-mutations.test.ts src/signals/routes/__tests__/integrations.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=4 --silent=passed-only` (125 passed)
- `pnpm knip --workspace api`
- `pnpm --dir turbo exec lefthook run pre-commit` (Prettier, full Knip, full TypeScript checks, file-size check)

The full local API suite is currently blocked by the independently reproducible `main` fixture failure tracked in #29822. The focused failure reproduces on clean `main` after `scripts/prepare.sh`; no Pi resource or object-storage code is changed here.

Closes #29767

Parent context: #28571
