### PR TITLE
refactor(runner): centralize service lock identity

### DIFF
--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -1,3 +1,4 @@
+use crate::cmd::service::RunnerServiceUnit;
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
@@ -36,7 +37,7 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
         // deleting a version that another process is installing or uninstalling.
         // Workspace GC owns base-dir lock lifecycle because those locks carry
         // the base_dir metadata needed to rediscover dead-runner workspaces.
-        if name.starts_with("service-")
+        if RunnerServiceUnit::is_lock_file_name(name)
             || entry.path() == home.systemd_daemon_reload_lock()
             || is_base_dir_lock_name(name)
         {
@@ -63,14 +64,18 @@ mod tests {
     use crate::cmd::gc::test_support::test_home;
 
     #[tokio::test]
-    async fn gc_orphaned_locks_preserves_service_locks() {
+    async fn gc_orphaned_locks_preserves_service_lock_namespace() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
-        let service_lock = locks_dir.join("service-vm0-runner-v1.0.0.lock");
+        let service_lock = RunnerServiceUnit::from_suffix("v1.0.0")
+            .unwrap()
+            .lock_path(&home);
+        let historical_service_lock = locks_dir.join("service-vm0-runner-OLD_NAME.lock");
         let stale_lock = locks_dir.join("workspace-image-cache-test.lock");
         std::fs::write(&service_lock, "").unwrap();
+        std::fs::write(&historical_service_lock, "").unwrap();
         std::fs::write(&stale_lock, "").unwrap();
 
         let report = gc_orphaned_locks(&home, false).await.unwrap();
@@ -79,7 +84,11 @@ mod tests {
         assert_eq!(report.freed_bytes, 0);
         assert!(
             service_lock.exists(),
-            "service locks must survive orphaned lock cleanup"
+            "canonical service locks must survive orphaned lock cleanup"
+        );
+        assert!(
+            historical_service_lock.exists(),
+            "historical service lock names must remain protected during rolling upgrades"
         );
         assert!(
             !stale_lock.exists(),

--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -37,7 +37,7 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
         // deleting a version that another process is installing or uninstalling.
         // Workspace GC owns base-dir lock lifecycle because those locks carry
         // the base_dir metadata needed to rediscover dead-runner workspaces.
-        if RunnerServiceUnit::is_lock_file_name(name)
+        if RunnerServiceUnit::is_reserved_lock_file_name(name)
             || entry.path() == home.systemd_daemon_reload_lock()
             || is_base_dir_lock_name(name)
         {

--- a/crates/runner/src/cmd/gc/version_service_locks.rs
+++ b/crates/runner/src/cmd/gc/version_service_locks.rs
@@ -1,5 +1,6 @@
 use tracing::warn;
 
+use crate::cmd::service::RunnerServiceUnit;
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
@@ -8,13 +9,10 @@ use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_loc
 use super::report::GcReport;
 use super::versions::parse_semver;
 
-fn version_from_service_lock_name(name: &str) -> Option<&str> {
-    const PREFIX: &str = "service-vm0-runner-";
-    const SUFFIX: &str = ".lock";
-
-    let version = name.strip_prefix(PREFIX)?.strip_suffix(SUFFIX)?;
-    parse_semver(version)?;
-    Some(version)
+fn version_service_unit_from_lock_file_name(name: &str) -> Option<RunnerServiceUnit> {
+    let unit = RunnerServiceUnit::from_lock_file_name(name)?;
+    parse_semver(unit.suffix())?;
+    Some(unit)
 }
 
 async fn version_has_gc_enumerable_dir(home: &HomePaths, version: &str) -> Result<bool, String> {
@@ -56,9 +54,10 @@ pub(super) async fn gc_orphaned_version_service_locks(
     {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
-        let Some(version) = version_from_service_lock_name(name) else {
+        let Some(unit) = version_service_unit_from_lock_file_name(name) else {
             continue;
         };
+        let version = unit.suffix();
 
         match version_has_gc_enumerable_dir(home, version).await {
             Ok(true) => continue,
@@ -107,14 +106,7 @@ mod tests {
 
     fn test_version_service_lock(home: &HomePaths, version: &str) -> PathBuf {
         let unit = service::RunnerServiceUnit::from_suffix(version).unwrap();
-        home.service_lock(unit.unit_name())
-    }
-
-    fn test_version_service_unit_name(version: &str) -> String {
-        service::RunnerServiceUnit::from_suffix(version)
-            .unwrap()
-            .unit_name()
-            .to_string()
+        unit.lock_path(home)
     }
 
     fn create_test_version_service_lock(home: &HomePaths, version: &str) -> PathBuf {
@@ -123,15 +115,20 @@ mod tests {
         path
     }
     #[test]
-    fn version_from_service_lock_name_parses_only_semver_runner_service_locks() {
+    fn version_service_unit_from_lock_file_name_parses_only_semver_runner_locks() {
+        let unit = service::RunnerServiceUnit::from_suffix("v1.0.0").unwrap();
         assert_eq!(
-            version_from_service_lock_name("service-vm0-runner-v1.0.0.lock"),
-            Some("v1.0.0")
+            version_service_unit_from_lock_file_name(unit.lock_file_name()),
+            Some(unit)
         );
-        assert!(version_from_service_lock_name("service-vm0-runner-staging.lock").is_none());
-        assert!(version_from_service_lock_name("service-vm0-runner-v1.0.lock").is_none());
-        assert!(version_from_service_lock_name("workspace-image-cache-v1.0.0.lock").is_none());
-        assert!(version_from_service_lock_name("service-vm0-runner-v1.0.0").is_none());
+        assert!(
+            version_service_unit_from_lock_file_name("service-vm0-runner-staging.lock").is_none()
+        );
+        assert!(version_service_unit_from_lock_file_name("service-vm0-runner-v1.0.lock").is_none());
+        assert!(
+            version_service_unit_from_lock_file_name("workspace-image-cache-v1.0.0.lock").is_none()
+        );
+        assert!(version_service_unit_from_lock_file_name("service-vm0-runner-v1.0.0").is_none());
     }
 
     #[tokio::test]
@@ -267,8 +264,8 @@ mod tests {
     async fn gc_orphaned_version_service_locks_keeps_non_semver_service_lock() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
-        let unit = test_version_service_unit_name("staging");
-        let service_lock = home.service_lock(&unit);
+        let unit = service::RunnerServiceUnit::from_suffix("staging").unwrap();
+        let service_lock = unit.lock_path(&home);
         drop(lock::open_lock_file(&service_lock).unwrap());
 
         let removed = gc_orphaned_version_service_locks(&home, false)

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -435,7 +435,7 @@ async fn version_retention_reason(
         Ok(unit) => unit,
         Err(e) => return Some(VersionRetentionReason::InvalidServiceSuffix(e.to_string())),
     };
-    let service_lock_path = home.service_lock(unit.unit_name());
+    let service_lock_path = unit.lock_path(home);
     let service_lock_parent = host_file::file_parent(&service_lock_path);
     match tokio::fs::symlink_metadata(service_lock_parent).await {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -632,7 +632,7 @@ async fn gc_versions_with_analysis_and_operations(
             Ok(u) => u,
             Err(_) => continue,
         };
-        let service_lock_path = home.service_lock(unit.unit_name());
+        let service_lock_path = unit.lock_path(home);
         let service_lock_name = service_lock_path
             .file_name()
             .and_then(|name| name.to_str())

--- a/crates/runner/src/cmd/gc/versions/tests.rs
+++ b/crates/runner/src/cmd/gc/versions/tests.rs
@@ -3,11 +3,8 @@ use nix::fcntl::{Flock, FlockArg};
 use super::*;
 use crate::cmd::gc::test_support::test_home;
 
-fn test_version_service_unit_name(version: &str) -> String {
-    service::RunnerServiceUnit::from_suffix(version)
-        .unwrap()
-        .unit_name()
-        .to_string()
+fn test_version_service_unit(version: &str) -> service::RunnerServiceUnit {
+    service::RunnerServiceUnit::from_suffix(version).unwrap()
 }
 
 fn age_version_past_gc_min_age(home: &HomePaths, name: &str) {
@@ -256,8 +253,7 @@ async fn gc_versions_keeps_binary_config_and_lock_when_config_removal_fails() {
         "config removal failure must preserve the binary discovery anchor"
     );
     assert!(
-        home.service_lock(&test_version_service_unit_name(version))
-            .exists(),
+        test_version_service_unit(version).lock_path(&home).exists(),
         "partial cleanup must preserve its lifecycle lock"
     );
 }
@@ -268,7 +264,7 @@ async fn gc_versions_retries_config_only_cleanup_after_removal_failure() {
     let home = test_home(dir.path());
     let version = "v1.0.0";
     let version_config = home.runners_dir().join(version);
-    let service_lock = home.service_lock(&test_version_service_unit_name(version));
+    let service_lock = test_version_service_unit(version).lock_path(&home);
     std::fs::create_dir_all(&version_config).unwrap();
     age_version_past_gc_min_age(&home, version);
 
@@ -344,11 +340,11 @@ async fn gc_versions_skips_version_when_service_lock_is_held() {
     let bin_dir = home.bin_dir();
     let runners_dir = home.runners_dir();
     let version = "v1.0.0";
-    let unit = test_version_service_unit_name(version);
+    let unit = test_version_service_unit(version);
     std::fs::create_dir_all(bin_dir.join(version)).unwrap();
     std::fs::create_dir_all(runners_dir.join(version)).unwrap();
     age_version_past_gc_min_age(&home, version);
-    let _service_lock = lock::acquire(home.service_lock(&unit)).await.unwrap();
+    let _service_lock = lock::acquire(unit.lock_path(&home)).await.unwrap();
 
     let removed = gc_versions(&home, false, None, None).await.unwrap();
 
@@ -365,8 +361,8 @@ async fn gc_versions_dry_run() {
 
     std::fs::create_dir_all(bin_dir.join("v1.0.0")).unwrap();
     age_version_past_gc_min_age(&home, "v1.0.0");
-    let unit = test_version_service_unit_name("v1.0.0");
-    let service_lock_path = home.service_lock(&unit);
+    let unit = test_version_service_unit("v1.0.0");
+    let service_lock_path = unit.lock_path(&home);
 
     let removed = gc_versions(&home, true, None, None).await.unwrap();
     assert_eq!(removed, ["v1.0.0"]);
@@ -404,8 +400,8 @@ async fn gc_versions_dry_run_preserves_existing_service_lock() {
 
     std::fs::create_dir_all(bin_dir.join(version)).unwrap();
     age_version_past_gc_min_age(&home, version);
-    let unit = test_version_service_unit_name(version);
-    let service_lock_path = home.service_lock(&unit);
+    let unit = test_version_service_unit(version);
+    let service_lock_path = unit.lock_path(&home);
     drop(lock::open_lock_file(&service_lock_path).unwrap());
 
     let removed = gc_versions(&home, true, None, None).await.unwrap();
@@ -424,12 +420,12 @@ async fn gc_versions_dry_run_skips_when_service_lock_is_held() {
     let bin_dir = home.bin_dir();
     let runners_dir = home.runners_dir();
     let version = "v1.0.0";
-    let unit = test_version_service_unit_name(version);
+    let unit = test_version_service_unit(version);
 
     std::fs::create_dir_all(bin_dir.join(version)).unwrap();
     std::fs::create_dir_all(runners_dir.join(version)).unwrap();
     age_version_past_gc_min_age(&home, version);
-    let lock_file = lock::open_lock_file(&home.service_lock(&unit)).unwrap();
+    let lock_file = lock::open_lock_file(&unit.lock_path(&home)).unwrap();
     let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
 
     let removed = gc_versions(&home, true, None, None).await.unwrap();
@@ -453,13 +449,13 @@ async fn gc_versions_dry_run_skips_dangling_service_lock_symlink() {
     let bin_dir = home.bin_dir();
     let runners_dir = home.runners_dir();
     let version = "v1.0.0";
-    let unit = test_version_service_unit_name(version);
+    let unit = test_version_service_unit(version);
 
     std::fs::create_dir_all(bin_dir.join(version)).unwrap();
     std::fs::create_dir_all(runners_dir.join(version)).unwrap();
     age_version_past_gc_min_age(&home, version);
 
-    let service_lock_path = home.service_lock(&unit);
+    let service_lock_path = unit.lock_path(&home);
     std::fs::create_dir_all(home.locks_dir()).unwrap();
     std::os::unix::fs::symlink(dir.path().join("missing-lock-target"), &service_lock_path).unwrap();
 
@@ -654,8 +650,8 @@ async fn gc_versions_skips_when_service_lock_is_held() {
     std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
     age_version_past_gc_min_age(&home, "v1.0.0");
 
-    let unit = test_version_service_unit_name("v1.0.0");
-    let lock_file = lock::open_lock_file(&home.service_lock(&unit)).unwrap();
+    let unit = test_version_service_unit("v1.0.0");
+    let lock_file = lock::open_lock_file(&unit.lock_path(&home)).unwrap();
     let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
 
     let removed = gc_versions(&home, false, None, None).await.unwrap();
@@ -680,8 +676,8 @@ async fn gc_versions_keeps_config_only_version_when_service_lock_is_held() {
     std::fs::create_dir_all(&version_config).unwrap();
     age_version_past_gc_min_age(&home, version);
 
-    let unit = test_version_service_unit_name(version);
-    let lock_file = lock::open_lock_file(&home.service_lock(&unit)).unwrap();
+    let unit = test_version_service_unit(version);
+    let lock_file = lock::open_lock_file(&unit.lock_path(&home)).unwrap();
     let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
 
     let removed = gc_versions(&home, false, None, None).await.unwrap();
@@ -701,8 +697,8 @@ async fn gc_versions_removes_service_lock_after_version_removal() {
     std::fs::create_dir_all(bin_dir.join(version)).unwrap();
     std::fs::create_dir_all(runners_dir.join(version)).unwrap();
     age_version_past_gc_min_age(&home, version);
-    let unit = test_version_service_unit_name(version);
-    let service_lock_path = home.service_lock(&unit);
+    let unit = test_version_service_unit(version);
+    let service_lock_path = unit.lock_path(&home);
     drop(lock::open_lock_file(&service_lock_path).unwrap());
 
     let removed = gc_versions(&home, false, None, None).await.unwrap();

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -165,7 +165,7 @@ async fn acquire_service_lock(
     unit: &RunnerServiceUnit,
     home: &HomePaths,
 ) -> RunnerResult<nix::fcntl::Flock<std::fs::File>> {
-    crate::lock::acquire(home.service_lock(unit.unit_name())).await
+    crate::lock::acquire(unit.lock_path(home)).await
 }
 
 struct ServiceActivationConfig {

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -103,7 +103,7 @@ async fn acquire_cleanup_service_lock(
     unit: &RunnerServiceUnit,
     home: &HomePaths,
 ) -> RunnerResult<nix::fcntl::Flock<std::fs::File>> {
-    let path = home.service_lock(unit.unit_name());
+    let path = unit.lock_path(home);
     let deadline = TokioInstant::now() + CLEANUP_LOCK_TIMEOUT;
 
     loop {

--- a/crates/runner/src/cmd/service/target.rs
+++ b/crates/runner/src/cmd/service/target.rs
@@ -75,7 +75,7 @@ impl RunnerServiceUnit {
     /// Accepts `service-vm0-runner-<suffix>.lock` only when `<suffix>` passes
     /// the same validation as [`Self::from_suffix`]. Historical lock names
     /// that use the reserved wrapper but fail current validation remain
-    /// classified by [`Self::is_lock_file_name`] for rolling compatibility.
+    /// classified by [`Self::is_reserved_lock_file_name`] for rolling compatibility.
     pub(crate) fn from_lock_file_name(file_name: &str) -> Option<Self> {
         let unit_name = file_name
             .strip_prefix(LOCK_PREFIX)?
@@ -90,7 +90,7 @@ impl RunnerServiceUnit {
     /// by historical runners, even when the enclosed unit name fails current
     /// validation. General lock GC must preserve those paths while older
     /// runner binaries can overlap with the current version.
-    pub(crate) fn is_lock_file_name(file_name: &str) -> bool {
+    pub(crate) fn is_reserved_lock_file_name(file_name: &str) -> bool {
         file_name.starts_with(LOCK_PREFIX) && file_name.ends_with(LOCK_SUFFIX)
     }
 
@@ -241,18 +241,20 @@ mod tests {
     }
 
     #[test]
-    fn lock_file_name_classifier_preserves_historical_namespace() {
-        assert!(RunnerServiceUnit::is_lock_file_name(
+    fn reserved_lock_file_name_classifier_preserves_historical_namespace() {
+        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
             "service-vm0-runner-v1.0.0.lock"
         ));
-        assert!(RunnerServiceUnit::is_lock_file_name(
+        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
             "service-vm0-runner-OLD_NAME.lock"
         ));
-        assert!(RunnerServiceUnit::is_lock_file_name("service-.lock"));
-        assert!(!RunnerServiceUnit::is_lock_file_name(
+        assert!(RunnerServiceUnit::is_reserved_lock_file_name(
+            "service-.lock"
+        ));
+        assert!(!RunnerServiceUnit::is_reserved_lock_file_name(
             "workspace-image-cache-v1.0.0.lock"
         ));
-        assert!(!RunnerServiceUnit::is_lock_file_name(
+        assert!(!RunnerServiceUnit::is_reserved_lock_file_name(
             "service-vm0-runner-v1.0.0"
         ));
     }

--- a/crates/runner/src/cmd/service/target.rs
+++ b/crates/runner/src/cmd/service/target.rs
@@ -1,17 +1,21 @@
 use std::path::PathBuf;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
 
 const UNIT_PREFIX: &str = "vm0-runner-";
+const LOCK_PREFIX: &str = "service-";
+const LOCK_SUFFIX: &str = ".lock";
 
 /// A validated identity for one runner systemd service.
 ///
-/// The suffix `pr-123` maps to four forms belonging to the same identity:
+/// The suffix `pr-123` maps to five forms belonging to the same identity:
 ///
 /// - suffix: `pr-123`
 /// - unit name: `vm0-runner-pr-123`
 /// - service name: `vm0-runner-pr-123.service`
 /// - unit-file path: `/etc/systemd/system/vm0-runner-pr-123.service`
+/// - lock filename: `service-vm0-runner-pr-123.lock`
 ///
 /// Construction validates the suffix before deriving the other forms, so an
 /// instance cannot contain names or a path for an invalid suffix.
@@ -21,6 +25,7 @@ pub(crate) struct RunnerServiceUnit {
     unit_name: String,
     service_name: String,
     unit_file_path: PathBuf,
+    lock_file_name: String,
 }
 
 impl RunnerServiceUnit {
@@ -42,11 +47,13 @@ impl RunnerServiceUnit {
         let unit_name = format!("{UNIT_PREFIX}{suffix}");
         let service_name = format!("{unit_name}.service");
         let unit_file_path = PathBuf::from(format!("/etc/systemd/system/{service_name}"));
+        let lock_file_name = format!("{LOCK_PREFIX}{unit_name}{LOCK_SUFFIX}");
         Ok(Self {
             suffix: suffix.to_string(),
             unit_name,
             service_name,
             unit_file_path,
+            lock_file_name,
         })
     }
 
@@ -61,6 +68,30 @@ impl RunnerServiceUnit {
             .strip_prefix(UNIT_PREFIX)?
             .strip_suffix(".service")?;
         Self::from_suffix(suffix).ok()
+    }
+
+    /// Parse a current runner service identity from a lifecycle-lock filename.
+    ///
+    /// Accepts `service-vm0-runner-<suffix>.lock` only when `<suffix>` passes
+    /// the same validation as [`Self::from_suffix`]. Historical lock names
+    /// that use the reserved wrapper but fail current validation remain
+    /// classified by [`Self::is_lock_file_name`] for rolling compatibility.
+    pub(crate) fn from_lock_file_name(file_name: &str) -> Option<Self> {
+        let unit_name = file_name
+            .strip_prefix(LOCK_PREFIX)?
+            .strip_suffix(LOCK_SUFFIX)?;
+        let suffix = unit_name.strip_prefix(UNIT_PREFIX)?;
+        Self::from_suffix(suffix).ok()
+    }
+
+    /// Return whether a filename belongs to the reserved service-lock namespace.
+    ///
+    /// This intentionally recognizes the broad `service-*.lock` wrapper used
+    /// by historical runners, even when the enclosed unit name fails current
+    /// validation. General lock GC must preserve those paths while older
+    /// runner binaries can overlap with the current version.
+    pub(crate) fn is_lock_file_name(file_name: &str) -> bool {
+        file_name.starts_with(LOCK_PREFIX) && file_name.ends_with(LOCK_SUFFIX)
     }
 
     /// Return the validated suffix before adding the `vm0-runner-` prefix or
@@ -83,6 +114,16 @@ impl RunnerServiceUnit {
     /// Return the absolute `/etc/systemd/system/<service-name>` unit-file path.
     pub(crate) fn unit_file_path(&self) -> &std::path::Path {
         &self.unit_file_path
+    }
+
+    /// Return the lifecycle-lock filename `service-vm0-runner-<suffix>.lock`.
+    pub(crate) fn lock_file_name(&self) -> &str {
+        &self.lock_file_name
+    }
+
+    /// Return this service's lifecycle-lock path under the runner home.
+    pub(crate) fn lock_path(&self, home: &HomePaths) -> PathBuf {
+        home.locks_dir().join(self.lock_file_name())
     }
 }
 
@@ -176,5 +217,43 @@ mod tests {
         assert!(RunnerServiceUnit::from_file_name("vm0-runner-v1.0.0.timer").is_none());
         assert!(RunnerServiceUnit::from_file_name("vm0-runner-.service").is_none());
         assert!(RunnerServiceUnit::from_file_name("vm0-runner-UPPER.service").is_none());
+    }
+
+    #[test]
+    fn lock_file_name_round_trips_current_runner_service() {
+        let unit = RunnerServiceUnit::from_suffix("v1.0.0").unwrap();
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+
+        assert_eq!(unit.lock_file_name(), "service-vm0-runner-v1.0.0.lock");
+        assert_eq!(
+            unit.lock_path(&home),
+            PathBuf::from("/test/locks/service-vm0-runner-v1.0.0.lock")
+        );
+        assert_eq!(
+            RunnerServiceUnit::from_lock_file_name(unit.lock_file_name()),
+            Some(unit)
+        );
+        assert!(RunnerServiceUnit::from_lock_file_name("service-vm0-runner-staging").is_none());
+        assert!(
+            RunnerServiceUnit::from_lock_file_name("workspace-image-cache-v1.0.0.lock").is_none()
+        );
+        assert!(RunnerServiceUnit::from_lock_file_name("service-vm0-runner-UPPER.lock").is_none());
+    }
+
+    #[test]
+    fn lock_file_name_classifier_preserves_historical_namespace() {
+        assert!(RunnerServiceUnit::is_lock_file_name(
+            "service-vm0-runner-v1.0.0.lock"
+        ));
+        assert!(RunnerServiceUnit::is_lock_file_name(
+            "service-vm0-runner-OLD_NAME.lock"
+        ));
+        assert!(RunnerServiceUnit::is_lock_file_name("service-.lock"));
+        assert!(!RunnerServiceUnit::is_lock_file_name(
+            "workspace-image-cache-v1.0.0.lock"
+        ));
+        assert!(!RunnerServiceUnit::is_lock_file_name(
+            "service-vm0-runner-v1.0.0"
+        ));
     }
 }

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -369,7 +369,7 @@ mod tests {
         let suffix = "a".repeat(crate::runner_dirname::MAX_NAME_BYTES);
         let unit = RunnerServiceUnit::from_suffix(&suffix).unwrap();
         let unit_file = unit.service_name().to_string();
-        let service_lock = format!("service-{}.lock", unit.unit_name());
+        let service_lock = unit.lock_file_name().to_string();
         let current_staging = format!(
             "{unit_file}{UNIT_STAGING_MARKER}{}.{}.{}",
             u32::MAX,

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -262,13 +262,6 @@ impl HomePaths {
         self.debootstrap_dir().join(".lock")
     }
 
-    /// Lock file for persistent service unit lifecycle operations.
-    ///
-    /// Callers should pass full unit names from `service::RunnerServiceUnit`.
-    pub fn service_lock(&self, unit: &str) -> PathBuf {
-        self.locks_dir().join(format!("service-{unit}.lock"))
-    }
-
     /// Host-global lock for systemd manager reload coordination.
     pub fn systemd_daemon_reload_lock(&self) -> PathBuf {
         self.locks_dir().join("systemd-daemon-reload.lock")
@@ -569,17 +562,6 @@ mod tests {
         assert_eq!(ca_lock, PathBuf::from("/test/locks/ca.lock"));
         let debootstrap_lock = home.debootstrap_lock();
         assert_eq!(debootstrap_lock, PathBuf::from("/test/debootstrap/.lock"));
-    }
-
-    #[test]
-    fn service_lock_path() {
-        let home = HomePaths::with_root(PathBuf::from("/test"));
-        let service_lock = home.service_lock("vm0-runner-v1.2.3");
-        assert_eq!(
-            service_lock,
-            PathBuf::from("/test/locks/service-vm0-runner-v1.2.3.lock")
-        );
-        assert_eq!(service_lock.parent(), Some(home.locks_dir().as_path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make `RunnerServiceUnit` own canonical lifecycle-lock filenames, paths, namespace classification, and strict reverse parsing
- migrate service acquisition and version GC away from the untyped `HomePaths::service_lock(&str)` formatter
- preserve the broad historical `service-*.lock` namespace during general GC while keeping stale-version cleanup strict-semver-only
- route GC and `NAME_MAX` regressions through the canonical typed owner

## Compatibility

The persisted `locks/service-vm0-runner-<suffix>.lock` path is unchanged. General GC intentionally keeps recognizing the broad wrapper namespace because historical runner versions accepted service suffixes rejected by the current validator and can overlap during independent deployments. This PR changes no API, database, configuration, migration, or network protocol.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- focused runner service identity, orphan-lock GC, version service-lock GC, version GC, and `NAME_MAX` tests
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3348 passed, 24 existing ignored; guest inventory passed)
- `lefthook run pre-commit`

Closes #29877
