### PR TITLE
perf(runner): reuse workspace cache snapshot for heartbeats

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -93,7 +93,7 @@ impl HeartbeatRequest {
     fn ordinary() -> Self {
         Self {
             force_send: true,
-            refresh_workspace_cache: true,
+            refresh_workspace_cache: false,
             workspace_cache_change: None,
         }
     }
@@ -957,12 +957,16 @@ mod tests {
 
     #[test]
     fn ordinary_heartbeat_forces_send_without_dropping_coalesced_cache_commits() {
+        let ordinary = HeartbeatRequest::ordinary();
         let cache_then_ordinary = HeartbeatRequest::workspace_cache(workspace_cache_change("a"))
             .merge(HeartbeatRequest::ordinary());
         let ordinary_then_cache = HeartbeatRequest::ordinary().merge(
             HeartbeatRequest::workspace_cache(workspace_cache_change("b")),
         );
 
+        assert!(ordinary.force_send);
+        assert!(!ordinary.refresh_workspace_cache);
+        assert!(ordinary.workspace_cache_change.is_none());
         assert!(cache_then_ordinary.force_send);
         assert!(cache_then_ordinary.refresh_workspace_cache);
         assert_eq!(
@@ -1107,6 +1111,12 @@ mod tests {
         let active_runs = test_active_runs();
         let (provider, _) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
         let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
+        refresh_initial_workspace_cache_snapshot(
+            &workspace_cache_snapshot,
+            Some(&cache),
+            &profiles,
+        )
+        .await;
         let hb = HeartbeatContext::new(HeartbeatContextInit {
             idle_pool: &idle_pool,
             runner_identity: test_runner_identity(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -81,8 +81,9 @@ use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::status::{StatusTracker, remove_stale_status_file};
-use crate::workspace_image_cache::WorkspaceCacheWatcher;
-use crate::workspace_image_cache::WorkspaceImageCache;
+use crate::workspace_image_cache::{
+    WorkspaceCacheChange, WorkspaceCacheWatcher, WorkspaceImageCache,
+};
 
 mod active_runs;
 mod factory_lifecycle;
@@ -125,6 +126,10 @@ use signals::{
 const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
 /// Bounds routine cache-budget and stale-state cleanup without returning full scans to promotions.
 const WORKSPACE_CACHE_GC_PERIOD: Duration = Duration::from_secs(60);
+/// Bounds authoritative state recovery when workspace-cache observation is unavailable.
+const WORKSPACE_CACHE_RECONCILIATION_PERIOD: Duration = Duration::from_secs(60);
+/// Staggers the first fallback inventory from the first routine cache GC.
+const WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY: Duration = Duration::from_secs(30);
 
 fn candidate_for_admission(
     candidate: JobCandidate,
@@ -1685,7 +1690,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         Some(cache) => match WorkspaceCacheWatcher::new(cache).await {
             Ok(watcher) => Some(watcher),
             Err(error) => {
-                warn!(error = %error, "workspace cache watcher unavailable; using routine reconciliation");
+                warn!(error = %error, "workspace cache watcher unavailable; using periodic reconciliation");
                 None
             }
         },
@@ -1726,7 +1731,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         {
             Ok(change) => change,
             Err(error) => {
-                warn!(error = %error, "workspace cache watcher failed during startup reconciliation; using routine reconciliation");
+                warn!(error = %error, "workspace cache watcher failed during startup reconciliation; using periodic reconciliation");
                 workspace_cache_watcher = None;
                 Some(crate::workspace_image_cache::WorkspaceCacheChange {
                     observed_at: tokio::time::Instant::now(),
@@ -1794,6 +1799,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         WORKSPACE_CACHE_GC_PERIOD,
     );
     workspace_cache_gc_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut workspace_cache_reconciliation_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY,
+        WORKSPACE_CACHE_RECONCILIATION_PERIOD,
+    );
+    workspace_cache_reconciliation_tick
+        .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut workspace_cache_gc_fut = None;
     let mut draining_idle_pool_drained = false;
     let mut pending_finalizing_candidate = None;
@@ -1974,14 +1985,29 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             .test_observer
                             .notify_workspace_cache_change_observed();
                         let live_mode = *mode_rx.borrow();
-                        if live_mode == RunnerMode::Running {
+                        if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {
                             heartbeat.request_workspace_cache(live_mode, change)?;
                         }
                     }
                     Err(error) => {
-                        warn!(error = %error, "workspace cache watcher failed; using routine reconciliation");
+                        warn!(error = %error, "workspace cache watcher failed; using periodic reconciliation");
                         workspace_cache_change_fut = None;
                     }
+                }
+            }
+            _ = workspace_cache_reconciliation_tick.tick(),
+                if exec_config.workspace_cache.is_some()
+                    && workspace_cache_change_fut.is_none() =>
+            {
+                let live_mode = *mode_rx.borrow();
+                if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {
+                    heartbeat.request_workspace_cache(
+                        live_mode,
+                        WorkspaceCacheChange {
+                            observed_at: tokio::time::Instant::now(),
+                            committed_cache_keys: std::collections::BTreeSet::new(),
+                        },
+                    )?;
                 }
             }
             result = next_workspace_cache_gc(&mut workspace_cache_gc_fut) => {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -126,9 +126,9 @@ use signals::{
 const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
 /// Bounds routine cache-budget and stale-state cleanup without returning full scans to promotions.
 const WORKSPACE_CACHE_GC_PERIOD: Duration = Duration::from_secs(60);
-/// Bounds authoritative state recovery when workspace-cache observation is unavailable.
+/// Bounds authoritative state recovery from missed workspace-cache observations.
 const WORKSPACE_CACHE_RECONCILIATION_PERIOD: Duration = Duration::from_secs(60);
-/// Staggers the first fallback inventory from the first routine cache GC.
+/// Staggers the first state inventory from the first routine cache GC.
 const WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY: Duration = Duration::from_secs(30);
 
 fn candidate_for_admission(
@@ -1996,8 +1996,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 }
             }
             _ = workspace_cache_reconciliation_tick.tick(),
-                if exec_config.workspace_cache.is_some()
-                    && workspace_cache_change_fut.is_none() =>
+                if exec_config.workspace_cache.is_some() =>
             {
                 let live_mode = *mode_rx.borrow();
                 if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -392,6 +392,15 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
         );
     }
 
+    tokio::time::advance(WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY - HEARTBEAT_PERIOD * 2).await;
+    assert_eq!(
+        workspace_cache
+            .wait_for_held_state_root_scan_after(0, Duration::from_secs(5))
+            .await,
+        1,
+        "independent reconciliation should scan once while the watcher remains healthy",
+    );
+
     shutdown(&env, run_handle).await;
 }
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -1,9 +1,10 @@
 use super::super::super::*;
 use super::super::support::{
-    WorkspacePromotionSeedSpec, assert_run_exits_within, context_with_session, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
+    WorkspacePromotionSeedSpec, assert_run_exits_within, context_with_session, minimal_context,
+    mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
     seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state, shutdown, test_profiles,
-    wait_budget_count, wait_discover_entered, wait_idle_pool_reuse_keys,
+    wait_budget_count, wait_cancel_token, wait_discover_entered, wait_idle_pool_reuse_keys,
+    wait_status_mode,
 };
 
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
@@ -213,6 +214,108 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
 }
 
 #[tokio::test(start_paused = true)]
+async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&gate),
+    ));
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config_with_overrides(profiles, 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
+    let home = config.paths.home.clone();
+    let group = config.runner.group.clone();
+    let observer_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let observer_cache = WorkspaceImageCache::shared(observer_paths, &home, &group);
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(observer_cache.clone());
+
+    let publisher_paths = RunnerPaths::new(env._temp_dir.path().join("draining-publisher"));
+    tokio::fs::create_dir_all(publisher_paths.base_dir())
+        .await
+        .unwrap();
+    let publisher_cache = WorkspaceImageCache::shared(publisher_paths.clone(), &home, &group);
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    env.drain();
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+
+    observer_cache.reset_held_state_root_scan_count();
+    let before_change = env.handle.heartbeat_count();
+    let watcher_cursor = env.start_observer.cursor();
+    let reuse_key = "thread:draining-watcher-change";
+    seed_workspace_cache_state(
+        &publisher_cache,
+        &publisher_paths,
+        reuse_key,
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    env.start_observer
+        .wait_workspace_cache_change_observed_after(watcher_cursor, Duration::from_secs(5))
+        .await;
+    assert!(
+        wait_heartbeat_matching_after(
+            &env.handle,
+            before_change,
+            Duration::from_secs(5),
+            |heartbeat| {
+                heartbeat.mode == "draining"
+                    && heartbeat
+                        .held_workspace_states
+                        .iter()
+                        .any(|state| state.reuse_key == reuse_key)
+            },
+        )
+        .await,
+        "a cache change consumed while draining should refresh the published snapshot",
+    );
+    assert_eq!(observer_cache.held_state_root_scan_count(), 1);
+
+    env.resume();
+    wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
+    let before_routine = env.handle.heartbeat_count();
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    assert!(
+        wait_heartbeat_matching_after(
+            &env.handle,
+            before_routine,
+            Duration::from_secs(5),
+            |heartbeat| {
+                heartbeat.mode == "running"
+                    && heartbeat
+                        .held_workspace_states
+                        .iter()
+                        .any(|state| state.reuse_key == reuse_key)
+            },
+        )
+        .await,
+        "the snapshot refreshed while draining should remain current after resume",
+    );
+    assert_eq!(
+        observer_cache.held_state_root_scan_count(),
+        1,
+        "the post-resume routine heartbeat should reuse the refreshed snapshot",
+    );
+
+    gate.notify_one();
+    assert!(
+        env.handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "the gated run should complete after resume",
+    );
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tick() {
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
@@ -233,7 +336,7 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
     .await;
     Arc::get_mut(&mut config.exec_config)
         .unwrap()
-        .workspace_cache = Some(workspace_cache);
+        .workspace_cache = Some(workspace_cache.clone());
 
     let run_handle = tokio::spawn(run(config));
     assert!(
@@ -246,6 +349,48 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
         .await,
         "non-empty initial cache should be published before the deferred routine tick",
     );
+
+    workspace_cache.reset_held_state_root_scan_count();
+    let mut heartbeat_cursor = env.start_observer.cursor();
+    for _ in 0..2 {
+        let before = env.handle.heartbeat_count();
+        tokio::time::advance(HEARTBEAT_PERIOD).await;
+        heartbeat_cursor = env
+            .start_observer
+            .wait_routine_heartbeat_requested_after(
+                heartbeat_cursor,
+                RunnerMode::Running,
+                Duration::from_secs(5),
+            )
+            .await;
+        assert!(
+            env.handle
+                .wait_heartbeat_past(before, Duration::from_secs(5))
+                .await,
+            "routine heartbeat should still reach the provider",
+        );
+    }
+    assert_eq!(
+        workspace_cache.held_state_root_scan_count(),
+        0,
+        "healthy routine heartbeats should reuse the committed cache snapshot",
+    );
+    {
+        let heartbeats = env
+            .handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert!(
+            heartbeats.last().is_some_and(|heartbeat| {
+                heartbeat
+                    .held_workspace_states
+                    .iter()
+                    .any(|state| state.reuse_key == "thread:initial-workspace-cache")
+            }),
+            "snapshot-only routine heartbeats should retain the initial cache capability",
+        );
+    }
 
     shutdown(&env, run_handle).await;
 }
@@ -385,7 +530,7 @@ async fn startup_unclassified_cache_invalidated_after_scan_is_reconciled() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
+async fn unavailable_workspace_cache_watcher_uses_periodic_reconciliation() {
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
     let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
@@ -406,6 +551,7 @@ async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
 
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
+    workspace_cache.reset_held_state_root_scan_count();
 
     tokio::fs::remove_file(cache_root).await.unwrap();
     let runner_paths = RunnerPaths::new(env._temp_dir.path().join("fallback-publisher"));
@@ -422,7 +568,25 @@ async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
     )
     .await;
     let before = env.handle.heartbeat_count();
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    let mut heartbeat_cursor = env.start_observer.cursor();
+    for _ in 0..2 {
+        tokio::time::advance(HEARTBEAT_PERIOD).await;
+        heartbeat_cursor = env
+            .start_observer
+            .wait_routine_heartbeat_requested_after(
+                heartbeat_cursor,
+                RunnerMode::Running,
+                Duration::from_secs(5),
+            )
+            .await;
+    }
+    assert_eq!(
+        workspace_cache.held_state_root_scan_count(),
+        0,
+        "ordinary heartbeats should not provide failed-watcher reconciliation",
+    );
+
+    tokio::time::advance(WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY - HEARTBEAT_PERIOD * 2).await;
     assert!(
         wait_heartbeat_matching_after(&env.handle, before, Duration::from_secs(5), |heartbeat| {
             heartbeat
@@ -431,8 +595,9 @@ async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
                 .any(|state| state.reuse_key == "thread:routine-fallback")
         })
         .await,
-        "routine heartbeat must converge after watcher setup failure",
+        "periodic reconciliation must converge after watcher setup failure",
     );
+    assert_eq!(workspace_cache.held_state_root_scan_count(), 1);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -717,6 +717,8 @@ impl WorkspaceImageCache {
         self.inner
             .held_state_root_scan_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        #[cfg(test)]
+        self.inner.held_state_root_scan_notify.notify_waiters();
         let root = self.workspace_image_cache_dir().to_path_buf();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
@@ -814,6 +816,38 @@ impl WorkspaceImageCache {
         self.inner
             .held_state_root_scan_count
             .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_held_state_root_scan_after(
+        &self,
+        previous_count: usize,
+        timeout: Duration,
+    ) -> usize {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.inner.held_state_root_scan_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            let count = self.held_state_root_scan_count();
+            if count > previous_count {
+                return count;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "workspace cache did not start a held-state root scan within {timeout:?}"
+            );
+            tokio::time::timeout(remaining, notified)
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "workspace cache did not start a held-state root scan within {timeout:?}"
+                    )
+                });
+        }
     }
 
     async fn publishable_held_workspace_state(

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -713,6 +713,10 @@ impl WorkspaceImageCache {
         }
 
         let mut locked_commit_keys = BTreeSet::new();
+        #[cfg(test)]
+        self.inner
+            .held_state_root_scan_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let root = self.workspace_image_cache_dir().to_path_buf();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
@@ -796,6 +800,20 @@ impl WorkspaceImageCache {
             states,
             locked_commit_keys,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_held_state_root_scan_count(&self) {
+        self.inner
+            .held_state_root_scan_count
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn held_state_root_scan_count(&self) -> usize {
+        self.inner
+            .held_state_root_scan_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     async fn publishable_held_workspace_state(

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -128,6 +128,8 @@ struct WorkspaceImageCacheInner {
     #[cfg(test)]
     held_state_root_scan_count: AtomicUsize,
     #[cfg(test)]
+    held_state_root_scan_notify: tokio::sync::Notify,
+    #[cfg(test)]
     fail_next_session_history_sidecar_metadata_commit: AtomicBool,
 }
 
@@ -211,6 +213,7 @@ impl WorkspaceImageCache {
                 fs_stats_override: fs_stats,
                 gc_root_scan_count: AtomicUsize::new(0),
                 held_state_root_scan_count: AtomicUsize::new(0),
+                held_state_root_scan_notify: tokio::sync::Notify::new(),
                 fail_next_session_history_sidecar_metadata_commit: AtomicBool::new(false),
             }),
             prepare_lock_test_gate: None,

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -126,6 +126,8 @@ struct WorkspaceImageCacheInner {
     #[cfg(test)]
     gc_root_scan_count: AtomicUsize,
     #[cfg(test)]
+    held_state_root_scan_count: AtomicUsize,
+    #[cfg(test)]
     fail_next_session_history_sidecar_metadata_commit: AtomicBool,
 }
 
@@ -208,6 +210,7 @@ impl WorkspaceImageCache {
                 cache_scope: cache_scope.to_owned(),
                 fs_stats_override: fs_stats,
                 gc_root_scan_count: AtomicUsize::new(0),
+                held_state_root_scan_count: AtomicUsize::new(0),
                 fail_next_session_history_sidecar_metadata_commit: AtomicBool::new(false),
             }),
             prepare_lock_test_gate: None,


### PR DESCRIPTION
## Summary

- make ordinary runner heartbeats reuse the committed workspace-cache snapshot instead of inventorying the shared cache root every 10 seconds
- retain immediate watcher-driven reconciliation in Running and Draining, and independently run an authoritative reconciliation every 60 seconds for every configured cache
- add full runner-loop coverage proving routine heartbeats perform zero scans, healthy and unavailable watchers both receive bounded reconciliation, and Draining changes survive resume

## Behavior and compatibility

- initial subscribe-before-scan handoff, committed-entry lock waiting, queue-overflow reconciliation, active-run filtering, heartbeat caps, and single-flight request coalescing are unchanged
- the independent scan covers watcher setup/runtime failure, silent misses, and entries whose watches are evicted by the retained 1,024-entry watch limit
- unobserved cache changes may now leave scheduling hints stale for up to 60 seconds instead of one heartbeat period; local cache checkout remains authoritative and fail-closed
- healthy cache inventory drops from six full scans per minute to one; the first scan starts at 30 seconds to avoid deterministic overlap with the 60-second cache GC tick
- runner-only change with no API, heartbeat payload, queue, database, migration, cache metadata, file layout, or runner/guest protocol changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner cmd::start::heartbeat::tests` (18 passed)
- `cargo test -p runner cmd::start::tests::idle_reuse::workspace_cache` (9 passed)
- `cargo test -p runner workspace_image_cache::watcher::tests` (11 passed)
- `cargo clippy -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner` (3345 passed, 24 intentional ignores; guest inventory passed)
- repository pre-commit Rust formatting, workspace Clippy, workspace rustdoc, file-size, and commit-message hooks

Closes #29838
