### PR TITLE
fix(api): keep model-provider observation rows inactive

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -692,6 +692,47 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     );
   });
 
+  it("keeps an observation-only route selectable to an in-flight resolver", async () => {
+    const startedAt = Date.UTC(2026, 7, 21, 0, 16, 0);
+    const claimed = await createClaimedVm0Run();
+    const primary = await resolveVm0BuiltInModelRouteFixture(
+      context,
+      claimed.selectedModel,
+      true,
+    );
+    if (!primary) {
+      throw new Error("Expected a built-in model primary route");
+    }
+    registerVm0BuiltInCandidateCooldownCleanup(
+      context,
+      claimed.selectedModel,
+      primary,
+    );
+
+    await withMockNowForTest(startedAt, async () => {
+      await expect(
+        runs.reportRunnerModelProviderFailure(claimed.runId, {
+          failureKind: "connection",
+          connectionSource: "upstream_transport",
+        }),
+      ).resolves.toStrictEqual({ outcome: "observed" });
+    });
+
+    // A resolver can capture time before the observation transaction commits.
+    await withMockNowForTest(startedAt - 1, async () => {
+      await expect(
+        resolveVm0BuiltInModelRouteFixture(
+          context,
+          claimed.selectedModel,
+          true,
+        ),
+      ).resolves.toMatchObject({
+        provider_type: primary.provider_type,
+        upstream_model: primary.upstream_model,
+      });
+    });
+  });
+
   it("does not extend an active cooldown for one transport observation", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 17, 0);
     const claimed = await createClaimedVm0Run();

--- a/turbo/apps/api/src/signals/services/built-in-model-provider-failure.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-provider-failure.service.ts
@@ -9,6 +9,9 @@ const DEFAULT_COOLDOWN_SECONDS = 5 * 60;
 const INTERVENTION_COOLDOWN_SECONDS = 30 * 60;
 const CONNECTION_OBSERVATION_MINIMUM_MS = 60 * 1000;
 const CONNECTION_OBSERVATION_MAX_GAP_MS = 60 * 1000;
+// A route resolver can capture its comparison time before this row is inserted.
+// Keep provisional evidence expired for every in-flight resolver.
+const INACTIVE_COOLDOWN_DEADLINE_MS = 0;
 
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
@@ -103,11 +106,13 @@ async function loadBuiltInModelRoute(
 async function materializeAndLockRoute(
   tx: WriteTx,
   route: BuiltInModelRouteIdentity,
-  receivedAt: Date,
 ): Promise<LockedBuiltInModelRoute> {
   await tx
     .insert(builtInModelCandidateCooldown)
-    .values({ ...route, unavailableUntil: receivedAt })
+    .values({
+      ...route,
+      unavailableUntil: new Date(INACTIVE_COOLDOWN_DEADLINE_MS),
+    })
     .onConflictDoNothing();
 
   const [lockedRoute] = await tx
@@ -268,11 +273,7 @@ export async function reportBuiltInModelProviderFailure(
     if (!route) {
       return { outcome: "ignored" };
     }
-    const lockedRoute = await materializeAndLockRoute(
-      tx,
-      route,
-      report.receivedAt,
-    );
+    const lockedRoute = await materializeAndLockRoute(tx, route);
     if (
       report.failureKind === "connection" &&
       report.connectionSource === "upstream_transport"


### PR DESCRIPTION
## Summary

- materialize a new model-provider observation row with a stable expired cooldown deadline
- keep existing cooldown deadlines unchanged when the exact route row already exists
- cover the race where a route resolver captured its comparison time before the observation transaction committed

## Scope

- no schema, API contract, cooldown-duration, runner, lifecycle, or logging changes
- no changes to sustained transport-failure interval semantics

## Testing

- focused regression test failed before the service fix and passed afterward
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts --maxWorkers=1 --silent=passed-only` (27 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full Knip, full Turbo type checks, Prettier, file-size check, and commitlint

Closes #29828

Parent: #29645
