### PR TITLE
test(api): fix pi resource snapshot fixture size mismatch

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1185,6 +1185,25 @@ export function getApiTestMocks(): ApiTestMocks {
   return apiTestMocks;
 }
 
+export function apiTestS3PresignedUrl(command: unknown): string {
+  const candidate = command as {
+    readonly constructor?: { readonly name?: string };
+    readonly input?: { readonly Bucket?: unknown; readonly Key?: unknown };
+  };
+  if (candidate.constructor?.name !== "GetObjectCommand") {
+    return "https://r2.example.com/upload?sig=test";
+  }
+  const bucket = candidate.input?.Bucket;
+  const key = candidate.input?.Key;
+  if (typeof bucket !== "string" || typeof key !== "string") {
+    throw new Error("Expected S3 GET presign request to identify an object");
+  }
+  const url = new URL("https://r2.example.com/storage/archive.tar.gz");
+  url.searchParams.set("sig", "bdd");
+  url.searchParams.set("object", `${bucket}/${key}`);
+  return url.toString();
+}
+
 export function resetApiTestMocks(): void {
   apiTestMocks.abortSignal.timeout.mockReset();
   apiTestMocks.ably.channelGet.mockReset();
@@ -1232,8 +1251,10 @@ export function resetApiTestMocks(): void {
   apiTestMocks.clerk.m2m.createToken.mockReset();
   apiTestMocks.s3.send.mockReset();
   apiTestMocks.s3.getSignedUrl.mockReset();
-  apiTestMocks.s3.getSignedUrl.mockResolvedValue(
-    "https://r2.example.com/upload?sig=test",
+  apiTestMocks.s3.getSignedUrl.mockImplementation(
+    (_client: unknown, command: unknown) => {
+      return Promise.resolve(apiTestS3PresignedUrl(command));
+    },
   );
   apiTestMocks.s3.clientConfig.mockReset();
   apiTestMocks.dns.lookupOverrides.clear();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -76,6 +76,7 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { setOrgModelPolicyProviderTypeFixture } from "../../../test-fixtures/org-model-policies";
 import { setChatThreadVideoModelFixture } from "../../../test-fixtures/chat-thread-events";
+import { seededSystemSkillArchive } from "../../../test-fixtures/seeded-system-skill-archive";
 import {
   API_TEST_CONNECTOR_CATALOG,
   apiTestConnectorCatalogValidationAuthority,
@@ -4794,9 +4795,7 @@ interface PiCheckpointS3Command {
   };
 }
 
-function piCheckpointObjectKey(
-  candidate: PiCheckpointS3Command,
-): string | undefined {
+function piS3ObjectKey(candidate: PiCheckpointS3Command): string | undefined {
   const bucket = candidate.input?.Bucket;
   const key = candidate.input?.Key;
   return typeof bucket === "string" && typeof key === "string"
@@ -4808,7 +4807,7 @@ function mockPiPutObject(
   objects: Map<string, Buffer>,
   candidate: PiCheckpointS3Command,
 ): Promise<unknown> | undefined {
-  const objectKey = piCheckpointObjectKey(candidate);
+  const objectKey = piS3ObjectKey(candidate);
   if (candidate.constructor?.name !== "PutObjectCommand" || !objectKey) {
     return undefined;
   }
@@ -4827,7 +4826,7 @@ function mockPiGetObject(
   objects: Map<string, Buffer>,
   candidate: PiCheckpointS3Command,
 ): Promise<unknown> | undefined {
-  const objectKey = piCheckpointObjectKey(candidate);
+  const objectKey = piS3ObjectKey(candidate);
   if (candidate.constructor?.name !== "GetObjectCommand" || !objectKey) {
     return undefined;
   }
@@ -4877,22 +4876,60 @@ function mockPiCheckpointObjectStore(): Map<string, Buffer> {
   return objects;
 }
 
-function latestStoredArchive(): Buffer {
+const PI_RESOURCE_ARCHIVE_DOWNLOAD_URL =
+  "https://r2.example.com/storage/archive.tar.gz";
+
+function uploadedPiS3Object(objectKey: string): Buffer | undefined {
   for (const [command] of [...context.mocks.s3.send.mock.calls].reverse()) {
-    const candidate = command as {
-      readonly constructor?: { readonly name?: string };
-      readonly input?: { readonly Body?: unknown; readonly Key?: unknown };
-    };
+    const candidate = command as PiCheckpointS3Command;
     if (
       candidate.constructor?.name === "PutObjectCommand" &&
-      typeof candidate.input?.Key === "string" &&
-      candidate.input.Key.endsWith("/archive.tar.gz") &&
-      candidate.input.Body instanceof Uint8Array
+      piS3ObjectKey(candidate) === objectKey
     ) {
+      if (!(candidate.input?.Body instanceof Uint8Array)) {
+        throw new Error(
+          `Expected uploaded Pi S3 object bytes for ${objectKey}`,
+        );
+      }
       return Buffer.from(candidate.input.Body);
     }
   }
-  throw new Error("Expected an uploaded Storage archive fixture");
+  return undefined;
+}
+
+function piS3Object(objectKey: string): Buffer {
+  const uploaded = uploadedPiS3Object(objectKey);
+  if (uploaded) {
+    return uploaded;
+  }
+  const bucketPrefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/`;
+  const seeded = objectKey.startsWith(bucketPrefix)
+    ? seededSystemSkillArchive(objectKey.slice(bucketPrefix.length))
+    : undefined;
+  if (seeded) {
+    return seeded;
+  }
+  throw new Error(`Expected Pi S3 object ${objectKey}`);
+}
+
+function mockPiResourceArchiveDownloads(unavailable = false): void {
+  server.use(
+    http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, ({ request }) => {
+      if (unavailable) {
+        return HttpResponse.json(
+          { error: "archive unavailable" },
+          { status: 503 },
+        );
+      }
+      const objectKey = new URL(request.url).searchParams.get("object");
+      if (!objectKey) {
+        throw new Error("Expected Pi resource archive object identity");
+      }
+      return new HttpResponse(piS3Object(objectKey), {
+        headers: { "content-type": "application/gzip" },
+      });
+    }),
+  );
 }
 
 function occurrences(haystack: string, needle: string): number {
@@ -5144,14 +5181,7 @@ describe("CHAT-02: model-first provider policies", () => {
         { ...actor, orgId },
         { [FeatureSwitchKey.PiLoop]: true },
       );
-      const discoveryArchive = latestStoredArchive();
-      server.use(
-        http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-          return new HttpResponse(discoveryArchive, {
-            headers: { "content-type": "application/gzip" },
-          });
-        }),
-      );
+      mockPiResourceArchiveDownloads();
       const checkpointObjects = mockPiCheckpointObjectStore();
       const modelRequests: {
         readonly authorization: string | null;
@@ -5310,14 +5340,9 @@ describe("CHAT-02: model-first provider policies", () => {
       { ...actor, orgId: actor.orgId },
       { [FeatureSwitchKey.PiLoop]: true },
     );
-    const archive = latestStoredArchive();
+    mockPiResourceArchiveDownloads();
     const consumedAgentEvents: Record<string, unknown>[] = [];
     server.use(
-      http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-        return new HttpResponse(archive, {
-          headers: { "content-type": "application/gzip" },
-        });
-      }),
       http.post(
         "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
         async ({ request }) => {
@@ -5442,19 +5467,7 @@ describe("CHAT-02: model-first provider policies", () => {
         { ...actor, orgId: actor.orgId },
         { [FeatureSwitchKey.PiLoop]: true },
       );
-      const archive = latestStoredArchive();
-      server.use(
-        http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-          return failResource
-            ? HttpResponse.json(
-                { error: "archive unavailable" },
-                { status: 503 },
-              )
-            : new HttpResponse(archive, {
-                headers: { "content-type": "application/gzip" },
-              });
-        }),
-      );
+      mockPiResourceArchiveDownloads(failResource);
       let modelCalls = 0;
       server.use(
         http.post("https://api.deepseek.com/responses", () => {
@@ -5512,14 +5525,7 @@ describe("CHAT-02: model-first provider policies", () => {
       { ...actor, orgId: actor.orgId },
       { [FeatureSwitchKey.PiLoop]: true },
     );
-    const archive = latestStoredArchive();
-    server.use(
-      http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-        return new HttpResponse(archive, {
-          headers: { "content-type": "application/gzip" },
-        });
-      }),
-    );
+    mockPiResourceArchiveDownloads();
     let modelCalls = 0;
     server.use(
       http.post("https://api.deepseek.com/responses", () => {
@@ -5613,14 +5619,7 @@ describe("CHAT-02: model-first provider policies", () => {
         [FeatureSwitchKey.ChatToolActivity]: true,
       },
     );
-    const archive = latestStoredArchive();
-    server.use(
-      http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-        return new HttpResponse(archive, {
-          headers: { "content-type": "application/gzip" },
-        });
-      }),
-    );
+    mockPiResourceArchiveDownloads();
     let modelCalls = 0;
     server.use(
       http.post("https://api.deepseek.com/responses", () => {
@@ -7260,14 +7259,7 @@ describe("CHAT-02: model-first provider policies", () => {
           modelProviderId: null,
         },
       ]);
-      const archive = latestStoredArchive();
-      server.use(
-        http.get("https://r2.example.com/storage/archive.tar.gz", () => {
-          return new HttpResponse(archive, {
-            headers: { "content-type": "application/gzip" },
-          });
-        }),
-      );
+      mockPiResourceArchiveDownloads();
       mockPiCheckpointObjectStore();
       const modelRequests: {
         readonly authorization: string | null;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -52,6 +52,7 @@ import {
   setupRawAppRequestWithRoutes,
 } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
+import { apiTestS3PresignedUrl } from "../../../../__tests__/mocks";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now, withNowScopeForTest } from "../../../../lib/time";
 import { createDeferredPromise } from "../../../utils";
@@ -337,8 +338,10 @@ export function createRunsApi(context: TestContext) {
     },
 
     acceptStorageDownloads(): void {
-      context.mocks.s3.getSignedUrl.mockResolvedValue(
-        "https://r2.example.com/storage/archive.tar.gz?sig=bdd",
+      context.mocks.s3.getSignedUrl.mockImplementation(
+        (_client: unknown, command: unknown) => {
+          return Promise.resolve(apiTestS3PresignedUrl(command));
+        },
       );
     },
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -20,6 +20,7 @@ import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-pr
 
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
+import { apiTestS3PresignedUrl } from "../../../../__tests__/mocks";
 import { now } from "../../../../lib/time";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import { authMeRoutes } from "../../auth-me";
@@ -200,8 +201,10 @@ export function createBddApi(context: TestContext) {
 
   function acceptAgentStorageWrites(): void {
     context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
-    context.mocks.s3.getSignedUrl.mockResolvedValue(
-      "https://r2.example.com/storage/archive.tar.gz?sig=bdd",
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      (_client: unknown, command: unknown) => {
+        return Promise.resolve(apiTestS3PresignedUrl(command));
+      },
     );
   }
 

--- a/turbo/apps/api/src/test-fixtures/seeded-system-skill-archive.ts
+++ b/turbo/apps/api/src/test-fixtures/seeded-system-skill-archive.ts
@@ -1,0 +1,77 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SEED_SKILLS } from "@okouai/core/seed-skills";
+import { create as createTar } from "tar";
+
+import rawDevSeedSkillVolumes from "../scripts/dev-seed-skill-volumes.json";
+
+interface SeededSystemSkillVolume {
+  readonly name: string;
+  readonly s3Key: string;
+  readonly versionSize: number;
+  readonly frontmatter: {
+    readonly name?: unknown;
+    readonly description?: unknown;
+  };
+}
+
+function representativeSkillMarkdown(volume: SeededSystemSkillVolume): string {
+  const { name, description } = volume.frontmatter;
+  if (typeof name !== "string" || typeof description !== "string") {
+    throw new Error(`Seeded system skill ${volume.name} needs frontmatter`);
+  }
+  return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n# ${name}\n`;
+}
+
+function createArchive(volume: SeededSystemSkillVolume): Buffer {
+  const root = mkdtempSync(join(tmpdir(), "vm0-api-seeded-skill-"));
+  const skillPath = join(root, "SKILL.md");
+  const archivePath = join(root, "archive.tar.gz");
+  writeFileSync(skillPath, representativeSkillMarkdown(volume));
+  chmodSync(skillPath, 0o644);
+  createTar(
+    {
+      cwd: root,
+      file: archivePath,
+      gzip: { portable: true },
+      mtime: new Date(0),
+      portable: true,
+      sync: true,
+    },
+    ["SKILL.md"],
+  );
+  const archive = readFileSync(archivePath);
+  rmSync(root, { recursive: true, force: true });
+  if (archive.length > volume.versionSize) {
+    throw new Error(
+      `Seeded system skill ${volume.name} archive exceeds ${volume.versionSize.toString()} bytes`,
+    );
+  }
+  return Buffer.concat(
+    [archive, Buffer.alloc(volume.versionSize - archive.length)],
+    volume.versionSize,
+  );
+}
+
+export function seededSystemSkillArchive(
+  archiveKey: string,
+): Buffer | undefined {
+  const volume = rawDevSeedSkillVolumes.find((candidate) => {
+    return (
+      SEED_SKILLS.includes(candidate.name) &&
+      `${candidate.s3Key}/archive.tar.gz` === archiveKey
+    );
+  });
+  if (!volume) {
+    return undefined;
+  }
+  return createArchive(volume);
+}


### PR DESCRIPTION
## Summary

- preserve the S3 bucket/key identity in API test presigned GET URLs
- serve Pi resource archives by their exact uploaded or seeded object key
- synthesize valid, deterministic archives for seeded system skills at their authoritative seeded sizes

## Scope

- test infrastructure only; production storage behavior is unchanged
- upload presigned URLs and existing user flows are unchanged
- unknown seeded object keys fail instead of falling back by archive size or request order

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (128 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'runs the Pi API first turn once for deepseek-v4-flash and resumes canonical JSONL' --maxWorkers=1 --silent=passed-only` (passed twice, including cache reuse)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/storage-presigned-url-cache.test.ts --maxWorkers=1 --silent=passed-only` (10 passed)
- pre-commit hook: Prettier, repository Knip, repository TypeScript checks, file-size check, and commitlint passed
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` was attempted three times locally. The first exposed a stale local schema; after migration and then a clean local DB reset/seed, later attempts still encountered varying cross-file 5-second timeouts and database-pool cascades. The focused Pi and storage-cache suites above remained green; CI is the authoritative full-suite run.

Closes #29822
