### PR TITLE
test(runner): cover speculative guest restore panic

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1162,10 +1162,20 @@ async fn assert_speculation_failure_falls_back_to_fresh(
         completion.reuse_result,
         Some(SandboxReuseResult::UnparkFailed)
     );
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 1, Duration::from_secs(5)).await;
+    assert_eq!(
+        env.idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id,
+        fresh_sandbox_id
+    );
     assert_eq!(overrides.start_agent_process_calls().len(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 2);
 }
 
 #[tokio::test]
@@ -1222,6 +1232,18 @@ async fn speculative_guest_restore_transport_failure_destroys_before_fresh_fallb
                 reason: sandbox::SandboxOperationReason::Guest,
                 message: "simulated guest restore transport failure".into(),
             }));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn speculative_guest_restore_panic_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Default,
+        None,
+        |overrides| {
+            overrides.push_guest_state_restore_panic("simulated guest restore panic");
         },
     )
     .await;

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -29,6 +29,20 @@ pub(crate) enum ExecMatcherOutcome {
     Panic(String),
 }
 
+pub(crate) enum GuestStateRestoreBehavior {
+    Return(Result<ExecResult>),
+    Panic(String),
+}
+
+impl GuestStateRestoreBehavior {
+    pub(crate) fn into_result(self) -> Result<ExecResult> {
+        match self {
+            Self::Return(result) => result,
+            Self::Panic(message) => std::panic::resume_unwind(Box::new(message)),
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct ExecOverrideState {
     /// Pattern-matched exec behaviors. First matching pattern wins and is
@@ -43,8 +57,8 @@ pub(crate) struct ExecOverrideState {
     pub(crate) storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
     /// Recorded fixed guest-state restore calls across all attached sandboxes.
     pub(crate) guest_state_restore_calls: Mutex<Vec<GuestStateRestoreCall>>,
-    /// FIFO results for fixed guest-state restore operations.
-    pub(crate) guest_state_restore_results: Mutex<VecDeque<Result<ExecResult>>>,
+    /// FIFO behaviors for fixed guest-state restore operations.
+    pub(crate) guest_state_restore_behaviors: Mutex<VecDeque<GuestStateRestoreBehavior>>,
     /// Wakes tests after a guest-state restore call is recorded.
     pub(crate) guest_state_restore_call_notify: tokio::sync::Notify,
     /// Wakes tests after an exec call is recorded.
@@ -476,9 +490,17 @@ impl MockSandboxOverrides {
     /// Queue a result for the next fixed guest-state restore operation.
     pub fn push_guest_state_restore_result(&self, result: Result<ExecResult>) {
         self.exec
-            .guest_state_restore_results
+            .guest_state_restore_behaviors
             .lock_ignoring_poison()
-            .push_back(result);
+            .push_back(GuestStateRestoreBehavior::Return(result));
+    }
+
+    /// Queue a panic for the next fixed guest-state restore operation.
+    pub fn push_guest_state_restore_panic(&self, message: impl Into<String>) {
+        self.exec
+            .guest_state_restore_behaviors
+            .lock_ignoring_poison()
+            .push_back(GuestStateRestoreBehavior::Panic(message.into()));
     }
 
     /// Return fixed guest-state restore calls across all attached sandboxes.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -15,7 +15,7 @@ use crate::call_records::{
     WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
-use crate::overrides::{ExecMatcherOutcome, MockSandboxOverrides};
+use crate::overrides::{ExecMatcherOutcome, GuestStateRestoreBehavior, MockSandboxOverrides};
 use crate::support::{
     LockIgnoringPoison, MOCK_COPY_FILE_MAX_BYTES, validate_mock_copy_host_path,
     validate_mock_exec_env_keys, validate_mock_guest_file_path,
@@ -829,11 +829,12 @@ impl Sandbox for MockSandbox {
             .pop_front()
             .or_else(|| {
                 self.overrides.as_ref().and_then(|overrides| {
-                    overrides
+                    let behavior = overrides
                         .exec
-                        .guest_state_restore_results
+                        .guest_state_restore_behaviors
                         .lock_ignoring_poison()
-                        .pop_front()
+                        .pop_front();
+                    behavior.map(GuestStateRestoreBehavior::into_result)
                 })
             })
             .unwrap_or_else(|| Ok(default_exec_result()))?;


### PR DESCRIPTION
## Summary

- add an ordered one-shot result/panic queue for the fixed mock guest-state restore boundary
- cover speculative exact-reuse restore panic containment and fresh fallback through the runner start integration suite
- verify cancellation cleanup, replacement sandbox ownership after completion, and idle/budget release after shutdown for all speculative preparation failures

## Scope

- no runner production behavior changes
- no new production logs
- no API, protocol, persistence, migration, or deployment compatibility changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner speculative_guest_restore_panic_destroys_before_fresh_fallback`
- `cargo test -p sandbox-mock`
- `cargo test -p runner`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Closes #29874
