### PR TITLE
test(runner): harden model provider fallback bounds

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -951,7 +951,9 @@ def _post_report(
     if remaining <= 0:
         return status
 
-    # TODO(#29882): Remove the legacy retry after pre-source APIs leave the rollback window.
+    # New runners can reach a pre-#29671 API during rollout or rollback. Remove this
+    # new-runner -> old-API fallback under #29882 after old runners and sandboxes drain
+    # and those APIs are neither serving nor retained rollback targets.
     return _post_report_once(
         url,
         bearer_credential,

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -419,7 +419,7 @@ def test_report_http_failure_logs_omission_and_reclaims_capacity(
     )
 
 
-# TODO(#29882): Remove these legacy retry tests with the runner compatibility branch.
+# Remove these rollout-only fallback tests with the compatibility branch under #29882.
 def test_source_aware_400_retries_once_with_legacy_body(
     tmp_path,
     real_flow,
@@ -456,6 +456,111 @@ def test_source_aware_400_retries_once_with_legacy_body(
     assert _report_omissions(proxy_log_path) == []
 
 
+@pytest.mark.parametrize(
+    (
+        "monotonic_values",
+        "fallback_status",
+        "expected_timeouts",
+        "expected_payloads",
+        "expected_http_status",
+    ),
+    [
+        (
+            (100.0, 100.25, 101.5),
+            204,
+            [2.75, 1.5],
+            [
+                {
+                    "failureKind": "connection",
+                    "connectionSource": "provider_response",
+                },
+                {"failureKind": "connection"},
+            ],
+            None,
+        ),
+        (
+            (100.0, 100.25, 103.0),
+            None,
+            [2.75],
+            [
+                {
+                    "failureKind": "connection",
+                    "connectionSource": "provider_response",
+                }
+            ],
+            400,
+        ),
+    ],
+    ids=("positive-fallback-budget", "exhausted-fallback-budget"),
+)
+def test_source_aware_400_fallback_shares_delivery_deadline(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    monotonic_values: tuple[float, float, float],
+    fallback_status: int | None,
+    expected_timeouts: list[float],
+    expected_payloads: list[dict[str, str]],
+    expected_http_status: int | None,
+    model_provider_failure_api,
+):
+    monotonic_ticks = iter(monotonic_values)
+    request_timeouts: list[float] = []
+    original_build_api_opener = platform_api.build_api_opener
+
+    class ReportTime:
+        @staticmethod
+        def monotonic() -> float:
+            return next(monotonic_ticks)
+
+    class TimeoutRecordingOpener:
+        def __init__(self):
+            self._opener = original_build_api_opener()
+
+        def open(self, request, *, timeout: float):
+            request_timeouts.append(timeout)
+            return self._opener.open(request, timeout=timeout)
+
+    body = b'{"error":{"code":"connection_error"}}'
+    proxy_log_path = tmp_path / "legacy-retry-deadline.jsonl"
+    flow = _make_flow(
+        real_flow,
+        proxy_log_path,
+        response_body=body,
+    )
+    model_provider_failure_api.queue_response(400)
+    if fallback_status is not None:
+        model_provider_failure_api.queue_response(fallback_status)
+
+    with (
+        patch.object(model_provider_failure, "time", ReportTime),
+        patch.object(
+            platform_api,
+            "build_api_opener",
+            side_effect=TimeoutRecordingOpener,
+        ),
+    ):
+        _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
+        assert _reported_payloads(model_provider_failure_api) == expected_payloads
+
+    assert request_timeouts == pytest.approx(expected_timeouts)
+    if expected_http_status is None:
+        assert not jsonl_exists_after_flush(proxy_log_path)
+    else:
+        _assert_single_report_omission(
+            proxy_log_path,
+            flow_id=flow.id,
+            reason="http_error",
+            failure_kind="connection",
+            http_status=expected_http_status,
+        )
+        _assert_full_report_capacity(
+            real_flow,
+            tmp_path / "exhausted-fallback-capacity-recovery.jsonl",
+            model_provider_failure_api,
+        )
+
+
 def test_source_aware_400_failed_fallback_is_not_retried(
     tmp_path,
     real_flow,
@@ -463,18 +568,34 @@ def test_source_aware_400_failed_fallback_is_not_retried(
     model_provider_failure_api,
 ):
     proxy_log_path = tmp_path / "legacy-retry-failed.jsonl"
+    release_target = threading.Event()
+    initial_request_count = model_provider_failure_api.request_count
     model_provider_failure_api.queue_response(400)
-    model_provider_failure_api.queue_response(503)
+    model_provider_failure_api.queue_response(503, release_event=release_target)
 
     flow = _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
 
-    assert _reported_payloads(model_provider_failure_api) == [
+    assert model_provider_failure_api.wait_for_request_count(initial_request_count + 2)
+    assert [
+        request.json_body()
+        for request in model_provider_failure_api.requests[
+            initial_request_count : initial_request_count + 2
+        ]
+    ] == [
         {
             "failureKind": "connection",
             "connectionSource": "upstream_transport",
         },
         {"failureKind": "connection"},
     ]
+    _assert_single_reclaimed_report_slot(
+        real_flow,
+        tmp_path / "legacy-retry-failed-capacity-recovery.jsonl",
+        model_provider_failure_api,
+        release_target,
+        initial_request_count=initial_request_count,
+        target_outbound_count=2,
+    )
     _assert_single_report_omission(
         proxy_log_path,
         flow_id=flow.id,
@@ -1283,6 +1404,12 @@ def test_combined_sse_overlapping_escaped_field_keeps_failure_byte_limit(
         (
             "model-provider:openai-api-key",
             "/v1/chat/completions",
+            b'{"error":{"code":"invalid_api_key"}}',
+            "authentication",
+        ),
+        (
+            "model-provider:openai-api-key",
+            "/v1/chat/completions",
             b'{"error":{"code":"insufficient_quota"}}',
             "billing",
         ),
@@ -1475,7 +1602,7 @@ def test_overlapping_inference_flows_report_independent_failures(
             "/v1/responses",
             b"event: response.failed\n"
             b'data: {"type":"response.failed","response":{'
-            b'"error":{"code":"connection_error"}}}\n\n',
+            b'"error":{"code":"connection"}}}\n\n',
             "connection",
         ),
     ],
@@ -1735,11 +1862,29 @@ def test_trailing_sse_failure_is_settled_once_during_response_interruption(
     ]
 
 
+@pytest.mark.parametrize(
+    ("failure_code", "expected_payload"),
+    [
+        (
+            "service_unavailable",
+            {"failureKind": "provider_unavailable"},
+        ),
+        (
+            "connection_error",
+            {
+                "failureKind": "connection",
+                "connectionSource": "provider_response",
+            },
+        ),
+    ],
+)
 def test_websocket_failure_is_reported(
     tmp_path,
     real_flow,
     mitm_ctx,
     monkeypatch: pytest.MonkeyPatch,
+    failure_code: str,
+    expected_payload: dict[str, str],
     model_provider_failure_api,
 ):
     flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
@@ -1748,7 +1893,8 @@ def test_websocket_failure_is_reported(
     mitm_addon.responseheaders(flow)
     full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
     failed_frame = (
-        b'{"type":"response.failed","response":{"id":"resp-1","error":{"code":"connection_error"}}}'
+        b'{"type":"response.failed","response":{"id":"resp-1",'
+        b'"error":{"code":"' + failure_code.encode() + b'"}}}'
     )
 
     with mitm_ctx():
@@ -1765,12 +1911,7 @@ def test_websocket_failure_is_reported(
         mitm_addon.websocket_end(flow)
 
     assert full_body_feeds.count(failed_frame) == 1
-    assert _reported_payloads(model_provider_failure_api) == [
-        {
-            "failureKind": "connection",
-            "connectionSource": "provider_response",
-        }
-    ]
+    assert _reported_payloads(model_provider_failure_api) == [expected_payload]
 
 
 def test_websocket_known_delta_skips_full_parse_without_disabling_failure_state(


### PR DESCRIPTION
## Summary

- follow up the #29672 implementation after #29889 won the first-merge race and established the canonical source-aware reporter on `main`
- make the existing new-runner -> old-API fallback's #29882 surface and removal gate explicit in production code and its rollout-only tests
- pin positive and exhausted shared three-second budgets at the real HTTP opener boundary, prove that an exhausted exact-400 sends no legacy request and settles its omission/slot, prove failed fallback slot reclamation, cover both accepted provider connection codes, and retain source-less WebSocket non-connection behavior

Follow-up to #29672.

## Fallbacks

- `crates/runner/mitm-addon/src/model_provider_failure.py:_post_report` — the existing source-aware HTTP 400 branch retries once without `connectionSource` inside the original future, capacity slot, and shared three-second deadline. It protects new runner -> old API compatibility when a runner reaches an API predating #29671 during rollout or rollback. Surface: new runner -> old API; gate: old runners and sandboxes have drained, and APIs predating #29671 are no longer serving or retained rollback targets. Remove the branch, legacy body construction, and rollout-only tests together after that gate; follow-up #29882, owner @lancy. This PR does not add another fallback; it makes the landed fallback's bounds and removal contract explicit.

## Validation

- `uv lock --check`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py` (96 passed)
- `uv run --no-sync python -m pytest tests/` (7,178 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `.github/scripts/runner-binary-build/context.sh validate-workspace /home/user/workspace/vm0`

The targeted Runner test binary could not link locally within the 4 GiB container limit (BFD and gold were both OOM-killed at about 3.7 GiB linker RSS). The canonical implementation passed the full Runner test gate on #29889, and this PR's normal CI remains authoritative for the rebased head.
