### PR TITLE
fix(python): report model provider connection sources

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -42,6 +42,7 @@ path calls ``release_flow()`` to remove the reducer state and the registered res
 
 import json
 import threading
+import time
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
@@ -77,6 +78,7 @@ FailureKind = Literal[
     "timeout",
     "connection",
 ]
+ConnectionSource = Literal["provider_response", "upstream_transport"]
 _Protocol = Literal[
     "anthropic_messages",
     "openai_chat_completions",
@@ -96,6 +98,7 @@ _MAX_PENDING_REPORTS = _REPORT_WORKERS * 4
 RUNNER_AUTH_ENV = "OKOU_MITM_RUNNER_TOKEN"
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
+_HTTP_STATUS_BAD_REQUEST = 400
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_PAYMENT_REQUIRED = 402
 _HTTP_STATUS_REQUEST_TIMEOUT = 408
@@ -144,6 +147,7 @@ _ANTHROPIC_IGNORED_HTTP_EVENTS = frozenset(
 class Failure:
     failure_kind: FailureKind
     retry_after_seconds: int | None = None
+    connection_source: ConnectionSource | None = None
 
 
 @dataclass(frozen=True)
@@ -451,7 +455,11 @@ def finish_connection_error(flow: http.HTTPFlow) -> None:
         if (
             flow_state.pending_intent == "normal" or flow_state.active_intent == "normal"
         ) and _upstream_connection_failed(flow):
-            _apply_outcome(flow, flow_state, _failure_outcome("connection"))
+            _apply_outcome(
+                flow,
+                flow_state,
+                _failure_outcome("connection", connection_source="upstream_transport"),
+            )
     else:
         response = flow.response
         failure_kind = (
@@ -468,7 +476,7 @@ def finish_connection_error(flow: http.HTTPFlow) -> None:
                 _retry_after_seconds(response.status_code, response.headers),
             )
         elif response is None and _upstream_connection_failed(flow):
-            outcome = _failure_outcome("connection")
+            outcome = _failure_outcome("connection", connection_source="upstream_transport")
         else:
             parsed_outcome = _finish_response_body(flow, flow_state.protocol)
             if flow_state.terminal_observed:
@@ -480,7 +488,10 @@ def finish_connection_error(flow: http.HTTPFlow) -> None:
                 and _HTTP_STATUS_SUCCESS_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
                 and _upstream_connection_failed(flow)
             ):
-                outcome = _failure_outcome("connection")
+                outcome = _failure_outcome(
+                    "connection",
+                    connection_source="upstream_transport",
+                )
             else:
                 outcome = _unknown_outcome()
         _apply_outcome(flow, flow_state, outcome)
@@ -708,7 +719,10 @@ def _failure_from_codes(codes: tuple[str, ...]) -> Failure | None:
     for code in codes:
         failure_kind = _failure_kind_from_code(code)
         if failure_kind is not None:
-            return Failure(failure_kind)
+            return Failure(
+                failure_kind,
+                connection_source=("provider_response" if failure_kind == "connection" else None),
+            )
     return None
 
 
@@ -778,8 +792,13 @@ def _retry_after_seconds(status: int, headers: http.Headers) -> int | None:
 def _failure_outcome(
     failure_kind: FailureKind,
     retry_after_seconds: int | None = None,
+    *,
+    connection_source: ConnectionSource | None = None,
 ) -> _Outcome:
-    return _Outcome("failure", Failure(failure_kind, retry_after_seconds))
+    return _Outcome(
+        "failure",
+        Failure(failure_kind, retry_after_seconds, connection_source),
+    )
 
 
 def _success_outcome() -> _Outcome:
@@ -882,6 +901,10 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
     payload: dict[str, str | int] = {"failureKind": failure.failure_kind}
     if failure.retry_after_seconds is not None:
         payload["retryAfterSeconds"] = failure.retry_after_seconds
+    legacy_content: bytes | None = None
+    if failure.connection_source is not None:
+        legacy_content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        payload["connectionSource"] = failure.connection_source
     content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     report_url = (
         f"{api_url}/api/runners/runs/{urllib.parse.quote(run_id, safe='')}/model-provider-failures"
@@ -895,6 +918,7 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
                     report_url,
                     bearer_credential,
                     content,
+                    legacy_content,
                 )
             except RuntimeError:
                 pass
@@ -907,12 +931,47 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
     future.add_done_callback(lambda completed: _finish_report(completed, report_context))
 
 
-def _post_report(url: str, bearer_credential: str, content: bytes) -> int:
+def _post_report(
+    url: str,
+    bearer_credential: str,
+    content: bytes,
+    legacy_content: bytes | None,
+) -> int:
+    deadline = time.monotonic() + _REPORT_TIMEOUT_SECONDS
+    status = _post_report_once(
+        url,
+        bearer_credential,
+        content,
+        timeout=deadline - time.monotonic(),
+    )
+    if status != _HTTP_STATUS_BAD_REQUEST or legacy_content is None:
+        return status
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return status
+
+    # TODO(#29882): Remove the legacy retry after pre-source APIs leave the rollback window.
+    return _post_report_once(
+        url,
+        bearer_credential,
+        legacy_content,
+        timeout=remaining,
+    )
+
+
+def _post_report_once(
+    url: str,
+    bearer_credential: str,
+    content: bytes,
+    *,
+    timeout: float,
+) -> int:
     request = platform_api.make_api_request(url, content, bearer_credential)
     try:
         with platform_api.build_api_opener().open(
             request,
-            timeout=_REPORT_TIMEOUT_SECONDS,
+            timeout=timeout,
         ) as response:
             return response.status
     except urllib.error.HTTPError as error:

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -449,6 +449,10 @@ def test_source_aware_400_retries_once_with_legacy_body(
         f"Bearer {id(model_provider_failure_api)}",
         f"Bearer {id(model_provider_failure_api)}",
     ]
+    assert [request.body for request in requests] == [
+        b'{"failureKind":"connection","connectionSource":"upstream_transport"}',
+        b'{"failureKind":"connection"}',
+    ]
     assert _report_omissions(proxy_log_path) == []
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -116,6 +116,16 @@ def _enqueue_provider_unavailable(real_flow, proxy_log_path: Path):
     return flow
 
 
+def _finish_upstream_transport_failure(real_flow, proxy_log_path: Path, mitm_ctx):
+    flow = _make_flow(real_flow, proxy_log_path)
+    flow.response = None
+    model_provider_failure.admit_flow(flow)
+    flow.error = Error("connection reset by peer")
+    with mitm_ctx():
+        mitm_addon.error(flow)
+    return flow
+
+
 def _queue_blocked_reports(
     real_flow,
     proxy_log_path: Path,
@@ -161,6 +171,7 @@ def _assert_report_omission_entry(
     *,
     flow_id: str,
     reason: str,
+    failure_kind: str = "provider_unavailable",
     **details: str | int,
 ) -> None:
     assert entry == {
@@ -173,7 +184,7 @@ def _assert_report_omission_entry(
         "run_id": "run-model-failure",
         "flow_id": flow_id,
         "firewall_name": "model-provider:openai-api-key",
-        "failure_kind": "provider_unavailable",
+        "failure_kind": failure_kind,
         **details,
     }
 
@@ -183,10 +194,17 @@ def _assert_single_report_omission(
     *,
     flow_id: str,
     reason: str,
+    failure_kind: str = "provider_unavailable",
     **details: str | int,
 ) -> None:
     [entry] = _report_omissions(proxy_log_path)
-    _assert_report_omission_entry(entry, flow_id=flow_id, reason=reason, **details)
+    _assert_report_omission_entry(
+        entry,
+        flow_id=flow_id,
+        reason=reason,
+        failure_kind=failure_kind,
+        **details,
+    )
 
 
 def _restart_reporter_after_callbacks(model_provider_failure_api) -> None:
@@ -398,6 +416,116 @@ def test_report_http_failure_logs_omission_and_reclaims_capacity(
         flow_id=flow.id,
         reason="http_error",
         http_status=404,
+    )
+
+
+# TODO(#29882): Remove these legacy retry tests with the runner compatibility branch.
+def test_source_aware_400_retries_once_with_legacy_body(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "legacy-retry.jsonl"
+    model_provider_failure_api.queue_response(400)
+    model_provider_failure_api.queue_response(204)
+
+    _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {
+            "failureKind": "connection",
+            "connectionSource": "upstream_transport",
+        },
+        {"failureKind": "connection"},
+    ]
+    requests = model_provider_failure_api.requests
+    assert [request.method for request in requests] == ["POST", "POST"]
+    assert [request.path for request in requests] == [
+        "/api/runners/runs/run-model-failure/model-provider-failures",
+        "/api/runners/runs/run-model-failure/model-provider-failures",
+    ]
+    assert [request.header("authorization") for request in requests] == [
+        f"Bearer {id(model_provider_failure_api)}",
+        f"Bearer {id(model_provider_failure_api)}",
+    ]
+    assert _report_omissions(proxy_log_path) == []
+
+
+def test_source_aware_400_failed_fallback_is_not_retried(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "legacy-retry-failed.jsonl"
+    model_provider_failure_api.queue_response(400)
+    model_provider_failure_api.queue_response(503)
+
+    flow = _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {
+            "failureKind": "connection",
+            "connectionSource": "upstream_transport",
+        },
+        {"failureKind": "connection"},
+    ]
+    _assert_single_report_omission(
+        proxy_log_path,
+        flow_id=flow.id,
+        reason="http_error",
+        failure_kind="connection",
+        http_status=503,
+    )
+
+
+def test_source_aware_non_400_failure_is_not_retried(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "source-aware-non-400.jsonl"
+    model_provider_failure_api.queue_response(404)
+
+    flow = _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {
+            "failureKind": "connection",
+            "connectionSource": "upstream_transport",
+        }
+    ]
+    _assert_single_report_omission(
+        proxy_log_path,
+        flow_id=flow.id,
+        reason="http_error",
+        failure_kind="connection",
+        http_status=404,
+    )
+
+
+def test_source_less_400_failure_is_not_retried(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    proxy_log_path = tmp_path / "source-less-400.jsonl"
+    model_provider_failure_api.queue_response(400)
+    flow = _make_flow(real_flow, proxy_log_path, response_status=503)
+
+    _finish_http_flow(flow, body=None, mitm_ctx=mitm_ctx)
+
+    assert _reported_payloads(model_provider_failure_api) == [
+        {"failureKind": "provider_unavailable"}
+    ]
+    _assert_single_report_omission(
+        proxy_log_path,
+        flow_id=flow.id,
+        reason="http_error",
+        http_status=400,
     )
 
 
@@ -1206,7 +1334,10 @@ def test_protocol_json_failures_are_reported(
 
     _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
 
-    assert _reported_payloads(model_provider_failure_api) == [{"failureKind": expected_kind}]
+    expected_payload = {"failureKind": expected_kind}
+    if expected_kind == "connection":
+        expected_payload["connectionSource"] = "provider_response"
+    assert _reported_payloads(model_provider_failure_api) == [expected_payload]
 
 
 @pytest.mark.parametrize(
@@ -1335,6 +1466,14 @@ def test_overlapping_inference_flows_report_independent_failures(
             b'"message":"provider failed","param":null}\n\n',
             "provider_unavailable",
         ),
+        (
+            "model-provider:openai-api-key",
+            "/v1/responses",
+            b"event: response.failed\n"
+            b'data: {"type":"response.failed","response":{'
+            b'"error":{"code":"connection_error"}}}\n\n',
+            "connection",
+        ),
     ],
 )
 def test_protocol_sse_failures_are_reported(
@@ -1358,7 +1497,10 @@ def test_protocol_sse_failures_are_reported(
 
     _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
 
-    assert _reported_payloads(model_provider_failure_api) == [{"failureKind": expected_kind}]
+    expected_payload = {"failureKind": expected_kind}
+    if expected_kind == "connection":
+        expected_payload["connectionSource"] = "provider_response"
+    assert _reported_payloads(model_provider_failure_api) == [expected_payload]
 
 
 def test_conflicting_sse_event_type_is_not_reported(
@@ -1456,15 +1598,14 @@ def test_connection_error_is_reported(
     mitm_ctx,
     model_provider_failure_api,
 ):
-    flow = _make_flow(real_flow, tmp_path / "proxy.jsonl")
-    flow.response = None
-    model_provider_failure.admit_flow(flow)
-    flow.error = Error("connection reset by peer")
+    _finish_upstream_transport_failure(real_flow, tmp_path / "proxy.jsonl", mitm_ctx)
 
-    with mitm_ctx():
-        mitm_addon.error(flow)
-
-    assert _reported_payloads(model_provider_failure_api) == [{"failureKind": "connection"}]
+    assert _reported_payloads(model_provider_failure_api) == [
+        {
+            "failureKind": "connection",
+            "connectionSource": "upstream_transport",
+        }
+    ]
 
 
 def test_client_disconnect_is_not_reported(
@@ -1565,7 +1706,7 @@ def test_trailing_sse_failure_is_settled_once_during_response_interruption(
     body = (
         b"event: response.failed\n"
         b'data: {"type":"response.failed","response":{'
-        b'"error":{"code":"server_error"}}}'
+        b'"error":{"code":"connection_error"}}}'
     )
     flow = _make_flow(
         real_flow,
@@ -1583,7 +1724,10 @@ def test_trailing_sse_failure_is_settled_once_during_response_interruption(
         mitm_addon.error(flow)
 
     assert _reported_payloads(model_provider_failure_api) == [
-        {"failureKind": "provider_unavailable"}
+        {
+            "failureKind": "connection",
+            "connectionSource": "provider_response",
+        }
     ]
 
 
@@ -1600,8 +1744,7 @@ def test_websocket_failure_is_reported(
     mitm_addon.responseheaders(flow)
     full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
     failed_frame = (
-        b'{"type":"response.failed","response":{"id":"resp-1",'
-        b'"error":{"code":"service_unavailable"}}}'
+        b'{"type":"response.failed","response":{"id":"resp-1","error":{"code":"connection_error"}}}'
     )
 
     with mitm_ctx():
@@ -1619,7 +1762,10 @@ def test_websocket_failure_is_reported(
 
     assert full_body_feeds.count(failed_frame) == 1
     assert _reported_payloads(model_provider_failure_api) == [
-        {"failureKind": "provider_unavailable"}
+        {
+            "failureKind": "connection",
+            "connectionSource": "provider_response",
+        }
     ]
 
 
@@ -1704,7 +1850,16 @@ def test_websocket_failure_only_flow_uses_one_parse_per_server_frame(
 @pytest.mark.parametrize(
     ("client_state", "server_state", "expected"),
     [
-        (ConnectionState.OPEN, ConnectionState.CLOSED, [{"failureKind": "connection"}]),
+        (
+            ConnectionState.OPEN,
+            ConnectionState.CLOSED,
+            [
+                {
+                    "failureKind": "connection",
+                    "connectionSource": "upstream_transport",
+                }
+            ],
+        ),
         (ConnectionState.CLOSED, ConnectionState.OPEN, []),
     ],
 )


### PR DESCRIPTION
## Summary

- classify reported `connection` failures as `provider_response` when the provider body supplies the failure code, or `upstream_transport` when the proxy observes a transport failure
- include `connectionSource` only for connection failures while preserving existing payloads for every other failure kind
- retry a source-aware report once with the exact legacy body when an older API returns 400, sharing the original reporting deadline

## Fallbacks

- `crates/runner/mitm-addon/src/model_provider_failure.py:_post_report` — protects a newly deployed runner from a pre-source API by retrying exact legacy content after 400. Surface: new runner -> old API. Remove after the old API is no longer serving or retained as a rollback target; follow-up #29882.

## Exclusions

- keeps one reporter future, one capacity slot, and one final omission outcome across the optional fallback attempt
- does not change API validation, persistence, or dashboards; API-side cleanup remains in #29805
- does not remove the temporary runner fallback; that rollout cleanup remains in #29882

## Testing

- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/`
- `cd crates && cargo fmt --all --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p runner --no-deps`
- `cd crates && cargo test -p runner`

Closes #29672

Parent: #29645

Follow-ups: #29805, #29882
