### PR TITLE
refactor(runner): remove legacy config name contract

### DIFF
--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -129,7 +129,7 @@ start_on_host() {
     --profile vm0/default \
     --rootfs-hash ${ROOTFS_HASH} \
     --snapshot-hash ${SNAPSHOT_HASH} \
-    --name ${RUNNER_NAME} \
+    --hostname ${HOST} \
     --group ${RUNNER_GROUP} \
     --runner-dirname ${RUNNER_DIRNAME} \
     --concurrency-factor 1.5 \

--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -90,10 +90,10 @@ fi
 
 read_host_capacity() {
   local HOST=$1
-  local RUNNER_NAME=$2
+  local RUNNER_SERVICE_SUFFIX=$2
   local REMOTE="${METAL_USER}@${HOST}"
   # shellcheck disable=SC2029
-  ssh "$REMOTE" "sudo ${BIN_DIR}/runner service wait-running --name ${RUNNER_NAME} --timeout-secs 120"
+  ssh "$REMOTE" "sudo ${BIN_DIR}/runner service wait-running --name ${RUNNER_SERVICE_SUFFIX} --timeout-secs 120"
 }
 
 start_on_host() {
@@ -101,11 +101,11 @@ start_on_host() {
 
   local HOST=$1
   local HOST_INDEX=$2
-  local RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
+  local RUNNER_SERVICE_SUFFIX="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
   local RUNNER_DIRNAME="${RUNNER_DIR##*/}"
   local REMOTE="${METAL_USER}@${HOST}"
   local MC
-  echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
+  echo "=== Starting runner service ${RUNNER_SERVICE_SUFFIX} on ${HOST} ==="
 
   local ROOTFS_HASH SNAPSHOT_HASH
   ROOTFS_HASH=$(echo "$ROOTFS_HASH_MAP" | jq -r --arg h "$HOST" '.[$h]')
@@ -137,24 +137,24 @@ start_on_host() {
     --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
   # shellcheck disable=SC2029
-  timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_NAME}' --force --cleanup partial-start"
+  timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_SERVICE_SUFFIX}' --force --cleanup partial-start"
   # shellcheck disable=SC2029
   ssh "$REMOTE" "sudo rm -f ${RUNNER_DIR}/status.json"
 
   # shellcheck disable=SC2029
   ssh "$REMOTE" "sudo ${BIN_DIR}/runner service start \
-    --name ${RUNNER_NAME} \
+    --name ${RUNNER_SERVICE_SUFFIX} \
     --config ${RUNNER_DIR}/runner.yaml \
     --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
     --env USE_MOCK_CLAUDE=true \
     --env USE_MOCK_CODEX=true"
 
-  if ! MC=$(read_host_capacity "$HOST" "$RUNNER_NAME"); then
+  if ! MC=$(read_host_capacity "$HOST" "$RUNNER_SERVICE_SUFFIX"); then
     return 1
   fi
   echo "Runner ready on ${HOST}: max_concurrent=${MC}"
   # shellcheck disable=SC2029
-  ssh "$REMOTE" "sudo ${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"
+  ssh "$REMOTE" "sudo ${BIN_DIR}/runner doctor --name ${RUNNER_SERVICE_SUFFIX}"
   echo "=== Runner started on ${HOST} ==="
 }
 
@@ -234,12 +234,12 @@ stop_started_hosts() {
   local HOST_INDEX=0
   for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
     HOST_INDEX=$((HOST_INDEX + 1))
-    local RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
+    local RUNNER_SERVICE_SUFFIX="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
     local REMOTE="${METAL_USER}@${HOST}"
-    echo "::warning::Requesting stop for partially started runner ${RUNNER_NAME} on ${HOST}"
+    echo "::warning::Requesting stop for partially started runner service ${RUNNER_SERVICE_SUFFIX} on ${HOST}"
     (
       # shellcheck disable=SC2029
-      timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_NAME}' --force --cleanup partial-start" >/dev/null || true
+      timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_SERVICE_SUFFIX}' --force --cleanup partial-start" >/dev/null || true
     ) &
     STOP_PIDS+=($!)
   done

--- a/.github/scripts/runner-behavior-balloon.sh
+++ b/.github/scripts/runner-behavior-balloon.sh
@@ -12,7 +12,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${JOB_REF}-balloon \
+  --hostname ${HOST} \
   --group vm0/balloon-${JOB_REF} \
   --runner-dirname ${JOB_REF}-balloon \
   --max-concurrent 2 \

--- a/.github/scripts/runner-behavior-benchmark.sh
+++ b/.github/scripts/runner-behavior-benchmark.sh
@@ -11,7 +11,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${JOB_REF}-bench \
+  --hostname ${HOST} \
   --group vm0/benchmark-${JOB_REF} \
   --runner-dirname ${JOB_REF}-bench \
   --api-url https://not-a-real-server.test \

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -21,7 +21,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${SVC} \
+  --hostname ${HOST} \
   --group ${GROUP} \
   --runner-dirname ${SVC} \
   --max-concurrent 1 \

--- a/.github/scripts/runner-behavior-drain-resume.sh
+++ b/.github/scripts/runner-behavior-drain-resume.sh
@@ -12,7 +12,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${JOB_REF}-drain \
+  --hostname ${HOST} \
   --group vm0/drain-${JOB_REF} \
   --runner-dirname ${JOB_REF}-drain \
   --max-concurrent 2 \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -9,7 +9,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${JOB_REF}-exec \
+  --hostname ${HOST} \
   --group vm0/exec-${JOB_REF} \
   --runner-dirname ${JOB_REF}-exec \
   --max-concurrent 2 \

--- a/.github/scripts/runner-behavior-keep-alive.sh
+++ b/.github/scripts/runner-behavior-keep-alive.sh
@@ -32,7 +32,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${SVC} \
+  --hostname ${HOST} \
   --group ${GROUP} \
   --runner-dirname ${SVC} \
   --max-concurrent 2 \

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -35,7 +35,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${SVC} \
+  --hostname ${HOST} \
   --group ${GROUP} \
   --runner-dirname ${SVC} \
   --max-concurrent 1 \

--- a/.github/scripts/runner-behavior-systemd-reload.sh
+++ b/.github/scripts/runner-behavior-systemd-reload.sh
@@ -11,7 +11,7 @@ for SUFFIX in systemd-reload-a systemd-reload-b; do
     --profile vm0/default \
     --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
     --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-    --name ${JOB_REF}-${SUFFIX} \
+    --hostname ${HOST} \
     --group ${GROUP} \
     --runner-dirname ${JOB_REF}-${SUFFIX} \
     --max-concurrent 1 \

--- a/.github/scripts/runner-behavior-upgrade-local.sh
+++ b/.github/scripts/runner-behavior-upgrade-local.sh
@@ -11,7 +11,7 @@ for SUFFIX in upgrade-a upgrade-b; do
     --profile vm0/default \
     --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
     --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-    --name ${JOB_REF}-${SUFFIX} \
+    --hostname ${HOST} \
     --group ${GROUP} \
     --runner-dirname ${JOB_REF}-${SUFFIX} \
     --max-concurrent 2 \

--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -35,7 +35,7 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${SVC} \
+  --hostname ${HOST} \
   --group ${GROUP} \
   --runner-dirname ${SVC} \
   --max-concurrent 1 \

--- a/.github/scripts/tests/dev-runner-test.sh
+++ b/.github/scripts/tests/dev-runner-test.sh
@@ -154,6 +154,7 @@ grep -q "service stop" "${TMPDIR}/arm64-success/service-stop.log" || fail "expec
 run_deploy x86-success x86_64 env >"${TMPDIR}/x86-success.out" 2>"${TMPDIR}/x86-success.err"
 grep -q -- "--target x86_64-unknown-linux-musl" "${TMPDIR}/x86-success/cargo.log" || fail "expected x86_64 cargo target"
 grep -q "service stop" "${TMPDIR}/x86-success/service-stop.log" || fail "expected x86_64 service stop"
