### PR TITLE
test(api): stabilize model stats cleanup batching

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
@@ -24,6 +24,12 @@ export interface ModelStatsFixtureScope {
   readonly statKeys: readonly ModelStatsStatKey[];
 }
 
+interface ModelStatsAggregationFixtureOptions extends ModelStatsFixtureScope {
+  readonly processedAt: Date;
+  readonly cleanupBatchSize?: number;
+  readonly cleanupMaxBatches?: number;
+}
+
 export interface ModelStatsObservationFixture {
   readonly idempotencyKey: string;
   readonly model: string;
@@ -110,19 +116,25 @@ function wireStatKeys(statKeys: readonly ModelStatsStatKey[]) {
 }
 
 function aggregateFixtureBody(
-  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+  args: ModelStatsAggregationFixtureOptions,
 ): TestModelStatsStateActionBody {
   return {
     action: "aggregate-fixture",
     processed_at: args.processedAt.toISOString(),
     observation_idempotency_keys: [...args.observationIdempotencyKeys],
     stat_keys: wireStatKeys(args.statKeys),
+    ...(args.cleanupBatchSize === undefined
+      ? {}
+      : { cleanup_batch_size: args.cleanupBatchSize }),
+    ...(args.cleanupMaxBatches === undefined
+      ? {}
+      : { cleanup_max_batches: args.cleanupMaxBatches }),
   };
 }
 
 export function requestAggregateModelStatsFixture(
   context: TestContext,
-  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+  args: ModelStatsAggregationFixtureOptions,
   signal: AbortSignal = context.signal,
 ): Promise<Response> {
   return requestModelStatsState(
@@ -139,7 +151,7 @@ export function requestAggregateModelStatsFixture(
 
 export async function aggregateModelStatsFixture(
   context: TestContext,
-  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+  args: ModelStatsAggregationFixtureOptions,
 ): Promise<ModelStatsAggregationResult> {
   const response = await postAction(context, aggregateFixtureBody(args));
   if (!response.aggregation) {

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1046,7 +1046,9 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       },
     ]);
 
-    const cleanupBatchIdempotencyKeys = Array.from({ length: 10_001 }, () => {
+    const cleanupBatchSize = 2;
+    const cleanupMaxBatches = 2;
+    const cleanupBatchIdempotencyKeys = Array.from({ length: 5 }, () => {
       return randomUUID();
     });
     fixtureObservationKeys.push(...cleanupBatchIdempotencyKeys);
@@ -1060,13 +1062,15 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const firstBatch = await aggregateModelStatsFixture(context, {
       ...fixtureScope(),
       processedAt: new Date(cleanupAt),
+      cleanupBatchSize,
+      cleanupMaxBatches,
     });
     expect(firstBatch).toStrictEqual({
       cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
       processedHours: 0,
       processedObservations: 0,
       updatedStats: 0,
-      deletedObservations: 10_000,
+      deletedObservations: 4,
     });
     await expect(
       readModelStatsObservations(context, cleanupBatchIdempotencyKeys),
@@ -1075,6 +1079,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const finalBatch = await aggregateModelStatsFixture(context, {
       ...fixtureScope(),
       processedAt: new Date(cleanupAt),
+      cleanupBatchSize,
+      cleanupMaxBatches,
     });
     expect(finalBatch).toStrictEqual({
       cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -421,6 +421,12 @@ async function mutateModelStatsState(
       const result = await aggregateModelStats(db, signal, {
         processedAt: new Date(body.processed_at),
         scope: aggregationScope(body),
+        ...(body.cleanup_batch_size === undefined
+          ? {}
+          : { cleanupBatchSize: body.cleanup_batch_size }),
+        ...(body.cleanup_max_batches === undefined
+          ? {}
+          : { cleanupMaxBatches: body.cleanup_max_batches }),
       });
       return {
         status: 200 as const,

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -93,6 +93,14 @@ export interface ModelStatsAggregationScope {
 interface ModelStatsAggregationOptions {
   readonly processedAt: Date;
   readonly scope: ModelStatsAggregationScope;
+  readonly cleanupBatchSize?: number;
+  readonly cleanupMaxBatches?: number;
+}
+
+interface ModelUsageObservationCleanupOptions {
+  readonly observationIdempotencyKeys: readonly string[] | undefined;
+  readonly batchSize: number;
+  readonly maxBatches: number;
 }
 
 interface ModelStatsRankingOptions {
@@ -441,15 +449,11 @@ async function cleanupAppliedModelUsageObservations(
   db: Db,
   cutoff: Date,
   signal: AbortSignal,
-  observationIdempotencyKeys: readonly string[] | undefined,
+  options: ModelUsageObservationCleanupOptions,
 ): Promise<number> {
   let deletedObservations = 0;
 
-  for (
-    let batch = 0;
-    batch < MODEL_USAGE_OBSERVATION_CLEANUP_MAX_BATCHES;
-    batch += 1
-  ) {
+  for (let batch = 0; batch < options.maxBatches; batch += 1) {
     signal.throwIfAborted();
     const candidates = db
       .select({
@@ -460,9 +464,9 @@ async function cleanupAppliedModelUsageObservations(
         and(
           isNotNull(modelUsageObservation.aggregatedAt),
           lt(modelUsageObservation.observedAt, cutoff),
-          observationIdempotencyKeys
+          options.observationIdempotencyKeys
             ? inArray(modelUsageObservation.idempotencyKey, [
-                ...observationIdempotencyKeys,
+                ...options.observationIdempotencyKeys,
               ])
             : undefined,
         ),
@@ -471,7 +475,7 @@ async function cleanupAppliedModelUsageObservations(
         asc(modelUsageObservation.observedAt),
         asc(modelUsageObservation.idempotencyKey),
       )
-      .limit(MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE)
+      .limit(options.batchSize)
       .for("update", { skipLocked: true });
     const { rowCount } = await db
       .delete(modelUsageObservation)
@@ -480,7 +484,7 @@ async function cleanupAppliedModelUsageObservations(
 
     const batchDeleted = rowCount ?? 0;
     deletedObservations += batchDeleted;
-    if (batchDeleted < MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE) {
+    if (batchDeleted < options.batchSize) {
       break;
     }
   }
@@ -630,7 +634,14 @@ export async function aggregateModelStats(
     db,
     cleanupCutoff,
     signal,
-    scope?.observationIdempotencyKeys,
+    {
+      observationIdempotencyKeys: scope?.observationIdempotencyKeys,
+      batchSize:
+        options?.cleanupBatchSize ?? MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE,
+      maxBatches:
+        options?.cleanupMaxBatches ??
+        MODEL_USAGE_OBSERVATION_CLEANUP_MAX_BATCHES,
+    },
   );
   signal.throwIfAborted();
 

--- a/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
@@ -60,6 +60,8 @@ export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
       processed_at: z.iso.datetime(),
       observation_idempotency_keys: idempotencyKeysSchema,
       stat_keys: modelStatKeysSchema,
+      cleanup_batch_size: z.number().int().positive().optional(),
+      cleanup_max_batches: z.number().int().positive().optional(),
     }),
     z.object({
       action: z.literal("read-fixture-rankings"),


### PR DESCRIPTION
## Summary

- add request-scoped cleanup batch limits to the gated model-stats test fixture path
- keep production cleanup defaults at 1,000 rows per batch and 10 batches per invocation
- replace the 10,001-row batching fixture with a 2 × 2 multi-batch scenario plus one continuation row

## Scope

This changes test support and internal optional aggregation parameters only. It does not change the public API, production cleanup policy, database schema, frontend, runner, or user-visible behavior. The test timeout is unchanged.

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @okouai/api-contracts`
- focused batching test: 6/6 sequential runs passed; test body reduced from 932ms baseline to 93–271ms
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts --reporter=dot` (15/15)
- pre-commit: full Knip and all-workspace type checks (14/14)

Closes #29845
