### PR TITLE
refactor(api): cut debug writers to canonical alias

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -323,7 +323,6 @@ runs:
         add_env CONCURRENT_RUN_LIMIT_CAP "$concurrent_run_limit_cap"
         if [[ "$INPUT_ENVIRONMENT" == "preview" ]]; then
           add_env OKOU_DEBUG "*"
-          add_env VM0_DEBUG "*"
         fi
         add_var CLAUDE_CODE_VERSION_URL CLAUDE_CODE_VERSION_URL
         add_secret SLACK_SIGNING_SECRET SLACK_SIGNING_SECRET

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -123,13 +123,11 @@ assert_preview_job_ref_aliases_absent() {
   assert_env_key_absent "$env_file" VM0_PREVIEW_JOB_REF
 }
 
-assert_debug_aliases_equal_dual() {
+assert_debug_canonical_only() {
   local env_file="$1"
   assert_env_key_count "$env_file" OKOU_DEBUG 1
-  assert_env_key_count "$env_file" VM0_DEBUG 1
   assert_env_value "$env_file" OKOU_DEBUG "*"
-  assert_env_value "$env_file" VM0_DEBUG "*"
-  assert_env_values_equal "$env_file" OKOU_DEBUG VM0_DEBUG
+  assert_env_key_absent "$env_file" VM0_DEBUG
 }
 
 assert_debug_aliases_absent() {
@@ -480,7 +478,7 @@ success_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${succ
 assert_contains "$success_output" "Rendered"
 assert_no_fixture_secret_values "$success_output"
 assert_zero_keys_with_live_readers_absent "$success_env_file"
-assert_debug_aliases_equal_dual "$success_env_file"
+assert_debug_canonical_only "$success_env_file"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
@@ -562,7 +560,7 @@ preview_web_output="$(run_action "$(build_doppler_secrets_json)" "$preview_web_d
 preview_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${preview_web_dir}/github-output")"
 assert_contains "$preview_web_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$preview_web_env_file"
-assert_debug_aliases_equal_dual "$preview_web_env_file"
+assert_debug_canonical_only "$preview_web_env_file"
 assert_api_backend_url_canonical_only "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_key_absent "$preview_web_env_file" OKOU_MACHINE_SECRET_KEY
 assert_env_key_absent "$preview_web_env_file" VM0_MACHINE_SECRET_KEY
@@ -574,7 +572,7 @@ empty_job_ref_output="$(run_action "$(build_doppler_secrets_json)" "$empty_job_r
 empty_job_ref_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_job_ref_dir}/github-output")"
 assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_aliases_absent "$empty_job_ref_env_file"
-assert_debug_aliases_equal_dual "$empty_job_ref_env_file"
+assert_debug_canonical_only "$empty_job_ref_env_file"
 assert_api_backend_url_canonical_only "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
 assert_machine_secret_canonical_only "$empty_job_ref_env_file" "github-atom-machine-secret"
 
@@ -585,7 +583,7 @@ empty_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${empty_
 assert_contains "$empty_output" "Rendered"
 assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
-assert_debug_aliases_equal_dual "$empty_env_file"
+assert_debug_canonical_only "$empty_env_file"
 assert_api_backend_url_canonical_only "$empty_env_file" "https://pr-123-api-backend.vm0.test"
 assert_machine_secret_canonical_only "$empty_env_file" "github-atom-machine-secret"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""

--- a/turbo/apps/api/scripts/dev.sh
+++ b/turbo/apps/api/scripts/dev.sh
@@ -192,7 +192,6 @@ start_clerk_webhook_forwarding
 cd "$API_APP_DIR"
 env \
   OKOU_DEBUG='*' \
-  VM0_DEBUG='*' \
   FEISHU_CALLBACK_BASE_URL="$TUNNEL_URL" \
   FINICITY_WEBHOOK_BASE_URL="$TUNNEL_URL" \
   tsx watch --env-file=.env.local src/server.ts

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -144,12 +144,11 @@ function resolveDebugConfiguration(): DebugConfiguration {
   return { state: "conflicting-dual" };
 }
 
-// The preview and local-development writers now emit byte-equal OKOU_DEBUG and
-// VM0_DEBUG values, with Turbo passing both aliases. VM0_DEBUG remains for API
-// rollback artifacts whose reader is legacy-only. Under #28914, refresh stale
-// Worker PR #25722 before the later canonical-only writer cutover, then retain
-// this resolver until bounded source evidence records zero legacy-only and
-// equal-dual states throughout the supported rollback window.
+// Repository-owned preview, local-development, and Turbo writers emit only
+// OKOU_DEBUG. This dual reader and value-free source telemetry remain for
+// external legacy input, old checkout/rerun visibility, and supported rollback
+// compatibility. Remove them only in a later #28914 cleanup after those sources
+// and the rollback window are proven drained.
 const debugConfiguration = singleton(resolveDebugConfiguration);
 
 function getDebugPatterns(): readonly string[] {

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -9,7 +9,6 @@
     "DB_POOL_CONNECT_TIMEOUT_MS",
     "DB_DRIVER",
     "OKOU_DEBUG",
-    "VM0_DEBUG",
     "DEV",
     "NODE_ENV",
     "SKIP_ENV_VALIDATION",


### PR DESCRIPTION
## Summary

- Stop the repository-owned Web/API preview action from emitting `VM0_DEBUG` while preserving the existing preview gate and production absence.
- Start local API development with only `OKOU_DEBUG=*` and pass only `OKOU_DEBUG` through Turbo.
- Update every existing preview action fixture to require exactly one `OKOU_DEBUG=*` and no `VM0_DEBUG`; keep both aliases absent in production fixtures.
- Preserve the validated `VM0_DEBUG` schema, complete dual reader, fail-closed conflict behavior, value-free telemetry, alias matrix, pattern semantics, and logger caching/reset behavior.
- Update only the compatibility comment around the retained reader to describe the canonical-only repository writers and the later cleanup gate.

## Base and overlap evidence

- Implementation started from the controller JIT base `main@59a1dc75def4f4ec2170d609ce92d36de1e4fbee`.
- The fully paginated pre-edit audit covered 33 open PRs and reconciled all 459 GitHub-declared changed-file records with all 459 fetched records; there were no mismatches.
- The fully paginated final-head audit for `450534b42cb7febfa79fb0680b73446d30f4bcc5` covered 38 open PRs and reconciled all 488 declared records with all 488 fetched records; there were no mismatches. Only #25722 required a second changed-files page.
- Only stale #25722 overlaps this boundary. It remains at head `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, last updated `2026-08-13T15:03:45Z`, and GitHub reports `CONFLICTING / DIRTY`. Its overlapping files are the preview action, its focused shell test, `env.ts`, `log.ts`, and `turbo.json`; this PR does not edit its branch, wait for it, or import its Worker/Cloudflare implementation.
- Before push, `origin/main` advanced to `04fa0f19126e9aa46192daf0a7d4936788661afb` through unrelated release/chat-activity commits. Those commits do not touch this boundary, and the read-only merge-tree is clean, so this PR proceeds under normal merge precedence.

## Verification

- Pinned Prettier 3.8.1 write/check for all five changed files.
- `pnpm --filter api lint`.
- `pnpm --filter api run check-types`.
- `pnpm exec knip --workspace apps/api`.
- Bash syntax and ShellCheck 0.9.0 for `turbo/apps/api/scripts/dev.sh`, `.github/scripts/tests/web-api-env-action-test.sh`, and the extracted composite-action script.
- `bash .github/scripts/tests/web-api-env-action-test.sh`.
- `jq empty turbo/turbo.json` plus focused exactly-once canonical/no-legacy Turbo assertions.
- Focused static assertion that the local API launch command contains exactly one `OKOU_DEBUG='*'` assignment and no `VM0_DEBUG` assignment.
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/lib/__tests__/log.test.ts --reporter=dot --silent=passed-only` (55 passed).
- Final exact-token inventory retains seven `VM0_DEBUG` occurrences, all limited to the validated schema, centralized reader/conflict contract, focused reader tests, and action absence assertions; no active repository-owned writer or pass-through remains.
- `git diff --check` and a clean diff assertion for `turbo/apps/api/src/lib/env.ts` and `turbo/apps/api/src/lib/__tests__/log.test.ts`.

## Fallbacks

- **Retained legacy reader:** `turbo/apps/api/src/lib/log.ts:resolveDebugConfiguration` continues to accept validated `VM0_DEBUG` input through the centralized API logging compatibility boundary. This protects external legacy input and supported old checkout/rerun visibility while repository-owned preview, local-development, and Turbo writers are canonical-only.
- **Supported rollback proof:** Production Rollback Dashboard #6792 retains `31f3b2e88e5b84873fd010c172d64fe3b0cd2cc0`, `a63585c6e9e84a0523900a6225aa80e7d87849da`, `58656533202285c048d5d86b60923d6f225fd182`, `be006a7c2783fe63fe5eb86a2737fce371665aab`, `e1e9e15aba8afc987d5cba60199c44ede7755385`, `045b339473384985f4d23be48d9c27e6738d5391`, and `1051a3ddca0d004a9eaa71e3c54b1906a6ba12a6`. All seven descend from both the dual-reader merge and equal-dual writer merge with `behind_by=0`, so every supported target accepts canonical-only input.
- **Removal gate:** The dual reader and value-free alias-resolution telemetry remain until a separate later #28914 cleanup proves external legacy inputs, old checkout/rerun paths, and the supported rollback window drained. This PR does not remove reader states, schema validation, telemetry, or tests.
- **Stale overlap:** #25722 remains inventory only. This PR neither edits nor waits for it and does not import its Worker allowlist or Cloudflare runtime work; if it continues later, that PR owns its rebase and conflict resolution against the canonical `main` established by merge precedence.

## Non-goals

- No production release, deployment, environment approval, production QA, or external configuration mutation.
- No Worker/Cloudflare implementation, namespace-guard cleanup, legacy-reader removal, telemetry removal, or unrelated environment-contract change.

Closes #29824

Parent EPIC: #28914
