### PR TITLE
test(e2e): preserve teardown vercel log links

### DIFF
--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -97,7 +97,7 @@ curl() {
             echo "Vercel logs: $MOCK_CURL_EXPECTED_VERCEL_URL" >&2
             return 22
             ;;
-        no-fail-with-body)
+        no-fail-with-body | no-fail-with-body-failure)
             [[ "$saw_no_fail_with_body" == true ]] || {
                 echo "curl did not receive --no-fail-with-body" >&2
                 return 94
@@ -110,7 +110,11 @@ curl() {
                 echo "curl did not retain the caller write-out" >&2
                 return 96
             }
-            printf '{"error":{"message":"Cannot delete agent while its configuration is being migrated","code":"CONFLICT"}}\n409'
+            if [[ "$MOCK_CURL_MODE" == "no-fail-with-body" ]]; then
+                printf '{"error":{"message":"Cannot delete agent while its configuration is being migrated","code":"CONFLICT"}}\n409'
+            else
+                printf '{"error":"Internal server error"}\n500'
+            fi
             ;;
         *)
             echo "unexpected mock curl mode: $MOCK_CURL_MODE" >&2
@@ -121,6 +125,15 @@ curl() {
 
 run_request() {
     if runner_api_curl "$@" >"$stdout_file" 2>"$stderr_file"; then
+        request_status=0
+    else
+        request_status=$?
+    fi
+}
+
+run_agent_teardown() {
+    if delete_runner_agent_for_stage0_teardown "$1" \
+        >"$stdout_file" 2>"$stderr_file"; then
         request_status=0
     else
         request_status=$?
@@ -157,14 +170,20 @@ assert_file_excludes "$stderr_file" "sensitive-query-value"
 MOCK_CURL_MODE=no-fail-with-body
 MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/agents/agent-1"
 MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fagents%%2Fagent-1+status%%3A%{http_code}&timeline=past12Hours\n'
-if delete_runner_agent_for_stage0_teardown "agent-1" \
-    >"$stdout_file" 2>"$stderr_file"; then
-    request_status=0
-else
-    request_status=$?
-fi
+run_agent_teardown "agent-1"
 assert_status 0
 assert_file_equals '' "$stdout_file"
 assert_file_equals '' "$stderr_file"
+
+MOCK_CURL_MODE=no-fail-with-body-failure
+run_agent_teardown "agent-1"
+assert_status 1
+assert_file_equals '' "$stdout_file"
+assert_file_equals \
+    $'Stage 0 Runner E2E agent teardown failed with HTTP 500: {"error":"Internal server error"}\nVercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fagents%2Fagent-1+status%3A500&timeline=past12Hours\n' \
+    "$stderr_file"
+assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
+assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
+assert_file_excludes "$stderr_file" "sensitive-request-payload"
 
 echo "runner_api_curl tests passed"

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -20,17 +20,11 @@ require_runner_api_credentials() {
     runner_api_token >/dev/null && runner_api_url >/dev/null
 }
 
-runner_api_curl() {
-    local path="$1"
-    shift
+_runner_api_vercel_logs_url_prefix() {
+    local base="$1"
+    local path="$2"
+    local request_host request_path request_host_search request_path_search
 
-    local token base request_url diagnostic_url request_host request_path
-    local request_host_search request_path_search vercel_logs_url_prefix
-    local vercel_logs_url_prefix_write_out vercel_log_write_out
-    token="$(runner_api_token)" || return 1
-    base="$(runner_api_url)" || return 1
-    request_url="$base$path"
-    diagnostic_url="${request_url%%\?*}"
     request_host="${base#*://}"
     request_host="${request_host%%/*}"
     request_path="${path%%\?*}"
@@ -39,7 +33,22 @@ runner_api_curl() {
     request_path_search="${request_path//%/%25}"
     request_path_search="${request_path_search//\//%2F}"
     request_path_search="${request_path_search//:/%3A}"
-    vercel_logs_url_prefix="https://vercel.com/vm0/vm0-api/logs?search=requestHost%3A${request_host_search}+requestPath%3A${request_path_search}+status%3A"
+    printf 'https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3A%s+requestPath%%3A%s+status%%3A' \
+        "$request_host_search" "$request_path_search"
+}
+
+runner_api_curl() {
+    local path="$1"
+    shift
+
+    local token base request_url diagnostic_url vercel_logs_url_prefix
+    local vercel_logs_url_prefix_write_out vercel_log_write_out
+    token="$(runner_api_token)" || return 1
+    base="$(runner_api_url)" || return 1
+    request_url="$base$path"
+    diagnostic_url="${request_url%%\?*}"
+    vercel_logs_url_prefix="$(_runner_api_vercel_logs_url_prefix \
+        "$base" "$path")"
     vercel_logs_url_prefix_write_out="${vercel_logs_url_prefix//%/%%}"
     vercel_log_write_out="%{onerror}%{stderr}Vercel logs: ${vercel_logs_url_prefix_write_out}%{http_code}&timeline=past12Hours\n"
 
@@ -157,11 +166,14 @@ delete_runner_agent() {
 # the production legacy-version deletion veto.
 delete_runner_agent_for_stage0_teardown() {
     local agent_id="$1"
-    local response http_status response_body attempt
+    local request_path response http_status response_body attempt
+    local base vercel_logs_url_prefix
+
+    request_path="/api/agents/$agent_id"
 
     for ((attempt = 1; attempt <= 5; attempt += 1)); do
         response="$(runner_api_curl \
-            "/api/agents/$agent_id" \
+            "$request_path" \
             -X DELETE \
             --no-fail-with-body \
             --write-out $'\n%{http_code}')" || return
@@ -208,6 +220,11 @@ delete_runner_agent_for_stage0_teardown() {
 
         printf 'Stage 0 Runner E2E agent teardown failed with HTTP %s: %s\n' \
             "$http_status" "$response_body" >&2
+        base="$(runner_api_url)" || return 1
+        vercel_logs_url_prefix="$(_runner_api_vercel_logs_url_prefix \
+            "$base" "$request_path")"
+        printf 'Vercel logs: %s%s&timeline=past12Hours\n' \
+            "$vercel_logs_url_prefix" "$http_status" >&2
         return 1
     done
 }


### PR DESCRIPTION
## Summary

- reuse one sanitized Vercel Logs URL prefix for Runner E2E API diagnostics
- print the copyable host/path/status link when Stage 0 teardown manually rejects an unexpected HTTP response
- preserve the existing silent 204/404/409 compatibility behavior and retry semantics
- cover the observed HTTP 500 path through the existing deterministic shell integration test

## Scope

This PR changes only Runner E2E failure diagnostics. It does not change agent deletion, R2 cleanup, provider retry policy, or API behavior.

## Validation

- `bash .github/scripts/tests/runner-api-curl-test.sh`
- `bash -n e2e/helpers/runner-chat.bash .github/scripts/tests/runner-api-curl-test.sh`
- `git diff --check`
- `lefthook run pre-commit`

`shellcheck` is not installed in the local development image; the repository security workflow runs it for these files.

Closes #29919
