### PR TITLE
refactor(rust): make shared jsonl cli state backend-neutral

### DIFF
--- a/crates/guest-agent/src/cli/claude.rs
+++ b/crates/guest-agent/src/cli/claude.rs
@@ -1,4 +1,4 @@
-//! Claude Code result parsing and tool tracking.
+//! Claude Code tool tracking.
 
 use crate::events;
 use std::collections::HashMap;
@@ -113,67 +113,6 @@ impl StuckToolTracker {
     }
 }
 
-/// Summary of Claude Code's terminal `type=result` event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ClaudeResultSummary {
-    /// Claude Code's reported turn count for the run, when present.
-    pub num_turns: Option<u64>,
-
-    /// Semantic status of Claude Code's terminal result event.
-    pub status: ClaudeResultStatus,
-}
-
-/// Semantic status derived from Claude Code's terminal `type=result` event.
-///
-/// This describes only the event's recognized semantic evidence. It is
-/// independent of the CLI process exit status and the outcome of any later
-/// post-result cleanup. When the event contains conflicting evidence,
-/// recognized error evidence takes precedence over recognized success evidence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ClaudeResultStatus {
-    /// The event contains recognized success evidence (`is_error` is `false` or
-    /// `subtype` is `"success"`) and no recognized error evidence.
-    Success,
-
-    /// The event contains recognized error evidence (`is_error` is `true` or
-    /// `subtype` is `"error"`).
-    ///
-    /// This status takes precedence over [`Self::Success`] when both kinds of
-    /// evidence are present.
-    Error,
-
-    /// The event contains neither recognized success nor recognized error
-    /// evidence.
-    ///
-    /// This status does not assert either success or failure.
-    Unknown,
-}
-
-impl ClaudeResultSummary {
-    pub(super) fn from_event(event: &serde_json::Value) -> Self {
-        Self {
-            num_turns: event.get("num_turns").and_then(|v| v.as_u64()),
-            status: ClaudeResultStatus::from_event(event),
-        }
-    }
-}
-
-impl ClaudeResultStatus {
-    fn from_event(event: &serde_json::Value) -> Self {
-        let is_error = event.get("is_error").and_then(|v| v.as_bool());
-        let subtype = event.get("subtype").and_then(|v| v.as_str());
-
-        if is_error == Some(true) || subtype == Some("error") {
-            return Self::Error;
-        }
-        if is_error == Some(false) || subtype == Some("success") {
-            return Self::Success;
-        }
-
-        Self::Unknown
-    }
-}
-
 pub(super) fn track_claude_tool_events(event: &serde_json::Value, tracker: &mut StuckToolTracker) {
     tracker.track_event(event)
 }
@@ -209,68 +148,6 @@ mod tests {
         for index in 0..MAX_TRACKED_STUCK_TOOLS {
             track_tool_use(tracker, &format!("tool-{index}"), "WebFetch");
         }
-    }
-
-    #[test]
-    fn claude_result_summary_captures_terminal_result_metadata() {
-        let event = serde_json::json!({
-            "type": "result",
-            "num_turns": 0,
-            "is_error": false,
-            "result": "done"
-        });
-
-        assert_eq!(
-            ClaudeResultSummary::from_event(&event),
-            ClaudeResultSummary {
-                num_turns: Some(0),
-                status: ClaudeResultStatus::Success,
-            }
-        );
-    }
-
-    #[test]
-    fn claude_result_summary_marks_is_error_result_as_error() {
-        let event = serde_json::json!({
-            "type": "result",
-            "num_turns": 1,
-            "is_error": true,
-            "result": "Error."
-        });
-
-        assert_eq!(
-            ClaudeResultSummary::from_event(&event).status,
-            ClaudeResultStatus::Error
-        );
-    }
-
-    #[test]
-    fn claude_result_summary_marks_error_subtype_as_error() {
-        let event = serde_json::json!({
-            "type": "result",
-            "num_turns": 1,
-            "subtype": "error",
-            "result": "Error."
-        });
-
-        assert_eq!(
-            ClaudeResultSummary::from_event(&event).status,
-            ClaudeResultStatus::Error
-        );
-    }
-
-    #[test]
-    fn claude_result_summary_marks_ambiguous_result_as_unknown() {
-        let event = serde_json::json!({
-            "type": "result",
-            "num_turns": 1,
-            "result": "Done."
-        });
-
-        assert_eq!(
-            ClaudeResultSummary::from_event(&event).status,
-            ClaudeResultStatus::Unknown
-        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -425,8 +425,8 @@ async fn run_codex_app_server(
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             event_delivery: None,
-            claude_result: None,
-            post_result_cleanup_result: None,
+            jsonl_result: None,
+            post_result_cleanup_jsonl_result: None,
             failure_diagnostic: ingestor.failure_diagnostic(),
             control_error: None,
             cli_termination: None,
@@ -510,8 +510,8 @@ async fn run_codex_app_server(
                 stderr_lines,
                 last_event_sequence: None,
                 event_delivery: None,
-                claude_result: None,
-                post_result_cleanup_result: None,
+                jsonl_result: None,
+                post_result_cleanup_jsonl_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),
                 control_error: Some(AgentError::Execution(format!(
                     "Agent execution timed out after {timeout_secs} seconds"
@@ -536,8 +536,8 @@ async fn run_codex_app_server(
                 stderr_lines,
                 last_event_sequence: None,
                 event_delivery: None,
-                claude_result: None,
-                post_result_cleanup_result: None,
+                jsonl_result: None,
+                post_result_cleanup_jsonl_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),
                 control_error: Some(AgentError::Execution("Run cancelled by user".to_string())),
                 cli_termination: Some(CliTerminationDiagnostic::new(

--- a/crates/guest-agent/src/cli/jsonl_result.rs
+++ b/crates/guest-agent/src/cli/jsonl_result.rs
@@ -1,0 +1,129 @@
+//! Shared terminal `type=result` parsing for JSONL CLI backends.
+
+/// Summary of a terminal JSONL `type=result` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonlResultSummary {
+    /// Reported turn count for the run, when present.
+    pub num_turns: Option<u64>,
+
+    /// Semantic status of the terminal result event.
+    pub status: JsonlResultStatus,
+}
+
+/// Semantic status derived from a terminal JSONL `type=result` event.
+///
+/// This describes only the event's recognized semantic evidence. It is
+/// independent of the CLI process exit status and the outcome of any later
+/// post-result cleanup. When the event contains conflicting evidence,
+/// recognized error evidence takes precedence over recognized success evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonlResultStatus {
+    /// The event contains recognized success evidence (`is_error` is `false` or
+    /// `subtype` is `"success"`) and no recognized error evidence.
+    Success,
+
+    /// The event contains recognized error evidence (`is_error` is `true` or
+    /// `subtype` is `"error"`).
+    ///
+    /// This status takes precedence over [`Self::Success`] when both kinds of
+    /// evidence are present.
+    Error,
+
+    /// The event contains neither recognized success nor recognized error
+    /// evidence.
+    ///
+    /// This status does not assert either success or failure.
+    Unknown,
+}
+
+impl JsonlResultSummary {
+    pub(super) fn from_event(event: &serde_json::Value) -> Self {
+        Self {
+            num_turns: event.get("num_turns").and_then(|value| value.as_u64()),
+            status: JsonlResultStatus::from_event(event),
+        }
+    }
+}
+
+impl JsonlResultStatus {
+    fn from_event(event: &serde_json::Value) -> Self {
+        let is_error = event.get("is_error").and_then(|value| value.as_bool());
+        let subtype = event.get("subtype").and_then(|value| value.as_str());
+
+        if is_error == Some(true) || subtype == Some("error") {
+            return Self::Error;
+        }
+        if is_error == Some(false) || subtype == Some("success") {
+            return Self::Success;
+        }
+
+        Self::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_summary_captures_terminal_metadata() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 0,
+            "is_error": false,
+            "result": "done"
+        });
+
+        assert_eq!(
+            JsonlResultSummary::from_event(&event),
+            JsonlResultSummary {
+                num_turns: Some(0),
+                status: JsonlResultStatus::Success,
+            }
+        );
+    }
+
+    #[test]
+    fn result_summary_marks_is_error_result_as_error() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "is_error": true,
+            "result": "Error."
+        });
+
+        assert_eq!(
+            JsonlResultSummary::from_event(&event).status,
+            JsonlResultStatus::Error
+        );
+    }
+
+    #[test]
+    fn result_summary_marks_error_subtype_as_error() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "subtype": "error",
+            "result": "Error."
+        });
+
+        assert_eq!(
+            JsonlResultSummary::from_event(&event).status,
+            JsonlResultStatus::Error
+        );
+    }
+
+    #[test]
+    fn result_summary_marks_ambiguous_result_as_unknown() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "result": "Done."
+        });
+
+        assert_eq!(
+            JsonlResultSummary::from_event(&event).status,
+            JsonlResultStatus::Unknown
+        );
+    }
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -9,13 +9,13 @@
 //! - `diagnostics`: bounded stderr tail collection.
 //! - `event_delivery`: event sender watermark state.
 //! - `provider_event_normalization`: provider semantic arrays before sequencing.
