### PR TITLE
fix(platform): clarify connector account and agent summaries

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2493,7 +2493,7 @@
       "access": {
         "add": "Zugriff hinzufügen",
         "manage": "Verwalten Sie den {{connector}}-Zugriff",
-        "summaryMany": "{{value}} Agents",
+        "summaryMany": "{{value}} Agenten",
         "unavailable": "Zugriff nicht verfügbar",
         "usedBy": "Verwendet von "
       },

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2427,7 +2427,7 @@
       "summaryOne": "{{value}} Konto",
       "summaryOne_one": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} erfordern Aufmerksamkeit",
+      "summaryWithAttention": "{{value}}/{{total}} erfordern Aufmerksamkeit",
       "summaryWithAttention_one": "",
       "summaryWithAttention_other": ""
     },

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2429,8 +2429,7 @@
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} erfordern Aufmerksamkeit",
       "summaryWithAttention_one": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Anwenden",
@@ -2494,6 +2493,8 @@
       "access": {
         "add": "Zugriff hinzufügen",
         "manage": "Verwalten Sie den {{connector}}-Zugriff",
+        "summaryMany": "{{value}} Agents",
+        "unavailable": "Zugriff nicht verfügbar",
         "usedBy": "Verwendet von "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2421,8 +2421,7 @@
       "skipName": "Skip",
       "summaryMany": "{{value}} accounts",
       "summaryOne": "{{value}} account",
-      "summaryWithAttention": "{{summary}} · {{value}} need attention",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention": "{{summary}} · {{value}} need attention"
     },
     "actions": {
       "apply": "Apply",
@@ -2486,6 +2485,8 @@
       "access": {
         "add": "Add access",
         "manage": "Manage {{connector}} access",
+        "summaryMany": "{{value}} agents",
+        "unavailable": "Access unavailable",
         "usedBy": "Used by "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2421,7 +2421,7 @@
       "skipName": "Skip",
       "summaryMany": "{{value}} accounts",
       "summaryOne": "{{value}} account",
-      "summaryWithAttention": "{{summary}} · {{value}} need attention"
+      "summaryWithAttention": "{{value}}/{{total}} need attention"
     },
     "actions": {
       "apply": "Apply",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2477,8 +2477,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} requieren atención",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Aplicar",
@@ -2542,6 +2541,8 @@
       "access": {
         "add": "Añadir acceso",
         "manage": "Gestionar el acceso a {{connector}}",
+        "summaryMany": "{{value}} agentes",
+        "unavailable": "Acceso no disponible",
         "usedBy": "Utilizado por"
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2474,7 +2474,7 @@
       "summaryOne_one": "",
       "summaryOne_many": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} requieren atención",
+      "summaryWithAttention": "{{value}}/{{total}} requieren atención",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": ""

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2477,8 +2477,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} nécessitent votre attention",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Appliquer",
@@ -2542,6 +2541,8 @@
       "access": {
         "add": "Ajouter l'accès",
         "manage": "Gérer l'accès à {{connector}}",
+        "summaryMany": "{{value}} agents",
+        "unavailable": "Accès indisponible",
         "usedBy": "Utilisé par"
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2474,7 +2474,7 @@
       "summaryOne_one": "",
       "summaryOne_many": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} nécessitent votre attention",
+      "summaryWithAttention": "{{value}}/{{total}} nécessitent votre attention",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": ""

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2429,8 +2429,7 @@
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} पर ध्यान देना आवश्यक है",
       "summaryWithAttention_one": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "आवेदन करना",
@@ -2494,6 +2493,8 @@
       "access": {
         "add": "पहुंच जोड़ें",
         "manage": "{{connector}} पहुंच प्रबंधित करें",
+        "summaryMany": "{{value}} एजेंट",
+        "unavailable": "पहुंच उपलब्ध नहीं है",
         "usedBy": "द्वारा उपयोग किया जाता है"
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2427,7 +2427,7 @@
       "summaryOne": "{{value}} खाता",
       "summaryOne_one": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} पर ध्यान देना आवश्यक है",
+      "summaryWithAttention": "{{value}}/{{total}} पर ध्यान देना आवश्यक है",
       "summaryWithAttention_one": "",
       "summaryWithAttention_other": ""
     },

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2421,8 +2421,7 @@
       "summaryOne": "{{value}} akun",
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} memerlukan perhatian",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Terapkan",
@@ -2486,6 +2485,8 @@
       "access": {
         "add": "Tambah akses",
         "manage": "Kelola akses {{connector}}",
+        "summaryMany": "{{value}} agen",
+        "unavailable": "Akses tidak tersedia",
         "usedBy": "Digunakan oleh "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2420,7 +2420,7 @@
       "summaryMany_other": "",
       "summaryOne": "{{value}} akun",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} memerlukan perhatian",
+      "summaryWithAttention": "{{value}}/{{total}} memerlukan perhatian",
       "summaryWithAttention_other": ""
     },
     "actions": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2477,8 +2477,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} richiedono attenzione",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Applicare",
@@ -2542,6 +2541,8 @@
       "access": {
         "add": "Aggiungi accesso",
         "manage": "Gestisci l'accesso {{connector}}",
+        "summaryMany": "{{value}} agent",
+        "unavailable": "Accesso non disponibile",
         "usedBy": "Utilizzato da "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2474,7 +2474,7 @@
       "summaryOne_one": "",
       "summaryOne_many": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} richiedono attenzione",
+      "summaryWithAttention": "{{value}}/{{total}} richiedono attenzione",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": ""

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2541,7 +2541,7 @@
       "access": {
         "add": "Aggiungi accesso",
         "manage": "Gestisci l'accesso {{connector}}",
-        "summaryMany": "{{value}} agent",
+        "summaryMany": "{{value}} agenti",
         "unavailable": "Accesso non disponibile",
         "usedBy": "Utilizzato da "
       },

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2420,7 +2420,7 @@
       "summaryMany_other": "",
       "summaryOne": "{{value}} 件のアカウント",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} 件に対応が必要",
+      "summaryWithAttention": "{{value}}/{{total}} 件に対応が必要",
       "summaryWithAttention_other": ""
     },
     "actions": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2421,8 +2421,7 @@
       "summaryOne": "{{value}} 件のアカウント",
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}} 件に対応が必要",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "申し込む",
@@ -2486,6 +2485,8 @@
       "access": {
         "add": "アクセス権の追加",
         "manage": "{{connector}} アクセスを管理する",
+        "summaryMany": "{{value}} 件のエージェント",
+        "unavailable": "アクセスを利用できません",
         "usedBy": "使用者 "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2421,8 +2421,7 @@
       "summaryOne": "계정 {{value}}개",
       "summaryOne_other": "",
       "summaryWithAttention": "{{summary}} · {{value}}개에 주의 필요",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "적용",
@@ -2486,6 +2485,8 @@
       "access": {
         "add": "접근 권한 추가",
         "manage": "{{connector}} 접근 권한 관리",
+        "summaryMany": "에이전트 {{value}}개",
+        "unavailable": "접근 권한을 사용할 수 없음",
         "usedBy": "사용 중 "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2420,7 +2420,7 @@
       "summaryMany_other": "",
       "summaryOne": "계정 {{value}}개",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}}개에 주의 필요",
+      "summaryWithAttention": "{{value}}/{{total}}개에 주의 필요",
       "summaryWithAttention_other": ""
     },
     "actions": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2477,8 +2477,7 @@
       "summaryWithAttention": "{{summary}} · {{value}} precisam de atenção",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
