### PR TITLE
refactor(api): cut preview job-reference writer to canonical alias

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -254,7 +254,6 @@ runs:
           fi
           if [[ "$INPUT_ENVIRONMENT" == "preview" && -n "$INPUT_JOB_REF" ]]; then
             add_env OKOU_PREVIEW_JOB_REF "$INPUT_JOB_REF"
-            add_env VM0_PREVIEW_JOB_REF "$INPUT_JOB_REF"
           fi
           if [[ -n "$atom_url" ]]; then
             add_env ATOM_URL "$atom_url"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -104,19 +104,6 @@ assert_env_key_count() {
   fi
 }
 
-assert_env_values_equal() {
-  local env_file="$1"
-  local first_key="$2"
-  local second_key="$3"
-  local first_value
-  local second_value
-  first_value="$(awk -F= -v key="$first_key" '$1 == key { sub(/^[^=]*=/, ""); print }' "$env_file")"
-  second_value="$(awk -F= -v key="$second_key" '$1 == key { sub(/^[^=]*=/, ""); print }' "$env_file")"
-  if [[ "$first_value" != "$second_value" ]]; then
-    fail "expected ${first_key} and ${second_key} values to be equal"
-  fi
-}
-
 assert_preview_job_ref_aliases_absent() {
   local env_file="$1"
   assert_env_key_absent "$env_file" OKOU_PREVIEW_JOB_REF
@@ -511,10 +498,8 @@ assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.
 assert_machine_secret_canonical_only "$success_env_file" "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
 assert_env_key_count "$success_env_file" OKOU_PREVIEW_JOB_REF 1
-assert_env_key_count "$success_env_file" VM0_PREVIEW_JOB_REF 1
 assert_env_value "$success_env_file" OKOU_PREVIEW_JOB_REF "pr-123"
-assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
-assert_env_values_equal "$success_env_file" OKOU_PREVIEW_JOB_REF VM0_PREVIEW_JOB_REF
+assert_env_key_absent "$success_env_file" VM0_PREVIEW_JOB_REF
 assert_api_backend_url_canonical_only "$success_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"

--- a/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts
@@ -41,12 +41,11 @@ function reportResolution(state: PreviewJobRefAliasState): void {
   logAliasResolutionInfo(log, PREVIEW_JOB_REF_ALIAS_RESOLUTION_EVENT, fields);
 }
 
-// The preview deployment action intentionally emits equal-dual aliases so old
-// API rollback targets keep the legacy input while current APIs exercise the
-// canonical reader. Cut the writer to canonical-only only after every eligible
-// API can read the canonical key; remove the legacy reader separately after
-// bounded evidence shows zero legacy-only or equal-dual resolutions through the
-// supported rollback window.
+// The repository-owned preview action now emits only OKOU_PREVIEW_JOB_REF.
+// This dual reader and value-free source telemetry remain for old
+// checkout/rerun visibility, active old-preview compatibility, and external
+// legacy input. Remove them only in a later #28914 cleanup after those sources
+// and the supported rollback window are proven drained.
 function resolveStripePreviewJobRef(): string | null {
   if (env("ENV") !== "preview") {
     return null;


### PR DESCRIPTION
## Summary

- stop the repository-owned API preview action from emitting `VM0_PREVIEW_JOB_REF`, while retaining exactly one canonical `OKOU_PREVIEW_JOB_REF` under the existing API/preview/non-empty gate
- update the focused action fixture to require one canonical `pr-123` value and no legacy alias, preserving all non-API, non-preview, and empty-input absence cases
- update only the Stripe preview rollout comment; the complete dual reader, fixed-state value-free telemetry, conflict failure, metadata behavior, and compatibility fixtures remain unchanged

Closes #29865

## Revalidation

- refreshed `main` immediately before editing and cut the branch from `b38f0fd3e107d6097b47ea8ead5f6f9855bed940`; the issue's JIT base was `2ce53ca93f3140e5a61339b7061c8a43d668ec28`, and the selected files had no intervening diff
- enumerated the action's three repository workflow call sites, every `stripePreviewMetadata` / `isCurrentStripePreviewMetadata` caller, all alias occurrences, the three retained legacy-only route/BDD fixtures, and the neutral `job-ref` / Stripe `job_ref` surfaces
- final-head pagination covered all 33 open PRs and every changed-file page: GitHub declared 425 files and the audit fetched 425, with no mismatch; only stale #25722 overlaps the selected boundary outside this PR

## Verification

- `npx --yes prettier@3.8.1 --check --ignore-unknown ../.github/actions/web-api-env/action.yml ../.github/scripts/tests/web-api-env-action-test.sh apps/api/src/signals/services/stripe-preview-metadata.service.ts`
- `bash -n .github/scripts/tests/web-api-env-action-test.sh`
- ShellCheck 0.11.0 on `.github/scripts/tests/web-api-env-action-test.sh` and on the Bash script extracted from `.github/actions/web-api-env/action.yml`
- `bash .github/scripts/tests/web-api-env-action-test.sh` (`web-api-env-action-test: ok`)
- static writer assertion: canonical writer count `1`, legacy writer count `0`
- behavioral hash assertion from `resolveStripePreviewJobRef` through both exported consumers remained byte-identical (`eeed16ad0c863d49f55d5b2517aaf888fedce8813eb887826f9db440bb3cece0`); the focused resolver matrix and legacy-only route/BDD fixture files have zero diff
- `git diff --check`
- no full local Vitest suite and no development server; protected PR CI is authoritative for repository-wide validation

## Fallbacks

- **Retained legacy reader:** `turbo/apps/api/src/signals/services/stripe-preview-metadata.service.ts` still accepts absent, canonical-only, legacy-only, and equal-dual input, fails closed on conflicting dual input, and emits only fixed key names and resolution states. The resolver matrix and three larger legacy-only route/BDD fixtures remain intact.
- **Seven-target rollback proof:** Production Rollback Dashboard #6792 still retains `ef41199bc788ed8ee6b192049389565c1a101c81`, `038a432348c6044c1dcb77a3e231cc4348d56e9e`, `bad577492af3e741a2e19532f6a3b75ae4b498d7`, `31f3b2e88e5b84873fd010c172d64fe3b0cd2cc0`, `a63585c6e9e84a0523900a6225aa80e7d87849da`, `58656533202285c048d5d86b60923d6f225fd182`, and `be006a7c2783fe63fe5eb86a2737fce371665aab`. Fresh GitHub comparisons show all seven descend from both reader merge `7700bfb122d984153432b7d309f7334336028566` and equal-dual writer merge `f4cc4066ea21b4158d75d104b737750ce90392a3`, with `behind_by=0` and the exact predecessor as merge base in all 14 comparisons.
- **Immediate writer revert:** reverting this PR restores the adjacent equal-dual action writer and its previous positive assertion without changing the reader or Stripe metadata.
- **Later cleanup gate:** remove the legacy reader and its value-free telemetry only in a separate later #28914 change after bounded evidence proves old checkout/rerun visibility, active old previews, external legacy input, and the supported rollback window are drained.
- **Stale Worker overlap:** #25722 remains open and `DIRTY` at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, last updated `2026-08-13T15:03:45Z`. This PR neither edits nor waits for that branch and imports none of its unrelated Worker changes; merge precedence applies normally.
