### PR TITLE
fix(runner): await multipart upload cancellation

### DIFF
--- a/crates/runner/src/r2_cache/multipart.rs
+++ b/crates/runner/src/r2_cache/multipart.rs
@@ -169,8 +169,18 @@ where
         // Drain at least one completion. JoinSet returns None only when
         // empty, which our outer loop condition prevents.
         if let Some(joined) = tasks.join_next().await {
-            let (pn, part) = joined.map_err(|e| R2Error::Io(io_other(e)))??;
-            parts.push((pn, part));
+            let result = match joined {
+                Ok(result) => result,
+                Err(error) => Err(R2Error::Io(io_other(error))),
+            };
+            match result {
+                Ok((pn, part)) => parts.push((pn, part)),
+                Err(error) => {
+                    // Finish cancelling uploads before the caller aborts the multipart session.
+                    tasks.shutdown().await;
+                    return Err(error);
+                }
+            }
         }
     }
 
@@ -308,7 +318,7 @@ mod tests {
 
     use tokio::{
         io::{AsyncRead, ReadBuf},
-        sync::{Notify, mpsc},
+        sync::{Barrier, Notify, mpsc},
     };
 
     use super::*;
@@ -450,5 +460,69 @@ mod tests {
                 (3, "etag-3".to_string()),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn multipart_scheduler_drops_siblings_before_returning_upload_error() {
+        struct DropFlag(Arc<AtomicBool>);
+
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let queued_read_allowed = Arc::new(AtomicBool::new(false));
+        let reader = WindowGuardReader {
+            inner: Cursor::new(b"aaaabbbbcccc".to_vec()),
+            blocked_at: 8,
+            queued_read_allowed,
+        };
+        let initial_uploads_ready = Arc::new(Barrier::new(2));
+        let sibling_dropped = Arc::new(AtomicBool::new(false));
+
+        let upload = {
+            let initial_uploads_ready = Arc::clone(&initial_uploads_ready);
+            let sibling_dropped = Arc::clone(&sibling_dropped);
+            move |part_number: i32, chunk: bytes::Bytes| {
+                let initial_uploads_ready = Arc::clone(&initial_uploads_ready);
+                let sibling_dropped = Arc::clone(&sibling_dropped);
+                async move {
+                    let expected_chunk: &[u8] = match part_number {
+                        1 => b"aaaa",
+                        2 => b"bbbb",
+                        _ => panic!("unexpected part_number {part_number}"),
+                    };
+                    assert_eq!(chunk.as_ref(), expected_chunk);
+
+                    let _drop_flag =
+                        (part_number == 1).then(|| DropFlag(Arc::clone(&sibling_dropped)));
+                    initial_uploads_ready.wait().await;
+
+                    if part_number == 1 {
+                        std::future::pending::<Result<CompletedPart, R2Error>>().await
+                    } else {
+                        Err(R2Error::S3("upload part 2 failed".to_string()))
+                    }
+                }
+            }
+        };
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(5),
+            upload_parts_streaming_with(reader, 4, 2, upload),
+        )
+        .await
+        .expect("multipart scheduler test timed out")
+        .expect_err("multipart scheduler should return the upload error");
+
+        assert!(
+            sibling_dropped.load(Ordering::SeqCst),
+            "sibling upload must be dropped before the scheduler returns"
+        );
+        match error {
+            R2Error::S3(message) => assert_eq!(message, "upload part 2 failed"),
+            other => panic!("expected upload error, got {other:?}"),
+        }
     }
 }