+grep -q -- "--hostname dev-host" "${TMPDIR}/x86-success/cf-ssh.log" || fail "expected config hostname"
 gc_command=$(grep " gc --keep-latest 3$" "${TMPDIR}/x86-success/cf-ssh.log")
 [[ "$gc_command" != *"R2_"* ]] || fail "gc should not receive R2 credentials"
 build_command=$(grep " build --profile vm0/default$" "${TMPDIR}/x86-success/cf-ssh.log")
@@ -163,7 +164,7 @@ start_line=$(grep -n " service start " "${TMPDIR}/x86-success/cf-ssh.log" | cut 
 readiness_line=$(grep -n " service wait-running " "${TMPDIR}/x86-success/cf-ssh.log" | cut -d: -f1)
 [ "$start_line" -lt "$readiness_line" ] || fail "readiness should follow service start"
 grep -q "\[runner\] Waiting for Runner readiness..." "${TMPDIR}/x86-success.err" || fail "expected readiness progress"
-grep -q "\[runner\] Done! Runner local-test deployed to dev-host" "${TMPDIR}/x86-success.err" || fail "expected completion after readiness"
+grep -q "\[runner\] Done! Runner service local-test deployed to dev-host" "${TMPDIR}/x86-success.err" || fail "expected completion after readiness"
 if grep -q '^4$' "${TMPDIR}/x86-success.out"; then
   fail "readiness capacity should not be printed"
 fi

--- a/.github/scripts/tests/runner-attribution-ansible-test.sh
+++ b/.github/scripts/tests/runner-attribution-ansible-test.sh
@@ -18,6 +18,10 @@ assert_line_count() {
   local file=$1
   local expected=$2
   local pattern=$3
+  if [ ! -f "$file" ]; then
+    echo "expected file to exist: $file" >&2
+    exit 1
+  fi
   local actual
   actual=$(grep -Fxc -- "$pattern" "$file" || true)
   if [ "$actual" -ne "$expected" ]; then
@@ -36,13 +40,12 @@ trap cleanup EXIT
 test_home="$tmp/home"
 mkdir -p "$test_home"
 
-prepare_configs() {
+prepare_fake_runners() {
   local hostname
   for hostname in runner-promotion-a runner-promotion-b; do
-    local runner_dir="$tmp/$hostname/runners/$runner_name"
-    mkdir -p "$runner_dir"
-    printf 'name: %s\nhostname: "stale-host"\n' "$runner_name" \
-      >"$runner_dir/runner.yaml"
+    local bin_dir="$tmp/$hostname/bin/$runner_name"
+    mkdir -p "$bin_dir"
+    cp "$tmp/fake-runner" "$bin_dir/runner"
   done
 }
 
@@ -50,12 +53,16 @@ verify_configs() {
   local hostname
   for hostname in runner-promotion-a runner-promotion-b; do
     local config="$tmp/$hostname/runners/$runner_name/runner.yaml"
-    assert_line_count "$config" 1 "name: $runner_name"
     assert_line_count "$config" 1 "hostname: \"$hostname\""
+    if grep -Eq '^name:' "$config"; then
+      echo "generated config retained removed top-level name: $config" >&2
+      sed -n '1,40p' "$config" >&2
+      exit 1
+    fi
   done
 }
 
-run_attribution_tasks() {
+run_config_tasks() {
   local playbook=$1
   HOME="$test_home" \
     ANSIBLE_CONFIG="$ansible_config" \
@@ -66,8 +73,62 @@ run_attribution_tasks() {
       --tags runner-config-attribution \
       -e "data_dir=$tmp/{{ inventory_hostname }}" \
       -e "runner_version=999.0.0" \
+      -e "default_rootfs_hash=rootfs" \
+      -e "default_snapshot_hash=snapshot" \
+      -e "api_url=https://www.vm0.ai" \
+      -e "official_runner_secret=test" \
       "$playbook" >"$tmp/ansible-output" 2>&1
 }
+
+cat >"$tmp/fake-runner" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "config" ]; then
+  echo "expected runner config, got: $*" >&2
+  exit 1
+fi
+shift
+
+hostname=
+runner_dirname=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --hostname)
+      hostname=$2
+      shift 2
+      ;;
+    --runner-dirname)
+      runner_dirname=$2
+      shift 2
+      ;;
+    --name)
+      echo "config generation retained removed --name: $*" >&2
+      exit 1
+      ;;
+    --profile|--rootfs-hash|--snapshot-hash|--group|--api-url|--token)
+      shift 2
+      ;;
+    *)
+      echo "unexpected runner config argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$hostname" ] || [ -z "$runner_dirname" ]; then
+  echo "runner config requires hostname and runner dirname" >&2
+  exit 1
+fi
+
+data_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+runner_dir="$data_dir/runners/$runner_dirname"
+mkdir -p "$runner_dir"
+printf 'hostname: "%s"\n' "$hostname" >"$runner_dir/runner.yaml"
+EOF
+chmod +x "$tmp/fake-runner"
+
+prepare_fake_runners
 
 for playbook in "$build_playbook" "$rollback_playbook"; do
   HOME="$test_home" \
@@ -75,24 +136,17 @@ for playbook in "$build_playbook" "$rollback_playbook"; do
     ANSIBLE_NOCOLOR=1 \
     ansible-playbook -i "$inventory" --syntax-check "$playbook" >/dev/null
 
-  prepare_configs
-  if ! run_attribution_tasks "$playbook"; then
+  if ! run_config_tasks "$playbook"; then
     sed -n '1,200p' "$tmp/ansible-output" >&2
     exit 1
   fi
   verify_configs
 
-  # A repeated deploy must replace the same key rather than append another.
-  if ! run_attribution_tasks "$playbook"; then
+  if ! run_config_tasks "$playbook"; then
     sed -n '1,200p' "$tmp/ansible-output" >&2
     exit 1
   fi
   verify_configs
 done
-
-if grep -Fq -- "--hostname" "$rollback_playbook"; then
-  echo "rollback must not pass a new hostname flag to retained binaries" >&2
-  exit 1
-fi
 
 echo "runner-attribution-ansible-test: ok"

--- a/.github/scripts/tests/runner-attribution-ansible-test.sh
+++ b/.github/scripts/tests/runner-attribution-ansible-test.sh
@@ -7,7 +7,7 @@ ansible_config="$repo_root/ansible/ansible.cfg"
 inventory="$script_dir/fixtures/runner-promotion-local.ini"
 build_playbook="$repo_root/ansible/playbooks/build-runner.yml"
 rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
-runner_name=v999.0.0
+runner_release=v999.0.0
 
 if ! command -v ansible-playbook >/dev/null; then
   echo "ansible-playbook is required" >&2
@@ -43,7 +43,7 @@ mkdir -p "$test_home"
 prepare_fake_runners() {
   local hostname
   for hostname in runner-promotion-a runner-promotion-b; do
-    local bin_dir="$tmp/$hostname/bin/$runner_name"
+    local bin_dir="$tmp/$hostname/bin/$runner_release"
     mkdir -p "$bin_dir"
     cp "$tmp/fake-runner" "$bin_dir/runner"
   done
@@ -52,7 +52,7 @@ prepare_fake_runners() {
 verify_configs() {
   local hostname
   for hostname in runner-promotion-a runner-promotion-b; do
-    local config="$tmp/$hostname/runners/$runner_name/runner.yaml"
+    local config="$tmp/$hostname/runners/$runner_release/runner.yaml"
     assert_line_count "$config" 1 "hostname: \"$hostname\""
   done
 }

--- a/.github/scripts/tests/runner-attribution-ansible-test.sh
+++ b/.github/scripts/tests/runner-attribution-ansible-test.sh
@@ -54,11 +54,6 @@ verify_configs() {
   for hostname in runner-promotion-a runner-promotion-b; do
     local config="$tmp/$hostname/runners/$runner_name/runner.yaml"
     assert_line_count "$config" 1 "hostname: \"$hostname\""
-    if grep -Eq '^name:' "$config"; then
-      echo "generated config retained removed top-level name: $config" >&2
-      sed -n '1,40p' "$config" >&2
-      exit 1
-    fi
   done
 }
 
@@ -101,10 +96,6 @@ while [ "$#" -gt 0 ]; do
     --runner-dirname)
       runner_dirname=$2
       shift 2
-      ;;
-    --name)
-      echo "config generation retained removed --name: $*" >&2
-      exit 1
       ;;
     --profile|--rootfs-hash|--snapshot-hash|--group|--api-url|--token)
       shift 2

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -59,17 +59,17 @@ trap cleanup EXIT
 test_home="$tmp/home"
 data_dir="$tmp/vm0-runner"
 test_bin="$tmp/bin"
