### PR TITLE
fix(sandbox-fc): guard balloon deflation after unpark

### DIFF
--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -34,7 +34,9 @@ pub(crate) const MIN_GUEST_MIB: u32 = 512;
 /// Poll interval for balloon stats.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Fast-start polling while a post-unpark controller protects the lifecycle's
-/// target-zero deflation from reactive policy.
+/// target-zero deflation from reactive policy. The cumulative 975 ms window
+/// covers the observed approximately 0.79-second deflation before normal
+/// polling resumes.
 const UNPARK_DEFLATE_FAST_POLL_INTERVALS: [Duration; 8] = [
     Duration::from_millis(25),
     Duration::from_millis(50),
@@ -547,20 +549,6 @@ mod tests {
         assert!(
             api.drain_requests().is_empty(),
             "the startup guard must never patch balloon policy"
-        );
-    }
-
-    #[test]
-    fn unpark_deflation_fast_poll_window_covers_expected_transition() {
-        let fast_poll_window: Duration = UNPARK_DEFLATE_FAST_POLL_INTERVALS.into_iter().sum();
-
-        assert!(
-            fast_poll_window >= Duration::from_millis(900),
-            "fast polling should cover the observed subsecond deflation window"
-        );
-        assert!(
-            fast_poll_window <= Duration::from_secs(1),
-            "fast polling must remain a bounded startup burst"
         );
     }
 

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -33,6 +33,18 @@ const MAX_INFLATE_PER_TICK_MIB: u32 = 256;
 pub(crate) const MIN_GUEST_MIB: u32 = 512;
 /// Poll interval for balloon stats.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
+/// Fast-start polling while a post-unpark controller protects the lifecycle's
+/// target-zero deflation from reactive policy.
+const UNPARK_DEFLATE_FAST_POLL_INTERVALS: [Duration; 7] = [
+    Duration::from_millis(25),
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(200),
+];
+const UNPARK_DEFLATE_MAX_POLL: Duration = Duration::from_millis(200);
 /// How often to emit balloon status logs (in ticks).
 /// 12 ticks × 5s = 60s.
 const STATUS_INTERVAL_TICKS: u64 = 12;
@@ -41,10 +53,20 @@ pub(crate) struct ControllerHandle {
     task: Option<tokio::task::JoinHandle<()>>,
 }
 
+enum ControllerStartup {
+    Active,
+    AwaitUnparkDeflation { log_id: String },
+}
+
 impl ControllerHandle {
-    fn spawn(client: ApiClient, memory_mb: u32, state_rx: watch::Receiver<SandboxState>) -> Self {
+    fn spawn(
+        client: ApiClient,
+        memory_mb: u32,
+        state_rx: watch::Receiver<SandboxState>,
+        startup: ControllerStartup,
+    ) -> Self {
         Self {
-            task: Some(tokio::spawn(run_loop(client, memory_mb, state_rx))),
+            task: Some(tokio::spawn(run_loop(client, memory_mb, state_rx, startup))),
         }
     }
 
@@ -97,16 +119,46 @@ pub(crate) fn spawn(
     memory_mb: u32,
     state_rx: watch::Receiver<SandboxState>,
 ) -> ControllerHandle {
-    ControllerHandle::spawn(client, memory_mb, state_rx)
+    ControllerHandle::spawn(client, memory_mb, state_rx, ControllerStartup::Active)
 }
 
-async fn run_loop(client: ApiClient, memory_mb: u32, mut state_rx: watch::Receiver<SandboxState>) {
+/// Spawn the controller after unpark without putting physical balloon
+/// deflation on the run-start critical path.
+///
+/// The task observes exact target-zero convergence in the background before
+/// entering normal reactive policy, so contradictory statistics from the
+/// in-flight lifecycle transition cannot reverse the deflation request.
+pub(crate) fn spawn_after_unpark_deflation(
+    client: ApiClient,
+    memory_mb: u32,
+    state_rx: watch::Receiver<SandboxState>,
+    log_id: String,
+) -> ControllerHandle {
+    ControllerHandle::spawn(
+        client,
+        memory_mb,
+        state_rx,
+        ControllerStartup::AwaitUnparkDeflation { log_id },
+    )
+}
+
+async fn run_loop(
+    client: ApiClient,
+    memory_mb: u32,
+    mut state_rx: watch::Receiver<SandboxState>,
+    startup: ControllerStartup,
+) {
     let max_inflate = memory_mb.saturating_sub(MIN_GUEST_MIB);
     if max_inflate == 0 {
         info!(
             memory_mb,
             MIN_GUEST_MIB, "balloon controller disabled: memory_mb <= MIN_GUEST_MIB"
         );
+        return;
+    }
+    if let ControllerStartup::AwaitUnparkDeflation { log_id } = startup
+        && !wait_for_unpark_deflation(&client, &mut state_rx, &log_id).await
+    {
         return;
     }
     let mut interval = tokio::time::interval(POLL_INTERVAL);
@@ -121,6 +173,55 @@ async fn run_loop(client: ApiClient, memory_mb: u32, mut state_rx: watch::Receiv
             _ = wait_for_crash_or_stop(&mut state_rx) => {
                 return;
             }
+        }
+    }
+}
+
+async fn wait_for_unpark_deflation(
+    client: &ApiClient,
+    state_rx: &mut watch::Receiver<SandboxState>,
+    log_id: &str,
+) -> bool {
+    let started_at = tokio::time::Instant::now();
+    let mut sample_count = 0_u32;
+    let mut fast_poll_intervals = UNPARK_DEFLATE_FAST_POLL_INTERVALS.into_iter();
+
+    loop {
+        let stats = tokio::select! {
+            stats = client.get_balloon_statistics() => stats,
+            () = wait_for_crash_or_stop(state_rx) => return false,
+        };
+        let poll_interval = match stats {
+            Ok(stats) => {
+                sample_count = sample_count.saturating_add(1);
+                if stats.target_mib == 0 && stats.actual_mib == 0 {
+                    info!(
+                        id = %log_id,
+                        target_mib = stats.target_mib,
+                        actual_mib = stats.actual_mib,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        sample_count,
+                        "balloon deflation completed after unpark"
+                    );
+                    return true;
+                }
+                fast_poll_intervals
+                    .next()
+                    .unwrap_or(UNPARK_DEFLATE_MAX_POLL)
+            }
+            Err(error) => {
+                warn!(
+                    id = %log_id,
+                    %error,
+                    "balloon deflation status unavailable after unpark"
+                );
+                POLL_INTERVAL
+            }
+        };
+
+        tokio::select! {
+            () = tokio::time::sleep(poll_interval) => {}
+            () = wait_for_crash_or_stop(state_rx) => return false,
         }
     }
 }
@@ -418,6 +519,61 @@ mod tests {
     #[tokio::test]
     async fn spawn_exits_when_state_crashed() {
         assert_spawn_exits_on_state(SandboxState::Crashed).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unpark_deflation_guard_retries_statistics_errors_without_patching() {
+        let mut api = MockFirecrackerApi::with_responses([
+            MockResponse::bad_request_fault("statistics unavailable"),
+            MockResponse::ok_body(
+                r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0}"#,
+            ),
+        ]);
+        let client = ApiClient::new(api.socket_path()).unwrap();
+        let (_state_tx, mut state_rx) = watch::channel(SandboxState::Running);
+        let guard = tokio::spawn(async move {
+            wait_for_unpark_deflation(&client, &mut state_rx, "test-unpark-retry").await
+        });
+
+        let first_request = api.next_request().await;
+        assert_firecracker_request(&first_request, "GET", "/balloon/statistics");
+        tokio::task::yield_now().await;
+        tokio::time::advance(POLL_INTERVAL).await;
+
+        let second_request = api.next_request().await;
+        assert_firecracker_request(&second_request, "GET", "/balloon/statistics");
+        assert!(
+            guard.await.unwrap(),
+            "exact deflation should release the guard"
+        );
+        assert!(
+            api.drain_requests().is_empty(),
+            "the startup guard must never patch balloon policy"
+        );
+    }
+
+    #[tokio::test]
+    async fn unpark_deflation_guard_exits_when_sandbox_stops() {
+        let (mut api, _bind_tx) = MockFirecrackerApi::deferred_repeating(
+            MockResponse::internal_error_raw("unused response"),
+        );
+        let client = ApiClient::new(api.socket_path()).unwrap();
+        let (state_tx, mut state_rx) = watch::channel(SandboxState::Running);
+        let guard = tokio::spawn(async move {
+            wait_for_unpark_deflation(&client, &mut state_rx, "test-unpark-stop").await
+        });
+
+        tokio::task::yield_now().await;
+        state_tx.send(SandboxState::Stopped).unwrap();
+
+        assert!(
+            !guard.await.unwrap(),
+            "stopped sandbox should cancel the guard"
+        );
+        assert!(
+            api.drain_requests().is_empty(),
+            "cancellation must not issue a policy request"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -44,7 +44,6 @@ const UNPARK_DEFLATE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(200),
     Duration::from_millis(200),
 ];
-const UNPARK_DEFLATE_MAX_POLL: Duration = Duration::from_millis(200);
 /// How often to emit balloon status logs (in ticks).
 /// 12 ticks × 5s = 60s.
 const STATUS_INTERVAL_TICKS: u64 = 12;
@@ -205,9 +204,7 @@ async fn wait_for_unpark_deflation(
                     );
                     return true;
                 }
-                fast_poll_intervals
-                    .next()
-                    .unwrap_or(UNPARK_DEFLATE_MAX_POLL)
+                fast_poll_intervals.next().unwrap_or(POLL_INTERVAL)
             }
             Err(error) => {
                 warn!(

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -35,12 +35,13 @@ pub(crate) const MIN_GUEST_MIB: u32 = 512;
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Fast-start polling while a post-unpark controller protects the lifecycle's
 /// target-zero deflation from reactive policy.
-const UNPARK_DEFLATE_FAST_POLL_INTERVALS: [Duration; 7] = [
+const UNPARK_DEFLATE_FAST_POLL_INTERVALS: [Duration; 8] = [
     Duration::from_millis(25),
     Duration::from_millis(50),
     Duration::from_millis(100),
     Duration::from_millis(100),
     Duration::from_millis(100),
+    Duration::from_millis(200),
     Duration::from_millis(200),
     Duration::from_millis(200),
 ];
@@ -546,6 +547,20 @@ mod tests {
         assert!(
             api.drain_requests().is_empty(),
             "the startup guard must never patch balloon policy"
+        );
+    }
+
+    #[test]
+    fn unpark_deflation_fast_poll_window_covers_expected_transition() {
+        let fast_poll_window: Duration = UNPARK_DEFLATE_FAST_POLL_INTERVALS.into_iter().sum();
+
+        assert!(
+            fast_poll_window >= Duration::from_millis(900),
+            "fast polling should cover the observed subsecond deflation window"
+        );
+        assert!(
+            fast_poll_window <= Duration::from_secs(1),
+            "fast polling must remain a bounded startup burst"
         );
     }
 

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -550,23 +550,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unpark_deflation_guard_exits_when_sandbox_stops() {
+    async fn controller_after_unpark_deflation_exits_when_sandbox_stops() {
         let (mut api, _bind_tx) = MockFirecrackerApi::deferred_repeating(
             MockResponse::internal_error_raw("unused response"),
         );
         let client = ApiClient::new(api.socket_path()).unwrap();
-        let (state_tx, mut state_rx) = watch::channel(SandboxState::Running);
-        let guard = tokio::spawn(async move {
-            wait_for_unpark_deflation(&client, &mut state_rx, "test-unpark-stop").await
-        });
+        let (state_tx, state_rx) = watch::channel(SandboxState::Running);
+        let controller = spawn_after_unpark_deflation(
+            client,
+            MIN_GUEST_MIB + 1,
+            state_rx,
+            "test-unpark-stop".into(),
+        );
 
         tokio::task::yield_now().await;
         state_tx.send(SandboxState::Stopped).unwrap();
 
-        assert!(
-            !guard.await.unwrap(),
-            "stopped sandbox should cancel the guard"
-        );
+        await_controller_exit(controller, "post-unpark controller after stop").await;
         assert!(
             api.drain_requests().is_empty(),
             "cancellation must not issue a policy request"

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3444,11 +3444,13 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Maximum time to wait for balloon deflation before reopening guest operations.
+const BALLOON_DEFLATE_TIMEOUT: Duration = BALLOON_SETTLE_TIMEOUT;
 /// Additional bounded wait when the balloon is still making progress and the
 /// guest reports enough unused memory to finish reclaiming safely.
 const BALLOON_SETTLE_PROGRESS_GRACE: Duration = Duration::from_secs(5);
-/// Fast-start poll intervals while waiting for balloon inflation.
-const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
+/// Fast-start poll intervals while waiting for a balloon lifecycle transition.
+const BALLOON_TRANSITION_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(25),
     Duration::from_millis(50),
     Duration::from_millis(100),
@@ -3457,8 +3459,8 @@ const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(200),
     Duration::from_millis(200),
 ];
-/// Maximum poll interval while waiting for balloon inflation.
-const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(200);
+/// Maximum poll interval while waiting for a balloon lifecycle transition.
+const BALLOON_TRANSITION_MAX_POLL: Duration = Duration::from_millis(200);
 /// Upper bound for accepting residual differences between requested and
 /// reported balloon size. Current 4 GiB production profiles commonly settle
 /// with low-hundreds MiB residuals when the guest reports little available
@@ -3788,7 +3790,7 @@ async fn wait_for_balloon_with_optional_handoff(
     let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
     let mut deadline = summary.started_at + settle_timeout;
     let mut progress_grace_used = false;
-    let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();
+    let mut fast_poll_intervals = BALLOON_TRANSITION_FAST_POLL_INTERVALS.into_iter();
     loop {
         if tokio::time::Instant::now() >= deadline {
             if !progress_grace_used && summary.can_extend_for_progress() {
@@ -3966,7 +3968,7 @@ async fn wait_for_balloon_with_optional_handoff(
 
         let poll_interval = fast_poll_intervals
             .next()
-            .unwrap_or(BALLOON_SETTLE_MAX_POLL);
+            .unwrap_or(BALLOON_TRANSITION_MAX_POLL);
         let next_poll = tokio::time::Instant::now() + poll_interval;
         let sleep = tokio::time::sleep_until(if next_poll < deadline {
             next_poll
@@ -3990,6 +3992,71 @@ async fn wait_for_balloon_with_optional_handoff(
             None => sleep.as_mut().await,
         }
     }
+}
+
+async fn wait_for_balloon_deflation(client: &ApiClient, log_id: &str) -> sandbox::Result<()> {
+    let started_at = tokio::time::Instant::now();
+    let deadline = started_at + BALLOON_DEFLATE_TIMEOUT;
+    let mut sample_count = 0_u32;
+    let mut last_target_mib = None;
+    let mut last_actual_mib = None;
+    let mut fast_poll_intervals = BALLOON_TRANSITION_FAST_POLL_INTERVALS.into_iter();
+
+    loop {
+        let stats = tokio::time::timeout_at(deadline, client.get_balloon_statistics())
+            .await
+            .map_err(|_| balloon_deflate_timeout_error(last_target_mib, last_actual_mib))?
+            .map_err(|error| {
+                idle_transition_error(
+                    SandboxIdleTransition::Unpark,
+                    format!("balloon deflate statistics: {error}"),
+                )
+            })?;
+        sample_count = sample_count.saturating_add(1);
+        last_target_mib = Some(stats.target_mib);
+        last_actual_mib = Some(stats.actual_mib);
+
+        if stats.target_mib == 0 && stats.actual_mib == 0 {
+            info!(
+                id = %log_id,
+                target_mib = stats.target_mib,
+                actual_mib = stats.actual_mib,
+                elapsed_ms = duration_ms(started_at.elapsed()),
+                sample_count,
+                "balloon fully deflated, proceeding to active operations"
+            );
+            return Ok(());
+        }
+
+        // Deflation timing tests advance paused time only after a completed sample.
+        #[cfg(test)]
+        tracing::event!(tracing::Level::TRACE, "waiting for balloon deflation");
+
+        let poll_interval = fast_poll_intervals
+            .next()
+            .unwrap_or(BALLOON_TRANSITION_MAX_POLL);
+        let next_poll = tokio::time::Instant::now() + poll_interval;
+        tokio::time::sleep_until(next_poll.min(deadline)).await;
+        if tokio::time::Instant::now() >= deadline {
+            return Err(balloon_deflate_timeout_error(
+                last_target_mib,
+                last_actual_mib,
+            ));
+        }
+    }
+}
+
+fn balloon_deflate_timeout_error(
+    last_target_mib: Option<u32>,
+    last_actual_mib: Option<u32>,
+) -> SandboxError {
+    idle_transition_error(
+        SandboxIdleTransition::Unpark,
+        format!(
+            "balloon deflate did not settle within {} ms (last target_mib: {last_target_mib:?}, last actual_mib: {last_actual_mib:?})",
+            duration_ms(BALLOON_DEFLATE_TIMEOUT)
+        ),
+    )
 }
 
 fn guest_memory_snapshot(snapshot: vsock_proto::MemorySnapshot) -> GuestMemorySnapshot {
@@ -4383,6 +4450,7 @@ async fn unpark_inner(
                 message: format!("balloon deflate: {e}"),
             })?;
 
+        wait_for_balloon_deflation(&client, log_id).await?;
         *balloon_controller = Some(balloon::spawn(client, memory_mb, state_rx));
     }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3444,13 +3444,11 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Maximum time to wait for balloon deflation before reopening guest operations.
-const BALLOON_DEFLATE_TIMEOUT: Duration = BALLOON_SETTLE_TIMEOUT;
 /// Additional bounded wait when the balloon is still making progress and the
 /// guest reports enough unused memory to finish reclaiming safely.
 const BALLOON_SETTLE_PROGRESS_GRACE: Duration = Duration::from_secs(5);
-/// Fast-start poll intervals while waiting for a balloon lifecycle transition.
-const BALLOON_TRANSITION_FAST_POLL_INTERVALS: [Duration; 7] = [
+/// Fast-start poll intervals while waiting for balloon inflation.
+const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(25),
     Duration::from_millis(50),
     Duration::from_millis(100),
@@ -3459,8 +3457,8 @@ const BALLOON_TRANSITION_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(200),
     Duration::from_millis(200),
 ];
-/// Maximum poll interval while waiting for a balloon lifecycle transition.
-const BALLOON_TRANSITION_MAX_POLL: Duration = Duration::from_millis(200);
+/// Maximum poll interval while waiting for balloon inflation.
+const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(200);
 /// Upper bound for accepting residual differences between requested and
 /// reported balloon size. Current 4 GiB production profiles commonly settle
 /// with low-hundreds MiB residuals when the guest reports little available
@@ -3790,7 +3788,7 @@ async fn wait_for_balloon_with_optional_handoff(
     let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
     let mut deadline = summary.started_at + settle_timeout;
     let mut progress_grace_used = false;
-    let mut fast_poll_intervals = BALLOON_TRANSITION_FAST_POLL_INTERVALS.into_iter();
+    let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();
     loop {
         if tokio::time::Instant::now() >= deadline {
             if !progress_grace_used && summary.can_extend_for_progress() {
@@ -3968,7 +3966,7 @@ async fn wait_for_balloon_with_optional_handoff(
 
         let poll_interval = fast_poll_intervals
             .next()
-            .unwrap_or(BALLOON_TRANSITION_MAX_POLL);
+            .unwrap_or(BALLOON_SETTLE_MAX_POLL);
         let next_poll = tokio::time::Instant::now() + poll_interval;
         let sleep = tokio::time::sleep_until(if next_poll < deadline {
             next_poll
@@ -3992,71 +3990,6 @@ async fn wait_for_balloon_with_optional_handoff(
             None => sleep.as_mut().await,
         }
     }
-}
-
-async fn wait_for_balloon_deflation(client: &ApiClient, log_id: &str) -> sandbox::Result<()> {
-    let started_at = tokio::time::Instant::now();
-    let deadline = started_at + BALLOON_DEFLATE_TIMEOUT;
-    let mut sample_count = 0_u32;
-    let mut last_target_mib = None;
-    let mut last_actual_mib = None;
-    let mut fast_poll_intervals = BALLOON_TRANSITION_FAST_POLL_INTERVALS.into_iter();
-
-    loop {
-        let stats = tokio::time::timeout_at(deadline, client.get_balloon_statistics())
-            .await
-            .map_err(|_| balloon_deflate_timeout_error(last_target_mib, last_actual_mib))?
-            .map_err(|error| {
-                idle_transition_error(
-                    SandboxIdleTransition::Unpark,
-                    format!("balloon deflate statistics: {error}"),
-                )
-            })?;
-        sample_count = sample_count.saturating_add(1);
-        last_target_mib = Some(stats.target_mib);
-        last_actual_mib = Some(stats.actual_mib);
-
-        if stats.target_mib == 0 && stats.actual_mib == 0 {
-            info!(
-                id = %log_id,
-                target_mib = stats.target_mib,
-                actual_mib = stats.actual_mib,
-                elapsed_ms = duration_ms(started_at.elapsed()),
-                sample_count,
-                "balloon fully deflated, proceeding to active operations"
-            );
-            return Ok(());
-        }
-
-        // Deflation timing tests advance paused time only after a completed sample.
-        #[cfg(test)]
-        tracing::event!(tracing::Level::TRACE, "waiting for balloon deflation");
-
-        let poll_interval = fast_poll_intervals
-            .next()
-            .unwrap_or(BALLOON_TRANSITION_MAX_POLL);
-        let next_poll = tokio::time::Instant::now() + poll_interval;
-        tokio::time::sleep_until(next_poll.min(deadline)).await;
-        if tokio::time::Instant::now() >= deadline {
-            return Err(balloon_deflate_timeout_error(
-                last_target_mib,
-                last_actual_mib,
-            ));
-        }
-    }
-}
-
-fn balloon_deflate_timeout_error(
-    last_target_mib: Option<u32>,
-    last_actual_mib: Option<u32>,
-) -> SandboxError {
-    idle_transition_error(
-        SandboxIdleTransition::Unpark,
-        format!(
-            "balloon deflate did not settle within {} ms (last target_mib: {last_target_mib:?}, last actual_mib: {last_actual_mib:?})",
-            duration_ms(BALLOON_DEFLATE_TIMEOUT)
-        ),
-    )
 }
 
 fn guest_memory_snapshot(snapshot: vsock_proto::MemorySnapshot) -> GuestMemorySnapshot {
@@ -4450,8 +4383,12 @@ async fn unpark_inner(
                 message: format!("balloon deflate: {e}"),
             })?;
 
-        wait_for_balloon_deflation(&client, log_id).await?;
-        *balloon_controller = Some(balloon::spawn(client, memory_mb, state_rx));
+        *balloon_controller = Some(balloon::spawn_after_unpark_deflation(
+            client,
+            memory_mb,
+            state_rx,
+            log_id.to_owned(),
+        ));
     }
 
     *is_parked = false;

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4262,6 +4262,10 @@ impl MockLifecycleApi {
         )
     }
 
+    fn with_actual(patch_statuses: std::collections::VecDeque<u16>, actual_mib: u32) -> Self {
+        Self::new(patch_statuses, Some(Arc::new(AtomicU32::new(actual_mib))))
+    }
+
     fn with_stats_source(
         patch_statuses: std::collections::VecDeque<u16>,
         balloon_stats_source: MockBalloonStatsSource,
@@ -4344,6 +4348,17 @@ async fn capture_balloon_timeout_after_sample<F>(future: F) -> (F::Output, Vec<C
 where
     F: Future,
 {
+    capture_timeout_after_sample(future, "waiting for balloon", BALLOON_SETTLE_TIMEOUT).await
+}
+
+async fn capture_timeout_after_sample<F>(
+    future: F,
+    waiting_message: &str,
+    timeout: Duration,
+) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: Future,
+{
     let captured = CapturedEvents::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
@@ -4352,7 +4367,7 @@ where
     tokio::time::pause();
 
     loop {
-        if has_captured_event(&captured.entries(), "waiting for balloon") {
+        if has_captured_event(&captured.entries(), waiting_message) {
             break;
         }
         tokio::select! {
@@ -4363,7 +4378,7 @@ where
         }
     }
 
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::advance(timeout).await;
     tokio::time::resume();
     let output = future.await;
     drop(guard);
@@ -4378,7 +4393,7 @@ async fn advance_balloon_wait_to_progress_grace<F>(
 {
     for expected_sample_count in 1..=2 {
         if expected_sample_count == 2 {
-            tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+            tokio::time::advance(BALLOON_TRANSITION_FAST_POLL_INTERVALS[0]).await;
             tokio::time::resume();
         }
         loop {
@@ -5718,7 +5733,7 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
 
 #[tokio::test]
 async fn unpark_resumes_and_deflates() {
-    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    let mut api = MockLifecycleApi::with_actual(std::collections::VecDeque::new(), 0);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -5754,6 +5769,147 @@ async fn unpark_resumes_and_deflates() {
     if let Some(h) = controller.take() {
         h.abort();
     }
+}
+
+#[tokio::test]
+async fn unpark_waits_for_actual_deflation_before_starting_controller() {
+    let stats_entered = Arc::new(Notify::new());
+    let release_lagging_stats = Arc::new(Notify::new());
+    let lagging_stats = MockBalloonStats::new(0, 3581).with_memory(
+        3431 * BYTES_PER_MIB,
+        3506 * BYTES_PER_MIB,
+        3934 * BYTES_PER_MIB,
+    );
+    let mut api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::GatedOk {
+                entered: Arc::clone(&stats_entered),
+                release: Arc::clone(&release_lagging_stats),
+                stats: lagging_stats,
+            },
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(0, 0)),
+        ]),
+    );
+    let api_socket = api.socket_path().to_path_buf();
+    let mut is_parked = true;
+    let mut controller: Option<balloon::ControllerHandle> = None;
+    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+
+    {
+        let unpark = unpark_inner(
+            &mut is_parked,
+            4096,
+            &mut controller,
+            &api_socket,
+            state_rx,
+            "test-unpark-lagging-actual",
+        );
+        tokio::pin!(unpark);
+        tokio::select! {
+            result = &mut unpark => panic!("unpark completed before lagging stats were released: {result:?}"),
+            () = stats_entered.notified() => {}
+        }
+
+        let pending_requests = api.drain_requests();
+        let pending_patches = patches(&pending_requests);
+        assert_eq!(
+            pending_patches.len(),
+            2,
+            "only resume and target-zero deflate may run before convergence"
+        );
+        assert_eq!(pending_patches[0].path, "/vm");
+        assert_eq!(pending_patches[1].path, "/balloon");
+        assert_eq!(mock_request_body_json(pending_patches[1])["amount_mib"], 0);
+
+        release_lagging_stats.notify_one();
+        unpark.await.unwrap();
+    }
+    assert!(!is_parked);
+    assert!(
+        controller.is_some(),
+        "controller starts after exact deflation"
+    );
+
+    let completed_requests = api.drain_requests();
+    assert!(
+        patches(&completed_requests).is_empty(),
+        "the contradictory high-free sample must not reverse target-zero deflation"
+    );
+
+    if let Some(handle) = controller.take() {
+        handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn unpark_propagates_deflation_statistics_error() {
+    let mut api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([MockBalloonStatsReply::Status(500)]),
+    );
+    let mut is_parked = true;
+    let mut controller: Option<balloon::ControllerHandle> = None;
+    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+
+    let result = unpark_inner(
+        &mut is_parked,
+        2048,
+        &mut controller,
+        api.socket_path(),
+        state_rx,
+        "test-unpark-stats-error",
+    )
+    .await;
+
+    assert_idle_transition_message(
+        result,
+        SandboxIdleTransition::Unpark,
+        "balloon deflate statistics: HTTP 500: test",
+    );
+    assert!(is_parked, "flag must stay true on statistics failure");
+    assert!(controller.is_none(), "controller must remain absent");
+
+    let requests = api.drain_requests();
+    let request_patches = patches(&requests);
+    assert_eq!(request_patches.len(), 2);
+    assert_eq!(request_patches[0].path, "/vm");
+    assert_eq!(request_patches[1].path, "/balloon");
+}
+
+#[tokio::test]
+async fn unpark_bounds_nonconverging_actual_deflation() {
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
+            0, 3581,
+        ))]),
+    );
+    let mut is_parked = true;
+    let mut controller: Option<balloon::ControllerHandle> = None;
+    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+
+    let (result, _) = capture_timeout_after_sample(
+        unpark_inner(
+            &mut is_parked,
+            4096,
+            &mut controller,
+            api.socket_path(),
+            state_rx,
+            "test-unpark-deflate-timeout",
+        ),
+        "waiting for balloon deflation",
+        BALLOON_DEFLATE_TIMEOUT,
+    )
+    .await;
+
+    assert_idle_transition_message(
+        result,
+        SandboxIdleTransition::Unpark,
+        "balloon deflate did not settle within 5000 ms (last target_mib: Some(0), last actual_mib: Some(3581))",
+    );
+    assert!(is_parked, "flag must stay true on deflation timeout");
+    assert!(controller.is_none(), "controller must remain absent");
 }
 
 #[tokio::test]
@@ -5864,7 +6020,7 @@ async fn double_park_is_idempotent() {
 
 #[tokio::test]
 async fn double_unpark_is_idempotent() {
-    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    let mut api = MockLifecycleApi::with_actual(std::collections::VecDeque::new(), 0);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -5941,7 +6097,11 @@ async fn unpark_without_park_is_noop() {
 
 #[tokio::test]
 async fn park_unpark_park_cycle() {
-    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    let balloon_actual = Arc::new(AtomicU32::new(1536));
+    let mut api = MockLifecycleApi::new(
+        std::collections::VecDeque::new(),
+        Some(Arc::clone(&balloon_actual)),
+    );
 
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
@@ -5961,6 +6121,7 @@ async fn park_unpark_park_cycle() {
     assert!(controller.is_none());
 
     // Turn 2: unpark → park.
+    balloon_actual.store(0, Ordering::Relaxed);
     unpark_inner(
         &mut is_parked,
         2048,
@@ -5974,6 +6135,7 @@ async fn park_unpark_park_cycle() {
     assert!(!is_parked);
     assert!(controller.is_some(), "unpark must respawn the controller");
 
+    balloon_actual.store(1536, Ordering::Relaxed);
     park_inner(
         &mut is_parked,
         2048,
@@ -6119,7 +6281,7 @@ async fn unpark_retry_after_failure_succeeds() {
     // First unpark: resume fails (500 — genuine error, not idempotent 400).
     // Second unpark: resume OK (204), deflate OK (204).
     let mut api =
-        MockLifecycleApi::new(std::collections::VecDeque::from(vec![500, 204, 204]), None);
+        MockLifecycleApi::with_actual(std::collections::VecDeque::from(vec![500, 204, 204]), 0);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -6250,9 +6412,9 @@ async fn unpark_resume_http_400_propagates_as_idle_transition() {
 async fn unpark_retry_after_partial_failure_resumes_idempotently() {
     // First unpark: resume OK (204), deflate fails (400).
     // Second unpark: repeated resume OK (204), deflate OK (204).
-    let api = MockLifecycleApi::new(
+    let api = MockLifecycleApi::with_actual(
         std::collections::VecDeque::from(vec![204, 400, 204, 204]),
-        None,
+        0,
     );
 
     let mut is_parked = true;

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4262,10 +4262,6 @@ impl MockLifecycleApi {
         )
     }
 
-    fn with_actual(patch_statuses: std::collections::VecDeque<u16>, actual_mib: u32) -> Self {
-        Self::new(patch_statuses, Some(Arc::new(AtomicU32::new(actual_mib))))
-    }
-
     fn with_stats_source(
         patch_statuses: std::collections::VecDeque<u16>,
         balloon_stats_source: MockBalloonStatsSource,
@@ -4348,17 +4344,6 @@ async fn capture_balloon_timeout_after_sample<F>(future: F) -> (F::Output, Vec<C
 where
     F: Future,
 {
-    capture_timeout_after_sample(future, "waiting for balloon", BALLOON_SETTLE_TIMEOUT).await
-}
-
-async fn capture_timeout_after_sample<F>(
-    future: F,
-    waiting_message: &str,
-    timeout: Duration,
-) -> (F::Output, Vec<CapturedEvent>)
-where
-    F: Future,
-{
     let captured = CapturedEvents::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
@@ -4367,7 +4352,7 @@ where
     tokio::time::pause();
 
     loop {
-        if has_captured_event(&captured.entries(), waiting_message) {
+        if has_captured_event(&captured.entries(), "waiting for balloon") {
             break;
         }
         tokio::select! {
@@ -4378,7 +4363,7 @@ where
         }
     }
 
-    tokio::time::advance(timeout).await;
+    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
     tokio::time::resume();
     let output = future.await;
     drop(guard);
@@ -4393,7 +4378,7 @@ async fn advance_balloon_wait_to_progress_grace<F>(
 {
     for expected_sample_count in 1..=2 {
         if expected_sample_count == 2 {
-            tokio::time::advance(BALLOON_TRANSITION_FAST_POLL_INTERVALS[0]).await;
+            tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
             tokio::time::resume();
         }
         loop {
@@ -5733,7 +5718,7 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
 
 #[tokio::test]
 async fn unpark_resumes_and_deflates() {
-    let mut api = MockLifecycleApi::with_actual(std::collections::VecDeque::new(), 0);
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -5772,9 +5757,13 @@ async fn unpark_resumes_and_deflates() {
 }
 
 #[tokio::test]
-async fn unpark_waits_for_actual_deflation_before_starting_controller() {
-    let stats_entered = Arc::new(Notify::new());
+async fn unpark_returns_while_controller_guards_pending_deflation() {
+    let lagging_stats_entered = Arc::new(Notify::new());
     let release_lagging_stats = Arc::new(Notify::new());
+    let converged_stats_entered = Arc::new(Notify::new());
+    let release_converged_stats = Arc::new(Notify::new());
+    let active_stats_entered = Arc::new(Notify::new());
+    let release_active_stats = Arc::new(Notify::new());
     let lagging_stats = MockBalloonStats::new(0, 3581).with_memory(
         3431 * BYTES_PER_MIB,
         3506 * BYTES_PER_MIB,
@@ -5784,132 +5773,71 @@ async fn unpark_waits_for_actual_deflation_before_starting_controller() {
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([
             MockBalloonStatsReply::GatedOk {
-                entered: Arc::clone(&stats_entered),
+                entered: Arc::clone(&lagging_stats_entered),
                 release: Arc::clone(&release_lagging_stats),
                 stats: lagging_stats,
             },
-            MockBalloonStatsReply::Ok(MockBalloonStats::new(0, 0)),
+            MockBalloonStatsReply::GatedOk {
+                entered: Arc::clone(&converged_stats_entered),
+                release: Arc::clone(&release_converged_stats),
+                stats: MockBalloonStats::new(0, 0),
+            },
+            MockBalloonStatsReply::GatedOk {
+                entered: Arc::clone(&active_stats_entered),
+                release: Arc::clone(&release_active_stats),
+                stats: MockBalloonStats::new(0, 0),
+            },
         ]),
     );
     let api_socket = api.socket_path().to_path_buf();
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
-    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+    let (state_tx, state_rx) = watch::channel(SandboxState::Running);
 
-    {
-        let unpark = unpark_inner(
-            &mut is_parked,
-            4096,
-            &mut controller,
-            &api_socket,
-            state_rx,
-            "test-unpark-lagging-actual",
-        );
-        tokio::pin!(unpark);
-        tokio::select! {
-            result = &mut unpark => panic!("unpark completed before lagging stats were released: {result:?}"),
-            () = stats_entered.notified() => {}
-        }
-
-        let pending_requests = api.drain_requests();
-        let pending_patches = patches(&pending_requests);
-        assert_eq!(
-            pending_patches.len(),
-            2,
-            "only resume and target-zero deflate may run before convergence"
-        );
-        assert_eq!(pending_patches[0].path, "/vm");
-        assert_eq!(pending_patches[1].path, "/balloon");
-        assert_eq!(mock_request_body_json(pending_patches[1])["amount_mib"], 0);
-
-        release_lagging_stats.notify_one();
-        unpark.await.unwrap();
-    }
+    unpark_inner(
+        &mut is_parked,
+        4096,
+        &mut controller,
+        &api_socket,
+        state_rx,
+        "test-unpark-lagging-actual",
+    )
+    .await
+    .unwrap();
     assert!(!is_parked);
     assert!(
         controller.is_some(),
-        "controller starts after exact deflation"
+        "protected controller should be installed without waiting for deflation"
     );
 
-    let completed_requests = api.drain_requests();
+    lagging_stats_entered.notified().await;
+    let unpark_requests = api.drain_requests();
+    let unpark_patches = patches(&unpark_requests);
+    assert_eq!(unpark_patches.len(), 2);
+    assert_eq!(unpark_patches[0].path, "/vm");
+    assert_eq!(unpark_patches[1].path, "/balloon");
+    assert_eq!(mock_request_body_json(unpark_patches[1])["amount_mib"], 0);
+
+    release_lagging_stats.notify_one();
+    converged_stats_entered.notified().await;
+    let guarded_requests = api.drain_requests();
     assert!(
-        patches(&completed_requests).is_empty(),
+        patches(&guarded_requests).is_empty(),
         "the contradictory high-free sample must not reverse target-zero deflation"
     );
 
+    release_converged_stats.notify_one();
+    active_stats_entered.notified().await;
+    assert!(
+        patches(&api.drain_requests()).is_empty(),
+        "normal policy must not start before exact deflation"
+    );
+
+    release_active_stats.notify_one();
+    state_tx.send(SandboxState::Stopped).unwrap();
     if let Some(handle) = controller.take() {
-        handle.abort();
+        handle.abort_and_join().await;
     }
-}
-
-#[tokio::test]
-async fn unpark_propagates_deflation_statistics_error() {
-    let mut api = MockLifecycleApi::with_stats(
-        std::collections::VecDeque::new(),
-        std::collections::VecDeque::from([MockBalloonStatsReply::Status(500)]),
-    );
-    let mut is_parked = true;
-    let mut controller: Option<balloon::ControllerHandle> = None;
-    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
-
-    let result = unpark_inner(
-        &mut is_parked,
-        2048,
-        &mut controller,
-        api.socket_path(),
-        state_rx,
-        "test-unpark-stats-error",
-    )
-    .await;
-
-    assert_idle_transition_message(
-        result,
-        SandboxIdleTransition::Unpark,
-        "balloon deflate statistics: HTTP 500: test",
-    );
-    assert!(is_parked, "flag must stay true on statistics failure");
-    assert!(controller.is_none(), "controller must remain absent");
-
-    let requests = api.drain_requests();
-    let request_patches = patches(&requests);
-    assert_eq!(request_patches.len(), 2);
-    assert_eq!(request_patches[0].path, "/vm");
-    assert_eq!(request_patches[1].path, "/balloon");
-}
-
-#[tokio::test]
-async fn unpark_bounds_nonconverging_actual_deflation() {
-    let api = MockLifecycleApi::with_stats(
-        std::collections::VecDeque::new(),
-        std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
-            0, 3581,
-        ))]),
-    );
-    let mut is_parked = true;
-    let mut controller: Option<balloon::ControllerHandle> = None;
-    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
-
-    let (result, _) = capture_timeout_after_sample(
-        unpark_inner(
-            &mut is_parked,
-            4096,
-            &mut controller,
-            api.socket_path(),
-            state_rx,
-            "test-unpark-deflate-timeout",
-        ),
-        "waiting for balloon deflation",
-        BALLOON_DEFLATE_TIMEOUT,
-    )
-    .await;
-
-    assert_idle_transition_message(
-        result,
-        SandboxIdleTransition::Unpark,
-        "balloon deflate did not settle within 5000 ms (last target_mib: Some(0), last actual_mib: Some(3581))",
-    );
-    assert!(is_parked, "flag must stay true on deflation timeout");
-    assert!(controller.is_none(), "controller must remain absent");
 }
 
 #[tokio::test]
@@ -6020,7 +5948,7 @@ async fn double_park_is_idempotent() {
 
 #[tokio::test]
 async fn double_unpark_is_idempotent() {
-    let mut api = MockLifecycleApi::with_actual(std::collections::VecDeque::new(), 0);
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -6097,11 +6025,7 @@ async fn unpark_without_park_is_noop() {
 
 #[tokio::test]
 async fn park_unpark_park_cycle() {
-    let balloon_actual = Arc::new(AtomicU32::new(1536));
-    let mut api = MockLifecycleApi::new(
-        std::collections::VecDeque::new(),
-        Some(Arc::clone(&balloon_actual)),
-    );
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
 
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
@@ -6121,7 +6045,6 @@ async fn park_unpark_park_cycle() {
     assert!(controller.is_none());
 
     // Turn 2: unpark → park.
-    balloon_actual.store(0, Ordering::Relaxed);
     unpark_inner(
         &mut is_parked,
         2048,
@@ -6135,7 +6058,6 @@ async fn park_unpark_park_cycle() {
     assert!(!is_parked);
     assert!(controller.is_some(), "unpark must respawn the controller");
 
-    balloon_actual.store(1536, Ordering::Relaxed);
     park_inner(
         &mut is_parked,
         2048,
@@ -6281,7 +6203,7 @@ async fn unpark_retry_after_failure_succeeds() {
     // First unpark: resume fails (500 — genuine error, not idempotent 400).
     // Second unpark: resume OK (204), deflate OK (204).
     let mut api =
-        MockLifecycleApi::with_actual(std::collections::VecDeque::from(vec![500, 204, 204]), 0);
+        MockLifecycleApi::new(std::collections::VecDeque::from(vec![500, 204, 204]), None);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -6412,9 +6334,9 @@ async fn unpark_resume_http_400_propagates_as_idle_transition() {
 async fn unpark_retry_after_partial_failure_resumes_idempotently() {
     // First unpark: resume OK (204), deflate fails (400).
     // Second unpark: repeated resume OK (204), deflate OK (204).
-    let api = MockLifecycleApi::with_actual(
+    let api = MockLifecycleApi::new(
         std::collections::VecDeque::from(vec![204, 400, 204, 204]),
-        0,
+        None,
     );
 
     let mut is_parked = true;


### PR DESCRIPTION
## Summary

- keep post-unpark balloon deflation off the run-start critical path
- start the controller in a protected mode that observes exact target/actual zero before enabling reactive policy
- keep polling responsive through the observed subsecond deflation window before backing off to the normal five-second cadence
- retry temporary statistics failures without allowing a contradictory inflate PATCH, and retain existing task cancellation on park, stop, crash, and teardown
- cover immediate unpark return, contradictory high-free statistics, error retry, convergence handoff, and lifecycle cancellation with deterministic mock API tests

## Root cause

The balloon controller previously started immediately after unpark requested target `0`. Its first interval tick is immediate, so a sample taken while the balloon is still physically inflated can look like high guest free memory and reverse the in-flight deflation. The runner then opens the reused sandbox while most guest memory remains ballooned, causing a required private-input write to stall until its timeout.

## Critical-path behavior

A synchronous convergence barrier was measured and rejected because Firecracker physical deflation takes approximately 0.79 seconds on local-1 and would add that delay to every reused run.

The revised path sends target `0`, installs the protected task, and returns. In 100 consecutive exact-reuse turns on one local-1 sandbox:

- 100/100 runs succeeded, with three private writes each
- zero balloon policy reversals, statistics errors, write stalls, or lifecycle failures
- unpark to ReadyForOperations: p50 16.9 ms, p95 18.4 ms, p99 19.5 ms, max 20.2 ms
- unpark to first private write: p50 26.4 ms, p95 30.2 ms, p99 30.9 ms, max 32.0 ms
- unpark to all private writes complete: p50 35.1 ms, p95 42.6 ms, p99 44.3 ms, max 44.9 ms
- unpark to authenticated Agent ready: p50 91.8 ms, p95 105.7 ms, p99 112.8 ms, max 118.7 ms

All 100 short runs completed before physical deflation reached zero, confirming that deflation overlaps startup instead of blocking it.

## Scope

This change owns the synchronization in the Firecracker balloon controller. It does not add vsock retries, extend write timeouts, or change queue, protocol, API, or persistence contracts.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox-fc --no-deps`
- `cargo test -p sandbox-fc` (812 library tests and 1 integration test passed)
- `git diff --check`
- local-1: 1 fresh warm-up followed by 100 exact-reuse turns on one sandbox; all passed

## Risk

Physical deflation now overlaps the beginning of a reused run. Guest operations can start while memory is transitioning from the parked allocation, although target `0` remains protected and the measured private-write and Agent-ready paths completed without stalls. If statistics stay unavailable or actual memory never reaches zero, normal reactive reclaim policy remains disabled for that run rather than risking reversal. Short runs may re-park before convergence; the existing park path cancels the controller, requests the parked target, and waits for inflation.

Closes #29812

Parent: #29631
