### PR TITLE
test(e2e): stabilize auth v2 bootstrap readiness

### DIFF
--- a/e2e/playwright/AUTH_V2.md
+++ b/e2e/playwright/AUTH_V2.md
@@ -11,6 +11,8 @@ projects and from `lib/auth.ts`.
 - Trace, screenshot, and video recording: off
 - Blob and merged HTML report artifacts: off for this project; GitHub-redacted
   list output only
+- Route navigation and hard reload wait up to 15 seconds for ClerkJS bootstrap
+  readiness before ordinary UI assertions begin
 - Test identities: unique generation-scoped `+clerk_test` addresses
 - Verification code: Clerk's documented development code, `424242`
 - Cleanup: exact organizations then exact users after every test, followed by
@@ -23,6 +25,11 @@ addresses, and Clerk resource identifiers while preserving the Playwright exit
 status. The project does not persist captured stdout to a Playwright report
 artifact. Helpers and assertions do not log Clerk response bodies, user IDs,
 organization IDs, credentials, or testing-token URLs.
+
+A terminal bootstrap timeout reports only whether ClerkJS is absent or unloaded
+and the last Clerk request's method, masked pathname, and coarse status. Query
+strings, hosts, headers, bodies, and Clerk resource identifiers are removed
+before the diagnostic reaches workflow redaction.
 
 ## Deterministic browser coverage
 