-runner_name=v999.0.0
-runner_dir="$data_dir/bin/$runner_name"
+runner_release=v999.0.0
+runner_bin_dir="$data_dir/bin/$runner_release"
 invocation_log="$data_dir/runner-invocations"
 gc_arrivals="$data_dir/gc-arrivals"
 mkdir -p \
   "$test_home" \
   "$test_bin" \
   "$data_dir/locks" \
-  "$data_dir/runners/$runner_name" \
+  "$data_dir/runners/$runner_release" \
   "$gc_arrivals" \
-  "$runner_dir"
+  "$runner_bin_dir"
 
 ln -s "$(command -v flock)" "$test_bin/real-flock"
 cat > "$test_bin/flock" <<'EOF'
@@ -87,7 +87,7 @@ exec "$(dirname "$0")/real-flock" "$@"
 EOF
 chmod +x "$test_bin/flock"
 
-fake_runner="$runner_dir/runner"
+fake_runner="$runner_bin_dir/runner"
 cat > "$fake_runner" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -172,9 +172,9 @@ if ! PATH="$test_bin:$PATH" \
 fi
 
 assert_line_count "$invocation_log" 2 \
-  "gc --keep-latest 6 --protect-version $runner_name"
-assert_line_count "$invocation_log" 4 "doctor --name $runner_name"
+  "gc --keep-latest 6 --protect-version $runner_release"
+assert_line_count "$invocation_log" 4 "doctor --name $runner_release"
 assert_line_count "$invocation_log" 2 \
-  "service wait-running --name $runner_name --timeout-secs 120"
+  "service wait-running --name $runner_release --timeout-secs 120"
 
 echo "runner-promotion-ansible-test: ok"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -27,6 +27,8 @@ grep -Fq "local RUNNER_DIRNAME=\"\${RUNNER_DIR##*/}\"" "$RUNNER_START_HELPER" ||
   fail "runner config dirname must come from the manifest runner directory"
 grep -Fq -- "--runner-dirname \${RUNNER_DIRNAME}" "$RUNNER_START_HELPER" ||
   fail "runner config must be written beneath the manifest runner directory"
+grep -Fq -- "--hostname \${HOST}" "$RUNNER_START_HELPER" ||
+  fail "runner config must use the metal host for attribution"
 grep -Fq -- "--config \${RUNNER_DIR}/runner.yaml" "$RUNNER_START_HELPER" ||
   fail "runner service must read the config from the manifest runner directory"
 if grep -Fq -- "--runner-dirname \${RUNNER_SERVICE_REF}" "$RUNNER_START_HELPER"; then

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -36,11 +36,11 @@
   become: true
 
   vars:
-    runner_name: "v{{ runner_version }}"
+    runner_release: "v{{ runner_version }}"
     runner_group: vm0/production
     data_dir: /var/lib/vm0-runner
-    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
-    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
+    bin_dir: "{{ data_dir }}/bin/{{ runner_release }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_release }}"
 
   tasks:
     - name: Validate runner architecture
@@ -116,7 +116,7 @@
         --snapshot-hash {{ default_snapshot_hash }}
         --hostname {{ inventory_hostname | quote }}
         --group {{ runner_group }}
