### PR TITLE
fix(auth): remove focus ring from error alerts

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -11,6 +11,10 @@ interface CheckboxPresentation {
   readonly width: string;
 }
 
+interface FocusedElementPresentation {
+  readonly boxShadow: string;
+}
+
 const checkboxTheme = `
   @theme {
     --spacing: 0.25rem;
@@ -22,6 +26,35 @@ const checkboxTheme = `
   }
   @tailwind utilities;
 `;
+
+const focusedElementTheme = `
+  @theme {
+    --color-ring: rgb(10 20 30);
+  }
+  @tailwind utilities;
+`;
+
+export async function renderedFocusedElementPresentation(
+  element: HTMLElement,
+  signal: AbortSignal,
+): Promise<FocusedElementPresentation> {
+  const compiler = await compile(focusedElementTheme);
+  const styleElement = document.createElement("style");
+  styleElement.textContent = [
+    "* { box-shadow: none; }",
+    compiler.build([...element.classList]),
+  ].join("\n");
+  document.head.append(styleElement);
+  signal.addEventListener(
+    "abort",
+    () => {
+      styleElement.remove();
+    },
+    { once: true },
+  );
+
+  return { boxShadow: getComputedStyle(element).boxShadow };
+}
 
 export async function renderedCheckboxPresentation(
   checkbox: HTMLElement,

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-error-alert.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-error-alert.tsx
@@ -12,7 +12,7 @@ export function AuthV2ErrorAlert({
   return (
     <Alert
       aria-atomic="true"
-      className="px-3 py-2 text-xs text-red-700 outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 dark:text-red-300"
+      className="px-3 py-2 text-xs text-red-700 outline-none dark:text-red-300"
       id={id}
       ref={(element) => {
         if (!element || element.dataset.authV2ErrorFocusKey === focusKey) {

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -1806,6 +1806,11 @@ describe("auth v2 sign-in flow", () => {
     const mismatchAlert = await screen.findByRole("alert");
     expect(mismatchAlert).toHaveTextContent("Passwords don't match.");
     expect(document.activeElement).toBe(mismatchAlert);
+    expect(mismatchAlert).not.toHaveClass(
+      "focus:ring-2",
+      "focus:ring-ring",
+      "focus:ring-offset-2",
+    );
     expectNoFieldErrorAssociation(newPasswordInput);
     expectFieldErrorAssociation(confirmPasswordInput, mismatchAlert);
     expect(mockedClerk.signInResetPassword).not.toHaveBeenCalled();

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -28,7 +28,10 @@ import { detachedNavigateTo$ } from "../../../../signals/route.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
 import { mockNow } from "../../../../lib/time.ts";
 import { renderedIdentityEditPresentation } from "../../__tests__/auth-v2-button-style-assertions.ts";
-import { renderedCheckboxPresentation } from "../../__tests__/auth-v2-style-assertions.ts";
+import {
+  renderedCheckboxPresentation,
+  renderedFocusedElementPresentation,
+} from "../../__tests__/auth-v2-style-assertions.ts";
 
 const context = testContext();
 
@@ -1806,11 +1809,9 @@ describe("auth v2 sign-in flow", () => {
     const mismatchAlert = await screen.findByRole("alert");
     expect(mismatchAlert).toHaveTextContent("Passwords don't match.");
     expect(document.activeElement).toBe(mismatchAlert);
-    expect(mismatchAlert).not.toHaveClass(
-      "focus:ring-2",
-      "focus:ring-ring",
-      "focus:ring-offset-2",
-    );
+    await expect(
+      renderedFocusedElementPresentation(mismatchAlert, context.signal),
+    ).resolves.toStrictEqual({ boxShadow: "none" });
     expectNoFieldErrorAssociation(newPasswordInput);
     expectFieldErrorAssociation(confirmPasswordInput, mismatchAlert);
     expect(mockedClerk.signInResetPassword).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- keep Auth v2 error alerts programmatically focused for assistive technology
- remove the visible focus ring from the non-interactive destructive alert surface
- cover the visual class contract in the existing password-reset page flow

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx --silent=passed-only` (58 tests)
- `pnpm exec prettier --check apps/platform/src/views/auth-v2/auth-v2-error-alert.tsx apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx`
- targeted Oxlint and ESLint for both changed files
- `pnpm -F @okouai/app check-types`
