### PR TITLE
refactor(ci): cut production api url source to canonical variable

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -104,6 +104,7 @@ runs:
           local accessor="$1"
           local canonical_key="$2"
           local legacy_key="$3"
+          local source_label="${4:-GitHub App}"
           local canonical_value
           local legacy_value
           local state
@@ -113,7 +114,8 @@ runs:
           legacy_value="$("$accessor" "$legacy_key")"
           if [[ -n "$canonical_value" && -n "$legacy_value" ]]; then
             if [[ "$canonical_value" != "$legacy_value" ]]; then
-              printf '::error::GitHub App source conflict canonical_key=%s legacy_key=%s state=conflict\n' \
+              printf '::error::%s source conflict canonical_key=%s legacy_key=%s state=conflict\n' \
+                "$source_label" \
                 "$canonical_key" \
                 "$legacy_key" \
                 >&2
@@ -131,7 +133,8 @@ runs:
             return 0
           fi
 
-          printf '::notice::GitHub App source canonical_key=%s legacy_key=%s state=%s\n' \
+          printf '::notice::%s source canonical_key=%s legacy_key=%s state=%s\n' \
+            "$source_label" \
             "$canonical_key" \
             "$legacy_key" \
             "$state" \
@@ -190,6 +193,10 @@ runs:
         github_app_client_secret="$(resolve_repo_alias repo_secret OKOU_GITHUB_APP_CLIENT_SECRET VM0_GITHUB_APP_CLIENT_SECRET)"
         github_app_webhook_secret="$(resolve_repo_alias repo_secret OKOU_GITHUB_APP_WEBHOOK_SECRET VM0_GITHUB_APP_WEBHOOK_SECRET)"
         github_app_private_key="$(resolve_repo_alias repo_secret OKOU_GITHUB_APP_PRIVATE_KEY VM0_GITHUB_APP_PRIVATE_KEY)"
+        api_backend_url="$INPUT_API_BACKEND_URL"
+        if [[ "$INPUT_ENVIRONMENT" == "production" && -z "$api_backend_url" ]]; then
+          api_backend_url="$(resolve_repo_alias repo_var OKOU_API_BACKEND_URL VM0_API_BACKEND_URL "API backend URL")"
+        fi
 
         : > "$env_file"
 
@@ -200,7 +207,6 @@ runs:
         if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
           web_url="${INPUT_WEB_URL:-https://www.vm0.ai}"
           app_url="${INPUT_APP_URL:-https://app.vm0.ai}"
-          api_backend_url="$(first_non_empty "$INPUT_API_BACKEND_URL" "$(repo_var VM0_API_BACKEND_URL)")"
           axiom_dataset_suffix="prod"
           deploy_env="production"
           runner_default_group="vm0/production"
@@ -218,7 +224,6 @@ runs:
         else
           web_url="$INPUT_WEB_URL"
           app_url="$INPUT_APP_URL"
-          api_backend_url="$INPUT_API_BACKEND_URL"
           axiom_dataset_suffix="dev"
           deploy_env="preview"
           runner_default_group="vm0/development-${INPUT_JOB_REF}"

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -297,6 +297,46 @@ ruby -e '
   rollback = rollback_config.fetch("jobs")
   release = release_config.fetch("jobs")
   turbo = turbo_config.fetch("jobs")
+  canonical_api_backend_source = "$" + "{{ vars.OKOU_API_BACKEND_URL }}"
+  legacy_api_backend_source = "$" + "{{ vars.VM0_API_BACKEND_URL }}"
+  release_api_step = release.fetch("promote-api-production").fetch("steps").find do |step|
+    step["name"] == "Resolve API production environment"
+  end
+  raise "missing release API production environment step" unless release_api_step
+  release_runner_step = release.fetch("build-runner-production").fetch("steps").find do |step|
+    step["name"] == "Build rootfs and snapshot on production hosts"
+  end
+  raise "missing release Runner build step" unless release_runner_step
+  rollback_runner_step = rollback.fetch("rollback-runner").fetch("steps").find do |step|
+    step["name"] == "Roll back Runner on production hosts"
+  end
+  raise "missing production Runner rollback step" unless rollback_runner_step
+
+  selected_api_backend_sources = [
+    release_api_step.fetch("with").fetch("api-backend-url"),
+    release_runner_step.fetch("env").fetch("API_URL"),
+    rollback_runner_step.fetch("env").fetch("API_URL"),
+  ]
+  unless selected_api_backend_sources == Array.new(3, canonical_api_backend_source)
+    raise "production API backend sources must use only the canonical GitHub variable"
+  end
+  if selected_api_backend_sources.include?(legacy_api_backend_source)
+    raise "selected production API backend sources must not use the legacy GitHub variable"
+  end
+
+  neutral_api_url = "$" + "{API_URL}"
+  {
+    "release Runner build" => release_runner_step,
+    "production Runner rollback" => rollback_runner_step,
+  }.each do |boundary, step|
+    env = step.fetch("env")
+    if env.key?("OKOU_API_BACKEND_URL") || env.key?("VM0_API_BACKEND_URL")
+      raise "#{boundary} must retain the neutral API_URL shell boundary"
+    end
+    unless step.fetch("run").include?("-e \"api_url=#{neutral_api_url}\"")
+      raise "#{boundary} must retain the neutral Ansible api_url input"
+    end
+  end
   raise "rollback resolver must wait for queue" unless rollback.fetch("resolve-target").fetch("needs") == "queue-production-deploy"
   raise "App must wait for resolver" unless rollback.fetch("rollback-app").fetch("needs") == "resolve-target"
   raise "Runner must wait for resolver" unless rollback.fetch("rollback-runner").fetch("needs") == "resolve-target"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -131,6 +131,38 @@ assert_api_backend_url_canonical_only() {
   assert_env_key_count "$env_file" VM0_API_BACKEND_URL 0
 }
 
