### PR TITLE
feat(platform): sync artifact search navigation

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
@@ -1,5 +1,9 @@
 import { command, computed } from "ccstate";
-import type { ArtifactDetail } from "@okouai/api-contracts/contracts/artifact-catalog";
+import {
+  artifactCatalogContract,
+  type ArtifactCatalogKind,
+  type ArtifactDetail,
+} from "@okouai/api-contracts/contracts/artifact-catalog";
 
 import { publicAttachmentUrl } from "../../views/okou-page/attachment-url.ts";
 import { downloadAttachment$ } from "../attachment-download.ts";
@@ -9,11 +13,21 @@ import {
   type BodyPreviewKind,
 } from "../chat-page/parse-body-blocks.ts";
 import {
+  closeLightboxWithDialogExit$,
   openAudioLightbox$,
   openDocumentLightbox$,
   openImageLightbox$,
   openVideoLightbox$,
 } from "../okou-page/attachment-chips.ts";
+import {
+  historyState$,
+  pathname$,
+  replaceSearchParams$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+import { onRef } from "../utils.ts";
 import { createArtifactCatalogSignals } from "./create-artifact-catalog-signals.ts";
 
 /**
@@ -24,13 +38,142 @@ const pageCatalog = createArtifactCatalogSignals();
 
 export const selectedArtifactCatalogKind$ = pageCatalog.selectedKind$;
 
-export const setArtifactCatalogKind$ = pageCatalog.setKind$;
+export const setArtifactCatalogKindFromRoute$ = pageCatalog.setKind$;
+
+export function artifactCatalogKindFromSearchParams(
+  params: URLSearchParams,
+): ArtifactCatalogKind {
+  const tab = params.get("tab");
+  switch (tab) {
+    case "file":
+    case "hosted-site":
+    case "image":
+    case "video":
+    case "avatar":
+    case "shared-thread":
+    case "presentation": {
+      return tab;
+    }
+    default: {
+      return "presentation";
+    }
+  }
+}
+
+export const setArtifactCatalogKind$ = command(
+  ({ get, set }, kind: ArtifactCatalogKind | null) => {
+    set(pageCatalog.setKind$, kind);
+    const next = new URLSearchParams(get(searchParams$));
+    if (!kind || kind === "presentation") {
+      next.delete("tab");
+    } else {
+      next.set("tab", kind);
+    }
+    set(updateSearchParams$, next);
+  },
+);
 
 export const reloadArtifactCatalog$ = pageCatalog.reload$;
 
 export const artifactCatalog$ = pageCatalog.catalog$;
 
 export const loadMoreArtifactCatalog$ = pageCatalog.loadMore$;
+
+export const loadThroughArtifactCatalog$ = pageCatalog.loadThroughArtifact$;
+
+export const scrollArtifactCardIntoViewRef$ = onRef(
+  command((_context, element: HTMLElement, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    element.scrollIntoView({ block: "center" });
+  }),
+);
+
+const ARTIFACT_PREVIEW_HISTORY_STATE_KEY = "artifactCatalogPreviewId";
+const ARTIFACT_SCROLL_HISTORY_STATE_KEY = "artifactCatalogScrollId";
+
+function artifactIdFromHistoryState(
+  state: unknown,
+  key:
+    | typeof ARTIFACT_PREVIEW_HISTORY_STATE_KEY
+    | typeof ARTIFACT_SCROLL_HISTORY_STATE_KEY,
+): string | null {
+  if (typeof state !== "object" || state === null) {
+    return null;
+  }
+  const value =
+    key === ARTIFACT_PREVIEW_HISTORY_STATE_KEY &&
+    ARTIFACT_PREVIEW_HISTORY_STATE_KEY in state
+      ? state.artifactCatalogPreviewId
+      : key === ARTIFACT_SCROLL_HISTORY_STATE_KEY &&
+          ARTIFACT_SCROLL_HISTORY_STATE_KEY in state
+        ? state.artifactCatalogScrollId
+        : null;
+  return typeof value === "string" ? value : null;
+}
+
+export function artifactIdFromCatalogSearchParams(
+  params: URLSearchParams,
+): string | null {
+  const artifactId = params.get("artifact");
+  const parsed = artifactCatalogContract.get.pathParams.safeParse({
+    artifactId,
+  });
+  return parsed.success ? artifactId : null;
+}
+
+export function artifactCatalogScrollTargetFromHistoryState(
+  historyState: unknown,
+): string | null {
+  return artifactIdFromHistoryState(
+    historyState,
+    ARTIFACT_SCROLL_HISTORY_STATE_KEY,
+  );
+}
+
+/**
+ * Give a routed preview its own entry above the catalog. Browser Back can then
+ * close the preview while leaving the user on the matching artifact tab.
+ */
+export const prepareArtifactCatalogPreviewHistory$ = command(
+  ({ get, set }, artifactId: string, previewSearchParams: URLSearchParams) => {
+    if (
+      artifactIdFromHistoryState(
+        get(historyState$),
+        ARTIFACT_PREVIEW_HISTORY_STATE_KEY,
+      ) === artifactId
+    ) {
+      return;
+    }
+    const catalogSearchParams = new URLSearchParams(previewSearchParams);
+    catalogSearchParams.delete("artifact");
+    set(replaceSearchParams$, catalogSearchParams, {
+      [ARTIFACT_SCROLL_HISTORY_STATE_KEY]: artifactId,
+    });
+    set(updateSearchParams$, previewSearchParams, {
+      [ARTIFACT_PREVIEW_HISTORY_STATE_KEY]: artifactId,
+      [ARTIFACT_SCROLL_HISTORY_STATE_KEY]: artifactId,
+    });
+  },
+);
+
+export const closeArtifactCatalogPreview$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    const artifactId = artifactIdFromCatalogSearchParams(get(searchParams$));
+    const previewArtifactId = artifactIdFromHistoryState(
+      get(historyState$),
+      ARTIFACT_PREVIEW_HISTORY_STATE_KEY,
+    );
+    if (
+      get(pathname$) === ROUTES.artifacts &&
+      artifactId !== null &&
+      artifactId === previewArtifactId
+    ) {
+      window.history.back();
+      return;
+    }
+    set(closeLightboxWithDialogExit$, signal);
+  },
+);
 
 export function artifactDetailPreview(detail: ArtifactDetail): {
   readonly kind: BodyPreviewKind;

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
@@ -6,19 +6,42 @@ import { ArtifactCatalogPage } from "../../views/artifacts-page/artifact-catalog
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { closeLightboxImmediately$ } from "../okou-page/attachment-chips.ts";
 import { onboardGuard$ } from "../okou-page/onboard-guard.ts";
+import { historyState$, searchParams$ } from "../route.ts";
 import {
+  artifactCatalogKindFromSearchParams,
+  artifactCatalogScrollTargetFromHistoryState,
+  artifactIdFromCatalogSearchParams,
+  loadThroughArtifactCatalog$,
+  openArtifact$,
+  prepareArtifactCatalogPreviewHistory$,
   reloadArtifactCatalog$,
-  setArtifactCatalogKind$,
+  setArtifactCatalogKindFromRoute$,
 } from "./artifact-catalog-signals.ts";
 
 export const setupArtifactsPage$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
+    const routeSearchParams = new URLSearchParams(get(searchParams$));
+    const artifactId = artifactIdFromCatalogSearchParams(routeSearchParams);
+    const kind = artifactCatalogKindFromSearchParams(routeSearchParams);
     // Entering the page always starts a fresh first page. Later pages are
     // fetched on scroll and never cached across visits.
-    set(setArtifactCatalogKind$, "presentation");
+    set(setArtifactCatalogKindFromRoute$, kind);
     set(reloadArtifactCatalog$);
-    set(updatePage$, createElement(ArtifactCatalogPage), "sidebar");
+    if (artifactId) {
+      set(prepareArtifactCatalogPreviewHistory$, artifactId, routeSearchParams);
+    } else {
+      set(closeLightboxImmediately$);
+    }
+    const scrollToArtifactId =
+      artifactId ??
+      artifactCatalogScrollTargetFromHistoryState(get(historyState$));
+    set(
+      updatePage$,
+      createElement(ArtifactCatalogPage, { scrollToArtifactId }),
+      "sidebar",
+    );
     set(
       updateDocumentTitle$,
       i18n.t(($) => {
@@ -28,5 +51,11 @@ export const setupArtifactsPage$ = command(
     await set(hideAppSkeleton$, signal);
 
     await set(onboardGuard$, signal);
+    if (artifactId) {
+      await set(openArtifact$, artifactId, signal);
+    }
+    if (scrollToArtifactId) {
+      await set(loadThroughArtifactCatalog$, scrollToArtifactId, signal);
+    }
   },
 );

--- a/turbo/apps/platform/src/signals/artifacts-page/create-artifact-catalog-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/create-artifact-catalog-signals.ts
@@ -58,6 +58,7 @@ export interface ArtifactCatalogSignals {
   readonly reload$: Command<void, []>;
   readonly catalog$: Computed<Promise<ArtifactCatalogPage>>;
   readonly loadMore$: Command<Promise<void>, [AbortSignal]>;
+  readonly loadThroughArtifact$: Command<Promise<void>, [string, AbortSignal]>;
   readonly selectArtifact$: Command<void, [string | null]>;
   readonly selectedArtifactDetail$: Computed<Promise<ArtifactDetail | null>>;
 }
@@ -221,6 +222,35 @@ export function createArtifactCatalogSignals(
     fetchedCursors$: internalFetchedCursors$,
   });
 
+  const loadThroughArtifact$ = command(
+    async ({ get, set }, artifactId: string, signal: AbortSignal) => {
+      while (true) {
+        const loaded = await get(catalog$);
+        signal.throwIfAborted();
+        if (
+          loaded.artifacts.some((artifact) => {
+            return artifact.id === artifactId;
+          }) ||
+          !loaded.nextCursor
+        ) {
+          return;
+        }
+        const loadedCount = loaded.artifacts.length;
+        const loadedCursor = loaded.nextCursor;
+        await set(loadMore$, signal);
+        signal.throwIfAborted();
+        const next = await get(catalog$);
+        signal.throwIfAborted();
+        if (
+          next.artifacts.length === loadedCount &&
+          next.nextCursor === loadedCursor
+        ) {
+          return;
+        }
+      }
+    },
+  );
+
   const selectArtifact$ = command(({ set }, artifactId: string | null) => {
     set(internalSelectedArtifactId$, artifactId);
   });
@@ -256,6 +286,7 @@ export function createArtifactCatalogSignals(
     reload$,
     catalog$,
     loadMore$,
+    loadThroughArtifact$,
     selectArtifact$,
     selectedArtifactDetail$,
   };

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -27,6 +27,7 @@ import { bootstrapGoogleAdsConversionMilestones$ } from "./bootstrap/google-ads-
 const L = logger("Route");
 
 const reloadPathname$ = state(0);
+const internalHistoryState$ = state<unknown>(window.history.state);
 
 export const pathname$ = computed((get) => {
   get(reloadPathname$);
@@ -38,10 +39,15 @@ export const searchParams$ = computed((get) => {
   return new URLSearchParams(search());
 });
 
+export const historyState$ = computed((get) => {
+  return get(internalHistoryState$);
+});
+
 export const updateSearchParams$ = command(
-  ({ set }, searchParams: URLSearchParams) => {
+  ({ set }, searchParams: URLSearchParams, historyState: unknown = {}) => {
     const str = searchParams.toString();
-    pushState({}, "", `${pathname()}${str ? `?${str}` : ""}`);
+    pushState(historyState, "", `${pathname()}${str ? `?${str}` : ""}`);
+    set(internalHistoryState$, historyState);
     set(reloadPathname$, (x) => {
       return x + 1;
     });
@@ -49,9 +55,10 @@ export const updateSearchParams$ = command(
 );
 
 export const replaceSearchParams$ = command(
-  ({ set }, searchParams: URLSearchParams) => {
+  ({ set }, searchParams: URLSearchParams, historyState: unknown = {}) => {
     const str = searchParams.toString();
-    replaceState({}, "", `${pathname()}${str ? `?${str}` : ""}`);
+    replaceState(historyState, "", `${pathname()}${str ? `?${str}` : ""}`);
+    set(internalHistoryState$, historyState);
     set(reloadPathname$, (x) => {
       return x + 1;
     });
@@ -68,6 +75,7 @@ export const replacePathSilently$ = command(
     const newPath = generateRouterPath(pathnameTemplate, pathParams);
     const searchStr = searchParams?.toString();
     replaceState({}, "", `${newPath}${searchStr ? `?${searchStr}` : ""}`);
+    set(internalHistoryState$, {});
     set(reloadPathname$, (x) => {
       return x + 1;
     });
@@ -178,6 +186,7 @@ const navigateToDefaultWhenInvalid$ = command(({ get, set }) => {
       return x + 1;
     });
     pushState({}, "", "/");
+    set(internalHistoryState$, {});
   }
 });
 
@@ -188,7 +197,8 @@ export const initRoutes$ = command(
 
     window.addEventListener(
       "popstate",
-      onDomEventFn(async () => {
+      onDomEventFn(async (event: PopStateEvent) => {
+        set(internalHistoryState$, event.state);
         set(clearPageForRouteBoundary$, pathname());
         set(reloadPathname$, (x) => {
           return x + 1;
@@ -233,6 +243,7 @@ const navigate$ = command(
       pushState({}, "", newPath);
       set(markNavigationPushState$);
     }
+    set(internalHistoryState$, {});
     set(reloadPathname$, (x) => {
       return x + 1;
     });

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -5,7 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/artifact-catalog";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   click,
@@ -14,6 +14,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { i18n } from "../../../i18n/index.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname, search } from "../../../signals/location.ts";
 
 const context = testContext();
 
@@ -36,10 +37,11 @@ function setupArtifactCatalogPage(
   featureSwitches: Partial<Record<FeatureSwitchKey, boolean>> = {
     [FeatureSwitchKey.SharedThreadSharing]: true,
   },
+  path = "/artifacts",
 ): void {
   detachedSetupPage({
     context,
-    path: "/artifacts",
+    path,
     user: { id: CATALOG_USER_ID, fullName: "Test User" },
     org: {
       activeOrg: { id: CATALOG_ORG_ID, name: "Test Org" },
@@ -196,6 +198,134 @@ describe("artifact catalog page", () => {
 
     await findCard("avatar-video.mp4");
     expect(requestedKinds).toStrictEqual(["presentation", "avatar"]);
+  });
+
+  it("syncs the selected artifact tab with browser history", async () => {
+    const requestedKinds: (string | undefined)[] = [];
+    context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {
+      requestedKinds.push(query.kind);
+      const kind = query.kind ?? "presentation";
+      return respond(200, {
+        artifacts: [artifact({ kind, title: `${kind}-artifact` })],
+        nextCursor: null,
+      });
+    });
+
+    setupArtifactCatalogPage(undefined, "/artifacts?tab=image");
+    await findCard("image-artifact");
+    expect(buttonByLabel("Show image artifacts")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(new URLSearchParams(search()).get("tab")).toBe("image");
+
+    const videoFilter = buttonByLabel("Show video artifacts");
+    if (!videoFilter) {
+      throw new Error("Expected a video kind filter");
+    }
+    await click(videoFilter);
+    await findCard("video-artifact");
+    expect(new URLSearchParams(search()).get("tab")).toBe("video");
+
+    act(() => {
+      window.history.back();
+    });
+
+    await findCard("image-artifact");
+    expect(buttonByLabel("Show image artifacts")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(new URLSearchParams(search()).get("tab")).toBe("image");
+    expect(requestedKinds.slice(0, 2)).toStrictEqual(["image", "video"]);
+    expect(requestedKinds.at(-1)).toBe("image");
+  });
+
+  it("opens a routed artifact and restores its card when the preview closes", async () => {
+    const targetArtifactId = "a0000000-0000-4000-a000-000000000099";
+    const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {
+      if (query.cursor === "image-cursor-2") {
+        return respond(200, {
+          artifacts: [
+            artifact({
+              id: targetArtifactId,
+              kind: "image",
+              title: "selected-image.png",
+            }),
+          ],
+          nextCursor: null,
+        });
+      }
+      return respond(200, {
+        artifacts: [
+          artifact({
+            id: "a0000000-0000-4000-a000-000000000098",
+            kind: "image",
+            title: "recent-image.png",
+          }),
+        ],
+        nextCursor: "image-cursor-2",
+      });
+    });
+    context.mocks.api(artifactCatalogContract.get, ({ params, respond }) => {
+      expect(params.artifactId).toBe(targetArtifactId);
+      return respond(200, {
+        ...artifact({
+          id: targetArtifactId,
+          kind: "image",
+          title: "selected-image.png",
+        }),
+        kind: "image",
+        file: {
+          id: "f0000000-0000-4000-a000-000000000099",
+          filename: "selected-image.png",
+          contentType: "image/png",
+          size: 4096,
+          url: "https://artifacts.example.com/selected-image.png",
+          previewImageUrl: null,
+        },
+        model: "image-model",
+        provider: "image-provider",
+      });
+    });
+
+    setupArtifactCatalogPage(
+      undefined,
+      `/artifacts?tab=image&artifact=${targetArtifactId}`,
+    );
+
+    await expect(
+      screen.findByTestId("attachment-lightbox-image"),
+    ).resolves.toHaveAttribute(
+      "src",
+      "https://artifacts.example.com/selected-image.png",
+    );
+    expect(pathname()).toBe("/artifacts");
+    expect(new URLSearchParams(search()).get("tab")).toBe("image");
+    expect(new URLSearchParams(search()).get("artifact")).toBe(
+      targetArtifactId,
+    );
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    });
+
+    await click(screen.getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox"),
+      ).not.toBeInTheDocument();
+      expect(new URLSearchParams(search()).has("artifact")).toBeFalsy();
+    });
+    expect(pathname()).toBe("/artifacts");
+    expect(new URLSearchParams(search()).get("tab")).toBe("image");
+    await findCard("selected-image.png");
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
   });
 
   it("keeps the avatar filter visible while avatar artifacts load", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -22,6 +22,7 @@ import {
   artifactCatalog$,
   loadMoreArtifactCatalog$,
   openArtifact$,
+  scrollArtifactCardIntoViewRef$,
   selectedArtifactCatalogKind$,
   setArtifactCatalogKind$,
 } from "../../signals/artifacts-page/artifact-catalog-signals.ts";
@@ -142,15 +143,20 @@ function ArtifactCatalogFallbackPreview({
 function ArtifactCatalogCard({
   artifact,
   onOpen,
+  scrollIntoView,
 }: {
   readonly artifact: CatalogArtifact;
   readonly onOpen: (artifactId: string) => void;
+  readonly scrollIntoView: boolean;
 }) {
   const { t } = useTranslation();
+  const scrollArtifactCardIntoViewRef = useSet(scrollArtifactCardIntoViewRef$);
   return (
     <article
+      ref={scrollIntoView ? scrollArtifactCardIntoViewRef : undefined}
       role="button"
       tabIndex={0}
+      data-artifact-id={artifact.id}
       aria-label={t(
         ($) => {
           return $.artifacts.catalog.cardPreview;
@@ -208,18 +214,27 @@ function ArtifactCatalogCard({
 function ArtifactSharedConversationList({
   artifacts,
   onOpen,
+  scrollToArtifactId,
 }: {
   readonly artifacts: readonly CatalogArtifact[];
   readonly onOpen: (artifactId: string) => void;
+  readonly scrollToArtifactId: string | null;
 }) {
   const { t } = useTranslation();
+  const scrollArtifactCardIntoViewRef = useSet(scrollArtifactCardIntoViewRef$);
   return (
     <ul className="zero-card divide-y divide-border overflow-hidden">
       {artifacts.map((artifact) => {
         return (
           <li key={artifact.id}>
             <button
+              ref={
+                artifact.id === scrollToArtifactId
+                  ? scrollArtifactCardIntoViewRef
+                  : undefined
+              }
               type="button"
+              data-artifact-id={artifact.id}
               aria-label={t(
                 ($) => {
                   return $.artifacts.catalog.cardPreview;
@@ -256,9 +271,11 @@ function ArtifactSharedConversationList({
 export function ArtifactCatalogGrid({
   artifacts,
   onOpen,
+  scrollToArtifactId = null,
 }: {
   readonly artifacts: readonly CatalogArtifact[];
   readonly onOpen: (artifactId: string) => void;
+  readonly scrollToArtifactId?: string | null;
 }) {
   return (
     <div
@@ -274,6 +291,7 @@ export function ArtifactCatalogGrid({
             key={artifact.id}
             artifact={artifact}
             onOpen={onOpen}
+            scrollIntoView={artifact.id === scrollToArtifactId}
           />
         );
       })}
@@ -474,7 +492,11 @@ function ArtifactCatalogKindFilter({
   );
 }
 
-export function ArtifactCatalogPage() {
+export function ArtifactCatalogPage({
+  scrollToArtifactId,
+}: {
+  readonly scrollToArtifactId: string | null;
+}) {
   const { t } = useTranslation();
   const selectedKind = useGet(selectedArtifactCatalogKind$);
   const setKind = useSet(setArtifactCatalogKind$);
@@ -487,7 +509,6 @@ export function ArtifactCatalogPage() {
   const sharedConversationLayout = selectedKind === "shared-thread";
   const hasMore =
     catalog.state === "hasData" && catalog.data.nextCursor !== null;
-
   const handleScroll = (event: ReactUIEvent<HTMLElement>) => {
     if (!hasMore) {
       return;
@@ -547,6 +568,7 @@ export function ArtifactCatalogPage() {
           ) : sharedConversationLayout ? (
             <ArtifactSharedConversationList
               artifacts={artifacts}
+              scrollToArtifactId={scrollToArtifactId}
               onOpen={(artifactId) => {
                 detach(
                   openArtifact(artifactId, pageSignal),
@@ -558,6 +580,7 @@ export function ArtifactCatalogPage() {
           ) : (
             <ArtifactCatalogGrid
               artifacts={artifacts}
+              scrollToArtifactId={scrollToArtifactId}
               onOpen={(artifactId) => {
                 detach(
                   openArtifact(artifactId, pageSignal),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1,11 +1,12 @@
 import {
+  act,
   cleanup,
   fireEvent,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   chatSearchContract,
@@ -46,7 +47,7 @@ import {
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { emptySearchImg } from "../platform-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { pathname } from "../../../signals/location.ts";
+import { pathname, search } from "../../../signals/location.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { setChatPageImageModelSelection$ } from "../../../signals/okou-page/chat-page.ts";
 import {
@@ -3592,6 +3593,10 @@ describe("zero sidebar", () => {
   });
 
   it("searches workflows and artifacts in the three-column spotlight", async () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn<HTMLElement["scrollIntoView"]>(),
+    });
     prepareAgents();
     mockSidebarThreadStory([
       createThread(RESEARCH_THREAD_ID, "Launch notes", {
@@ -3658,7 +3663,7 @@ describe("zero sidebar", () => {
     context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {
       return respond(200, {
         artifacts:
-          query.keyword === "launch"
+          query.keyword === "launch" || query.kind === "video"
             ? [
                 {
                   id: ARTIFACT_ID,
@@ -3753,6 +3758,12 @@ describe("zero sidebar", () => {
     ).not.toBeInTheDocument();
     click(within(dialog).getByText("launch-demo.mp4"));
 
+    await waitFor(() => {
+      expect(pathname()).toBe("/artifacts");
+      const params = new URLSearchParams(search());
+      expect(params.get("tab")).toBe("video");
+      expect(params.get("artifact")).toBe(ARTIFACT_ID);
+    });
     await expect(
       screen.findByLabelText("Video preview for launch-demo.mp4"),
     ).resolves.toHaveAttribute(
@@ -3764,6 +3775,17 @@ describe("zero sidebar", () => {
       expect(
         screen.queryByLabelText("Video preview for launch-demo.mp4"),
       ).not.toBeInTheDocument();
+      expect(pathname()).toBe("/artifacts");
+      const params = new URLSearchParams(search());
+      expect(params.get("tab")).toBe("video");
+      expect(params.has("artifact")).toBeFalsy();
+    });
+
+    act(() => {
+      window.history.back();
+    });
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
     });
 
     const searchEvent = new KeyboardEvent("keydown", {

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -57,6 +57,7 @@ import {
   type AttachmentLightboxState,
 } from "../../signals/okou-page/attachment-chips.ts";
 import { openThreadArtifactSplitView$ } from "../../signals/chat-page/thread-sidebar-coordinator.ts";
+import { closeArtifactCatalogPreview$ } from "../../signals/artifacts-page/artifact-catalog-signals.ts";
 import { FilePreviewIcon } from "./file-preview-icon.tsx";
 import {
   artifactPreviewUrlsMatch,
@@ -1255,6 +1256,7 @@ function ArtifactPreviewDialogActions({
   const { t } = useTranslation();
   const rootSignal = useGet(rootSignal$);
   const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
+  const closeArtifactCatalogPreview = useSet(closeArtifactCatalogPreview$);
   const openArtifactSidebarPreview = useSet(openThreadArtifactSplitView$);
   const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
   const toggleLightboxDialogFullscreen = useSet(
@@ -1346,7 +1348,7 @@ function ArtifactPreviewDialogActions({
           return $.artifacts.actions.close;
         })}
         onClick={() => {
-          closeLightboxWithDialogExit(rootSignal);
+          closeArtifactCatalogPreview(rootSignal);
         }}
       >
         <X size={18} />
@@ -1367,14 +1369,14 @@ function ArtifactPreviewDialogContent({
   const { t } = useTranslation();
   const rootSignal = useGet(rootSignal$);
   const dialogMountRef = useSet(lightboxDialogMountRef$);
-  const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
+  const closeArtifactCatalogPreview = useSet(closeArtifactCatalogPreview$);
   const filename = artifact?.filename ?? artifactDialogFilename(preview);
   const subtitle = artifactDialogKindLabel(preview, artifact);
   const visible = useGet(lightboxDialogVisible$);
   const fullscreen = useGet(lightboxDialogFullscreen$);
 
   const closeWithAnimation = () => {
-    closeLightboxWithDialogExit(rootSignal);
+    closeArtifactCatalogPreview(rootSignal);
   };
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -1332,7 +1332,7 @@ interface SpotlightSearchResultsProps {
   readonly showNoResults: boolean;
   readonly onSelectChatThread: (threadId: string) => void;
   readonly onSelectWorkflow: (workflowId: string) => void;
-  readonly onSelectArtifact: (artifactId: string) => void;
+  readonly onSelectArtifact: (artifact: ThreeColumnArtifactSearchItem) => void;
 }
 
 interface SpotlightQueryResult {
@@ -1509,7 +1509,7 @@ function SpotlightSearchResults({
                   key={artifact.id}
                   artifact={artifact}
                   onSelect={() => {
-                    return onSelectArtifact(artifact.id);
+                    return onSelectArtifact(artifact);
                   }}
                 />
               );
@@ -1561,7 +1561,7 @@ export function ThreeColumnSearchDialog({
   readonly onOpenChange: (open: boolean) => void;
   readonly onSelectChatThread: (threadId: string) => void;
   readonly onSelectWorkflow: (workflowId: string) => void;
-  readonly onSelectArtifact: (artifactId: string) => void;
+  readonly onSelectArtifact: (artifact: ThreeColumnArtifactSearchItem) => void;
 }) {
   const { t } = useTranslation("agents");
   const query = useGet(chatListQuery$);
@@ -1643,9 +1643,9 @@ export function ThreeColumnSearchDialog({
     onOpenChange(false);
     onSelectWorkflow(workflowId);
   };
-  const selectArtifact = (artifactId: string) => {
+  const selectArtifact = (artifact: ThreeColumnArtifactSearchItem) => {
     onOpenChange(false);
-    onSelectArtifact(artifactId);
+    onSelectArtifact(artifact);
   };
 
   return (

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -64,7 +64,6 @@ import {
   newChatThreadDisabled$,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
-import { openArtifact$ } from "../../signals/artifacts-page/artifact-catalog-signals.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -807,8 +806,6 @@ function ThreeColumnSearchDialogContainer() {
   const open = useGet(threeColumnSearchOpen$);
   const onOpenChange = useSet(setThreeColumnSearchOpen$);
   const navigate = useSet(detachedNavigateTo$);
-  const openArtifact = useSet(openArtifact$);
-  const rootSignal = useGet(rootSignal$);
 
   if (!open) {
     return null;
@@ -828,12 +825,14 @@ function ThreeColumnSearchDialogContainer() {
           pathParams: { workflowId },
         });
       }}
-      onSelectArtifact={(artifactId) => {
-        detach(
-          openArtifact(artifactId, rootSignal),
-          Reason.DomCallback,
-          "open artifact from workspace search",
-        );
+      onSelectArtifact={(artifact) => {
+        const searchParams = new URLSearchParams({
+          artifact: artifact.id,
+        });
+        if (artifact.kind !== "presentation") {
+          searchParams.set("tab", artifact.kind);
+        }
+        navigate("/artifacts", { searchParams });
       }}
     />
   );


### PR DESCRIPTION
## Summary

- sync artifact catalog tabs with the URL and browser history
- route workspace artifact search results to the matching catalog tab and deep-linked preview
- preserve Back/Forward preview semantics while loading and centering the selected artifact card

## Testing

- pnpm -F @okouai/app check-types
- pnpm -F @okouai/app exec vitest run src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
- pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t "searches workflows and artifacts in the three-column spotlight"
- pnpm -F @okouai/app exec oxlint on changed files
- pnpm -F @okouai/app exec oxlint --type-aware on changed files
- pnpm -F @okouai/app exec eslint on changed files --max-warnings 0