--- a/crates/runner/src/r2_cache/multipart.rs
+++ b/crates/runner/src/r2_cache/multipart.rs
@@ -463,7 +463,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multipart_scheduler_drops_siblings_before_returning_upload_error() {
+    async fn multipart_scheduler_drops_siblings_before_returning_terminal_errors() {
+        #[derive(Clone, Copy)]
+        enum Failure {
+            Upload,
+            Join,
+        }
+
         struct DropFlag(Arc<AtomicBool>);
 
         impl Drop for DropFlag {
@@ -472,57 +478,71 @@ mod tests {
             }
         }
 
-        let queued_read_allowed = Arc::new(AtomicBool::new(false));
-        let reader = WindowGuardReader {
-            inner: Cursor::new(b"aaaabbbbcccc".to_vec()),
-            blocked_at: 8,
-            queued_read_allowed,
-        };
-        let initial_uploads_ready = Arc::new(Barrier::new(2));
-        let sibling_dropped = Arc::new(AtomicBool::new(false));
+        for failure in [Failure::Upload, Failure::Join] {
+            let reader = WindowGuardReader {
+                inner: Cursor::new(b"aaaabbbbcccc".to_vec()),
+                blocked_at: 8,
+                queued_read_allowed: Arc::new(AtomicBool::new(false)),
+            };
+            let initial_uploads_ready = Arc::new(Barrier::new(2));
+            let sibling_dropped = Arc::new(AtomicBool::new(false));
 
-        let upload = {
-            let initial_uploads_ready = Arc::clone(&initial_uploads_ready);
-            let sibling_dropped = Arc::clone(&sibling_dropped);
-            move |part_number: i32, chunk: bytes::Bytes| {
+            let upload = {
                 let initial_uploads_ready = Arc::clone(&initial_uploads_ready);
                 let sibling_dropped = Arc::clone(&sibling_dropped);
-                async move {
-                    let expected_chunk: &[u8] = match part_number {
-                        1 => b"aaaa",
-                        2 => b"bbbb",
-                        _ => panic!("unexpected part_number {part_number}"),
-                    };
-                    assert_eq!(chunk.as_ref(), expected_chunk);
+                move |part_number: i32, chunk: bytes::Bytes| {
+                    let initial_uploads_ready = Arc::clone(&initial_uploads_ready);
+                    let sibling_dropped = Arc::clone(&sibling_dropped);
+                    async move {
+                        let expected_chunk: &[u8] = match part_number {
+                            1 => b"aaaa",
+                            2 => b"bbbb",
+                            _ => panic!("unexpected part_number {part_number}"),
+                        };
+                        assert_eq!(chunk.as_ref(), expected_chunk);
 
-                    let _drop_flag =
-                        (part_number == 1).then(|| DropFlag(Arc::clone(&sibling_dropped)));
-                    initial_uploads_ready.wait().await;
+                        let _drop_flag =
+                            (part_number == 1).then(|| DropFlag(Arc::clone(&sibling_dropped)));
+                        initial_uploads_ready.wait().await;
 
-                    if part_number == 1 {
-                        std::future::pending::<Result<CompletedPart, R2Error>>().await
-                    } else {
-                        Err(R2Error::S3("upload part 2 failed".to_string()))
+                        if part_number == 1 {
+                            std::future::pending::<Result<CompletedPart, R2Error>>().await
+                        } else {
+                            match failure {
+                                Failure::Upload => {
+                                    Err(R2Error::S3("upload part 2 failed".to_string()))
+                                }
+                                Failure::Join => panic!("upload part 2 panicked"),
+                            }
+                        }
                     }
                 }
+            };
+
+            let error = tokio::time::timeout(
+                Duration::from_secs(5),
+                upload_parts_streaming_with(reader, 4, 2, upload),
+            )
+            .await
+            .expect("multipart scheduler test timed out")
+            .expect_err("multipart scheduler should return the terminal error");
+
+            assert!(
+                sibling_dropped.load(Ordering::SeqCst),
+                "sibling upload must be dropped before the scheduler returns"
+            );
+            match (failure, error) {
+                (Failure::Upload, R2Error::S3(message)) => {
+                    assert_eq!(message, "upload part 2 failed");
+                }
+                (Failure::Join, R2Error::Io(error)) => {
+                    assert!(
+                        error.to_string().contains("upload part 2 panicked"),
+                        "join error must preserve the task panic: {error}"
+                    );
+                }
+                (_, other) => panic!("unexpected scheduler error: {other:?}"),
             }
-        };
-
-        let error = tokio::time::timeout(
-            Duration::from_secs(5),
-            upload_parts_streaming_with(reader, 4, 2, upload),
-        )
-        .await
-        .expect("multipart scheduler test timed out")
-        .expect_err("multipart scheduler should return the upload error");
-
-        assert!(
-            sibling_dropped.load(Ordering::SeqCst),
-            "sibling upload must be dropped before the scheduler returns"
-        );
-        match error {
-            R2Error::S3(message) => assert_eq!(message, "upload part 2 failed"),
-            other => panic!("expected upload error, got {other:?}"),
         }
     }
 }

--- a/crates/runner/src/r2_cache/tests/upload.rs
+++ b/crates/runner/src/r2_cache/tests/upload.rs
@@ -209,6 +209,7 @@ async fn multipart_upload_guard_aborts_on_drop() {
 async fn upload_part_missing_etag_errors_with_part_number() {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadOutput;
+    use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
     use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
     use aws_sdk_s3::operation::upload_part::UploadPartOutput;
 
@@ -221,12 +222,14 @@ async fn upload_part_missing_etag_errors_with_part_number() {
     // runs (pack→stream→complete pipeline short-circuits on upload error).
     let upload_part =
         mock!(Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete = mock!(Client::complete_multipart_upload)
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
     // Abort is best-effort on any error path — include a mock so the SDK
     // dispatch doesn't panic on unmatched.
     let abort = mock!(Client::abort_multipart_upload)
         .then_output(|| AbortMultipartUploadOutput::builder().build());
 
-    let cache = mock_cache("test-bucket", &[&create, &upload_part, &abort]);
+    let cache = mock_cache("test-bucket", &[&create, &upload_part, &complete, &abort]);
 
     let (_dir, path) = small_src_file().await;
     let err = cache.upload_template("abc", &path, true).await.unwrap_err();
@@ -241,6 +244,8 @@ async fn upload_part_missing_etag_errors_with_part_number() {
         }
         other => panic!("expected R2Error::S3 with pinned part_number, got {other:?}"),
     }
+    assert_eq!(abort.num_calls(), 1, "failed upload must abort once");
+    assert_eq!(complete.num_calls(), 0, "failed upload must not complete");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- wait for all sibling `upload_part` tasks to finish cancellation before returning a terminal multipart scheduler error
- preserve the original upload or join error while stopping any further part admission
- cover both upload errors and task join failures with deterministic concurrent cleanup assertions
- assert the public upload path aborts once without completing

## Scope

This changes only the runner's R2 multipart failure cleanup. Successful scheduling, concurrency, part ordering, retry behavior, public APIs, persisted data, and protocols are unchanged.

## Validation

- `cargo test -p runner r2_cache::multipart::tests::multipart_scheduler_drops_siblings_before_returning_terminal_errors -- --exact`
- `cargo test -p runner r2_cache::tests::upload::upload_part_missing_etag_errors_with_part_number -- --exact`
- `cargo test -p runner` (3345 passed, 24 ignored; guest inventory 1 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- pre-commit hooks: cargo fmt, Clippy, docs, file-size, and commitlint

Closes #29836
