### PR TITLE
fix(guest-agent): persist bootstrap alias source events

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -26,6 +26,204 @@ const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "OKOU_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV_KEY: &str = "OKOU_TEST_CODEX_HOME_DIR";
 
+const BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT: usize = 16;
+
+#[derive(Clone, Copy)]
+struct BootstrapAliasSourceEventSpec {
+    family: &'static str,
+    canonical_key: &'static str,
+}
+
+const BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY: [BootstrapAliasSourceEventSpec;
+    BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT] = [
+    BootstrapAliasSourceEventSpec {
+        family: "api_url_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_API_URL_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "guest_agent_tuning_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "guest_agent_tuning_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "guest_agent_tuning_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "guest_agent_tuning_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "private_payload_file_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "private_payload_file_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "api_token_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "run_metadata_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "run_metadata_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "run_metadata_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "run_metadata_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "run_metadata_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "agent_execution_timeout_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "mock_binary_path_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+    },
+    BootstrapAliasSourceEventSpec {
+        family: "mock_binary_path_env_source",
+        canonical_key: guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+    },
+];
+
+#[derive(Clone, Copy)]
+enum BootstrapAlias {
+    ApiUrl,
+    StuckToolTimeout,
+    PostResultSigtermGrace,
+    PostResultTotalCap,
+    PostResultSigkillGrace,
+    UserEnvFile,
+    RunPayloadFile,
+    ApiToken,
+    SandboxId,
+    SandboxReuseResult,
+    WorkspaceReuseResult,
+    ResumeSessionId,
+    ApiStartTime,
+    AgentExecutionTimeout,
+    MockClaudePath,
+    MockCodexPath,
+}
+
+#[derive(Clone, Copy)]
+enum BootstrapAliasSource {
+    CanonicalOnly,
+    LegacyOnly,
+    Dual,
+}
+
+impl BootstrapAliasSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CanonicalOnly => "canonical-only",
+            Self::LegacyOnly => "legacy-only",
+            Self::Dual => "dual",
+        }
+    }
+}
+
+/// Fixed-size, value-free source evidence captured while resolving bootstrap aliases.
+///
+/// The internal slots correspond exactly to the 16 canonical keys in
+/// `BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY`. Only guest-agent's environment
+/// resolvers can populate them.
+#[derive(Clone, Default)]
+pub struct BootstrapAliasSourceEvents {
+    api_url: Option<BootstrapAliasSource>,
+    stuck_tool_timeout: Option<BootstrapAliasSource>,
+    post_result_sigterm_grace: Option<BootstrapAliasSource>,
+    post_result_total_cap: Option<BootstrapAliasSource>,
+    post_result_sigkill_grace: Option<BootstrapAliasSource>,
+    user_env_file: Option<BootstrapAliasSource>,
+    run_payload_file: Option<BootstrapAliasSource>,
+    api_token: Option<BootstrapAliasSource>,
+    sandbox_id: Option<BootstrapAliasSource>,
+    sandbox_reuse_result: Option<BootstrapAliasSource>,
+    workspace_reuse_result: Option<BootstrapAliasSource>,
+    resume_session_id: Option<BootstrapAliasSource>,
+    api_start_time: Option<BootstrapAliasSource>,
+    agent_execution_timeout: Option<BootstrapAliasSource>,
+    mock_claude_path: Option<BootstrapAliasSource>,
+    mock_codex_path: Option<BootstrapAliasSource>,
+}
+
+impl BootstrapAliasSourceEvents {
+    fn record(&mut self, alias: BootstrapAlias, source: BootstrapAliasSource) {
+        let slot = match alias {
+            BootstrapAlias::ApiUrl => &mut self.api_url,
+            BootstrapAlias::StuckToolTimeout => &mut self.stuck_tool_timeout,
+            BootstrapAlias::PostResultSigtermGrace => &mut self.post_result_sigterm_grace,
+            BootstrapAlias::PostResultTotalCap => &mut self.post_result_total_cap,
+            BootstrapAlias::PostResultSigkillGrace => &mut self.post_result_sigkill_grace,
+            BootstrapAlias::UserEnvFile => &mut self.user_env_file,
+            BootstrapAlias::RunPayloadFile => &mut self.run_payload_file,
+            BootstrapAlias::ApiToken => &mut self.api_token,
+            BootstrapAlias::SandboxId => &mut self.sandbox_id,
+            BootstrapAlias::SandboxReuseResult => &mut self.sandbox_reuse_result,
+            BootstrapAlias::WorkspaceReuseResult => &mut self.workspace_reuse_result,
+            BootstrapAlias::ResumeSessionId => &mut self.resume_session_id,
+            BootstrapAlias::ApiStartTime => &mut self.api_start_time,
+            BootstrapAlias::AgentExecutionTimeout => &mut self.agent_execution_timeout,
+            BootstrapAlias::MockClaudePath => &mut self.mock_claude_path,
+            BootstrapAlias::MockCodexPath => &mut self.mock_codex_path,
+        };
+        *slot = Some(source);
+    }
+
+    fn sources(&self) -> [Option<BootstrapAliasSource>; BOOTSTRAP_ALIAS_SOURCE_EVENT_COUNT] {
+        [
+            self.api_url,
+            self.stuck_tool_timeout,
+            self.post_result_sigterm_grace,
+            self.post_result_total_cap,
+            self.post_result_sigkill_grace,
+            self.user_env_file,
+            self.run_payload_file,
+            self.api_token,
+            self.sandbox_id,
+            self.sandbox_reuse_result,
+            self.workspace_reuse_result,
+            self.resume_session_id,
+            self.api_start_time,
+            self.agent_execution_timeout,
+            self.mock_claude_path,
+            self.mock_codex_path,
+        ]
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&'static str, &'static str, &'static str)> + '_ {
+        BOOTSTRAP_ALIAS_SOURCE_EVENT_INVENTORY
+            .into_iter()
+            .zip(self.sources())
+            .filter_map(|(event, source)| {
+                source.map(|source| (event.family, event.canonical_key, source.label()))
+            })
+    }
+
+    fn emit(&self) {
+        for (family, canonical_key, source) in self.iter() {
+            log_info!(LOG_TAG, "{family} key={canonical_key} source={source}");
+        }
+    }
+}
+
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
 }