-//! - `claude`: Claude result parsing and tool tracking.
+//! - `claude`: Claude Code tool tracking.
+//! - `jsonl_result`: shared terminal result parsing for JSONL CLI backends.
 //! - `termination`: process-group termination FSM.
 //!
-//! `execute_cli` owns the Claude Code subprocess orchestration, while
-//! `codex_app_server_backend` owns the Codex JSON-RPC lifecycle and
-//! Pi uses the same JSONL subprocess lifecycle as Claude Code. Each path retains
-//! ownership of its process, event delivery, heartbeat races, and child
+//! `execute_cli` owns the shared Claude Code/Pi JSONL subprocess orchestration,
+//! while `codex_app_server_backend` owns the Codex JSON-RPC lifecycle. Each path
+//! retains ownership of its process, event delivery, heartbeat races, and child
 //! reaping until completion.
 
 mod child_env;
@@ -33,15 +33,16 @@ mod command;
 mod diagnostics;
 mod event_delivery;
 mod exec_boundary;
+mod jsonl_result;
 mod line_reader;
 mod pi_rpc;
 mod process_group;
 mod provider_event_normalization;
 mod termination;
 
-pub use claude::{ClaudeResultStatus, ClaudeResultSummary};
 pub use codex_setup::setup_codex_for_config;
 pub use codex_startup::CodexStartupTiming;
+pub use jsonl_result::{JsonlResultStatus, JsonlResultSummary};
 
 use crate::active_input::{ActiveInputController, ActiveInputWriter, ReplayUserEventAction};
 use crate::constants;
