### PR TITLE
fix(platform): hide template rename check after submit

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -4421,6 +4421,71 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("releases rename focus after confirming an uploaded template title", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    let template = presentationTemplateDetail({
+      id: "34c41aed-b488-4e09-b7ea-23a712a270dd",
+      title: "Focus deck",
+      sourceFilename: "focus-deck.pptx",
+      coverUrl: "https://example.com/focus-deck-cover.png",
+      pageCount: 1,
+      visibility: "private",
+      canManage: true,
+      pageUrls: ["https://example.com/focus-deck-cover.png"],
+      createdAt: "2026-08-21T02:41:59.522Z",
+      updatedAt: "2026-08-21T02:41:59.522Z",
+    });
+    setMockPresentationTemplates([template]);
+    const updateStarted = context.mocks.deferred<void>();
+    const releaseUpdate = context.mocks.deferred<void>();
+    context.mocks.api(
+      presentationTemplatesContract.update,
+      async ({ body, params, respond }) => {
+        expect(params.templateId).toBe(template.id);
+        expect(body).toStrictEqual({ title: "Renamed focus deck" });
+        updateStarted.resolve();
+        await releaseUpdate.promise;
+        template = {
+          ...template,
+          title: body.title ?? template.title,
+          updatedAt: "2026-08-27T02:41:59.522Z",
+        };
+        return respond(200, presentationTemplateSummary(template));
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(await screen.findByLabelText("Template"));
+    await user.click(
+      await screen.findByLabelText("Preview Focus deck at current slide"),
+    );
+    const titleInput = await screen.findByRole("textbox", {
+      name: "Rename template",
+    });
+    await fill(titleInput, "Renamed focus deck");
+    const renameButton = queryAllByRoleFast("button").find((candidate) => {
+      return candidate.getAttribute("aria-label") === "Rename template";
+    });
+    if (!renameButton) {
+      throw new Error("Imported template Rename button not found");
+    }
+    await user.click(renameButton);
+    await updateStarted.promise;
+
+    expect(renameButton).not.toHaveFocus();
+
+    releaseUpdate.resolve();
+    await expect(
+      screen.findByTestId("Renamed focus deck imported detail image preview"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("keeps loaded uploaded slides mounted while visibility metadata refreshes", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context, { threadId: THREAD_ID });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5671,6 +5671,9 @@ function ImportedPresentationTemplateRenameControl({
         }
         const normalized = normalizeImportedTemplateTitle(nextTitle);
         if (normalized.length > 0 && normalized !== title) {
+          // Confirming ends this edit. Keeping the submit control focused pins
+          // the check visible through the form's focus-within affordance.
+          event.currentTarget.querySelector<HTMLElement>(":focus")?.blur();
           onRename(normalized);
         }
       }}


### PR DESCRIPTION
## Summary

- release the uploaded-template rename control focus as soon as a valid title is confirmed
- prevent the form focus state from pinning the checkmark after save
- cover the behavior while the update request is still pending

## Test plan

- `pnpm exec prettier --check apps/platform/src/views/okou-page/chat-composer.tsx apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx`