### PR TITLE
fix(platform): wait for org role before revealing home layout

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1253,8 +1253,24 @@ test("home content stays fixed while the growth entry loads", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
+  const orgRoleRequested = deferred();
+  const releaseOrgRole = deferred();
   const slackStatusRequested = deferred();
   const releaseSlackStatus = deferred();
+  await page.route(
+    (url) => url.pathname === "/api/org",
+    async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      orgRoleRequested.resolve();
+      await releaseOrgRole.promise;
+      await route.fulfill({
+        json: { id: "org_admin", name: "Admin Org", role: "admin" },
+      });
+    },
+  );
   await page.route("**/api/integrations/slack", async (route) => {
     if (route.request().method() !== "GET") {
       await route.continue();
@@ -1284,11 +1300,18 @@ test("home content stays fixed while the growth entry loads", async ({
 
   await page.goto(appUrl);
   await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
-  await slackStatusRequested.promise;
 
   const growthEntry = page.getByTestId("growth-entry");
+  const appSkeleton = page.locator("#app-bootstrap-skeleton");
   const main = page.locator("main");
   const tagline = page.getByTestId("chat-tagline");
+  await orgRoleRequested.promise;
+  await expect(appSkeleton).toBeVisible();
+  await expect(growthEntry).not.toBeAttached();
+
+  releaseOrgRole.resolve();
+  await slackStatusRequested.promise;
+  await expect(appSkeleton).toBeHidden();
   await expect(tagline).toBeVisible({ timeout: 20_000 });
   await expect(growthEntry).not.toBeAttached();
   const mainBefore = await main.boundingBox();
@@ -1328,30 +1351,12 @@ test("non-admin home content keeps its original top edge", async ({ page }) => {
       });
     },
   );
-  const memberOrgLoaded = page.waitForResponse((response) => {
-    const request = response.request();
-    return (
-      response.ok() &&
-      request.method() === "GET" &&
-      new URL(response.url()).pathname === "/api/org"
-    );
-  });
 
   await page.goto(appUrl);
   await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
-  await memberOrgLoaded;
+  await expect(page.locator("#app-bootstrap-skeleton")).toBeHidden();
   await expect(page.getByTestId("chat-tagline")).toBeVisible({
     timeout: 20_000,
-  });
-  // Let the member role commit before reading the stable layout.
-  await page.evaluate(async () => {
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          resolve();
-        });
-      });
-    });
   });
 
   await expect(page.getByTestId("growth-entry")).not.toBeAttached();

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
@@ -17,7 +17,6 @@ import {
 } from "../agent.ts";
 import { setChatAgentId$ } from "../agent-chat.ts";
 import { setTalkDraft$, talkDraft$ } from "./chat-draft.ts";