-        --runner-dirname {{ runner_name }}
+        --runner-dirname {{ runner_release }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
       tags:

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -114,20 +114,10 @@
         --profile vm0/default
         --rootfs-hash {{ default_rootfs_hash }}
         --snapshot-hash {{ default_snapshot_hash }}
-        --name {{ runner_name }}
+        --hostname {{ inventory_hostname | quote }}
         --group {{ runner_group }}
         --runner-dirname {{ runner_name }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
-
-    # Keep deployment identity separate from the version-shaped runner name.
-    # JSON strings are valid YAML scalars and preserve inventory_hostname
-    # without relying on manual quote escaping.
-    - name: Persist canonical runner hostname
-      lineinfile:
-        path: "{{ runner_dir }}/runner.yaml"
-        regexp: "^hostname:"
-        insertafter: "^name:"
-        line: "hostname: {{ inventory_hostname | to_json }}"
       tags:
         - runner-config-attribution

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -32,10 +32,10 @@
     # Connection failures can replay the current task. Keep remote tasks
     # convergent or protect their complete operation with a stable lock.
     ansible_ssh_retries: 1
-    runner_name: "v{{ runner_version }}"
+    runner_release: "v{{ runner_version }}"
     data_dir: /var/lib/vm0-runner
-    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
-    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
+    bin_dir: "{{ data_dir }}/bin/{{ runner_release }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_release }}"
 
   tasks:
     - name: Validate runner architecture
@@ -49,7 +49,7 @@
         - name: Install and start runner service
           command: >
             {{ bin_dir }}/runner service install
-            --name {{ runner_name }}
+            --name {{ runner_release }}
             --config {{ runner_dir }}/runner.yaml
             {% if sentry_dsn is defined and sentry_dsn %}
             --env SENTRY_DSN={{ sentry_dsn }}
@@ -65,19 +65,19 @@
         # Phase 4: Readiness + health check
         # ========================================
         - name: Wait for target runner readiness
-          command: "{{ bin_dir }}/runner service wait-running --name {{ runner_name }} --timeout-secs 120"
+          command: "{{ bin_dir }}/runner service wait-running --name {{ runner_release }} --timeout-secs 120"
           changed_when: false
 
         - name: Verify runner health
-          command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+          command: "{{ bin_dir }}/runner doctor --name {{ runner_release }}"
       rescue:
         - name: Stop failed target runner service with runner cleanup
-          command: "{{ bin_dir }}/runner service stop --name {{ runner_name }} --force --cleanup failed-start"
+          command: "{{ bin_dir }}/runner service stop --name {{ runner_release }} --force --cleanup failed-start"
 
         - name: Fail promote after target runner readiness failure
           fail:
             msg: >-
-              Runner {{ runner_name }} failed readiness or health checks and
+              Runner {{ runner_release }} failed readiness or health checks and
               was stopped to avoid leaving a non-admitting service running.
 
     # ========================================
@@ -96,7 +96,7 @@
     - name: Drain old runner services
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
       loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
-      when: item != runner_name
+      when: item != runner_release
       ignore_errors: true
 
     - name: Garbage collect old artifacts
@@ -106,4 +106,4 @@
     # Phase 6: Final health check
     # ========================================
     - name: Verify runner health after cleanup
-      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_release }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -69,11 +69,11 @@
   become: true
 
   vars:
-    runner_name: "v{{ runner_version }}"
+    runner_release: "v{{ runner_version }}"
     runner_group: vm0/production
     data_dir: /var/lib/vm0-runner
-    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
-    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
+    bin_dir: "{{ data_dir }}/bin/{{ runner_release }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_release }}"
 
   tasks:
     # ========================================
@@ -116,7 +116,7 @@
     # Subsequent phases dispatch on `target_state` and short-circuit at the
     # first sufficient action.
     - name: Probe target ActiveState
-      command: systemctl show vm0-runner-{{ runner_name }}.service --property=ActiveState --value
+      command: systemctl show vm0-runner-{{ runner_release }}.service --property=ActiveState --value
       register: tgt_active
       changed_when: false
 
@@ -222,7 +222,7 @@
     # become ready in-place or is already running.
     - name: Attempt resume from Draining
       when: target_state == "draining"
-      command: "{{ bin_dir }}/runner service resume --name {{ runner_name }}"
+      command: "{{ bin_dir }}/runner service resume --name {{ runner_release }}"
       failed_when: false
 
     - name: Re-read target status.json after resume
@@ -276,7 +276,7 @@
     # SIGKILL.
     - name: Wait for target to go inactive
       when: target_state in ["stopping", "stopped"]
-      command: systemctl is-active --quiet vm0-runner-{{ runner_name }}.service
+      command: systemctl is-active --quiet vm0-runner-{{ runner_release }}.service
       register: wait_inactive
       retries: 60
       delay: 2
@@ -399,7 +399,7 @@
         --snapshot-hash {{ default_snapshot_hash }}
         --hostname {{ inventory_hostname | quote }}
         --group {{ runner_group }}
-        --runner-dirname {{ runner_name }}
+        --runner-dirname {{ runner_release }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
       tags:
@@ -430,26 +430,26 @@
           when: not (skip_install | default(false))
           command: >
             {{ bin_dir }}/runner service install
-            --name {{ runner_name }}
+            --name {{ runner_release }}
             --config {{ runner_dir }}/runner.yaml
             {% if sentry_dsn is defined and sentry_dsn %}
             --env SENTRY_DSN={{ sentry_dsn }}
             {% endif %}
 
         - name: Wait for target runner readiness
-          command: "{{ bin_dir }}/runner service wait-running --name {{ runner_name }} --timeout-secs 120"
+          command: "{{ bin_dir }}/runner service wait-running --name {{ runner_release }} --timeout-secs 120"
           changed_when: false
 
         - name: Verify target runner health
-          command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+          command: "{{ bin_dir }}/runner doctor --name {{ runner_release }}"
       rescue:
         - name: Stop failed target runner service with runner cleanup
-          command: "{{ bin_dir }}/runner service stop --name {{ runner_name }} --force --cleanup failed-start"
+          command: "{{ bin_dir }}/runner service stop --name {{ runner_release }} --force --cleanup failed-start"
 
         - name: Fail rollback after target runner readiness failure
           fail:
             msg: >-
-              Runner {{ runner_name }} failed readiness or health checks and
+              Runner {{ runner_release }} failed readiness or health checks and
               was stopped to avoid leaving a non-admitting service running.
 
     # ========================================
@@ -492,13 +492,13 @@
     - name: Drain non-target runners (graceful)
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
       loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
-      when: item != runner_name and rollback_mode == "graceful"
+      when: item != runner_release and rollback_mode == "graceful"
       failed_when: false
 
     - name: Stop non-target runners (emergency)
       command: "{{ bin_dir }}/runner service stop --name {{ item }} --force"
       loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
-      when: item != runner_name and rollback_mode == "emergency"
+      when: item != runner_release and rollback_mode == "emergency"
       failed_when: false
 
     # ========================================
@@ -510,4 +510,4 @@
       include_tasks: ../tasks/garbage-collect-runner.yml
 
     - name: Verify runner health after cleanup
-      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_release }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -397,22 +397,11 @@
         --profile vm0/default
         --rootfs-hash {{ default_rootfs_hash }}
         --snapshot-hash {{ default_snapshot_hash }}
-        --name {{ runner_name }}
+        --hostname {{ inventory_hostname | quote }}
         --group {{ runner_group }}
         --runner-dirname {{ runner_name }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
-
-    # Write the additive YAML field after invoking the retained target binary.
-    # Older Serde readers ignore this field, while an older CLI would reject a
-    # new command-line option.
-    - name: Persist canonical runner hostname
-      when: not (skip_install | default(false))
-      lineinfile:
-        path: "{{ runner_dir }}/runner.yaml"
-        regexp: "^hostname:"
-        insertafter: "^name:"
-        line: "hostname: {{ inventory_hostname | to_json }}"
       tags:
         - runner-config-attribution
 

--- a/ansible/tasks/garbage-collect-runner.yml
+++ b/ansible/tasks/garbage-collect-runner.yml
@@ -9,4 +9,4 @@
       - --keep-latest
       - "6"
       - --protect-version
-      - "{{ runner_name }}"
+      - "{{ runner_release }}"

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -157,7 +157,6 @@ pub async fn run_benchmark(
         crate::live_runner_instances::LiveRunnerInstanceMetadata {
             config_path: registry_config_path,
             base_dir: base_dir_canonical,
-            runner_name: runner_config.name.clone(),
             runner_group: runner_config.group.clone(),
             subcommand: "benchmark".into(),
         },

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -459,12 +459,6 @@ mod tests {
         assert_eq!(profile.rootfs_disk_mb, 12288);
         assert_eq!(profile.workspace_disk_mb, 16384);
         assert_eq!(runner_config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
-        assert!(
-            config_content
-                .lines()
-                .all(|line| !line.starts_with("name:")),
-            "generated config must not contain the removed top-level name field"
-        );
     }
 
     fn args_with_concurrency_factor(factor: f64) -> ConfigArgs {

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -24,9 +24,6 @@ pub struct ConfigArgs {
     #[arg(long, required = true)]
     snapshot_hash: Vec<String>,
 
-    /// Legacy release-shaped Runner name retained for compatibility
-    #[arg(long)]
-    name: String,
     /// Canonical physical hostname used for diagnostic attribution
     #[arg(long)]
     hostname: Option<String>,
@@ -138,7 +135,6 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
 
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);
     let runner_config = RunnerConfig {
-        name: Some(args.name),
         hostname: args.hostname,
         group: args.group,
         base_dir: runner_dir.clone(),
@@ -182,7 +178,6 @@ mod tests {
             profile: vec!["vm0/default".into()],
             rootfs_hash: vec!["dummy".into()],
             snapshot_hash: vec!["dummy".into()],
-            name: "test".into(),
             hostname: None,
             group: "vm0/test".into(),
             runner_dirname: dirname.into(),
@@ -463,8 +458,13 @@ mod tests {
         assert_eq!(profile.snapshot_hash, snapshot_hash);
         assert_eq!(profile.rootfs_disk_mb, 12288);
         assert_eq!(profile.workspace_disk_mb, 16384);
-        assert_eq!(runner_config.name.as_deref(), Some("test"));
         assert_eq!(runner_config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
+        assert!(
+            config_content
+                .lines()
+                .all(|line| !line.starts_with("name:")),
+            "generated config must not contain the removed top-level name field"
+        );
     }
 
     fn args_with_concurrency_factor(factor: f64) -> ConfigArgs {
@@ -472,7 +472,6 @@ mod tests {
             profile: vec!["vm0/default".into()],
             rootfs_hash: vec!["dummy".into()],
             snapshot_hash: vec!["dummy".into()],
-            name: "test".into(),
             hostname: None,
             group: "vm0/test".into(),
             runner_dirname: "runner-01".into(),

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -2633,7 +2633,7 @@ mod tests {
         proxy_port: Option<u16>,
         dns_port: Option<u16>,
     ) -> DoctorReportFixture {
-        doctor_report_fixture_for_runner("test-runner", mode, proxy_port, dns_port, None)
+        doctor_report_fixture_with_server(mode, proxy_port, dns_port, None)
     }
 
     fn doctor_report_fixture_without_status() -> DoctorReportFixture {
@@ -2642,8 +2642,7 @@ mod tests {
         fixture
     }
 
-    fn doctor_report_fixture_for_runner(
-        runner_name: &str,
+    fn doctor_report_fixture_with_server(
         mode: &str,
         proxy_port: Option<u16>,
         dns_port: Option<u16>,
@@ -2655,7 +2654,6 @@ mod tests {
 
         let config_path = dir.path().join("runner.yaml");
         let mut config = serde_json::json!({
-            "name": runner_name,
             "group": "vm0/test",
             "base_dir": base_dir.display().to_string(),
             "ca_dir": dir.path().join("ca").display().to_string(),
@@ -2703,21 +2701,11 @@ mod tests {
         config_path: PathBuf,
         base_dir: PathBuf,
     ) -> LiveRunnerInstance {
-        live_runner_instance_named(pid, config_path, base_dir, Some("test-runner"))
-    }
-
-    fn live_runner_instance_named(
-        pid: u32,
-        config_path: PathBuf,
-        base_dir: PathBuf,
-        runner_name: Option<&str>,
-    ) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid,
             starttime: 0,
             config_path,
             base_dir,
-            runner_name: runner_name.map(String::from),
             runner_group: "vm0/test".into(),
             subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
@@ -2985,7 +2973,6 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("runner.yaml"),
                 base_dir: base_dir.clone(),
-                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },
@@ -3033,7 +3020,6 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("runner.yaml"),
                 base_dir: base_dir.clone(),
-                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },
@@ -3221,58 +3207,50 @@ mod tests {
         let fast_a_url = server.url("/fast-a");
         let fast_b_url = server.url("/fast-b");
         let fast_c_url = server.url("/fast-c");
-        let slow_fixture = doctor_report_fixture_for_runner(
-            "runner-a",
+        let slow_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&slow_url, "token-slow")),
         );
-        let fast_a_fixture = doctor_report_fixture_for_runner(
-            "runner-b",
+        let fast_a_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&fast_a_url, "token-a")),
         );
-        let fast_b_fixture = doctor_report_fixture_for_runner(
-            "runner-c",
+        let fast_b_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&fast_b_url, "token-b")),
         );
-        let fast_c_fixture = doctor_report_fixture_for_runner(
-            "runner-d",
+        let fast_c_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&fast_c_url, "token-c")),
         );
         let runners = vec![
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX - 3,
                 slow_fixture.config_path.clone(),
                 slow_fixture.base_dir.clone(),
-                Some("runner-a"),
             ),
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX - 2,
                 fast_a_fixture.config_path.clone(),
                 fast_a_fixture.base_dir.clone(),
-                Some("runner-b"),
             ),
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX - 1,
                 fast_b_fixture.config_path.clone(),
                 fast_b_fixture.base_dir.clone(),
-                Some("runner-c"),
             ),
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX,
                 fast_c_fixture.config_path.clone(),
                 fast_c_fixture.base_dir.clone(),
-                Some("runner-d"),
             ),
         ];
         let client = build_api_client();
@@ -3320,45 +3298,28 @@ mod tests {
             .await;
         let target_url = server.url("/target");
         let other_url = server.url("/other");
-        let target_fixture = doctor_report_fixture_for_runner(
-            "target-runner",
+        let target_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&target_url, "target-token")),
         );
-        let mut target_config: serde_yaml_ng::Value =
-            serde_yaml_ng::from_str(&std::fs::read_to_string(&target_fixture.config_path).unwrap())
-                .unwrap();
-        target_config
-            .as_mapping_mut()
-            .unwrap()
-            .remove(serde_yaml_ng::Value::String("name".into()))
-            .unwrap();
-        std::fs::write(
-            &target_fixture.config_path,
-            serde_yaml_ng::to_string(&target_config).unwrap(),
-        )
-        .unwrap();
-        let other_fixture = doctor_report_fixture_for_runner(
-            "other-runner",
+        let other_fixture = doctor_report_fixture_with_server(
             "running",
             None,
             None,
             Some((&other_url, "other-token")),
         );
         let runners = vec![
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX - 1,
                 other_fixture.config_path.clone(),
                 other_fixture.base_dir.clone(),
-                Some("shared-legacy-name"),
             ),
-            live_runner_instance_named(
+            live_runner_instance(
                 u32::MAX,
                 target_fixture.config_path.clone(),
                 target_fixture.base_dir.clone(),
-                None,
             ),
         ];
         let client = build_api_client();

--- a/crates/runner/src/cmd/kill/target.rs
+++ b/crates/runner/src/cmd/kill/target.rs
@@ -369,7 +369,6 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: dir.path().join("benchmark.yaml"),
                 base_dir: dir.path().join("benchmark-base"),
-                runner_name: Some("bench-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "benchmark".into(),
             },

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -882,7 +882,6 @@ mod tests {
             config_path,
             format!(
                 r#"
-name: test
 group: test/group
 base_dir: {base_dir}
 ca_dir: {ca_dir}
@@ -1009,17 +1008,12 @@ profiles:
         }
     }
 
-    fn live_runner_instance(
-        runner_name: Option<&str>,
-        config_path: PathBuf,
-        base_dir: PathBuf,
-    ) -> LiveRunnerInstance {
+    fn live_runner_instance(config_path: PathBuf, base_dir: PathBuf) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid: 123,
             starttime: 456,
             config_path,
             base_dir,
-            runner_name: runner_name.map(String::from),
             runner_group: "test/group".to_string(),
             subcommand: "start".to_string(),
             started_at: "2026-01-01T00:00:00.000Z".to_string(),
@@ -1099,9 +1093,8 @@ profiles:
         let actual_base_dir = PathBuf::from("/vm0-runner/runners/pr-123");
         let config_path = actual_base_dir.join("runner.yaml");
         let instances = vec![
-            live_runner_instance(None, config_path.clone(), actual_base_dir.clone()),
+            live_runner_instance(config_path.clone(), actual_base_dir.clone()),
             live_runner_instance(
-                Some("pr-123-1"),
                 PathBuf::from("/vm0-runner/runners/other/runner.yaml"),
                 PathBuf::from("/vm0-runner/runners/other"),
             ),
@@ -1119,12 +1112,10 @@ profiles:
         let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
         let instances = vec![
             live_runner_instance(
-                Some("legacy-a"),
                 config_path.clone(),
                 PathBuf::from("/vm0-runner/runners/pr-123"),
             ),
             live_runner_instance(
-                Some("legacy-b"),
                 config_path.clone(),
                 PathBuf::from("/vm0-runner/runners/other"),
             ),
@@ -1152,10 +1143,10 @@ profiles:
         let unit = service_unit();
         let base_dir = Path::new("/var/lib/vm0-runner/runners/test");
 
-        let first = service_activation_config_snapshot_path(&unit, base_dir, b"name: test\n");
-        let second = service_activation_config_snapshot_path(&unit, base_dir, b"name: test\n");
+        let first = service_activation_config_snapshot_path(&unit, base_dir, b"group: test\n");
+        let second = service_activation_config_snapshot_path(&unit, base_dir, b"group: test\n");
         let different =
-            service_activation_config_snapshot_path(&unit, base_dir, b"name: different\n");
+            service_activation_config_snapshot_path(&unit, base_dir, b"group: different\n");
 
         assert_eq!(first, second);
         assert_ne!(first, different);
@@ -1227,7 +1218,7 @@ profiles:
                 assert_ne!(snapshot_path, config_path);
                 assert!(snapshot_path.starts_with(base_dir.join(SERVICE_CONFIG_SNAPSHOT_DIR)));
 
-                tokio::fs::write(&config_path, "name: mutated\n")
+                tokio::fs::write(&config_path, "group: mutated\n")
                     .await
                     .unwrap();
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -518,7 +518,6 @@ async fn run_start_with_home(
         client_session_id: runner_client_session_id.clone(),
     })?;
     let background_fill = crate::storage_cache::StorageCacheBackgroundFillCoordinator::new()?;
-    let legacy_name = runner_config.name;
     let hostname = runner_config.hostname;
     let group = runner_config.group;
     let cancel_tokens = RunCancellationRegistry::new();
@@ -832,7 +831,6 @@ async fn run_start_with_home(
     let live_runner_instance_metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: registry_config_path,
         base_dir: base_dir_canonical.clone(),
-        runner_name: legacy_name,
         runner_group: group_name.clone(),
         subcommand: "start".into(),
     };

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -220,7 +220,6 @@ done
     let metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: dir.path().join("runner.yaml"),
         base_dir: dir.path().join("base"),
-        runner_name: Some("test-runner".into()),
         runner_group: "vm0/test".into(),
         subcommand: "start".into(),
     };

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -72,10 +72,6 @@ pub(crate) const DIAGNOSTIC_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 /// are resolved against the YAML file's parent directory during [`load`].
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunnerConfig {
-    /// Legacy release-shaped identifier retained during the local identity
-    /// compatibility window. Current runtime selection must not depend on it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
     /// Canonical physical host identity used only for diagnostic attribution.
     /// The raw configured value is preserved and never used for scheduling,
     /// authorization, targeting, or ownership.

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -49,13 +49,12 @@ impl ConfigFixture {
     }
 
     fn yaml(&self, body: &str) -> String {
-        self.yaml_with_identity("test", "test/group", body)
+        self.yaml_with_group("test/group", body)
     }
 
-    fn yaml_with_identity(&self, name: &str, group: &str, body: &str) -> String {
+    fn yaml_with_group(&self, group: &str, body: &str) -> String {
         format!(
             r#"
-name: {name}
 group: {group}
 base_dir: {base_dir}
 ca_dir: {ca_dir}
@@ -305,8 +304,7 @@ async fn diagnostic_config_read_rejects_oversized_file() {
 #[tokio::test]
 async fn load_config_with_profiles() {
     let fixture = ConfigFixture::new().await;
-    let yaml = fixture.yaml_with_identity(
-        "test-runner",
+    let yaml = fixture.yaml_with_group(
         "vm0/prod",
         &format!(
             r#"
@@ -331,7 +329,6 @@ server:
     );
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
-    assert_eq!(config.name.as_deref(), Some("test-runner"));
     assert_eq!(config.hostname, None);
     assert_eq!(config.profiles.len(), 1);
     let default = &config.profiles["vm0/default"];
@@ -353,19 +350,6 @@ async fn load_preserves_optional_hostname() {
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
 
-    assert_eq!(config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
-}
-
-#[tokio::test]
-async fn load_accepts_missing_legacy_name() {
-    let fixture = ConfigFixture::new().await;
-    let yaml = fixture
-        .yaml_with_default_profile("hostname: prod-1.aws.vm3.ai\n")
-        .replacen("name: test\n", "", 1);
-
-    let config = fixture.load_config(&yaml, true).await.unwrap();
-
-    assert_eq!(config.name, None);
     assert_eq!(config.hostname.as_deref(), Some("prod-1.aws.vm3.ai"));
 }
 
@@ -1152,7 +1136,6 @@ async fn generate_then_load_round_trip() {
     let fixture = ConfigFixture::new().await;
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
-        name: Some("test-runner".into()),
         hostname: Some("prod-1.aws.vm3.ai".into()),
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
@@ -1179,6 +1162,7 @@ async fn generate_then_load_round_trip() {
     let generated = tokio::fs::read_to_string(&config_path).await.unwrap();
     assert!(generated.contains("rootfs_disk_mb: 8192"));
     assert!(generated.contains("workspace_disk_mb: 16384"));
+    assert!(generated.lines().all(|line| !line.starts_with("name:")));
     assert!(
         generated
             .lines()
@@ -1212,7 +1196,6 @@ async fn generate_tightens_existing_runner_dir_and_config_file() {
     std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
     let config = RunnerConfig {
-        name: Some("test-runner".into()),
         hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),
@@ -1253,7 +1236,6 @@ async fn load_resolves_relative_paths() {
 
     let yaml = format!(
         r#"
-name: test
 group: test/group
 base_dir: my-runner
 ca_dir: artifacts
@@ -1291,7 +1273,6 @@ fn factory_config_resolves_paths() {
     let home = HomePaths::with_root(dir.path().to_path_buf());
 
     let config = RunnerConfig {
-        name: Some("test".into()),
         hostname: None,
         group: "test/group".into(),
         base_dir: dir.path().join("runner"),
@@ -1324,7 +1305,6 @@ async fn idle_pool_config_round_trip() {
     let fixture = ConfigFixture::new().await;
     let runner_dir = fixture.path().join("my-runner");
     let config = RunnerConfig {
-        name: Some("test-runner".into()),
         hostname: None,
         group: "vm0/prod".into(),
         base_dir: runner_dir.clone(),

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -1162,7 +1162,6 @@ async fn generate_then_load_round_trip() {
     let generated = tokio::fs::read_to_string(&config_path).await.unwrap();
     assert!(generated.contains("rootfs_disk_mb: 8192"));
     assert!(generated.contains("workspace_disk_mb: 16384"));
-    assert!(generated.lines().all(|line| !line.starts_with("name:")));
     assert!(
         generated
             .lines()

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -16,8 +16,6 @@ const LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES: u64 = 64 * 1024;
 pub(crate) struct LiveRunnerInstanceMetadata {
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
-    /// Legacy release-shaped compatibility metadata.
-    pub runner_name: Option<String>,
     pub runner_group: String,
     pub subcommand: String,
 }
@@ -34,8 +32,6 @@ pub(crate) struct LiveRunnerInstance {
     pub starttime: u64,
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
-    /// Legacy release-shaped compatibility metadata.
-    pub runner_name: Option<String>,
     pub runner_group: String,
     pub subcommand: String,
     pub started_at: String,
@@ -90,8 +86,6 @@ struct LiveRunnerInstanceRecord {
     euid: u32,
     config_path: PathBuf,
     base_dir: PathBuf,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    runner_name: Option<String>,
     runner_group: String,
     subcommand: String,
     started_at: String,
@@ -123,7 +117,6 @@ pub(crate) async fn publish(
         euid: identity.euid,
         config_path: metadata.config_path,
         base_dir: metadata.base_dir,
-        runner_name: metadata.runner_name,
         runner_group: metadata.runner_group,
         subcommand: metadata.subcommand,
         started_at: chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
@@ -206,7 +199,6 @@ async fn try_list_with_liveness(
                 starttime: record.starttime,
                 config_path: record.config_path,
                 base_dir: record.base_dir,
-                runner_name: record.runner_name,
                 runner_group: record.runner_group,
                 subcommand: record.subcommand,
                 started_at: record.started_at,
@@ -853,7 +845,6 @@ mod tests {
             LiveRunnerInstanceMetadata {
                 config_path: self.root().join("runner.yaml"),
                 base_dir: self.root().join("base"),
-                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             }
@@ -876,7 +867,6 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("stale-runner.yaml"),
                 base_dir: self.root().join("stale-base"),
-                runner_name: Some("stale-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -895,7 +885,6 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("other-runner.yaml"),
                 base_dir: self.root().join("other-base"),
-                runner_name: Some("other-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -910,7 +899,6 @@ mod tests {
                 euid: current_euid(),
                 config_path: self.root().join("procfs-runner.yaml"),
                 base_dir: self.root().join("procfs-base"),
-                runner_name: Some("procfs-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
                 started_at: TEST_STARTED_AT.into(),
@@ -956,16 +944,6 @@ mod tests {
         serde_json::to_vec_pretty(&value).unwrap()
     }
 
-    fn serialize_record_without_runner_name(record: &LiveRunnerInstanceRecord) -> Vec<u8> {
-        let mut value = serde_json::to_value(record).unwrap();
-        value
-            .as_object_mut()
-            .unwrap()
-            .remove("runner_name")
-            .unwrap();
-        serde_json::to_vec_pretty(&value).unwrap()
-    }
-
     #[tokio::test]
     async fn publish_writes_private_record_without_secret_fields() {
         let registry = TestRegistry::new();
@@ -980,13 +958,8 @@ mod tests {
         assert_eq!(record.pid, std::process::id());
         assert_eq!(record.euid, current_euid());
         assert_eq!(record.base_dir, registry.root().join("base"));
-
-        #[derive(Deserialize)]
-        struct LegacyRecord {
-            runner_name: String,
-        }
-        let legacy_record: LegacyRecord = serde_json::from_str(&content).unwrap();
-        assert_eq!(legacy_record.runner_name, "test-runner");
+        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(value.get("runner_name").is_none());
 
         #[cfg(unix)]
         {
@@ -1066,42 +1039,9 @@ mod tests {
         assert_eq!(instance.starttime, handle.identity.starttime);
         assert_eq!(instance.config_path, registry.root().join("runner.yaml"));
         assert_eq!(instance.base_dir, registry.root().join("base"));
-        assert_eq!(instance.runner_name.as_deref(), Some("test-runner"));
         assert_eq!(instance.runner_group, "vm0/test");
         assert_eq!(instance.subcommand, "start");
         assert!(!instance.started_at.is_empty());
-    }
-
-    #[tokio::test]
-    async fn try_list_accepts_record_without_legacy_runner_name() {
-        let registry = TestRegistry::new();
-        let handle = publish(&registry.home, registry.metadata()).await.unwrap();
-        let record = read_valid_record(&handle.path).await.unwrap();
-        crate::state_file::write_private_atomic(
-            &handle.path,
-            &serialize_record_without_runner_name(&record),
-        )
-        .await
-        .unwrap();
-
-        let instances = try_list(&registry.home).await.unwrap();
-
-        assert_eq!(instances.len(), 1);
-        assert_eq!(instances[0].runner_name, None);
-    }
-
-    #[tokio::test]
-    async fn publish_omits_absent_legacy_runner_name() {
-        let registry = TestRegistry::new();
-        let mut metadata = registry.metadata();
-        metadata.runner_name = None;
-
-        let handle = publish(&registry.home, metadata).await.unwrap();
-
-        let content = tokio::fs::read_to_string(&handle.path).await.unwrap();
-        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert!(value.get("runner_name").is_none());
-        assert_eq!(try_list(&registry.home).await.unwrap()[0].runner_name, None);
     }
 
     #[cfg(unix)]
@@ -1282,12 +1222,6 @@ mod tests {
             .into_iter()
             .next()
             .unwrap();
-
-        assert!(is_current(&registry.home, &instance).await.unwrap());
-
-        let mut record = read_valid_record(&handle.path).await.unwrap();
-        record.runner_name = None;
-        write_record(&handle.path, &record).await;
 
         assert!(is_current(&registry.home, &instance).await.unwrap());
 

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -958,8 +958,6 @@ mod tests {
         assert_eq!(record.pid, std::process::id());
         assert_eq!(record.euid, current_euid());
         assert_eq!(record.base_dir, registry.root().join("base"));
-        let value: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert!(value.get("runner_name").is_none());
 
         #[cfg(unix)]
         {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -546,34 +546,6 @@ mod tests {
     }
 
     #[test]
-    fn runner_config_rejects_removed_name_argument() {
-        let error = Cli::try_parse_from([
-            "runner",
-            "config",
-            "--profile",
-            "vm0/default",
-            "--rootfs-hash",
-            "rootfs-hash",
-            "--snapshot-hash",
-            "snapshot-hash",
-            "--name",
-            "v1.2.3",
-            "--group",
-            "vm0/test",
-            "--runner-dirname",
-            "v1.2.3",
-            "--api-url",
-            "https://api.example.test",
-            "--token",
-            "runner-token",
-        ])
-        .err()
-        .expect("runner config must reject the removed --name argument");
-
-        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
-    }
-
-    #[test]
     fn runner_hostname_partial_read_preserves_valid_value() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("runner.yaml");

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -496,8 +496,6 @@ mod tests {
                 "rootfs-hash",
                 "--snapshot-hash",
                 "snapshot-hash",
-                "--name",
-                "runner-test",
                 "--group",
                 "vm0/test",
                 "--runner-dirname",
@@ -525,8 +523,6 @@ mod tests {
                 "rootfs-hash",
                 "--snapshot-hash",
                 "snapshot-hash",
-                "--name",
-                "runner-test",
                 "--group",
                 "vm0/test",
                 "--runner-dirname",
@@ -550,14 +546,38 @@ mod tests {
     }
 
     #[test]
+    fn runner_config_rejects_removed_name_argument() {
+        let error = Cli::try_parse_from([
+            "runner",
+            "config",
+            "--profile",
+            "vm0/default",
+            "--rootfs-hash",
+            "rootfs-hash",
+            "--snapshot-hash",
+            "snapshot-hash",
+            "--name",
+            "v1.2.3",
+            "--group",
+            "vm0/test",
+            "--runner-dirname",
+            "v1.2.3",
+            "--api-url",
+            "https://api.example.test",
+            "--token",
+            "runner-token",
+        ])
+        .err()
+        .expect("runner config must reject the removed --name argument");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
     fn runner_hostname_partial_read_preserves_valid_value() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("runner.yaml");
-        std::fs::write(
-            &config_path,
-            "name: v0.174.0\nhostname: prod-1.aws.vm3.ai\n",
-        )
-        .unwrap();
+        std::fs::write(&config_path, "hostname: prod-1.aws.vm3.ai\n").unwrap();
 
         assert_eq!(
             runner_hostname_from_config(&config_path).as_deref(),
@@ -569,10 +589,10 @@ mod tests {
     fn runner_hostname_partial_read_omits_missing_or_invalid_value() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("runner.yaml");
-        std::fs::write(&config_path, "name: v0.174.0\n").unwrap();
+        std::fs::write(&config_path, "group: vm0/test\n").unwrap();
         assert_eq!(runner_hostname_from_config(&config_path), None);
 
-        std::fs::write(&config_path, "name: v0.174.0\nhostname: ''\n").unwrap();
+        std::fs::write(&config_path, "hostname: ''\n").unwrap();
         assert_eq!(runner_hostname_from_config(&config_path), None);
     }
 

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -172,7 +172,6 @@ mod tests {
             starttime: 1,
             config_path: base_dir.join("runner.yaml"),
             base_dir: base_dir.to_path_buf(),
-            runner_name: Some("test-runner".into()),
             runner_group: "vm0/test".into(),
             subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
@@ -373,7 +372,6 @@ mod tests {
             crate::live_runner_instances::LiveRunnerInstanceMetadata {
                 config_path: base.join("runner.yaml"),
                 base_dir: base,
-                runner_name: Some("test-runner".into()),
                 runner_group: "vm0/test".into(),
                 subcommand: "start".into(),
             },

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -13,9 +13,11 @@ the raw value. Existing configuration files without `hostname` continue to
 load and omit the canonical hostname fields.
 
 Hostname does not select a service, directory, release, or rollback target.
-Systemd suffixes and versioned binary/Runner directories remain explicit
-release lifecycle identities. Live processes are selected by their exact
-config path and process identity, and rolling log files use the release
+Systemd service suffixes are opaque local instance names. Production currently
+passes its explicit `runner_release` value as the service name and Runner
+directory name, but version logic uses `runner_release` directly and does not
+interpret a runner name as a version. Live processes are selected by their
+exact config path and process identity, and rolling log files use the release
 compiled into the Runner binary. Current Runner binaries send optional
 canonical `runnerHostname` from configuration and canonical `runnerVersion`
 compiled into the binary. They no longer send legacy `runnerName` in
@@ -24,11 +26,11 @@ persist, or map that field. During deployment overlap, an extra `runnerName`
 from an older Runner payload is tolerated but discarded before request
 handling.
 
-Current `runner.yaml` has no release-shaped `name` field. Repository automation
-writes `hostname` through `runner config`, while `--runner-dirname` and systemd
-service `--name` remain explicit release-lifecycle inputs. Live-runner records
-contain exact config/process metadata and no legacy runner name. Readiness and
-doctor select live processes by the unit's exact config path.
+Current `runner.yaml` has no legacy `name` field. Repository automation writes
+`hostname` through `runner config`, while `--runner-dirname` and systemd service
+`--name` remain opaque local lifecycle inputs. Live-runner records contain exact
+config/process metadata and no legacy runner name. Readiness and doctor select
+live processes by the unit's exact config path.
 
 Operational queries and alerts should use `runner_hostname` and
 `runner_version`. A bounded historical fallback may use `runner_name` only for

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -24,10 +24,11 @@ persist, or map that field. During deployment overlap, an extra `runnerName`
 from an older Runner payload is tolerated but discarded before request
 handling.
 
-The version-shaped YAML `name` remains an optional local compatibility field
-while retained Runner binaries and operator automation still require it.
-Current production configuration continues writing it, but current runtime,
-readiness, and doctor selection do not use it as process identity.
+Current `runner.yaml` has no release-shaped `name` field. Repository automation
+writes `hostname` through `runner config`, while `--runner-dirname` and systemd
+service `--name` remain explicit release-lifecycle inputs. Live-runner records
+contain exact config/process metadata and no legacy runner name. Readiness and
+doctor select live processes by the unit's exact config path.
 
 Operational queries and alerts should use `runner_hostname` and
 `runner_version`. A bounded historical fallback may use `runner_name` only for

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -50,14 +50,14 @@ source "$ENV_FILE"
 HOST="${RUNNER_LOCAL_HOST:?RUNNER_LOCAL_HOST not set in $ENV_FILE}"
 SSH_USER="${RUNNER_LOCAL_USER:-ubuntu}"
 
-# --- Runner name from RUNNER_DEFAULT_GROUP ---
+# --- Opaque local service suffix from RUNNER_DEFAULT_GROUP ---
 RUNNER_GROUP="${RUNNER_DEFAULT_GROUP:?RUNNER_DEFAULT_GROUP not set in $ENV_FILE}"
 # vm0/local-alice-macbook -> alice-macbook
-RUNNER_NAME="${RUNNER_GROUP##*/}"
+RUNNER_SERVICE_SUFFIX="${RUNNER_GROUP##*/}"
 
-REMOTE_BIN_DIR="/var/lib/vm0-runner/bin/${RUNNER_NAME}"
+REMOTE_BIN_DIR="/var/lib/vm0-runner/bin/${RUNNER_SERVICE_SUFFIX}"
 RUNNER_BIN="sudo $REMOTE_BIN_DIR/runner"
-RUNNER_DIR="/var/lib/vm0-runner/runners/$RUNNER_NAME"
+RUNNER_DIR="/var/lib/vm0-runner/runners/$RUNNER_SERVICE_SUFFIX"
 
 CF_SSH="$SCRIPT_DIR/cf-ssh.sh"
 SSH_KEY="$PROJECT_ROOT/.certs/vm0-metal-local.pem"
@@ -109,8 +109,8 @@ cmd_deploy() {
   RUNNER_SECRET="${OFFICIAL_RUNNER_SECRET:?OFFICIAL_RUNNER_SECRET not set in $ENV_FILE}"
   TARGET=$(select_runner_target)
   # alice-macbook -> https://tunnel-alice-macbook-www.vm7.ai
-  API_URL="https://tunnel-${RUNNER_NAME#local-}-www.vm7.ai"
-  log "Runner: $RUNNER_NAME (group: $RUNNER_GROUP, api: $API_URL)"
+  API_URL="https://tunnel-${RUNNER_SERVICE_SUFFIX#local-}-www.vm7.ai"
+  log "Runner service: $RUNNER_SERVICE_SUFFIX (group: $RUNNER_GROUP, api: $API_URL)"
 
   runner_guest_binaries_load
   local guest_cargo_args=()
@@ -136,7 +136,7 @@ cmd_deploy() {
   # Stop old service before uploading (avoids "Text file busy").
   # Try --force first (new runner), fall back to no-flag (old runner).
   log "Stopping old service..."
-  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force" || ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME" || true
+  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_SERVICE_SUFFIX --force" || ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_SERVICE_SUFFIX" || true
 
   # Upload
   log "Deploying to $SSH_USER@$HOST..."
@@ -185,9 +185,9 @@ cmd_deploy() {
   log "Generating config..."
   ssh_cmd "$RUNNER_BIN config \
     $CONFIG_ARGS \
-    --name $RUNNER_NAME \
+    --hostname $HOST \
     --group $RUNNER_GROUP \
-    --runner-dirname $RUNNER_NAME \
+    --runner-dirname $RUNNER_SERVICE_SUFFIX \
     --api-url $API_URL \
     --token vm0_official_${RUNNER_SECRET}"
 
@@ -199,19 +199,19 @@ cmd_deploy() {
     LOCAL_FLAG="--local"
     MOCK_FLAG="--env USE_MOCK_CLAUDE=true"
   fi
-  ssh_cmd "$RUNNER_BIN service start --name $RUNNER_NAME \
+  ssh_cmd "$RUNNER_BIN service start --name $RUNNER_SERVICE_SUFFIX \
     --config $RUNNER_DIR/runner.yaml $LOCAL_FLAG $MOCK_FLAG"
 
   log "Waiting for Runner readiness..."
-  ssh_cmd "$RUNNER_BIN service wait-running --name $RUNNER_NAME --timeout-secs 120" >/dev/null
+  ssh_cmd "$RUNNER_BIN service wait-running --name $RUNNER_SERVICE_SUFFIX --timeout-secs 120" >/dev/null
 
-  log "Done! Runner $RUNNER_NAME deployed to $HOST"
+  log "Done! Runner service $RUNNER_SERVICE_SUFFIX deployed to $HOST"
 }
 
 cmd_submit() {
   PROFILE="${2:?Usage: $0 submit <profile> <prompt>}"
   PROMPT="${3:?Usage: $0 submit <profile> <prompt>}"
-  log "Submitting job to $RUNNER_NAME (profile: $PROFILE, prompt: $PROMPT)..."
+  log "Submitting job through runner service $RUNNER_SERVICE_SUFFIX (profile: $PROFILE, prompt: $PROMPT)..."
   # Use printf %q to safely escape the prompt for remote shell
   ESCAPED_PROMPT=$(printf '%q' "$PROMPT")
   ssh_cmd "$RUNNER_BIN local submit --group $RUNNER_GROUP --profile $PROFILE --prompt $ESCAPED_PROMPT --timeout 120"
@@ -232,12 +232,12 @@ cmd_exec() {
 }
 
 cmd_remove() {
-  log "Removing runner $RUNNER_NAME from $HOST..."
+  log "Removing runner service $RUNNER_SERVICE_SUFFIX from $HOST..."
 
-  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME --force" || ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME" || true
+  ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_SERVICE_SUFFIX --force" || ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_SERVICE_SUFFIX" || true
   ssh_cmd "sudo rm -rf $REMOTE_BIN_DIR $RUNNER_DIR"
 
-  log "Done! Runner $RUNNER_NAME removed from $HOST"
+  log "Done! Runner service $RUNNER_SERVICE_SUFFIX removed from $HOST"
 }
 
 # --- Main ---


### PR DESCRIPTION
## Summary

- remove the legacy Runner config `name` field, `runner config --name`, and live-record `runner_name` metadata
- pass the physical hostname through every current vm0 config-generation path, including CI behavior jobs and `scripts/dev-runner.sh`
- retain service-command `--name` as an opaque local service suffix and name script variables accordingly
- use explicit `runner_release` for version-owned Ansible paths and garbage collection, even where production currently passes that value as an opaque service name

## Scope

- applies to the current vm0 repository contract only; compatibility with previously released Runner binaries and external automation is intentionally excluded
- keeps service-command `--name` and `--runner-dirname` as opaque local lifecycle interfaces; version logic consumes explicit `runner_release` instead
- does not change heartbeat, telemetry, or persisted `runner_state` contracts

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner`
- shell syntax checks for all changed Runner CI/behavior scripts
- `bash .github/scripts/tests/dev-runner-test.sh`
- `.github/scripts/tests/runner-attribution-ansible-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`

Closes #29772

Parent context: #29497