### PR TITLE
perf(python): reuse bounded aws request classification

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -357,44 +357,41 @@ def _prebind_requestheaders_upstream_destination(
 def _prebind_bounded_requestheaders_upstream_destination(
     flow: http.HTTPFlow,
 ) -> request_classification.RequestClassification | None:
+    """Classify and prebind while leaving successful probe metadata in place.
+
+    The caller owns restoring requestheaders probe metadata after every call
+    unless it retains the returned classification.
+    """
     if getattr(ctx, "options", None) is None:
         return None
     api_url = get_api_url()
-    metadata_snapshot = {
-        key: flow.metadata[key]
-        for key in _request_headers_probe_metadata_keys()
-        if key in flow.metadata
-    }
     try:
-        try:
-            trusted_authority = get_trusted_authority(flow)
-        except AuthorityValidationError:
-            return None
-        flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        is_api_destination = upstream_admission.api_destination_matches(
-            api_url,
-            scheme=flow.request.scheme,
-            hostname=trusted_authority.host,
-            port=trusted_authority.port,
-        )
-        if (
-            not is_api_destination
-            and upstream_admission.has_bound_destination(
-                flow,
-                allowed_kinds=frozenset(("connector_auth",)),
-            )
-            and not _request_may_use_aws_sigv4(flow)
-        ):
-            return None
-        classification = _classify_request_for_flow_with_trusted_authority(
+        trusted_authority = get_trusted_authority(flow)
+    except AuthorityValidationError:
+        return None
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
+    is_api_destination = upstream_admission.api_destination_matches(
+        api_url,
+        scheme=flow.request.scheme,
+        hostname=trusted_authority.host,
+        port=trusted_authority.port,
+    )
+    if (
+        not is_api_destination
+        and upstream_admission.has_bound_destination(
             flow,
-            trusted_authority=trusted_authority,
-            defer_unresolved_public_destination=True,
+            allowed_kinds=frozenset(("connector_auth",)),
         )
-        _prebind_requestheaders_upstream_destination(flow, classification)
-        return classification
-    finally:
-        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        and not _request_may_use_aws_sigv4(flow)
+    ):
+        return None
+    classification = _classify_request_for_flow_with_trusted_authority(
+        flow,
+        trusted_authority=trusted_authority,
+        defer_unresolved_public_destination=True,
+    )
+    _prebind_requestheaders_upstream_destination(flow, classification)
+    return classification
 
 
 def _start_request_timing(flow: http.HTTPFlow) -> None:
@@ -773,25 +770,35 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     body_fits_stream_buffer = (
         auth_base_body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
     )
+    metadata_snapshot = {
+        key: flow.metadata[key]
+        for key in _request_headers_probe_metadata_keys()
+        if key in flow.metadata
+    }
     if body_fits_stream_buffer:
-        bounded_classification = _prebind_bounded_requestheaders_upstream_destination(flow)
+        try:
+            bounded_classification = _prebind_bounded_requestheaders_upstream_destination(flow)
+        except BaseException:
+            _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+            raise
         if (
             bounded_classification is None
             or bounded_classification.kind != "firewall_allow"
             or _firewall_allow_auth_base(bounded_classification.firewall_allow)
             or not _firewall_allow_uses_aws_sigv4(bounded_classification.firewall_allow)
         ):
+            _restore_request_headers_probe_metadata(flow, metadata_snapshot)
             return None
-
-    metadata_snapshot = {
-        key: flow.metadata[key]
-        for key in _request_headers_probe_metadata_keys()
-        if key in flow.metadata
-    }
-    classification = _classify_request_for_flow(
-        flow,
-        defer_unresolved_public_destination=True,
-    )
+        classification = request_classification.revalidate_classification_for_current_destination(
+            flow,
+            bounded_classification,
+            defer_unresolved_public_destination=True,
+        )
+    else:
+        classification = _classify_request_for_flow(
+            flow,
+            defer_unresolved_public_destination=True,
+        )
     if classification.kind == "public_destination_denied":
         _start_request_timing(flow)
         _block_public_destination_denied(

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -284,10 +284,22 @@ def classification_for_request(
             api_url=api_url,
             tls_admission=tls_admission,
         )
+    return revalidate_classification_for_current_destination(flow, classification)
+
+
+def revalidate_classification_for_current_destination(
+    flow: http.HTTPFlow,
+    classification: RequestClassification,
+    *,
+    defer_unresolved_public_destination: bool = False,
+) -> RequestClassification:
+    """Recheck destination-dependent policy for an existing classification."""
+
     if isinstance(classification, FirewallAllow | FirewallPolicyAllow):
         public_destination_denial = current_public_destination_denial(
             flow,
             classification.firewall_allow,
+            defer_unresolved_hostnames=defer_unresolved_public_destination,
         )
         if public_destination_denial is not None:
             return PublicDestinationDenied(
@@ -567,11 +579,14 @@ def firewall_allow_uses_public_destination(allow: matching.FirewallAllow) -> boo
 def current_public_destination_denial(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
+    *,
+    defer_unresolved_hostnames: bool = False,
 ) -> PublicDestinationDenial | None:
-    """Revalidate a cached firewall allow against the current runtime destination.
+    """Revalidate an existing firewall allow against the current runtime destination.
 
     Header-phase publicDestination checks may defer unresolved runtime hostnames
-    until the request phase can observe the final destination.
+    until the request phase can observe the final destination. Callers must opt
+    into that header-phase behavior explicitly.
     """
 
     trusted_authority_host = flow_metadata.trusted_authority_host(flow.metadata)
@@ -584,6 +599,7 @@ def current_public_destination_denial(
         flow,
         allow,
         trusted_authority_host=trusted_authority_host,
+        defer_unresolved_hostnames=defer_unresolved_hostnames,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -740,6 +740,40 @@ async def test_bounded_payload_dependent_sigv4_classifies_once_before_buffering(
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
+def test_bounded_sigv4_classification_failure_restores_probe_metadata(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(
+            matching,
+            "match_compiled_firewall_request",
+            side_effect=RuntimeError("bounded classification failed"),
+        ),
+        pytest.raises(RuntimeError, match="bounded classification failed"),
+    ):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert metadata_keys.SANDBOX_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
+    assert metadata_keys.TRUSTED_AUTHORITY_HOST not in flow.metadata
+    assert metadata_keys.NETWORK_LOG_TARGET not in flow.metadata
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
 def test_bounded_sigv4_revalidates_public_destination_after_prebind(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -16,9 +16,13 @@ from mitmproxy.websocket import WebSocketData
 import auth
 import aws_sigv4_body_admission
 import flow_metadata_keys as metadata_keys
+import matching
 import mitm_addon
+import registry
 import request_classification
 import request_streaming
+import upstream_admission
+import upstream_destination_binding
 from aws_sigv4 import MAX_AWS_SIGV4_QUERY_PAIRS, AwsSigV4BodyHash, hash_request_body
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.aws_sigv4_helpers import (
@@ -40,6 +44,7 @@ from tests.request_handler_helpers import _single_firewall_sandbox, _write_regis
 from tests.requestheaders_helpers import (
     _assert_no_request_stream,
     await_requestheaders_result,
+    track_trusted_authority_validations,
 )
 from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
@@ -231,6 +236,55 @@ async def test_payload_independent_sigv4_signs_before_streaming(
     get_headers.assert_awaited_once()
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
+
+async def test_bounded_payload_independent_sigv4_classifies_once_before_auth(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    monkeypatch,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=b"",
+        content_length="0",
+        content_hash="UNSIGNED-PAYLOAD",
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    validated_flows = track_trusted_authority_validations(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(
+            registry,
+            "load_registry_state",
+            wraps=registry.load_registry_state,
+        ) as registry_load,
+        patch.object(
+            matching,
+            "match_compiled_firewall_request",
+            wraps=matching.match_compiled_firewall_request,
+        ) as firewall_match,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+
+        assert validated_flows == [flow]
+        assert registry_load.call_count == 1
+        assert firewall_match.call_count == 1
+
+        await await_requestheaders_result(requestheaders_result)
+        await mitm_addon.request(flow)
+        assert f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+
+        flow.response = http.Response.make(200, b"ok")
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
 async def test_payload_independent_large_fixed_length_bypasses_buffer_limit(
@@ -636,6 +690,116 @@ async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
     assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
     assert metadata_keys.AWS_SIGV4_REQUEST_INSPECTION not in flow.metadata
+
+
+async def test_bounded_payload_dependent_sigv4_classifies_once_before_buffering(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    monkeypatch,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    validated_flows = track_trusted_authority_validations(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(
+            registry,
+            "load_registry_state",
+            wraps=registry.load_registry_state,
+        ) as registry_load,
+        patch.object(
+            matching,
+            "match_compiled_firewall_request",
+            wraps=matching.match_compiled_firewall_request,
+        ) as firewall_match,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        assert validated_flows == [flow]
+        assert registry_load.call_count == 1
+        assert firewall_match.call_count == 1
+        assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+
+        await mitm_addon.request(flow)
+        assert f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+
+        flow.response = http.Response.make(200, b"ok")
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+def test_bounded_sigv4_revalidates_public_destination_after_prebind(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    monkeypatch,
+) -> None:
+    registry_path = _write_aws_registry(
+        tmp_path,
+        host_policy={"kind": "publicDestination"},
+    )
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    ensure_bound_destination = upstream_admission.ensure_bound_destination
+
+    def connect_private_destination_after_prebind(
+        current_flow: http.HTTPFlow,
+        *,
+        kind: upstream_destination_binding.BindingKind,
+        api_url: str,
+    ) -> bool:
+        admitted = ensure_bound_destination(
+            current_flow,
+            kind=kind,
+            api_url=api_url,
+        )
+        if admitted:
+            mark_connected_tls_upstream(
+                current_flow,
+                sni=STS_HOST,
+                server_address=(STS_HOST, 443),
+                peername=("10.0.0.1", 443),
+            )
+        return admitted
+
+    monkeypatch.setattr(
+        upstream_admission,
+        "ensure_bound_destination",
+        connect_private_destination_after_prebind,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+
+    get_headers.assert_not_called()
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_public_destination"
+    assert RESOLVED_AWS_ACCESS_KEY_ID not in flow.request.headers["authorization"]
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
 async def test_payload_dependent_sigv4_revalidates_network_policy_before_auth(


### PR DESCRIPTION
## Summary

- retain the bounded AWS SigV4 firewall classification through the synchronous `requestheaders()` continuation instead of running the full classifier twice
- revalidate the retained classification against the post-prebind runtime destination while preserving header-phase unresolved-hostname deferral
- add real-hook regression coverage for header-signable, buffered, post-prebind private-destination, and synchronous failure-cleanup paths

## Scope

The reuse remains inside one unchanged synchronous hook invocation. It does not add flow-scoped, cross-hook, cross-request, TTL, or process-wide classification caching. Existing post-await and `request()` registry, authority, firewall, connector-binding, and builtin host-policy checks remain unchanged.

There are no API, persisted-data, configuration, protocol, migration, UI, or user-flow changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_aws_sigv4_body.py` (36 passed)
- `uv run --no-sync python -m pytest tests/test_request_headers_connector_admission.py tests/test_request_handler_firewall_auth_revalidation.py tests/test_request_handler_public_destination.py tests/test_request_handler_authority_validation.py`
- `uv run --no-sync python -m pytest tests/test_request_headers_streaming.py tests/test_request_headers_api_admission.py tests/test_request_headers_firewall_auth.py tests/test_request_handler_auth_base_body.py tests/test_mitmproxy_request_body_admission_framing.py`
- `uv run --no-sync python -m pytest tests/` (6,721 passed)

Closes #29851
