### PR TITLE
feat: expose agent run execution limit

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -104,6 +104,10 @@ pub mod runners {
     /// The API validates the materialized prompt against this shared limit before committing claimed chat events.
     pub const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: u64 = 1048576;
 
+    /// Maximum execution budget for one agent run, in seconds.
+    /// The runner enforces this deadline and the API includes it in the agent-facing system prompt.
+    pub const AGENT_EXECUTION_TIMEOUT_SECONDS: u64 = 7200;
+
     /// Schema version written to builtin firewall catalog cache files and accepted by the mitm addon.
     /// This value is generated for both Rust and Python consumers so cache compatibility cannot drift between them.
     pub const BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION: u32 = 1;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -77,7 +77,7 @@ use api_contracts::generated::constants::runners::{
 };
 use guest_contracts::exec_terminal::EXEC_TERMINAL_CLEANUP_BUDGET;
 
-/// Maximum guest-side runtime budget for a single agent process (2 hours).
+/// Maximum guest-side runtime budget for a single agent process.
 const JOB_TIMEOUT: Duration = Duration::from_secs(AGENT_EXECUTION_TIMEOUT_SECONDS);
 /// Exit code used when the runner's job timeout stops an agent process.
 const JOB_TIMEOUT_EXIT_CODE: i32 = guest_contracts::diagnostics::AGENT_EXECUTION_TIMEOUT_EXIT_CODE;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -72,13 +72,13 @@ use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationSignals;
 use api_contracts::generated::constants::runners::{
-    RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
+    AGENT_EXECUTION_TIMEOUT_SECONDS, RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
     paths::{CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR},
 };
 use guest_contracts::exec_terminal::EXEC_TERMINAL_CLEANUP_BUDGET;
 
 /// Maximum guest-side runtime budget for a single agent process (2 hours).
-const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
+const JOB_TIMEOUT: Duration = Duration::from_secs(AGENT_EXECUTION_TIMEOUT_SECONDS);
 /// Exit code used when the runner's job timeout stops an agent process.
 const JOB_TIMEOUT_EXIT_CODE: i32 = guest_contracts::diagnostics::AGENT_EXECUTION_TIMEOUT_EXIT_CODE;
 /// Bounded best-effort window after the execution budget for recovery

--- a/turbo/apps/api/src/lib/presentation-runbook-archive-versions.ts
+++ b/turbo/apps/api/src/lib/presentation-runbook-archive-versions.ts
@@ -11,7 +11,8 @@
  * whose execution context pinned a `CLI_PKG_URL` from before this change
  * carries a CLI whose bundled registry only knows the pre-cutover digest, and
  * it keeps asking for that digest for the queue lifetime plus a claimed run —
- * bounded by `JOB_TIMEOUT = Duration::from_secs(7200)` in
+ * bounded by the shared `AGENT_EXECUTION_TIMEOUT_SECONDS` contract in
+ * `turbo/packages/api-contracts/src/contracts/runners.ts`, enforced by
  * `crates/runner/src/executor/mod.rs`. See the "Commit-addressed CLI artifacts"
  * section of `docs/deployment-compatibility.md`.
  *

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4969,6 +4969,7 @@ describe("CHAT-02: model-first provider policies", () => {
     let previousSectionIndex = -1;
     for (const section of [
       "# Agent Identity",
+      "# Execution Time Limit",
       "# Agent Tools",
       "# Current User Info",
       "# Current Integration",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14267,6 +14267,13 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain(
       "Be brief and to the point. Skip pleasantries and filler",
     );
+    expect(appendSystemPrompt).toContain("# Execution Time Limit");
+    expect(appendSystemPrompt).toContain(
+      "A single agent run has a maximum execution time of 2 hours.",
+    );
+    expect(appendSystemPrompt).toContain(
+      "provide a final response before the run ends",
+    );
     expect(appendSystemPrompt).toContain("# Agent Tools");
     for (const toolHint of [
       "okou web download-file -h",

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -166,7 +166,8 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
  * whose execution context pinned a `CLI_PKG_URL` from before a republication
  * carries a CLI whose bundled registry only knows the previous digest, and it
  * keeps asking for that digest for the queue lifetime plus a claimed run —
- * bounded by `JOB_TIMEOUT = Duration::from_secs(7200)` in
+ * bounded by the shared `AGENT_EXECUTION_TIMEOUT_SECONDS` contract in
+ * `turbo/packages/api-contracts/src/contracts/runners.ts`, enforced by
  * `crates/runner/src/executor/mod.rs`. See the "Commit-addressed CLI artifacts"
  * section of `docs/deployment-compatibility.md`.
  *

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -1,5 +1,6 @@
 import { PLAN_UPGRADE_CLI_HINT } from "@okouai/api-contracts/contracts/errors";
 import {
+  AGENT_EXECUTION_TIMEOUT_SECONDS,
   CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_WORKING_DIR,
@@ -264,6 +265,17 @@ function buildAgentIdentityPrompt(
   return parts.length > 0 ? `# Agent Identity\n${parts.join("\n")}` : null;
 }
 
+function buildExecutionTimeLimitPrompt(): string {
+  const executionHours = AGENT_EXECUTION_TIMEOUT_SECONDS / (60 * 60);
+  const executionHourUnit = executionHours === 1 ? "hour" : "hours";
+  return [
+    "# Execution Time Limit",
+    "",
+    `A single agent run has a maximum execution time of ${executionHours} ${executionHourUnit}.`,
+    "Plan and prioritize the work so you can complete the most important in-scope tasks and provide a final response before the run ends.",
+  ].join("\n");
+}
+
 function buildIntegrationToolsPrompt(
   triggerSource: TriggerSource,
 ): readonly string[] {
@@ -477,6 +489,7 @@ function buildAppendSystemPrompt(args: {
   const identity = buildAgentIdentityPrompt(args.agent, args.publicBrand);
   return [
     identity,
+    buildExecutionTimeLimitPrompt(),
     buildAgentToolsPrompt({
       triggerSource: args.triggerSource,
       cloudBrowserEnabled: args.cloudBrowserEnabled,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  AGENT_EXECUTION_TIMEOUT_SECONDS,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
   activeInputDeliveryReserveResponseSchema,
   compatibleStoredExecutionContextSchema,
@@ -35,6 +36,12 @@ import {
 } from "../runners";
 import { runRunnerContract } from "../run-routes";
 import { MAX_EVENT_SEQUENCE_NUMBER } from "../runs";
+
+describe("agent execution timing contract", () => {
+  it("keeps one run bounded to two hours", () => {
+    expect(AGENT_EXECUTION_TIMEOUT_SECONDS).toBe(2 * 60 * 60);
+  });
+});
 
 describe("active-input reservation contract", () => {
   const deliveryId = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -37,6 +37,9 @@ export const CANONICAL_PI_SESSION_DIR = `${PI_AGENT_DIR}/sessions/--home-user-wo
 // binding from `api_contracts::generated::constants`.
 export const RESUME_SESSION_HISTORY_MAX_BYTES = 128 * 1024 * 1024;
 export const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES = 1024 * 1024;
+// Shared by the runner's enforced deadline and the agent-facing system prompt
+// so the documented execution budget cannot drift from runtime behavior.
+export const AGENT_EXECUTION_TIMEOUT_SECONDS = 2 * 60 * 60;
 export const SESSION_HISTORY_ENCODING_IDENTITY = "identity";
 export const SESSION_HISTORY_ENCODING_GZIP = "gzip";
 export const SESSION_HISTORY_ENCODING_ZSTD = "zstd";

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../contracts/client-headers";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  AGENT_EXECUTION_TIMEOUT_SECONDS,
   BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION,
   BUILTIN_FIREWALL_CATALOG_MAX_BYTES,
   CANONICAL_CLAUDE_CONFIG_DIR,
@@ -102,6 +103,10 @@ const resumeSessionHistoryMaxBytesDoc = [
 const activeInputControlPayloadMaxBytesDoc = [
   "Maximum serialized active-input control payload accepted by runner and guest process control.",
   "The API validates the materialized prompt against this shared limit before committing claimed chat events.",
+] as const;
+const agentExecutionTimeoutSecondsDoc = [
+  "Maximum execution budget for one agent run, in seconds.",
+  "The runner enforces this deadline and the API includes it in the agent-facing system prompt.",
 ] as const;
 const builtinFirewallCatalogMaxBytesDoc = [
   "Maximum builtin firewall catalog response and cache size accepted by runners.",
@@ -257,6 +262,12 @@ const expectedBindings = [
     rustConstName: "ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES",
     value: rustU64(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES),
     rustDoc: activeInputControlPayloadMaxBytesDoc,
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "AGENT_EXECUTION_TIMEOUT_SECONDS",
+    value: rustU64(AGENT_EXECUTION_TIMEOUT_SECONDS),
+    rustDoc: agentExecutionTimeoutSecondsDoc,
   },
   {
     rustModulePath: ["runners"],
@@ -575,6 +586,9 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: u64 = ${ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES};`,
+    );
+    expect(firstRender).toContain(
+      `pub const AGENT_EXECUTION_TIMEOUT_SECONDS: u64 = ${AGENT_EXECUTION_TIMEOUT_SECONDS};`,
     );
     expect(firstRender).toContain(
       `pub const BUILTIN_FIREWALL_CATALOG_MAX_BYTES: u64 = ${BUILTIN_FIREWALL_CATALOG_MAX_BYTES};`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -16,6 +16,7 @@ import {
 } from "../contracts/client-headers";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  AGENT_EXECUTION_TIMEOUT_SECONDS,
   BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION,
   BUILTIN_FIREWALL_CATALOG_MAX_BYTES,
   CANONICAL_CLAUDE_CONFIG_DIR,
@@ -289,6 +290,15 @@ export const rustConstantBindings = [
     rustDoc: [
       "Maximum serialized active-input control payload accepted by runner and guest process control.",
       "The API validates the materialized prompt against this shared limit before committing claimed chat events.",
+    ],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "AGENT_EXECUTION_TIMEOUT_SECONDS",
+    value: rustU64(AGENT_EXECUTION_TIMEOUT_SECONDS),
+    rustDoc: [
+      "Maximum execution budget for one agent run, in seconds.",
+      "The runner enforces this deadline and the API includes it in the agent-facing system prompt.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

- disclose the two-hour execution budget early in every base agent system prompt
- share one generated TypeScript/Rust timeout constant between prompt rendering and runner enforcement
- cover the numeric contract, generated Rust binding, prompt content, and base-section ordering

## Scope

- keeps the enforced timeout at 7,200 seconds
- does not change the job protocol, public API, database, timeout exit semantics, or grace windows

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/api-contracts generate:rust`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts src/rust-bindings/__tests__/constants.test.ts --maxWorkers=2 --silent=passed-only` (102 tests passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "injects agent identity, tool hints, and user info into the runner context" --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "adds Codex image upload guidance for web chat Codex sends" --maxWorkers=1 --silent=passed-only`
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=2 cargo clippy -p api-contracts -p runner --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 RUSTDOCFLAGS='-D warnings' cargo doc -p api-contracts -p runner --no-deps`
- `CARGO_BUILD_JOBS=2 cargo test -p api-contracts` (34 tests passed)
- `git diff --check`

The focused runner timeout test compiled through the runner and dependencies but its monolithic test binary was killed during final linking by the local 3.8 GiB, no-swap environment (exit 137). Retrying with one build job, test debuginfo disabled, and lld hit the same environment ceiling. Runner clippy and rustdoc both completed successfully; the PR pipeline will provide the runner test result.

Closes #29870
