### PR TITLE
test(platform): stabilize image annotation send coverage

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -243,53 +243,15 @@ describe("composer image annotation", () => {
     });
     mockAgentChatPage();
     failImageDecodes();
-    const savedDraftAttachments: (readonly SavedDraft[] | null)[] = [];
-    mockDraftWithImage(null, savedDraftAttachments);
+    mockDraftWithImage([boxMark()]);
 
     setup(true);
-
-    // Drawn through the UI rather than seeded from the draft response: the
-    // marks have to survive the whole path, and committing them is the step
-    // that used to leave them behind.
-    const chip = await screen.findByLabelText(
-      "Open image preview for billing-page.png",
-    );
-    await user.click(chip);
-    await user.click(await screen.findByTestId("artifact-dialog-annotate"));
-    await screen.findByTestId("image-annotation-editor");
-    await dragOnSurface();
-
-    await user.click(await screen.findByTestId("annotation-mark-1"));
-    await user.type(
-      await screen.findByPlaceholderText("Say what should change here"),
-      "Tighten this spacing",
-    );
-    await user.click(attachMarksButton());
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("composer-attachment-mark-count"),
-      ).toHaveTextContent("1");
-    });
-
-    // Attaching has to reach the stored draft. It used to write the signal and
-    // stop, so anything that reloaded the draft took the marks with it.
-    await waitFor(() => {
-      expect(
-        savedDraftAttachments.some((saved) => {
-          return saved?.some((attachment) => {
-            return attachment.annotation !== undefined;
-          });
-        }),
-      ).toBeTruthy();
-    });
 
     await fillComposer(await composerEditor(), "Fix the billing page");
     await user.click(screen.getByLabelText("Send"));
 
-    // jsdom loads no images, so the flattened copy never renders and the send
-    // falls back on the deadline. That is the failure it has to survive: the
-    // notes still have to arrive.
+    // The image stub fails the flattened copy immediately. The send falls back
+    // to the original image, but the notes still have to arrive.
     await waitFor(() => {
       expect(sentPrompts.length).toBeGreaterThan(0);
     });
@@ -333,7 +295,8 @@ describe("composer image annotation", () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);
     mockAgentChatPage();
-    mockDraftWithImage(null);
+    const savedDraftAttachments: (readonly SavedDraft[] | null)[] = [];
+    mockDraftWithImage(null, savedDraftAttachments);
 
     setup(true);
 
@@ -374,6 +337,18 @@ describe("composer image annotation", () => {
     expect(
       screen.getAllByLabelText("Open image preview for billing-page.png"),
     ).toHaveLength(1);
+
+    // Attaching has to reach the stored draft. It used to write the signal and
+    // stop, so anything that reloaded the draft took the marks with it.
+    await waitFor(() => {
+      expect(
+        savedDraftAttachments.some((saved) => {
+          return saved?.some((attachment) => {
+            return attachment.annotation !== undefined;
+          });
+        }),
+      ).toBeTruthy();
+    });
   });
 
   it("draws stored marks in the read-only viewer, not just in the editor", async () => {


### PR DESCRIPTION
## Summary

- move the draft PATCH regression assertion into the existing draw-and-attach page test
- start the send-boundary test from a persisted annotated draft so it only exercises restore, send, fallback, and prompt construction
- correct the send-test comment to match the immediate image-error stub

## Why

The previous test combined the annotation editor and composer send flows inside Vitest's 5-second budget. It intermittently timed out under CI shard contention even though each regression can be protected at the persisted draft contract that connects those flows.

The focused send case dropped from a 1537ms isolated baseline to 639–691ms while retaining the outgoing prompt assertions. The draw-and-attach case now explicitly verifies that committed annotations reach the draft PATCH.

## Exclusions

- no production behavior changes
- no test or production timeout changes
- no internal module mocks

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/image-annotation.test.tsx --reporter=verbose`
- three additional sequential focused file runs (30/30 tests passed)
- `pnpm exec prettier --write apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit full-repository Knip and TypeScript checks

Closes #29937
