### PR TITLE
refactor(api): remove singleton feishu account mutations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -13,7 +13,10 @@ import {
   chatThreadConnectorSelectionContract,
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
+import {
+  connectorAccountsContract,
+  type ConnectorAccountMutationIntent,
+} from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   customConnectorByIdContract,
   customConnectorOAuth2Contract,
@@ -259,6 +262,16 @@ async function expectExactFeishuMemberConnector(args: {
   expect(connected.body.installations?.[0]?.connectedUserName).toBe(
     "Feishu User",
   );
+  const connectUrl = requireValue(
+    connected.body.installations?.[0]?.connectUrl,
+    "Expected Feishu OAuth connect URL",
+  );
+  const appConnectUrl = new URL(connectUrl);
+  appConnectUrl.searchParams.set("callbackTarget", "app");
+  const oauthApp = createAppWithRoutes({
+    signal: context.signal,
+    routes: feishuOauthRoutes,
+  });
   const orgId = requireValue(args.member.orgId, "Expected an organization");
   const memberConnection = await readFeishuMemberConnectorState(context, {
     orgId,
@@ -323,6 +336,11 @@ async function expectExactFeishuMemberConnector(args: {
     installationId: args.installationId,
     connectorId: foreignConnectorId,
   });
+  const foreignLinkStart = await oauthApp.request(appConnectUrl);
+  expect(foreignLinkStart.status).toBe(400);
+  await expect(foreignLinkStart.json()).resolves.toStrictEqual({
+    error: "Connector account not found",
+  });
   const mismatched = await accept(
     args.client.getStatus({
       headers: { authorization: "Bearer clerk-session" },
@@ -348,6 +366,11 @@ async function expectExactFeishuMemberConnector(args: {
     userId: args.member.userId,
     installationId: args.installationId,
     connectorId: null,
+  });
+  const unlinkedStart = await oauthApp.request(appConnectUrl);
+  expect(unlinkedStart.status).toBe(400);
+  await expect(unlinkedStart.json()).resolves.toStrictEqual({
+    error: "Additional connector accounts are not enabled yet",
   });
   const unlinked = await accept(
     args.client.getStatus({
@@ -1027,6 +1050,7 @@ describe("Feishu integration", () => {
   async function completeFeishuAuthorization(
     authorizationUrl: URL,
     openId: string,
+    expectedAccountMutation: ConnectorAccountMutationIntent,
   ): Promise<URL> {
     const state = requireValue(
       authorizationUrl.searchParams.get("state"),
@@ -1035,7 +1059,7 @@ describe("Feishu integration", () => {
     await expect(
       readConnectorOAuthAccountMutation(context, state),
     ).resolves.toMatchObject({
-      account_mutation: { intent: "single-account" },
+      account_mutation: expectedAccountMutation,
     });
     oauthUserOpenId = openId;
     const oauthApp = createAppWithRoutes({
@@ -1104,6 +1128,7 @@ describe("Feishu integration", () => {
     const completionUrl = await completeFeishuAuthorization(
       authorizationUrl,
       openId,
+      { intent: "add" },
     );
     expect(completionUrl.toString()).toBe(
       `https://applink.feishu.cn/client/bot/open?appId=${fixture.appId}`,
@@ -2184,6 +2209,7 @@ describe("Feishu integration", () => {
       customConnectorId: managedConnector.id,
       storageVersion: managedConnector.storageVersion,
       redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
+      providerContext: { completionTarget: "custom" },
     });
     const legacyGenericCallbackResponse = await createAppWithRoutes({
       signal: context.signal,
@@ -2393,7 +2419,7 @@ describe("Feishu integration", () => {
     await expect(
       readConnectorOAuthAccountMutation(context, state),
     ).resolves.toMatchObject({
-      account_mutation: { intent: "single-account" },
+      account_mutation: { intent: "add" },
     });
 
     const handoffResponse = await oauthApp.request(
@@ -2426,6 +2452,70 @@ describe("Feishu integration", () => {
       `${APP_ORIGIN}/connectors/feishu/callback`,
     ]);
 
+    const linkedMemberState = await readFeishuMemberConnectorState(context, {
+      orgId: requireValue(member.orgId, "Expected an organization"),
+      userId: member.userId,
+      installationId,
+    });
+    const linkedConnectorId = requireValue(
+      linkedMemberState.feishu_member_connection?.connector_id,
+      "Expected linked Feishu connector account",
+    );
+    const reconnectResponse = await oauthApp.request(appConnectUrl);
+    expect(reconnectResponse.status).toBe(307);
+    const reconnectState = requireValue(
+      new URL(reconnectResponse.headers.get("location") ?? "").searchParams.get(
+        "state",
+      ),
+      "Expected reconnect OAuth state",
+    );
+    await expect(
+      readConnectorOAuthAccountMutation(context, reconnectState),
+    ).resolves.toMatchObject({
+      account_mutation: {
+        intent: "reconnect",
+        connectionId: linkedConnectorId,
+      },
+    });
+
+    const persistedSingletonState = `legacy-managed-feishu-${randomUUID()}`;
+    await seedLegacyCustomFeishuOAuthState(context, {
+      state: persistedSingletonState,
+      orgId: requireValue(member.orgId, "Expected an organization"),
+      userId: member.userId,
+      customConnectorId: managedConnector.id,
+      storageVersion: managedConnector.storageVersion,
+      redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
+      providerContext: {
+        completionTarget: "feishu",
+        installationId,
+        expectedOpenId: "ou_oauth_user",
+      },
+    });
+    await expect(
+      readConnectorOAuthAccountMutation(context, persistedSingletonState),
+    ).resolves.toMatchObject({
+      account_mutation: { intent: "single-account" },
+    });
+    oauthUserOpenId = "ou_oauth_user";
+    clearConnectorInvalidationMocks();
+    const persistedSingletonResponse = await oauthApp.request(
+      `${feishuOauthContract.callback.path}?${new URLSearchParams({
+        code: "persisted-singleton-feishu-code",
+        responseMode: "json",
+        state: persistedSingletonState,
+      })}`,
+    );
+    expect(persistedSingletonResponse.status).toBe(200);
+    expectCustomConnectorInvalidations([member.userId]);
+    await expect(persistedSingletonResponse.json()).resolves.toStrictEqual({
+      redirectUrl: `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
+    });
+    expect(oauthTokenRedirectUris).toStrictEqual([
+      `${APP_ORIGIN}/connectors/feishu/callback`,
+      `${APP_ORIGIN}/connectors/feishu/callback`,
+    ]);
+
     clearConnectorInvalidationMocks();
     const legacyCallbackResponse = await oauthApp.request(
       `${feishuOauthContract.callback.path}?${new URLSearchParams({
@@ -2442,6 +2532,7 @@ describe("Feishu integration", () => {
     expect(legacyCallbackResponse.status).toBe(200);
     expectCustomConnectorInvalidations([member.userId]);
     expect(oauthTokenRedirectUris).toStrictEqual([
+      `${APP_ORIGIN}/connectors/feishu/callback`,
       `${APP_ORIGIN}/connectors/feishu/callback`,
       `${FEISHU_CALLBACK_ORIGIN}/api/integrations/feishu/oauth/callback`,
     ]);
@@ -3335,6 +3426,7 @@ describe("Feishu integration", () => {
     const completionUrl = await completeFeishuAuthorization(
       authorizationUrl,
       "ou_feishu_user",
+      { intent: "add" },
     );
     expect(completionUrl.toString()).toBe(
       `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
@@ -3402,7 +3494,19 @@ describe("Feishu integration", () => {
     );
     const retryAuthorizationUrl =
       await feishuAuthorizationUrlFromResponse(retryConnectResponse);
-    await completeFeishuAuthorization(retryAuthorizationUrl, "ou_feishu_user");
+    const memberState = await readFeishuMemberConnectorState(context, {
+      orgId: requireValue(actor.orgId, "Expected an organization"),
+      userId: actor.userId,
+      installationId: fixture.installationId,
+    });
+    const memberConnectorId = requireValue(
+      memberState.feishu_member_connection?.connector_id,
+      "Expected Feishu member connector linkage",
+    );
+    await completeFeishuAuthorization(retryAuthorizationUrl, "ou_feishu_user", {
+      intent: "reconnect",
+      connectionId: memberConnectorId,
+    });
     const preservedAccess = await accept(
       agentAccessClient.get({
         headers: { authorization: "Bearer clerk-session" },
@@ -3446,6 +3550,7 @@ describe("Feishu integration", () => {
     const rebindCompletionUrl = await completeFeishuAuthorization(
       rebindAuthorizationUrl,
       "ou_feishu_user",
+      { intent: "add" },
     );
     expect(rebindCompletionUrl.pathname).toBe("/settings/feishu");
     expect(rebindCompletionUrl.searchParams.get("error")).toBe(
@@ -3495,7 +3600,20 @@ describe("Feishu integration", () => {
     await completeFeishuAuthorization(
       replacementAuthorizationUrl,
       replacementOpenId,
+      { intent: "reconnect", connectionId: memberConnectorId },
     );
+    await expect(
+      readFeishuMemberConnectorState(context, {
+        orgId: requireValue(actor.orgId, "Expected an organization"),
+        userId: actor.userId,
+        installationId: fixture.installationId,
+      }),
+    ).resolves.toMatchObject({
+      feishu_member_connection: {
+        connector_id: memberConnectorId,
+        open_id: replacementOpenId,
+      },
+    });
     await flushWaitUntilForTest();
 
     outboundMessages = [];

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -251,6 +251,7 @@ async function expectExactFeishuMemberConnector(args: {
   readonly client: FeishuConnectClient;
   readonly installationId: string;
   readonly member: ApiTestUser;
+  readonly expectedOpenId: string;
 }): Promise<void> {
   const connected = await accept(
     args.client.getStatus({
@@ -279,8 +280,8 @@ async function expectExactFeishuMemberConnector(args: {
     installationId: args.installationId,
   });
   expect(memberConnection.feishu_member_connection).toMatchObject({
-    connector_external_id: "ou_oauth_user",
-    open_id: "ou_oauth_user",
+    connector_external_id: args.expectedOpenId,
+    open_id: args.expectedOpenId,
   });
   const memberConnectorId = requireValue(
     memberConnection.feishu_member_connection?.connector_id,
@@ -321,7 +322,7 @@ async function expectExactFeishuMemberConnector(args: {
     orgId,
     userId: args.member.userId,
     connectorId: memberConnectorId,
-    externalId: "ou_oauth_user",
+    externalId: args.expectedOpenId,
   });
 
   const foreignConnectorId = await seedConnectorStorageRow(context, {
@@ -2516,6 +2517,8 @@ describe("Feishu integration", () => {
       `${APP_ORIGIN}/connectors/feishu/callback`,
     ]);
 
+    const legacyReplacementOpenId = "ou_legacy_replacement_user";
+    oauthUserOpenId = legacyReplacementOpenId;
     clearConnectorInvalidationMocks();
     const legacyCallbackResponse = await oauthApp.request(
       `${feishuOauthContract.callback.path}?${new URLSearchParams({
@@ -2536,6 +2539,18 @@ describe("Feishu integration", () => {
       `${APP_ORIGIN}/connectors/feishu/callback`,
       `${FEISHU_CALLBACK_ORIGIN}/api/integrations/feishu/oauth/callback`,
     ]);
+    await expect(
+      readFeishuMemberConnectorState(context, {
+        orgId: requireValue(member.orgId, "Expected an organization"),
+        userId: member.userId,
+        installationId,
+      }),
+    ).resolves.toMatchObject({
+      feishu_member_connection: {
+        connector_id: linkedConnectorId,
+        open_id: legacyReplacementOpenId,
+      },
+    });
     await flushWaitUntilForTest();
 
     mocks.clerk.session(member.userId, member.orgId, member.orgRole);
@@ -2543,6 +2558,7 @@ describe("Feishu integration", () => {
       client,
       installationId,
       member,
+      expectedOpenId: legacyReplacementOpenId,
     });
     const connectedConnectorList = await accept(
       customConnectorClient.list({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -166,6 +166,13 @@ export async function seedLegacyCustomFeishuOAuthState(
     readonly customConnectorId: string;
     readonly storageVersion: number;
     readonly redirectUri: string;
+    readonly providerContext:
+      | { readonly completionTarget: "custom" }
+      | {
+          readonly completionTarget: "feishu";
+          readonly installationId: string;
+          readonly expectedOpenId?: string;
+        };
   },
 ): Promise<void> {
   await postAction(context, {
@@ -176,6 +183,16 @@ export async function seedLegacyCustomFeishuOAuthState(
     custom_connector_id: args.customConnectorId,
     storage_version: args.storageVersion,
     redirect_uri: args.redirectUri,
+    provider_context:
+      args.providerContext.completionTarget === "custom"
+        ? { completion_target: "custom" }
+        : {
+            completion_target: "feishu",
+            installation_id: args.providerContext.installationId,
+            ...(args.providerContext.expectedOpenId
+              ? { expected_open_id: args.providerContext.expectedOpenId }
+              : {}),
+          },
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
@@ -21,6 +21,7 @@ import { startCustomConnectorOAuth2$ } from "../services/custom-connector-oauth2
 import {
   ensureFeishuCustomConnector$,
   hasFeishuCustomConnectorOAuthConnection,
+  resolveFeishuConnectorAccountMutation,
 } from "../services/feishu-custom-connector.service";
 import {
   feishuBotOpenUrl,
@@ -120,6 +121,11 @@ const startFeishuAccountOAuth$ = command(
     if (!connectorId) {
       return { kind: "installation_not_found" };
     }
+    const account = await resolveFeishuConnectorAccountMutation(db, {
+      installationId: args.installationId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
     const oauth = await set(
       startCustomConnectorOAuth2$,
       {
@@ -128,7 +134,7 @@ const startFeishuAccountOAuth$ = command(
         connectorId,
         redirectUri: feishuOAuthAppCallbackUrl(),
         publicBrand: args.publicBrand,
-        account: { intent: "single-account" },
+        account,
         feishuContext: {
           installationId: args.installationId,
           expectedOpenId: args.openId,

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -36,7 +36,10 @@ import {
   type CustomConnectorOAuthStateContext,
   type OAuthTokenResult,
 } from "../services/custom-connector-oauth2.service";
-import { ensureFeishuCustomConnector$ } from "../services/feishu-custom-connector.service";
+import {
+  ensureFeishuCustomConnector$,
+  resolveFeishuConnectorAccountMutation,
+} from "../services/feishu-custom-connector.service";
 import {
   feishuBotOpenUrl,
   feishuOAuthAppCallbackUrl,
@@ -645,6 +648,11 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!connectorId) {
     return jsonErrorResponse("Feishu connector not found");
   }
+  const account = await resolveFeishuConnectorAccountMutation(db, {
+    installationId: state.installationId,
+    userId: state.userId,
+  });
+  signal.throwIfAborted();
   const result = await set(
     startCustomConnectorOAuth2$,
     {
@@ -653,7 +661,7 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
       connectorId,
       redirectUri: oauthRedirectUri(query.callbackTarget),
       publicBrand: state.publicBrand,
-      account: { intent: "single-account" },
+      account,
       feishuContext: {
         installationId: state.installationId,
       },
@@ -773,7 +781,7 @@ const completeLegacyFeishuOAuth$ = command(
         db,
         state: {
           ...state,
-          accountMutation: { intent: "single-account" },
+          accountMutation: { intent: "add" },
         },
         installation,
         connector,

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -38,7 +38,7 @@ import {
 } from "../services/custom-connector-oauth2.service";
 import {
   ensureFeishuCustomConnector$,
-  resolveFeishuConnectorAccountMutation,
+  resolveFeishuConnectorAccountMutation as resolveFeishuAccountMutation,
 } from "../services/feishu-custom-connector.service";
 import {
   feishuBotOpenUrl,
@@ -648,7 +648,7 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!connectorId) {
     return jsonErrorResponse("Feishu connector not found");
   }
-  const account = await resolveFeishuConnectorAccountMutation(db, {
+  const account = await resolveFeishuAccountMutation(db, {
     installationId: state.installationId,
     userId: state.userId,
   });
@@ -753,6 +753,8 @@ const completeLegacyFeishuOAuth$ = command(
         query.responseMode,
       );
     }
+    const accountMutation = await resolveFeishuAccountMutation(db, state);
+    signal.throwIfAborted();
     const exchanged = await exchangeOAuthTokenAndUserInfo(
       {
         connector,
@@ -781,7 +783,7 @@ const completeLegacyFeishuOAuth$ = command(
         db,
         state: {
           ...state,
-          accountMutation: { intent: "add" },
+          accountMutation,
         },
         installation,
         connector,

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -405,7 +405,15 @@ async function seedLegacyCustomFeishuOAuthState(
       storageVersion: body.storage_version,
       providerContext: {
         provider: "feishu",
-        completionTarget: "custom",
+        ...(body.provider_context.completion_target === "custom"
+          ? { completionTarget: "custom" }
+          : {
+              completionTarget: "feishu",
+              installationId: body.provider_context.installation_id,
+              ...(body.provider_context.expected_open_id
+                ? { expectedOpenId: body.provider_context.expected_open_id }
+                : {}),
+            }),
       },
     }),
     accountMutation: { intent: "single-account" },

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/feishu-connect";
 import { connectors } from "@okouai/db/schema/connector";
 import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
@@ -665,6 +666,32 @@ export const deleteFeishuInstallationAndCustomConnector$ = command(
     return true;
   },
 );
+
+export async function resolveFeishuConnectorAccountMutation(
+  db: ReadonlyDb,
+  args: {
+    readonly installationId: string;
+    readonly userId: string;
+  },
+): Promise<ConnectorAccountMutationIntent> {
+  const connectionRows = await db
+    .select({ connectorId: feishuOrgConnections.connectorId })
+    .from(feishuOrgConnections)
+    .where(
+      and(
+        eq(feishuOrgConnections.installationId, args.installationId),
+        eq(feishuOrgConnections.userId, args.userId),
+      ),
+    )
+    .limit(2);
+  if (connectionRows.length > 1) {
+    throw new Error("Multiple Feishu member connections found");
+  }
+  const connection = connectionRows[0];
+  return connection?.connectorId
+    ? { intent: "reconnect", connectionId: connection.connectorId }
+    : { intent: "add" };
+}
 
 export async function hasFeishuCustomConnectorOAuthConnection(
   db: ReadonlyDb,

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -89,6 +89,14 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       custom_connector_id: z.uuid(),
       storage_version: z.number().int().positive(),
       redirect_uri: z.url(),
+      provider_context: z.discriminatedUnion("completion_target", [
+        z.object({ completion_target: z.literal("custom") }),
+        z.object({
+          completion_target: z.literal("feishu"),
+          installation_id: z.uuid(),
+          expected_open_id: z.string().min(1).optional(),
+        }),
+      ]),
     }),
     z.object({
       action: z.literal("seed-owned-secret"),


### PR DESCRIPTION
## Summary

- replace Feishu OAuth start-time `single-account` mutations with member-slot-aware `add` or exact `reconnect` intents
- keep Feishu provider identity validation separate from connector account selection
- preserve completion support for already-persisted legacy `single-account` OAuth states during the rollout window

## Behavior

- a Feishu member with an existing linked connector account reconnects that exact account
- a member without a linked account starts an add mutation and continues through the existing integration-managed sibling policy
- the direct legacy signed callback resolves the same Integration-owned member slot to preserve exact reconnect and identity replacement during rollout
- existing UI and user operation flow are unchanged

## Scope

- no UI changes
- no database schema or migration changes
- no removal of the shared `single-account` decoder or completion path; that remains follow-up cleanup after legacy state drains

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts` (39 passed)
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test` (637 passed)
- `pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks (14/14 tasks passed)

The API-wide suite completed 3,575 of 3,584 tests successfully. Nine unrelated tests in `chat-events.bdd.test.ts`, `workflow-automations.test.ts`, and `webhooks-google-workspace-events.test.ts` failed against persistent local test state (stale Pi object size, retained Calendar watch state, and a duplicate fixed Google Meet subscription name). `scripts/prepare.sh` did not clear those external/persisted fixtures; the focused Feishu suite remained green.

Closes #29768

Parent context: #28571