+assert_api_backend_url_aliases_absent() {
+  local env_file="$1"
+  assert_env_key_absent "$env_file" OKOU_API_BACKEND_URL
+  assert_env_key_absent "$env_file" VM0_API_BACKEND_URL
+}
+
+assert_api_backend_url_source_state() {
+  local output="$1"
+  local state="$2"
+  local expected
+  local source_lines
+  expected="::notice::API backend URL source canonical_key=OKOU_API_BACKEND_URL legacy_key=VM0_API_BACKEND_URL state=${state}"
+  source_lines="$(grep -F "API backend URL source" <<< "$output" || true)"
+  if [[ "$source_lines" != "$expected" ]]; then
+    fail "unexpected API backend URL source evidence for ${state}"
+  fi
+}
+
+assert_api_backend_url_source_evidence_absent() {
+  local output="$1"
+  assert_not_contains "$output" "API backend URL source"
+}
+
+assert_api_backend_url_values_absent_from_output() {
+  local output="$1"
+  shift
+  local value
+  for value in "$@"; do
+    assert_not_contains "$output" "$value"
+  done
+}
+
 assert_machine_secret_canonical_only() {
   local env_file="$1"
   local expected="$2"
@@ -317,6 +349,8 @@ run_action() {
   local github_app_vars_json="${7:-}"
   local github_app_secrets_json="${8:-}"
   local input_job_ref="${9-pr-123}"
+  local input_api_backend_url="${10-https://pr-123-api-backend.vm0.test}"
+  local api_backend_repo_vars_json="${11:-}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
   local repo_vars_json
@@ -336,6 +370,14 @@ run_action() {
     repo_vars_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_vars_json")"
     repo_secrets_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_secrets_json")"
   fi
+  if [[ -n "$api_backend_repo_vars_json" ]]; then
+    repo_vars_json="$(
+      jq -c \
+        --argjson api_backend_vars "$api_backend_repo_vars_json" \
+        'del(.OKOU_API_BACKEND_URL, .VM0_API_BACKEND_URL) + $api_backend_vars' \
+        <<< "$repo_vars_json"
+    )"
+  fi
   repo_vars_json="$(jq -c --argjson github_app_vars "$github_app_vars_json" '. + $github_app_vars' <<< "$repo_vars_json")"
   repo_secrets_json="$(jq -c --argjson github_app_secrets "$github_app_secrets_json" '. + $github_app_secrets' <<< "$repo_secrets_json")"
 
@@ -351,7 +393,7 @@ run_action() {
     INPUT_JOB_REF="$input_job_ref" \
     INPUT_WEB_URL="https://pr-123-www.vm0.test" \
     INPUT_APP_URL="https://pr-123-app.vm0.test" \
-    INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
+    INPUT_API_BACKEND_URL="$input_api_backend_url" \
     INPUT_CLI_PKG_URL="$input_cli_pkg_url" \
     REPO_VARS_JSON="$repo_vars_json" \
     REPO_SECRETS_JSON="$repo_secrets_json" \
@@ -372,6 +414,43 @@ run_github_app_action() {
     canonical \
     "$repo_vars_json" \
     "$repo_secrets_json"
+}
+
+run_api_backend_url_action() {
+  local test_dir="$1"
+  local repo_vars_json="$2"
+  local input_api_backend_url="${3-}"
+  run_action \
+    "$(build_doppler_secrets_json)" \
+    "$test_dir" \
+    api \
+    production \
+    "https://static.vm0.io/okou-cli/test-sha/package.tgz" \
+    canonical \
+    "" \
+    "" \
+    pr-123 \
+    "$input_api_backend_url" \
+    "$repo_vars_json"
+}
+
+assert_api_backend_url_fallback_case() {
+  local state="$1"
+  local repo_vars_json="$2"
+  local expected="$3"
+  local test_dir
+  local output
+  local env_file
+  test_dir="$(mktemp -d)"
+  TEMP_DIRS+=("$test_dir")
+  output="$(run_api_backend_url_action "$test_dir" "$repo_vars_json" 2>&1)"
+  env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${test_dir}/github-output")"
+  assert_contains "$output" "Rendered"
+  assert_api_backend_url_source_state "$output" "$state"
+  assert_api_backend_url_values_absent_from_output "$output" "$expected"
+  assert_api_backend_url_canonical_only "$env_file" "$expected"
+  assert_env_value "$env_file" FEISHU_CALLBACK_BASE_URL "$expected"
+  assert_env_value "$env_file" FINICITY_WEBHOOK_BASE_URL "$expected"
 }
 
 if grep -En 'add_(var|secret) [A-Z0-9_]+_OAUTH_CLIENT_(ID|SECRET)' "$ACTION"; then
@@ -457,6 +536,74 @@ assert_contains "$github_app_secret_conflict_output" "canonical_key=OKOU_GITHUB_
 assert_no_fixture_secret_values "$github_app_secret_conflict_output"
 assert_file_absent "${github_app_secret_conflict_dir}/github-output"
 assert_file_absent "${github_app_secret_conflict_dir}/web-api-api-preview.env"
+
+assert_api_backend_url_fallback_case \
+  canonical-only \
+  '{"OKOU_API_BACKEND_URL":"https://canonical-api.example.test"}' \
+  "https://canonical-api.example.test"
+assert_api_backend_url_fallback_case \
+  legacy-only \
+  '{"VM0_API_BACKEND_URL":"https://legacy-api.example.test"}' \
+  "https://legacy-api.example.test"
+assert_api_backend_url_fallback_case \
+  dual \
+  '{"OKOU_API_BACKEND_URL":"https://dual-api.example.test","VM0_API_BACKEND_URL":"https://dual-api.example.test"}' \
+  "https://dual-api.example.test"
+
+api_backend_url_conflict_dir="$(mktemp -d)"
+TEMP_DIRS+=("$api_backend_url_conflict_dir")
+status=0
+api_backend_url_conflict_output="$(
+  run_api_backend_url_action \
+    "$api_backend_url_conflict_dir" \
+    '{"OKOU_API_BACKEND_URL":"https://canonical-conflict.example.test","VM0_API_BACKEND_URL":"https://legacy-conflict.example.test"}' \
+    2>&1
+)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+  fail "expected conflicting API backend URL aliases to fail"
+fi
+expected_api_backend_url_conflict="::error::API backend URL source conflict canonical_key=OKOU_API_BACKEND_URL legacy_key=VM0_API_BACKEND_URL state=conflict"
+api_backend_url_conflict_lines="$(grep -F "API backend URL source" <<< "$api_backend_url_conflict_output" || true)"
+if [[ "$api_backend_url_conflict_lines" != "$expected_api_backend_url_conflict" ]]; then
+  fail "unexpected API backend URL conflict evidence"
+fi
+assert_api_backend_url_values_absent_from_output \
+  "$api_backend_url_conflict_output" \
+  "https://canonical-conflict.example.test" \
+  "https://legacy-conflict.example.test"
+assert_file_absent "${api_backend_url_conflict_dir}/github-output"
+assert_file_absent "${api_backend_url_conflict_dir}/web-api-api-production.env"
+
+api_backend_url_explicit_dir="$(mktemp -d)"
+TEMP_DIRS+=("$api_backend_url_explicit_dir")
+api_backend_url_explicit_output="$(
+  run_api_backend_url_action \
+    "$api_backend_url_explicit_dir" \
+    '{"OKOU_API_BACKEND_URL":"https://ignored-canonical.example.test","VM0_API_BACKEND_URL":"https://ignored-legacy.example.test"}' \
+    "https://explicit-api.example.test" \
+    2>&1
+)"
+api_backend_url_explicit_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${api_backend_url_explicit_dir}/github-output")"
+assert_contains "$api_backend_url_explicit_output" "Rendered"
+assert_api_backend_url_source_evidence_absent "$api_backend_url_explicit_output"
+assert_api_backend_url_values_absent_from_output \
+  "$api_backend_url_explicit_output" \
+  "https://explicit-api.example.test" \
+  "https://ignored-canonical.example.test" \
+  "https://ignored-legacy.example.test"
+assert_api_backend_url_canonical_only "$api_backend_url_explicit_env_file" "https://explicit-api.example.test"
+assert_env_value "$api_backend_url_explicit_env_file" FEISHU_CALLBACK_BASE_URL "https://explicit-api.example.test"
+assert_env_value "$api_backend_url_explicit_env_file" FINICITY_WEBHOOK_BASE_URL "https://explicit-api.example.test"
+
+api_backend_url_absent_dir="$(mktemp -d)"
+TEMP_DIRS+=("$api_backend_url_absent_dir")
+api_backend_url_absent_output="$(run_api_backend_url_action "$api_backend_url_absent_dir" '{}' 2>&1)"
+api_backend_url_absent_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${api_backend_url_absent_dir}/github-output")"
+assert_contains "$api_backend_url_absent_output" "Rendered"
+assert_api_backend_url_source_evidence_absent "$api_backend_url_absent_output"
+assert_api_backend_url_aliases_absent "$api_backend_url_absent_env_file"
+assert_env_value "$api_backend_url_absent_env_file" FEISHU_CALLBACK_BASE_URL ""
+assert_env_value "$api_backend_url_absent_env_file" FINICITY_WEBHOOK_BASE_URL ""
 
 success_dir="$(mktemp -d)"
 TEMP_DIRS+=("$success_dir")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1168,7 +1168,7 @@ jobs:
           database-url: ${{ steps.get-db-url.outputs.database-url }}
           web-url: https://www.vm0.ai
           app-url: https://app.vm0.ai
-          api-backend-url: ${{ vars.VM0_API_BACKEND_URL }}
+          api-backend-url: ${{ vars.OKOU_API_BACKEND_URL }}
           cli-pkg-url: ${{ steps.cli-artifact.outputs.package-url }}
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
@@ -2227,7 +2227,7 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           RUNNER_TARGET: ${{ matrix.target }}
-          API_URL: ${{ vars.VM0_API_BACKEND_URL }}
+          API_URL: ${{ vars.OKOU_API_BACKEND_URL }}
           # R2 image cache credentials — from resolve-image-cache job (repo-level,
           # not production-scoped) so the runner uses the same bucket as CI.
           # R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY come from $GITHUB_ENV

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -298,7 +298,7 @@ jobs:
 
       - name: Roll back Runner on production hosts
         env:
-          API_URL: ${{ vars.VM0_API_BACKEND_URL }}
+          API_URL: ${{ vars.OKOU_API_BACKEND_URL }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}


### PR DESCRIPTION
## Summary

- switch the production API environment action input, Runner build, and Runner rollback sources to `vars.OKOU_API_BACKEND_URL`
- preserve explicit action-input precedence and resolve the production repository-variable fallback as canonical-only, legacy-only, equal dual, absent, or fail-closed conflict
- keep the runtime environment writer canonical-only and retain the neutral Runner `API_URL` to Ansible `api_url` boundaries

## Scope safeguards

- the retained GitHub production `VM0_API_BACKEND_URL` variable is unchanged for old workflow reruns and code rollback
- preview/E2E, CLI, Runner operator, Runner-to-Guest, Guest, callback, webhook, release ordering, Ansible, rollback target, promotion, and health behavior are unchanged
- fallback diagnostics contain only fixed source keys and state; neither URL nor any derivative is logged
- no release, deployment, rollback, production approval, or external configuration mutation was performed

## Refreshed inventory evidence

- reviewed from a fresh clean exact current `main@b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` immediately before editing
- a complete repository inventory found 301 API backend alias matches across 179 files, exactly three selected legacy production workflow sources, one canonical runtime writer, and no runtime legacy writer
- a live GitHub read at `2026-08-27T14:35:00Z` found exactly one nonempty `OKOU_API_BACKEND_URL` and one retained nonempty `VM0_API_BACKEND_URL` in the `production` environment; their values were byte-equal without logging either value
- the canonical variable was last updated at `2026-08-27T14:12:21Z`; the retained legacy variable was last updated at `2026-05-14T17:59:48Z`; neither spelling exists at repository scope
- fully paginated all 30 open PRs and reconciled 412/412 declared changed files with zero mismatch
- #29925 overlaps only unrelated Desktop signing-identity hunks in `release-please.yml`; stale #25722 overlaps the five scoped files only through unrelated Cloudflare Worker deployment/rollback work; neither is a functional dependency or ordering blocker

## Verification

- Prettier 3.8.1 write/check on all five scoped files
- `bash -n` on both changed shell contract tests and the extracted composite-action script
- ShellCheck 0.9.0 on both changed shell contract tests and the extracted composite-action script
- actionlint 1.7.12 with the repository-pinned verified archive
- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- semantic workflow comparison proving that normalizing only the three canonical source expressions produces byte-equal reviewed-base workflows
- five-file whitelist, canonical/legacy source and runtime-writer counts, and `git diff --check`

## Reviewed revisions

- base: `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc`
- head: `0aa2edf074f6748d664a00f4de806522218172a4`

Closes #29924

Parent EPIC: #28914
