### PR TITLE
perf(api): overlap runtime context reads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -71,6 +71,7 @@ import {
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogFilteredAuthMethods,
   replaceApiTestConnectorCatalogStoredBytes,
+  setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook,
   setApiTestConnectorCatalogRuntimeProjectionIdentityReplacements,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
@@ -650,6 +651,7 @@ async function expectBuiltInModelRunRuntimeRoute(
 
 function useSecretKmsClientForTests(args: {
   readonly failAfterGenerateDataKeys?: number;
+  readonly onDecrypt?: () => void;
   readonly onGenerateDataKey?: (callNumber: number) => void;
 }): void {
   let generateDataKeyCalls = 0;
@@ -677,6 +679,7 @@ function useSecretKmsClientForTests(args: {
       });
     },
     decrypt(): Promise<Uint8Array> {
+      args.onDecrypt?.();
       return Promise.resolve(TEST_DATA_KEY);
     },
   };
@@ -2279,6 +2282,136 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         "fixture-confidential-secret",
       ]);
     }
+  });
+
+  it("overlaps runtime catalog and provider reads while preserving cancellation", async () => {
+    const api = createRunsApi(context);
+    const fw = createFirewallApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-runtime-context-overlap-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-runtime-context-overlap-${randomUUID()}`,
+      runtimeProjection: true,
+    });
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await api.createOrgModelProvider(actor, {
+      type: "aws-bedrock",
+      authMethod: "access-keys",
+      secrets: {
+        AWS_ACCESS_KEY_ID: "runtime-context-access-key",
+        AWS_SECRET_ACCESS_KEY: "runtime-context-secret-key",
+        AWS_REGION: "us-east-1",
+      },
+    });
+    await fw.seedTestConnector(actor, {
+      connectorSlug: "x",
+      authMethod: "oauth",
+      accessToken: "runtime-context-x-access",
+      refreshToken: "runtime-context-x-refresh",
+    });
+
+    const providerDecryptStarted = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!providerDecryptStarted.settled()) {
+        providerDecryptStarted.resolve(undefined);
+      }
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    });
+    setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(async () => {
+      await providerDecryptStarted.promise;
+    });
+    useSecretKmsClientForTests({
+      onDecrypt: () => {
+        if (!providerDecryptStarted.settled()) {
+          providerDecryptStarted.resolve(undefined);
+        }
+      },
+    });
+
+    const run = await api.createDirectRun(actor, {
+      ...zeroBackedDirectRunBody({
+        agentId,
+        prompt: "overlap runtime catalog and provider reads",
+      }),
+      modelProviderType: "aws-bedrock",
+      connectorScope: {
+        allowedConnectorSlugs: ["x"],
+        allowedCustomConnectorIds: [],
+      },
+    });
+    expect(providerDecryptStarted.settled()).toBeTruthy();
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(timingEvents, [
+      "api_dispatch_connector_catalog_load_runtime_snapshot",
+      "api_dispatch_prepare_context_resolve_model_provider",
+    ]);
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.cliAgentType).toBe("claude-code");
+    expect(claim.environment).toMatchObject({
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      AWS_ACCESS_KEY_ID: "runtime-context-access-key",
+      AWS_SECRET_ACCESS_KEY: "runtime-context-secret-key",
+      AWS_REGION: "us-east-1",
+    });
+    expect(claim.connectorRuntimeTargets).toContainEqual(
+      expect.objectContaining({ kind: "builtin", connectorSlug: "x" }),
+    );
+    await api.requestCancelRun(actor, run.runId, [200]);
+
+    clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-runtime-context-cancel-${randomUUID()}`,
+      runtimeProjection: true,
+    });
+    const cancelledDecryptStarted = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!cancelledDecryptStarted.settled()) {
+        cancelledDecryptStarted.resolve(undefined);
+      }
+    });
+    setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(async () => {
+      await cancelledDecryptStarted.promise;
+    });
+    const requestController = new AbortController();
+    const cancellation = new Error("runtime context preparation cancelled");
+    cancellation.name = "AbortError";
+    useSecretKmsClientForTests({
+      onDecrypt: () => {
+        if (!cancelledDecryptStarted.settled()) {
+          cancelledDecryptStarted.resolve(undefined);
+          requestController.abort(cancellation);
+        }
+      },
+    });
+    const cancellableApi = createRunsApi({
+      ...context,
+      signal: requestController.signal,
+    });
+    const cancelledPrompt = `cancel overlapped runtime context ${randomUUID()}`;
+    await expect(
+      cancellableApi.createDirectRun(actor, {
+        ...zeroBackedDirectRunBody({ agentId, prompt: cancelledPrompt }),
+        modelProviderType: "aws-bedrock",
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
+      }),
+    ).rejects.toThrow(cancellation.message);
+    expect(cancelledDecryptStarted.settled()).toBeTruthy();
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((candidate) => {
+        return candidate.prompt === cancelledPrompt;
+      }),
+    ).toHaveLength(0);
   });
 
   it("memoizes scoped runtime entries by exact catalog identity", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -8895,10 +8895,18 @@ async function prepareRunRuntimeContext(
 ): Promise<PreparedRuntimeContext | CreateRunErrorResult> {
   const { body, resolved, requestedFramework, featureSwitchContext } =
     args.bodyContext;
-  const connectorCatalogSelection = await connectorCatalogSelectionForRun({
-    ...args,
-    orgId: args.createArgs.orgId,
-  });
+  const [connectorCatalogSelectionResult, modelProviderResult] =
+    await Promise.allSettled([
+      connectorCatalogSelectionForRun({
+        ...args,
+        orgId: args.createArgs.orgId,
+      }),
+      resolvePreparedRunModelProvider(args, signal),
+    ]);
+  if (connectorCatalogSelectionResult.status === "rejected") {
+    throw connectorCatalogSelectionResult.reason;
+  }
+  const connectorCatalogSelection = connectorCatalogSelectionResult.value;
   signal.throwIfAborted();
   const threadConnectorSelectionIds =
     await resolvePreparedThreadConnectorSelections(
@@ -8920,7 +8928,10 @@ async function prepareRunRuntimeContext(
           connectorCatalogSelection.selection,
         )
       : args.connectorScope;
-  const modelProvider = await resolvePreparedRunModelProvider(args, signal);
+  if (modelProviderResult.status === "rejected") {
+    throw modelProviderResult.reason;
+  }
+  const modelProvider = modelProviderResult.value;
   if (isRouteError(modelProvider)) {
     return modelProvider;
   }

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -203,6 +203,12 @@ export function setApiTestConnectorCatalogRuntimeProjectionIdentityReplacements(
   });
 }
 
+export function setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(
+  hook: () => Promise<void>,
+): void {
+  setConnectorCatalogRuntimeProjectionIdentityReadHookForTest(hook);
+}
+
 export function clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements(): void {
   clearConnectorCatalogRuntimeProjectionIdentityReadHookForTest();
 }


### PR DESCRIPTION
## Summary

- settle the independent connector-catalog and model-provider reads concurrently while preserving the existing catalog, cancellation, thread, and provider error priority
- add deterministic API integration coverage for successful Bedrock and connector runtime output plus request cancellation during the overlapped reads

## Compatibility and exclusions

- no API, database, queue, runner protocol, persisted-state, or feature-switch changes
- thread connector selection remains serial after catalog resolution
- no runtime-context cache or additional read overlap is introduced

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/test-fixtures/connector-catalog.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "overlaps runtime catalog and provider reads while preserving cancellation"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `git diff --check`

## Post-deploy gate

Evaluate the existing runtime-context timing spans on a pinned API/Runner cohort. Keep the change only if it produces at least a 25 ms p90 improvement or another material latency reduction without increasing database pressure or tail latency.

Closes #29817

Parent context: #24203