--- a/e2e/playwright/lib/auth-v2-ui.test.ts
+++ b/e2e/playwright/lib/auth-v2-ui.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { test } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+import { openAuthV2 } from "./auth-v2-ui";
+
+type AuthV2FixtureMode = "absent" | "delayed" | "incomplete" | "pending";
+
+interface AuthV2Fixture {
+  readonly appUrl: string;
+  readonly releaseFrontendRequest: (status: number) => void;
+  readonly waitForFrontendRequest: () => Promise<void>;
+}
+
+const FIXTURE_QUERY_SECRET = "do-not-log-capability";
+const FIXTURE_SESSION_ID = "sess_do_not_log";
+
+test("uses a bounded Auth v2 bootstrap boundary", async (context) => {
+  const browser = await chromium.launch();
+  try {
+    await context.test("waits for a delayed Clerk bootstrap", async () => {
+      await withAuthV2Fixture("delayed", async (fixture) => {
+        const page = await browser.newPage();
+        try {
+          const opening = openAuthV2(page, fixture.appUrl, {
+            timeoutMs: 1_000,
+          });
+          await fixture.waitForFrontendRequest();
+          assert.equal(await page.getByTestId("app-auth-v2").count(), 0);
+
+          fixture.releaseFrontendRequest(200);
+          await opening;
+
+          assert.equal(await page.getByTestId("app-auth-v2").count(), 1);
+          assert.equal(await page.getByTestId("app-auth-layout").count(), 1);
+        } finally {
+          await page.close();
+        }
+      });
+    });
+
+    await context.test(
+      "reports an unloaded Clerk bootstrap without sensitive request data",
+      async () => {
+        await withAuthV2Fixture("incomplete", async (fixture) => {
+          const page = await browser.newPage();
+          try {
+            await assert.rejects(
+              openAuthV2(page, fixture.appUrl, { timeoutMs: 250 }),
+              (error: unknown) => {
+                assert(error instanceof Error);
+                assert.match(
+                  error.message,
+                  /ClerkJS present but not loaded; last Clerk request: GET \/v1\/client\/sessions\/\[masked-clerk-resource-id\]\/tokens -> 503/u,
+                );
+                assert.doesNotMatch(
+                  error.message,
+                  new RegExp(FIXTURE_QUERY_SECRET),
+                );
+                assert.doesNotMatch(
+                  error.message,
+                  new RegExp(FIXTURE_SESSION_ID),
+                );
+                return true;
+              },
+            );
+          } finally {
+            await page.close();
+          }
+        });
+      },
+    );
+
+    await context.test("distinguishes an absent ClerkJS global", async () => {
+      await withAuthV2Fixture("absent", async (fixture) => {
+        const page = await browser.newPage();
+        try {
+          await assert.rejects(
+            openAuthV2(page, fixture.appUrl, { timeoutMs: 250 }),
+            /ClerkJS absent; last Clerk request: GET \/v1\/client\/sessions\/\[masked-clerk-resource-id\]\/tokens -> 200/u,
+          );
+        } finally {
+          await page.close();
+        }
+      });
+    });
+
+    await context.test(
+      "reports an in-flight Clerk request as pending",
+      async () => {
+        await withAuthV2Fixture("pending", async (fixture) => {
+          const page = await browser.newPage();
+          try {
+            await assert.rejects(
+              openAuthV2(page, fixture.appUrl, { timeoutMs: 250 }),
+              /ClerkJS present but not loaded; last Clerk request: GET \/v1\/client\/sessions\/\[masked-clerk-resource-id\]\/tokens -> pending/u,
+            );
+            fixture.releaseFrontendRequest(503);
+          } finally {
+            await page.close();
+          }
+        });
+      },
+    );
+  } finally {
+    await browser.close();
+  }
+});
+
+async function withAuthV2Fixture<Result>(
+  mode: AuthV2FixtureMode,
+  use: (fixture: AuthV2Fixture) => Promise<Result>,
+): Promise<Result> {
+  let frontendResponse: ServerResponse | undefined;
+  let resolveFrontendRequest!: () => void;
+  const frontendRequest = new Promise<void>((resolve) => {
+    resolveFrontendRequest = resolve;
+  });
+  const server = createServer((request, response) => {
+    if (request.url?.startsWith("/v1/")) {
+      frontendResponse = response;
+      resolveFrontendRequest();
+      if (mode === "absent") {
+        releaseResponse(response, 200);
+      } else if (mode === "incomplete") {
+        releaseResponse(response, 503);
+      }
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end(authV2FixtureDocument(mode));
+  });
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await close(server);
+    throw new Error("Auth v2 fixture server did not expose a TCP address");
+  }
+
+  const previousFrontendApi = process.env.CLERK_FAPI;
+  process.env.CLERK_FAPI = `127.0.0.1:${address.port}`;
+  try {
+    return await use({
+      appUrl: `http://127.0.0.1:${address.port}/v2/sign-up`,
+      releaseFrontendRequest: (status: number): void => {
+        if (!frontendResponse) {
+          throw new Error("Clerk fixture request has not started");
+        }
+        releaseResponse(frontendResponse, status);
+      },
+      waitForFrontendRequest: async (): Promise<void> => frontendRequest,
+    });
+  } finally {
+    restoreEnvironmentVariable("CLERK_FAPI", previousFrontendApi);
+    if (frontendResponse && !frontendResponse.writableEnded) {
+      frontendResponse.destroy();
+    }
+    await close(server);
+  }
+}
+
+function authV2FixtureDocument(mode: AuthV2FixtureMode): string {
+  const clerkState =
+    mode === "absent" ? "" : "window.Clerk = { loaded: false };";
+  const finishBootstrap =
+    mode === "delayed"
+      ? `
+    window.Clerk.loaded = true;
+    document.body.innerHTML =
+      '<div data-testid="app-auth-layout"><div data-testid="app-auth-v2">Ready</div></div>';`
+      : "";
+  return `<!doctype html>
+<script>
+  ${clerkState}
+  fetch("/v1/client/sessions/${FIXTURE_SESSION_ID}/tokens?__clerk_testing_token=${FIXTURE_QUERY_SECRET}").then(() => {
+    ${finishBootstrap}
+  });
+</script>`;
+}
+
+function releaseResponse(response: ServerResponse, status: number): void {
+  if (response.writableEnded) {
+    throw new Error("Clerk fixture response was already released");
+  }
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end("{}");
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    server.closeAllConnections();
+  });
+}
+
+function restoreEnvironmentVariable(
+  name: "CLERK_FAPI",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/e2e/playwright/lib/auth-v2-ui.ts
+++ b/e2e/playwright/lib/auth-v2-ui.ts
@@ -1,4 +1,11 @@
-import { expect, type Locator, type Page } from "@playwright/test";
+import {
+  errors,
+  expect,
+  type Locator,
+  type Page,
+  type Request,
+  type Response,
+} from "@playwright/test";
 
 export type AuthV2InputName =
   | "code"
@@ -25,6 +32,26 @@ const SIGN_IN_METHOD_NAMES: Record<AuthV2SignInMethod, RegExp> = {
   "password-reset": /^reset your password$/i,
 };
 
+const AUTH_V2_BOOTSTRAP_TIMEOUT_MS = 15_000;
+const CLERK_RESOURCE_PATH_SEGMENT = /\/(?:org|sess|sia|sua|user)_[^/]*/gu;
+
+type AuthV2BootstrapRequestStatus = number | "failed" | "pending";
+
+interface AuthV2BootstrapRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly status: AuthV2BootstrapRequestStatus;
+}
+
+interface AuthV2BootstrapOptions {
+  readonly timeoutMs?: number;
+}
+
+interface AuthV2BootstrapState {
+  readonly hasClerk: boolean;
+  readonly hasLoadedClerk: boolean;
+}
+
 export function authV2Root(page: Page): Locator {
   return page.getByTestId("app-auth-v2");
 }
