### PR TITLE
docs(rust): make sandbox id contract provider-neutral

### DIFF
--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-/// Identity of a Firecracker VM sandbox — the workspace directory basename
-/// and socket directory name. A newly created sandbox receives this ID, and
-/// subsequent reuse jobs retain it.
+/// Provider-neutral identity of a sandbox lifecycle. A newly created sandbox
+/// receives this ID, and subsequent reuse jobs retain it. Providers use it to
+/// identify the same sandbox instance across lifecycle operations.
 ///
 /// Distinct from `RunId` (a per-job server identifier defined in the
 /// `runner` crate). A new sandbox receives its ID independently of the current


### PR DESCRIPTION
## Summary

- Clarify that `SandboxId` is a provider-neutral sandbox lifecycle identity.
- Preserve the distinction from per-job `RunId` values and the reuse semantics.
- Keep Firecracker workspace and socket path details in the Firecracker provider documentation.

## Scope

- Documentation-only change in `crates/sandbox/src/config.rs`.
- No changes to the public type shape, UUID serialization, runtime behavior, provider implementations, tests, or migration behavior.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo check -p sandbox`
- `cargo clippy -p sandbox --lib --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox --no-deps`
- `cargo test -p sandbox --test error` (9 tests)
- `git diff --check`

The package-wide `cargo test -p sandbox` and `cargo clippy -p sandbox --all-targets --all-features` commands cannot compile the unchanged `#[tokio::test]` at `crates/sandbox/src/types.rs:1514` because the package's direct Tokio dependency enables `sync` but not `macros`. The same pre-existing configuration error occurs on this documentation-only branch; the valid library and integration-test checks above pass.

Closes #29835
