### PR TITLE
refactor(api): cut codex service-tier writer to canonical alias

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6925,9 +6925,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(fastClaim.claim.cliAgentType).toBe("codex");
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-sol");
     expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBe(
-      environment.OKOU_CODEX_SERVICE_TIER,
-    );
+    expect(environment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     expect(environment.OPENAI_API_KEY).toBeTruthy();
     expect(environment.CHATGPT_ACCESS_TOKEN).toBeUndefined();
     await cancelChatRun(actor, fast.runId, fastClaim.sandboxHeaders);
@@ -7125,9 +7123,7 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-luna");
     expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBe(
-      environment.OKOU_CODEX_SERVICE_TIER,
-    );
+    expect(environment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     expect(
       (await readThreadProjection(actor, first.threadId)).serviceTier,
     ).toBe("priority");

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4387,9 +4387,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const fastClaim = await runs.claimRunnerJob(fastRunId);
     expect(fastClaim.cliAgentType).toBe("codex");
     expect(fastClaim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBe(
-      fastClaim.environment?.OKOU_CODEX_SERVICE_TIER,
-    );
+    expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     const fastOkouToken = fastClaim.environment?.OKOU_TOKEN;
     if (!fastOkouToken) {
       throw new Error("Expected the Slack Fast run to expose OKOU_TOKEN");
@@ -5509,9 +5507,7 @@ describe("INT-02: Telegram integration", () => {
     const claim = await runs.claimRunnerJob(runId);
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.environment?.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBe(
-      claim.environment?.OKOU_CODEX_SERVICE_TIER,
-    );
+    expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     const okouToken = claim.environment?.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the Telegram Fast run to expose OKOU_TOKEN");

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -565,7 +565,6 @@ function buildAgentRunPlatformEnvironment(args: {
     ...(args.codexServiceTier
       ? {
           OKOU_CODEX_SERVICE_TIER: args.codexServiceTier,
-          VM0_CODEX_SERVICE_TIER: args.codexServiceTier,
         }
       : {}),
   };


### PR DESCRIPTION
## Summary

- stop `buildAgentRunPlatformEnvironment` from emitting `VM0_CODEX_SERVICE_TIER`, while keeping `OKOU_CODEX_SERVICE_TIER` derived from the existing validated `args.codexServiceTier`
- update the four existing fast-tier runner-claim assertions to require `OKOU_CODEX_SERVICE_TIER=fast` and no legacy alias; the existing standard-tier claim continues to require both aliases to be absent
- retain the Guest Agent dual reader, value-free source telemetry, conflict handling, legacy compatibility tests, Runner projection compatibility tests, trusted `platformEnvironment` boundary, and all model/credential/fast-mode behavior unchanged

Closes #29886
Parent EPIC: #28914

## Revalidation

- refreshed `main` immediately before editing and cut the branch from `fd6e791529b7b2ef0d99d8d3f46aaa6b552704d2`; implementation head is `37ecf1c942aea204a5a67e3fa05da33873e2fba1`
- repository-wide inventory found 11 initial `VM0_CODEX_SERVICE_TIER` matches in seven files: one production API writer, five API claim assertions, the retained Guest Agent reader/compatibility tests, and Runner projection compatibility tests
- final inventory has zero production API matches for `VM0_CODEX_SERVICE_TIER`; the ten retained matches are only the focused API absence assertions and mandated Guest/Runner compatibility coverage
- fully paginated all 29 open PR changed-file pages: GitHub declared 423 files and the audit fetched 423, with zero mismatches; #29809 overlaps the service file outside `buildAgentRunPlatformEnvironment`, and #29068 overlaps `chat-events.bdd.test.ts` near website-generation assertions, so both are semantically disjoint inventory rather than ordering blockers

## Verification

- `pnpm format` (lockfile-pinned Prettier 3.8.1)
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; existing non-fatal Oxlint warnings only)
- `pnpm knip` (passed; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- focused Vitest A/B for the two edited chat claim scenarios: both branch and untouched `main@fd6e7915...` fail before the assertions with the identical local sandbox `404 Job not found in queue` runner-claim limitation
- focused Vitest A/B for the edited Slack and Telegram claim scenarios: both branch and untouched `main@fd6e7915...` fail before the assertions with the identical local sandbox runner-poll timeout
- `git diff --check`
- no full local Vitest suite and no development server; protected PR CI is authoritative

## Fallbacks

- the deployed Guest Agent still accepts canonical-only, legacy-only, and equal-dual inputs, fails closed on conflicting dual inputs, and reports only the value-free resolution source
- rolling the API back restores equal-dual claims, which the retained reader continues to accept
- reverting this PR restores the adjacent equal-dual writer and its previous positive assertions without changing readers, telemetry, Runner projection, models, credentials, or fast-mode startup
- legacy-reader removal remains a separate later #28914 wave gated on production release lineage, a bounded canonical-only observation window, rollback-window expiry, and zero legacy-only observations
