### PR TITLE
fix(platform): hide create workspace after limit reached

### DIFF
--- a/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
+++ b/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
@@ -4,6 +4,7 @@ import {
   type ClerkOrganizationMembership,
   type ClerkOrganizationsApi,
   type ClerkReadContext,
+  type ClerkUsersApi,
 } from "./clerk";
 
 const ORGANIZATION_LIST_PAGE_SIZE = 100;
@@ -20,6 +21,32 @@ export async function listAllOrganizationMemberships(
     const page = await organizations.getOrganizationMembershipList(
       {
         organizationId,
+        limit: ORGANIZATION_LIST_PAGE_SIZE,
+        offset,
+      },
+      context,
+      signal,
+    );
+    signal.throwIfAborted();
+    memberships.push(...page.data);
+    if (page.data.length < ORGANIZATION_LIST_PAGE_SIZE) {
+      return memberships;
+    }
+  }
+}
+
+export async function listAllUserOrganizationMemberships(
+  users: Pick<ClerkUsersApi, "getOrganizationMembershipList">,
+  userId: string,
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
+): Promise<ClerkOrganizationMembership[]> {
+  const memberships: ClerkOrganizationMembership[] = [];
+  for (let offset = 0; ; offset += ORGANIZATION_LIST_PAGE_SIZE) {
+    signal.throwIfAborted();
+    const page = await users.getOrganizationMembershipList(
+      {
+        userId,
         limit: ORGANIZATION_LIST_PAGE_SIZE,
         offset,
       },

--- a/turbo/apps/api/src/signals/external/clerk.ts
+++ b/turbo/apps/api/src/signals/external/clerk.ts
@@ -49,6 +49,7 @@ export interface ClerkOrganization {
   readonly imageUrl: string;
   readonly hasImage: boolean;
   readonly createdAt: number;
+  readonly createdBy?: string;
 }
 
 export interface ClerkOrganizationMembershipPublicUserData {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -828,6 +828,17 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       return response.body;
     },
 
+    async readCreatedOrganizationsCount(actor: ApiTestUser): Promise<number> {
+      const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
+        orgContract,
+      );
+      const response = await accept(
+        client.createdCount({ headers: authenticate(actor) }),
+        [200],
+      );
+      return response.body.createdOrganizationsCount;
+    },
+
     async requestReadOrg(
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401 | 404)[],

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -101,6 +101,31 @@ function logoForm(file: File): FormData {
   return form;
 }
 
+describe("ORG-00: user-level organization creation count", () => {
+  it("counts owned workspaces independently of the active workspace", async () => {
+    const actor = api.user();
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          organization: {
+            id: orgIdOf(actor),
+            createdBy: "other-user",
+          },
+        },
+        {
+          organization: {
+            id: "org_owned",
+            createdBy: actor.userId,
+          },
+        },
+      ],
+      totalCount: 2,
+    });
+
+    await expect(api.readCreatedOrganizationsCount(actor)).resolves.toBe(1);
+  });
+});
+
 describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
   it("serves, uploads, and removes the org logo across auth, validation, and clerk error arms [ORG-LOGO-A]", async () => {
     const admin = api.user();

--- a/turbo/apps/api/src/signals/routes/org-read.ts
+++ b/turbo/apps/api/src/signals/routes/org-read.ts
@@ -17,6 +17,7 @@ import {
 import type { RouteEntry } from "../route-entry";
 import { clerkRateLimit } from "../external/clerk";
 import {
+  createdOrganizationsCount$,
   leaveOrg$,
   orgDetail$,
   orgMembersList$,
@@ -40,6 +41,32 @@ const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   return { status: 200 as const, body: org };
 });
+
+const getCreatedOrganizationsCountInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const result = await settle(
+      set(createdOrganizationsCount$, auth.userId, signal),
+      signal,
+    );
+    if (result.ok) {
+      return {
+        status: 200 as const,
+        body: { createdOrganizationsCount: result.value },
+      };
+    }
+
+    const rateLimit = clerkRateLimit(result.error);
+    if (!rateLimit) {
+      throw result.error;
+    }
+    set(setResHeader$, "Retry-After", String(rateLimit.retryAfterSeconds));
+    set(setResHeader$, "Cache-Control", "no-store");
+    return providerUnavailable(
+      "Organization creation status is temporarily unavailable",
+    );
+  },
+);
 
 const updateOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