-import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { reloadTagline$, resetChatPageModelSelection$ } from "./chat-page.ts";
 import {
   ensureAgentDraft$,
@@ -53,8 +52,6 @@ export const setupAgentChatPage$ = command(
     set(reloadTagline$);
     set(resetChatPageModelSelection$);
     set(updatePage$, createElement(AgentChatPage), "sidebar");
-
-    await set(hideAppSkeleton$, signal);
 
     const agents = await get(agents$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname, search } from "../../../signals/location.ts";
+import { refreshOrg$ } from "../../../signals/org.ts";
 import { AGENT_ID, context, mockAgent } from "./chat-composer-test-helpers.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
@@ -89,6 +90,45 @@ describe("home growth entry", () => {
     await waitFor(() => {
       expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
     });
+  });
+
+  it("hides admin controls while the organization role refreshes", async () => {
+    const refreshRequested = context.mocks.deferred<void>();
+    const releaseRefresh = context.mocks.deferred<void>();
+    let requestCount = 0;
+    mockAgent();
+    mockSlackStatus({ isConnected: false, isInstalled: true });
+    context.mocks.api(orgContract.get, async ({ respond }) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return respond(200, {
+          id: "org_1",
+          name: "Test Org",
+          role: "admin",
+        });
+      }
+      refreshRequested.resolve(undefined);
+      await releaseRefresh.promise;
+      return respond(200, {
+        id: "org_1",
+        name: "Test Org",
+        role: "admin",
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await screen.findByTestId("growth-entry");
+    context.store.set(refreshOrg$);
+    await refreshRequested.promise;
+
+    expect(screen.queryByTestId("growth-entry")).not.toBeInTheDocument();
+
+    releaseRefresh.resolve(undefined);
+    await screen.findByTestId("growth-entry");
   });
 
   it("hides the growth entry from non-admin members", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-growth-entry.test.tsx
@@ -3,6 +3,7 @@ import {
   integrationsSlackContract,
   type SlackOrgStatus,
 } from "@okouai/api-contracts/contracts/integrations-slack";
+import { orgContract } from "@okouai/api-contracts/contracts/org-routes";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
@@ -58,6 +59,38 @@ function setupGrowthEntry(
 }
 
 describe("home growth entry", () => {
+  it("keeps the app skeleton until the current admin role resolves", async () => {
+    const orgRequested = context.mocks.deferred<void>();
+    const releaseOrg = context.mocks.deferred<void>();
+    mockAgent();
+    mockSlackStatus({ isConnected: false, isInstalled: true });
+    context.mocks.api(orgContract.get, async ({ respond }) => {
+      orgRequested.resolve(undefined);
+      await releaseOrg.promise;
+      return respond(200, {
+        id: "org_1",
+        name: "Test Org",
+        role: "admin",
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await orgRequested.promise;
+    const appSkeleton = await screen.findByTestId("app-skeleton");
+    expect(appSkeleton).not.toHaveAttribute("aria-hidden");
+
+    releaseOrg.resolve(undefined);
+
+    await screen.findByTestId("growth-entry");
+    await waitFor(() => {
+      expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
   it("hides the growth entry from non-admin members", async () => {
     setupGrowthEntry(
       { isConnected: false, isInstalled: false },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
@@ -204,7 +204,9 @@ describe("home route", () => {
 
     await team.started.promise;
     expect(pathname()).toBe(`/agents/${RETURNING_AGENT_ID}/chat`);
-    expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    await waitFor(() => {
+      expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    });
     await expect(
       screen.findByRole("textbox", { name: "Message" }),
     ).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, ChevronDown, Coins, PlusCircle } from "lucide-react";
@@ -13,6 +13,7 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
+import { hideAppSkeletonOnContentReadyRef$ } from "../../signals/app-skeleton.ts";
 import { assistantName$ } from "../../signals/branding.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { openSettingsDialogAt$ } from "../../signals/okou-page/settings/settings-dialog.ts";
@@ -293,18 +294,30 @@ function AdminGrowthEntryHeader() {
 }
 
 export function GrowthEntryHeader() {
-  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
-  const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
-  if (!isAdmin) {
-    return null;
-  }
+  const currentIsAdminLoadable = useLoadable(isOrgAdmin$);
+  const lastIsAdminLoadable = useLastLoadable(isOrgAdmin$);
+  const hideAppSkeletonOnContentReadyRef = useSet(
+    hideAppSkeletonOnContentReadyRef$,
+  );
+  const roleReady = currentIsAdminLoadable.state === "hasData";
+  const isAdmin = roleReady
+    ? currentIsAdminLoadable.data
+    : lastIsAdminLoadable.state === "hasData" && lastIsAdminLoadable.data;
   return (
     <>
-      {/* Match the former in-flow header's 16px + 32px + 8px height. The
-          controls stay absolute, but the home content keeps its established
-          desktop position before and after the async entry resolves. */}
-      <div aria-hidden className="hidden h-14 shrink-0 md:block" />
-      <AdminGrowthEntryHeader />
+      {/* Reveal only after the current role and its layout commit together. */}
+      {roleReady ? (
+        <span ref={hideAppSkeletonOnContentReadyRef} hidden />
+      ) : null}
+      {isAdmin ? (
+        <>
+          {/* Match the former in-flow header's 16px + 32px + 8px height. The
+              controls stay absolute, but the home content keeps its
+              established desktop position while Slack resolves. */}
+          <div aria-hidden className="hidden h-14 shrink-0 md:block" />
+          <AdminGrowthEntryHeader />
+        </>
+      ) : null}
     </>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -300,24 +300,25 @@ export function GrowthEntryHeader() {
     hideAppSkeletonOnContentReadyRef$,
   );
   const roleReady = currentIsAdminLoadable.state === "hasData";
-  const isAdmin = roleReady
-    ? currentIsAdminLoadable.data
-    : lastIsAdminLoadable.state === "hasData" && lastIsAdminLoadable.data;
+  const isCurrentAdmin = roleReady && currentIsAdminLoadable.data;
+  const preserveAdminLayout =
+    isCurrentAdmin ||
+    (!roleReady &&
+      lastIsAdminLoadable.state === "hasData" &&
+      lastIsAdminLoadable.data);
   return (
     <>
       {/* Reveal only after the current role and its layout commit together. */}
       {roleReady ? (
         <span ref={hideAppSkeletonOnContentReadyRef} hidden />
       ) : null}
-      {isAdmin ? (
-        <>
-          {/* Match the former in-flow header's 16px + 32px + 8px height. The
-              controls stay absolute, but the home content keeps its
-              established desktop position while Slack resolves. */}
-          <div aria-hidden className="hidden h-14 shrink-0 md:block" />
-          <AdminGrowthEntryHeader />
-        </>
+      {/* Match the former in-flow header's 16px + 32px + 8px height. Preserve
+          only its layout while the role refreshes; stale role data must not
+          keep admin controls available. */}
+      {preserveAdminLayout ? (
+        <div aria-hidden className="hidden h-14 shrink-0 md:block" />
       ) : null}
+      {isCurrentAdmin ? <AdminGrowthEntryHeader /> : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- keep the home bootstrap skeleton visible until the current organization role and its layout commit together
- preserve only the admin header spacer during later role refreshes while hiding authorization-dependent controls until the current role resolves
- make the Playwright coverage delay organization role and Slack status independently, and synchronize member layout assertions on the skeleton lifecycle

## Validation

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/home-growth-entry.test.tsx src/views/okou-page/__tests__/home-route.test.tsx --maxWorkers=1 --silent=passed-only` (21 tests)
- `pnpm knip`
- `pnpm check-types` (from `e2e/`)
- pre-commit hook: Prettier, Knip, full Turbo `check-types`, file-size check, and commitlint

## Exclusions

- The Playwright feature test was not run locally because its configuration targets an externally deployed environment that does not contain this branch; PR preview CI will exercise it against the submitted code.

Closes #29935
