### PR TITLE
refactor(desktop): cut signing identity writer to canonical alias

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -234,7 +234,7 @@ jobs:
       RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
       OKOU_RELEASE_TAG: okou-desktop-v${{ needs.release-please.outputs.desktop_version }}
       RELEASE_TARGET: ${{ needs.release-please.outputs.release_target }}
-      VM0_DESKTOP_SIGNING_IDENTITY: "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
+      OKOU_DESKTOP_SIGNING_IDENTITY: "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
       MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
       MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
       MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
@@ -429,7 +429,7 @@ jobs:
             "$keychain_path"
           security list-keychains -d user -s "$keychain_path"
 
-          if ! security find-identity -p codesigning -v "$keychain_path" | grep -F "$VM0_DESKTOP_SIGNING_IDENTITY"; then
+          if ! security find-identity -p codesigning -v "$keychain_path" | grep -F "$OKOU_DESKTOP_SIGNING_IDENTITY"; then
             echo "::error::Developer ID Application identity not found in imported certificate"
             exit 1
           fi
@@ -476,7 +476,7 @@ jobs:
               --out "$dmg_artifact_path" \
               --volume-name "$volume_name" \
               "${background_args[@]}"
-            codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
+            codesign --force --sign "$OKOU_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
             xcrun notarytool submit "$dmg_artifact_path" \
               --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
               --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
@@ -566,11 +566,11 @@ jobs:
             file "$app_dir/Contents/MacOS/$app_name" | grep -q "arm64"
             file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
             codesign --verify --deep --strict --verbose=2 "$app_dir"
-            codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
+            codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
             xcrun stapler validate "$app_dir"
             unzip -l "$zip_artifact_path" | grep -q "$app_name.app/Contents/MacOS/$app_name"
             codesign --verify --verbose=2 "$dmg_artifact_path"
-            codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
+            codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$OKOU_DESKTOP_SIGNING_IDENTITY"
             xcrun stapler validate "$dmg_artifact_path"
             hdiutil verify "$dmg_artifact_path"
 

--- a/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
+++ b/turbo/apps/desktop/scripts/desktop-signing-identity-environment.js
@@ -1,11 +1,11 @@
 const CANONICAL_SIGNING_IDENTITY = "OKOU_DESKTOP_SIGNING_IDENTITY";
 const LEGACY_SIGNING_IDENTITY = "VM0_DESKTOP_SIGNING_IDENTITY";
 
-// The production release workflow remains legacy-only during this reader
-// stage. Remove the legacy alias only after an ordinary signed Desktop release
-// proves legacy-only evidence from both readers, a later writer cutover records
-// canonical-only production evidence, and the supported rollback window plus
-// zero legacy-use gate complete under #28914.
+// The production release workflow is canonical-only during this writer stage.
+// Keep the legacy alias for rollback until an exact signed Desktop release
+// proves two canonical-only reader events with zero legacy-only, dual, or
+// conflict events, signing and notarization outputs remain unchanged, and the
+// supported rollback window completes under #28914.
 function resolveDesktopSigningIdentityEnvironment() {
   const canonicalValue = process.env[CANONICAL_SIGNING_IDENTITY];
   const legacyValue = process.env[LEGACY_SIGNING_IDENTITY];

--- a/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
+++ b/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
@@ -84,7 +84,7 @@ await sign({
   app: options.appPath,
   batchCodesignCalls: true,
   identity: requiredEnvironmentVariable(
-    "VM0_DESKTOP_SIGNING_IDENTITY",
+    "OKOU_DESKTOP_SIGNING_IDENTITY",
     resolveDesktopSigningIdentityEnvironment(),
   ),
   identityValidation: true,

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -1026,7 +1026,7 @@ describe("packaged Desktop signing identity entry point", () => {
     ]);
     expectSigningIdentitySource(result, undefined);
     expect(result.process.stderr).toContain(
-      "VM0_DESKTOP_SIGNING_IDENTITY is required",
+      "OKOU_DESKTOP_SIGNING_IDENTITY is required",
     );
     expectNoSensitiveValueDisclosure(result);
   });
@@ -1046,7 +1046,7 @@ describe("packaged Desktop signing identity entry point", () => {
       expect(result.trace).toBe("");
       expectSigningIdentitySource(result, source);
       expect(result.process.stderr).toContain(
-        "VM0_DESKTOP_SIGNING_IDENTITY is required",
+        "OKOU_DESKTOP_SIGNING_IDENTITY is required",
       );
       expectNoSensitiveValueDisclosure(result);
     },


### PR DESCRIPTION
## Summary

- switch the production Desktop signing-identity writer, certificate lookup, DMG signing, and final app/DMG Authority verification to `OKOU_DESKTOP_SIGNING_IDENTITY`
- update the packaged-app required-variable diagnostic and rollout annotation for the canonical-only writer stage
- retain the shared canonical/legacy dual reader, value-free source telemetry, Forge fallback behavior, and complete compatibility matrix

## Scope safeguards

- the identity remains exactly `Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)`
- certificate import, keychain handling, app/DMG signing, notarization, stapling, timestamps, verification, artifacts, product/platform identities, and release control flow are unchanged
- the shared legacy reader remains in place; this PR does not release production
- the diff is limited to the four files authorized by #29922

## Refreshed inventory evidence

- refreshed and reviewed from clean current `main@b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` immediately before editing
- repeated the complete repository inventory for `VM0_DESKTOP_SIGNING_IDENTITY`, `OKOU_DESKTOP_SIGNING_IDENTITY`, and `desktop_signing_identity_env_source`
- fully paginated all 29 open PRs and reconciled 408/408 declared changed files with zero mismatch
- only #25722 overlaps `.github/workflows/release-please.yml`; its exact `base@505aae73170efd5b484599eb7d433f404f5c3d2f...head@2aed1f0de2a54db881ca266151c1362ea6c9dd62` hunks remain confined to unrelated Cloudflare Worker/API deployment sections and contain no Desktop signing semantics

## Verification

- Prettier 3.8.1 write/check on all four changed files
- `corepack pnpm --filter @okouai/desktop run lint`
- `corepack pnpm --filter @okouai/desktop run check-types`
- `corepack pnpm --filter @okouai/desktop exec vitest run src/desktop-notarize-entry-points.test.ts` (54 passed)
- `node --check` on both changed Desktop scripts
- `git diff --check`
- normalized workflow comparison: replacing only the legacy key spelling in the reviewed base produces the exact worktree SHA-256 `58c99bc2f3e9982dc5c43e90292a07bd46cbcf12bdeb630b76c8c2d9e390b347`

## Reviewed revisions

- base: `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc`
- head: `598b1461a342bbe23b8d4b63aedce3db00f42845`

Closes #29922

Parent EPIC: #28914
