### PR TITLE
fix(platform): restore home header offset

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1296,6 +1296,9 @@ test("home content stays fixed while the growth entry loads", async ({
   if (!mainBefore || !taglineBefore) {
     throw new Error("Home content has no measurable layout before entry load");
   }
+  // The async entry is absolute, but its former 56px header slot remains in
+  // flow so the landing content does not jump upward.
+  expect(mainBefore.y).toBe(56);
 
   releaseSlackStatus.resolve();
   await expect(growthEntry).toBeVisible();

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1314,6 +1314,54 @@ test("home content stays fixed while the growth entry loads", async ({
   expect(taglineAfter.y).toBe(taglineBefore.y);
 });
 
+test("non-admin home content keeps its original top edge", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.route(
+    (url) => url.pathname === "/api/org",
+    async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        json: { id: "org_member", name: "Member Org", role: "member" },
+      });
+    },
+  );
+  const memberOrgLoaded = page.waitForResponse((response) => {
+    const request = response.request();
+    return (
+      response.ok() &&
+      request.method() === "GET" &&
+      new URL(response.url()).pathname === "/api/org"
+    );
+  });
+
+  await page.goto(appUrl);
+  await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
+  await memberOrgLoaded;
+  await expect(page.getByTestId("chat-tagline")).toBeVisible({
+    timeout: 20_000,
+  });
+  // Let the member role commit before reading the stable layout.
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+    });
+  });
+
+  await expect(page.getByTestId("growth-entry")).not.toBeAttached();
+  const mainBox = await page.locator("main").boundingBox();
+  if (!mainBox) {
+    throw new Error("Non-admin home content has no measurable layout");
+  }
+  expect(mainBox.y).toBe(0);
+});
+
 test("checkmark keeps its column across selection states and previews deactivation", async ({
   page,
 }) => {

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -295,8 +295,13 @@ function AdminGrowthEntryHeader() {
 export function GrowthEntryHeader() {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
-  if (!isAdmin) {
-    return null;
-  }
-  return <AdminGrowthEntryHeader />;
+  return (
+    <>
+      {/* Match the former in-flow header's 16px + 32px + 8px height. The
+          controls stay absolute, but the home content keeps its established
+          desktop position before and after the async entry resolves. */}
+      <div aria-hidden className="hidden h-14 shrink-0 md:block" />
+      {isAdmin ? <AdminGrowthEntryHeader /> : null}
+    </>
+  );
 }

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -295,13 +295,16 @@ function AdminGrowthEntryHeader() {
 export function GrowthEntryHeader() {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
+  if (!isAdmin) {
+    return null;
+  }
   return (
     <>
       {/* Match the former in-flow header's 16px + 32px + 8px height. The
           controls stay absolute, but the home content keeps its established
           desktop position before and after the async entry resolves. */}
       <div aria-hidden className="hidden h-14 shrink-0 md:block" />
-      {isAdmin ? <AdminGrowthEntryHeader /> : null}
+      <AdminGrowthEntryHeader />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- preserve the former 56px desktop header slot while keeping the growth entry controls absolute
- keep the mobile layout unchanged
- lock the landing-page baseline into the existing growth-entry layout regression coverage

## Root cause

#29723 moved the growth entry header out of normal flow to eliminate an async layout shift. That also removed its 56px layout slot, which permanently moved the desktop home content upward.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/home-growth-entry.test.tsx --maxWorkers=1 --silent=passed-only` (7 tests passed)

Local browser/E2E verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested.
