### PR TITLE
fix(api): reject retired cli connector account intent

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
+  CLIENT_FORCE_UPGRADE_STATUS,
+  CLIENT_TYPE_CLI,
+  CLIENT_TYPE_HEADER,
+} from "@okouai/api-contracts/contracts/client-headers";
+import {
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
   connectorsBySlugContract,
@@ -51,6 +56,13 @@ const CONNECTOR_SLUGS_TO_CLEAN_UP = [
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
+}
+
+function cliAuthHeaders() {
+  return {
+    ...authHeaders(),
+    [CLIENT_TYPE_HEADER]: CLIENT_TYPE_CLI,
+  };
 }
 
 function featureSwitchesClient() {
@@ -199,6 +211,53 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     expect(response.status).toBe(400);
   });
 
+  it("requires identified CLI callers to send account-explicit intent", async () => {
+    await seedFixture();
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const request = (account?: { intent: "single-account" }) => {
+      return app.request("/api/connectors/openai/manual-grant", {
+        method: "POST",
+        headers: {
+          ...cliAuthHeaders(),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          authMethod: "api-token",
+          values: { apiKey: "sk-retired-cli" },
+          ...(account ? { account } : {}),
+        }),
+      });
+    };
+
+    const omitted = await request();
+    expect(omitted.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
+    await expect(omitted.json()).resolves.toStrictEqual({
+      error: {
+        message: "Update the CLI to connect this connector",
+        code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
+      },
+    });
+
+    const singleton = await request({ intent: "single-account" });
+    expect(singleton.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
+    await expect(singleton.json()).resolves.toStrictEqual({
+      error: {
+        message: "Update the CLI to connect this connector",
+        code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
+      },
+    });
+
+    const list = await accept(
+      setupApp({ context, routes: connectorsRoutes })(
+        connectorsMainContract,
+      ).list({ headers: authHeaders() }),
+      [200],
+    );
+    expect(list.body.connectors).not.toContainEqual(
+      expect.objectContaining({ slug: "openai" }),
+    );
+  });
+
   it("accepts server-authored identity syntax before catalog rejection", async () => {
     await seedFixture();
     const connectorSlug = "server-authored-connector";
@@ -318,6 +377,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
+          account: { intent: "single-account" },
           values: { apiKey: " sk-test\n" },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -340,7 +400,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     });
   });
 
-  it("adds the first account, reconnects it exactly, and rejects a sibling", async () => {
+  it("accepts CLI add and reconnect while preserving account errors", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
@@ -354,7 +414,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "add", displayName: "Work" },
           values: { apiKey: "sk-first" },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [200],
     );
@@ -367,7 +427,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "reconnect", connectionId: added.body.id },
           values: { apiKey: "sk-reconnected" },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [200],
     );
@@ -381,7 +441,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "add", displayName: "Personal" },
           values: { apiKey: "sk-sibling" },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [409],
     );
@@ -397,7 +457,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "reconnect", connectionId: randomUUID() },
           values: { apiKey: "sk-missing" },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [404],
     );
@@ -412,7 +472,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "reconnect", connectionId: added.body.id },
           values: { apiKey: "sk-wrong-owner" },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [404],
     );
@@ -431,7 +491,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
             subdomain: "example",
           },
         },
-        headers: authHeaders(),
+        headers: cliAuthHeaders(),
       }),
       [404],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   CLIENT_FORCE_UPGRADE_STATUS,
+  CLIENT_TYPE_APP,
   CLIENT_TYPE_CLI,
   CLIENT_TYPE_HEADER,
 } from "@okouai/api-contracts/contracts/client-headers";
@@ -62,6 +63,13 @@ function cliAuthHeaders() {
   return {
     ...authHeaders(),
     [CLIENT_TYPE_HEADER]: CLIENT_TYPE_CLI,
+  };
+}
+
+function appAuthHeaders() {
+  return {
+    ...authHeaders(),
+    [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
   };
 }
 
@@ -366,7 +374,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     );
   });
 
-  it("connects a first-time manual grant connector with connector-owned state", async () => {
+  it("preserves App single-account manual grants with connector-owned state", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
@@ -380,7 +388,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           account: { intent: "single-account" },
           values: { apiKey: " sk-test\n" },
         },
-        headers: { authorization: "Bearer clerk-session" },
+        headers: appAuthHeaders(),
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -9,6 +9,11 @@ import {
   connectorsMainContract,
   connectorsSearchContract,
 } from "@okouai/api-contracts/contracts/connectors";
+import {
+  CLIENT_FORCE_UPGRADE_STATUS,
+  CLIENT_TYPE_CLI,
+  CLIENT_TYPE_HEADER,
+} from "@okouai/api-contracts/contracts/client-headers";
 import type { PublicConnectorCatalogDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import { connectorGrantScopes } from "@okouai/connectors/connector-auth-method";
 
@@ -258,6 +263,21 @@ const connectManualGrantConnectorInner$ = command(
     signal.throwIfAborted();
     if (!bodyResult.ok) {
       return bodyResult.response;
+    }
+    if (
+      get(request$).header(CLIENT_TYPE_HEADER) === CLIENT_TYPE_CLI &&
+      (!bodyResult.data.account ||
+        bodyResult.data.account.intent === "single-account")
+    ) {
+      return {
+        status: CLIENT_FORCE_UPGRADE_STATUS,
+        body: {
+          error: {
+            message: "Update the CLI to connect this connector",
+            code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
+          },
+        },
+      };
     }
     const agentTarget = await set(
       validateConnectorAuthorizationTarget$,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -126,10 +126,17 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("accepts replacement and installed CLI manual grant requests", () => {
+  it("preserves manual grant inputs and declares the CLI retirement response", () => {
     expect(
       connectorManualGrantContract.connect.body.safeParse({
         authMethod: "api-token",
+        values: { apiKey: "test" },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorManualGrantContract.connect.body.safeParse({
+        authMethod: "api-token",
+        account: { intent: "single-account" },
         values: { apiKey: "test" },
       }).success,
     ).toBe(true);
@@ -145,6 +152,14 @@ describe("connector account contracts", () => {
         authMethod: "api-token",
         account: { intent: "reconnect", connectionId },
         values: { apiKey: "test" },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorManualGrantContract.connect.responses[426].safeParse({
+        error: {
+          message: "Update the CLI to connect this connector",
+          code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
+        },
       }).success,
     ).toBe(true);
   });

--- a/turbo/packages/api-contracts/src/contracts/connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors.ts
@@ -149,6 +149,7 @@ export const connectorManualGrantContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema,
+      426: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Connect a connector with a manual grant",


### PR DESCRIPTION
## Summary

- reject identified CLI manual-grant requests that omit account intent or request the retired singleton intent
- return a typed `426` response with the stable `CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED` code
- preserve explicit CLI add/reconnect behavior and all non-CLI callers, including the App

## Rollout guard

- the account-explicit replacement shipped in CLI `9.294.0` from #29814
- the conservative drain bound elapsed at 2026-08-27 12:20:56Z
- the bounded production zero-state query found 924 pre-cutoff runs resolved and 0 unresolved; evidence is recorded in #29774
- post-activation grouped request evidence remains to be recorded after deployment
- this PR relates to, but intentionally does not auto-close, #29774

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-accounts.test.ts` (12 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts` (29 passed)

The full repository Vitest run completed with 714 files passing, 1 skipped, and 4 failures outside the changed paths. The failures were caused by the local synced CLI API URL not matching an MSW fixture, retained Google Workspace subscription database state, retained Calendar watch state, and one isolated UTC test that passed when rerun alone.

Relates to #29774
Parent: #28571