### PR TITLE
perf(python): bound codex catalog query parsing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -88,7 +88,16 @@ _FIREWALL_NAME = "model-provider:codex-oauth-token"
 _CATALOG_HOST = "chatgpt.com"
 _CATALOG_PATH = "/backend-api/codex/models"
 _RESPONSES_PATH = "/backend-api/codex/responses"
+_CLIENT_VERSION_QUERY_NAME = "client_version"
 _MAX_CLIENT_VERSION_BYTES = 128
+_PERCENT_ENCODED_CHARACTERS_PER_BYTE = 3
+MAX_CATALOG_QUERY_FIELDS = 1
+# The name and value may encode every byte as %XX; the separating "=" stays literal.
+MAX_CATALOG_QUERY_BYTES = (
+    _PERCENT_ENCODED_CHARACTERS_PER_BYTE
+    * (len(_CLIENT_VERSION_QUERY_NAME.encode()) + _MAX_CLIENT_VERSION_BYTES)
+    + 1
+)
 _MAX_ETAG_BYTES = 512
 _MAX_CONTENT_TYPE_BYTES = 256
 _MAX_JSON_NESTING = 128
@@ -307,15 +316,23 @@ def _catalog_url(original_url: str) -> str | None:
     parsed = _split_expected_url(original_url)
     if parsed is None or parsed.path != _CATALOG_PATH:
         return None
+    raw_query = parsed.query
+    # Bound the allocation used to reconstruct mitmproxy's surrogate-escaped path bytes.
+    if (
+        len(raw_query) > MAX_CATALOG_QUERY_BYTES
+        or len(raw_query.encode("utf-8", "surrogateescape")) > MAX_CATALOG_QUERY_BYTES
+    ):
+        return None
     try:
         query = urllib.parse.parse_qsl(
-            parsed.query,
+            raw_query,
             keep_blank_values=True,
             strict_parsing=True,
+            max_num_fields=MAX_CATALOG_QUERY_FIELDS,
         )
     except ValueError:
         return None
-    if len(query) != 1 or query[0][0] != "client_version":
+    if len(query) != MAX_CATALOG_QUERY_FIELDS or query[0][0] != _CLIENT_VERSION_QUERY_NAME:
         return None
     client_version = query[0][1]
     if (
@@ -328,7 +345,7 @@ def _catalog_url(original_url: str) -> str | None:
     ):
         return None
     encoded_version = urllib.parse.quote(client_version, safe="")
