### PR TITLE
fix(platform): prevent stale page renders during navigation

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/nav.ts
+++ b/turbo/apps/platform/src/signals/okou-page/nav.ts
@@ -229,9 +229,14 @@ export function isChatRoute(key: RouteKey | null): boolean {
   );
 }
 
-export const handleNavSelect$ = command(({ set }, id: SidebarNavId) => {
+export const handleNavSelect$ = command(({ get, set }, id: SidebarNavId) => {
   if (id === "queues") {
     set(openQueueDrawer$);
+  } else if (
+    id === "chat" &&
+    (get(activeRoute$) === "home" || get(activeRoute$) === "agentChat")
+  ) {
+    return;
   } else {
     const navRoutes = {
       chat: ROUTES.home,

--- a/turbo/apps/platform/src/signals/okou-page/nav.ts
+++ b/turbo/apps/platform/src/signals/okou-page/nav.ts
@@ -229,14 +229,9 @@ export function isChatRoute(key: RouteKey | null): boolean {
   );
 }
 
-export const handleNavSelect$ = command(({ get, set }, id: SidebarNavId) => {
+export const handleNavSelect$ = command(({ set }, id: SidebarNavId) => {
   if (id === "queues") {
     set(openQueueDrawer$);
-  } else if (
-    id === "chat" &&
-    (get(activeRoute$) === "home" || get(activeRoute$) === "agentChat")
-  ) {
-    return;
   } else {
     const navRoutes = {
       chat: ROUTES.home,

--- a/turbo/apps/platform/src/signals/react-router.ts
+++ b/turbo/apps/platform/src/signals/react-router.ts
@@ -14,6 +14,11 @@ export const page$ = computed((get) => {
   return get(internalPage$);
 });
 
+// Detach the committed page before route-derived state moves to a new location.
+export const clearPage$ = command(({ set }) => {
+  set(internalPage$, undefined);
+});
+
 export const updatePage$ = command(
   ({ set }, page: ReactNode, layout: PageLayout = "none") => {
     set(internalLayout$, layout);

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -4,6 +4,7 @@ import type { RoutePath } from "./route-paths";
 import { clerk$, needsOrgSelection$, resolveAppAuthUrl } from "./auth.ts";
 import { pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
+import { clearPage$ } from "./react-router.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import {
   bestEffort,
@@ -173,6 +174,7 @@ export const initRoutes$ = command(
     window.addEventListener(
       "popstate",
       onDomEventFn(async () => {
+        set(clearPage$);
         set(reloadPathname$, (x) => {
           return x + 1;
         });
@@ -209,6 +211,7 @@ const navigate$ = command(
     const searchStr = options.searchParams?.toString();
     const newPath = `${pathname}${searchStr ? `?${searchStr}` : ""}${routeHash(options.hash)}`;
     L.debug("navigating to", newPath);
+    set(clearPage$);
     if (options.replace) {
       replaceState({}, "", newPath);
     } else {

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -82,14 +82,10 @@ interface Route {
 
 const internalRouteConfig$ = state<Route[] | undefined>(undefined);
 
-const currentRoute$ = computed((get) => {
-  const config = get(internalRouteConfig$);
-  if (!config) {
-    return null;
-  }
-
-  const currentPath = get(pathname$);
-
+function findRoute(
+  config: readonly Route[],
+  currentPath: string,
+): Route | null {
   for (const route of config) {
     const matcher = match(route.path, { decode: decodeURIComponent });
     const result = matcher(currentPath);
@@ -99,7 +95,26 @@ const currentRoute$ = computed((get) => {
   }
 
   return null;
+}
+
+const currentRoute$ = computed((get) => {
+  const config = get(internalRouteConfig$);
+  if (!config) {
+    return null;
+  }
+
+  return findRoute(config, get(pathname$));
 });
+
+const clearPageForRouteBoundary$ = command(
+  ({ get, set }, nextPathname: string) => {
+    const config = get(internalRouteConfig$);
+    const nextRoute = config ? findRoute(config, nextPathname) : null;
+    if (get(currentRoute$) !== nextRoute) {
+      set(clearPage$);
+    }
+  },
+);
 
 export const pathParams$ = computed((get) => {
   const currentRoute = get(currentRoute$);
@@ -174,7 +189,7 @@ export const initRoutes$ = command(
     window.addEventListener(
       "popstate",
       onDomEventFn(async () => {
-        set(clearPage$);
+        set(clearPageForRouteBoundary$, pathname());
         set(reloadPathname$, (x) => {
           return x + 1;
         });
@@ -211,7 +226,7 @@ const navigate$ = command(
     const searchStr = options.searchParams?.toString();
     const newPath = `${pathname}${searchStr ? `?${searchStr}` : ""}${routeHash(options.hash)}`;
     L.debug("navigating to", newPath);
-    set(clearPage$);
+    set(clearPageForRouteBoundary$, pathname);
     if (options.replace) {
       replaceState({}, "", newPath);
     } else {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
@@ -256,6 +256,8 @@ describe("home route", () => {
       await expect(
         screen.findByRole("textbox", { name: "Message" }),
       ).resolves.toBeInTheDocument();
+      const pageMain = document.querySelector("main");
+      expect(pageMain).not.toBeNull();
       expect(draftLoads()).not.toContain(candidate.candidateId);
 
       team.release.resolve(undefined);
@@ -263,6 +265,7 @@ describe("home route", () => {
         expect(pathname()).toBe(`/agents/${candidate.recoveryAgentId}/chat`);
         expect(document.title).toContain(candidate.recoveryAgentName);
       });
+      expect(document.querySelector("main")).toBe(pageMain);
       expect(draftLoads()).not.toContain(candidate.candidateId);
     },
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3302,6 +3302,43 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the new-chat rail responsive across consecutive clicks", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Existing conversation"),
+    ]);
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const rail = await screen.findByTestId("labeled-nav-rail");
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    expect(
+      within(screen.getByTestId("chat-list-column")).getByText(
+        "Existing conversation",
+      ),
+    ).toBeInTheDocument();
+    const newChatLink = within(rail).getByLabelText("New chat");
+    click(newChatLink);
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+    });
+    click(
+      within(screen.getByTestId("labeled-nav-rail")).getByLabelText("New chat"),
+    );
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+  });
+
   it("hides only the three-column chat list and keeps search available", async () => {
     prepareDefaultAgent();
 


### PR DESCRIPTION
## Summary

- invalidate committed page content before a navigation crosses into a different route boundary and exposes new route-derived state
- preserve the persistent app shell and the current page instance for same-route parameter recovery
- cover consecutive New chat clicks and stale-agent recovery without remounting the page

## Root cause

A second New chat navigation changed route-derived agent state while the previous Agent Chat page was still committed. The stale composer rendered without an active agent, threw, and tripped the root error boundary.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t "keeps the new-chat rail responsive across consecutive clicks"`
- `pnpm --filter @okouai/app exec vitest run src/views/router/__tests__/link-navigation.test.tsx`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/home-route.test.tsx`

### PR preview — PASS

- Head SHA: `07dca9fa50369c41a2f279ee80d1d609bdea7049`
- App: `https://pr-29829-app.omby.ai` (`https://12d8cbb0.okou-app.pages.dev` deployment)
- API: `https://pr-29829-api.vm6.ai`
- Browser: Headless Chrome 151, 1440 x 900
- Fixture: fresh Clerk test user and test organization; onboarding completed with "I will explore on my own" (not bypassed)
- Feature switch: `threeColumnNav` enabled and verified in the rendered Lab control
- Flow 1: double-clicked rail `New chat` on the agent chat route; chat composer and labeled navigation rail remained mounted
- Flow 2: navigated to Agents, double-clicked rail `New chat`; returned to `/agents/:id/chat` with the composer and rail responsive
- Page errors and console errors after each controlled interaction: none
- [Screenshot after the second double-click](https://cdn.vm0.io/artifacts/k86phmtigj.png)
