### PR TITLE
fix(connectors): preserve oauth scope grant semantics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -373,6 +373,7 @@ describe("Steam OpenID connector", () => {
       externalId: STEAM_ID,
       externalUsername: STEAM_ID,
       connectionStatus: "connected",
+      oauthScopes: [],
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -865,7 +865,9 @@ describe("CONN-02: OAuth device authorization", () => {
   });
 
   it("starts and completes a device authorization session, with state visible through connector APIs", async () => {
-    mockTestOAuthDeviceConnectorProvider();
+    const provider = mockTestOAuthDeviceConnectorProvider({
+      tokenScope: "read provider-added",
+    });
 
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -896,6 +898,7 @@ describe("CONN-02: OAuth device authorization", () => {
       userCode: "TEST-DEVICE",
       verificationUri: "https://oauth-device.test/device",
     });
+    expect(provider.deviceCodeBodies[0]?.get("scope")).toBe("read");
 
     const otherActor = bdd.user({ orgId: actor.orgId });
     const crossUserPoll = await connectorsApi.requestDeviceAuthPoll(
@@ -922,7 +925,7 @@ describe("CONN-02: OAuth device authorization", () => {
       slug: "test-oauth-device",
       authMethod: "oauth",
       connectionStatus: "connected",
-      oauthScopes: ["read"],
+      oauthScopes: ["read", "provider-added"],
     });
 
     const readBack = await connectorsApi.readConnectorBySlug(
@@ -935,6 +938,32 @@ describe("CONN-02: OAuth device authorization", () => {
     expect(connectorBySlug(listed.connectors, "test-oauth-device")?.id).toBe(
       poll.connector.id,
     );
+
+    mockTestOAuthDeviceConnectorProvider({ tokenScope: "" });
+    const emptyReconnect = await connectorsApi.startDeviceAuth(
+      actor,
+      "test-oauth-device",
+      "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: poll.connector.id },
+    );
+    const emptyPoll = await connectorsApi.pollDeviceAuth(
+      actor,
+      "test-oauth-device",
+      emptyReconnect.sessionId,
+      emptyReconnect.sessionToken,
+    );
+    expect(emptyPoll.status).toBe("complete");
+    if (emptyPoll.status !== "complete") {
+      throw new Error(
+        `Expected explicit-empty device auth, received ${emptyPoll.status}`,
+      );
+    }
+    expect(emptyPoll.connector).toMatchObject({
+      id: poll.connector.id,
+      connectionStatus: "connected",
+      oauthScopes: [],
+    });
 
     const removedReconnect = await connectorsApi.startDeviceAuth(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -3696,45 +3696,50 @@ describe("connector catalog valid lifecycle", () => {
   }, 30_000);
 
   it("executes an external device grant with catalog-owned storage", async () => {
-    const provider = mockTestOAuthDeviceConnectorProvider();
+    const provider = mockTestOAuthDeviceConnectorProvider({ tokenScope: null });
     configureSource();
-    const release = buildRelease({
-      version: "2026-07-15.external-device-grant",
-      connectorSlug: "test-oauth-device",
-      label: "Catalog Device OAuth",
-      mutateCatalog: (artifact) => {
-        const method = publicAuthMethod({
-          id: "api",
-          grantKind: "device-auth",
-        });
-        method.startOptions = [
-          {
-            id: "environment",
-            kind: "select",
-            label: "Environment",
-            required: true,
-            defaultValue: null,
-            options: [
-              { value: "test", label: "Test" },
-              { value: "live", label: "Live" },
-            ],
-          },
-        ];
-        setArtifactAuthMethods(artifact, [method]);
-      },
-      mutateRuntime: (artifact) => {
-        const method = devicePrivateAuthMethod({
-          accessTokenName: "CATALOG_DEVICE_ACCESS_TOKEN",
-          clientId: "test-oauth-device-api-client",
-          scopes: ["read"],
-        });
-        method.id = "api";
-        recordValue(method.grant, "device grant").startOptionMappings = [
-          { privateName: "mode", publicId: "environment" },
-        ];
-        setArtifactAuthMethods(artifact, [method]);
-      },
-    });
+    const deviceGrantRelease = (version: string, scopes: readonly string[]) => {
+      return buildRelease({
+        version,
+        connectorSlug: "test-oauth-device",
+        label: "Catalog Device OAuth",
+        mutateCatalog: (artifact) => {
+          const method = publicAuthMethod({
+            id: "api",
+            grantKind: "device-auth",
+          });
+          method.startOptions = [
+            {
+              id: "environment",
+              kind: "select",
+              label: "Environment",
+              required: true,
+              defaultValue: null,
+              options: [
+                { value: "test", label: "Test" },
+                { value: "live", label: "Live" },
+              ],
+            },
+          ];
+          setArtifactAuthMethods(artifact, [method]);
+        },
+        mutateRuntime: (artifact) => {
+          const method = devicePrivateAuthMethod({
+            accessTokenName: "CATALOG_DEVICE_ACCESS_TOKEN",
+            clientId: "test-oauth-device-api-client",
+            scopes,
+          });
+          method.id = "api";
+          recordValue(method.grant, "device grant").startOptionMappings = [
+            { privateName: "mode", publicId: "environment" },
+          ];
+          setArtifactAuthMethods(artifact, [method]);
+        },
+      });
+    };
+    const release = deviceGrantRelease("2026-07-15.external-device-grant", [
+      "read",
+    ]);
     serveObjects(catalogObjects([release], release));
     await syncCatalog();
 
@@ -3767,6 +3772,16 @@ describe("connector catalog valid lifecycle", () => {
       { environment: "live" },
     );
     expect(provider.deviceCodeBodies[0]?.get("mode")).toBe("live");
+    expect(provider.deviceCodeBodies[0]?.get("scope")).toBe("read");
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+
+    const changedScopes = deviceGrantRelease(
+      "2026-07-15.external-device-scope-change",
+      ["read", "future_scope"],
+    );
+    serveObjects(catalogObjects([release, changedScopes], changedScopes));
+    await syncCatalog();
+    const callsBeforeCompletion = context.mocks.s3.send.mock.calls.length;
     await connectorsApi.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.TestOauthConnector]: false,
     });
@@ -3787,6 +3802,14 @@ describe("connector catalog valid lifecycle", () => {
       authMethod: "api",
       oauthScopes: ["read"],
     });
+    await expect(
+      connectorsApi.readScopeDiff(actor, "test-oauth-device"),
+    ).resolves.toStrictEqual({
+      addedScopes: ["future_scope"],
+      removedScopes: [],
+      currentScopes: ["read", "future_scope"],
+      storedScopes: ["read"],
+    });
     zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const secrets = await readUserSecrets(context, {
       orgId: actor.orgId ?? "",
@@ -3798,7 +3821,7 @@ describe("connector catalog valid lifecycle", () => {
         type: "connector",
       }),
     );
-    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeCompletion);
   });
 
   it("executes an external OpenID grant with catalog-owned storage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -844,7 +844,7 @@ interface TestOAuthDeviceConnectorProviderOptions {
   readonly deviceCode?: string;
   readonly interval?: number;
   readonly expiresIn?: number;
-  readonly tokenScope?: string;
+  readonly tokenScope?: string | null;
   readonly tokenBehavior?: "ok" | "emptyJson";
 }
 
@@ -957,7 +957,9 @@ export function mockTestOAuthDeviceConnectorProvider(
         access_token: `test-device-access:${deviceCode}`,
         token_type: "Bearer",
         expires_in: 3600,
-        scope: options.tokenScope ?? "read",
+        ...(options.tokenScope === null
+          ? {}
+          : { scope: options.tokenScope ?? "read" }),
       });
     }),
   );
@@ -1062,7 +1064,6 @@ export function mockBase44OAuthProvider(): Base44OAuthProviderRecorder {
         refresh_token: "base44-refresh-token",
         token_type: "Bearer",
         expires_in: 3600,
-        scope: "apps:read apps:write offline",
       });
     }),
     http.get(BASE44_USERINFO_URL, ({ request }) => {

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -905,12 +905,17 @@ async function runClaimedSession(
     session: args.session,
     connectorSlug: args.resolvedMethod.connectorSlug,
   });
+  const requestedScopes = deviceRequestedOauthScopes(
+    args.session.oauthRequestedScopes,
+    args.resolvedMethod,
+  );
   const pollResult = await pollConnectorDeviceAuthorizationWithMethod({
     connectorSlug: args.resolvedMethod.connectorSlug,
     authMethodId: args.resolvedMethod.authMethodId,
     method: args.resolvedMethod.method,
     authClient: args.authClient,
     deviceCode: providerState.deviceCode,
+    scopes: requestedScopes,
     ...(providerState.pollState === undefined
       ? {}
       : { pollState: providerState.pollState }),

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1174,6 +1174,7 @@ interface RuntimeDeviceAuthorizationPollArgs {
   readonly authClient: ConnectorAuthClient;
   readonly deviceCode: string;
   readonly pollState?: string;
+  readonly scopes: readonly string[];
 }
 
 interface RuntimeRefreshTokenAccessArgs {
@@ -1462,6 +1463,7 @@ export async function pollConnectorDeviceAuthorizationWithMethod(
     readonly authClient: ConnectorAuthClient;
     readonly deviceCode: string;
     readonly pollState?: string;
+    readonly scopes: readonly string[];
   },
 ): Promise<OAuthDeviceAuthPollResultBase> {
   const provider = connectorDeviceAuthGrantProviderFor(args);
@@ -1480,6 +1482,7 @@ export async function pollConnectorDeviceAuthorizationWithMethod(
   >(provider.pollDeviceAuth, {
     authClient: args.authClient,
     deviceCode: args.deviceCode,
+    scopes: args.scopes,
     ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
   });
   if (result.status === "complete") {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-store.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-store.test.ts
@@ -82,6 +82,7 @@ async function startNintendoStoreSession() {
 function mockNintendoStoreTokenExchange(args?: {
   readonly accessToken?: string;
   readonly idToken?: string;
+  readonly scope?: string | readonly string[] | null;
 }) {
   const captured: {
     profileRequestHeaders?: Headers;
@@ -111,7 +112,13 @@ function mockNintendoStoreTokenExchange(args?: {
             email: "player@example.com",
             name: "Nintendo Player",
           }),
-        scope: "openid user user.mii user.email user.links[].id",
+        ...(args?.scope === null
+          ? {}
+          : {
+              scope:
+                args?.scope ??
+                "openid user user.mii user.email user.links[].id",
+            }),
         token_type: "Bearer",
       });
     }),
@@ -230,6 +237,42 @@ describe("Nintendo Store external-code provider", () => {
       NINTENDO_STORE_USER_AGENT,
     );
   });
+
+  it.each([
+    {
+      name: "reported empty",
+      tokenScope: "",
+      expectedScopes: [],
+    },
+    {
+      name: "omitted",
+      tokenScope: null,
+      expectedScopes: [
+        "openid",
+        "user",
+        "user.mii",
+        "user.email",
+        "user.links[].id",
+      ],
+    },
+  ] as const)(
+    "preserves $name token scope semantics",
+    async ({ tokenScope, expectedScopes }) => {
+      const { result, providerState } = await startNintendoStoreSession();
+      mockNintendoStoreTokenExchange({ scope: tokenScope });
+
+      const completed = await completeConnectorExternalCodeAuthorization({
+        connectorSlug: "nintendo-store",
+        authMethod: "api",
+        authClient: nintendoStoreAuthClient(),
+        providerState: result.providerState,
+        code: `${NINTENDO_STORE_REDIRECT_URI}#session_token_code=nintendo-session-code&state=${providerState.state}`,
+        signal: testSignal(),
+      });
+
+      expect(completed.scopes).toStrictEqual(expectedScopes);
+    },
+  );
 
   it("accepts a raw Nintendo session token code", async () => {
     const { result } = await startNintendoStoreSession();

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
@@ -131,6 +131,8 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
       federationBody?: unknown;
       federationHeaders?: Headers;
     } = {};
+    let tokenScope: string | null =
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes.join(" ");
 
     server.use(
       http.post(
@@ -148,7 +150,7 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
             access_token: "account-access-token",
             expires_in: 3600,
             id_token: idToken,
-            scope: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes.join(" "),
+            ...(tokenScope === null ? {} : { scope: tokenScope }),
             token_type: "Bearer",
           });
         },
@@ -289,6 +291,34 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
         notificationToken: null,
       },
     });
+
+    tokenScope = "";
+    const { result: emptyStarted, providerState: emptyProviderState } =
+      await startNintendoSwitchParentalControlsSession();
+    const emptyCompleted = await completeConnectorExternalCodeAuthorization({
+      connectorSlug: "nintendo-switch-parental-controls",
+      authMethod: "api",
+      authClient: nintendoSwitchParentalControlsAuthClient(),
+      providerState: emptyStarted.providerState,
+      code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri}#session_token_code=empty-session-code&state=${emptyProviderState.state}`,
+      signal: testSignal(),
+    });
+    expect(emptyCompleted.scopes).toStrictEqual([]);
+
+    tokenScope = null;
+    const { result: omittedStarted, providerState: omittedProviderState } =
+      await startNintendoSwitchParentalControlsSession();
+    const omittedCompleted = await completeConnectorExternalCodeAuthorization({
+      connectorSlug: "nintendo-switch-parental-controls",
+      authMethod: "api",
+      authClient: nintendoSwitchParentalControlsAuthClient(),
+      providerState: omittedStarted.providerState,
+      code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri}#session_token_code=omitted-session-code&state=${omittedProviderState.state}`,
+      signal: testSignal(),
+    });
+    expect(omittedCompleted.scopes).toStrictEqual(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes,
+    );
   });
 
   it("refreshes both tokens and omits only a transiently unavailable catalog", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/base44/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/base44/oauth.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../provider-flow-types";
 import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
-import { reportedOAuthScopes } from "../../oauth/scope";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
 
 const BASE44_DEVICE_AUTH_URL = "https://app.base44.com/oauth/device/code";
 const BASE44_TOKEN_URL = "https://app.base44.com/oauth/token";
@@ -51,10 +51,6 @@ const userInfoResponseSchema = z
     email: z.string().nullable().optional(),
   })
   .passthrough();
