### PR TITLE
refactor: remove connector discovery feature switch

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -169,7 +169,7 @@ async function mockComposerConnectorState(page: Page): Promise<void> {
       contentType: "image/svg+xml",
     });
   });
-  await page.route("**/api/connector-catalog/status", async (route) => {
+  await page.route("**/api/connector-catalog/discovery", async (route) => {
     const response = await route.fetch();
     const body: unknown = await response.json();
     if (!isConnectorCatalogStatusResponse(body)) {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -500,30 +500,8 @@ describe("GET /api/connector-catalog", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("hides connector discovery when its feature switch is disabled", async () => {
-    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
-
-    const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      connectorCatalogContract,
-    );
-    const response = await accept(
-      client.discovery({
-        query: {},
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [404],
-    );
-
-    expect(response.body.error.code).toBe("NOT_FOUND");
-  });
-
   it("returns bounded featured connectors and searches only slug or label", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    await enableConnectorFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.ConnectorDiscovery]: true,
-    });
-    mocks.clerk.session(userId, orgId);
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
       connectorCatalogContract,

--- a/turbo/apps/api/src/signals/routes/connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/connector-catalog.ts
@@ -53,10 +53,6 @@ function connectorCatalogUnavailable() {
   return providerUnavailable("Connector catalog is temporarily unavailable");
 }
 
-function connectorDiscoveryNotFound() {
-  return notFound("Connector discovery not found");
-}
-
 async function settleConnectorCatalogRead<T>(
   read: Promise<T>,
   signal: AbortSignal,
@@ -152,9 +148,6 @@ const discoverConnectorCatalogInner$ = command(
     const query = get(queryOf(connectorCatalogContract.discovery));
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
-    if (!context.featureStates[FeatureSwitchKey.ConnectorDiscovery]) {
-      return connectorDiscoveryNotFound();
-    }
 
     const connectorState = await settleConnectorCatalogRead(
       get(

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -4,10 +4,8 @@ import { connectorAccountsContract } from "@okouai/api-contracts/contracts/conne
 import {
   connectorCatalogContract,
   type PublicConnectorCatalogDiscoveryResponse,
-  type PublicConnectorCatalogStatusResponse,
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { apiClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
 import { featureSwitch$ } from "./feature-switch.ts";
@@ -60,18 +58,8 @@ export const connectorCatalogStatusBySlug$ = computed(async (get) => {
 
 export function relatedConnectorCatalog(
   keyword$: Computed<string>,
-): Computed<
-  Promise<
-    | PublicConnectorCatalogDiscoveryResponse
-    | PublicConnectorCatalogStatusResponse
-  >
-> {
+): Computed<Promise<PublicConnectorCatalogDiscoveryResponse>> {
   return computed(async (get) => {
-    const featureStates = get(featureSwitch$);
-    if (!featureStates[FeatureSwitchKey.ConnectorDiscovery]) {
-      return await get(connectorCatalogStatus$);
-    }
-
     get(connectorsReloadVersion$);
     const keyword = get(keyword$).trim();
     const createClient = get(apiClient$);
@@ -89,13 +77,6 @@ export function connectorCatalogItemBySlug(
 ): Computed<Promise<PlatformConnectorCatalogStatusItem | null>> {
   return computed(async (get) => {
     get(connectorsReloadVersion$);
-    const featureStates = get(featureSwitch$);
-    if (!featureStates[FeatureSwitchKey.ConnectorDiscovery]) {
-      return (
-        (await get(connectorCatalogStatusBySlug$)).get(connectorSlug) ?? null
-      );
-    }
-
     const createClient = get(apiClient$);
     const client = createClient(connectorCatalogContract);
     const result = await accept(

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -61,6 +61,7 @@ export function relatedConnectorCatalog(
 ): Computed<Promise<PublicConnectorCatalogDiscoveryResponse>> {
   return computed(async (get) => {
     get(connectorsReloadVersion$);
+    get(featureSwitch$);
     const keyword = get(keyword$).trim();
     const createClient = get(apiClient$);
     const client = createClient(connectorCatalogContract);
@@ -77,6 +78,7 @@ export function connectorCatalogItemBySlug(
 ): Computed<Promise<PlatformConnectorCatalogStatusItem | null>> {
   return computed(async (get) => {
     get(connectorsReloadVersion$);
+    get(featureSwitch$);
     const createClient = get(apiClient$);
     const client = createClient(connectorCatalogContract);
     const result = await accept(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -1547,7 +1547,6 @@ describe("chat composer connector connection", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const dialog = await openAddConnectorsDialog(user);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -214,6 +214,12 @@ function mockCatalog(
   context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
   });
+  context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
+    return respond(200, {
+      connectors: [...connectors],
+      totalConnectorCount: connectors.length,
+    });
+  });
 }
 
 function createMockAuthWindow(): Window {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3185,7 +3185,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const initialThread = await screen.findByLabelText("Chat thread");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -162,7 +162,7 @@ function mockConnectorCatalogStatus(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
   // Register the dynamic slug route first so the subsequently registered
-  // static /status route takes precedence in runtime MSW handlers.
+  // static routes take precedence in runtime MSW handlers.
   context.mocks.api(connectorCatalogContract.get, ({ params, respond }) => {
     const connector = connectors.find((candidate) => {
       return candidate.slug === params.connectorSlug;
@@ -175,6 +175,12 @@ function mockConnectorCatalogStatus(
   });
   context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
+  });
+  context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
+    return respond(200, {
+      connectors: [...connectors],
+      totalConnectorCount: connectors.length,
+    });
   });
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-action-cards.test.tsx
@@ -668,7 +668,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const loadingCard = await screen.findByTestId(
@@ -1804,7 +1803,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const displayedCopyElement = await screen.findByText(displayedCopy);
@@ -1942,7 +1940,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
@@ -2037,7 +2034,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
@@ -2835,7 +2831,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
@@ -2881,7 +2876,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: "/chats/e4000000-0000-4000-a000-000000000011",
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const userMessage = await screen.findByText(
@@ -2990,7 +2984,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: "/chats/e4000000-0000-4000-a000-000000000012",
-      featureSwitches: { [FeatureSwitchKey.ConnectorDiscovery]: true },
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -459,6 +459,13 @@ function mockPublicConnectorStatus(
       ...(categoryMetadata ? { categoryMetadata } : {}),
     });
   });
+  context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
+    return respond(200, {
+      connectors: [...connectors],
+      totalConnectorCount: connectors.length,
+      ...(categoryMetadata ? { categoryMetadata } : {}),
+    });
+  });
 }
 
 function mockCustomConnectorStory(): {
@@ -838,7 +845,7 @@ describe("connectors page", () => {
   });
 
   it("shows only the update dialog when the client requires an upgrade", async () => {
-    context.mocks.http.get("*/api/connector-catalog/status", () => {
+    context.mocks.http.get("*/api/connector-catalog/discovery", () => {
       return Response.json(
         { error: "Client update required" },
         { status: CLIENT_FORCE_UPGRADE_STATUS },
@@ -2590,7 +2597,7 @@ describe("connectors page", () => {
     expect(screen.queryByLabelText("Connect Meta Ads")).not.toBeInTheDocument();
   });
 
-  it("refreshes connector catalog status when connector feature switches change", async () => {
+  it("refreshes connector discovery when connector feature switches change", async () => {
     mockConnectors([]);
 
     detachedSetupPage({
@@ -3997,9 +4004,12 @@ describe("connectors page", () => {
     ];
     let catalogStatusRequestCount = 0;
     let manualGrantConnectResponded = false;
-    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
       catalogStatusRequestCount += 1;
-      return respond(200, { connectors: [...catalogStatusItems] });
+      return respond(200, {
+        connectors: [...catalogStatusItems],
+        totalConnectorCount: catalogStatusItems.length,
+      });
     });
     context.mocks.api(
       connectorManualGrantContract.connect,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -712,7 +712,6 @@ describe("connectors page", () => {
       context,
       path: "/connectors",
       featureSwitches: {
-        [FeatureSwitchKey.ConnectorDiscovery]: true,
         [FeatureSwitchKey.ConnectorCatalogCount]: true,
       },
     });
@@ -788,7 +787,6 @@ describe("connectors page", () => {
       context,
       path: "/connectors",
       featureSwitches: {
-        [FeatureSwitchKey.ConnectorDiscovery]: true,
         [FeatureSwitchKey.ConnectorCatalogCount]: true,
       },
     });

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -17,7 +17,6 @@ import type { ConnectorAccountSummary } from "@okouai/api-contracts/contracts/co
 import type {
   PublicConnectorCatalogCategoryMetadata,
   PublicConnectorCatalogDiscoveryResponse,
-  PublicConnectorCatalogStatusResponse,
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
@@ -875,18 +874,12 @@ function connectorLabelForSlug(
 }
 
 function effectiveConnectorCatalogCount(
-  catalogStatusLoadable: Loadable<
-    | PublicConnectorCatalogDiscoveryResponse
-    | PublicConnectorCatalogStatusResponse
-  >,
+  catalogStatusLoadable: Loadable<PublicConnectorCatalogDiscoveryResponse>,
 ): number | null {
   if (catalogStatusLoadable.state !== "hasData") {
     return null;
   }
-  if ("totalConnectorCount" in catalogStatusLoadable.data) {
-    return catalogStatusLoadable.data.totalConnectorCount;
-  }
-  return catalogStatusLoadable.data.connectors.length;
+  return catalogStatusLoadable.data.totalConnectorCount;
 }
 
 interface SettingsConnectorCardProps {

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
@@ -281,7 +281,6 @@ export const connectorCatalogContract = c.router({
       200: publicConnectorCatalogDiscoveryResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
-      404: apiErrorSchema,
       503: apiErrorSchema,
     },
     summary: "Browse featured connectors or search by slug and label",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -134,7 +134,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       true,
@@ -165,7 +164,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,7 +56,6 @@ export enum FeatureSwitchKey {
   BuiltInModelProviderFallback = "builtInModelProviderFallback",
   ChatForward = "chatForward",
   ResponsiveFollowupCards = "responsiveFollowupCards",
-  ConnectorDiscovery = "connectorDiscovery",
   ConnectorCatalogCount = "connectorCatalogCount",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "personalModelProviderAccounts",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -393,13 +393,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // Ming only for the first pass; widen once the system mapping settles.
     enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
   },
-  [FeatureSwitchKey.ConnectorDiscovery]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Browse a bounded featured connector catalog and search it by slug or label.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ConnectorCatalogCount]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the exact effective connector catalog size.",


### PR DESCRIPTION
## Summary

- Permanently roll out the `connectorDiscovery` feature by keeping its enabled behavior.
- Remove the feature-switch key, registry entry, server guard, client fallback branches, and switch-only test setup.
- Keep bounded featured browsing, server-side slug/label search, per-slug catalog reads, connected-item inclusion, and `totalConnectorCount`.
- Remove the now-impossible 404 response from the discovery contract.

## Terminal decision

- Outcome: `fully-rolled-out`.
- Basis: the user explicitly selected a full feature-switch rollout. The retained branch is the current enabled behavior used by the staff organization.
- Introduction commit: `16bf8c7429e3ec81c3b3e489e212bf3c52ee0a03` (`feat: add bounded connector discovery (#26142)`).
- Follow-up stabilization reviewed: `9eb39fbd41c5e801e6000b47a6b35414aeaefd72` (`fix(platform): stabilize composer connector discovery (#26174)`).

## Behavior comparison

The introduction commit added the bounded discovery route, the ranked 100-connector catalog, the platform discovery path, and the feature-switch branches. Comparing it with its parent and the current implementation showed two terminal branches:

- Retained: the enabled branch that calls `/api/connector-catalog/discovery` and reads individual catalog items by slug.
- Removed: the disabled branch that returned the full `/api/connector-catalog/status` response, plus the API 404 guard and switch-specific fixtures.
- Preserved permanent implementation: `CONNECTOR_DISCOVERY_LIMIT`, `FEATURED_CONNECTOR_SLUGS`, discovery response types, discovery route/service code, mocks, and positive product behavior tests.

## Cleanup verification

- Second-pass search covered the exact key and camel/kebab/snake variants, plus `connector-catalog-featured`, `CONNECTOR_DISCOVERY_LIMIT`, `FEATURED_CONNECTOR_SLUGS`, discovery route/type names, `totalConnectorCount`, mocks, comments, and test fixtures.
- No feature-switch references remain. Generic CLI connector-discovery helpers and the permanent discovery implementation are unrelated to the removed switch and remain intentionally.
- Knip baseline: clean, exit 0 with no findings.
- Knip after cleanup: clean, exit 0 with no findings.
- Removed the disabled API test and rewrote switch-enabled tests to exercise the permanent behavior without overrides.

## Validation

- `@okouai/core` targeted feature-switch test: 26 passed.
- Platform targeted UI coverage: 11 affected tests passed. Two composer tests initially hit the shared 5-second timeout under parallel load and passed individually with one worker and a 15-second timeout.
- Type checks passed for `@okouai/core`, `@okouai/api-contracts`, `@okouai/app`, and the complete ordered `api` type-check pipeline.
- Lint passed for `@okouai/core`, `@okouai/api-contracts`, `@okouai/app`, and `api`.
- Prettier and `git diff --check` passed.
- The targeted API route Vitest could not initialize because local Postgres was unavailable at `localhost:5432`; it did not execute assertions. The PR pipeline owns that database-backed check.