-      "summaryWithAttention_other": "",
-      "summaryWithDefault": "{{summary}} · {{account}}"
+      "summaryWithAttention_other": ""
     },
     "actions": {
       "apply": "Aplicar",
@@ -2542,6 +2541,8 @@
       "access": {
         "add": "Adicionar acesso",
         "manage": "Gerenciar acesso ao {{connector}}",
+        "summaryMany": "{{value}} agentes",
+        "unavailable": "Acesso indisponível",
         "usedBy": "Usado por "
       },
       "categories": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2474,7 +2474,7 @@
       "summaryOne_one": "",
       "summaryOne_many": "",
       "summaryOne_other": "",
-      "summaryWithAttention": "{{summary}} · {{value}} precisam de atenção",
+      "summaryWithAttention": "{{value}}/{{total}} precisam de atenção",
       "summaryWithAttention_one": "",
       "summaryWithAttention_many": "",
       "summaryWithAttention_other": ""

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -870,7 +870,11 @@ type DialogState =
   | { kind: "create" }
   | { kind: "edit"; connector: CustomConnectorResponse }
   | { kind: "connect"; connector: CustomConnectorResponse }
-  | { kind: "access"; connector: CustomConnectorResponse }
+  | {
+      kind: "access";
+      connector: CustomConnectorResponse;
+      allowAccessIncrease: boolean;
+    }
   | { kind: "delete"; connector: CustomConnectorResponse };
 
 const internalDialog$ = state<DialogState>({ kind: "none" });
@@ -919,8 +923,14 @@ export const openCustomConnectorConnectDialog$ = command(
   },
 );
 export const openCustomConnectorAccessDialog$ = command(
-  ({ set }, connector: CustomConnectorResponse) => {
-    set(internalDialog$, { kind: "access", connector });
+  (
+    { set },
+    args: {
+      readonly connector: CustomConnectorResponse;
+      readonly allowAccessIncrease: boolean;
+    },
+  ) => {
+    set(internalDialog$, { kind: "access", ...args });
   },
 );
 export const openCustomConnectorDeleteDialog$ = command(

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -870,11 +870,7 @@ type DialogState =
   | { kind: "create" }
   | { kind: "edit"; connector: CustomConnectorResponse }
   | { kind: "connect"; connector: CustomConnectorResponse }
-  | {
-      kind: "access";
-      connector: CustomConnectorResponse;
-      allowAccessIncrease: boolean;
-    }
+  | { kind: "access"; connector: CustomConnectorResponse }
   | { kind: "delete"; connector: CustomConnectorResponse };
 
 const internalDialog$ = state<DialogState>({ kind: "none" });
@@ -923,14 +919,8 @@ export const openCustomConnectorConnectDialog$ = command(
   },
 );
 export const openCustomConnectorAccessDialog$ = command(
-  (
-    { set },
-    args: {
-      readonly connector: CustomConnectorResponse;
-      readonly allowAccessIncrease: boolean;
-    },
-  ) => {
-    set(internalDialog$, { kind: "access", ...args });
+  ({ set }, connector: CustomConnectorResponse) => {
+    set(internalDialog$, { kind: "access", connector });
   },
 );
 export const openCustomConnectorDeleteDialog$ = command(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1486,6 +1486,33 @@ describe("connectors page", () => {
     });
   });
 
+  it("keeps the zero-account connect action disabled while connection starts", async () => {
+    mockConnectors([]);
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, { summaries: [] });
+    });
+    const authWindow = createMockAuthWindow();
+    const openMock = context.mocks.browser.open(authWindow);
+    context.mocks.api(connectorOauthStartContract.start, ({ never }) => {
+      return never();
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const connectAction = await screen.findByLabelText("Connect GitHub");
+    click(connectAction);
+
+    await waitFor(() => {
+      expect(openMock.calls).toHaveLength(1);
+      expect(connectAction).toBeDisabled();
+    });
+    expect(screen.getByLabelText("Connect GitHub")).toBe(connectAction);
+  });
+
   it("shows an account identity while agent access is unavailable", async () => {
     const [connector] = mockConnectors([
       { connectorSlug: "github", externalUsername: "work" },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1579,17 +1579,13 @@ describe("connectors page", () => {
     });
   });
 
-  it("keeps retained agent access revocable after the last account is removed", async () => {
+  it("shows the connector description after the last account is removed", async () => {
     const researchAgentId = "c0000000-0000-4000-a000-000000000001";
-    const supportAgentId = "c0000000-0000-4000-a000-000000000002";
     mockConnectors([]);
     context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
       return respond(200, { summaries: [] });
     });
-    context.mocks.data.agents([
-      listAgent(researchAgentId, "Research"),
-      listAgent(supportAgentId, "Support"),
-    ]);
+    context.mocks.data.agents([listAgent(researchAgentId, "Research")]);
     context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
       return respond(200, {
         enabledConnectorSlugs: params.id === researchAgentId ? ["github"] : [],
@@ -1605,28 +1601,18 @@ describe("connectors page", () => {
       featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
     });
 
-    const card = await waitFor(() => {
+    await waitFor(() => {
       const githubCard = connectorCardByLabel("GitHub");
-      expect(within(githubCard).getByText("No accounts")).toBeInTheDocument();
       expect(
-        within(githubCard).getByTestId("connector-card-agent-access"),
-      ).toHaveTextContent("Used by Research");
-      return githubCard;
+        within(githubCard).getByTestId("connector-help-text"),
+      ).toHaveTextContent(
+        "Connect your GitHub account to access repositories and GitHub features.",
+      );
+      expect(within(githubCard).queryByText("No accounts")).toBeNull();
+      expect(
+        within(githubCard).queryByTestId("connector-card-agent-access"),
+      ).toBeNull();
     });
-    const connectButton = within(card).getByLabelText("Connect GitHub");
-    const manageAccess = within(card).getByLabelText("Manage GitHub access");
-    expect(connectButton).not.toContainElement(manageAccess);
-    click(manageAccess);
-
-    const dialog = await screen.findByRole("dialog", {
-      name: "Manage GitHub access",
-    });
-    expect(
-      within(dialog).getByLabelText("Revoke GitHub access for Research"),
-    ).toBeEnabled();
-    expect(
-      within(dialog).getByLabelText("Authorize GitHub access for Support"),
-    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("names the exact account after a feature-on manual account addition", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -6537,6 +6537,87 @@ describe("connectors page", () => {
     expect(oauthStartCount).toBe(1);
   });
 
+  it("updates custom connector access eligibility while the dialog is open", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000051";
+    const supportAgentId = "c0000000-0000-4000-a000-000000000052";
+    const connector = customConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+    });
+    context.mocks.data.agents([
+      listAgent(researchAgentId, "Research"),
+      listAgent(supportAgentId, "Support"),
+    ]);
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(
+      agentCustomConnectorsContract.get,
+      ({ params, respond }) => {
+        const grants: AgentCustomConnectorGrant[] =
+          params.id === researchAgentId
+            ? [{ customConnectorId: connector.id, permissionNames: [] }]
+            : [];
+        return respond(200, { grants });
+      },
+    );
+    let summariesRequestStarted = false;
+    let resolveSummaries = (): void => {
+      throw new Error("Account summaries request did not start");
+    };
+    context.mocks.api(
+      connectorAccountsContract.summaries,
+      async ({ deferred, respond }) => {
+        const summariesDeferred = deferred<void>();
+        resolveSummaries = () => {
+          summariesDeferred.resolve();
+        };
+        summariesRequestStarted = true;
+        await summariesDeferred.promise;
+        return respond(200, {
+          summaries: [
+            {
+              target: {
+                kind: "custom",
+                customConnectorId: connector.id,
+              },
+              accountCount: 1,
+              attentionCount: 0,
+              defaultConnection: null,
+            },
+          ],
+        });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors?tab=custom",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    await waitFor(() => {
+      expect(summariesRequestStarted).toBeTruthy();
+      expect(
+        screen.getByLabelText("Manage Acme Search access"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Manage Acme Search access"));
+    const accessDialog = await screen.findByRole("dialog", {
+      name: "Manage Acme Search access",
+    });
+    const supportAccessSwitch = within(accessDialog).getByLabelText(
+      "Authorize Acme Search access for Support",
+    );
+    expect(supportAccessSwitch).toHaveAttribute("aria-disabled", "true");
+
+    resolveSummaries();
+
+    await waitFor(() => {
+      expect(supportAccessSwitch).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
   it.each([
     { label: "HTTP", connector: customConnector({}) },
     { label: "MCP", connector: mcpCustomConnector({ connected: false }) },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2969,7 +2969,7 @@ describe("connectors page", () => {
       const access = within(card).getByLabelText("Manage GitHub access");
       expect(access.textContent).toContain("Used by\u00a04 agents");
       expect(access).not.toHaveTextContent("Growth");
-      expect(access).toHaveAttribute("title", "Research, Support, Growth, Ops");
+      expect(access).not.toHaveAttribute("title");
     });
 
     click(
@@ -7190,7 +7190,7 @@ describe("connectors page", () => {
       within(connectorCardByLabel("Acme API")).getByTestId(
         "connector-card-agent-access",
       ),
-    ).toHaveAttribute("title", "Zero, Research, Support");
+    ).not.toHaveAttribute("title");
     expect(
       within(connectorCardByLabel("Acme API")).getByText(
         "https://api.acme.test/v1/",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -4949,7 +4949,9 @@ describe("connectors page", () => {
       expect(
         within(card).queryByTestId("connector-card-agent-access"),
       ).not.toBeInTheDocument();
-      expect(card).toHaveAccessibleName("Connect Acme Search");
+      expect(within(card).getByLabelText("Connect Acme Search").tagName).toBe(
+        "BUTTON",
+      );
     });
 
     click(screen.getByLabelText("More options"));
@@ -6663,6 +6665,21 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(supportAccessSwitch).not.toHaveAttribute("aria-disabled", "true");
     });
+    click(within(accessDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Manage Acme Search access" }),
+      ).toBeNull();
+    });
+    const manageAccounts = await waitForButtonByAriaLabel(
+      "Manage Acme Search accounts",
+    );
+    const manageAccess = within(
+      connectorCardByLabel("Acme Search"),
+    ).getByLabelText("Manage Acme Search access");
+    expect(manageAccounts.tagName).toBe("BUTTON");
+    expect(manageAccounts.querySelector("button")).toBeNull();
+    expect(manageAccounts).not.toContainElement(manageAccess);
   });
 
   it.each([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1462,6 +1462,30 @@ describe("connectors page", () => {
     });
   });
 
+  it("shows the connector description when there are no accounts or agent access", async () => {
+    mockConnectors([]);
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, { summaries: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("GitHub");
+      expect(within(card).getByTestId("connector-help-text")).toHaveTextContent(
+        "Connect your GitHub account to access repositories and GitHub features.",
+      );
+      expect(within(card).queryByText("No accounts")).toBeNull();
+      expect(
+        within(card).queryByTestId("connector-card-agent-access"),
+      ).toBeNull();
+    });
+  });
+
   it("shows an account identity while agent access is unavailable", async () => {
     const [connector] = mockConnectors([
       { connectorSlug: "github", externalUsername: "work" },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1490,7 +1490,7 @@ describe("connectors page", () => {
         summaries: [
           {
             target: account.target,
-            accountCount: 1,
+            accountCount: 2,
             attentionCount: 1,
             defaultConnection: account,
           },
@@ -1514,13 +1514,44 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       const card = connectorCardByLabel("GitHub");
-      expect(
-        within(card).getByText("Work · 1 need attention"),
-      ).toBeInTheDocument();
+      expect(within(card).getByText("1/2 need attention")).toBeInTheDocument();
       expect(within(card).getByText("Access unavailable")).toBeInTheDocument();
       expect(
         within(card).getByLabelText("Manage GitHub access"),
       ).toBeDisabled();
+    });
+  });
+
+  it("shows when every connector account needs attention", async () => {
+    const [connector] = mockConnectors([
+      { connectorSlug: "github", externalUsername: "work" },
+    ]);
+    if (!connector) {
+      throw new Error("Expected GitHub fixture connector");
+    }
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: { kind: "builtin", connectorSlug: "github" },
+            accountCount: 2,
+            attentionCount: 2,
+            defaultConnection: null,
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        within(connectorCardByLabel("GitHub")).getByText("2/2 need attention"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -1671,7 +1702,9 @@ describe("connectors page", () => {
     });
 
     await waitFor(() => {
-      expect(connectorCardByLabel("GitHub")).toHaveTextContent("7 accounts");
+      expect(connectorCardByLabel("GitHub")).toHaveTextContent(
+        "1/7 need attention",
+      );
     });
     const manageAccounts = await waitForButtonByAriaLabel(
       "Manage GitHub accounts",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1462,6 +1462,118 @@ describe("connectors page", () => {
     });
   });
 
+  it("shows an account identity while agent access is unavailable", async () => {
+    const [connector] = mockConnectors([
+      { connectorSlug: "github", externalUsername: "work" },
+    ]);
+    if (!connector) {
+      throw new Error("Expected GitHub fixture connector");
+    }
+    const account = {
+      id: connector.id,
+      target: { kind: "builtin" as const, connectorSlug: "github" },
+      authMethod: connector.authMethod,
+      displayName: "Work",
+      isDefault: true,
+      externalId: null,
+      externalUsername: "work",
+      externalEmail: null,
+      oauthScopes: [],
+      connectionStatus: "reconnect-required" as const,
+      reconnectReason: "authorization_expired_or_revoked" as const,
+      tokenExpiresAt: null,
+      createdAt: connector.createdAt,
+      updatedAt: connector.updatedAt,
+    } satisfies ConnectorAccountConnection;
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: account.target,
+            accountCount: 1,
+            attentionCount: 1,
+            defaultConnection: account,
+          },
+        ],
+      });
+    });
+    context.mocks.data.agents([
+      listAgent("c0000000-0000-4000-a000-000000000001", "Research"),
+    ]);
+    context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+      return respond(500, {
+        error: { message: "Agent access unavailable", code: "UNAVAILABLE" },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("GitHub");
+      expect(
+        within(card).getByText("Work · 1 need attention"),
+      ).toBeInTheDocument();
+      expect(within(card).getByText("Access unavailable")).toBeInTheDocument();
+      expect(
+        within(card).getByLabelText("Manage GitHub access"),
+      ).toBeDisabled();
+    });
+  });
+
+  it("keeps retained agent access revocable after the last account is removed", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000001";
+    const supportAgentId = "c0000000-0000-4000-a000-000000000002";
+    mockConnectors([]);
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, { summaries: [] });
+    });
+    context.mocks.data.agents([
+      listAgent(researchAgentId, "Research"),
+      listAgent(supportAgentId, "Support"),
+    ]);
+    context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
+      return respond(200, {
+        enabledConnectorSlugs: params.id === researchAgentId ? ["github"] : [],
+      });
+    });
+    context.mocks.api(userPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    const card = await waitFor(() => {
+      const githubCard = connectorCardByLabel("GitHub");
+      expect(within(githubCard).getByText("No accounts")).toBeInTheDocument();
+      expect(
+        within(githubCard).getByTestId("connector-card-agent-access"),
+      ).toHaveTextContent("Used by Research");
+      return githubCard;
+    });
+    const connectButton = within(card).getByLabelText("Connect GitHub");
+    const manageAccess = within(card).getByLabelText("Manage GitHub access");
+    expect(connectButton).not.toContainElement(manageAccess);
+    click(manageAccess);
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(
+      within(dialog).getByLabelText("Revoke GitHub access for Research"),
+    ).toBeEnabled();
+    expect(
+      within(dialog).getByLabelText("Authorize GitHub access for Support"),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
   it("names the exact account after a feature-on manual account addition", async () => {
     mockConnectors([]);
     const connectionId = crypto.randomUUID();
@@ -2778,7 +2890,7 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows authorized agent names with an overflow count on connector cards", async () => {
+  it("shows an exact authorized-agent count on connector cards", async () => {
     const agentIds = [
       "c0000000-0000-4000-a000-000000000001",
       "c0000000-0000-4000-a000-000000000002",
@@ -2812,10 +2924,9 @@ describe("connectors page", () => {
     await waitFor(() => {
       const card = connectorCardByLabel("GitHub");
       const access = within(card).getByLabelText("Manage GitHub access");
-      expect(access.textContent).toContain("Used by\u00a0Research, Support");
-      expect(access).toHaveTextContent("Research, Support");
-      expect(access).toHaveTextContent("+2");
+      expect(access.textContent).toContain("Used by\u00a04 agents");
       expect(access).not.toHaveTextContent("Growth");
+      expect(access).toHaveAttribute("title", "Research, Support, Growth, Ops");
     });
 
     click(
@@ -4512,7 +4623,9 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(
-        within(connectorCardByLabel("AWS")).getByText("Connected"),
+        within(connectorCardByLabel("AWS")).getByText(
+          "arn:aws:iam::000000000000:user/mock-aws",
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -5458,7 +5571,7 @@ describe("connectors page", () => {
         within(connectorCardByLabel("Acme MCP")).getByTestId(
           "connector-card-agent-access",
         ),
-      ).toHaveTextContent("Used by Research, Support");
+      ).toHaveTextContent("Used by 2 agents");
       expect(
         within(connectorCardByLabel("Acme MCP")).getByText("Connected"),
       ).toBeInTheDocument();
@@ -6369,7 +6482,7 @@ describe("connectors page", () => {
       expect(within(card).getByText("Connected")).toBeInTheDocument();
       expect(
         within(card).getByTestId("connector-card-agent-access"),
-      ).toHaveTextContent("Used by Zero, Research");
+      ).toHaveTextContent("Used by 2 agents");
     });
     expect(browserOpen.calls).toStrictEqual([
       {
@@ -6489,7 +6602,7 @@ describe("connectors page", () => {
       await waitFor(() => {
         expect(
           within(connectorCardByLabel(connector.displayName)).getByText(
-            "Connected",
+            `Account #${connectionId.slice(0, 8)}`,
           ),
         ).toBeInTheDocument();
       });
@@ -6853,7 +6966,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(
         within(connectorCardByLabel(connector.displayName)).getByText(
-          "Connected",
+          `Account #${connectionId.slice(0, 8)}`,
         ),
       ).toBeInTheDocument();
     });
@@ -6927,7 +7040,7 @@ describe("connectors page", () => {
       expect(within(card).getByText("Connected")).toBeInTheDocument();
       expect(
         within(card).getByTestId("connector-card-agent-access"),
-      ).toHaveTextContent("Used by Zero, Research +1");
+      ).toHaveTextContent("Used by 3 agents");
     });
     expect(
       within(connectorCardByLabel("Acme API")).getByTestId(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2984,6 +2984,26 @@ describe("connectors page", () => {
     expect(dialog).toBeInTheDocument();
   });
 
+  it("keeps a single long authorized-agent name available on the card", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+    const agentName = "Research Operations for International Partnerships";
+    mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);
+    context.mocks.data.agents([listAgent(agentId, agentName)]);
+    context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledConnectorSlugs: ["github"] });
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      const access = within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      );
+      expect(access).toHaveTextContent(`Used by ${agentName}`);
+      expect(access).toHaveAttribute("title", agentName);
+    });
+  });
+
   it("shows an add-access affordance when no agents are authorized", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000001";
     mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
@@ -70,6 +70,7 @@ import { IconTooltipButton } from "../../../components/icon-tooltip.tsx";
 interface ConnectorAccessManagementDialogProps {
   readonly connectorSlug: ConnectorSlug;
   readonly connectorLabel: string;
+  readonly allowAccessIncrease: boolean;
   readonly onClose: () => void;
 }
 
@@ -459,6 +460,7 @@ function AgentPermissionDialog({
 export function ConnectorAccessManagementDialog({
   connectorSlug,
   connectorLabel,
+  allowAccessIncrease,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
   const { t } = useTranslation();
@@ -528,6 +530,7 @@ export function ConnectorAccessManagementDialog({
         rows={filterRows(rows, search)}
         rowsLoaded={rowsLoadable.state === "hasData"}
         hasPermissions={(metadata?.permissionCount ?? 0) > 0}
+        allowAccessIncrease={allowAccessIncrease}
         savingAgentId={savingAgentId}
         search={search}
         onSearchChange={setSearch}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
@@ -34,9 +34,8 @@ export function ConnectorAgentAccessButton({
   const unnamed = t(($) => {
     return $.connectors.catalog.unnamedAgent;
   });
-  const agentNames = agents.map((agent) => {
-    return agent.displayName ?? unnamed;
-  });
+  const singleAgentName =
+    agents.length === 1 ? (agents[0]?.displayName ?? unnamed) : undefined;
 
   if (status === "ready" && agents.length === 0 && !allowAccessIncrease) {
     return null;
@@ -55,7 +54,7 @@ export function ConnectorAgentAccessButton({
         { connector: connectorLabel },
       )}
       data-testid="connector-card-agent-access"
-      title={agents.length === 1 ? agentNames[0] : undefined}
+      title={singleAgentName}
       disabled={status !== "ready"}
       onClick={onClick}
     >
@@ -89,7 +88,7 @@ export function ConnectorAgentAccessButton({
             data-testid="connector-card-access-names"
           >
             {agents.length === 1
-              ? agentNames[0]
+              ? singleAgentName
               : t(
                   ($) => {
                     return $.connectors.catalog.access.summaryMany;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
@@ -47,7 +47,7 @@ export function ConnectorAgentAccessButton({
       type="button"
       variant="quiet"
       size="xs"
-      className="min-w-0 gap-0 px-2 text-xs"
+      className="min-w-0 max-w-full gap-0 px-2 text-xs"
       aria-label={t(
         ($) => {
           return $.connectors.catalog.access.manage;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
@@ -1,25 +1,32 @@
 import { useTranslation } from "react-i18next";
+import type { LoadableState } from "ccstate-react";
 import { Button } from "@okouai/ui";
 import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
 
-const AGENT_NAME_LIMIT = 2;
-const AGENT_NAME_MAX_CHARS = 12;
+export type ConnectorAgentAccessStatus = "loading" | "unavailable" | "ready";
 
-function truncateAgentName(name: string): string {
-  if (name.length <= AGENT_NAME_MAX_CHARS) {
-    return name;
+export function connectorAgentAccessStatus(
+  state: LoadableState,
+): ConnectorAgentAccessStatus {
+  if (state === "hasData") {
+    return "ready";
   }
-  return `${name.slice(0, AGENT_NAME_MAX_CHARS - 1)}…`;
+  if (state === "hasError") {
+    return "unavailable";
+  }
+  return "loading";
 }
 
 export function ConnectorAgentAccessButton({
   agents,
-  loading,
+  status,
+  allowAccessIncrease,
   connectorLabel,
   onClick,
 }: {
   readonly agents: readonly AgentResponse[];
-  readonly loading: boolean;
+  readonly status: ConnectorAgentAccessStatus;
+  readonly allowAccessIncrease: boolean;
   readonly connectorLabel: string;
   readonly onClick: () => void;
 }) {
@@ -30,10 +37,10 @@ export function ConnectorAgentAccessButton({
   const agentNames = agents.map((agent) => {
     return agent.displayName ?? unnamed;
   });
-  const visibleNames = agentNames.slice(0, AGENT_NAME_LIMIT).map((name) => {
-    return truncateAgentName(name);
-  });
-  const overflowCount = agents.length - visibleNames.length;
+
+  if (status === "ready" && agents.length === 0 && !allowAccessIncrease) {
+    return null;
+  }
 
   return (
     <Button
@@ -49,10 +56,17 @@ export function ConnectorAgentAccessButton({
       )}
       data-testid="connector-card-agent-access"
       title={agentNames.length > 0 ? agentNames.join(", ") : undefined}
+      disabled={status !== "ready"}
       onClick={onClick}
     >
-      {loading ? (
+      {status === "loading" ? (
         <span className="block h-3 w-20 animate-pulse rounded bg-muted" />
+      ) : status === "unavailable" ? (
+        <span className="truncate text-muted-foreground">
+          {t(($) => {
+            return $.connectors.catalog.access.unavailable;
+          })}
+        </span>
       ) : agents.length === 0 ? (
         <span
           className="underline decoration-dotted decoration-muted-foreground/40 underline-offset-2"
@@ -74,13 +88,15 @@ export function ConnectorAgentAccessButton({
             className="min-w-0 truncate underline decoration-dotted decoration-muted-foreground/40 underline-offset-2"
             data-testid="connector-card-access-names"
           >
-            {visibleNames.join(", ")}
+            {agents.length === 1
+              ? agentNames[0]
+              : t(
+                  ($) => {
+                    return $.connectors.catalog.access.summaryMany;
+                  },
+                  { value: agents.length },
+                )}
           </span>
-          {overflowCount > 0 ? (
-            <span className="shrink-0 text-muted-foreground/70">
-              {"\u00a0"}+{overflowCount}
-            </span>
-          ) : null}
         </>
       )}
     </Button>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-agent-access-button.tsx
@@ -55,7 +55,7 @@ export function ConnectorAgentAccessButton({
         { connector: connectorLabel },
       )}
       data-testid="connector-card-agent-access"
-      title={agentNames.length > 0 ? agentNames.join(", ") : undefined}
+      title={agents.length === 1 ? agentNames[0] : undefined}
       disabled={status !== "ready"}
       onClick={onClick}
     >

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -565,7 +565,7 @@ function AccountsConnectorCard({
             status={summaryStatus}
             className="min-w-0 flex-1 text-xs text-muted-foreground"
           />
-          <div className="relative z-20">{manageAccess}</div>
+          <div className="relative z-20 min-w-0 max-w-full">{manageAccess}</div>
         </div>
       )}
     </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -66,6 +66,7 @@ type AccountsConnectorCardProps = {
   readonly connector: PlatformConnectorCatalogStatusItem;
   readonly summary: ConnectorAccountSummary | undefined;
   readonly summaryStatus: ConnectorAccountSummaryStatus;
+  readonly showCatalogDescription: boolean;
   readonly busy: boolean;
   readonly connect: ConnectorConnectHandlers;
   readonly manageAccess?: ReactNode;
@@ -468,6 +469,7 @@ function AccountsConnectorCard({
   connector,
   summary,
   summaryStatus,
+  showCatalogDescription,
   busy,
   connect,
   manageAccess,
@@ -475,6 +477,8 @@ function AccountsConnectorCard({
 }: AccountsConnectorCardProps) {
   const { t } = useTranslation();
   const accountCount = summary?.accountCount ?? 0;
+  const showDescription =
+    summaryStatus === "ready" && accountCount === 0 && showCatalogDescription;
   const canManage = summaryStatus === "ready" && accountCount > 0 && !busy;
   const canConnect = summaryStatus === "ready" && accountCount === 0 && !busy;
   const canActivate = canManage || canConnect;
@@ -491,6 +495,7 @@ function AccountsConnectorCard({
     <div
       className={cn(
         "zero-card relative flex flex-col text-left",
+        showDescription && "overflow-hidden",
         canActivate && "cursor-pointer",
       )}
     >
@@ -516,7 +521,12 @@ function AccountsConnectorCard({
           onClick={activate}
         />
       ) : null}
-      <div className="flex h-14 items-center gap-2.5 px-5">
+      <div
+        className={cn(
+          "flex items-center gap-2.5 px-5",
+          showDescription ? "pb-1 pt-4" : "h-14",
+        )}
+      >
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
           <ConnectorIcon icon={connector.icon} size={20} />
         </span>
@@ -542,14 +552,25 @@ function AccountsConnectorCard({
           </span>
         ) : null}
       </div>
-      <div className="flex h-11 items-center gap-2 border-t border-border/50 pl-5 pr-2">
-        <ConnectorAccountSummaryText
-          summary={summary}
-          status={summaryStatus}
-          className="min-w-0 flex-1 text-xs text-muted-foreground"
-        />
-        <div className="relative z-20">{manageAccess}</div>
-      </div>
+      {showDescription ? (
+        <div className="px-5 pb-4 pt-1">
+          <div
+            data-testid="connector-help-text"
+            className="line-clamp-2 text-xs text-muted-foreground"
+          >
+            {connector.description}
+          </div>
+        </div>
+      ) : (
+        <div className="flex h-11 items-center gap-2 border-t border-border/50 pl-5 pr-2">
+          <ConnectorAccountSummaryText
+            summary={summary}
+            status={summaryStatus}
+            className="min-w-0 flex-1 text-xs text-muted-foreground"
+          />
+          <div className="relative z-20">{manageAccess}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -385,40 +385,26 @@ export function ConnectorAccountSummaryText({
   }
   if (status === "unavailable") {
     return (
-      <span className={className}>
-        {t(($) => {
-          return $.connectors.accounts.accountsUnavailable;
-        })}
+      <span className={cn("flex min-w-0 items-center gap-2", className)}>
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
+        <span className="min-w-0 truncate text-amber-600 dark:text-amber-400">
+          {t(($) => {
+            return $.connectors.accounts.accountsUnavailable;
+          })}
+        </span>
       </span>
     );
   }
   const accountCount = summary?.accountCount ?? 0;
-  let summaryText =
-    accountCount === 0
-      ? t(($) => {
-          return $.connectors.accounts.noAccounts;
-        })
-      : accountCount === 1
-        ? t(
-            ($) => {
-              return $.connectors.accounts.summaryOne;
-            },
-            { value: accountCount },
-          )
-        : t(
-            ($) => {
-              return $.connectors.accounts.summaryMany;
-            },
-            { value: accountCount },
-          );
-  if (summary?.defaultConnection) {
-    summaryText = t(
-      ($) => {
-        return $.connectors.accounts.summaryWithDefault;
-      },
-      {
-        summary: summaryText,
-        account: connectorAccountEffectiveLabel(
+  let summaryText = (() => {
+    if (accountCount === 0) {
+      return t(($) => {
+        return $.connectors.accounts.noAccounts;
+      });
+    }
+    if (accountCount === 1) {
+      if (summary?.defaultConnection) {
+        return connectorAccountEffectiveLabel(
           summary.defaultConnection,
           t(
             ($) => {
@@ -426,10 +412,22 @@ export function ConnectorAccountSummaryText({
             },
             { id: summary.defaultConnection.id.slice(0, 8) },
           ),
-        ),
+        );
+      }
+      return t(
+        ($) => {
+          return $.connectors.accounts.summaryOne;
+        },
+        { value: accountCount },
+      );
+    }
+    return t(
+      ($) => {
+        return $.connectors.accounts.summaryMany;
       },
+      { value: accountCount },
     );
-  }
+  })();
   if (summary && summary.attentionCount > 0) {
     summaryText = t(
       ($) => {
@@ -438,7 +436,32 @@ export function ConnectorAccountSummaryText({
       { summary: summaryText, value: summary.attentionCount },
     );
   }
-  return <span className={className}>{summaryText}</span>;
+  return (
+    <span className={cn("flex min-w-0 items-center gap-2", className)}>
+      <span
+        className={cn(
+          "h-1.5 w-1.5 shrink-0 rounded-full",
+          accountCount === 0 && "bg-muted-foreground/50",
+          accountCount > 0 && summary?.attentionCount === 0 && "bg-emerald-500",
+          accountCount > 0 &&
+            summary !== undefined &&
+            summary.attentionCount > 0 &&
+            "bg-amber-500",
+        )}
+      />
+      <span
+        className={cn(
+          "min-w-0 truncate",
+          summary !== undefined &&
+            summary.attentionCount > 0 &&
+            "text-amber-600 dark:text-amber-400",
+        )}
+        title={summaryText}
+      >
+        {summaryText}
+      </span>
+    </span>
+  );
 }
 
 function AccountsConnectorCard({
@@ -452,35 +475,45 @@ function AccountsConnectorCard({
 }: AccountsConnectorCardProps) {
   const { t } = useTranslation();
   const accountCount = summary?.accountCount ?? 0;
-  if (summaryStatus === "ready" && accountCount === 0) {
-    return (
-      <CatalogConnectorCard
-        variant="catalog"
-        connector={connector}
-        busy={busy}
-        connect={connect}
-      />
-    );
-  }
   const canManage = summaryStatus === "ready" && accountCount > 0 && !busy;
+  const canConnect = summaryStatus === "ready" && accountCount === 0 && !busy;
+  const canActivate = canManage || canConnect;
+  const activate = () => {
+    if (canManage) {
+      onManage();
+      return;
+    }
+    if (canConnect) {
+      runConnect(connector, connect, busy);
+    }
+  };
   return (
     <div
       className={cn(
         "zero-card relative flex flex-col text-left",
-        canManage && "cursor-pointer",
+        canActivate && "cursor-pointer",
       )}
     >
-      {canManage ? (
+      {canActivate ? (
         <button
           type="button"
-          aria-label={t(
-            ($) => {
-              return $.connectors.accounts.managerTitle;
-            },
-            { connector: connector.label },
-          )}
+          aria-label={
+            canManage
+              ? t(
+                  ($) => {
+                    return $.connectors.accounts.managerTitle;
+                  },
+                  { connector: connector.label },
+                )
+              : t(
+                  ($) => {
+                    return $.connectors.card.connectAria;
+                  },
+                  { connector: connector.label },
+                )
+          }
           className="absolute inset-0 z-10 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          onClick={onManage}
+          onClick={activate}
         />
       ) : null}
       <div className="flex h-14 items-center gap-2.5 px-5">
@@ -493,35 +526,28 @@ function AccountsConnectorCard({
         >
           {connector.label}
         </span>
+        {accountCount === 0 && summaryStatus === "ready" ? (
+          <span
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+              !busy && "border border-border/60",
+            )}
+            aria-hidden="true"
+          >
+            {busy ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Plus size={14} />
+            )}
+          </span>
+        ) : null}
       </div>
       <div className="flex h-11 items-center gap-2 border-t border-border/50 pl-5 pr-2">
-        {summaryStatus === "ready" ? (
-          <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-xs text-muted-foreground">
-            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
-            <span>
-              {t(($) => {
-                return $.connectors.accounts.connected;
-              })}
-            </span>
-            {accountCount > 1 ? (
-              <span>
-                ·{" "}
-                {t(
-                  ($) => {
-                    return $.connectors.accounts.summaryMany;
-                  },
-                  { value: accountCount },
-                )}
-              </span>
-            ) : null}
-          </span>
-        ) : (
-          <ConnectorAccountSummaryText
-            summary={summary}
-            status={summaryStatus}
-            className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
-          />
-        )}
+        <ConnectorAccountSummaryText
+          summary={summary}
+          status={summaryStatus}
+          className="min-w-0 flex-1 text-xs text-muted-foreground"
+        />
         <div className="relative z-20">{manageAccess}</div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -66,7 +66,6 @@ type AccountsConnectorCardProps = {
   readonly connector: PlatformConnectorCatalogStatusItem;
   readonly summary: ConnectorAccountSummary | undefined;
   readonly summaryStatus: ConnectorAccountSummaryStatus;
-  readonly showCatalogDescription: boolean;
   readonly busy: boolean;
   readonly connect: ConnectorConnectHandlers;
   readonly manageAccess?: ReactNode;
@@ -469,7 +468,6 @@ function AccountsConnectorCard({
   connector,
   summary,
   summaryStatus,
-  showCatalogDescription,
   busy,
   connect,
   manageAccess,
@@ -477,8 +475,7 @@ function AccountsConnectorCard({
 }: AccountsConnectorCardProps) {
   const { t } = useTranslation();
   const accountCount = summary?.accountCount ?? 0;
-  const showDescription =
-    summaryStatus === "ready" && accountCount === 0 && showCatalogDescription;
+  const showDescription = summaryStatus === "ready" && accountCount === 0;
   const canManage = summaryStatus === "ready" && accountCount > 0 && !busy;
   const canConnect = summaryStatus === "ready" && accountCount === 0 && !busy;
   const canActivate = canManage || canConnect;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -476,10 +476,13 @@ function AccountsConnectorCard({
   const { t } = useTranslation();
   const accountCount = summary?.accountCount ?? 0;
   const showDescription = summaryStatus === "ready" && accountCount === 0;
-  const canManage = summaryStatus === "ready" && accountCount > 0 && !busy;
-  const canConnect = summaryStatus === "ready" && accountCount === 0 && !busy;
-  const canActivate = canManage || canConnect;
+  const canManage = summaryStatus === "ready" && accountCount > 0;
+  const canConnect = summaryStatus === "ready" && accountCount === 0;
+  const canActivate = !busy && (canManage || canConnect);
   const activate = () => {
+    if (!canActivate) {
+      return;
+    }
     if (canManage) {
       onManage();
       return;
@@ -496,7 +499,7 @@ function AccountsConnectorCard({
         canActivate && "cursor-pointer",
       )}
     >
-      {canActivate ? (
+      {canManage || canConnect ? (
         <button
           type="button"
           aria-label={
@@ -514,7 +517,11 @@ function AccountsConnectorCard({
                   { connector: connector.label },
                 )
           }
-          className="absolute inset-0 z-10 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className={cn(
+            "absolute inset-0 z-10 rounded-[inherit] border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            busy ? "cursor-default" : "cursor-pointer",
+          )}
+          disabled={busy}
           onClick={activate}
         />
       ) : null}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -433,7 +433,7 @@ export function ConnectorAccountSummaryText({
       ($) => {
         return $.connectors.accounts.summaryWithAttention;
       },
-      { summary: summaryText, value: summary.attentionCount },
+      { total: accountCount, value: summary.attentionCount },
     );
   }
   return (

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -234,6 +234,7 @@ function CustomConnectorCardFooter({
       )}
       {connector.connected || accountManagement ? (
         <div
+          className="min-w-0 max-w-full"
           onClick={(event) => {
             event.stopPropagation();
           }}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -233,15 +233,7 @@ function CustomConnectorCardFooter({
         <CustomConnectorConnectionStatus connected={connector.connected} />
       )}
       {connector.connected || accountManagement ? (
-        <div
-          className="min-w-0 max-w-full"
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          onKeyDown={(event) => {
-            event.stopPropagation();
-          }}
-        >
+        <div className="relative z-20 min-w-0 max-w-full">
           <CustomConnectorAgentAccess
             connector={connector}
             allowAccessIncrease={allowAccessIncrease}
@@ -276,36 +268,25 @@ function CustomConnectorActivationCard({
   readonly children: ReactNode;
 }) {
   const { t } = useTranslation();
-  const activate = () => {
-    if (canActivate) {
-      onActivate();
-    }
-  };
   return (
     <div
-      role={canActivate ? "button" : undefined}
-      tabIndex={canActivate ? 0 : undefined}
-      aria-label={
-        canActivate
-          ? t(
-              ($) => {
-                return managesAccounts
-                  ? $.connectors.accounts.managerTitle
-                  : $.connectors.card.connectAria;
-              },
-              { connector: connectorLabel },
-            )
-          : undefined
-      }
-      className={`zero-card flex flex-col ${canActivate ? "cursor-pointer" : ""}`}
-      onClick={activate}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          activate();
-        }
-      }}
+      className={`zero-card relative flex flex-col ${canActivate ? "cursor-pointer" : ""}`}
     >
+      {canActivate ? (
+        <button
+          type="button"
+          aria-label={t(
+            ($) => {
+              return managesAccounts
+                ? $.connectors.accounts.managerTitle
+                : $.connectors.card.connectAria;
+            },
+            { connector: connectorLabel },
+          )}
+          className="absolute inset-0 z-10 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onActivate}
+        />
+      ) : null}
       {children}
     </div>
   );
@@ -340,7 +321,7 @@ function CustomConnectorActions({
   }
   const directOAuth = connectsDirectlyWithOAuth(connector);
   return (
-    <div className="absolute bottom-2 right-2">
+    <div className="absolute bottom-2 right-2 z-20">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -47,7 +47,10 @@ import { CustomConnectorCreateDialog } from "./custom-connector-create-dialog.ts
 import { CustomConnectorConnectDialog } from "./custom-connector-connect-dialog.tsx";
 import { CustomConnectorDeleteConfirm } from "./custom-connector-delete-confirm.tsx";
 import { CustomConnectorAccessManagementDialog } from "./connector-access-management-dialog.tsx";
-import { ConnectorAgentAccessButton } from "./connector-agent-access-button.tsx";
+import {
+  ConnectorAgentAccessButton,
+  connectorAgentAccessStatus,
+} from "./connector-agent-access-button.tsx";
 import { DropdownMenuModalItem } from "../../../components/dropdown-menu-modal-item.tsx";
 import { noConnectorImg } from "../../platform-assets.ts";
 import { customConnectorTarget } from "./custom-connector-display.ts";
@@ -106,14 +109,11 @@ function CustomConnectorAgentAccess({
       ? (authorizedAgentsByIdLoadable.data.get(connector.id) ?? [])
       : [];
 
-  if (!allowAccessIncrease && authorizedAgents.length === 0) {
-    return null;
-  }
-
   return (
     <ConnectorAgentAccessButton
       agents={authorizedAgents}
-      loading={authorizedAgentsByIdLoadable.state === "loading"}
+      status={connectorAgentAccessStatus(authorizedAgentsByIdLoadable.state)}
+      allowAccessIncrease={allowAccessIncrease}
       connectorLabel={connector.displayName}
       onClick={onManageAccess}
     />
@@ -217,8 +217,6 @@ function CustomConnectorCardFooter({
   accountSummaryStatus,
   accountManagement,
 }: Omit<CustomConnectorCardContentProps, "canConnect">) {
-  const { t } = useTranslation();
-  const accountCount = accountSummary?.accountCount ?? 0;
   return (
     <div
       className={`flex h-11 items-center justify-between gap-2 border-t border-border/50 pl-5 ${
@@ -226,32 +224,15 @@ function CustomConnectorCardFooter({
       }`}
     >
       {accountManagement ? (
-        accountSummaryStatus === "ready" ? (
-          <div className="min-w-0 flex-1">
-            <CustomConnectorConnectionStatus connected={accountCount > 0} />
-            {accountCount > 1 ? (
-              <span className="ml-2 text-xs text-muted-foreground">
-                ·{" "}
-                {t(
-                  ($) => {
-                    return $.connectors.accounts.summaryMany;
-                  },
-                  { value: accountCount },
-                )}
-              </span>
-            ) : null}
-          </div>
-        ) : (
-          <ConnectorAccountSummaryText
-            summary={accountSummary}
-            status={accountSummaryStatus}
-            className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
-          />
-        )
+        <ConnectorAccountSummaryText
+          summary={accountSummary}
+          status={accountSummaryStatus}
+          className="min-w-0 flex-1 text-xs text-muted-foreground"
+        />
       ) : (
         <CustomConnectorConnectionStatus connected={connector.connected} />
       )}
-      {connector.connected || (accountManagement && accountCount > 0) ? (
+      {connector.connected || accountManagement ? (
         <div
           onClick={(event) => {
             event.stopPropagation();
@@ -448,7 +429,9 @@ function CustomConnectorRow({
     <CustomConnectorCardContent
       connector={connector}
       hasActions={hasActions}
-      allowAccessIncrease={mcpActionsEnabled}
+      allowAccessIncrease={
+        mcpActionsEnabled && (!accountManagement || accountCount > 0)
+      }
       onManageAccess={onManageAccess}
       accountSummary={accountSummary}
       accountSummaryStatus={accountSummaryStatus}
@@ -482,11 +465,7 @@ function CustomConnectorRow({
   );
 }
 
-function CustomConnectorDialogs({
-  mcpEnabled,
-}: {
-  readonly mcpEnabled: boolean;
-}) {
+function CustomConnectorDialogs() {
   const dialog = useGet(customConnectorDialog$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
   return (
@@ -501,7 +480,7 @@ function CustomConnectorDialogs({
       {dialog.kind === "access" && (
         <CustomConnectorAccessManagementDialog
           connector={dialog.connector}
-          allowAccessIncrease={dialog.connector.kind === "http" || mcpEnabled}
+          allowAccessIncrease={dialog.allowAccessIncrease}
           onClose={closeDialog}
         />
       )}
@@ -634,7 +613,13 @@ function CustomConnectorGrid({
               return openEdit(connector);
             }}
             onManageAccess={() => {
-              return openAccess(connector);
+              return openAccess({
+                connector,
+                allowAccessIncrease:
+                  (connector.kind === "http" || mcpEnabled) &&
+                  (!connectorAccountsEnabled ||
+                    (accountSummary?.accountCount ?? 0) > 0),
+              });
             }}
             onDelete={() => {
               return openDelete(connector);
@@ -765,7 +750,7 @@ export function CustomConnectorsPanel() {
           mcpEnabled={mcpEnabled}
         />
       ) : null}
-      <CustomConnectorDialogs mcpEnabled={mcpEnabled} />
+      <CustomConnectorDialogs />
       <CustomAccountDialogs mcpEnabled={mcpEnabled} />
     </section>
   );

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -465,9 +465,28 @@ function CustomConnectorRow({
   );
 }
 
-function CustomConnectorDialogs() {
+function CustomConnectorDialogs({
+  mcpEnabled,
+}: {
+  readonly mcpEnabled: boolean;
+}) {
   const dialog = useGet(customConnectorDialog$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
+  const accountManagement =
+    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
+  const accountSummariesLoadable = useLoadable(
+    connectorAccountSummaryByTarget$,
+  );
+  const accessAccountSummary =
+    dialog.kind === "access" && accountSummariesLoadable.state === "hasData"
+      ? accountSummariesLoadable.data.get(`custom:${dialog.connector.id}`)
+      : undefined;
+  const allowAccessIncrease =
+    dialog.kind === "access" &&
+    (dialog.connector.kind === "http" || mcpEnabled) &&
+    (!accountManagement ||
+      (accountSummariesLoadable.state === "hasData" &&
+        (accessAccountSummary?.accountCount ?? 0) > 0));
   return (
     <>
       {dialog.kind === "create" && <CustomConnectorCreateDialog />}
@@ -480,7 +499,7 @@ function CustomConnectorDialogs() {
       {dialog.kind === "access" && (
         <CustomConnectorAccessManagementDialog
           connector={dialog.connector}
-          allowAccessIncrease={dialog.allowAccessIncrease}
+          allowAccessIncrease={allowAccessIncrease}
           onClose={closeDialog}
         />
       )}
@@ -613,13 +632,7 @@ function CustomConnectorGrid({
               return openEdit(connector);
             }}
             onManageAccess={() => {
-              return openAccess({
-                connector,
-                allowAccessIncrease:
-                  (connector.kind === "http" || mcpEnabled) &&
-                  (!connectorAccountsEnabled ||
-                    (accountSummary?.accountCount ?? 0) > 0),
-              });
+              return openAccess(connector);
             }}
             onDelete={() => {
               return openDelete(connector);
@@ -750,7 +763,7 @@ export function CustomConnectorsPanel() {
           mcpEnabled={mcpEnabled}
         />
       ) : null}
-      <CustomConnectorDialogs />
+      <CustomConnectorDialogs mcpEnabled={mcpEnabled} />
       <CustomAccountDialogs mcpEnabled={mcpEnabled} />
     </section>
   );

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -944,8 +944,31 @@ function ConnectorCatalogHeader(props: ConnectorCatalogHeaderProps) {
 }
 
 function SettingsConnectorCard(props: SettingsConnectorCardProps) {
+  const manageAccess = (
+    <ConnectorAccessButton
+      connectorSlug={props.connector.slug}
+      connectorLabel={props.connector.label}
+      allowAccessIncrease={
+        !props.accountManagement ||
+        (props.accountSummaryStatus === "ready" &&
+          (props.accountSummary?.accountCount ?? 0) > 0)
+      }
+      onClick={props.onManageAccess}
+    />
+  );
   if (props.accountManagement) {
-    return <AccountManagedSettingsConnectorCard {...props} />;
+    return (
+      <ConnectorCard
+        variant="accounts"
+        connector={props.connector}
+        summary={props.accountSummary}
+        summaryStatus={props.accountSummaryStatus}
+        busy={props.busy}
+        connect={props.connect}
+        onManage={props.onManageAccounts}
+        manageAccess={manageAccess}
+      />
+    );
   }
   if (!props.connected) {
     return (
@@ -957,14 +980,6 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
       />
     );
   }
-  const manageAccess = (
-    <ConnectorAccessButton
-      connectorSlug={props.connector.slug}
-      connectorLabel={props.connector.label}
-      allowAccessIncrease
-      onClick={props.onManageAccess}
-    />
-  );
   return (
     <ConnectorCard
       variant="connection"
@@ -976,44 +991,6 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
       onDisconnect={props.onDisconnect}
       manageAccess={manageAccess}
       onReviewScopes={props.onReviewScopes}
-    />
-  );
-}
-
-function AccountManagedSettingsConnectorCard(
-  props: SettingsConnectorCardProps,
-) {
-  const agentsBySlugLoadable = useLastLoadable(
-    connectorAuthorizedAgentsBySlug$,
-  );
-  const agents =
-    agentsBySlugLoadable.state === "hasData"
-      ? (agentsBySlugLoadable.data.get(props.connector.slug) ?? [])
-      : [];
-  const accessStatus = connectorAgentAccessStatus(agentsBySlugLoadable.state);
-  const accountCount = props.accountSummary?.accountCount ?? 0;
-  const manageAccess = (
-    <ConnectorAgentAccessButton
-      agents={agents}
-      status={accessStatus}
-      allowAccessIncrease={
-        props.accountSummaryStatus === "ready" && accountCount > 0
-      }
-      connectorLabel={props.connector.label}
-      onClick={props.onManageAccess}
-    />
-  );
-  return (
-    <ConnectorCard
-      variant="accounts"
-      connector={props.connector}
-      summary={props.accountSummary}
-      summaryStatus={props.accountSummaryStatus}
-      showCatalogDescription={accessStatus === "ready" && agents.length === 0}
-      busy={props.busy}
-      connect={props.connect}
-      onManage={props.onManageAccounts}
-      manageAccess={manageAccess}
     />
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -944,31 +944,8 @@ function ConnectorCatalogHeader(props: ConnectorCatalogHeaderProps) {
 }
 
 function SettingsConnectorCard(props: SettingsConnectorCardProps) {
-  const manageAccess = (
-    <ConnectorAccessButton
-      connectorSlug={props.connector.slug}
-      connectorLabel={props.connector.label}
-      allowAccessIncrease={
-        !props.accountManagement ||
-        (props.accountSummaryStatus === "ready" &&
-          (props.accountSummary?.accountCount ?? 0) > 0)
-      }
-      onClick={props.onManageAccess}
-    />
-  );
   if (props.accountManagement) {
-    return (
-      <ConnectorCard
-        variant="accounts"
-        connector={props.connector}
-        summary={props.accountSummary}
-        summaryStatus={props.accountSummaryStatus}
-        busy={props.busy}
-        connect={props.connect}
-        onManage={props.onManageAccounts}
-        manageAccess={manageAccess}
-      />
-    );
+    return <AccountManagedSettingsConnectorCard {...props} />;
   }
   if (!props.connected) {
     return (
@@ -980,6 +957,14 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
       />
     );
   }
+  const manageAccess = (
+    <ConnectorAccessButton
+      connectorSlug={props.connector.slug}
+      connectorLabel={props.connector.label}
+      allowAccessIncrease
+      onClick={props.onManageAccess}
+    />
+  );
   return (
     <ConnectorCard
       variant="connection"
@@ -991,6 +976,44 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
       onDisconnect={props.onDisconnect}
       manageAccess={manageAccess}
       onReviewScopes={props.onReviewScopes}
+    />
+  );
+}
+
+function AccountManagedSettingsConnectorCard(
+  props: SettingsConnectorCardProps,
+) {
+  const agentsBySlugLoadable = useLastLoadable(
+    connectorAuthorizedAgentsBySlug$,
+  );
+  const agents =
+    agentsBySlugLoadable.state === "hasData"
+      ? (agentsBySlugLoadable.data.get(props.connector.slug) ?? [])
+      : [];
+  const accessStatus = connectorAgentAccessStatus(agentsBySlugLoadable.state);
+  const accountCount = props.accountSummary?.accountCount ?? 0;
+  const manageAccess = (
+    <ConnectorAgentAccessButton
+      agents={agents}
+      status={accessStatus}
+      allowAccessIncrease={
+        props.accountSummaryStatus === "ready" && accountCount > 0
+      }
+      connectorLabel={props.connector.label}
+      onClick={props.onManageAccess}
+    />
+  );
+  return (
+    <ConnectorCard
+      variant="accounts"
+      connector={props.connector}
+      summary={props.accountSummary}
+      summaryStatus={props.accountSummaryStatus}
+      showCatalogDescription={accessStatus === "ready" && agents.length === 0}
+      busy={props.busy}
+      connect={props.connect}
+      onManage={props.onManageAccounts}
+      manageAccess={manageAccess}
     />
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -78,7 +78,10 @@ import {
 } from "./components/settings/launch-connector-connect.ts";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { ConnectorAccessManagementDialog } from "./components/settings/connector-access-management-dialog.tsx";
-import { ConnectorAgentAccessButton } from "./components/settings/connector-agent-access-button.tsx";
+import {
+  ConnectorAgentAccessButton,
+  connectorAgentAccessStatus,
+} from "./components/settings/connector-agent-access-button.tsx";
 import {
   closeConnectorAccessManagement$,
   connectorAuthorizedAgentsBySlug$,
@@ -736,10 +739,12 @@ function connectorAgentName(agent: AgentResponse): string {
 function ConnectorAccessButton({
   connectorSlug,
   connectorLabel,
+  allowAccessIncrease,
   onClick,
 }: {
   readonly connectorSlug: ConnectorSlug;
   readonly connectorLabel: string;
+  readonly allowAccessIncrease: boolean;
   readonly onClick: () => void;
 }) {
   const agentsBySlugLoadable = useLastLoadable(
@@ -749,11 +754,11 @@ function ConnectorAccessButton({
     agentsBySlugLoadable.state === "hasData"
       ? (agentsBySlugLoadable.data.get(connectorSlug) ?? [])
       : [];
-  const loading = agentsBySlugLoadable.state === "loading";
   return (
     <ConnectorAgentAccessButton
       agents={agents}
-      loading={loading}
+      status={connectorAgentAccessStatus(agentsBySlugLoadable.state)}
+      allowAccessIncrease={allowAccessIncrease}
       connectorLabel={connectorLabel}
       onClick={onClick}
     />
@@ -943,6 +948,11 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
     <ConnectorAccessButton
       connectorSlug={props.connector.slug}
       connectorLabel={props.connector.label}
+      allowAccessIncrease={
+        !props.accountManagement ||
+        (props.accountSummaryStatus === "ready" &&
+          (props.accountSummary?.accountCount ?? 0) > 0)
+      }
       onClick={props.onManageAccess}
     />
   );
@@ -985,6 +995,41 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
   );
 }
 
+function ManagedConnectorAccessDialog() {
+  const connectorSlug = useGet(managedConnectorAccessSlug$);
+  const close = useSet(closeConnectorAccessManagement$);
+  const catalogItemsLoadable = useLastLoadable(relatedCatalogItems$);
+  const accountSummariesLoadable = useLoadable(
+    connectorAccountSummaryByTarget$,
+  );
+  const accountManagement =
+    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
+  if (!connectorSlug || catalogItemsLoadable.state !== "hasData") {
+    return null;
+  }
+  const connectorLabel = connectorLabelForSlug(
+    catalogItemsLoadable.data,
+    connectorSlug,
+  );
+  if (!connectorLabel) {
+    return null;
+  }
+  const accountSummary =
+    accountSummariesLoadable.state === "hasData"
+      ? accountSummariesLoadable.data.get(`builtin:${connectorSlug}`)
+      : undefined;
+  return (
+    <ConnectorAccessManagementDialog
+      connectorSlug={connectorSlug}
+      connectorLabel={connectorLabel}
+      allowAccessIncrease={
+        !accountManagement || (accountSummary?.accountCount ?? 0) > 0
+      }
+      onClose={close}
+    />
+  );
+}
+
 export function ConnectorsPage() {
   const { t } = useTranslation();
   const relatedCatalogItemsLoadable = useLastLoadable(relatedCatalogItems$);
@@ -1020,9 +1065,7 @@ export function ConnectorsPage() {
   const setSelected = useSet(setSelectedConnectorSlug$);
   const scopeReviewConnectorSlug = useGet(scopeReviewConnectorSlug$);
   const setScopeReviewConnectorSlug = useSet(setScopeReviewConnectorSlug$);
-  const managedConnectorSlug = useGet(managedConnectorAccessSlug$);
   const setManagedConnectorSlug = useSet(setManagedConnectorAccessSlug$);
-  const closeManagedConnector = useSet(closeConnectorAccessManagement$);
   const optimisticConnected = useGet(justConnectedSlugs$);
   const activeTab = useGet(connectorsPageTab$);
   const setActiveTab = useSet(setConnectorsPageTab$);
@@ -1067,10 +1110,6 @@ export function ConnectorsPage() {
         return connector.slug === selectedConnectorSlug;
       })
     : undefined;
-  const managedConnectorLabel = connectorLabelForSlug(
-    allConnectors,
-    managedConnectorSlug,
-  );
   const disconnecting = disconnectLoadable.state === "loading";
 
   const connectHandlers = (
@@ -1416,13 +1455,7 @@ export function ConnectorsPage() {
       )}
       <ConnectorAccountNameDialog />
 
-      {managedConnectorSlug && managedConnectorLabel && (
-        <ConnectorAccessManagementDialog
-          connectorSlug={managedConnectorSlug}
-          connectorLabel={managedConnectorLabel}
-          onClose={closeManagedConnector}
-        />
-      )}
+      <ManagedConnectorAccessDialog />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- show a single connector account's identity and exact counts for multiple accounts
- replace abbreviated agent lists with a single CSS-bounded agent name or an exact agent count when accounts are available
- keep account and agent status failures visible independently
- preserve the connector description and connect action for every zero-account card, including when authorization remains persisted
- share the same account summary behavior across built-in and custom connector cards
- derive custom connector access eligibility from the latest account summary while the dialog remains open

## UI behavior

- no accounts: show the connector description and connect action regardless of retained agent authorization
- one account: show its display name or provider identity
- multiple accounts: show the exact account count
- attention required: show the exact affected/total account ratio
- one authorized agent: show the agent's full name with CSS truncation when necessary
- multiple authorized agents: show the exact agent count
- connection starting: keep the primary card action present but disabled while progress is shown
- custom cards: expose the account or connect action as a true button, separate from access and overflow controls, with visible keyboard focus

## Scope

- preserves the existing card click, account management, connect, reconnect, disconnect, and access management flows
- does not revoke retained connector-level authorization when the last account is removed; it is shown again after an account is reconnected
- does not add account-to-agent mapping
- does not remove legacy single-account APIs or complete the broader multi-account migration

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (119 tests)
- local browser verification across the 0/1/many account × 0/1/many agent matrix, plus an account-attention state

Closes #29858

Parent: #28571