-    return f"https://{_CATALOG_HOST}{_CATALOG_PATH}?client_version={encoded_version}"
+    return f"https://{_CATALOG_HOST}{_CATALOG_PATH}?{_CLIENT_VERSION_QUERY_NAME}={encoded_version}"
 
 
 def _is_catalog_path(original_url: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import urllib.parse
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Literal
@@ -38,6 +39,12 @@ from tests.upstream_connection_helpers import mark_connected_tls_upstream
 class _DecodeGuardPrefetchMarker(bytes):
     def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
         raise AssertionError("Codex prefetch marker must not be decoded")
+
+
+def _set_catalog_query(flow: http.HTTPFlow, raw_query: str) -> None:
+    path = f"/backend-api/codex/models?{raw_query}"
+    flow.request.path = path
+    flow.metadata[metadata_keys.ORIGINAL_URL] = f"https://chatgpt.com{path}"
 
 
 async def test_request_bypasses_do_not_touch_unrelated_traffic(real_flow):
@@ -169,6 +176,100 @@ async def test_unsafe_catalog_requests_never_enter_cache(
     assert telemetry == {
         "model_catalog_cache_status": "model_catalog_bypass",
         "model_catalog_cache_bypass_reason": reason,
+    }
+
+
+async def test_fully_percent_encoded_maximum_catalog_query_reuses_canonical_cache(real_flow):
+    encoded_name = "".join(f"%{byte:02X}" for byte in b"client_version")
+    raw_query = f"{encoded_name}={'%61' * 128}"
+    assert len(raw_query.encode()) == catalog_cache.MAX_CATALOG_QUERY_BYTES
+
+    encoded_flow = catalog_flow(real_flow, version="a" * 128)
+    _set_catalog_query(encoded_flow, raw_query)
+    await install_catalog(encoded_flow)
+    catalog_cache.release_flow_state(encoded_flow)
+
+    canonical_flow = catalog_flow(real_flow, version="a" * 128)
+    await catalog_cache.prepare_request(canonical_flow, request_end_stream=True)
+
+    assert canonical_flow.response is not None
+    assert canonical_flow.response.content == CATALOG_BODY
+
+
+@pytest.mark.parametrize(
+    ("raw_query", "character_bounded"),
+    [
+        pytest.param(
+            "client_version="
+            + "a" * (catalog_cache.MAX_CATALOG_QUERY_BYTES - len("client_version=") + 1),
+            False,
+            id="characters",
+        ),
+        pytest.param(
+            "client_version="
+            + "é" * ((catalog_cache.MAX_CATALOG_QUERY_BYTES - len("client_version=")) // 2 + 1),
+            True,
+            id="utf8-bytes",
+        ),
+    ],
+)
+async def test_oversized_catalog_query_bypasses_before_pair_parsing(
+    real_flow,
+    raw_query: str,
+    character_bounded: bool,
+):
+    assert (len(raw_query) <= catalog_cache.MAX_CATALOG_QUERY_BYTES) is character_bounded
+    assert len(raw_query.encode()) > catalog_cache.MAX_CATALOG_QUERY_BYTES
+    flow = catalog_flow(real_flow)
+    _set_catalog_query(flow, raw_query)
+
+    with patch.object(
+        urllib.parse,
+        "parse_qsl",
+        side_effect=AssertionError("oversized catalog query must not be parsed"),
+    ):
+        await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    assert flow.response is None
+    assert flow.request.path == f"/backend-api/codex/models?{raw_query}"
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_url",
+    }
+
+
+async def test_high_cardinality_catalog_query_bypasses_before_percent_decoding(real_flow):
+    raw_query = "&".join(["x="] * 64)
+    assert len(raw_query.encode()) <= catalog_cache.MAX_CATALOG_QUERY_BYTES
+    flow = catalog_flow(real_flow)
+    _set_catalog_query(flow, raw_query)
+    real_parse_qsl = urllib.parse.parse_qsl
+
+    with (
+        patch.object(urllib.parse, "parse_qsl", wraps=real_parse_qsl) as parse_qsl,
+        patch.object(
+            urllib.parse,
+            "unquote_plus",
+            side_effect=AssertionError("over-cardinality catalog query must not be decoded"),
+        ),
+    ):
+        await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    parse_qsl.assert_called_once_with(
+        raw_query,
+        keep_blank_values=True,
+        strict_parsing=True,
+        max_num_fields=catalog_cache.MAX_CATALOG_QUERY_FIELDS,
+    )
+    assert flow.response is None
+    assert flow.request.path == f"/backend-api/codex/models?{raw_query}"
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_url",
     }
 
 

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -147,6 +147,15 @@ async def test_non_ows_request_content_length_bypasses_catalog_cache(
             "request_url",
             id="query",
         ),
+        pytest.param(
+            "GET",
+            True,
+            b"",
+            False,
+            "https://chatgpt.com/backend-api/codex/models?invalid\udcff=1",
+            "request_url",
+            id="surrogate-escaped-query",
+        ),
     ],
 )
 async def test_unsafe_catalog_requests_never_enter_cache(


### PR DESCRIPTION
## Summary

- bound Codex catalog cache query admission to the exact 427-byte maximum valid encoded request
- reject multi-field queries through `parse_qsl(max_num_fields=1)` before pair materialization and percent-decoding
- preserve canonical cache identity and upstream `request_url` bypass behavior with integration coverage for encoded, oversized, multibyte, malformed-byte, and high-cardinality queries

## Scope

- keeps the synchronous catalog hook lifecycle and existing telemetry unchanged
- does not add a proxy-wide request-target limit or change mitmproxy request-head buffering

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7183 passed)

Closes #29887
