### PR TITLE
docs(runner): clarify storage cache gc limit accounting

### DIFF
--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -17,12 +17,14 @@ use super::filesystem::{
 use super::lock_file::{LockProbe, probe_lock};
 use super::report::GcReport;
 
-/// Per-host storage archive cache size cap. Enforced by `gc_storage_cache`
-/// as an LRU by `<version>/` dir mtime.
+/// Per-host storage archive cache byte target for best-effort eviction.
+/// `gc_storage_cache` may leave the cache above this target when protected or
+/// unmeasured entries leave no safe eviction candidate.
 const STORAGE_CACHE_MAX_BYTES: u64 = 1 << 30; // 1 GiB
-/// Per-host storage archive cache entry cap. The byte cap alone does not
-/// bound many tiny storage versions, and each cached version also creates a
-/// lock file.
+/// Per-host storage archive cache entry target for best-effort eviction. The
+/// byte target alone does not bound many tiny storage versions, and each
+/// cached version also creates a lock file. Recent, held-lock, and
+/// lock-probe-error entries can leave this target exceeded after one pass.
 const STORAGE_CACHE_MAX_ENTRIES: u64 = 5_000;
 
 /// Eligible `<version>` directory discovered during the scan phase.
@@ -56,7 +58,7 @@ impl From<&std::fs::Metadata> for StorageDirectoryIdentity {
 struct StorageEvictionResult {
     freed: u64,
     /// Candidate contribution to keep in `total_size` after this attempt.
-    /// `None` removes the scan-time size from the cap calculation.
+    /// `None` removes the scan-time size from this pass's measured accounting.
     remaining_size: Option<u64>,
     /// Candidate contribution to keep in `total_entries` after this attempt.
     /// Dry-runs set this to false to model the real deletion while leaving
@@ -66,14 +68,22 @@ struct StorageEvictionResult {
     evicted: bool,
 }
 
-/// Bound `/var/lib/vm0-runner/storages/` to storage cache size and entry
-/// limits by evicting least-recently-used `<version>` directories.
+/// Best-effort eviction for `/var/lib/vm0-runner/storages/` using storage
+/// cache byte and entry targets, evicting least-recently-used `<version>`
+/// directories first. The targets are not unconditional post-GC caps: a pass
+/// may finish above either target when recent, held-lock, or lock-probe-error
+/// entries cannot be safely evicted.
 ///
 /// Entries younger than [`GC_MIN_AGE`] or whose per-version flock is held
 /// are always protected — the former prevents races with a writer's
 /// atomic rename-in, the latter protects an in-flight cache read. Stale
 /// `<version>.tmp/` staging directories are removed under the final
 /// version's flock so crashed writers do not leak disk indefinitely.
+/// Entries whose locks are held or whose lock probes fail are not safely
+/// measured for byte accounting. Consequently, `remaining_bytes` in the
+/// storage-cache GC log is a lower bound on cache disk usage when such entries
+/// exist. A candidate can also become locked or recent during deletion
+/// revalidation and remain on disk after that pass.
 ///
 /// A missing `storages_dir` is a no-op: a host without a populated storage
 /// cache has nothing to collect.
@@ -121,11 +131,12 @@ async fn gc_storage_cache_with_limits_report(
 
     let now = SystemTime::now();
     let mut candidates: Vec<StorageCandidate> = Vec::new();
-    // Bytes known to be on disk under the cap. Recent (age-protected) entries
-    // count toward this so we shrink observed disk use to within the cap;
-    // locked entries deliberately do NOT count — we cannot safely stat them
-    // without racing the writer, and counting them would evict eligible
-    // entries to make room for unmeasurable ones.
+    // Measured bytes considered for this pass. Recent (age-protected) entries
+    // count toward this total but are not eviction candidates; entries whose
+    // locks are held or whose lock probes fail deliberately do NOT count
+    // because they cannot be safely measured without racing the writer.
+    // Therefore this total is a lower bound on cache disk usage when any
+    // entry is unmeasured.
     let mut total_size: u64 = 0;
     // Entry cardinality is independent from byte accounting: locked or
     // probe-error entries still contribute to filesystem pressure even when
@@ -247,7 +258,9 @@ async fn gc_storage_cache_with_limits_report(
         return Ok(GcReport::cleanup(activity_count, freed));
     }
 
-    // LRU: evict oldest first until within cap.
+    // LRU: evict oldest first while the measured accounting model exceeds a
+    // target. Protected or unmeasured entries can prevent the target from
+    // being reached in this pass.
     candidates.sort_by_key(|c| c.mtime);
 
     for c in candidates {
@@ -271,6 +284,12 @@ async fn gc_storage_cache_with_limits_report(
     }
 
     let eviction_action = if dry_run { "would_evict" } else { "evicted" };
+    // `total_size` is measured accounting, not a complete filesystem
+    // inventory. Entries skipped because their locks were held or their lock
+    // probes failed are absent from it. A candidate that becomes locked or
+    // recent during revalidation remains on disk and contributes according to
+    // what could be safely observed, so `remaining_bytes` can be only a lower
+    // bound when unmeasured entries exist.
     info!(
         "storage cache gc: scanned={scanned_entries}, eligible={eligible_entries}, skipped_recent={skipped_recent}, skipped_locked={skipped_locked}, lock_probe_errors={lock_probe_errors}, eviction_action={eviction_action}, evicted_entries={evicted_entries}, freed={}, remaining_bytes={}, remaining_entries={total_entries}, limits=({}, {max_entries} entries)",
         human_bytes(freed),


### PR DESCRIPTION
## Summary

- Clarify that storage-cache byte and entry limits are best-effort eviction targets, not unconditional post-GC caps.
- Document how recent, held-lock, and lock-probe-error entries affect one-pass cleanup and byte accounting.
- Explain that `remaining_bytes` is a lower bound when entries could not be safely measured, including deletion-time revalidation cases.

Closes #29876

## Scope

This PR changes only Rust documentation and comments in `crates/runner/src/cmd/gc/storage.rs`. It preserves the GC algorithm, locking, grace window, eviction behavior, accounting calculation, tests, telemetry keys, and the `remaining_bytes` value calculation.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo check -p runner --tests` — passed with `CARGO_BUILD_JOBS=1`, `CARGO_PROFILE_TEST_DEBUG=0`, and a private workspace `TMPDIR`.
- `cargo clippy -p runner --all-targets --all-features` — passed with the same low-resource settings.
- `cargo doc -p runner --all-features --no-deps` — passed with the same low-resource settings.
- `cargo test -p runner cmd::gc::storage::tests` — attempted with normal and low-resource settings; both attempts were terminated with exit 137 while linking the runner test binary in the 3.8 GiB, no-swap environment. The source/test compilation completed without a diagnostic, and the equivalent test-target compile check passed above.