@@ -141,6 +168,13 @@ export const orgReadRoutes: readonly RouteEntry[] = [
   {
     route: orgContract.get,
     handler: authRoute({ acceptAnySandboxCapability: true }, getOrgInner$),
+  },
+  {
+    route: orgContract.createdCount,
+    handler: authRoute(
+      { accept: ["session"] },
+      getCreatedOrganizationsCountInner$,
+    ),
   },
   {
     route: orgContract.update,

--- a/turbo/apps/api/src/signals/services/org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/org-data.service.ts
@@ -29,6 +29,7 @@ import {
 import {
   listAllOrganizationMemberships,
   listAllPendingOrganizationInvitations,
+  listAllUserOrganizationMemberships,
 } from "../external/clerk-organization-lists";
 import { fetchClerkMembershipRequests } from "../external/clerk-membership-requests";
 import { badRequestMessage, notFound } from "../../lib/error";
@@ -189,6 +190,23 @@ interface OrgDetailArgs {
   readonly userId: string;
   readonly orgRole?: OrgRole;
 }
+
+export const createdOrganizationsCount$ = command(
+  async ({ get }, userId: string, signal: AbortSignal): Promise<number> => {
+    const client = get(clerk$);
+    const memberships = await listAllUserOrganizationMemberships(
+      client.users,
+      userId,
+      createClerkReadContext(),
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return memberships.filter((membership) => {
+      return membership.organization.createdBy === userId;
+    }).length;
+  },
+);
 
 export const orgDetail$ = command(
   async (

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -135,6 +135,7 @@ interface MockedUser {
   primaryEmailAddress: { emailAddress: string } | null;
   unsafeMetadata: Record<string, unknown>;
   createOrganizationEnabled: boolean;
+  createOrganizationsLimit: number | null;
   organizationMemberships: MockedMembership[];
   getOrganizationInvitations: (params?: {
     status?: string;
@@ -380,6 +381,7 @@ export function mockUser(
     imageUrl?: string;
     createdAt?: Date;
     createOrganizationEnabled?: boolean;
+    createOrganizationsLimit?: number | null;
     clientSessions?: MockedClientSession[];
   } | null,
   session: { token: string } | null,
@@ -391,6 +393,7 @@ export function mockUser(
       primaryEmailAddress: user.email ? { emailAddress: user.email } : null,
       unsafeMetadata: {},
       createOrganizationEnabled: user.createOrganizationEnabled ?? false,
+      createOrganizationsLimit: user.createOrganizationsLimit ?? null,
       get organizationMemberships() {
         return internalMockedMemberships;
       },

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -91,6 +91,7 @@ export async function setupPage(options: {
     firstName?: string;
     imageUrl?: string;
     createOrganizationEnabled?: boolean;
+    createOrganizationsLimit?: number | null;
     clientSessions?: MockedClientSession[];
   } | null;
   session?: { token: string } | null;

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -4,6 +4,7 @@ import { apiClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 
 const reloadOrg$ = state(0);
+const reloadCreatedOrganizationsCount$ = state(0);
 
 /**
  * Current user's default org.
@@ -21,6 +22,14 @@ export const org$ = computed(async (get) => {
   }
 
   return result.body;
+});
+
+export const createdOrganizationsCount$ = computed(async (get) => {
+  get(reloadCreatedOrganizationsCount$);
+  const createClient = get(apiClient$);
+  const client = createClient(orgContract);
+  const result = await accept(client.createdCount(), [200]);
+  return result.body.createdOrganizationsCount;
 });
 
 /**
@@ -45,6 +54,12 @@ export const isOrgAdmin$ = computed(async (get) => {
  */
 export const refreshOrg$ = command(({ set }) => {
   set(reloadOrg$, (x) => {
+    return x + 1;
+  });
+});
+
+export const refreshCreatedOrganizationsCount$ = command(({ set }) => {
+  set(reloadCreatedOrganizationsCount$, (x) => {
     return x + 1;
   });
 });

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -28,8 +28,12 @@ export const createdOrganizationsCount$ = computed(async (get) => {
   get(reloadCreatedOrganizationsCount$);
   const createClient = get(apiClient$);
   const client = createClient(orgContract);
-  const result = await accept(client.createdCount(), [200]);
-  return result.body.createdOrganizationsCount;
+  const result = await accept(client.createdCount(), [200, 404]);
+  // Rollout fallback for new App -> old API: the old API predates this
+  // additive route, so preserve its Clerk-gated creation-entry behavior.
+  // Remove after that API no longer serves or remains a rollback target.
+  // Follow-up: https://github.com/vm0-ai/vm0/issues/29866
+  return result.status === 200 ? result.body.createdOrganizationsCount : 0;
 });
 
 /**

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
@@ -212,6 +212,63 @@ describe("zero org switcher", () => {
     });
   });
 
+  it("preserves workspace creation while the count endpoint rolls out", async () => {
+    context.mocks.api(orgContract.createdCount, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Not found", code: "NOT_FOUND" },
+      });
+    });
+    context.mocks.data.org({
+      id: "org_current",
+      name: "Solo",
+      role: "admin",
+      createdBy: "other-user-456",
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+        createOrganizationEnabled: true,
+        createOrganizationsLimit: 1,
+      },
+      org: {
+        activeOrg: {
+          id: "org_current",
+          name: "Solo",
+          slug: "solo",
+        },
+        memberships: [
+          {
+            id: "membership_current",
+            organization: {
+              id: "org_current",
+              name: "Solo",
+            },
+          },
+        ],
+      },
+    });
+
+    const orgSwitcher = await waitFor(() => {
+      const label = screen.getByText("Solo");
+      const trigger = label.closest("button");
+      if (!trigger) {
+        throw new Error("Org switcher trigger not found");
+      }
+      return trigger;
+    });
+
+    click(orgSwitcher);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create workspace")).toBeInTheDocument();
+    });
+  });
+
   it("hides workspace creation after reaching the limit while another workspace is active", async () => {
     context.mocks.api(orgContract.createdCount, ({ respond }) => {
       return respond(200, { createdOrganizationsCount: 1 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { orgContract } from "@okouai/api-contracts/contracts/org-routes";
 
 import {
   click,
@@ -145,6 +146,9 @@ describe("zero org switcher", () => {
   });
 
   it("creates a new workspace from the org switcher menu", async () => {
+    context.mocks.api(orgContract.createdCount, ({ respond }) => {
+      return respond(200, { createdOrganizationsCount: 0 });
+    });
     context.mocks.data.org({
       id: "org_current",
       name: "Solo",
@@ -208,12 +212,15 @@ describe("zero org switcher", () => {
     });
   });
 
-  it("hides workspace creation after the user reaches the single-workspace limit", async () => {
+  it("hides workspace creation after reaching the limit while another workspace is active", async () => {
+    context.mocks.api(orgContract.createdCount, ({ respond }) => {
+      return respond(200, { createdOrganizationsCount: 1 });
+    });
     context.mocks.data.org({
       id: "org_current",
-      name: "Solo",
+      name: "Shared",
       role: "admin",
-      createdBy: "test-user-123",
+      createdBy: "other-user-456",
     });
 
     detachedSetupPage({
@@ -229,15 +236,22 @@ describe("zero org switcher", () => {
       org: {
         activeOrg: {
           id: "org_current",
-          name: "Solo",
-          slug: "solo",
+          name: "Shared",
+          slug: "shared",
         },
         memberships: [
           {
             id: "membership_current",
             organization: {
               id: "org_current",
-              name: "Solo",
+              name: "Shared",
+            },
+          },
+          {
+            id: "membership_owned",
+            organization: {
+              id: "org_owned",
+              name: "Owned",
             },
           },
         ],
@@ -245,7 +259,7 @@ describe("zero org switcher", () => {
     });
 
     const orgSwitcher = await waitFor(() => {
-      const label = screen.getByText("Solo");
+      const label = screen.getByText("Shared");
       const trigger = label.closest("button");
       if (!trigger) {
         throw new Error("Org switcher trigger not found");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-switcher.test.tsx
@@ -149,6 +149,7 @@ describe("zero org switcher", () => {
       id: "org_current",
       name: "Solo",
       role: "admin",
+      createdBy: "other-user-456",
     });
 
     detachedSetupPage({
@@ -159,6 +160,7 @@ describe("zero org switcher", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
         createOrganizationEnabled: true,
+        createOrganizationsLimit: 1,
       },
       org: {
         activeOrg: {
@@ -203,6 +205,59 @@ describe("zero org switcher", () => {
       expect(mockedClerk.setActive).toHaveBeenCalledWith({
         organization: "new-org-id",
       });
+    });
+  });
+
+  it("hides workspace creation after the user reaches the single-workspace limit", async () => {
+    context.mocks.data.org({
+      id: "org_current",
+      name: "Solo",
+      role: "admin",
+      createdBy: "test-user-123",
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+        createOrganizationEnabled: true,
+        createOrganizationsLimit: 1,
+      },
+      org: {
+        activeOrg: {
+          id: "org_current",
+          name: "Solo",
+          slug: "solo",
+        },
+        memberships: [
+          {
+            id: "membership_current",
+            organization: {
+              id: "org_current",
+              name: "Solo",
+            },
+          },
+        ],
+      },
+    });
+
+    const orgSwitcher = await waitFor(() => {
+      const label = screen.getByText("Solo");
+      const trigger = label.closest("button");
+      if (!trigger) {
+        throw new Error("Org switcher trigger not found");
+      }
+      return trigger;
+    });
+
+    click(orgSwitcher);
+
+    await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(screen.queryByText("Create workspace")).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
+++ b/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
@@ -13,9 +13,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@okouai/ui";
+import type { Clerk } from "@clerk/clerk-js";
 import { ChevronDown, Plus, Mail } from "lucide-react";
 import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
-import { org$ } from "../../signals/org.ts";
+import {
+  createdOrganizationsCount$,
+  refreshCreatedOrganizationsCount$,
+} from "../../signals/org.ts";
 import {
   bestEffort,
   detach,
@@ -96,48 +100,34 @@ function InvitationRow({
   );
 }
 
-function CreateWorkspaceItem() {
-  const clerkLoadable = useLastLoadable(clerk$);
-  const orgLoadable = useLastLoadable(org$);
-  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+function CreateWorkspaceMenuItem({ clerk }: { clerk: Clerk }) {
   const creatingOrg = useGet(creatingOrg$);
   const setCreating = useSet(setCreatingOrg$);
+  const refreshCreatedOrganizationsCount = useSet(
+    refreshCreatedOrganizationsCount$,
+  );
   const { t } = useTranslation();
-  const user = clerk?.user;
-  const reachedSingleOrgLimit =
-    orgLoadable.state === "hasData" &&
-    user?.createOrganizationsLimit === 1 &&
-    orgLoadable.data?.createdBy === user.id;
-  const canCreateOrg =
-    orgLoadable.state === "hasData" &&
-    user?.createOrganizationEnabled === true &&
-    !reachedSingleOrgLimit;
 
   const handleCreateOrg = onDomEventFn(async () => {
-    if (!clerk) {
-      return;
-    }
     setCreating(true);
     const slug = `workspace-${crypto.randomUUID().slice(0, 8)}`;
     await bestEffort(
       (async () => {
         const org = await clerk.createOrganization({ name: slug, slug });
-        await clerk.setActive({ organization: org.id });
+        await clerk.setActive({ organization: org.id }).finally(() => {
+          refreshCreatedOrganizationsCount();
+        });
       })(),
     );
     setCreating(false);
   });
-
-  if (!canCreateOrg) {
-    return null;
-  }
 
   return (
     <div className="shrink-0">
       <DropdownMenuSeparator />
       <DropdownMenuItem
         onClick={handleCreateOrg}
-        disabled={clerk === null || creatingOrg}
+        disabled={creatingOrg}
         className="min-w-0 gap-3 px-3 py-2.5"
       >
         <Plus size={18} className="shrink-0" />
@@ -153,6 +143,40 @@ function CreateWorkspaceItem() {
       </DropdownMenuItem>
     </div>
   );
+}
+
+function LimitedCreateWorkspaceItem({
+  clerk,
+  limit,
+}: {
+  clerk: Clerk;
+  limit: number;
+}) {
+  const createdCountLoadable = useLastLoadable(createdOrganizationsCount$);
+  if (
+    createdCountLoadable.state !== "hasData" ||
+    createdCountLoadable.data >= limit
+  ) {
+    return null;
+  }
+
+  return <CreateWorkspaceMenuItem clerk={clerk} />;
+}
+
+function CreateWorkspaceItem() {
+  const clerkLoadable = useLastLoadable(clerk$);
+  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const user = clerk?.user;
+  if (!clerk || user?.createOrganizationEnabled !== true) {
+    return null;
+  }
+
+  const limit = user.createOrganizationsLimit;
+  if (limit === null) {
+    return <CreateWorkspaceMenuItem clerk={clerk} />;
+  }
+
+  return <LimitedCreateWorkspaceItem clerk={clerk} limit={limit} />;
 }
 
 function OtherMembershipsList() {

--- a/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
+++ b/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
@@ -15,6 +15,7 @@ import {
 } from "@okouai/ui";
 import { ChevronDown, Plus, Mail } from "lucide-react";
 import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
+import { org$ } from "../../signals/org.ts";
 import {
   bestEffort,
   detach,
@@ -97,10 +98,20 @@ function InvitationRow({
 
 function CreateWorkspaceItem() {
   const clerkLoadable = useLastLoadable(clerk$);
+  const orgLoadable = useLastLoadable(org$);
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const creatingOrg = useGet(creatingOrg$);
   const setCreating = useSet(setCreatingOrg$);
   const { t } = useTranslation();
+  const user = clerk?.user;
+  const reachedSingleOrgLimit =
+    orgLoadable.state === "hasData" &&
+    user?.createOrganizationsLimit === 1 &&
+    orgLoadable.data?.createdBy === user.id;
+  const canCreateOrg =
+    orgLoadable.state === "hasData" &&
+    user?.createOrganizationEnabled === true &&
+    !reachedSingleOrgLimit;
 
   const handleCreateOrg = onDomEventFn(async () => {
     if (!clerk) {
@@ -117,8 +128,12 @@ function CreateWorkspaceItem() {
     setCreating(false);
   });
 
+  if (!canCreateOrg) {
+    return null;
+  }
+
   return (
-    <>
+    <div className="shrink-0">
       <DropdownMenuSeparator />
       <DropdownMenuItem
         onClick={handleCreateOrg}
@@ -136,7 +151,7 @@ function CreateWorkspaceItem() {
               })}
         </span>
       </DropdownMenuItem>
-    </>
+    </div>
   );
 }
 
@@ -207,7 +222,6 @@ function OrgDropdownContent() {
     );
   });
   const hasOrgOptions = hasOtherMemberships || hasPendingInvitations;
-  const canCreateOrg = clerk?.user?.createOrganizationEnabled ?? false;
 
   return (
     <DropdownMenuContent
@@ -251,11 +265,7 @@ function OrgDropdownContent() {
         </div>
       )}
 
-      {canCreateOrg && (
-        <div className="shrink-0">
-          <CreateWorkspaceItem />
-        </div>
-      )}
+      <CreateWorkspaceItem />
     </DropdownMenuContent>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/org-routes.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-routes.ts
@@ -22,6 +22,20 @@ export const orgContract = c.router({
     },
     summary: "Get current org",
   },
+  createdCount: {
+    method: "GET",
+    path: "/api/org/created-count",
+    headers: authHeadersSchema,
+    responses: {
+      200: z.object({
+        createdOrganizationsCount: z.number().int().nonnegative(),
+      }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Get current user's created organization count",
+  },
   update: {
     method: "PUT",
     path: "/api/org",

--- a/turbo/packages/api-contracts/src/contracts/org-routes.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-routes.ts
@@ -32,6 +32,7 @@ export const orgContract = c.router({
       }),
       401: apiErrorSchema,
       403: apiErrorSchema,
+      404: apiErrorSchema,
       503: apiErrorSchema,
     },
     summary: "Get current user's created organization count",


### PR DESCRIPTION
## Summary

- keep Clerk's user-level organization creation permission gate
- compare the authenticated user's global created-organization count with Clerk's actual per-user limit (`null` remains unlimited)
- hide `Create workspace` after the quota is exhausted even while a workspace created by someone else is active
- add API and Platform regression coverage for available, exhausted, and rollout-compatibility states

## Root cause

PR #8835 changed menu visibility to rely only on `createOrganizationEnabled`. That flag represents whether organization creation is enabled for the user, but it can remain `true` after a user has exhausted a numeric organization limit. The menu therefore stayed visible even though Clerk rejected the create request with 403.

The active workspace cannot represent a user's global creation quota because a user can belong to and activate workspaces created by other users. This PR reads the authenticated user's memberships through the backend, counts organizations whose Clerk `createdBy` matches that user, and compares the count with Clerk's user-specific limit.

## Fallbacks

- `turbo/apps/platform/src/signals/org.ts:createdOrganizationsCount$` — accepts `404` from an API that predates the additive `createdCount` route and preserves the prior Clerk-gated creation-entry behavior. Surface: new app -> old API. Remove after that API is no longer serving or retained as a rollback target; follow-up #29866.

## Test plan

- [x] `pnpm format`
- [x] bounded full-repository lint
- [x] TypeScript checks
- [x] Platform org-switcher integration tests
- [x] focused API BDD coverage for the authenticated user's global created count

Browser verification was not run because repository instructions prohibit starting a local development server; the PR preview and pipeline provide that validation.
