### PR TITLE
refactor(runtime): cut root cgroup placement writers to canonical aliases

### DIFF
--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -52,18 +52,24 @@ pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 /// variable and uses cloned descriptors only from CLI-child `pre_exec` hooks.
 pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
-/// Canonical reader alias for [`WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV`].
+/// Canonical alias for [`WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV`].
 ///
-/// `vsock-guest` keeps writing the legacy alias until the deployed reader
-/// floor, sandbox drain, rollback window, and legacy-read-zero gates in #28914
-/// are complete.
+/// `vsock-guest` writes only this canonical alias. Guest readers retain
+/// [`WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback fallback until the
+/// cutover release, observation window, rollback window, and legacy-read-zero
+/// gates in #28914 are complete.
 pub const CANONICAL_WORKLOAD_CGROUP_PROCS_ENV: &str = "OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
 /// Runner-owned endpoint used by [`TOOL_EXEC_PATH`] to request a unique tool
 /// cgroup before it executes user code.
 pub const TOOL_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_TOOL_CGROUP_PROCS_ENDPOINT";
 
-/// Canonical reader alias for [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`].
+/// Canonical alias for [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`].
+///
+/// `vsock-guest` writes only this canonical alias to Guest Agent. Guest readers
+/// retain [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback fallback until the
+/// root-writer cutover release, observation window, rollback window, and
+/// legacy-read-zero gates in #28914 are complete.
 ///
 /// Guest Agent keeps writing the legacy alias to managed CLI children until
 /// the deployed reader floor, sandbox drain, rollback window, and

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -53,6 +53,7 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use guest_contracts::process_containment::{
+    CANONICAL_TOOL_CGROUP_PROCS_ENV, CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
     TOOL_CGROUP_PROCS_ENDPOINT_ENV, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
 };
 use vsock_proto::{
@@ -2051,10 +2052,16 @@ fn append_exec_control_environment<'a>(
     process_control_endpoint: &'a str,
     workload_endpoints: Option<(&'a str, &'a str)>,
 ) {
+    env.retain(|(key, _)| {
+        *key != WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV
+            && *key != CANONICAL_WORKLOAD_CGROUP_PROCS_ENV
+            && *key != TOOL_CGROUP_PROCS_ENDPOINT_ENV
+            && *key != CANONICAL_TOOL_CGROUP_PROCS_ENV
+    });
     env.push((process_control_ipc::BOOTSTRAP_ENV, process_control_endpoint));
     if let Some((workload_endpoint, tool_endpoint)) = workload_endpoints {
-        env.push((WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV, workload_endpoint));
-        env.push((TOOL_CGROUP_PROCS_ENDPOINT_ENV, tool_endpoint));
+        env.push((CANONICAL_WORKLOAD_CGROUP_PROCS_ENV, workload_endpoint));
+        env.push((CANONICAL_TOOL_CGROUP_PROCS_ENV, tool_endpoint));
     }
 }
 
@@ -2285,8 +2292,33 @@ mod tests {
     }
 
     #[test]