@@ -33,10 +60,27 @@ export function authV2Input(page: Page, name: AuthV2InputName): Locator {
   return authV2Root(page).locator(`input[name="${name}"]`);
 }
 
-export async function openAuthV2(page: Page, url: string): Promise<void> {
-  await page.goto(url, { waitUntil: "domcontentloaded" });
-  await expect(authV2Root(page)).toBeVisible();
-  await expect(page.getByTestId("app-auth-layout")).toBeVisible();
+export async function openAuthV2(
+  page: Page,
+  url: string,
+  options: AuthV2BootstrapOptions = {},
+): Promise<void> {
+  await navigateToReadyAuthV2(
+    page,
+    async () => page.goto(url, { waitUntil: "domcontentloaded" }),
+    options,
+  );
+}
+
+export async function reloadAuthV2(
+  page: Page,
+  options: AuthV2BootstrapOptions = {},
+): Promise<void> {
+  await navigateToReadyAuthV2(
+    page,
+    async () => page.reload({ waitUntil: "domcontentloaded" }),
+    options,
+  );
 }
 
 export async function submitSignInIdentifier(
@@ -97,4 +141,112 @@ export async function waitForPathname(
   await page.waitForURL((url) => url.pathname === pathname, {
     waitUntil: "domcontentloaded",
   });
+}
+
+async function navigateToReadyAuthV2(
+  page: Page,
+  navigate: () => Promise<Response | null>,
+  options: AuthV2BootstrapOptions,
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? AUTH_V2_BOOTSTRAP_TIMEOUT_MS;
+  const frontendApiHost = clerkFrontendApiHost();
+  let lastRequest: AuthV2BootstrapRequest | undefined;
+  const recordRequest = (request: Request): void => {
+    const path = clerkFrontendApiPath(request, frontendApiHost);
+    if (path) {
+      lastRequest = { method: request.method(), path, status: "pending" };
+    }
+  };
+  const recordResponse = (response: Response): void => {
+    const request = response.request();
+    const path = clerkFrontendApiPath(request, frontendApiHost);
+    if (path) {
+      lastRequest = {
+        method: request.method(),
+        path,
+        status: response.status(),
+      };
+    }
+  };
+  const recordFailedRequest = (request: Request): void => {
+    const path = clerkFrontendApiPath(request, frontendApiHost);
+    if (path) {
+      lastRequest = { method: request.method(), path, status: "failed" };
+    }
+  };
+
+  page.on("request", recordRequest);
+  page.on("response", recordResponse);
+  page.on("requestfailed", recordFailedRequest);
+  try {
+    await navigate();
+    try {
+      await page.waitForFunction(
+        () => Boolean(window.Clerk?.loaded),
+        undefined,
+        { timeout: timeoutMs },
+      );
+    } catch (error) {
+      if (!(error instanceof errors.TimeoutError)) {
+        throw error;
+      }
+      const state = await page.evaluate<AuthV2BootstrapState>(() => {
+        return {
+          hasClerk: window.Clerk !== undefined,
+          hasLoadedClerk: Boolean(window.Clerk?.loaded),
+        };
+      });
+      throw new Error(
+        `Auth v2 bootstrap timed out after ${timeoutMs}ms: ${formatAuthV2BootstrapDiagnostic(
+          state,
+          lastRequest,
+        )}`,
+        { cause: error },
+      );
+    }
+  } finally {
+    page.off("request", recordRequest);
+    page.off("response", recordResponse);
+    page.off("requestfailed", recordFailedRequest);
+  }
+
+  await expect(authV2Root(page)).toBeVisible();
+  await expect(page.getByTestId("app-auth-layout")).toBeVisible();
+}
+
+function clerkFrontendApiHost(): string {
+  const frontendApi = process.env.CLERK_FAPI;
+  if (!frontendApi) {
+    throw new Error("CLERK_FAPI environment variable is required");
+  }
+  return new URL(`https://${frontendApi}`).host;
+}
+
+function clerkFrontendApiPath(
+  request: Request,
+  frontendApiHost: string,
+): string | undefined {
+  const url = new URL(request.url());
+  if (url.host !== frontendApiHost || !url.pathname.startsWith("/v1/")) {
+    return undefined;
+  }
+  return url.pathname.replace(
+    CLERK_RESOURCE_PATH_SEGMENT,
+    "/[masked-clerk-resource-id]",
+  );
+}
+
+function formatAuthV2BootstrapDiagnostic(
+  state: AuthV2BootstrapState,
+  lastRequest: AuthV2BootstrapRequest | undefined,
+): string {
+  const clerkState = state.hasLoadedClerk
+    ? "ClerkJS loaded after wait timeout"
+    : state.hasClerk
+      ? "ClerkJS present but not loaded"
+      : "ClerkJS absent";
+  if (!lastRequest) {
+    return clerkState;
+  }
+  return `${clerkState}; last Clerk request: ${lastRequest.method} ${lastRequest.path} -> ${lastRequest.status}`;
 }

--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -11,6 +11,7 @@ import {
   expectNoOrganizationCreation,
   expectStepAnnouncement,
   openAuthV2,
+  reloadAuthV2,
   signInMethodButton,
   submitSignInIdentifier,
   waitForPathname,
@@ -45,8 +46,7 @@ test("base, nested, refreshed, and legacy auth routes coexist on desktop", async
     await openAuthV2(page, route);
     const expectedPathname = new URL(route, "https://auth-v2.invalid").pathname;
     expect(new URL(page.url()).pathname).toBe(expectedPathname);
-    await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(authV2Root(page)).toBeVisible();
+    await reloadAuthV2(page);
     expect(new URL(page.url()).pathname).toBe(expectedPathname);
   }
 
@@ -508,7 +508,7 @@ async function waitForActivatedSessionOrRedirect(
         window.location.pathname === redirectPathname ||
         Boolean(
           window.Clerk?.client?.signUp.status === "complete" &&
-            window.Clerk.session,
+          window.Clerk.session,
         )
       );
     },


### PR DESCRIPTION
## Summary

- wait for ClerkJS bootstrap readiness before Auth v2 route and reload assertions
- include sanitized terminal Clerk request diagnostics when bootstrap times out
- cover delayed, absent, unloaded, and pending bootstrap states with real Chromium

## Scope

This change is limited to the Auth v2 Playwright helper, its integration coverage, the existing hard-reload scenario, and Auth v2 E2E documentation. It does not change product authentication behavior, shared Playwright timeouts, whole-test retries, CI artifact retention, or provider retry behavior.

Closes #29856

## Validation

- `cd turbo && pnpm exec prettier --check ../e2e/playwright/lib/auth-v2-ui.ts ../e2e/playwright/lib/auth-v2-ui.test.ts ../e2e/playwright/tests/auth-v2.spec.ts ../e2e/playwright/AUTH_V2.md`
- `cd e2e && pnpm exec tsx --test playwright/lib/auth-v2-ui.test.ts` (5 passed)
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (46 passed)
- `cd e2e && VM0_API_BACKEND_URL=http://127.0.0.1 OKOU_APP_URL=http://127.0.0.1 pnpm exec playwright test --config playwright/playwright.config.ts --project=auth-v2 --list` (19 tests)
- `git diff --check`

The PR's Auth v2 Playwright job is the authoritative validation against the real Clerk environment.
