### PR TITLE
refactor(runtime): cut guest runtime writers to canonical alias

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -522,7 +522,7 @@ async fn verify_final_identity_metadata(
     runtime_dir: &str,
 ) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
     let env = [(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         runtime_dir,
     )];
     let request = ExecRequest {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -584,7 +584,7 @@ fn build_env_json_with_host_env_inner(
         sandbox_id.into(),
     );
     env.insert(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV.into(),
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV.into(),
         guest_runtime_dir(context.run_id)?,
     );
     env.insert(

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -30,7 +30,7 @@ pub(super) fn guest_download_env<'a>(
     [
         (guest_contracts::env::RUN_ID_ENV, run_id),
         (
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             runtime_dir,
         ),
     ]

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -261,12 +261,13 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         assert!(call.cmd.contains(&metadata.history_size_bytes.to_string()));
         assert_eq!(
             call.env_keys,
-            vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
+            vec![guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV]
         );
         assert!(
-            !call.env_keys.iter().any(|key| {
-                key == guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
-            })
+            !call
+                .env_keys
+                .iter()
+                .any(|key| { key == guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV })
         );
         assert!(!call.sudo);
         assert!(call.stdin_bytes.is_none());

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -453,11 +453,11 @@ fn build_env_json_required_keys() {
         "7200"
     );
     assert_eq!(
-        env.get(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+        env.get(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
-    assert!(!env.contains_key(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV));
+    assert!(!env.contains_key(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV));
     assert!(!env.contains_key("VM0_PROMPT"));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
@@ -796,14 +796,11 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
     );
     assert_eq!(
         bootstrap_env
-            .get(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+            .get(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
-    assert!(
-        !bootstrap_env
-            .contains_key(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
-    );
+    assert!(!bootstrap_env.contains_key(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV));
     assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert_eq!(user_env.get("OKOU_TOKEN").unwrap(), "legitimate-okou-token");

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -82,14 +82,15 @@ fn guest_download_env_contains_run_identity_values() {
         [
             (guest_contracts::env::RUN_ID_ENV, run_id.as_str()),
             (
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 runtime_dir.as_str(),
             ),
         ]
     );
-    assert!(!env.iter().any(|(key, _)| {
-        *key == guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
-    }));
+    assert!(
+        !env.iter()
+            .any(|(key, _)| { *key == guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV })
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -242,7 +242,7 @@ async fn export_session_history_sidecar(
     ]
     .join(" ");
     let env = [(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         verification.runtime_dir,
     )];
     let request = ExecRequest {

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -417,7 +417,7 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
     assert_eq!(
         exec_calls[0].env_keys,
-        vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
+        vec![guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV]
     );
     assert!(exec_calls[1].cmd.contains("rm -f --"));
     assert!(exec_calls[1].cmd.contains("/session-history-sidecar"));

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -327,7 +327,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         .arg("--manifest-stdin")
         .env(guest_contracts::env::RUN_ID_ENV, run_id)
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             runtime_dir,
         )
         .stdin(Stdio::piped())

--- a/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
+++ b/crates/vsock-guest/tests/connection/guest_storage_manifest.rs
@@ -82,8 +82,8 @@ fn guest_storage_manifest_runs_fixed_argv_env_and_stdin() {
         r#"
 [ "$1" = "--manifest-stdin" ]
 [ "$OKOU_RUN_ID" = "run-1" ]
-[ "$VM0_GUEST_RUNTIME_DIR" = "/run/vm0/runs/run-1" ]
-[ "${OKOU_GUEST_RUNTIME_DIR+x}" != x ]
+[ "$OKOU_GUEST_RUNTIME_DIR" = "/run/vm0/runs/run-1" ]
+[ "${VM0_GUEST_RUNTIME_DIR+x}" != x ]
 [ "$(cat)" = '{"storages":[]}' ]
 printf 'applied\n'
 printf 'helper stderr\n' >&2


### PR DESCRIPTION
## Summary

- switch all five repository-owned guest runtime-directory writers from `GUEST_RUNTIME_DIR_ENV` to `CANONICAL_GUEST_RUNTIME_DIR_ENV`
- preserve each existing runtime path value and all bootstrap, helper, storage, session-history, workspace-promotion, and guest-download behavior
- flip only the focused writer assertions to require canonical presence and legacy absence while preserving the user-controlled legacy sentinel and temporary `VM0_*` ownership guard coverage

Closes #29909

Parent: #28914

## Acceptance evidence

- Reviewed base: `eace6a3e439043f31c35dd4f48b85891107c423c`
- Implementation head: `b4f457bfe21df0c47765f2a493d71c7c9ecd3826`
- The refreshed inventory found the same five production writers named in #29909. All five now use `guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV`; none uses `GUEST_RUNTIME_DIR_ENV`.
- The diff changes only each environment key expression. Existing path values, argv, stdin, timeouts, privileges, expected exit codes, output limits, storage transport, session-history verification/export, workspace promotion, and guest-download behavior are unchanged.
- The five focused assertion files require `OKOU_GUEST_RUNTIME_DIR` with the existing exact path and reject `VM0_GUEST_RUNTIME_DIR`.
- The `env_tests` user-controlled `GUEST_RUNTIME_DIR_ENV` sentinel and its temporary `VM0_*` ownership/filtering guard list are unchanged.
- `crates/guest-contracts`, `crates/guest-agent`, and `crates/guest-download` have no diff. The legacy constant, shared dual reader, telemetry, conflict and non-Unicode behavior, fallback layout, helper readers, and CLI isolation remain unchanged.
- The final diff is exactly the five production writer files plus the five focused writer-assertion files, with no unrelated cleanup.

## Overlap audit

Immediately before editing, the fully paginated audit covered all 30 open PRs and all 442 declared changed files; 442 files were fetched with no pagination mismatch. Only #25722 overlaps scoped files (`crates/runner/src/executor/env.rs` and `crates/runner/src/executor/tests/env_tests.rs`). Its patches contain neither runtime-directory alias nor either shared constant. No work from that PR was modified, absorbed, rebased, or delayed on.

## Fallbacks

- This PR adds no fallback branch. It changes only repository-owned writers to the canonical alias after the reader-floor and drain evidence recorded in #29909.
- The bounded dual reader merged in #29101 remains unchanged and continues to accept canonical-only, legacy-only, and equal-dual values while failing closed on conflicts.
- Rollback remains safe because every active and retained reader accepts a rolled-back legacy-only writer. Legacy-reader removal and telemetry cleanup remain separate #28914 work after the canonical-only observation and rollback gates.

## Verification

Passed locally:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path crates/Cargo.toml --no-deps -p runner -p vsock-guest --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path crates/Cargo.toml -p runner -p vsock-guest --all-targets`
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml --no-deps -p runner -p vsock-guest`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p vsock-guest guest_storage_manifest_runs_fixed_argv_env_and_stdin`
- `git diff --check`

The focused runner test binary was attempted with `CARGO_BUILD_JOBS=1` and was killed during final linking with exit `137`, before any test executed. Protected PR CI is authoritative for these exact filters:

- `build_env_json_required_keys`
- `fieldless_context_preserves_pre_platform_environment_filtering`
- `guest_download_env_contains_run_identity_values`
- `run_in_sandbox_skips_checkpointed_final_session_history_restore`
- `active_workspace_promotion_exports_session_history_sidecar`