-    fn control_bootstrap_environment_writers_remain_legacy_only() {
-        let mut env = vec![("USER_KEY", "user-value")];
+    fn control_bootstrap_environment_replaces_cgroup_aliases_with_canonical() {
+        let mut env = vec![
+            ("FIRST_USER_KEY", "first-user-value"),
+            (
+                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+                "stale-legacy-workload-endpoint",
+            ),
+            (
+                process_control_ipc::BOOTSTRAP_ENV,
+                "stale-process-control-endpoint",
+            ),
+            ("SECOND_USER_KEY", "second-user-value"),
+            (
+                CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+                "stale-canonical-workload-endpoint",
+            ),
+            (
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+                "existing-canonical-process-control-endpoint",
+            ),
+            (TOOL_CGROUP_PROCS_ENDPOINT_ENV, "stale-legacy-tool-endpoint"),
+            ("THIRD_USER_KEY", "third-user-value"),
+            (
+                CANONICAL_TOOL_CGROUP_PROCS_ENV,
+                "stale-canonical-tool-endpoint",
+            ),
+        ];
 
         append_exec_control_environment(
             &mut env,
@@ -2297,20 +2329,39 @@ mod tests {
         assert_eq!(
             env,
             [
-                ("USER_KEY", "user-value"),
+                ("FIRST_USER_KEY", "first-user-value"),
+                (
+                    process_control_ipc::BOOTSTRAP_ENV,
+                    "stale-process-control-endpoint"
+                ),
+                ("SECOND_USER_KEY", "second-user-value"),
+                (
+                    process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+                    "existing-canonical-process-control-endpoint"
+                ),
+                ("THIRD_USER_KEY", "third-user-value"),
                 (
                     process_control_ipc::BOOTSTRAP_ENV,
                     "process-control-endpoint"
                 ),
-                (WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV, "workload-endpoint"),
-                (TOOL_CGROUP_PROCS_ENDPOINT_ENV, "tool-endpoint"),
+                (CANONICAL_WORKLOAD_CGROUP_PROCS_ENV, "workload-endpoint"),
+                (CANONICAL_TOOL_CGROUP_PROCS_ENV, "tool-endpoint"),
             ]
         );
         for canonical_key in [
-            guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-            guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
+            CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+            CANONICAL_TOOL_CGROUP_PROCS_ENV,
         ] {
-            assert!(env.iter().all(|(key, _)| *key != canonical_key));
+            assert_eq!(
+                env.iter().filter(|(key, _)| *key == canonical_key).count(),
+                1
+            );
+        }
+        for legacy_key in [
+            WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+            TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+        ] {
+            assert!(env.iter().all(|(key, _)| *key != legacy_key));
         }
     }
 

--- a/crates/vsock-guest/tests/connection/exec_control.rs
+++ b/crates/vsock-guest/tests/connection/exec_control.rs
@@ -1,5 +1,9 @@
 use std::thread;
 
+use guest_contracts::process_containment::{
+    CANONICAL_TOOL_CGROUP_PROCS_ENV, CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+    TOOL_CGROUP_PROCS_ENDPOINT_ENV, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+};
 use vsock_proto::{
     self, ExecControlPolicy, ExecControlStatus, ExecLifecyclePolicy, ExecOutputPolicy,
     ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MSG_EXEC_RESULT,
@@ -114,7 +118,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
     let control_nonce = unique_exec_control_nonce(u64::from(target_seq));
     let endpoint = process_control_ipc::endpoint_name(target_seq, &control_nonce);
     let command = format!(
-        "printf '%s' \"$$\" > '{}'; if [ \"${{OKOU_PROCESS_CONTROL_ENDPOINT+x}}\" = x ]; then exit 42; fi; if [ \"${{OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT+x}}\" = x ] || [ \"${{OKOU_TOOL_CGROUP_PROCS_ENDPOINT+x}}\" = x ]; then exit 43; fi; printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60",
+        "printf '%s' \"$$\" > '{}'; if [ \"${{OKOU_PROCESS_CONTROL_ENDPOINT+x}}\" = x ]; then exit 42; fi; if [ \"${{VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT-}}\" = stale-legacy-workload-endpoint ] || [ \"${{OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT-}}\" = stale-canonical-workload-endpoint ] || [ \"${{VM0_TOOL_CGROUP_PROCS_ENDPOINT-}}\" = stale-legacy-tool-endpoint ] || [ \"${{OKOU_TOOL_CGROUP_PROCS_ENDPOINT-}}\" = stale-canonical-tool-endpoint ]; then exit 43; fi; printf '%s' \"$VM0_PROCESS_CONTROL_ENDPOINT\"; sleep 60",
         pid_path.as_str()
     );
     let (handle, mut host_stream) = start_guest_connection();
@@ -127,7 +131,22 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
             role: vsock_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::None,
             command: &command,
-            env: &[(process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint")],
+            env: &[
+                (process_control_ipc::BOOTSTRAP_ENV, "stale-endpoint"),
+                (
+                    WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+                    "stale-legacy-workload-endpoint",
+                ),
+                (
+                    CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+                    "stale-canonical-workload-endpoint",
+                ),
+                (TOOL_CGROUP_PROCS_ENDPOINT_ENV, "stale-legacy-tool-endpoint"),
+                (
+                    CANONICAL_TOOL_CGROUP_PROCS_ENV,
+                    "stale-canonical-tool-endpoint",
+                ),
+            ],
             sudo: false,
             label: "supervised-test",
             stdout: ExecOutputPolicy::CaptureAndStream {


### PR DESCRIPTION
## Summary

- remove incoming legacy and canonical workload/tool Cgroup placement aliases at the trusted root `vsock-guest` writer boundary
- append exactly one canonical workload endpoint and one canonical tool endpoint with the operation-local values, preserving unrelated order
- keep process-control behavior on the refreshed base unchanged and keep the Guest Agent managed-CLI tool writer legacy-only
- update only the adjacent shared-contract stage documentation for the root writer cutover

## Scope and inventory

- refreshed base: `5f1e9dd431dd393fd588812a10593bf2ad842ef8`
- implementation head: `3b63c8786b0890597d24e812a3ebef19567284ad`
- the complete refreshed literal/symbol inventory covered 129 matching lines across 18 files and confirmed the only two root production writes are together in `append_exec_control_environment`
- a fully paginated audit covered 28 open PRs, 29 changed-file pages, and all 468 declared changed files with zero mismatch
- #29915 is the only overlap, touching the same two `vsock-guest` files for the independent process-control writer cutover; this PR did not modify, rebase, push to, absorb, or wait for that contributor PR
- the diff is limited to `crates/vsock-guest/src/exec_operation.rs`, `crates/vsock-guest/tests/connection/exec_control.rs`, and adjacent root-writer stage rustdoc in `crates/guest-contracts/src/process_containment.rs`

## Acceptance evidence

- all four incoming Cgroup aliases are removed before the trusted pair is appended
- the root writer emits one `OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT` and one `OKOU_TOOL_CGROUP_PROCS_ENDPOINT` with the existing operation-local values
- neither root legacy alias remains, duplicate canonical inputs cannot survive, and unrelated entries retain their original order and values
- the refreshed-base process-control entry ordering and real control forwarding behavior are unchanged
- `WorkloadContainment::tool_placement_env` remains byte-for-byte unchanged and continues to emit only `VM0_TOOL_CGROUP_PROCS_ENDPOINT` to managed CLI children
- the shared dual readers, telemetry, descriptor transfer, containment, lifecycle, and compatibility behavior are unchanged

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features --no-deps -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p vsock-guest --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --lib exec_operation::tests::control_bootstrap_environment_replaces_cgroup_aliases_with_canonical -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection supervised_exec_control_forwards_to_bootstrap_sink`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts process_containment::tests::cgroup_placement_environment_contracts_preserve_legacy_writers -- --exact`
- `git diff --check origin/main...HEAD`

The full local test suite and a development server were intentionally not run. Protected PR CI is authoritative.

## Fallbacks

- `crates/guest-agent/src/workload_containment.rs:WorkloadContainment::from_process_env` remains the unchanged dual reader for both root placement aliases. Existing and rollback-retained Guests accept the new canonical-only root pair, while rollback to the previous root writer restores legacy-only input. Remove its legacy branches only after #28914 proves the cutover release, bounded canonical-only observation, rollback-window expiry, and zero legacy-only root observations.
- `crates/guest-tool-exec/src/lib.rs:tool_placement_endpoint_from_process_env` remains the unchanged downstream dual reader. Guest Agent still writes only the legacy tool alias to managed CLI children; its writer cutover and any later reader removal remain separate #28914 stages.

Closes #29914
Parent: #28914
