### PR TITLE
feat(auth): add custom add-account rollout

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -41,6 +41,7 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
       ),
       mode,
       navigation: platformContext.navigation,
+      presentation: "route",
     });
     const continuationSignals = diagnostics.instrumentContinuation(
       continuationController,

--- a/turbo/apps/platform/src/signals/auth-v2/continuation.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/continuation.test.ts
@@ -72,6 +72,7 @@ async function setupContinuation(options: {
     ),
     mode,
     navigation: platformContext.navigation,
+    presentation: "route",
   });
 }
 

--- a/turbo/apps/platform/src/signals/auth-v2/continuation.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/continuation.ts
@@ -77,6 +77,7 @@ export interface AuthV2ContinuationDependencies {
   readonly isContinuationRoute: boolean;
   readonly mode: AuthV2RouteMode;
   readonly navigation: AuthV2Navigation;
+  readonly presentation: "inline" | "route";
 }
 
 type ContinuationSessionSource = "organization" | "recovery" | "session";
@@ -209,7 +210,10 @@ function createApplySessionCommand(
             status: "incomplete",
             task: "choose-organization",
           });
-          if (!dependencies.isContinuationRoute) {
+          if (
+            dependencies.presentation === "route" &&
+            !dependencies.isContinuationRoute
+          ) {
             set(
               navigateToTask$,
               decorateUrl(
@@ -409,7 +413,7 @@ function createRestartCommand(
   runtime: ContinuationRuntime,
   dependencies: AuthV2ContinuationDependencies,
 ): Command<Promise<void>, [AbortSignal]> {
-  return command(async ({ get }, signal: AbortSignal): Promise<void> => {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const current = get(runtime.inFlight$);
     if (current) {
       await current;
@@ -424,6 +428,15 @@ function createRestartCommand(
       if (!signedOut.ok) {
         return;
       }
+    }
+    if (dependencies.presentation === "inline") {
+      set(atoms.sessionId$, null);
+      set(runtime.activatedOrganizationId$, null);
+      set(runtime.handledSessionId$, null);
+      set(runtime.redirected$, false);
+      set(runtime.taskNavigated$, false);
+      set(atoms.state$, { status: "inactive" });
+      return;
     }
     window.location.href = dependencies.navigation.href(dependencies.mode);
   });

--- a/turbo/apps/platform/src/signals/auth-v2/platform-context.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/platform-context.test.ts
@@ -152,3 +152,23 @@ describe("Auth v2 platform context", () => {
     expect(nestedUrl.searchParams.get("redirect_url")).toBe(redirectUrl);
   });
 });
+
+describe("Auth v2 app-owned platform context", () => {
+  it("does not inherit the current page URL", () => {
+    setBrowserUrl(
+      "https://app.vm0.ai/agents?redirect_url=https%3A%2F%2Fwww.vm0.ai%2Fconnector%2Fsuccess#private-page-state",
+    );
+
+    const { navigation } = resolveAuthV2PlatformContext("sign-in", {
+      authHash: "",
+      authSearch: "",
+    });
+    const signInUrl = absoluteNavigationUrl(navigation.href("sign-in"));
+
+    expect(navigation.completionRedirectUrl).toBe("https://app.vm0.ai");
+    expect(signInUrl.searchParams.get("redirect_url")).toBe(
+      "https://app.vm0.ai",
+    );
+    expect(signInUrl.hash).toBe("");
+  });
+});

--- a/turbo/apps/platform/src/signals/auth-v2/platform-context.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/platform-context.ts
@@ -22,11 +22,17 @@ export interface AuthV2PlatformContext {
   readonly satelliteConfig: AuthV2SatelliteConfig;
 }
 
+interface ResolveAuthV2PlatformContextOptions {
+  readonly authHash?: string;
+  readonly authSearch?: string;
+}
+
 export function resolveAuthV2PlatformContext(
   mode: AuthV2RouteMode,
+  options: ResolveAuthV2PlatformContextOptions = {},
 ): AuthV2PlatformContext {
-  const authSearch = location.search;
-  const authHash = location.hash;
+  const authSearch = options.authSearch ?? location.search;
+  const authHash = options.authHash ?? location.hash;
   const allowedRedirectOrigins = getAllowedAuthRedirectOriginsForCurrentPage();
   const signUpCompletionRedirectUrl = buildSignupRedirectUrl(
     authSearch,

--- a/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
@@ -1,0 +1,99 @@
+import { command, computed, state } from "ccstate";
+
+import { captureAuthV2DiagnosticEvent } from "../../lib/posthog.ts";
+import {
+  createAuthV2ContinuationSignals,
+  type AuthV2ContinuationSignals,
+} from "../auth-v2/continuation.ts";
+import { createAuthV2Diagnostics } from "../auth-v2/diagnostics.ts";
+import {
+  resolveAuthV2PlatformContext,
+  type AuthV2PlatformContext,
+} from "../auth-v2/platform-context.ts";
+import {
+  createAuthV2SignInSignals,
+  type AuthV2SignInSignals,
+} from "../auth-v2/sign-in-flow.ts";
+import { resetSignal } from "../utils.ts";
+
+export interface AuthV2AddAccountDialogModel {
+  readonly continuationSignals: AuthV2ContinuationSignals;
+  readonly platformContext: AuthV2PlatformContext;
+  readonly signInSignals: AuthV2SignInSignals;
+}
+
+const internalDialogModel$ = state<AuthV2AddAccountDialogModel | null>(null);
+const resetDialogSignal$ = resetSignal();
+
+export const authV2AddAccountDialogModel$ = computed((get) => {
+  return get(internalDialogModel$);
+});
+
+const releaseAuthV2AddAccountDialog$ = command(({ set }) => {
+  set(internalDialogModel$, null);
+});
+
+export const closeAuthV2AddAccountDialog$ = command(({ set }) => {
+  set(resetDialogSignal$);
+  set(releaseAuthV2AddAccountDialog$);
+});
+
+export const openAuthV2AddAccountDialog$ = command(
+  async ({ get, set }, pageSignal: AbortSignal): Promise<void> => {
+    const dialogSignal = set(resetDialogSignal$, pageSignal);
+    dialogSignal.addEventListener(
+      "abort",
+      () => {
+        set(releaseAuthV2AddAccountDialog$);
+      },
+      { once: true },
+    );
+
+    // Add-account is an app-owned entry point, so it intentionally ignores
+    // unrelated query/hash state from the page underneath the modal.
+    const platformContext = resolveAuthV2PlatformContext("sign-in", {
+      authHash: "",
+      authSearch: "",
+    });
+    const diagnostics = createAuthV2Diagnostics(
+      "sign-in",
+      captureAuthV2DiagnosticEvent,
+    );
+    const continuationController = createAuthV2ContinuationSignals({
+      isContinuationRoute: false,
+      mode: "sign-in",
+      navigation: platformContext.navigation,
+    });
+    const continuationSignals = diagnostics.instrumentContinuation(
+      continuationController,
+    );
+    const signInSignals = diagnostics.instrumentSignIn(
+      createAuthV2SignInSignals({
+        continuation: continuationController,
+        isBaseRoute: true,
+        isOAuthCallbackRoute: false,
+        navigation: platformContext.navigation,
+      }),
+      {
+        continuationState$: continuationController.state$,
+        isBaseRoute: true,
+        isOAuthCallbackRoute: false,
+      },
+    );
+
+    set(internalDialogModel$, {
+      continuationSignals,
+      platformContext,
+      signInSignals,
+    });
+
+    await set(continuationSignals.initialize$, dialogSignal);
+    pageSignal.throwIfAborted();
+    dialogSignal.throwIfAborted();
+    if (get(continuationSignals.state$).status === "inactive") {
+      await set(signInSignals.initialize$, dialogSignal);
+      pageSignal.throwIfAborted();
+      dialogSignal.throwIfAborted();
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
@@ -80,6 +80,7 @@ export const openAuthV2AddAccountDialog$ = command(
         isOAuthCallbackRoute: false,
       },
     );
+    set(signInSignals.useAnotherAccount$);
 
     set(internalDialogModel$, {
       continuationSignals,

--- a/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 
 import { captureAuthV2DiagnosticEvent } from "../../lib/posthog.ts";
 import {
@@ -18,6 +18,7 @@ import { resetSignal } from "../utils.ts";
 
 export interface AuthV2AddAccountDialogModel {
   readonly continuationSignals: AuthV2ContinuationSignals;
+  readonly operationSignal$: Computed<AbortSignal>;
   readonly platformContext: AuthV2PlatformContext;
   readonly signInSignals: AuthV2SignInSignals;
 }
@@ -63,8 +64,9 @@ export const openAuthV2AddAccountDialog$ = command(
       isContinuationRoute: false,
       mode: "sign-in",
       navigation: platformContext.navigation,
+      presentation: "inline",
     });
-    const continuationSignals = diagnostics.instrumentContinuation(
+    const instrumentedContinuationSignals = diagnostics.instrumentContinuation(
       continuationController,
     );
     const signInSignals = diagnostics.instrumentSignIn(
@@ -81,9 +83,21 @@ export const openAuthV2AddAccountDialog$ = command(
       },
     );
     set(signInSignals.useAnotherAccount$);
+    const continuationSignals: AuthV2ContinuationSignals = {
+      ...instrumentedContinuationSignals,
+      restart$: command(async ({ set }, signal: AbortSignal): Promise<void> => {
+        await set(instrumentedContinuationSignals.restart$, signal);
+        signal.throwIfAborted();
+        set(signInSignals.restart$);
+      }),
+    };
+    const operationSignal$ = computed(() => {
+      return dialogSignal;
+    });
 
     set(internalDialogModel$, {
       continuationSignals,
+      operationSignal$,
       platformContext,
       signInSignals,
     });

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
@@ -49,6 +49,7 @@ function AuthV2AddAccountDialogContent({
         {continuationState.status !== "inactive" ? (
           <AuthV2ContinuationCard
             authBrand={model.platformContext.authBrand}
+            operationSignal$={model.operationSignal$}
             signals={model.continuationSignals}
             state={continuationState}
             surface="dialog"
@@ -57,6 +58,7 @@ function AuthV2AddAccountDialogContent({
           <AuthV2SignInCard
             authBrand={model.platformContext.authBrand}
             navigation={model.platformContext.navigation}
+            operationSignal$={model.operationSignal$}
             signals={model.signInSignals}
             surface="dialog"
           />

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
@@ -1,0 +1,72 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@okouai/ui/components/ui/dialog";
+import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+
+import {
+  authV2AddAccountDialogModel$,
+  closeAuthV2AddAccountDialog$,
+  type AuthV2AddAccountDialogModel,
+} from "../../signals/okou-page/auth-v2-add-account-dialog.ts";
+import { AuthV2ContinuationCard } from "./continuation/continuation-card.tsx";
+import { AuthV2SignInCard } from "./sign-in/sign-in-card.tsx";
+import { useAuthV2SignInCopy } from "./sign-in/sign-in-copy.ts";
+
+function AuthV2AddAccountDialogContent({
+  model,
+}: {
+  readonly model: AuthV2AddAccountDialogModel;
+}) {
+  const { t } = useTranslation();
+  const copy = useAuthV2SignInCopy(model.platformContext.authBrand);
+  const closeDialog = useSet(closeAuthV2AddAccountDialog$);
+  const continuationState = useGet(model.continuationSignals.state$);
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          closeDialog();
+        }
+      }}
+    >
+      <DialogContent
+        className="zero-app max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[25rem] gap-0 overflow-y-auto border-0 bg-transparent p-0 shadow-none [&_[data-slot=dialog-close]]:right-4 [&_[data-slot=dialog-close]]:top-4 [&_[data-slot=dialog-close]]:z-10"
+        closeLabel={t(($) => {
+          return $.settings.shared.close;
+        })}
+        data-testid="auth-v2-add-account-dialog"
+      >
+        <DialogTitle className="sr-only">{copy.signInTitle}</DialogTitle>
+        <DialogDescription className="sr-only">
+          {copy.startSubtitle}
+        </DialogDescription>
+        {continuationState.status !== "inactive" ? (
+          <AuthV2ContinuationCard
+            authBrand={model.platformContext.authBrand}
+            signals={model.continuationSignals}
+            state={continuationState}
+            surface="dialog"
+          />
+        ) : (
+          <AuthV2SignInCard
+            authBrand={model.platformContext.authBrand}
+            navigation={model.platformContext.navigation}
+            signals={model.signInSignals}
+            surface="dialog"
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function AuthV2AddAccountDialog() {
+  const model = useGet(authV2AddAccountDialogModel$);
+  return model ? <AuthV2AddAccountDialogContent model={model} /> : null;
+}

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
@@ -29,6 +29,7 @@ interface AuthV2ShellProps {
   readonly focusKey: string;
   readonly headerDetail?: ReactNode;
   readonly layout?: "choice" | "default";
+  readonly surface?: "dialog" | "page";
   readonly title: ReactNode;
 }
 
@@ -41,6 +42,7 @@ export function AuthV2Shell({
   focusKey,
   headerDetail,
   layout = "default",
+  surface = "page",
   title,
 }: AuthV2ShellProps) {
   const focusHeading = useSet(focusAuthV2HeadingRef$);
@@ -48,7 +50,12 @@ export function AuthV2Shell({
   const choiceLayout = layout === "choice";
 
   return (
-    <div className="w-[calc(100%+0.5rem)] max-w-[25rem] shrink-0 space-y-4">
+    <div
+      className={cn(
+        "max-w-[25rem] shrink-0 space-y-4",
+        surface === "dialog" ? "w-full" : "w-[calc(100%+0.5rem)]",
+      )}
+    >
       <Card
         aria-describedby={description ? AUTH_V2_DESCRIPTION_ID : undefined}
         aria-labelledby={AUTH_V2_TITLE_ID}

--- a/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
@@ -1,4 +1,5 @@
 import { Button, cn } from "@okouai/ui";
+import type { Computed } from "ccstate";
 import { useGet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Loader2 } from "lucide-react";
@@ -79,14 +80,16 @@ function LoadingContent({ label }: { readonly label: string }) {
 
 function OrganizationContent({
   copy,
+  operationSignal$,
   signals,
   state,
 }: {
   readonly copy: AuthV2ContinuationCopy;
+  readonly operationSignal$: Computed<AbortSignal>;
   readonly signals: AuthV2ContinuationSignals;
   readonly state: Extract<AuthV2ContinuationState, { status: "incomplete" }>;
 }) {
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const [selectionLoadable, selectOrganization] = useLoadableSet(
     signals.selectOrganization$,
   );
@@ -112,7 +115,7 @@ function OrganizationContent({
             }
             onSelect={() => {
               detach(
-                selectOrganization(organization.id, pageSignal),
+                selectOrganization(organization.id, operationSignal),
                 Reason.DomCallback,
                 "select auth v2 organization",
               );
@@ -128,13 +131,15 @@ function OrganizationContent({
 function OrganizationFooter({
   accountIdentifier,
   copy,
+  operationSignal$,
   signals,
 }: {
   readonly accountIdentifier: string;
   readonly copy: AuthV2ContinuationCopy;
+  readonly operationSignal$: Computed<AbortSignal>;
   readonly signals: AuthV2ContinuationSignals;
 }) {
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const [restartLoadable, restart] = useLoadableSet(signals.restart$);
   const signingOut = restartLoadable.state === "loading";
   return (
@@ -152,7 +157,7 @@ function OrganizationFooter({
         disabled={signingOut}
         onClick={() => {
           detach(
-            restart(pageSignal),
+            restart(operationSignal),
             Reason.DomCallback,
             "sign out of auth v2 organization continuation",
           );
@@ -172,12 +177,14 @@ function OrganizationFooter({
 
 function RecoveryContent({
   copy,
+  operationSignal$,
   signals,
 }: {
   readonly copy: AuthV2ContinuationCopy;
+  readonly operationSignal$: Computed<AbortSignal>;
   readonly signals: AuthV2ContinuationSignals;
 }) {
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const [restartLoadable, restart] = useLoadableSet(signals.restart$);
   const restarting = restartLoadable.state === "loading";
   return (
@@ -188,7 +195,7 @@ function RecoveryContent({
       disabled={restarting}
       onClick={() => {
         detach(
-          restart(pageSignal),
+          restart(operationSignal),
           Reason.DomCallback,
           "restart auth v2 after continuation failure",
         );
@@ -206,11 +213,13 @@ function RecoveryContent({
 
 export function AuthV2ContinuationCard({
   authBrand,
+  operationSignal$ = pageSignal$,
   signals,
   state,
   surface = "page",
 }: {
   readonly authBrand: AuthBrandContext;
+  readonly operationSignal$?: Computed<AbortSignal>;
   readonly signals: AuthV2ContinuationSignals;
   readonly state: AuthV2ContinuationState;
   readonly surface?: "dialog" | "page";
@@ -226,9 +235,18 @@ export function AuthV2ContinuationCard({
       : `continuation:${state.status}`;
   const content =
     state.status === "incomplete" ? (
-      <OrganizationContent copy={copy} signals={signals} state={state} />
+      <OrganizationContent
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
     ) : state.status === "failure" || state.status === "unknown" ? (
-      <RecoveryContent copy={copy} signals={signals} />
+      <RecoveryContent
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+      />
     ) : (
       <LoadingContent label={heading.description} />
     );
@@ -241,6 +259,7 @@ export function AuthV2ContinuationCard({
           <OrganizationFooter
             accountIdentifier={state.accountIdentifier}
             copy={copy}
+            operationSignal$={operationSignal$}
             signals={signals}
           />
         ) : null

--- a/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/continuation/continuation-card.tsx
@@ -208,10 +208,12 @@ export function AuthV2ContinuationCard({
   authBrand,
   signals,
   state,
+  surface = "page",
 }: {
   readonly authBrand: AuthBrandContext;
   readonly signals: AuthV2ContinuationSignals;
   readonly state: AuthV2ContinuationState;
+  readonly surface?: "dialog" | "page";
 }) {
   const copy = useAuthV2ContinuationCopy(authBrand.brandName);
   if (state.status === "inactive") {
@@ -246,6 +248,7 @@ export function AuthV2ContinuationCard({
       description={heading.description}
       focusKey={focusKey}
       layout={state.status === "incomplete" ? "choice" : "default"}
+      surface={surface}
       title={heading.title}
     >
       {content}

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -20,12 +20,14 @@ export function AuthV2SignInCard({
   authBrand,
   navigation,
   signals,
+  surface = "page",
 }: {
   readonly authBrand: AuthBrandContext;
   readonly navigation: AuthV2Navigation;
   readonly signals: AuthV2SignInSignals;
+  readonly surface?: "dialog" | "page";
 }) {
-  const copy = useAuthV2SignInCopy();
+  const copy = useAuthV2SignInCopy(authBrand);
   const flowState = useGet(signals.state$);
   const identifier = useGet(signals.identifier$);
   const backToIdentifier = useSet(signals.backToIdentifier$);
@@ -73,6 +75,7 @@ export function AuthV2SignInCard({
         ) : null
       }
       layout={showsAccountChooser ? "choice" : "default"}
+      surface={surface}
       title={title}
     >
       <SignInCardContent

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-card.tsx
@@ -1,8 +1,10 @@
+import type { Computed } from "ccstate";
 import { useGet, useSet } from "ccstate-react";
 
 import type { AuthV2Navigation } from "../../../signals/auth-v2/navigation.ts";
 import type { AuthV2SignInSignals } from "../../../signals/auth-v2/sign-in-flow.ts";
 import type { AuthBrandContext } from "../../../signals/auth.ts";
+import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { AuthV2IdentityPreview } from "../auth-v2-identity-preview.tsx";
 import { AuthV2Shell } from "../auth-v2-shell.tsx";
 import {
@@ -19,11 +21,13 @@ import {
 export function AuthV2SignInCard({
   authBrand,
   navigation,
+  operationSignal$ = pageSignal$,
   signals,
   surface = "page",
 }: {
   readonly authBrand: AuthBrandContext;
   readonly navigation: AuthV2Navigation;
+  readonly operationSignal$?: Computed<AbortSignal>;
   readonly signals: AuthV2SignInSignals;
   readonly surface?: "dialog" | "page";
 }) {
@@ -80,6 +84,7 @@ export function AuthV2SignInCard({
     >
       <SignInCardContent
         copy={copy}
+        operationSignal$={operationSignal$}
         signUpHref={signUpHref}
         signals={signals}
         state={flowState}

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-content.tsx
@@ -1,4 +1,5 @@
 import { Button, Checkbox, cn, Input } from "@okouai/ui";
+import type { Computed } from "ccstate";
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { ChevronRight, Loader2, Mail } from "lucide-react";
@@ -11,7 +12,6 @@ import type {
   AuthV2SignInSignals,
   AuthV2SignInState,
 } from "../../../signals/auth-v2/sign-in-flow.ts";
-import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
 import { Link } from "../../router/link.tsx";
@@ -48,6 +48,10 @@ type SignInFactorKind = NonNullable<
 interface SignInStepProps {
   readonly copy: AuthV2SignInCopy;
   readonly signals: AuthV2SignInSignals;
+}
+
+interface SignInOperationStepProps extends SignInStepProps {
+  readonly operationSignal$: Computed<AbortSignal>;
 }
 
 const AUTH_V2_SIGN_IN_ERROR_ID = "auth-v2-sign-in-error";
@@ -110,10 +114,10 @@ function OAuthFactorButton({
 function selectRecoveryFactor(
   selectFactor: (factorId: string, signal: AbortSignal) => Promise<void>,
   factorId: string,
-  pageSignal: AbortSignal,
+  operationSignal: AbortSignal,
 ): void {
   detach(
-    selectFactor(factorId, pageSignal),
+    selectFactor(factorId, operationSignal),
     Reason.DomCallback,
     "select auth v2 password recovery factor",
   );
@@ -312,13 +316,14 @@ function identifierFieldPresentation(
 
 function IdentifierStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & { readonly state: IncompleteSignInState }) {
+}: SignInOperationStepProps & { readonly state: IncompleteSignInState }) {
   const identifier = useGet(signals.identifier$);
   const error = useGet(signals.error$);
   const pendingFactorId = useGet(signals.pendingFactorId$);
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const setIdentifier = useSet(signals.setIdentifier$);
   const [submitLoadable, submit] = useLoadableSet(signals.submit$);
   const [selectLoadable, selectFactor] = useLoadableSet(signals.selectFactor$);
@@ -335,11 +340,15 @@ function IdentifierStep({
   const field = identifierFieldPresentation(state.identifierMode, copy);
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign in");
+    detach(
+      submit(operationSignal),
+      Reason.DomCallback,
+      "submit auth v2 sign in",
+    );
   };
   const handleSelectFactor = (factorId: string): void => {
     detach(
-      selectFactor(factorId, pageSignal),
+      selectFactor(factorId, operationSignal),
       Reason.DomCallback,
       "select auth v2 sign in factor",
     );
@@ -420,17 +429,18 @@ function IdentifierStep({
 
 function ChooseSessionStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & { readonly state: IncompleteSignInState }) {
-  const pageSignal = useGet(pageSignal$);
+}: SignInOperationStepProps & { readonly state: IncompleteSignInState }) {
+  const operationSignal = useGet(operationSignal$);
   const useAnotherAccount = useSet(signals.useAnotherAccount$);
   const [selectionLoadable, selectSession] = useLoadableSet(
     signals.selectSession$,
   );
   const selectAccount = (sessionId: string): void => {
     detach(
-      selectSession(sessionId, pageSignal),
+      selectSession(sessionId, operationSignal),
       Reason.DomCallback,
       "select existing auth v2 session",
     );
@@ -493,10 +503,11 @@ function ChooseSessionStep({
 
 function ChooseFactorStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & { readonly state: IncompleteSignInState }) {
-  const pageSignal = useGet(pageSignal$);
+}: SignInOperationStepProps & { readonly state: IncompleteSignInState }) {
+  const operationSignal = useGet(operationSignal$);
   const pendingFactorId = useGet(signals.pendingFactorId$);
   const back = useSet(signals.backFromMethods$);
   const [selectLoadable, selectFactor] = useLoadableSet(signals.selectFactor$);
@@ -515,7 +526,7 @@ function ChooseFactorStep({
   });
   const handleSelectFactor = (factorId: string): void => {
     detach(
-      selectFactor(factorId, pageSignal),
+      selectFactor(factorId, operationSignal),
       Reason.DomCallback,
       "select auth v2 sign in factor",
     );
@@ -596,12 +607,13 @@ function ChooseFactorStep({
 
 function PasswordStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & { readonly state: IncompleteSignInState }) {
+}: SignInOperationStepProps & { readonly state: IncompleteSignInState }) {
   const password = useGet(signals.password$);
   const error = useGet(signals.error$);
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const setPassword = useSet(signals.setPassword$);
   const backToMethods = useSet(signals.backToMethods$);
   const showPasswordRecovery = useSet(signals.showPasswordRecovery$);
@@ -611,7 +623,11 @@ function PasswordStep({
   });
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign in");
+    detach(
+      submit(operationSignal),
+      Reason.DomCallback,
+      "submit auth v2 sign in",
+    );
   };
   const submitting = submitLoadable.state === "loading";
   return (
@@ -687,10 +703,11 @@ function passwordRecoveryFactors(state: IncompleteSignInState) {
 
 function PasswordRecoveryStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & { readonly state: IncompleteSignInState }) {
-  const pageSignal = useGet(pageSignal$);
+}: SignInOperationStepProps & { readonly state: IncompleteSignInState }) {
+  const operationSignal = useGet(operationSignal$);
   const pendingFactorId = useGet(signals.pendingFactorId$);
   const back = useSet(signals.backFromPasswordRecovery$);
   const [selectLoadable, selectFactor] = useLoadableSet(signals.selectFactor$);
@@ -699,7 +716,7 @@ function PasswordRecoveryStep({
   const selecting = selectLoadable.state === "loading";
   const selectingFactorId = selecting ? pendingFactorId : null;
   const handleSelectFactor = (factorId: string): void => {
-    selectRecoveryFactor(selectFactor, factorId, pageSignal);
+    selectRecoveryFactor(selectFactor, factorId, operationSignal);
   };
   return (
     <div className="flex flex-col gap-6">
@@ -848,15 +865,16 @@ function ClientTrustNotice({
 
 function CodeStep({
   copy,
+  operationSignal$,
   signals,
   state,
-}: SignInStepProps & {
+}: SignInOperationStepProps & {
   readonly state: IncompleteSignInState;
 }) {
   const code = useGet(signals.code$);
   const error = useGet(signals.error$);
   const resendState = useGet(signals.resendState$);
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const setCode = useSet(signals.setCode$);
   const backToIdentifier = useSet(signals.backToIdentifier$);
   const backToMethods = useSet(signals.backToMethods$);
@@ -874,11 +892,15 @@ function CodeStep({
   const clientTrust = selectedFactor?.kind === "client-trust-email-code";
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign in");
+    detach(
+      submit(operationSignal),
+      Reason.DomCallback,
+      "submit auth v2 sign in",
+    );
   };
   const handleResend = (): void => {
     detach(
-      resendCode(pageSignal),
+      resendCode(operationSignal),
       Reason.DomCallback,
       "resend auth v2 sign in code",
     );
@@ -999,12 +1021,16 @@ function CodeStepBottomAction({
   );
 }
 
-function NewPasswordStep({ copy, signals }: SignInStepProps) {
+function NewPasswordStep({
+  copy,
+  operationSignal$,
+  signals,
+}: SignInOperationStepProps) {
   const newPassword = useGet(signals.newPassword$);
   const confirmPassword = useGet(signals.confirmPassword$);
   const signOutOfOtherSessions = useGet(signals.signOutOfOtherSessions$);
   const error = useGet(signals.error$);
-  const pageSignal = useGet(pageSignal$);
+  const operationSignal = useGet(operationSignal$);
   const setNewPassword = useSet(signals.setNewPassword$);
   const setConfirmPassword = useSet(signals.setConfirmPassword$);
   const setSignOutOfOtherSessions = useSet(signals.setSignOutOfOtherSessions$);
@@ -1020,7 +1046,11 @@ function NewPasswordStep({ copy, signals }: SignInStepProps) {
       : null;
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    detach(submit(pageSignal), Reason.DomCallback, "submit auth v2 sign in");
+    detach(
+      submit(operationSignal),
+      Reason.DomCallback,
+      "submit auth v2 sign in",
+    );
   };
   const submitting = submitLoadable.state === "loading";
   return (
@@ -1152,10 +1182,11 @@ function UnknownStep({ copy, signals }: SignInStepProps) {
 
 export function SignInCardContent({
   copy,
+  operationSignal$,
   signUpHref,
   signals,
   state,
-}: SignInStepProps & {
+}: SignInOperationStepProps & {
   readonly signUpHref: string;
   readonly state: AuthV2SignInState;
 }) {
@@ -1174,33 +1205,95 @@ export function SignInCardContent({
     return <UnknownStep copy={copy} signals={signals} />;
   }
   if (state.step === "choose-session") {
-    return <ChooseSessionStep copy={copy} signals={signals} state={state} />;
+    return (
+      <ChooseSessionStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "identifier") {
-    return <IdentifierStep copy={copy} signals={signals} state={state} />;
+    return (
+      <IdentifierStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "choose-factor") {
-    return <ChooseFactorStep copy={copy} signals={signals} state={state} />;
+    return (
+      <ChooseFactorStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "password") {
-    return <PasswordStep copy={copy} signals={signals} state={state} />;
+    return (
+      <PasswordStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "password-recovery") {
-    return <PasswordRecoveryStep copy={copy} signals={signals} state={state} />;
+    return (
+      <PasswordRecoveryStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "help") {
     return <HelpStep copy={copy} signals={signals} />;
   }
   if (state.step === "email-code") {
-    return <CodeStep copy={copy} signals={signals} state={state} />;
+    return (
+      <CodeStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "client-trust-code") {
-    return <CodeStep copy={copy} signals={signals} state={state} />;
+    return (
+      <CodeStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
   if (state.step === "password-reset-code") {
-    return <CodeStep copy={copy} signals={signals} state={state} />;
+    return (
+      <CodeStep
+        copy={copy}
+        operationSignal$={operationSignal$}
+        signals={signals}
+        state={state}
+      />
+    );
   }
-  return <NewPasswordStep copy={copy} signals={signals} />;
+  return (
+    <NewPasswordStep
+      copy={copy}
+      operationSignal$={operationSignal$}
+      signals={signals}
+    />
+  );
 }
 
 export function SignInSwitch({

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/sign-in-copy.ts
@@ -367,9 +367,10 @@ function signInTerminalCopy(
   };
 }
 
-export function useAuthV2SignInCopy(): AuthV2SignInCopy {
+export function useAuthV2SignInCopy(
+  authBrand: AuthBrandContext = resolveAuthBrandContext(),
+): AuthV2SignInCopy {
   const { t } = useTranslation();
-  const authBrand = resolveAuthBrandContext();
   return {
     ...signInEntryCopy(t, authBrand.brandName),
     ...signInCodeCopy(t, authBrand.brandName),

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "./error-boundary.tsx";
 import { AppSkeletonOverlay, Router } from "./router.tsx";
 import { VM0ClerkProvider } from "./clerk/clerk-provider.tsx";
 import { ForceUpgradeDialog } from "./components/force-upgrade-dialog.tsx";
+import { AuthV2AddAccountDialog } from "./auth-v2/auth-v2-add-account-dialog.tsx";
 import { InspectLogFileInput } from "./inspect-log-file-input.tsx";
 import { listenForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
 import { setupAuthenticatedDaemons$ } from "../signals/authenticated-daemons.ts";
@@ -73,6 +74,7 @@ export const setupRouter = (
           <AppSkeletonOverlay />
           <VM0ClerkProvider>
             <Router />
+            <AuthV2AddAccountDialog />
           </VM0ClerkProvider>
           <InspectLogFileInput />
           <ForceUpgradeDialog />

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1448,7 +1448,7 @@ describe("zero sidebar account menu", () => {
     });
   });
 
-  it("opens the custom v2 sign-in flow for add account when enabled", async () => {
+  it("opens the custom v2 sign-in flow in a dialog when enabled", async () => {
     prepareDefaultAgent();
 
     detachedSetupPage({
@@ -1463,12 +1463,22 @@ describe("zero sidebar account menu", () => {
     });
 
     const menu = await openAccountMenu();
+    const originalUrl = window.location.href;
     click(within(menu).getByText("Add account"));
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/v2/sign-in");
-    });
+    const dialog = await screen.findByTestId("auth-v2-add-account-dialog");
+    expect(dialog).toHaveAttribute("role", "dialog");
+    expect(within(dialog).getByTestId("app-auth-v2")).toBeVisible();
+    expect(window.location.href).toBe(originalUrl);
     expect(mockedClerk.openSignIn).not.toHaveBeenCalled();
+
+    click(buttonByLabel("Close", dialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("auth-v2-add-account-dialog"),
+      ).not.toBeInTheDocument();
+    });
+    expect(window.location.href).toBe(originalUrl);
   });
 
   it("preserves satellite session sync after signing out", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1448,7 +1448,7 @@ describe("zero sidebar account menu", () => {
     });
   });
 
-  it("opens the custom v2 sign-in flow in a dialog when enabled", async () => {
+  it("opens the custom v2 add-account dialog at identifier entry", async () => {
     prepareDefaultAgent();
 
     detachedSetupPage({
@@ -1469,6 +1469,9 @@ describe("zero sidebar account menu", () => {
     const dialog = await screen.findByTestId("auth-v2-add-account-dialog");
     expect(dialog).toHaveAttribute("role", "dialog");
     expect(within(dialog).getByTestId("app-auth-v2")).toBeVisible();
+    await expect(
+      within(dialog).findByLabelText("Email address"),
+    ).resolves.toBeVisible();
     expect(window.location.href).toBe(originalUrl);
     expect(mockedClerk.openSignIn).not.toHaveBeenCalled();
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1448,6 +1448,29 @@ describe("zero sidebar account menu", () => {
     });
   });
 
+  it("opens the custom v2 sign-in flow for add account when enabled", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.AuthV2AddAccount]: true },
+    });
+
+    const menu = await openAccountMenu();
+    click(within(menu).getByText("Add account"));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/v2/sign-in");
+    });
+    expect(mockedClerk.openSignIn).not.toHaveBeenCalled();
+  });
+
   it("preserves satellite session sync after signing out", async () => {
     prepareDefaultAgent();
     context.mocks.browser.url("https://app.okou.ai/");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -26,11 +26,15 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
-import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import {
+  mockedClerk,
+  mockSignInResource,
+} from "../../../__tests__/mock-auth.ts";
 import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { foregroundReady$ } from "../../../signals/auth-retry.ts";
 import { subscribeRealtimeReadyCatchUp$ } from "../../../signals/realtime.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -128,8 +132,11 @@ function prepareDefaultAgent(): void {
   ]);
 }
 
-function buttonByText(text: string): HTMLElement {
-  const button = queryAllByRoleFast("button").find((candidate) => {
+function buttonByText(
+  text: string,
+  container: ParentNode = document.body,
+): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
     return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
   });
   if (!button) {
@@ -159,6 +166,14 @@ function buttonByLabel(
     throw new Error(`${label} button not found`);
   }
   return button;
+}
+
+function containingForm(element: HTMLElement): HTMLFormElement {
+  const form = element.closest("form");
+  if (!(form instanceof HTMLFormElement)) {
+    throw new Error("Expected element to be inside a form");
+  }
+  return form;
 }
 
 function formatResetInTimeZone(resetAt: string, timeZone: string): string {
@@ -202,6 +217,26 @@ async function openAccountMenu(): Promise<HTMLElement> {
   }
   click(accountButton);
   return screen.findByRole("menu");
+}
+
+function setupAuthV2AddAccountPage(): void {
+  prepareDefaultAgent();
+  detachedSetupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    user: {
+      id: "test-user-123",
+      fullName: "Alex Rivera",
+      email: "alex.rivera@example.test",
+    },
+    featureSwitches: { [FeatureSwitchKey.AuthV2AddAccount]: true },
+  });
+}
+
+async function openAuthV2AddAccountDialog(): Promise<HTMLElement> {
+  const menu = await openAccountMenu();
+  click(within(menu).getByText("Add account"));
+  return screen.findByTestId("auth-v2-add-account-dialog");
 }
 
 interface MockAdminBillingStatusOptions {
@@ -1449,24 +1484,9 @@ describe("zero sidebar account menu", () => {
   });
 
   it("opens the custom v2 add-account dialog at identifier entry", async () => {
-    prepareDefaultAgent();
-
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/chat`,
-      user: {
-        id: "test-user-123",
-        fullName: "Alex Rivera",
-        email: "alex.rivera@example.test",
-      },
-      featureSwitches: { [FeatureSwitchKey.AuthV2AddAccount]: true },
-    });
-
-    const menu = await openAccountMenu();
+    setupAuthV2AddAccountPage();
     const originalUrl = window.location.href;
-    click(within(menu).getByText("Add account"));
-
-    const dialog = await screen.findByTestId("auth-v2-add-account-dialog");
+    const dialog = await openAuthV2AddAccountDialog();
     expect(dialog).toHaveAttribute("role", "dialog");
     expect(within(dialog).getByTestId("app-auth-v2")).toBeVisible();
     await expect(
@@ -1481,6 +1501,129 @@ describe("zero sidebar account menu", () => {
         screen.queryByTestId("auth-v2-add-account-dialog"),
       ).not.toBeInTheDocument();
     });
+    expect(window.location.href).toBe(originalUrl);
+  });
+
+  it("keeps add-account organization continuation and restart in the dialog", async () => {
+    setupAuthV2AddAccountPage();
+    const originalUrl = window.location.href;
+    const dialog = await openAuthV2AddAccountDialog();
+    const organizationMembership = {
+      id: "membership_target",
+      organization: {
+        id: "org_target",
+        imageUrl: null,
+        name: "Target Organization",
+      },
+    };
+
+    mockedClerk.setActive.mockImplementation(async (params) => {
+      await params.navigate?.({
+        decorateUrl: (url) => {
+          return url;
+        },
+        session: {
+          currentTask: { key: "choose-organization" },
+          id: "session_pending",
+          status: "pending",
+          user: { organizationMemberships: [organizationMembership] },
+        },
+      });
+    });
+
+    mockSignInResource({
+      status: "needs_first_factor",
+      supportedFirstFactors: [{ strategy: "password" }],
+    });
+    mockedClerk.clientSignInCreate.mockResolvedValue(mockedClerk.client.signIn);
+    const identifier = await within(dialog).findByLabelText("Email address");
+    fireEvent.change(identifier, {
+      target: { value: "second.account@example.test" },
+    });
+    fireEvent.submit(containingForm(identifier));
+
+    const password = await within(dialog).findByLabelText("Password");
+    mockSignInResource({
+      createdSessionId: "session_pending",
+      status: "complete",
+    });
+    mockedClerk.signInAttemptFirstFactor.mockResolvedValue(
+      mockedClerk.client.signIn,
+    );
+    fireEvent.change(password, { target: { value: "correct-password" } });
+    fireEvent.submit(containingForm(password));
+
+    await expect(
+      within(dialog).findByRole("heading", {
+        name: "Choose an organization",
+      }),
+    ).resolves.toBeVisible();
+    expect(window.location.href).toBe(originalUrl);
+
+    await waitFor(() => {
+      expect(
+        buttonByLabel("Continue with Target Organization", dialog),
+      ).toBeVisible();
+    });
+    click(buttonByLabel("Continue with Target Organization", dialog));
+    await waitFor(() => {
+      expect(buttonByText("Start over", dialog)).toBeVisible();
+    });
+    expect(window.location.href).toBe(originalUrl);
+
+    click(buttonByText("Start over", dialog));
+    await expect(
+      within(dialog).findByLabelText("Email address"),
+    ).resolves.toBeVisible();
+    expect(mockedClerk.signOut).toHaveBeenCalledWith({
+      sessionId: "session_pending",
+    });
+    expect(window.location.href).toBe(originalUrl);
+  });
+
+  it("cancels an in-flight add-account attempt when the dialog closes", async () => {
+    setupAuthV2AddAccountPage();
+    const originalUrl = window.location.href;
+    const dialog = await openAuthV2AddAccountDialog();
+
+    mockSignInResource({
+      status: "needs_first_factor",
+      supportedFirstFactors: [{ strategy: "password" }],
+    });
+    mockedClerk.clientSignInCreate.mockResolvedValue(mockedClerk.client.signIn);
+    const identifier = await within(dialog).findByLabelText("Email address");
+    fireEvent.change(identifier, {
+      target: { value: "second.account@example.test" },
+    });
+    fireEvent.submit(containingForm(identifier));
+
+    const attempt = createDeferredPromise<typeof mockedClerk.client.signIn>(
+      context.signal,
+    );
+    mockedClerk.signInAttemptFirstFactor.mockReturnValue(attempt.promise);
+    const password = await within(dialog).findByLabelText("Password");
+    fireEvent.change(password, { target: { value: "correct-password" } });
+    fireEvent.submit(containingForm(password));
+    await waitFor(() => {
+      expect(mockedClerk.signInAttemptFirstFactor).toHaveBeenCalledTimes(1);
+    });
+
+    click(buttonByLabel("Close", dialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("auth-v2-add-account-dialog"),
+      ).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mockSignInResource({
+        createdSessionId: "session_after_close",
+        status: "complete",
+      });
+      attempt.resolve(mockedClerk.client.signIn);
+      await attempt.promise;
+    });
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
     expect(window.location.href).toBe(originalUrl);
   });
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -51,7 +51,6 @@ import {
   type SettingsSection,
 } from "../../signals/okou-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { ROUTES } from "../../signals/route-paths.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
@@ -77,6 +76,7 @@ import {
   okouDebugRealtimeIndicator$,
   type OkouDebugRealtimeIndicator,
 } from "../../signals/okou-page/realtime-status.ts";
+import { openAuthV2AddAccountDialog$ } from "../../signals/okou-page/auth-v2-add-account-dialog.ts";
 
 interface SessionAccount {
   sessionId: string;
@@ -765,6 +765,7 @@ export function AccountDropdown({
   const actionLoadable = useLoadable(personalActionPromise$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
+  const openAuthV2AddAccountDialog = useSet(openAuthV2AddAccountDialog$);
 
   const current = accounts.find((a) => {
     return a.isActive;
@@ -819,7 +820,11 @@ export function AccountDropdown({
 
   const handleAddAccount = () => {
     if (authV2AddAccountEnabled) {
-      window.location.href = ROUTES.signInV2;
+      detach(
+        openAuthV2AddAccountDialog(pageSignal),
+        Reason.DomCallback,
+        "open auth v2 add account dialog",
+      );
       return;
     }
     detach(

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -51,6 +51,7 @@ import {
   type SettingsSection,
 } from "../../signals/okou-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
@@ -736,6 +737,8 @@ export function AccountDropdown({
     userInfoLoadable.state === "hasData" ? userInfoLoadable.data : undefined;
   const features = useLastResolved(featureSwitch$);
   const labEnabled = features?.[FeatureSwitchKey.Lab] ?? false;
+  const authV2AddAccountEnabled =
+    features?.[FeatureSwitchKey.AuthV2AddAccount] ?? false;
   const subscriptionsEnabled =
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
   // The three-column nav stacks the account mark under the workspace logo, so
@@ -815,6 +818,10 @@ export function AccountDropdown({
   };
 
   const handleAddAccount = () => {
+    if (authV2AddAccountEnabled) {
+      window.location.href = ROUTES.signInV2;
+      return;
+    }
     detach(
       clerk?.openSignIn({
         fallbackRedirectUrl: "/",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -118,6 +118,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.AuthV2AddAccount]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
       true,
@@ -149,6 +150,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.AuthV2AddAccount]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BuiltInModelProviderFallback]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -35,6 +35,7 @@ export enum FeatureSwitchKey {
   OkouDebug = "okouDebug",
   Banking = "banking",
   Lab = "lab",
+  AuthV2AddAccount = "authV2AddAccount",
   NotionWorkflowAutomations = "notionWorkflowAutomations",
   GoogleFormsWorkflowAutomations = "googleFormsWorkflowAutomations",
   StripeInvoicePaidWorkflowAutomations = "stripeInvoicePaidWorkflowAutomations",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -197,6 +197,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.AuthV2AddAccount]: {
+    maintainer: "linghan@vm0.ai",
+    description:
+      "Use the custom Auth v2 sign-in flow when adding another account.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.MorningBrief]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add an `AuthV2AddAccount` feature switch with staff rollout and Lab overrides
- open the custom Auth v2 add-account flow in an app-owned dialog while preserving the current page URL
- skip the existing-session chooser because the Add account action already expresses that intent
- reuse the `/v2/sign-in` card, continuation UI, signal flow, and diagnostics inside the dialog
- preserve Clerk `openSignIn` behavior while the switch is disabled
- isolate modal auth navigation from unrelated query and hash state on the underlying page

## Verification

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/app exec vitest run src/signals/auth-v2/platform-context.test.ts src/views/okou-page/__tests__/sidebar-account-menu.test.tsx --no-file-parallelism`
- `pnpm -F @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace @okouai/app --workspace @okouai/core`

## Staging QA

- Deployed head: `110d83d7382624946cc89e9fa5ad20fda18a216a`
- App: https://pr-29901-app.omby.ai
- API: https://pr-29901-api.vm6.ai
- Browser: Headless Chrome 151, 1440x1000 desktop and 390x844 mobile
- Feature switch: `authV2AddAccount` verified as `checked=true`
- PASS: one Add account action opens the custom Auth v2 dialog directly at Email address without changing the chat URL
- PASS: completed password and client-trust verification for a fresh second Clerk test account, activated its own agent page, switched back to the original account, and verified the added account under Switch account
- PASS: mobile dialog measured 358px wide in a 390px viewport with no horizontal overflow
- PASS: no browser runtime errors were reported
- Recording: https://cdn.vm0.io/artifacts/o2y90fnucf.webm
- Screenshot: https://cdn.vm0.io/artifacts/emwycbwcxn.png
- Fixture note: used two isolated Clerk test accounts and bypassed preview onboarding through the deployed API because onboarding was out of scope; the add-account sign-in itself used the real test password and client-trust flow