@@ -264,14 +265,14 @@ pub struct CliExecutionResult {
     /// Bounded event-delivery failure details, when delivery was terminally incomplete.
     pub event_delivery: Option<EventDeliveryDiagnostic>,
 
-    /// Claude Code's final result metadata, when a terminal result event was
-    /// observed. Codex uses its own event schema and leaves this unset.
-    pub claude_result: Option<ClaudeResultSummary>,
+    /// Final JSONL result metadata, when a terminal result event was observed.
+    /// Codex uses its own event schema and leaves this unset.
+    pub jsonl_result: Option<JsonlResultSummary>,
 
-    /// Claude Code result that armed post-result cleanup, when cleanup was
-    /// armed. This is intentionally separate from `claude_result` because late
-    /// drained stdout may contain another result event after cleanup starts.
-    pub post_result_cleanup_result: Option<ClaudeResultSummary>,
+    /// JSONL result that armed post-result cleanup, when cleanup was armed.
+    /// This is intentionally separate from `jsonl_result` because late drained
+    /// stdout may contain another result event after cleanup starts.
+    pub post_result_cleanup_jsonl_result: Option<JsonlResultSummary>,
 
     /// Best-effort, secret-masked terminal failure diagnostic parsed from the
     /// framework event stream.
@@ -1116,7 +1117,7 @@ async fn execute_cli_inner(
 
     let mut child = cmd.spawn()?;
 
-    let Some(claude_stdin) = child.stdin.take() else {
+    let Some(cli_stdin) = child.stdin.take() else {
         let _ = child.start_kill();
         return Err(AgentError::Execution("no stdin".into()));
     };
@@ -1146,14 +1147,14 @@ async fn execute_cli_inner(
         )
     });
     let mut pi_rpc_startup_boundary = pi_execution.then(pi_rpc::PiRpcStartupBoundary::default);
-    let mut claude_stdin_write_handle = Some({
+    let mut stdin_write_handle = Some({
         let run_id = runtime.run_id.to_string();
         let prompt = runtime.prompt.to_string();
         let pi_rpc_cancellation = pi_rpc_cancellation.clone();
         tokio::spawn(async move {
             if pi_execution {
                 pi_rpc::write_commands(
-                    claude_stdin,
+                    cli_stdin,
                     &run_id,
                     &prompt,
                     active_input,
@@ -1163,13 +1164,12 @@ async fn execute_cli_inner(
                 .await
             } else {
                 drop(pi_rpc_response_rx);
-                write_claude_stream_json_to_stdin(claude_stdin, &run_id, &prompt, active_input)
-                    .await
+                write_claude_stream_json_to_stdin(cli_stdin, &run_id, &prompt, active_input).await
             }
         })
     });
 
-    // Stream Claude Code stdout JSONL, racing against heartbeat and process exit.
+    // Stream CLI stdout JSONL, racing against heartbeat and process exit.
     //
     // Event sending is decoupled from stdout reading via an mpsc channel
     // to prevent a deadlock: Bun (Claude CLI runtime) uses blocking stdout
@@ -1252,8 +1252,8 @@ async fn execute_cli_inner(
     let mut user_cancellation_handled = false;
     let mut pi_user_cancelled = false;
     let mut cli_exit_at: Option<Instant> = None;
-    let mut claude_result = None;
-    let mut post_result_cleanup_result = None;
+    let mut jsonl_result = None;
+    let mut post_result_cleanup_jsonl_result = None;
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             () = user_cancellation.cancelled(), if !user_cancellation_handled && cli_status.is_none() => {
@@ -1330,12 +1330,12 @@ async fn execute_cli_inner(
                 );
             }
             stdin_write_result = async {
-                match claude_stdin_write_handle.as_mut() {
+                match stdin_write_handle.as_mut() {
                     Some(handle) => Some(handle.await),
                     None => std::future::pending().await,
                 }
-            }, if claude_stdin_write_handle.is_some() => {
-                claude_stdin_write_handle = None;
+            }, if stdin_write_handle.is_some() => {
+                stdin_write_handle = None;
                 match try_observe_cli_exit(
                     &mut child,
                     &mut cli_status,
@@ -1359,7 +1359,7 @@ async fn execute_cli_inner(
                         termination_runtime.begin_control_failure(
                             TerminationReason::InitialPromptStdin,
                             error,
-                            ControlTerminationLog::ClaudeStdinWriterFailed { error: error_log },
+                            ControlTerminationLog::StdinWriterFailed { error: error_log },
                             termination_deadline.as_mut(),
                         );
                     }
@@ -1370,11 +1370,11 @@ async fn execute_cli_inner(
                         active_input_controller.close_terminal();
                         let error_log = error.to_string();
                         let control_error =
-                            AgentError::Execution(format!("Claude stdin writer task failed: {error_log}"));
+                            AgentError::Execution(format!("CLI stdin writer task failed: {error_log}"));
                         termination_runtime.begin_control_failure(
                             TerminationReason::InitialPromptStdin,
                             control_error,
-                            ControlTerminationLog::ClaudeStdinWriterTaskFailed { error: error_log },
+                            ControlTerminationLog::StdinWriterTaskFailed { error: error_log },
                             termination_deadline.as_mut(),
                         );
                     }
@@ -1586,22 +1586,33 @@ async fn execute_cli_inner(
                                     CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                                 }
                             }
-                            // Print Claude Code final result to stdout if applicable.
+                            // Print the terminal JSONL result to stdout if applicable.
                             if is_terminal_result_event {
-                                let result_summary = ClaudeResultSummary::from_event(&event);
-                                claude_result = Some(result_summary);
+                                let result_summary = JsonlResultSummary::from_event(&event);
+                                jsonl_result = Some(result_summary);
                                 if let Some(diagnostic) =
-                                    events::masked_claude_failure_diagnostic(&event, masker)
+                                    events::masked_jsonl_result_failure_diagnostic(&event, masker)
                                 {
                                     let subtype = diagnostic.subtype.unwrap_or("unknown");
+                                    let (source, result_owner) = match runtime.framework {
+                                        env::Framework::ClaudeCode => {
+                                            (FailureDetailSource::ClaudeResult, "Claude")
+                                        }
+                                        env::Framework::Pi => {
+                                            (FailureDetailSource::PiResult, "Pi")
+                                        }
+                                        env::Framework::Codex => {
+                                            (FailureDetailSource::CodexJsonl, "Codex")
+                                        }
+                                    };
                                     let candidate = CliFailureDiagnostic {
                                         message: diagnostic.message,
-                                        source: FailureDetailSource::ClaudeResult,
+                                        source,
                                         failure_reason: None,
                                     };
                                     log_warn!(
                                         LOG_TAG,
-                                        "Claude JSONL failure result seq={} subtype={subtype}: {}",
+                                        "{result_owner} JSONL failure result seq={} subtype={subtype}: {}",
                                         event_pipeline.ingestor.current_sequence(),
                                         candidate.message
                                     );
@@ -1613,7 +1624,7 @@ async fn execute_cli_inner(
                                 {
                                     // Guest-agent stdout is captured as
                                     // system-stream logs, so mask before
-                                    // printing Claude's final result.
+                                    // printing the final result.
                                     println!("{}", masker.mask_string(result));
                                 }
                                 let active_input_idle =
@@ -1630,7 +1641,7 @@ async fn execute_cli_inner(
                                         termination_deadline.as_mut(),
                                     )
                                 {
-                                    post_result_cleanup_result = Some(result_summary);
+                                    post_result_cleanup_jsonl_result = Some(result_summary);
                                 }
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names).
@@ -1923,27 +1934,24 @@ async fn execute_cli_inner(
 
     active_input_controller.close_terminal();
     let mut active_input_error = None;
-    if let Some(handle) = claude_stdin_write_handle.take() {
+    if let Some(handle) = stdin_write_handle.take() {
         if handle.is_finished() {
             match handle.await {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => {
                     log_warn!(
                         LOG_TAG,
-                        "Claude stdin writer finished after CLI loop with error: {error}"
+                        "CLI stdin writer finished after CLI loop with error: {error}"
                     );
                     if active_input_controller.has_activity() {
                         active_input_error = Some(error);
                     }
                 }
                 Err(error) => {
-                    log_warn!(
-                        LOG_TAG,
-                        "Claude stdin writer failed after CLI loop: {error}"
-                    );
+                    log_warn!(LOG_TAG, "CLI stdin writer failed after CLI loop: {error}");
                     if active_input_controller.has_activity() {
                         active_input_error = Some(AgentError::Execution(format!(
-                            "Claude stdin writer task failed during active-input quiescence: {error}"
+                            "CLI stdin writer task failed during active-input quiescence: {error}"
                         )));
                     }
                 }
@@ -1960,21 +1968,21 @@ async fn execute_cli_inner(
                 Ok(Ok(Err(error))) => active_input_error = Some(error),
                 Ok(Err(error)) => {
                     active_input_error = Some(AgentError::Execution(format!(
-                        "Claude stdin writer task failed during active-input quiescence: {error}"
+                        "CLI stdin writer task failed during active-input quiescence: {error}"
                     )));
                 }
                 Err(_) => {
                     handle.abort();
                     let _ = handle.await;
                     active_input_error = Some(AgentError::Execution(
-                        "Claude stdin writer did not quiesce after terminal close".to_string(),
+                        "CLI stdin writer did not quiesce after terminal close".to_string(),
                     ));
                 }
             }
         } else {
             handle.abort();
             let _ = handle.await;
-            log_info!(LOG_TAG, "Stopped Claude stdin writer after CLI loop");
+            log_info!(LOG_TAG, "Stopped CLI stdin writer after CLI loop");
         }
     }
 
@@ -2034,8 +2042,7 @@ async fn execute_cli_inner(
         );
     }
     let (mut exit_code, cli_observed_exit) = cli_exit_summary_from_status(&status);
-    if pi_execution
-        && claude_result.is_some_and(|result| result.status == ClaudeResultStatus::Error)
+    if pi_execution && jsonl_result.is_some_and(|result| result.status == JsonlResultStatus::Error)
     {
         exit_code = 1;
     }
@@ -2083,8 +2090,8 @@ async fn execute_cli_inner(
         stderr_lines: masked_stderr_lines,
         last_event_sequence: delivery_report.last_acknowledged_sequence,
         event_delivery: delivery_report.diagnostic,
-        claude_result,
-        post_result_cleanup_result,
+        jsonl_result,
+        post_result_cleanup_jsonl_result,
         failure_diagnostic,
         control_error,
         cli_termination,

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -226,8 +226,8 @@ impl PostResultCleanupState {
 pub(super) enum ControlTerminationLog {
     ExecutionTimeout { timeout_secs: u64 },
     UserCancellation,
-    ClaudeStdinWriterFailed { error: String },
-    ClaudeStdinWriterTaskFailed { error: String },
+    StdinWriterFailed { error: String },
+    StdinWriterTaskFailed { error: String },
     StuckTool { name: String, elapsed: u64 },
     HeartbeatFailed,
     HeartbeatTaskPanicked,
@@ -248,16 +248,16 @@ impl ControlTerminationLog {
             Self::UserCancellation => {
                 log_warn!(LOG_TAG, "User cancelled run, SIGTERM pgid={pgid}");
             }
-            Self::ClaudeStdinWriterFailed { error } => {
+            Self::StdinWriterFailed { error } => {
                 log_warn!(
                     LOG_TAG,
-                    "Claude stdin writer failed, SIGTERM pgid={pgid}: {error}"
+                    "CLI stdin writer failed, SIGTERM pgid={pgid}: {error}"
                 );
             }
-            Self::ClaudeStdinWriterTaskFailed { error } => {
+            Self::StdinWriterTaskFailed { error } => {
                 log_warn!(
                     LOG_TAG,
-                    "Claude stdin writer task failed, SIGTERM pgid={pgid}: {error}"
+                    "CLI stdin writer task failed, SIGTERM pgid={pgid}: {error}"
                 );
             }
             Self::StuckTool { name, elapsed } => {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -32,7 +32,7 @@ pub(crate) struct CodexFailureDiagnostic {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct ClaudeFailureDiagnostic {
+pub(crate) struct JsonlResultFailureDiagnostic {
     pub subtype: Option<&'static str>,
     pub message: String,
 }
@@ -168,17 +168,17 @@ pub(crate) fn masked_codex_failure_diagnostic(
     })
 }
 
-/// Extract a secret-masked Claude Code terminal failure diagnostic.
+/// Extract a secret-masked terminal JSONL result failure diagnostic.
 ///
-/// Claude Code reports the terminal run outcome as `type=result`. On failure,
-/// the `result` field carries the concise terminal reason that is otherwise
-/// lost when stderr is empty.
-pub(crate) fn masked_claude_failure_diagnostic(
+/// JSONL CLI backends report the terminal run outcome as `type=result`. On
+/// failure, the `result` field carries the concise terminal reason that is
+/// otherwise lost when stderr is empty.
+pub(crate) fn masked_jsonl_result_failure_diagnostic(
     event: &Value,
     masker: &SecretMasker,
-) -> Option<ClaudeFailureDiagnostic> {
-    let diagnostic = extract_claude_failure_diagnostic(event)?;
-    Some(ClaudeFailureDiagnostic {
+) -> Option<JsonlResultFailureDiagnostic> {
+    let diagnostic = extract_jsonl_result_failure_diagnostic(event)?;
+    Some(JsonlResultFailureDiagnostic {
         subtype: diagnostic.subtype,
         message: mask_and_truncate_diagnostic(&diagnostic.message, masker),
     })
@@ -211,7 +211,7 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
     }
 }
 
-fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagnostic> {
+fn extract_jsonl_result_failure_diagnostic(event: &Value) -> Option<JsonlResultFailureDiagnostic> {
     if event.get("type").and_then(Value::as_str)? != "result" {
         return None;
     }
@@ -227,7 +227,7 @@ fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagn
         return None;
     }
 
-    Some(ClaudeFailureDiagnostic {
+    Some(JsonlResultFailureDiagnostic {
         subtype,
         message: raw_message_from_field(event.get("result"))?,
     })
@@ -1020,7 +1020,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_error_result_yields_failure_diagnostic() {
+    fn jsonl_error_result_yields_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "result",
             "subtype": "error",
@@ -1029,8 +1029,8 @@ mod tests {
         });
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
-            Some(ClaudeFailureDiagnostic {
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(JsonlResultFailureDiagnostic {
                 subtype: Some("error"),
                 message: "permission denied while running command".to_string(),
             })
@@ -1038,7 +1038,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_error_subtype_without_is_error_yields_failure_diagnostic() {
+    fn jsonl_error_subtype_without_is_error_yields_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "result",
             "subtype": "error",
@@ -1046,8 +1046,8 @@ mod tests {
         });
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
-            Some(ClaudeFailureDiagnostic {
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(JsonlResultFailureDiagnostic {
                 subtype: Some("error"),
                 message: "terminal result failed".to_string(),
             })
@@ -1055,7 +1055,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_failure_diagnostic_drops_unrecognized_subtype() {
+    fn jsonl_result_failure_diagnostic_drops_unrecognized_subtype() {
         let event = serde_json::json!({
             "type": "result",
             "subtype": "secret\nsubtype",
@@ -1064,8 +1064,8 @@ mod tests {
         });
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
-            Some(ClaudeFailureDiagnostic {
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(JsonlResultFailureDiagnostic {
                 subtype: None,
                 message: "terminal result failed".to_string(),
             })
@@ -1073,7 +1073,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_success_result_has_no_failure_diagnostic() {
+    fn jsonl_success_result_has_no_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "result",
             "subtype": "success",
@@ -1082,13 +1082,13 @@ mod tests {
         });
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw("")),
             None
         );
     }
 
     #[test]
-    fn claude_error_result_requires_nonempty_result_message() {
+    fn jsonl_error_result_requires_nonempty_result_message() {
         let event = serde_json::json!({
             "type": "result",
             "subtype": "error",
@@ -1097,13 +1097,13 @@ mod tests {
         });
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw("")),
             None
         );
     }
 
     #[test]
-    fn claude_failure_diagnostic_masks_and_escapes_line_breaks() {
+    fn jsonl_result_failure_diagnostic_masks_and_escapes_line_breaks() {
         let event = serde_json::json!({
             "type": "result",
             "is_error": true,
@@ -1112,8 +1112,8 @@ mod tests {
         let masker = SecretMasker::from_raw("c3VwZXJzZWNyZXQ=");
 
         assert_eq!(
-            masked_claude_failure_diagnostic(&event, &masker),
-            Some(ClaudeFailureDiagnostic {
+            masked_jsonl_result_failure_diagnostic(&event, &masker),
+            Some(JsonlResultFailureDiagnostic {
                 subtype: None,
                 message: "first line with ***\\nsecond\\rthird".to_string(),
             })
@@ -1121,14 +1121,15 @@ mod tests {
     }
 
     #[test]
-    fn claude_failure_diagnostic_truncates_to_max_bytes() {
+    fn jsonl_result_failure_diagnostic_truncates_to_max_bytes() {
         let event = serde_json::json!({
             "type": "result",
             "is_error": true,
             "result": "é".repeat(FAILURE_DIAGNOSTIC_MAX_BYTES)
         });
-        let diagnostic = masked_claude_failure_diagnostic(&event, &SecretMasker::from_raw(""))
-            .expect("Claude error result should produce a diagnostic");
+        let diagnostic =
+            masked_jsonl_result_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+                .expect("JSONL error result should produce a diagnostic");
 
         assert_eq!(diagnostic.message.len(), FAILURE_DIAGNOSTIC_MAX_BYTES);
         assert!(

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -66,7 +66,7 @@ pub fn cli_control_failure_for_config(
         session_metadata,
         FailureClass::CliExecutionError,
         cli_result.exit_code,
-        cli_result.claude_result,
+        cli_result.jsonl_result,
     );
     let diagnostic =
         with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit.as_ref().cloned());
@@ -85,7 +85,7 @@ pub fn event_delivery_failure_for_config(
         session_metadata,
         FailureClass::EventUploadFailed,
         cli_result.exit_code,
-        cli_result.claude_result,
+        cli_result.jsonl_result,
     )
     .with_event_delivery(event_delivery);
     let diagnostic =
@@ -109,7 +109,7 @@ pub fn cli_nonzero_failure_for_config(
         session_metadata,
         FailureClass::CliNonzero,
         cli_result.exit_code,
-        cli_result.claude_result,
+        cli_result.jsonl_result,
     )
     .with_failure_detail_source(failure_message.source);
     let diagnostic =
@@ -221,7 +221,7 @@ fn cli_result_failure_diagnostic_for_config(
     session_metadata: Option<&CapturedSessionMetadata>,
     failure_class: FailureClass,
     cli_exit_code: i32,
-    claude_result: Option<cli::ClaudeResultSummary>,
+    jsonl_result: Option<cli::JsonlResultSummary>,
 ) -> FailureDiagnostic {
     let mut diagnostic = base_failure_diagnostic_for_config(config, failure_class)
         .with_cli_exit_code(cli_exit_code)
@@ -229,7 +229,9 @@ fn cli_result_failure_diagnostic_for_config(
             config,
             session_metadata,
         ));
-    if let Some(result) = claude_result {
+    if matches!(config.framework, env::Framework::ClaudeCode)
+        && let Some(result) = jsonl_result
+    {
         diagnostic = diagnostic.with_claude_num_turns(result.num_turns);
     }
     diagnostic

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -910,6 +910,7 @@ fn cli_failure_reason_rejects_untrusted_mid_response_failure_contexts() {
         for (framework, source) in [
             (AgentFramework::ClaudeCode, FailureDetailSource::Stderr),
             (AgentFramework::Codex, FailureDetailSource::ClaudeResult),
+            (AgentFramework::Pi, FailureDetailSource::PiResult),
         ] {
             let reason = super::classify_cli_failure_reason(framework, source, message);
 
@@ -924,6 +925,27 @@ fn cli_failure_reason_rejects_untrusted_mid_response_failure_contexts() {
         );
 
         assert_eq!(reason, None, "message: {explanatory_message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_claude_signatures_from_pi_results() {
+    for message in [
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials.",
+        "API Error: Overloaded",
+        "API Error: Stream idle timeout - no chunks received",
+        CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
+        CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE,
+        CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE,
+        "API Error: Claude's response exceeded the 32000 output token maximum.",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Pi,
+            FailureDetailSource::PiResult,
+            message,
+        );
+
+        assert_eq!(reason, None, "message: {message}");
     }
 }
 

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -929,27 +929,6 @@ fn cli_failure_reason_rejects_untrusted_mid_response_failure_contexts() {
 }
 
 #[test]
-fn cli_failure_reason_rejects_claude_signatures_from_pi_results() {
-    for message in [
-        "Failed to authenticate. API Error: 401 Invalid authentication credentials.",
-        "API Error: Overloaded",
-        "API Error: Stream idle timeout - no chunks received",
-        CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
-        CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE,
-        CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE,
-        "API Error: Claude's response exceeded the 32000 output token maximum.",
-    ] {
-        let reason = super::classify_cli_failure_reason(
-            AgentFramework::Pi,
-            FailureDetailSource::PiResult,
-            message,
-        );
-
-        assert_eq!(reason, None, "message: {message}");
-    }
-}
-
-#[test]
 fn cli_failure_reason_classifies_claude_output_token_limit() {
     for message in [
         "API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -690,8 +690,8 @@ fn preserves_successful_post_result_cleanup(
         && cli_result.control_error.is_none()
         && cli_result.exit_code != 0
         && cli_result
-            .post_result_cleanup_result
-            .is_some_and(|result| result.status == cli::ClaudeResultStatus::Success)
+            .post_result_cleanup_jsonl_result
+            .is_some_and(|result| result.status == cli::JsonlResultStatus::Success)
         && cli_result
             .cli_termination
             .as_ref()
@@ -1247,12 +1247,12 @@ mod tests {
 
     #[test]
     fn successful_post_result_cleanup_preserves_semantic_success_only_for_narrow_case() {
-        let success_result = cli::ClaudeResultSummary {
+        let success_result = cli::JsonlResultSummary {
             num_turns: Some(1),
-            status: cli::ClaudeResultStatus::Success,
+            status: cli::JsonlResultStatus::Success,
         };
-        let make_result = |claude_result: cli::ClaudeResultSummary,
-                           cleanup_result: cli::ClaudeResultSummary,
+        let make_result = |jsonl_result: cli::JsonlResultSummary,
+                           cleanup_result: cli::JsonlResultSummary,
                            termination_reason: CliTerminationReason| {
             let termination = CliTerminationDiagnostic::new(termination_reason)
                 .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(1_000))
@@ -1263,8 +1263,8 @@ mod tests {
                 stderr_lines: Vec::new(),
                 last_event_sequence: None,
                 event_delivery: None,
-                claude_result: Some(claude_result),
-                post_result_cleanup_result: Some(cleanup_result),
+                jsonl_result: Some(jsonl_result),
+                post_result_cleanup_jsonl_result: Some(cleanup_result),
                 failure_diagnostic: None,
                 control_error: None,
                 cli_termination: Some(termination),
@@ -1287,9 +1287,9 @@ mod tests {
         ));
 
         let late_error_result_after_successful_cleanup = make_result(
-            cli::ClaudeResultSummary {
+            cli::JsonlResultSummary {
                 num_turns: Some(1),
-                status: cli::ClaudeResultStatus::Error,
+                status: cli::JsonlResultStatus::Error,
             },
             success_result,
             CliTerminationReason::PostResultReap,
@@ -1301,9 +1301,9 @@ mod tests {
 
         let error_cleanup = make_result(
             success_result,
-            cli::ClaudeResultSummary {
+            cli::JsonlResultSummary {
                 num_turns: Some(1),
-                status: cli::ClaudeResultStatus::Error,
+                status: cli::JsonlResultStatus::Error,
             },
             CliTerminationReason::PostResultReap,
         );

--- a/crates/guest-agent/tests/claude_task_notification_result.rs
+++ b/crates/guest-agent/tests/claude_task_notification_result.rs
@@ -119,8 +119,8 @@ async fn task_notification_result_does_not_end_the_user_command()
             .reason,
         CliTerminationReason::ExecutionTimeout
     );
-    assert!(result.claude_result.is_none());
-    assert!(result.post_result_cleanup_result.is_none());
+    assert!(result.jsonl_result.is_none());
+    assert!(result.post_result_cleanup_jsonl_result.is_none());
 
     let agent_log = std::fs::read_to_string(runtime.paths.agent_log_file())?;
     assert!(agent_log.contains(r#""kind":"task-notification""#));

--- a/crates/guest-agent/tests/cli_agent_log_buffering.rs
+++ b/crates/guest-agent/tests/cli_agent_log_buffering.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use guest_agent::cli::ClaudeResultStatus;
+use guest_agent::cli::JsonlResultStatus;
 use std::time::Duration;
 
 const INIT_RECORD: &str = r#"{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"00000000-0000-4000-8000-000000000001","tools":["Bash"],"model":"mock-claude"}"#;
@@ -32,8 +32,8 @@ async fn agent_log_flushes_exact_buffered_records_before_claude_run_returns()
 
     assert_eq!(execution.exit_code, common::CLEAN_EXIT);
     assert_eq!(
-        execution.claude_result.map(|result| result.status),
-        Some(ClaudeResultStatus::Success)
+        execution.jsonl_result.map(|result| result.status),
+        Some(JsonlResultStatus::Success)
     );
     let expected = format!("{payload}\n");
     assert_eq!(

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -59,7 +59,7 @@ async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
     assert_eq!(execution.exit_code, common::CLEAN_EXIT);
     assert!(execution.control_error.is_none());
     assert!(execution.cli_termination.is_none());
-    assert!(execution.claude_result.is_some());
+    assert!(execution.jsonl_result.is_some());
     let system_log = std::fs::read_to_string(system_log_path)?;
     assert_eq!(system_log.matches(AGENT_LOG_WARNING).count(), 1);
 

--- a/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use guest_agent::cli::ClaudeResultStatus;
+use guest_agent::cli::JsonlResultStatus;
 use std::time::Duration;
 
 const AGENT_LOG_WARNING: &str = "Agent log flush failed; continuing without local transcript";
@@ -64,8 +64,8 @@ async fn agent_log_flush_failure_keeps_claude_run_successful()
     assert!(execution.control_error.is_none());
     assert!(execution.cli_termination.is_none());
     assert_eq!(
-        execution.claude_result.map(|result| result.status),
-        Some(ClaudeResultStatus::Success)
+        execution.jsonl_result.map(|result| result.status),
+        Some(JsonlResultStatus::Success)
     );
     assert_eq!(execution.last_event_sequence, None);
     assert_eq!(

--- a/crates/guest-agent/tests/cli_stdin_unread.rs
+++ b/crates/guest-agent/tests/cli_stdin_unread.rs
@@ -39,7 +39,7 @@ tail -f /dev/null
 
     assert_eq!(cli_result.exit_code, common::SIGTERM_EXIT);
     assert_eq!(
-        cli_result.claude_result.and_then(|result| result.num_turns),
+        cli_result.jsonl_result.and_then(|result| result.num_turns),
         Some(1)
     );
     Ok(())

--- a/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
@@ -34,7 +34,7 @@ tail -f /dev/null
     let masker = SecretMasker::from_raw("");
     let checkpoints = [common::VirtualTimeCheckpoint::new(
         runtime.paths.system_log_file(),
-        "Claude stdin writer failed, SIGTERM",
+        "CLI stdin writer failed, SIGTERM",
         runtime.config.post_result_sigkill_grace,
     )];
 

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -167,8 +167,8 @@ fi
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
     assert_eq!(result.last_event_sequence, Some(15));
     assert_eq!(
-        result.claude_result.map(|summary| summary.status),
-        Some(guest_agent::cli::ClaudeResultStatus::Success)
+        result.jsonl_result.map(|summary| summary.status),
+        Some(guest_agent::cli::JsonlResultStatus::Success)
     );
     let mut delivered_events = Vec::new();
     for request in server.requests()? {

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{AgentFramework, FailureDetailSource};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -123,8 +124,29 @@ fi
     std::env::set_current_dir(original_directory)?;
     assert_eq!(result.exit_code, 1);
     assert_eq!(
-        result.claude_result.map(|summary| summary.status),
-        Some(guest_agent::cli::ClaudeResultStatus::Error)
+        result.jsonl_result.map(|summary| summary.status),
+        Some(guest_agent::cli::JsonlResultStatus::Error)
+    );
+    let terminal_failure = guest_agent::failure_diagnostics::cli_nonzero_failure_for_config(
+        &runtime.config,
+        None,
+        &result,
+    );
+    assert_eq!(terminal_failure.diagnostic.framework, AgentFramework::Pi);
+    assert_eq!(
+        terminal_failure.diagnostic.failure_detail_source,
+        Some(FailureDetailSource::PiResult)
+    );
+    assert_eq!(terminal_failure.diagnostic.claude_num_turns, None);
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+    assert!(
+        system_log.contains("Pi JSONL failure result"),
+        "system log should attribute the result failure to Pi: {system_log}"
+    );
+    assert!(
+        !system_log.contains("Claude JSONL failure result"),
+        "system log should not attribute a Pi result failure to Claude: {system_log}"
     );
 
     let mut delivered_events = Vec::new();

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -138,6 +138,7 @@ fi
         Some(FailureDetailSource::PiResult)
     );
     assert_eq!(terminal_failure.diagnostic.claude_num_turns, None);
+    assert_eq!(terminal_failure.diagnostic.failure_reason, None);
 
     let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
     assert!(
@@ -192,10 +193,10 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "responseId": "response-error",
             "usage": {},
             "stopReason": "error",
-            "errorMessage": "provider failed",
+            "errorMessage": "API Error: Overloaded",
             "timestamp": 1,
         }),
-        "provider failed",
+        "API Error: Overloaded",
         &base_path,
         &original_directory,
     )

--- a/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
@@ -1,0 +1,146 @@
+//! Pi initial-prompt stdin failures keep neutral diagnostics and bounded reaping.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test]
+async fn pi_initial_prompt_stdin_failure_reap_escalates_to_sigkill()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let npx = bin_dir.join("npx");
+    std::fs::write(
+        &npx,
+        r#"#!/bin/sh
+set -eu
+trap '' TERM
+printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandboxEventSequenceStart":1}'
+IFS= read -r state_command
+case "$state_command" in
+  *'"type":"get_state"'*) ;;
+  *) exit 21 ;;
+esac
+printf '%s\n' "{\"id\":\"${OKOU_RUN_ID}:pi:get-state\",\"type\":\"response\",\"command\":\"get_state\",\"success\":true,\"data\":{\"sessionId\":\"11111111-1111-4111-8111-111111111146\",\"sessionFile\":\"/home/user/.pi/agent/sessions/--home-user-workspace--/session.jsonl\"}}"
+exec 0<&-
+exec tail -f /dev/null
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&npx)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&npx, permissions)?;
+
+    let run_id = "00000000-0000-4000-8000-000000000146";
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)?;
+    let large_prompt = "x".repeat(2 * 1024 * 1024);
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
+        std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
+        std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::set_var(
+            guest_contracts::env::SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "3",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "1",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "60",
+        );
+        std::env::set_var("HOME", tmp.path());
+        let mut paths = vec![bin_dir];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(paths)?);
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: large_prompt,
+                pi_launch_config:
+                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#
+                        .to_string(),
+                pi_model_config: "{}".to_string(),
+                pi_session_id: "11111111-1111-4111-8111-111111111146".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
+        common::set_user_env_file_env_for_test(
+            &runtime_dir,
+            &HashMap::from([(
+                "CLI_PKG_URL".to_string(),
+                "https://example.invalid/current-okou-cli.tgz".to_string(),
+            )]),
+        )?;
+    }
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(tmp.path())?;
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        runtime.paths.system_log_file(),
+        "CLI stdin writer failed, SIGTERM",
+        runtime.config.post_result_sigkill_grace,
+    )];
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(
+                &runtime,
+                &SecretMasker::from_raw(""),
+                common::spawn_dummy_heartbeat(),
+            ),
+            &checkpoints,
+        ),
+    )
+    .await
+    .expect("Pi execute_cli did not return within 15s - stdin failure reap likely broken")?;
+
+    let result = result.expect("Pi execute_cli returned Err before controlled termination");
+    let control_error = result
+        .control_error
+        .as_ref()
+        .expect("Pi stdin writer failure should preserve a controlled execution error");
+    assert!(
+        control_error.to_string().contains("Broken pipe"),
+        "expected broken pipe stdin error, got {control_error}"
+    );
+    assert!(
+        !control_error.to_string().contains("Claude"),
+        "Pi control error should not attribute the writer to Claude: {control_error}"
+    );
+    let termination = result
+        .cli_termination
+        .expect("Pi stdin writer failure should attach CLI termination diagnostics");
+    assert_eq!(termination.reason, CliTerminationReason::InitialPromptStdin);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+    assert!(
+        system_log.contains("CLI stdin writer failed, SIGTERM"),
+        "Pi stdin failure should use neutral CLI ownership: {system_log}"
+    );
+    assert!(
+        !system_log.contains("Claude stdin writer"),
+        "Pi stdin failure should not be attributed to Claude: {system_log}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_error_result.rs
+++ b/crates/guest-agent/tests/post_result_reap_error_result.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use guest_agent::cli::ClaudeResultStatus;
+use guest_agent::cli::JsonlResultStatus;
 use guest_contracts::diagnostics::{
     CliTerminationReason, CliTerminationSignal, FailureDetailSource,
 };
@@ -32,14 +32,14 @@ async fn post_result_reap_preserves_error_diagnostic() -> Result<(), Box<dyn std
     let result = result.expect("execute_cli returned Err");
     assert_eq!(result.exit_code, common::SIGTERM_EXIT);
     assert_eq!(
-        result.claude_result.map(|summary| summary.status),
-        Some(ClaudeResultStatus::Error)
+        result.jsonl_result.map(|summary| summary.status),
+        Some(JsonlResultStatus::Error)
     );
     assert_eq!(
         result
-            .post_result_cleanup_result
+            .post_result_cleanup_jsonl_result
             .map(|summary| summary.status),
-        Some(ClaudeResultStatus::Error)
+        Some(JsonlResultStatus::Error)
     );
 
     let diagnostic = result

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -49,7 +49,7 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
     // exit without a parsed `type=result` event would not validate the
     // reap arming/drain race this test exists to cover.
     assert!(
-        result.claude_result.is_some(),
+        result.jsonl_result.is_some(),
         "expected the mock type=result event to be observed before clean exit"
     );
 

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -687,6 +687,8 @@ impl FailureReason {
 pub enum FailureDetailSource {
     /// The reason came from a Claude result payload.
     ClaudeResult,
+    /// The reason came from a Pi result payload.
+    PiResult,
     /// The reason came from a Codex compatibility JSONL event.
     CodexJsonl,
     /// The reason came from stderr output.
@@ -701,6 +703,7 @@ impl FailureDetailSource {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::ClaudeResult => "claude_result",
+            Self::PiResult => "pi_result",
             Self::CodexJsonl => "codex_jsonl",
             Self::Stderr => "stderr",
             Self::FallbackExitCode => "fallback_exit_code",
@@ -892,6 +895,23 @@ mod tests {
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureDetailSource"], "claude_result");
         assert_eq!(json["failureReason"], "insufficient_credits");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_pi_result_source() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Pi,
+            PromptMetadata::from_prompt("debug Pi failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::PiResult);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureDetailSource"], "pi_result");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -587,6 +587,30 @@ mod tests {
     }
 
     #[test]
+    fn pi_result_source_logs_pi_attribution() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Pi,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::PiResult)
+        .with_session_history_status(SessionHistoryStatus::NotApplicable);
+        let failure = executor::ExecutionFailure::new(1, "provider failed", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert_field_eq(&event, "failure_class", "cli_nonzero");
+        assert_field_eq(&event, "failure_framework", "pi");
+        assert_field_eq(&event, "failure_detail_source", "pi_result");
+    }
+
+    #[test]
     fn claude_result_provider_overloaded_logs_job_execution_failed_at_info() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,


### PR DESCRIPTION
## Summary

- move terminal `type=result` parsing from the Claude-specific module into shared JSONL CLI state
- attribute Pi terminal failures to the new `pi_result` diagnostic source while preserving Claude and Codex attribution
- make shared stdin-writer lifecycle names backend-neutral and cover Pi failure/reaping behavior through integration tests

## Explicit exclusions

- no provider-specific adapter abstraction
- no changes to Pi event projection or public event payloads
- no changes to Claude-only failure classification rules

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner job_terminal_log`
- `cargo test --manifest-path crates/Cargo.toml -p runner diagnostics_tests`
- `git diff --check`

Closes #29879