-
-function parseScopes(scope: string | undefined): string[] {
-  return scope?.split(/\s+/).filter(Boolean) ?? [];
-}
 
 function devicePollErrorResult(args: {
   readonly error: string;
@@ -133,6 +129,7 @@ export async function startBase44DeviceAuth(args: {
 export async function pollBase44DeviceAuth(args: {
   readonly clientId: string;
   readonly deviceCode: string;
+  readonly scopes: readonly string[];
 }): Promise<OAuthDeviceAuthPollResult<"base44", "oauth">> {
   const response = await fetch(BASE44_TOKEN_URL, {
     method: "POST",
@@ -178,7 +175,7 @@ export async function pollBase44DeviceAuth(args: {
         refreshToken: data.refresh_token ?? null,
       },
       expiresIn: data.expires_in,
-      scopes: parseScopes(data.scope),
+      scopes: effectiveOAuthScopes(data.scope, args.scopes, /\s+/),
       userInfo,
     },
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/base44/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/base44/provider.ts
@@ -21,6 +21,7 @@ export const base44Provider: DeviceAuthConnectorAuthProvider<"base44"> = {
       return await pollBase44DeviceAuth({
         clientId,
         deviceCode: args.deviceCode,
+        scopes: args.scopes,
       });
     },
   },

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
@@ -70,10 +70,7 @@ function createNintendoStoreExternalCodeGrantProvider(): ExternalCodeConnectorAu
           locale: locale.locale,
         },
         expiresIn: token.expiresIn,
-        scopes:
-          token.scopes !== null && token.scopes.length > 0
-            ? token.scopes
-            : args.externalCodeGrant.scopes,
+        scopes: token.scopes ?? args.externalCodeGrant.scopes,
         userInfo: nintendoStoreUserInfo(token.idToken),
       };
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
@@ -95,10 +95,7 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
           deviceCatalog,
         },
         expiresIn: token.expiresIn,
-        scopes:
-          token.scopes !== null && token.scopes.length > 0
-            ? token.scopes
-            : args.externalCodeGrant.scopes,
+        scopes: token.scopes ?? args.externalCodeGrant.scopes,
         userInfo: nintendoSwitchParentalControlsUserInfo(token.idToken),
       };
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/oauth.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../provider-flow-types";
 import type { ConnectorAuthProviderGrantResult } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes } from "../../oauth/scope";
 import {
   resolveTestOAuthProviderUrl,
   testOAuthPreviewBypassHeaders,
@@ -133,6 +134,7 @@ function devicePollErrorResult(args: {
 export async function pollTestOAuthDeviceAuth(args: {
   readonly clientId: string;
   readonly deviceCode: string;
+  readonly scopes: readonly string[];
 }): Promise<TestOAuthDevicePollResult> {
   const response = await fetch(getDeviceTokenUrl(), {
     method: "POST",
@@ -180,7 +182,7 @@ export async function pollTestOAuthDeviceAuth(args: {
         accessToken: data.access_token,
       },
       expiresIn: data.expires_in,
-      scopes: data.scope?.split(" ") ?? [],
+      scopes: effectiveOAuthScopes(data.scope, args.scopes, " "),
       userInfo: {
         id: "test-oauth-device-user",
         username: "test-oauth-device-user",

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth-device/provider.ts
@@ -22,6 +22,7 @@ function createTestOauthDeviceGrant(): DeviceAuthGrantProvider<
       return await pollTestOAuthDeviceAuth({
         clientId,
         deviceCode: args.deviceCode,
+        scopes: args.scopes,
       });
     },
   };
@@ -46,6 +47,7 @@ function createTestOauthDeviceApiGrant(): DeviceAuthGrantProvider<
       return await pollTestOAuthDeviceAuth({
         clientId,
         deviceCode: args.deviceCode,
+        scopes: args.scopes,
       });
     },
   };

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -61,6 +61,7 @@ interface OAuthDeviceAuthStartFlowArgs {
 interface OAuthDeviceAuthPollFlowArgs {
   readonly deviceCode: string;
   readonly pollState?: string;
+  readonly scopes: readonly string[];
 }
 
 interface ExternalCodeCompleteFlowArgs {


### PR DESCRIPTION
## Summary

- preserve the exact device-authorization scope snapshot when a provider omits `scope` from its token response
- distinguish an explicitly empty external-code token scope from an omitted scope for Nintendo grants
- cover provider-reported, explicit-empty, omitted, catalog-change, and deterministic empty-scope behavior through provider and API integration tests

## Explicit exclusions

- no database migration or historical grant backfill, because existing empty scope arrays do not retain enough provenance to distinguish omission from an explicit empty response
- no public API, persisted schema, runner protocol, or catalog contract changes

## Validation

- `pnpm format`
- `pnpm -F @okouai/connectors lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F @okouai/connectors test` (44 files, 1082 tests)
- `pnpm knip --workspace @okouai/connectors`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api test` (220 files, 3605 tests)
- `pnpm knip --workspace api`
- post-rebase focused API validation (3 files, 194 tests)
- `git diff --check`

Closes #29469

Parent context: #29462