@@ -36,7 +234,7 @@ fn env_or_empty(name: &str) -> String {
 /// Remove the legacy reader only after the exact production Runner plus
 /// embedded-Guest reader floor, complete pre-reader service and reusable-sandbox
 /// drain, supported rollback window, and value-free legacy-source-zero gates.
-fn api_url_env_or_empty() -> Result<String, String> {
+fn api_url_env_or_empty(events: &mut BootstrapAliasSourceEvents) -> Result<String, String> {
     let canonical_key = guest_contracts::env::CANONICAL_API_URL_ENV;
     let legacy_key = guest_contracts::env::API_URL_ENV;
     let canonical = std::env::var(canonical_key).ok();
@@ -44,9 +242,11 @@ fn api_url_env_or_empty() -> Result<String, String> {
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, "canonical-only"),
-        (None, Some(value)) => (value, "legacy-only"),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            (canonical, BootstrapAliasSource::Dual)
+        }
         (Some(_), Some(_)) => {
             return Err(format!(
                 "conflicting API backend URL environment aliases: canonical_key={canonical_key} \
@@ -55,31 +255,11 @@ fn api_url_env_or_empty() -> Result<String, String> {
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "api_url_env_source key={canonical_key} source={source}"
-    );
+    events.record(BootstrapAlias::ApiUrl, source);
     Ok(value)
 }
 
-#[derive(Clone, Copy)]
-enum PrivatePayloadFileEnvSource {
-    CanonicalOnly,
-    LegacyOnly,
-    Dual,
-}
-
-type PrivatePayloadFileEnvResolution = (String, Option<PrivatePayloadFileEnvSource>);
-
-impl PrivatePayloadFileEnvSource {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CanonicalOnly => "canonical-only",
-            Self::LegacyOnly => "legacy-only",
-            Self::Dual => "dual",
-        }
-    }
-}
+type PrivatePayloadFileEnvResolution = (String, Option<BootstrapAliasSource>);
 
 /// Resolve Stage 1 compatibility between existing runners or sandboxes and a
 /// new guest reader. Existing pointers can remain live through the two-hour
@@ -100,10 +280,10 @@ fn private_payload_file_env(
 
     match (canonical, legacy) {
         (None, None) => Ok((String::new(), None)),
-        (Some(value), None) => Ok((value, Some(PrivatePayloadFileEnvSource::CanonicalOnly))),
-        (None, Some(value)) => Ok((value, Some(PrivatePayloadFileEnvSource::LegacyOnly))),
+        (Some(value), None) => Ok((value, Some(BootstrapAliasSource::CanonicalOnly))),
+        (None, Some(value)) => Ok((value, Some(BootstrapAliasSource::LegacyOnly))),
         (Some(canonical), Some(legacy)) if canonical == legacy => {
-            Ok((canonical, Some(PrivatePayloadFileEnvSource::Dual)))
+            Ok((canonical, Some(BootstrapAliasSource::Dual)))
         }
         (Some(_), Some(_)) => Err(format!(
             "conflicting private payload file environment aliases: canonical_key={canonical_key} \
@@ -113,22 +293,19 @@ fn private_payload_file_env(
 }
 
 fn record_private_payload_file_env_source(
-    canonical_key: &'static str,
-    source: Option<PrivatePayloadFileEnvSource>,
+    events: &mut BootstrapAliasSourceEvents,
+    alias: BootstrapAlias,
+    source: Option<BootstrapAliasSource>,
 ) {
     if let Some(source) = source {
-        log_info!(
-            LOG_TAG,
-            "private_payload_file_env_source key={canonical_key} source={}",
-            source.label()
-        );
+        events.record(alias, source);
     }
 }
 
 /// Resolve the sensitive runner-to-guest API token at the single process-env
 /// capture boundary. Both aliases are reader-only during #28914 migration
 /// Stage 1; the runner writer remains [`guest_contracts::env::API_TOKEN_ENV`].
-fn api_token_env_or_empty() -> Result<String, String> {
+fn api_token_env_or_empty(events: &mut BootstrapAliasSourceEvents) -> Result<String, String> {
     let canonical_key = guest_contracts::env::CANONICAL_API_TOKEN_ENV;
     let legacy_key = guest_contracts::env::API_TOKEN_ENV;
     let canonical = std::env::var(canonical_key).ok();
@@ -136,9 +313,11 @@ fn api_token_env_or_empty() -> Result<String, String> {
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, "canonical-only"),
-        (None, Some(value)) => (value, "legacy-only"),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            (canonical, BootstrapAliasSource::Dual)
+        }
         (Some(_), Some(_)) => {
             return Err(format!(
                 "conflicting API token environment aliases: canonical_key={canonical_key} \
@@ -147,10 +326,7 @@ fn api_token_env_or_empty() -> Result<String, String> {
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "api_token_env_source key={canonical_key} source={source}"
-    );
+    events.record(BootstrapAlias::ApiToken, source);
     Ok(value)
 }
 
@@ -158,7 +334,9 @@ fn api_token_env_or_empty() -> Result<String, String> {
 /// capture boundary. Both aliases are reader-only during #28914 migration
 /// Stage 1; the runner writer remains
 /// [`guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV`].
-fn agent_execution_timeout_env_or_empty() -> Result<String, String> {
+fn agent_execution_timeout_env_or_empty(
+    events: &mut BootstrapAliasSourceEvents,
+) -> Result<String, String> {
     let canonical_key = guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV;
     let legacy_key = guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV;
     let canonical = std::env::var(canonical_key).ok();
@@ -166,9 +344,11 @@ fn agent_execution_timeout_env_or_empty() -> Result<String, String> {
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, "canonical-only"),
-        (None, Some(value)) => (value, "legacy-only"),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            (canonical, BootstrapAliasSource::Dual)
+        }
         (Some(_), Some(_)) => {
             return Err(format!(
                 "conflicting agent execution timeout environment aliases: \
@@ -177,10 +357,7 @@ fn agent_execution_timeout_env_or_empty() -> Result<String, String> {
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "agent_execution_timeout_env_source key={canonical_key} source={source}"
-    );
+    events.record(BootstrapAlias::AgentExecutionTimeout, source);
     Ok(value)
 }
 
@@ -190,17 +367,21 @@ fn agent_execution_timeout_env_or_empty() -> Result<String, String> {
 /// Remove the legacy reader only after #28914's existing runner/sandbox drain
 /// and rollback gates close and source telemetry shows zero legacy-only reads.
 fn guest_agent_tuning_env_or_empty(
+    alias: BootstrapAlias,
     canonical_key: &'static str,
     legacy_key: &'static str,
+    events: &mut BootstrapAliasSourceEvents,
 ) -> Result<String, String> {
     let canonical = std::env::var(canonical_key).ok();
     let legacy = std::env::var(legacy_key).ok();
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, "canonical-only"),
-        (None, Some(value)) => (value, "legacy-only"),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            (canonical, BootstrapAliasSource::Dual)
+        }
         (Some(_), Some(_)) => {
             return Err(format!(
                 "conflicting guest agent tuning environment aliases: \
@@ -209,10 +390,7 @@ fn guest_agent_tuning_env_or_empty(
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "guest_agent_tuning_env_source key={canonical_key} source={source}"
-    );
+    events.record(alias, source);
     Ok(value)
 }
 
@@ -220,17 +398,21 @@ fn guest_agent_tuning_env_or_empty(
 /// process-env capture boundary. Canonical aliases are reader-only during
 /// #28914 Stage 1; all existing test/debug writers remain legacy-only.
 fn mock_binary_path_env(
+    alias: BootstrapAlias,
     canonical_key: &'static str,
     legacy_key: &'static str,
+    events: &mut BootstrapAliasSourceEvents,
 ) -> Result<Option<String>, String> {
     let canonical = std::env::var(canonical_key).ok();
     let legacy = std::env::var(legacy_key).ok();
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(None),
-        (Some(value), None) => (value, "canonical-only"),
-        (None, Some(value)) => (value, "legacy-only"),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (canonical, "dual"),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
+        (Some(canonical), Some(legacy)) if canonical == legacy => {
+            (canonical, BootstrapAliasSource::Dual)
+        }
         (Some(_), Some(_)) => {
             return Err(format!(
                 "conflicting mock binary path environment aliases: \
@@ -239,28 +421,8 @@ fn mock_binary_path_env(
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "mock_binary_path_env_source key={canonical_key} source={source}"
-    );
+    events.record(alias, source);
     Ok(Some(value))
-}
-
-#[derive(Clone, Copy)]
-enum RunMetadataEnvSource {
-    CanonicalOnly,
-    LegacyOnly,
-    Dual,
-}
-
-impl RunMetadataEnvSource {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CanonicalOnly => "canonical-only",
-            Self::LegacyOnly => "legacy-only",
-            Self::Dual => "dual",
-        }
-    }
 }
 
 /// Resolve Stage 1 compatibility between an existing runner or sandbox and a
@@ -268,18 +430,20 @@ impl RunMetadataEnvSource {
 /// issues; remove the legacy branch only after the reader floor, sandbox drain,
 /// rollback window, and legacy-read-zero gates are complete.
 fn run_metadata_env_or_empty(
+    alias: BootstrapAlias,
     canonical_key: &'static str,
     legacy_key: &'static str,
+    events: &mut BootstrapAliasSourceEvents,
 ) -> Result<String, String> {
     let canonical = std::env::var(canonical_key).ok();
     let legacy = std::env::var(legacy_key).ok();
 
     let (value, source) = match (canonical, legacy) {
         (None, None) => return Ok(String::new()),
-        (Some(value), None) => (value, RunMetadataEnvSource::CanonicalOnly),
-        (None, Some(value)) => (value, RunMetadataEnvSource::LegacyOnly),
+        (Some(value), None) => (value, BootstrapAliasSource::CanonicalOnly),
+        (None, Some(value)) => (value, BootstrapAliasSource::LegacyOnly),
         (Some(canonical), Some(legacy)) if canonical == legacy => {
-            (canonical, RunMetadataEnvSource::Dual)
+            (canonical, BootstrapAliasSource::Dual)
         }
         (Some(_), Some(_)) => {
             return Err(format!(
@@ -289,11 +453,7 @@ fn run_metadata_env_or_empty(
         }
     };
 
-    log_info!(
-        LOG_TAG,
-        "run_metadata_env_source key={canonical_key} source={}",
-        source.label()
-    );
+    events.record(alias, source);
     Ok(value)
 }
 
@@ -472,6 +632,10 @@ pub struct GuestConfigRaw {
     pub post_result_sigterm_grace_secs: String,
     pub post_result_total_cap_secs: String,
     pub post_result_sigkill_grace_secs: String,
+    /// Opaque, value-free bootstrap alias source state retained until the
+    /// run-scoped system-log sink is installed.
+    #[doc(hidden)]
+    pub bootstrap_alias_sources: BootstrapAliasSourceEvents,
 }
 
 impl GuestConfigRaw {
@@ -492,23 +656,32 @@ impl GuestConfigRaw {
         guest_runtime_dir: guest_contracts::runtime_paths::GuestRuntimeDirEnvResolution,
     ) -> Result<Self, String> {
         let (guest_runtime_dir, _source) = guest_runtime_dir.into_parts();
-        let api_url = api_url_env_or_empty()?;
+        let mut bootstrap_alias_sources = BootstrapAliasSourceEvents::default();
+        let api_url = api_url_env_or_empty(&mut bootstrap_alias_sources)?;
 
         let stuck_tool_timeout_secs = guest_agent_tuning_env_or_empty(
+            BootstrapAlias::StuckToolTimeout,
             guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
             guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
+            &mut bootstrap_alias_sources,
         )?;
         let post_result_sigterm_grace_secs = guest_agent_tuning_env_or_empty(
+            BootstrapAlias::PostResultSigtermGrace,
             guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
             guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            &mut bootstrap_alias_sources,
         )?;
         let post_result_total_cap_secs = guest_agent_tuning_env_or_empty(
+            BootstrapAlias::PostResultTotalCap,
             guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
             guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+            &mut bootstrap_alias_sources,
         )?;
         let post_result_sigkill_grace_secs = guest_agent_tuning_env_or_empty(
+            BootstrapAlias::PostResultSigkillGrace,
             guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
             guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            &mut bootstrap_alias_sources,
         )?;
 
         let (user_env_file, user_env_file_source) = private_payload_file_env(
@@ -521,52 +694,70 @@ impl GuestConfigRaw {
         )?;
 
         record_private_payload_file_env_source(
-            guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+            &mut bootstrap_alias_sources,
+            BootstrapAlias::UserEnvFile,
             user_env_file_source,
         );
         record_private_payload_file_env_source(
-            guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+            &mut bootstrap_alias_sources,
+            BootstrapAlias::RunPayloadFile,
             run_payload_file_source,
         );
 
         Ok(Self {
             run_id: env_or_empty(guest_contracts::env::RUN_ID_ENV),
             api_url,
-            api_token: api_token_env_or_empty()?,
+            api_token: api_token_env_or_empty(&mut bootstrap_alias_sources)?,
             sandbox_id: run_metadata_env_or_empty(
+                BootstrapAlias::SandboxId,
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 guest_contracts::env::SANDBOX_ID_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             sandbox_reuse_result: run_metadata_env_or_empty(
+                BootstrapAlias::SandboxReuseResult,
                 guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
                 guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             workspace_reuse_result: run_metadata_env_or_empty(
+                BootstrapAlias::WorkspaceReuseResult,
                 guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
                 guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
             resume_session_id: run_metadata_env_or_empty(
+                BootstrapAlias::ResumeSessionId,
                 guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
                 guest_contracts::env::RESUME_SESSION_ID_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             api_start_time: run_metadata_env_or_empty(
+                BootstrapAlias::ApiStartTime,
                 guest_contracts::env::CANONICAL_API_START_TIME_ENV,
                 guest_contracts::env::API_START_TIME_ENV,
+                &mut bootstrap_alias_sources,
             )?,
-            agent_execution_timeout_secs: agent_execution_timeout_env_or_empty()?,
+            agent_execution_timeout_secs: agent_execution_timeout_env_or_empty(
+                &mut bootstrap_alias_sources,
+            )?,
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: mock_binary_path_env(
+                BootstrapAlias::MockClaudePath,
                 guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
                 guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
             user_env_file,
             run_payload_file,
             use_mock_codex: env_or_empty(guest_contracts::env::USE_MOCK_CODEX_ENV),
             mock_codex_path: mock_binary_path_env(
+                BootstrapAlias::MockCodexPath,
                 guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
                 guest_contracts::env::MOCK_CODEX_PATH_ENV,
+                &mut bootstrap_alias_sources,
             )?,
             home: std::env::var("HOME").ok(),
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
@@ -583,7 +774,21 @@ impl GuestConfigRaw {
             post_result_sigterm_grace_secs,
             post_result_total_cap_secs,
             post_result_sigkill_grace_secs,
+            bootstrap_alias_sources,
         })
+    }
+
+    /// Iterate the captured fixed event family, canonical key, and source
+    /// label without exposing any selected environment value.
+    #[doc(hidden)]
+    pub fn bootstrap_alias_source_events(
+        &self,
+    ) -> impl Iterator<Item = (&'static str, &'static str, &'static str)> + '_ {
+        self.bootstrap_alias_sources.iter()
+    }
+
+    pub(crate) fn emit_bootstrap_alias_source_events(&self) {
+        self.bootstrap_alias_sources.emit();
     }
 
     pub(crate) fn require_run_payload_file(&self) -> Result<(), String> {

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -91,6 +91,7 @@ impl GuestRuntime {
                 );
             }
         }
+        raw.emit_bootstrap_alias_source_events();
 
         let config = GuestConfig::from_raw(raw)?;
         let http = HttpClient::for_config(&config).map_err(|error| error.to_string())?;

--- a/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
+++ b/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
@@ -288,15 +288,24 @@ fn clear_timeout_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_source_evidence(log: &str, case_name: &str, expected_source: Option<&str>) {

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -191,15 +191,24 @@ fn clear_api_token_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_value_free(text: &str, context: &str) {

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -201,15 +201,24 @@ fn clear_api_token_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_value_free(text: &str, context: &str) {

--- a/crates/guest-agent/tests/bootstrap_alias_source_events.rs
+++ b/crates/guest-agent/tests/bootstrap_alias_source_events.rs
@@ -1,0 +1,303 @@
+//! Bootstrap alias source evidence is persisted only after runtime sink setup.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::process::Command;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CHILD_TEST: &str = "bootstrap_alias_source_events_isolated_child";
+const CHILD_GUARD: &str = "OKOU_BOOTSTRAP_ALIAS_SOURCE_EVENTS_CHILD";
+const CHILD_GUARD_VALUE: &str = "1";
+const CHILD_MARKER: &str = "bootstrap-alias-source-events-child-complete";
+const CHILD_TIMEOUT: Duration = Duration::from_secs(15);
+
+const API_URL_VALUE: &str = "http://api-url-value-must-not-leak.example.test";
+const API_TOKEN_VALUE: &str = "api-token-value-must-not-leak";
+const MOCK_CLAUDE_PATH_VALUE: &str = "/mock-claude-path-value-must-not-leak";
+const MOCK_CODEX_PATH_VALUE: &str = "/mock-codex-path-value-must-not-leak";
+const SANDBOX_ID_VALUE: &str = "sandbox-id-value-must-not-leak";
+const SANDBOX_REUSE_VALUE: &str = "sandbox-reuse-value-must-not-leak";
+const WORKSPACE_REUSE_VALUE: &str = "workspace-reuse-value-must-not-leak";
+const RESUME_SESSION_VALUE: &str = "resume-session-value-must-not-leak";
+const API_START_TIME_VALUE: &str = "api-start-time-value-must-not-leak";
+
+const SOURCE_EVENT_FAMILIES: [&str; 7] = [
+    "api_url_env_source",
+    "private_payload_file_env_source",
+    "api_token_env_source",
+    "agent_execution_timeout_env_source",
+    "guest_agent_tuning_env_source",
+    "mock_binary_path_env_source",
+    "run_metadata_env_source",
+];
+
+const SOURCE_EVENTS: [(&str, &str); 16] = [
+    (
+        "api_url_env_source",
+        guest_contracts::env::CANONICAL_API_URL_ENV,
+    ),
+    (
+        "guest_agent_tuning_env_source",
+        guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+    ),
+    (
+        "guest_agent_tuning_env_source",
+        guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+    ),
+    (
+        "guest_agent_tuning_env_source",
+        guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+    ),
+    (
+        "guest_agent_tuning_env_source",
+        guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+    ),
+    (
+        "private_payload_file_env_source",
+        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+    ),
+    (
+        "private_payload_file_env_source",
+        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+    ),
+    (
+        "api_token_env_source",
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+    ),
+    (
+        "run_metadata_env_source",
+        guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+    ),
+    (
+        "run_metadata_env_source",
+        guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+    ),
+    (
+        "run_metadata_env_source",
+        guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
+    ),
+    (
+        "run_metadata_env_source",
+        guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+    ),
+    (
+        "run_metadata_env_source",
+        guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+    ),
+    (
+        "agent_execution_timeout_env_source",
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+    ),
+    (
+        "mock_binary_path_env_source",
+        guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+    ),
+    (
+        "mock_binary_path_env_source",
+        guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+    ),
+];
+
+struct PrivateFiles {
+    user_env_path: PathBuf,
+    run_payload_path: PathBuf,
+}
+
+fn write_private_files(runtime_dir: &Path) -> TestResult<PrivateFiles> {
+    let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
+    let user_env_path = user_env_dir.join(guest_contracts::env::USER_ENV_FILENAME);
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::create_dir_all(&run_payload_dir)?;
+    std::fs::write(&user_env_path, b"{}")?;
+    std::fs::write(
+        &run_payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+    )?;
+    Ok(PrivateFiles {
+        user_env_path,
+        run_payload_path,
+    })
+}
+
+fn source_messages(text: &str) -> Vec<&str> {
+    text.lines()
+        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
+        .filter(|message| {
+            SOURCE_EVENT_FAMILIES.iter().any(|family| {
+                message
+                    .strip_prefix(family)
+                    .is_some_and(|suffix| suffix.starts_with(" key="))
+            })
+        })
+        .collect()
+}
+
+fn expected_source_messages() -> Vec<String> {
+    SOURCE_EVENTS
+        .iter()
+        .map(|(family, key)| format!("{family} key={key} source=canonical-only"))
+        .collect()
+}
+
+fn assert_value_free(text: &str, runtime_dir: &Path) {
+    for value in [
+        API_URL_VALUE,
+        API_TOKEN_VALUE,
+        MOCK_CLAUDE_PATH_VALUE,
+        MOCK_CODEX_PATH_VALUE,
+        SANDBOX_ID_VALUE,
+        SANDBOX_REUSE_VALUE,
+        WORKSPACE_REUSE_VALUE,
+        RESUME_SESSION_VALUE,
+        API_START_TIME_VALUE,
+    ] {
+        assert!(!text.contains(value), "source evidence exposed {value}");
+    }
+    assert!(
+        !text.contains(runtime_dir.to_string_lossy().as_ref()),
+        "source evidence exposed the runtime or private-file path"
+    );
+}
+
+#[tokio::test]
+async fn runtime_bootstrap_persists_each_fixed_source_event_once() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let runtime_dir = tmp.path().join("runtime-path-value-must-not-leak");
+    let private_files = write_private_files(&runtime_dir)?;
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .arg("--exact")
+        .arg(CHILD_TEST)
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env_clear()
+        .env(CHILD_GUARD, CHILD_GUARD_VALUE)
+        .env(guest_contracts::env::RUN_ID_ENV, "bootstrap-source-run")
+        .env("HOME", tmp.path().join("home"))
+        .env(
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        )
+        .env(guest_contracts::env::CANONICAL_API_URL_ENV, API_URL_VALUE)
+        .env(
+            guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+            &private_files.user_env_path,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+            &private_files.run_payload_path,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+            API_TOKEN_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "37",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+            "38",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "39",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "40",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "41",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            MOCK_CLAUDE_PATH_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+            MOCK_CODEX_PATH_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            SANDBOX_ID_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            SANDBOX_REUSE_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
+            WORKSPACE_REUSE_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+            RESUME_SESSION_VALUE,
+        )
+        .env(
+            guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+            API_START_TIME_VALUE,
+        );
+    if let Some(llvm_profile_file) = std::env::var_os("LLVM_PROFILE_FILE") {
+        command.env("LLVM_PROFILE_FILE", llvm_profile_file);
+    }
+
+    let output = common::command_output_with_timeout(
+        &mut command,
+        CHILD_TIMEOUT,
+        "isolated bootstrap source-event test did not finish",
+    )
+    .await?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "isolated bootstrap failed with {}; stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status
+    );
+    assert!(stdout.contains(CHILD_MARKER), "stdout:\n{stdout}");
+
+    let system_log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
+        &runtime_dir,
+    ))?;
+    let expected = expected_source_messages();
+    let expected = expected.iter().map(String::as_str).collect::<Vec<_>>();
+    assert_eq!(source_messages(&stderr), expected, "stderr source events");
+    assert_eq!(
+        source_messages(&system_log),
+        expected,
+        "system-log source events"
+    );
+    assert_value_free(&stderr, &runtime_dir);
+    assert_value_free(&system_log, &runtime_dir);
+    assert!(!private_files.user_env_path.exists());
+    assert!(!private_files.run_payload_path.exists());
+    Ok(())
+}
+
+#[test]
+#[ignore = "spawned exactly by the bootstrap source-event parent test"]
+fn bootstrap_alias_source_events_isolated_child() -> TestResult {
+    if std::env::var(CHILD_GUARD).ok().as_deref() != Some(CHILD_GUARD_VALUE) {
+        return Ok(());
+    }
+
+    let runtime = guest_agent::run_context::GuestRuntime::from_process_env()
+        .map_err(std::io::Error::other)?;
+    assert!(runtime.config.user_env.is_empty());
+    assert_eq!(runtime.config.api_url, API_URL_VALUE);
+    assert_eq!(runtime.config.api_token, API_TOKEN_VALUE);
+    assert_eq!(runtime.config.mock_claude_path, MOCK_CLAUDE_PATH_VALUE);
+    assert_eq!(runtime.config.mock_codex_path, MOCK_CODEX_PATH_VALUE);
+    println!("{CHILD_MARKER}");
+    Ok(())
+}

--- a/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
@@ -316,15 +316,24 @@ fn clear_tuning_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_source_evidence(

--- a/crates/guest-agent/tests/mock_binary_path_env_aliases.rs
+++ b/crates/guest-agent/tests/mock_binary_path_env_aliases.rs
@@ -238,15 +238,24 @@ fn clear_mock_path_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_value_free(text: &str, context: &str) {

--- a/crates/guest-agent/tests/private_payload_file_env_aliases.rs
+++ b/crates/guest-agent/tests/private_payload_file_env_aliases.rs
@@ -238,26 +238,46 @@ fn apply_alias(key: &str, input: AliasInput) {
     }
 }
 
-fn read_log(path: &Path) -> std::io::Result<String> {
-    match std::fs::read_to_string(path) {
-        Ok(log) => Ok(log),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
-        Err(error) => Err(error),
-    }
-}
-
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    Ok((raw, read_log(log_path)?))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn capture_config(log_path: &Path) -> std::io::Result<(Result<GuestConfig, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let config = GuestConfig::from_process_env();
     guest_common::log::clear_system_log_file();
-    Ok((config, read_log(log_path)?))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw.and_then(GuestConfig::from_raw), evidence))
 }
 
 fn assert_value_free(text: &str, forbidden_values: &[&str], context: &str) {

--- a/crates/guest-agent/tests/run_metadata_env_aliases.rs
+++ b/crates/guest-agent/tests/run_metadata_env_aliases.rs
@@ -66,15 +66,24 @@ fn clear_run_metadata_env() {
 }
 
 fn capture_raw(log_path: &Path) -> std::io::Result<(Result<GuestConfigRaw, String>, String)> {
-    guest_common::log::set_system_log_file(log_path);
-    let raw = GuestConfigRaw::from_process_env();
     guest_common::log::clear_system_log_file();
-    let log = match std::fs::read_to_string(log_path) {
-        Ok(log) => log,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(error),
-    };
-    Ok((raw, log))
+    let raw = GuestConfigRaw::from_process_env();
+    assert!(
+        !log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let evidence = raw
+        .as_ref()
+        .map(|raw| {
+            raw.bootstrap_alias_source_events()
+                .map(|(family, key, source)| {
+                    format!("[captured] {family} key={key} source={source}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    Ok((raw, evidence))
 }
 
 fn assert_source_log(
@@ -248,17 +257,24 @@ fn assert_guest_config_for_source(tmp: &Path, canonical: bool) -> TestResult {
     }
 
     let config_log_path = tmp.join(format!("{source}-config.log"));
-    guest_common::log::set_system_log_file(&config_log_path);
-    let config =
-        guest_agent::env::GuestConfig::from_process_env().map_err(std::io::Error::other)?;
     guest_common::log::clear_system_log_file();
+    let raw = GuestConfigRaw::from_process_env().map_err(std::io::Error::other)?;
+    let config_log = raw
+        .bootstrap_alias_source_events()
+        .map(|(family, key, source)| format!("[captured] {family} key={key} source={source}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !config_log_path.exists(),
+        "raw capture installed or wrote a system-log sink"
+    );
+    let config = guest_agent::env::GuestConfig::from_raw(raw).map_err(std::io::Error::other)?;
 
     assert_eq!(config.sandbox_id, values[0]);
     assert_eq!(config.sandbox_reuse_result, values[1]);
     assert_eq!(config.workspace_reuse_result, values[2]);
     assert_eq!(config.resume_session_id, values[3]);
     assert_eq!(config.api_start_time, values[4]);
-    let config_log = std::fs::read_to_string(config_log_path)?;
     for (pair, value) in RUN_METADATA_ENV_PAIRS.into_iter().zip(values) {
         assert_source_log(&config_log, pair, source_label, Some(value));
     }


### PR DESCRIPTION
Fixes #29916
Part of #28914

## Summary

- retain the seven existing Guest Agent bootstrap alias source families in a fixed, value-free 16-slot carrier during raw environment capture
- emit each selected source exactly once after the existing run-scoped system-log sink installation, without changing readers, writers, paths, or guest-common logging
- preserve the complete alias matrices and private-file/CLI behavior while adding a process-isolated real-bootstrap persistence assertion

## Scope and audit

- initial clean issue base: `5f1e9dd431dd393fd588812a10593bf2ad842ef8`
- refreshed final base after current `main` advanced: `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc`
- PR head: `d45177137bfc85f062ef9e00015c1138157aaaa9`
- fully paginated open-PR audit before editing: 30 open PRs, 477 declared changed files, 477 fetched, zero mismatches, zero overlap with the 10 scoped files
- one focused commit; production changes are limited to `env.rs` and `run_context.rs`, plus the seven named matrix tests and one focused runtime-bootstrap test

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- focused process-isolated tests: all seven named `*_env_aliases` matrices; `bootstrap_alias_source_events`; Guest runtime directory, process-control, Cgroup evidence; and CLI child-environment isolation

Protected CI remains authoritative. No production release is included.
