### PR TITLE
perf(runner): batch required private guest writes

### DIFF
--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -16,7 +16,7 @@ struct Args {
     path: Option<PathBuf>,
 }
 
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch";
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch [--private]";
 
 fn parse_args<I>(args: I) -> Result<Args, String>
 where
@@ -65,10 +65,8 @@ where
     }
 
     if batch {
-        if append || create_parents || private {
-            return Err(
-                "--batch cannot be used with --append, --create-parents, or --private".to_string(),
-            );
+        if append || create_parents {
+            return Err("--batch cannot be used with --append or --create-parents".to_string());
         }
         if path.is_some() {
             return Err("--batch does not accept a path".to_string());
@@ -77,7 +75,7 @@ where
             append: false,
             batch: true,
             create_parents: false,
-            private: false,
+            private,
             path: None,
         });
     }
@@ -101,7 +99,7 @@ where
 
 fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
     if args.batch {
-        return run_batch(stdin);
+        return run_batch(stdin, args.private);
     }
     let Some(path) = args.path else {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, "missing path"));
@@ -123,7 +121,7 @@ fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
     file.flush()
 }
 
-fn run_batch(mut stdin: impl Read) -> io::Result<()> {
+fn run_batch(mut stdin: impl Read, private: bool) -> io::Result<()> {
     let mut payload = Vec::new();
     let max_payload_size = vsock_proto::MAX_MESSAGE_SIZE - vsock_proto::MIN_BODY_SIZE;
     let mut limited = stdin.by_ref().take(max_payload_size as u64 + 1);
@@ -139,12 +137,16 @@ fn run_batch(mut stdin: impl Read) -> io::Result<()> {
 
     for file in files {
         let path = Path::new(file.path);
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent)?;
-        }
-        let mut output = open_output_file(path, false)?;
+        let mut output = if private {
+            open_private_output_file(path, false)?
+        } else {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent)?;
+            }
+            open_output_file(path, false)?
+        };
         output.write_all(file.content)?;
         output.flush()?;
     }
@@ -236,7 +238,7 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 ///
 /// ```text
 /// guest-write-file [--private] [--append | --create-parents] [--] <path>
-/// guest-write-file --batch
+/// guest-write-file --batch [--private]
 /// ```
 ///
 /// Use `--` before `<path>` when the literal path begins with `-`. `stdin`
@@ -251,7 +253,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// parent components.
 ///
 /// `--batch` reads a `vsock-proto` `write_files` payload from stdin and writes
-/// every ordinary file entry with create-parent and truncate semantics.
+/// every entry with create-parent and truncate semantics. Combined with
+/// `--private`, every entry uses the private runtime-file behavior described
+/// above.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.
@@ -376,6 +380,22 @@ mod tests {
                 batch: true,
                 create_parents: false,
                 private: false,
+                path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_private_batch() {
+        let args = parse_args(["--batch".to_string(), "--private".to_string()]).unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                append: false,
+                batch: true,
+                create_parents: false,
+                private: true,
                 path: None,
             }
         );

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -4,7 +4,7 @@
 //!
 //! ```text
 //! guest-write-file [--private] [--append | --create-parents] [--] <path>
-//! guest-write-file --batch
+//! guest-write-file --batch [--private]
 //! ```
 //!
 //! Content is read from stdin. Create mode truncates or creates the target.
@@ -15,7 +15,8 @@
 //! parent directories are private, creating missing parent directories even
 //! with append mode, and rejecting symlinked parent components.
 //! Batch mode reads a `vsock-proto` `write_files` payload from stdin and writes
-//! every ordinary file entry with create-parent and truncate semantics.
+//! every entry with create-parent and truncate semantics. Private batch mode
+//! applies private runtime-file semantics to every entry.
 //! Use `--` before a path that begins with `-`.
 //!
 //! The detailed canonical CLI contract is documented on

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{self, Receiver};
 use std::time::{Duration, Instant};
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch";
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch [--private]";
 const HELPER_KILL_TIMEOUT: Duration = Duration::from_secs(1);
 const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
@@ -421,6 +421,88 @@ fn batch_mode_truncates_existing_files() {
 
     assert!(output.status.success(), "stderr={:?}", output.stderr);
     assert_eq!(std::fs::read(path).unwrap(), b"new");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_batch_mode_writes_private_files_with_restrictive_umask() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("run/user-env/env.json");
+    let second = dir.path().join("run/run-payload/payload.json");
+    let payload = vsock_proto::encode_write_files(&[
+        vsock_proto::WriteFileBatchEntry {
+            path: first.to_str().unwrap(),
+            content: b"env",
+        },
+        vsock_proto::WriteFileBatchEntry {
+            path: second.to_str().unwrap(),
+            content: b"payload",
+        },
+    ])
+    .unwrap();
+
+    let output = run_helper_with_umask(&["--batch", "--private"], &payload, 0o777);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&first).unwrap(), b"env");
+    assert_eq!(std::fs::read(&second).unwrap(), b"payload");
+    assert_eq!(mode(&dir.path().join("run")), 0o700);
+    assert_eq!(mode(&dir.path().join("run/user-env")), 0o700);
+    assert_eq!(mode(&dir.path().join("run/run-payload")), 0o700);
+    assert_eq!(mode(&first), 0o600);
+    assert_eq!(mode(&second), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn private_batch_mode_truncates_existing_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let path = dir.path().join("payload.json");
+    std::fs::write(&path, b"old longer content").unwrap();
+    let payload = vsock_proto::encode_write_files(&[vsock_proto::WriteFileBatchEntry {
+        path: path.to_str().unwrap(),
+        content: b"new",
+    }])
+    .unwrap();
+
+    let output = run_helper(&["--batch", "--private"], &payload);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn private_batch_mode_reports_later_failure_after_partial_progress() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("run/user-env/env.json");
+    let target = dir.path().join("target");
+    let link = dir.path().join("link");
+    std::fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let second = link.join("payload.json");
+    let payload = vsock_proto::encode_write_files(&[
+        vsock_proto::WriteFileBatchEntry {
+            path: first.to_str().unwrap(),
+            content: b"env",
+        },
+        vsock_proto::WriteFileBatchEntry {
+            path: second.to_str().unwrap(),
+            content: b"payload",
+        },
+    ])
+    .unwrap();
+
+    let output = run_helper(&["--batch", "--private"], &payload);
+
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&first).unwrap(), b"env");
+    assert_eq!(mode(&first), 0o600);
+    assert!(!target.join("payload.json").exists());
 }
 
 #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -41,7 +41,7 @@ use super::diagnostics::{
 use super::effective_cli_framework;
 use super::env::{
     PreparedRunPayload, build_env_json_for_run, build_user_env_json,
-    write_connector_account_context_file, write_run_payload_file, write_user_env_file,
+    write_connector_account_context_file, write_required_agent_files,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_cpu::{SessionHistoryCpuJob, SessionHistoryPrefixOutcome};
@@ -2037,28 +2037,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             );
         }
     }
-    let user_env_started = Instant::now();
-    let user_env_file = match write_user_env_file(sandbox, context.run_id, &user_env_map).await {
-        Ok(user_env_file) => {
-            telemetry.record(
-                "runner_user_env_write",
-                user_env_started.elapsed(),
-                true,
-                None,
-            );
-            user_env_file
-        }
-        Err(error) => {
-            telemetry.record_with_outcome(
-                "runner_user_env_write",
-                user_env_started.elapsed(),
-                false,
-                None,
-                private_write_timeout_stage(&error),
-            );
-            return Err(error);
-        }
-    };
     let env_build_started = Instant::now();
     let run_payload = match prepared_run_payload.into_run_payload(context) {
         Ok(run_payload) => run_payload,
@@ -2084,29 +2062,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         feature_flags_bytes = run_payload.feature_flags.len(),
         "guest-agent run payload prepared"
     );
-    let run_payload_write_started = Instant::now();
-    let run_payload_file = match write_run_payload_file(sandbox, context.run_id, &run_payload).await
-    {
-        Ok(path) => {
-            telemetry.record(
-                "runner_run_payload_write",
-                run_payload_write_started.elapsed(),
-                true,
-                None,
-            );
-            path
-        }
-        Err(error) => {
-            telemetry.record_with_outcome(
-                "runner_run_payload_write",
-                run_payload_write_started.elapsed(),
-                false,
-                None,
-                private_write_timeout_stage(&error),
-            );
-            return Err(error);
-        }
-    };
     let mut env_map = match build_env_json_for_run(
         context,
         &config.api_url,
@@ -2125,6 +2080,38 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             return Err(error);
         }
     };
+    telemetry.record(
+        "runner_agent_env_build",
+        env_build_started.elapsed(),
+        true,
+        None,
+    );
+
+    let required_private_files_started = Instant::now();
+    let required_files =
+        match write_required_agent_files(sandbox, context.run_id, &user_env_map, &run_payload).await {
+            Ok(required_files) => {
+                telemetry.record(
+                    "runner_required_private_files_write",
+                    required_private_files_started.elapsed(),
+                    true,
+                    None,
+                );
+                required_files
+            }
+            Err(error) => {
+                telemetry.record_with_outcome(
+                    "runner_required_private_files_write",
+                    required_private_files_started.elapsed(),
+                    false,
+                    None,
+                    private_write_timeout_stage(&error),
+                );
+                return Err(error);
+            }
+        };
+    let user_env_file = required_files.user_env_file;
+    let run_payload_file = required_files.run_payload_file;
     if let Some(path) = user_env_file {
         env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
     }
@@ -2138,12 +2125,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    telemetry.record(
-        "runner_agent_env_build",
-        env_build_started.elapsed(),
-        true,
-        None,
-    );
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
     // Spawn guest-agent with stdout streamed to the host via vsock. Its stderr

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -9,7 +9,7 @@ use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use guest_contracts::connector_account_context::{
     RunConnectorAccountContext, RunConnectorAccountTarget,
 };
-use sandbox::Sandbox;
+use sandbox::{Sandbox, WriteFileEntry};
 
 use super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
@@ -480,34 +480,49 @@ pub(super) async fn write_connector_account_context_file(
     Ok(file_path)
 }
 
-pub(super) async fn write_user_env_file(
+pub(super) struct RequiredAgentFiles {
+    pub(super) user_env_file: Option<String>,
+    pub(super) run_payload_file: String,
+}
+
+pub(super) async fn write_required_agent_files(
     sandbox: &dyn Sandbox,
     run_id: RunId,
     user_env: &HashMap<String, String>,
-) -> RunnerResult<Option<String>> {
-    if user_env.is_empty() {
-        return Ok(None);
-    }
-
-    let file_path = guest_user_env_file_path(run_id)?;
-    let payload = serde_json::to_vec(user_env)
-        .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
-    sandbox.write_private_file(&file_path, &payload).await?;
-
-    Ok(Some(file_path))
-}
-
-pub(super) async fn write_run_payload_file(
-    sandbox: &dyn Sandbox,
-    run_id: RunId,
     run_payload: &guest_contracts::env::RunPayload,
-) -> RunnerResult<String> {
-    let file_path = guest_run_payload_file_path(run_id)?;
-    let payload = serde_json::to_vec(run_payload)
+) -> RunnerResult<RequiredAgentFiles> {
+    let run_payload_file = guest_run_payload_file_path(run_id)?;
+    let run_payload_bytes = serde_json::to_vec(run_payload)
         .map_err(|e| RunnerError::Internal(format!("serialize run payload: {e}")))?;
-    sandbox.write_private_file(&file_path, &payload).await?;
 
-    Ok(file_path)
+    let user_env_file = if user_env.is_empty() {
+        sandbox
+            .write_private_file(&run_payload_file, &run_payload_bytes)
+            .await?;
+        None
+    } else {
+        let user_env_file = guest_user_env_file_path(run_id)?;
+        let user_env_bytes = serde_json::to_vec(user_env)
+            .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
+        sandbox
+            .write_private_files(&[
+                WriteFileEntry {
+                    path: &user_env_file,
+                    content: &user_env_bytes,
+                },
+                WriteFileEntry {
+                    path: &run_payload_file,
+                    content: &run_payload_bytes,
+                },
+            ])
+            .await?;
+        Some(user_env_file)
+    };
+
+    Ok(RequiredAgentFiles {
+        user_env_file,
+        run_payload_file,
+    })
 }
 
 pub(super) fn build_env_json_with_host_env(

--- a/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
@@ -310,6 +310,7 @@ async fn run_in_sandbox_starts_no_guest_work_when_already_cancelled() {
     assert!(overrides.exec_calls().is_empty());
     assert!(overrides.write_file_calls().is_empty());
     assert!(overrides.private_write_file_calls().is_empty());
+    assert!(overrides.private_write_files_calls().is_empty());
     assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }
@@ -343,6 +344,7 @@ async fn run_in_sandbox_observes_cancellation_while_guest_helper_is_pending() {
     assert_eq!(failure.error, "cancelled by user");
     assert!(overrides.exec_calls().is_empty());
     assert!(overrides.private_write_file_calls().is_empty());
+    assert!(overrides.private_write_files_calls().is_empty());
     assert!(overrides.start_agent_process_calls().is_empty());
     assert!(overrides.wait_process_calls().is_empty());
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -16,7 +16,7 @@ use super::super::env::{
     guest_connector_account_context_file_path, guest_run_payload_file_path,
     guest_user_env_file_path, is_runner_owned_env_key, validate_execution_context_before_sandbox,
     validate_model_provider_env_placeholders, write_connector_account_context_file,
-    write_run_payload_file, write_user_env_file,
+    write_required_agent_files,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -1176,94 +1176,144 @@ fn build_env_json_user_vars_cannot_override_system() {
 }
 
 #[tokio::test]
-async fn write_user_env_file_skips_empty_env() {
+async fn write_required_agent_files_uses_single_write_for_empty_user_env() {
     let sandbox = MockSandbox::new("test");
     let run_id = RunId::nil();
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "test prompt".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
 
-    let path = write_user_env_file(&sandbox, run_id, &HashMap::new())
+    let files = write_required_agent_files(&sandbox, run_id, &HashMap::new(), &payload)
         .await
         .unwrap();
 
-    assert!(path.is_none());
+    assert!(files.user_env_file.is_none());
+    assert_eq!(
+        files.run_payload_file,
+        guest_run_payload_file_path(run_id).unwrap()
+    );
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
-    assert!(sandbox.private_write_file_calls().is_empty());
+    assert!(sandbox.private_write_files_calls().is_empty());
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, files.run_payload_file);
+    let decoded: guest_contracts::env::RunPayload =
+        serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(decoded, payload);
 }
 
 #[tokio::test]
-async fn write_user_env_file_uses_private_write_for_small_env() {
+async fn write_required_agent_files_batches_user_env_before_run_payload() {
     let sandbox = MockSandbox::new("test");
     let run_id = RunId::nil();
     let user_env = HashMap::from([
         ("CUSTOM_ENV".to_string(), "value".to_string()),
         ("TZ".to_string(), "Asia/Shanghai".to_string()),
     ]);
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "test prompt".to_string(),
+        secret_values: "secret".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
 
-    let path = write_user_env_file(&sandbox, run_id, &user_env)
+    let files = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
         .await
-        .unwrap()
         .unwrap();
 
-    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
+    let user_env_file = files.user_env_file.unwrap();
+    assert_eq!(user_env_file, guest_user_env_file_path(run_id).unwrap());
+    assert_eq!(
+        files.run_payload_file,
+        guest_run_payload_file_path(run_id).unwrap()
+    );
     assert!(
-        path.ends_with(&format!(
+        user_env_file.ends_with(&format!(
             "/{}/{}",
             guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME,
             guest_contracts::env::USER_ENV_FILENAME
         )),
-        "got: {path}"
+        "got: {user_env_file}"
     );
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    let decoded: HashMap<String, String> = serde_json::from_slice(&writes[0].content).unwrap();
+    assert!(sandbox.private_write_file_calls().is_empty());
+    let batches = sandbox.private_write_files_calls();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].files.len(), 2);
+    assert_eq!(batches[0].files[0].path, user_env_file);
+    let decoded: HashMap<String, String> =
+        serde_json::from_slice(&batches[0].files[0].content).unwrap();
     assert_eq!(decoded, user_env);
+    assert_eq!(batches[0].files[1].path, files.run_payload_file);
+    let decoded: guest_contracts::env::RunPayload =
+        serde_json::from_slice(&batches[0].files[1].content).unwrap();
+    assert_eq!(decoded, payload);
 }
 
 #[tokio::test]
-async fn write_user_env_file_uses_private_write_for_large_env() {
+async fn write_required_agent_files_batches_large_values_without_truncation() {
     let sandbox = MockSandbox::new("test");
     let run_id = RunId::nil();
     let user_env = HashMap::from([(
         "CUSTOM_ENV".to_string(),
         "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
     )]);
-    let payload = serde_json::to_vec(&user_env).unwrap();
-    assert!(payload.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
+    let user_env_bytes = serde_json::to_vec(&user_env).unwrap();
+    assert!(user_env_bytes.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "y".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+        ..guest_contracts::env::RunPayload::default()
+    };
+    let run_payload_bytes = serde_json::to_vec(&payload).unwrap();
+    assert!(run_payload_bytes.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
 
-    let path = write_user_env_file(&sandbox, run_id, &user_env)
+    let files = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
         .await
-        .unwrap()
         .unwrap();
 
-    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
+    assert_eq!(
+        files.user_env_file,
+        Some(guest_user_env_file_path(run_id).unwrap())
+    );
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    assert_eq!(writes[0].content, payload);
+    assert!(sandbox.private_write_file_calls().is_empty());
+    let batches = sandbox.private_write_files_calls();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].files.len(), 2);
+    assert_eq!(batches[0].files[0].content, user_env_bytes);
+    assert_eq!(batches[0].files[1].content, run_payload_bytes);
 }
 
 #[tokio::test]
-async fn write_user_env_file_returns_private_write_error() {
+async fn write_required_agent_files_returns_private_batch_error() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_private_write_file_result(Err(sandbox_write_file_error("private write failed")));
+    sandbox.push_private_write_files_result(Err(sandbox_write_file_error(
+        "private batch write failed",
+    )));
     let run_id = RunId::nil();
     let user_env = HashMap::from([("CUSTOM_ENV".to_string(), "value".to_string())]);
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "test prompt".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
 
-    let err = write_user_env_file(&sandbox, run_id, &user_env)
+    let err = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
         .await
-        .unwrap_err();
+        .err()
+        .unwrap();
     let message = err.to_string();
 
-    assert!(message.contains("private write failed"), "got: {message}");
+    assert!(
+        message.contains("private batch write failed"),
+        "got: {message}"
+    );
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
+    assert!(sandbox.private_write_file_calls().is_empty());
+    assert_eq!(sandbox.private_write_files_calls().len(), 1);
 }
 
 #[tokio::test]
@@ -1341,53 +1391,6 @@ async fn write_connector_account_context_file_writes_known_empty_projection() {
             targets: Vec::new(),
         }
     );
-}
-
-#[tokio::test]
-async fn write_run_payload_file_uses_private_write_for_large_payload() {
-    let sandbox = MockSandbox::new("test");
-    let run_id = RunId::nil();
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-        append_system_prompt: "system".to_string(),
-        secret_values: "secret".to_string(),
-        ..guest_contracts::env::RunPayload::default()
-    };
-
-    let path = write_run_payload_file(&sandbox, run_id, &payload)
-        .await
-        .unwrap();
-
-    assert_eq!(path, guest_run_payload_file_path(run_id).unwrap());
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    let decoded: guest_contracts::env::RunPayload =
-        serde_json::from_slice(&writes[0].content).unwrap();
-    assert_eq!(decoded, payload);
-}
-
-#[tokio::test]
-async fn write_run_payload_file_returns_private_write_error() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_private_write_file_result(Err(sandbox_write_file_error("private write failed")));
-    let run_id = RunId::nil();
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "test prompt".to_string(),
-        ..guest_contracts::env::RunPayload::default()
-    };
-
-    let err = write_run_payload_file(&sandbox, run_id, &payload)
-        .await
-        .unwrap_err();
-    let message = err.to_string();
-
-    assert!(message.contains("private write failed"), "got: {message}");
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    assert_eq!(sandbox.private_write_file_calls().len(), 1);
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -13,15 +13,14 @@ use super::super::cli_framework::{
 };
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_run_payload_for_run, build_user_env_json,
-    guest_connector_account_context_file_path, guest_run_payload_file_path,
-    guest_user_env_file_path, is_runner_owned_env_key, validate_execution_context_before_sandbox,
-    validate_model_provider_env_placeholders, write_connector_account_context_file,
-    write_required_agent_files,
+    guest_connector_account_context_file_path, is_runner_owned_env_key,
+    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
+    write_connector_account_context_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
     api_artifact, api_storage, build_env_for_test, build_env_for_test_result,
-    build_env_for_test_with_host_env, context_with_env, minimal_context, sandbox_write_file_error,
+    build_env_for_test_with_host_env, context_with_env, minimal_context,
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::{
@@ -1173,147 +1172,6 @@ fn build_env_json_user_vars_cannot_override_system() {
     assert!(!env.contains_key("CUSTOM"));
     assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
     assert!(!user_env.contains_key("VM0_PROMPT"));
-}
-
-#[tokio::test]
-async fn write_required_agent_files_uses_single_write_for_empty_user_env() {
-    let sandbox = MockSandbox::new("test");
-    let run_id = RunId::nil();
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "test prompt".to_string(),
-        ..guest_contracts::env::RunPayload::default()
-    };
-
-    let files = write_required_agent_files(&sandbox, run_id, &HashMap::new(), &payload)
-        .await
-        .unwrap();
-
-    assert!(files.user_env_file.is_none());
-    assert_eq!(
-        files.run_payload_file,
-        guest_run_payload_file_path(run_id).unwrap()
-    );
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    assert!(sandbox.private_write_files_calls().is_empty());
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, files.run_payload_file);
-    let decoded: guest_contracts::env::RunPayload =
-        serde_json::from_slice(&writes[0].content).unwrap();
-    assert_eq!(decoded, payload);
-}
-
-#[tokio::test]
-async fn write_required_agent_files_batches_user_env_before_run_payload() {
-    let sandbox = MockSandbox::new("test");
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([
-        ("CUSTOM_ENV".to_string(), "value".to_string()),
-        ("TZ".to_string(), "Asia/Shanghai".to_string()),
-    ]);
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "test prompt".to_string(),
-        secret_values: "secret".to_string(),
-        ..guest_contracts::env::RunPayload::default()
-    };
-
-    let files = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
-        .await
-        .unwrap();
-
-    let user_env_file = files.user_env_file.unwrap();
-    assert_eq!(user_env_file, guest_user_env_file_path(run_id).unwrap());
-    assert_eq!(
-        files.run_payload_file,
-        guest_run_payload_file_path(run_id).unwrap()
-    );
-    assert!(
-        user_env_file.ends_with(&format!(
-            "/{}/{}",
-            guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME,
-            guest_contracts::env::USER_ENV_FILENAME
-        )),
-        "got: {user_env_file}"
-    );
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    assert!(sandbox.private_write_file_calls().is_empty());
-    let batches = sandbox.private_write_files_calls();
-    assert_eq!(batches.len(), 1);
-    assert_eq!(batches[0].files.len(), 2);
-    assert_eq!(batches[0].files[0].path, user_env_file);
-    let decoded: HashMap<String, String> =
-        serde_json::from_slice(&batches[0].files[0].content).unwrap();
-    assert_eq!(decoded, user_env);
-    assert_eq!(batches[0].files[1].path, files.run_payload_file);
-    let decoded: guest_contracts::env::RunPayload =
-        serde_json::from_slice(&batches[0].files[1].content).unwrap();
-    assert_eq!(decoded, payload);
-}
-
-#[tokio::test]
-async fn write_required_agent_files_batches_large_values_without_truncation() {
-    let sandbox = MockSandbox::new("test");
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([(
-        "CUSTOM_ENV".to_string(),
-        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-    )]);
-    let user_env_bytes = serde_json::to_vec(&user_env).unwrap();
-    assert!(user_env_bytes.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "y".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-        ..guest_contracts::env::RunPayload::default()
-    };
-    let run_payload_bytes = serde_json::to_vec(&payload).unwrap();
-    assert!(run_payload_bytes.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
-
-    let files = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
-        .await
-        .unwrap();
-
-    assert_eq!(
-        files.user_env_file,
-        Some(guest_user_env_file_path(run_id).unwrap())
-    );
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    assert!(sandbox.private_write_file_calls().is_empty());
-    let batches = sandbox.private_write_files_calls();
-    assert_eq!(batches.len(), 1);
-    assert_eq!(batches[0].files.len(), 2);
-    assert_eq!(batches[0].files[0].content, user_env_bytes);
-    assert_eq!(batches[0].files[1].content, run_payload_bytes);
-}
-
-#[tokio::test]
-async fn write_required_agent_files_returns_private_batch_error() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_private_write_files_result(Err(sandbox_write_file_error(
-        "private batch write failed",
-    )));
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([("CUSTOM_ENV".to_string(), "value".to_string())]);
-    let payload = guest_contracts::env::RunPayload {
-        prompt: "test prompt".to_string(),
-        ..guest_contracts::env::RunPayload::default()
-    };
-
-    let err = write_required_agent_files(&sandbox, run_id, &user_env, &payload)
-        .await
-        .err()
-        .unwrap();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("private batch write failed"),
-        "got: {message}"
-    );
-    assert!(sandbox.exec_calls().is_empty());
-    assert!(sandbox.write_file_calls().is_empty());
-    assert!(sandbox.private_write_file_calls().is_empty());
-    assert_eq!(sandbox.private_write_files_calls().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1040,9 +1040,14 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
+    ctx.prompt = "p".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES);
     ctx.user_timezone = Some("Asia/Shanghai".into());
     ctx.environment = Some(HashMap::from([
         ("CUSTOM_USER_ENV".into(), "visible-to-cli".into()),
+        (
+            "LARGE_USER_ENV".into(),
+            "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+        ),
         (
             "OKOU_APP_URL".into(),
             "https://app.runner-env.example.test/path".into(),
@@ -1130,6 +1135,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     }
     for key in [
         "CUSTOM_USER_ENV",
+        "LARGE_USER_ENV",
         "OKOU_APP_URL",
         "ZERO_APP_URL",
         "VM0_APP_URL",
@@ -1167,6 +1173,10 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let user_env: HashMap<String, String> =
         serde_json::from_slice(&user_env_write.content).unwrap();
     assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
+    assert_eq!(
+        user_env.get("LARGE_USER_ENV").unwrap().len(),
+        vsock_proto::MAX_EXEC_STDIN_BYTES
+    );
     assert_eq!(
         user_env.get("OKOU_APP_URL").unwrap(),
         "https://app.runner-env.example.test/path"

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1152,19 +1152,18 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "user env file should not be written through shell exec"
     );
     let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 3);
-    let user_env_write = private_writes
-        .iter()
-        .find(|write| write.path == expected_user_env_file)
-        .unwrap();
-    let run_payload_write = private_writes
-        .iter()
-        .find(|write| write.path == expected_run_payload_file)
-        .unwrap();
+    assert_eq!(private_writes.len(), 1);
     let connector_account_context_write = private_writes
         .iter()
         .find(|write| write.path == expected_connector_account_context_file)
         .unwrap();
+    let private_batches = overrides.private_write_files_calls();
+    assert_eq!(private_batches.len(), 1);
+    assert_eq!(private_batches[0].files.len(), 2);
+    let user_env_write = &private_batches[0].files[0];
+    assert_eq!(user_env_write.path, expected_user_env_file);
+    let run_payload_write = &private_batches[0].files[1];
+    assert_eq!(run_payload_write.path, expected_run_payload_file);
     let user_env: HashMap<String, String> =
         serde_json::from_slice(&user_env_write.content).unwrap();
     assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
@@ -1235,6 +1234,7 @@ async fn execute_inner_continues_when_connector_account_context_write_fails() {
     assert!(error_msg.is_none());
     let private_writes = overrides.private_write_file_calls();
     assert_eq!(private_writes.len(), 2);
+    assert!(overrides.private_write_files_calls().is_empty());
     assert_eq!(
         private_writes[0].path,
         guest_connector_account_context_file_path(context.run_id).unwrap()
@@ -1255,8 +1255,7 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_private_write_file_result(Ok(()));
-    overrides.push_private_write_file_result(Ok(()));
-    overrides.push_private_write_file_result(Err(sandbox_write_file_error(
+    overrides.push_private_write_files_result(Err(sandbox_write_file_error(
         "No space left on device (os error 28)",
     )));
     overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
@@ -1287,13 +1286,23 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
         Some(ResourceFailureKind::GuestRootFilesystemFull)
     );
     let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 3);
+    assert_eq!(private_writes.len(), 1);
     assert!(
-        private_writes[2]
+        private_writes[0]
+            .path
+            .ends_with("/connector-account-context/context.json"),
+        "got: {}",
+        private_writes[0].path
+    );
+    let private_batches = overrides.private_write_files_calls();
+    assert_eq!(private_batches.len(), 1);
+    assert_eq!(private_batches[0].files.len(), 2);
+    assert!(
+        private_batches[0].files[1]
             .path
             .ends_with("/run-payload/payload.json"),
         "got: {}",
-        private_writes[2].path
+        private_batches[0].files[1].path
     );
     assert!(
         overrides.start_agent_process_calls().is_empty(),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -10,6 +10,7 @@ use sandbox::{
     SandboxInitializationPhase, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
     SandboxNbdNetlinkConnectStage, SandboxOperation, SandboxOperationReason,
     SandboxOperationTimeoutStage, SandboxStartObserver, SandboxStartStage, StartProcessRequest,
+    WriteFileEntry,
 };
 use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
@@ -383,6 +384,10 @@ impl Sandbox for ObservedStartSandbox {
 
     async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         self.inner.write_private_file(path, content).await
+    }
+
+    async fn write_private_files(&self, files: &[WriteFileEntry<'_>]) -> sandbox::Result<()> {
+        self.inner.write_private_files(files).await
     }
 
     async fn start_process(
@@ -1112,7 +1117,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_fresh_sandbox_proxy_register",
         "runner_fresh_sandbox_start",
         "runner_guest_timezone_sync",
-        "runner_user_env_write",
+        "runner_required_private_files_write",
         "runner_agent_env_build",
         "runner_agent_start_process",
         "runner_agent_start_to_ready",
@@ -1571,7 +1576,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         "runner_claim_to_agent_ready",
         "runner_reused_sandbox_prepare",
         "runner_guest_state_restore",
-        "runner_user_env_write",
+        "runner_required_private_files_write",
         "runner_agent_env_build",
         "runner_agent_start_process",
         "runner_agent_start_to_ready",
@@ -1603,8 +1608,6 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 
 async fn assert_reused_private_write_timeout_telemetry(
     context: crate::types::ExecutionContext,
-    expected_action: &str,
-    successful_writes_before: usize,
     stage: SandboxOperationTimeoutStage,
     expected_outcome: &str,
 ) {
@@ -1618,10 +1621,8 @@ async fn assert_reused_private_write_timeout_telemetry(
     let source_ip = sandbox.source_ip().to_string();
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
-    for _ in 0..successful_writes_before {
-        overrides.push_private_write_file_result(Ok(()));
-    }
-    overrides.push_private_write_file_result(Err(SandboxError::OperationTimeout {
+    overrides.push_private_write_file_result(Ok(()));
+    overrides.push_private_write_files_result(Err(SandboxError::OperationTimeout {
         operation: SandboxOperation::WriteFile,
         stage,
         timeout_ms: 60_000,
@@ -1649,13 +1650,15 @@ async fn assert_reused_private_write_timeout_telemetry(
         outcome.sandbox_reuse_disposition,
         SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain)
     );
-    assert_action_bounded_outcome(&telemetry, expected_action, expected_outcome);
+    assert_action_bounded_outcome(
+        &telemetry,
+        "runner_required_private_files_write",
+        expected_outcome,
+    );
     assert_lacks_action(&telemetry, "runner_agent_start_process");
     assert!(overrides.start_agent_process_calls().is_empty());
-    assert_eq!(
-        overrides.private_write_file_calls().len(),
-        successful_writes_before + 1
-    );
+    assert_eq!(overrides.private_write_file_calls().len(), 1);
+    assert_eq!(overrides.private_write_files_calls().len(), 1);
 }
 
 #[tokio::test]
@@ -1714,7 +1717,7 @@ async fn reused_connector_account_context_timeout_records_failure_and_continues(
 }
 
 #[tokio::test]
-async fn reused_user_env_write_timeout_records_bounded_stage_before_agent_start() {
+async fn reused_required_private_files_timeout_records_bounded_stage_before_agent_start() {
     let context = context_with_env(HashMap::from([(
         "CUSTOM_ENV".to_string(),
         "value".to_string(),
@@ -1722,22 +1725,8 @@ async fn reused_user_env_write_timeout_records_bounded_stage_before_agent_start(
 
     assert_reused_private_write_timeout_telemetry(
         context,
-        "runner_user_env_write",
-        1,
         SandboxOperationTimeoutStage::FrameWrite,
         "frame_write",
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn reused_run_payload_write_timeout_records_bounded_stage_before_agent_start() {
-    assert_reused_private_write_timeout_telemetry(
-        minimal_context(),
-        "runner_run_payload_write",
-        2,
-        SandboxOperationTimeoutStage::AwaitingTerminalResponse,
-        "await_terminal_response",
     )
     .await;
 }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2586,6 +2586,22 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
+    async fn write_private_files(&self, files: &[WriteFileEntry<'_>]) -> sandbox::Result<()> {
+        let operation = SandboxOperation::WriteFile;
+        let files = files
+            .iter()
+            .map(|file| vsock_host::WriteFileEntry {
+                path: file.path,
+                content: file.content,
+            })
+            .collect::<Vec<_>>();
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.write_private_files(&files).await
+        })
+        .await
+    }
+
     async fn start_process(
         &self,
         request: &StartProcessRequest<'_>,

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -78,6 +78,10 @@ pub(crate) struct FileOverrideState {
     pub(crate) private_write_file_calls: Mutex<Vec<WriteFileCall>>,
     /// FIFO queue of write_private_file results consumed by factory-created sandboxes.
     pub(crate) private_write_file_results: Mutex<VecDeque<Result<()>>>,
+    /// Recorded write_private_files calls across all sandboxes built from this override set.
+    pub(crate) private_write_files_calls: Mutex<Vec<WriteFilesCall>>,
+    /// FIFO queue of write_private_files results consumed by factory-created sandboxes.
+    pub(crate) private_write_files_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of read_file results consumed by factory-created sandboxes.
     pub(crate) read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     /// FIFO queue of copy_file results consumed by factory-created sandboxes.
@@ -590,12 +594,31 @@ impl MockSandboxOverrides {
             .clone()
     }
 
+    /// Return recorded private write-files batch calls across all sandboxes
+    /// built from this override set.
+    pub fn private_write_files_calls(&self) -> Vec<WriteFilesCall> {
+        self.file
+            .private_write_files_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
     /// Queue a write_private_file result applied to the next private write made
     /// through any sandbox built from these overrides after that sandbox's
     /// local private-write queue is empty.
     pub fn push_private_write_file_result(&self, result: Result<()>) {
         self.file
             .private_write_file_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    /// Queue a write_private_files result applied to the next private batch
+    /// made through any sandbox built from these overrides after that
+    /// sandbox's local private-batch queue is empty.
+    pub fn push_private_write_files_result(&self, result: Result<()>) {
+        self.file
+            .private_write_files_results
             .lock_ignoring_poison()
             .push_back(result);
     }

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -48,6 +48,8 @@ pub struct MockSandbox {
     write_files_calls: Mutex<Vec<WriteFilesCall>>,
     private_write_file_results: Mutex<VecDeque<Result<()>>>,
     private_write_file_calls: Mutex<Vec<WriteFileCall>>,
+    private_write_files_results: Mutex<VecDeque<Result<()>>>,
+    private_write_files_calls: Mutex<Vec<WriteFilesCall>>,
     write_file_gate: Mutex<Option<MockLifecycleGate>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when an override requests a
@@ -91,6 +93,8 @@ impl MockSandbox {
             write_files_calls: Mutex::new(Vec::new()),
             private_write_file_results: Mutex::new(VecDeque::new()),
             private_write_file_calls: Mutex::new(Vec::new()),
+            private_write_files_results: Mutex::new(VecDeque::new()),
+            private_write_files_calls: Mutex::new(Vec::new()),
             write_file_gate: Mutex::new(None),
             overrides,
             stdout_tx: Mutex::new(None),
@@ -338,6 +342,22 @@ impl MockSandbox {
     /// [`MockSandboxOverrides::private_write_file_calls`].
     pub fn private_write_file_calls(&self) -> Vec<WriteFileCall> {
         self.private_write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Queue a write_private_files result. Results are consumed in FIFO order.
+    /// When the queue is empty, a valid non-empty private batch returns
+    /// `Ok(())` unless a shared override result is available.
+    pub fn push_private_write_files_result(&self, result: Result<()>) {
+        self.private_write_files_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    /// Return this sandbox's recorded private write-files batch calls.
+    pub fn private_write_files_calls(&self) -> Vec<WriteFilesCall> {
+        self.private_write_files_calls
+            .lock_ignoring_poison()
+            .clone()
     }
 
     /// Block every write operation with a durable lifecycle gate.
@@ -1101,6 +1121,58 @@ impl Sandbox for MockSandbox {
             overrides
                 .file
                 .private_write_file_results
+                .lock_ignoring_poison()
+                .pop_front()
+        }) {
+            return result;
+        }
+        Ok(())
+    }
+
+    async fn write_private_files(&self, files: &[WriteFileEntry<'_>]) -> Result<()> {
+        if files.is_empty() {
+            return Ok(());
+        }
+        if let Some(overrides) = &self.overrides {
+            wait_lifecycle_gate(&overrides.file.private_write_file_gate).await;
+        }
+        let batch_call = WriteFilesCall {
+            files: files
+                .iter()
+                .map(|file| WriteFileCall {
+                    path: file.path.to_string(),
+                    content: file.content.to_vec(),
+                })
+                .collect(),
+        };
+        self.private_write_files_calls
+            .lock_ignoring_poison()
+            .push(batch_call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .file
+                .private_write_files_calls
+                .lock_ignoring_poison()
+                .push(batch_call);
+        }
+        for file in files {
+            validate_mock_guest_file_path(
+                SandboxOperation::WriteFile,
+                "write_private_files",
+                file.path,
+            )?;
+        }
+        if let Some(result) = self
+            .private_write_files_results
+            .lock_ignoring_poison()
+            .pop_front()
+        {
+            return result;
+        }
+        if let Some(result) = self.overrides.as_ref().and_then(|overrides| {
+            overrides
+                .file
+                .private_write_files_results
                 .lock_ignoring_poison()
                 .pop_front()
         }) {

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -650,6 +650,99 @@ async fn sandbox_write_private_file_queued_error_and_records_calls() {
 }
 
 #[tokio::test]
+async fn sandbox_write_private_files_consumes_one_result_and_records_one_batch() {
+    let sandbox = MockSandbox::new("test-1");
+    sandbox.push_private_write_files_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "private batch failed".into(),
+    }));
+    let files = [
+        WriteFileEntry {
+            path: "/tmp/private-a.env",
+            content: b"alpha",
+        },
+        WriteFileEntry {
+            path: "/tmp/private-b.json",
+            content: b"beta",
+        },
+    ];
+
+    let error = sandbox.write_private_files(&files).await.unwrap_err();
+    assert_operation_error(
+        error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "private batch failed",
+    );
+    sandbox.write_private_files(&files).await.unwrap();
+
+    assert!(sandbox.private_write_file_calls().is_empty());
+    let calls = sandbox.private_write_files_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].files.len(), 2);
+    assert_eq!(calls[0].files[0].path, "/tmp/private-a.env");
+    assert_eq!(calls[0].files[0].content, b"alpha");
+    assert_eq!(calls[0].files[1].path, "/tmp/private-b.json");
+    assert_eq!(calls[0].files[1].content, b"beta");
+}
+
+#[tokio::test]
+async fn shared_private_write_gate_blocks_private_batch_before_recording() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let gate = MockLifecycleGate::new();
+    overrides.set_private_write_file_lifecycle_gate(gate.clone());
+    overrides.push_private_write_files_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "queued private batch failed".into(),
+    }));
+    let sandbox = Arc::new(MockSandbox::with_overrides(
+        "test-1",
+        Arc::clone(&overrides),
+    ));
+
+    let blocked_write = {
+        let sandbox = Arc::clone(&sandbox);
+        tokio::spawn(async move {
+            sandbox
+                .write_private_files(&[
+                    WriteFileEntry {
+                        path: "/tmp/private-a.env",
+                        content: b"alpha",
+                    },
+                    WriteFileEntry {
+                        path: "/tmp/private-b.json",
+                        content: b"beta",
+                    },
+                ])
+                .await
+        })
+    };
+    assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+    assert!(overrides.private_write_files_calls().is_empty());
+
+    blocked_write.abort();
+    assert!(blocked_write.await.unwrap_err().is_cancelled());
+    overrides.clear_private_write_file_lifecycle_gate();
+
+    let error = sandbox
+        .write_private_files(&[WriteFileEntry {
+            path: "/tmp/private-next.env",
+            content: b"next",
+        }])
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "queued private batch failed",
+    );
+    assert_eq!(overrides.private_write_files_calls().len(), 1);
+}
+
+#[tokio::test]
 async fn shared_private_write_gate_blocks_before_recording_or_result_consumption() {
     let overrides = Arc::new(MockSandboxOverrides::new());
     let gate = MockLifecycleGate::new();

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -825,6 +825,22 @@ pub trait Sandbox: Send + Sync + Any {
     /// The guest path must be non-empty and must not contain NUL bytes.
     async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()>;
 
+    /// Write multiple private runtime files inside the guest.
+    ///
+    /// Each entry has the same private path, parent, ownership, and permission
+    /// semantics as [`write_private_file`](Self::write_private_file). An empty
+    /// batch is accepted as a no-op. A later failure can leave earlier entries
+    /// complete, but the operation returns an error.
+    ///
+    /// The default implementation preserves compatibility by writing entries
+    /// sequentially with [`write_private_file`](Self::write_private_file).
+    async fn write_private_files(&self, files: &[WriteFileEntry<'_>]) -> Result<()> {
+        for file in files {
+            self.write_private_file(file.path, file.content).await?;
+        }
+        Ok(())
+    }
+
     /// Start `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_process`](Self::wait_process).
     ///

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -41,11 +41,10 @@ pub const EXEC_OUTPUT_LIMIT_1_MIB: ExecOutputLimits = ExecOutputLimits::same(102
 /// Larger output budget used by interactive runner exec-style tooling.
 pub const EXEC_OUTPUT_LIMIT_7_MIB: ExecOutputLimits = ExecOutputLimits::same(7 * 1024 * 1024);
 
-/// One ordinary guest file write entry for a multi-file write operation.
+/// One guest file entry for a typed multi-file write operation.
 ///
-/// Entries use the same semantics as [`crate::Sandbox::write_file`]: create
-/// missing parent directories, create or truncate the target file, and write
-/// the provided bytes without private runtime-file semantics.
+/// The selected [`crate::Sandbox`] method defines whether entries use ordinary
+/// or private runtime-file semantics.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WriteFileEntry<'a> {
     /// Guest path to create or replace.

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -11,7 +11,7 @@ use vsock_proto::{
     MSG_GUEST_DNS_READINESS, MSG_GUEST_STATE_RESTORE, MSG_GUEST_STORAGE_MANIFEST,
     MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
-    MSG_WRITE_FILE, MSG_WRITE_FILES,
+    MSG_WRITE_FILE, MSG_WRITE_FILES, MSG_WRITE_PRIVATE_FILES,
 };
 
 use crate::error::to_io_error;
@@ -138,6 +138,7 @@ fn is_real_host_work_message(msg_type: u8) -> bool {
             | MSG_EXEC_CONTROL
             | MSG_WRITE_FILE
             | MSG_WRITE_FILES
+            | MSG_WRITE_PRIVATE_FILES
             | MSG_GUEST_DNS_READINESS
             | MSG_GUEST_STATE_RESTORE
             | MSG_GUEST_STORAGE_MANIFEST
@@ -365,6 +366,7 @@ impl ConnectionDispatcher {
             MSG_EXEC_CONTROL => self.handle_exec_control(msg)?,
             MSG_WRITE_FILE => self.handle_file_write(msg, FileWriteKind::File)?,
             MSG_WRITE_FILES => self.handle_file_write(msg, FileWriteKind::Files)?,
+            MSG_WRITE_PRIVATE_FILES => self.handle_file_write(msg, FileWriteKind::PrivateFiles)?,
             MSG_GUEST_DNS_READINESS => self.handle_guest_dns_readiness(msg)?,
             MSG_GUEST_STATE_RESTORE => self.handle_guest_state_restore(msg)?,
             MSG_GUEST_STORAGE_MANIFEST => self.handle_guest_storage_manifest(msg)?,
@@ -1180,6 +1182,7 @@ mod tests {
             MSG_EXEC_CONTROL,
             MSG_WRITE_FILE,
             MSG_WRITE_FILES,
+            MSG_WRITE_PRIVATE_FILES,
             MSG_GUEST_DNS_READINESS,
             MSG_GUEST_STORAGE_MANIFEST,
             MSG_QUIESCE_OPERATIONS,

--- a/crates/vsock-guest/src/file_write_worker.rs
+++ b/crates/vsock-guest/src/file_write_worker.rs
@@ -21,6 +21,7 @@ const THREAD_FILE_WRITE: &str = "vsock-file-write";
 pub(crate) enum FileWriteKind {
     File,
     Files,
+    PrivateFiles,
 }
 
 impl FileWriteKind {
@@ -28,13 +29,14 @@ impl FileWriteKind {
         match self {
             Self::File => "write_file",
             Self::Files => "write_files",
+            Self::PrivateFiles => "write_private_files",
         }
     }
 
     pub(crate) fn validate_payload(self, payload: &[u8]) -> Result<(), vsock_proto::ProtocolError> {
         match self {
             Self::File => decode_write_file_message(payload).map(|_| ()),
-            Self::Files => decode_write_files_message(payload).map(|_| ()),
+            Self::Files | Self::PrivateFiles => decode_write_files_message(payload).map(|_| ()),
         }
     }
 }
@@ -156,7 +158,12 @@ fn handle_request(
         FileWriteKind::Files => decode_write_files_message(&payload)
             .map_err(protocol_error)
             .and_then(|decoded| {
-                handle_decoded_write_files_message(seq, decoded, connection_cancel)
+                handle_decoded_write_files_message(seq, decoded, false, connection_cancel)
+            }),
+        FileWriteKind::PrivateFiles => decode_write_files_message(&payload)
+            .map_err(protocol_error)
+            .and_then(|decoded| {
+                handle_decoded_write_files_message(seq, decoded, true, connection_cancel)
             }),
     };
     // Admission may be released at the writer boundary, but do not retain the

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -82,14 +82,20 @@ fn handle_write_files(
     payload: &[u8],
     file_count: usize,
     content_bytes: usize,
+    private: bool,
     connection_cancel: &AtomicBool,
 ) -> (bool, String) {
+    let operation = if private {
+        "write_private_files"
+    } else {
+        "write_files"
+    };
     log(
         "INFO",
-        &format!("write_files: files={file_count} content_bytes={content_bytes}"),
+        &format!("{operation}: files={file_count} content_bytes={content_bytes}"),
     );
 
-    let child = match spawn_write_files_command() {
+    let child = match spawn_write_files_command(private) {
         Ok(c) => c,
         Err(e) => return (false, format!("Failed to spawn batch write command: {e}")),
     };
@@ -279,10 +285,13 @@ fn spawn_write_file_command(
     spawn_in_own_process_group(&mut command)
 }
 
-fn spawn_write_files_command() -> io::Result<Child> {
+fn spawn_write_files_command(private: bool) -> io::Result<Child> {
     let mut command = Command::new(guest_write_file_path());
+    command.arg("--batch");
+    if private {
+        command.arg("--private");
+    }
     command
-        .arg("--batch")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
@@ -358,12 +367,14 @@ pub(crate) fn handle_decoded_write_file_message(
 pub(crate) fn handle_decoded_write_files_message(
     seq: u32,
     decoded: DecodedWriteFilesMessage<'_>,
+    private: bool,
     connection_cancel: &AtomicBool,
 ) -> io::Result<Vec<u8>> {
     let (success, error) = handle_write_files(
         decoded.payload,
         decoded.file_count,
         decoded.content_bytes,
+        private,
         connection_cancel,
     );
     let payload = vsock_proto::encode_write_files_result(success, &error);

--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -4,7 +4,7 @@ use vsock_proto::{
     self, ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_MEMORY_SNAPSHOT,
     MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
     MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
-    WriteFileBatchEntry,
+    MSG_WRITE_PRIVATE_FILES, WriteFileBatchEntry,
 };
 
 use super::support::*;
@@ -152,6 +152,7 @@ fn quiesced_connection_rejects_file_write_variants_without_creating_files() {
     for (variant, msg_type) in [
         ("write-file", MSG_WRITE_FILE),
         ("write-files", MSG_WRITE_FILES),
+        ("write-private-files", MSG_WRITE_PRIVATE_FILES),
     ] {
         let (handle, mut host_stream) = start_guest_connection();
         let path = unique_tmp_path(&format!("quiesce-{variant}"), ".txt");
@@ -188,6 +189,7 @@ fn quiesced_connection_rejects_file_write_zero_sequences_before_quiesce_state() 
     for (msg_type, operation_label) in [
         (MSG_WRITE_FILE, "write_file"),
         (MSG_WRITE_FILES, "write_files"),
+        (MSG_WRITE_PRIVATE_FILES, "write_private_files"),
     ] {
         let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use vsock_proto::{self, MSG_WRITE_FILE, MSG_WRITE_FILES, WriteFileBatchEntry};
+use vsock_proto::{
+    self, MSG_WRITE_FILE, MSG_WRITE_FILES, MSG_WRITE_PRIVATE_FILES, WriteFileBatchEntry,
+};
 
 use super::support::{
     assert_ping_pong, finish_guest_connection, read_error_response, send_control_payload,
@@ -52,6 +54,24 @@ fn write_files_seq_zero_does_not_write_valid_payload() {
 }
 
 #[test]
+fn write_private_files_seq_zero_does_not_write_valid_payload() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let path = unique_tmp_path("write-private-files-seq-zero", ".txt");
+    let payload = vsock_proto::encode_write_files(&[WriteFileBatchEntry {
+        path: path.as_str(),
+        content: b"should-not-write",
+    }])
+    .expect("encode write_private_files");
+
+    send_control_payload(&mut host_stream, MSG_WRITE_PRIVATE_FILES, 0, &payload);
+    let error = read_error_response(&mut host_stream, 0);
+    assert_eq!(error, "write_private_files requires non-zero sequence");
+    assert!(!Path::new(path.as_str()).exists());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn malformed_write_file_payload_returns_error_and_keeps_connection_open() {
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -73,6 +93,19 @@ fn malformed_write_files_payload_returns_error_and_keeps_connection_open() {
     assert_eq!(error, "invalid payload: write_files path_len truncated");
 
     assert_ping_pong(&mut host_stream, 42);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn malformed_write_private_files_payload_returns_error_and_keeps_connection_open() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_control_payload(&mut host_stream, MSG_WRITE_PRIVATE_FILES, 51, &[0, 1]);
+    let error = read_error_response(&mut host_stream, 51);
+    assert_eq!(error, "invalid payload: write_files path_len truncated");
+
+    assert_ping_pong(&mut host_stream, 52);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -227,4 +227,18 @@ pub(crate) mod test_support {
         )
         .await
     }
+
+    pub(crate) async fn write_private_files_with_small_limits(
+        host: &VsockHost,
+        files: &[crate::WriteFileEntry<'_>],
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
+        host.write_private_files_with_write_observer_and_limits(
+            files,
+            write_observer,
+            TEST_WRITE_FILE_CHUNK_LIMIT,
+            TEST_WRITE_FILE_CHUNK_LIMIT,
+        )
+        .await
+    }
 }

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -765,7 +765,12 @@ impl VsockHost {
         }
 
         let validated = validate_write_files(files, WriteFilesMode::Private)?;
-        if files.len() == 1 || validated.total_content_len > batch_content_limit {
+        let batch_fits_protocol =
+            vsock_proto::validate_write_files(&validated.proto_entries).is_ok();
+        if files.len() == 1
+            || validated.total_content_len > batch_content_limit
+            || !batch_fits_protocol
+        {
             for file in files {
                 self.write_private_file_with_write_observer_and_chunk_limit(
                     file.path,

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -73,13 +73,46 @@ impl<'a> WriteFileChunkRequest<'a> {
     }
 }
 
-/// One ordinary guest file write entry for [`VsockHost::write_files`].
+/// One guest file entry for [`VsockHost::write_files`] or
+/// [`VsockHost::write_private_files`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WriteFileEntry<'a> {
     /// Guest path to create or replace.
     pub path: &'a str,
     /// Bytes to write to the guest path.
     pub content: &'a [u8],
+}
+
+#[derive(Clone, Copy)]
+enum WriteFilesMode {
+    Ordinary,
+    Private,
+}
+
+impl WriteFilesMode {
+    const fn operation_name(self) -> &'static str {
+        match self {
+            Self::Ordinary => "write_files",
+            Self::Private => "write_private_files",
+        }
+    }
+
+    fn encode_frame(
+        self,
+        frame: &mut Vec<u8>,
+        seq: u32,
+        files: &[vsock_proto::WriteFileBatchEntry<'_>],
+    ) -> Result<(), vsock_proto::ProtocolError> {
+        match self {
+            Self::Ordinary => vsock_proto::encode_write_files_frame_into(frame, seq, files),
+            Self::Private => vsock_proto::encode_private_write_files_frame_into(frame, seq, files),
+        }
+    }
+}
+
+struct ValidatedWriteFiles<'a> {
+    proto_entries: Vec<vsock_proto::WriteFileBatchEntry<'a>>,
+    total_content_len: usize,
 }
 
 #[derive(Debug)]
@@ -379,9 +412,11 @@ impl VsockHost {
     /// This contract applies to every public file-write future on [`VsockHost`]:
     /// this method, [`write_files`](Self::write_files),
     /// [`write_private_file`](Self::write_private_file),
+    /// [`write_private_files`](Self::write_private_files),
     /// [`write_file_with_write_observer`](Self::write_file_with_write_observer),
     /// [`write_files_with_write_observer`](Self::write_files_with_write_observer),
-    /// and [`write_private_file_with_write_observer`](Self::write_private_file_with_write_observer).
+    /// [`write_private_file_with_write_observer`](Self::write_private_file_with_write_observer),
+    /// and [`write_private_files_with_write_observer`](Self::write_private_files_with_write_observer).
     ///
     /// Dropping one of these futures before any request frame starts writing
     /// sends no file-write request and leaves the connection reusable for later
@@ -404,8 +439,9 @@ impl VsockHost {
     /// does not prove the destination outcome or restore connection reuse. A
     /// chunked private write modifies the final path directly, can leave partial
     /// content, and has no rollback cleanup. The effects of a cancelled
-    /// [`write_files`](Self::write_files) batch are likewise unproven once its
-    /// frame starts writing.
+    /// [`write_files`](Self::write_files) or
+    /// [`write_private_files`](Self::write_private_files) batch are likewise
+    /// unproven once its frame starts writing.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
         self.write_file_with_write_observer(path, content, sudo, FrameWriteObserver::default())
             .await
@@ -424,6 +460,24 @@ impl VsockHost {
     /// [shared file-write cancellation contract](Self::write_file).
     pub async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> io::Result<()> {
         self.write_files_with_write_observer(files, FrameWriteObserver::default())
+            .await
+    }
+
+    /// Write multiple private runtime files on the guest.
+    ///
+    /// A fitting multi-entry request uses one private batch helper. Empty input
+    /// is a no-op, one entry uses [`write_private_file`](Self::write_private_file),
+    /// and aggregate content above the batch limit falls back to sequential
+    /// private writes so existing chunking behavior is preserved.
+    ///
+    /// All paths and the entry-count bound are validated before any fallback
+    /// write begins. A later failure can leave earlier entries complete, but
+    /// the operation still returns an error.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file).
+    pub async fn write_private_files(&self, files: &[WriteFileEntry<'_>]) -> io::Result<()> {
+        self.write_private_files_with_write_observer(files, FrameWriteObserver::default())
             .await
     }
 
@@ -660,41 +714,86 @@ impl VsockHost {
         if files.is_empty() {
             return Ok(());
         }
-        if files.len() > WRITE_FILES_BATCH_FILE_LIMIT {
+        let validated = validate_write_files(files, WriteFilesMode::Ordinary)?;
+        if validated.total_content_len > WRITE_FILES_BATCH_CONTENT_LIMIT {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
-                    "write_files batch contains {} files, limit is {WRITE_FILES_BATCH_FILE_LIMIT}",
-                    files.len()
+                    "write_files batch contains {} content bytes, limit is {WRITE_FILES_BATCH_CONTENT_LIMIT}",
+                    validated.total_content_len
                 ),
             ));
+        }
+        self.write_validated_files_batch(
+            files,
+            validated.proto_entries,
+            WriteFilesMode::Ordinary,
+            write_observer,
+        )
+        .await
+    }
+
+    /// Write multiple private runtime files and report before each request
+    /// frame is written.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file); the observer
+    /// reports the frame-write boundaries described there.
+    pub async fn write_private_files_with_write_observer(
+        &self,
+        files: &[WriteFileEntry<'_>],
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
+        self.write_private_files_with_write_observer_and_limits(
+            files,
+            write_observer,
+            WRITE_FILES_BATCH_CONTENT_LIMIT,
+            WRITE_FILE_CHUNK_LIMIT,
+        )
+        .await
+    }
+
+    pub(super) async fn write_private_files_with_write_observer_and_limits(
+        &self,
+        files: &[WriteFileEntry<'_>],
+        write_observer: FrameWriteObserver,
+        batch_content_limit: usize,
+        chunk_limit: usize,
+    ) -> io::Result<()> {
+        if files.is_empty() {
+            return Ok(());
         }
 
-        let mut total_content_len = 0usize;
-        let mut proto_entries = Vec::with_capacity(files.len());
-        for file in files {
-            validate_guest_file_path(file.path)?;
-            total_content_len = total_content_len
-                .checked_add(file.content.len())
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "write_files content length overflow",
-                    )
-                })?;
-            proto_entries.push(vsock_proto::WriteFileBatchEntry {
-                path: file.path,
-                content: file.content,
-            });
+        let validated = validate_write_files(files, WriteFilesMode::Private)?;
+        if files.len() == 1 || validated.total_content_len > batch_content_limit {
+            for file in files {
+                self.write_private_file_with_write_observer_and_chunk_limit(
+                    file.path,
+                    file.content,
+                    write_observer.clone(),
+                    chunk_limit,
+                )
+                .await?;
+            }
+            return Ok(());
         }
-        if total_content_len > WRITE_FILES_BATCH_CONTENT_LIMIT {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "write_files batch contains {total_content_len} content bytes, limit is {WRITE_FILES_BATCH_CONTENT_LIMIT}"
-                ),
-            ));
-        }
+
+        self.write_validated_files_batch(
+            files,
+            validated.proto_entries,
+            WriteFilesMode::Private,
+            write_observer,
+        )
+        .await
+    }
+
+    async fn write_validated_files_batch(
+        &self,
+        files: &[WriteFileEntry<'_>],
+        proto_entries: Vec<vsock_proto::WriteFileBatchEntry<'_>>,
+        mode: WriteFilesMode,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
         vsock_proto::validate_write_files(&proto_entries).map_err(protocol_invalid_input)?;
 
         let _path_guards = self
@@ -709,7 +808,7 @@ impl VsockHost {
             timeout,
             write_observer,
             move |seq, frame| {
-                vsock_proto::encode_write_files_frame_into(frame, seq, &proto_entries)
+                mode.encode_frame(frame, seq, &proto_entries)
                     .map_err(protocol_invalid_input)
             },
         )
@@ -794,6 +893,47 @@ impl VsockHost {
 
         Ok(())
     }
+}
+
+fn validate_write_files<'a>(
+    files: &[WriteFileEntry<'a>],
+    mode: WriteFilesMode,
+) -> io::Result<ValidatedWriteFiles<'a>> {
+    let operation_name = mode.operation_name();
+    if files.len() > WRITE_FILES_BATCH_FILE_LIMIT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{operation_name} batch contains {} files, limit is {WRITE_FILES_BATCH_FILE_LIMIT}",
+                files.len()
+            ),
+        ));
+    }
+
+    let mut total_content_len = 0usize;
+    let mut proto_entries = Vec::with_capacity(files.len());
+    for file in files {
+        validate_guest_file_path(file.path)?;
+        vsock_proto::validate_write_file(file.path, &[], false, false)
+            .map_err(protocol_invalid_input)?;
+        total_content_len = total_content_len
+            .checked_add(file.content.len())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("{operation_name} content length overflow"),
+                )
+            })?;
+        proto_entries.push(vsock_proto::WriteFileBatchEntry {
+            path: file.path,
+            content: file.content,
+        });
+    }
+
+    Ok(ValidatedWriteFiles {
+        proto_entries,
+        total_content_len,
+    })
 }
 
 fn validate_write_file_chunk_request(request: WriteFileChunkRequest<'_>) -> io::Result<()> {

--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -8,7 +8,8 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 use vsock_proto::{
     DecodedExecStart, ExecOutputPolicy, MSG_ERROR, MSG_EXEC_START, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, RawMessage,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, MSG_WRITE_PRIVATE_FILES,
+    RawMessage,
 };
 
 use super::super::support::read_guest_message;
@@ -143,6 +144,22 @@ pub(super) fn spawn_write_files(
     })
 }
 
+pub(super) fn spawn_write_private_files(
+    host: Arc<VsockHost>,
+    files: Vec<(&'static str, Vec<u8>)>,
+) -> JoinHandle<io::Result<()>> {
+    tokio::spawn(async move {
+        let entries = files
+            .iter()
+            .map(|(path, content)| WriteFileEntry {
+                path,
+                content: content.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        host.write_private_files(&entries).await
+    })
+}
+
 pub(super) struct ExecStartFrame {
     pub(super) msg: RawMessage,
     pub(super) command: String,
@@ -242,8 +259,19 @@ pub(super) async fn expect_write_file(guest: &mut UnixStream) -> WriteFileFrame 
 }
 
 pub(super) async fn expect_write_files(guest: &mut UnixStream) -> WriteFilesFrame {
+    expect_write_files_message(guest, MSG_WRITE_FILES).await
+}
+
+pub(super) async fn expect_write_private_files(guest: &mut UnixStream) -> WriteFilesFrame {
+    expect_write_files_message(guest, MSG_WRITE_PRIVATE_FILES).await
+}
+
+async fn expect_write_files_message(
+    guest: &mut UnixStream,
+    expected_msg_type: u8,
+) -> WriteFilesFrame {
     let msg = read_guest_message(guest).await;
-    assert_eq!(msg.msg_type, MSG_WRITE_FILES);
+    assert_eq!(msg.msg_type, expected_msg_type);
     let files = vsock_proto::decode_write_files(&msg.payload)
         .unwrap()
         .into_iter()

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -1635,6 +1635,40 @@ async fn write_files_rejects_protocol_message_too_large_before_waiting_for_write
 }
 
 #[tokio::test]
+async fn write_private_files_protocol_oversize_falls_back_to_private_single_writes() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let path = format!("/{}", "a".repeat(u16::MAX as usize - 1));
+            let content = vec![0u8; WRITE_FILES_BATCH_CONTENT_LIMIT];
+            let files = (0..17)
+                .map(|index| WriteFileEntry {
+                    path: &path,
+                    content: if index == 0 { &content } else { &[] },
+                })
+                .collect::<Vec<_>>();
+
+            host.write_private_files(&files).await
+        })
+    };
+
+    for index in 0..17 {
+        let write = expect_write_file(&mut guest).await;
+        assert!(write.private);
+        if index == 0 {
+            assert_eq!(write.content.len(), WRITE_FILES_BATCH_CONTENT_LIMIT);
+        } else {
+            assert!(write.content.is_empty());
+        }
+        send_write_file_success(&mut guest, write.seq()).await;
+    }
+
+    write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn write_file_observer_error_cleans_pending_without_sending_frame() {
     let (host, guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -18,13 +18,16 @@ use super::super::support::{
     setup_host_and_guest, setup_host_and_mock_guest,
 };
 use super::support::{
-    expect_write_file, expect_write_files, send_guest_error, send_write_file_failure,
-    send_write_file_success, send_write_files_failure, send_write_files_success, spawn_write_file,
-    spawn_write_files,
+    expect_write_file, expect_write_files, expect_write_private_files, send_guest_error,
+    send_write_file_failure, send_write_file_success, send_write_files_failure,
+    send_write_files_success, spawn_write_file, spawn_write_files, spawn_write_private_files,
 };
 use crate::{
     FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, WriteFileEntry,
-    file::test_support::{WRITE_FILES_BATCH_CONTENT_LIMIT, WRITE_FILES_BATCH_FILE_LIMIT},
+    file::test_support::{
+        WRITE_FILES_BATCH_CONTENT_LIMIT, WRITE_FILES_BATCH_FILE_LIMIT,
+        write_private_files_with_small_limits,
+    },
     operation_tracker::NormalOperationReadiness,
 };
 
@@ -143,6 +146,212 @@ async fn write_files_guest_failure_releases_tracker() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+}
+
+#[tokio::test]
+async fn write_private_files_sends_one_private_batch_and_tracks_until_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_private_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/private-a.txt", b"alpha".to_vec()),
+            ("/tmp/private-b.txt", b"beta".to_vec()),
+        ],
+    );
+
+    let write = expect_write_private_files(&mut guest).await;
+    assert_eq!(
+        write.files,
+        vec![
+            ("/tmp/private-a.txt".to_string(), b"alpha".to_vec()),
+            ("/tmp/private-b.txt".to_string(), b"beta".to_vec()),
+        ]
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_write_files_success(&mut guest, write.seq()).await;
+
+    write_task.await.unwrap().unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_private_files_guest_failure_releases_tracker_and_connection_reuses() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_private_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/private-a.txt", b"alpha".to_vec()),
+            ("/tmp/private-b.txt", b"beta".to_vec()),
+        ],
+    );
+
+    let write = expect_write_private_files(&mut guest).await;
+    send_write_files_failure(&mut guest, write.seq(), "permission denied").await;
+
+    let error = write_task.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("permission denied"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_private_files_single_entry_uses_private_single_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_private_files(
+        Arc::clone(&host),
+        vec![("/tmp/private.txt", b"secret".to_vec())],
+    );
+
+    let write = expect_write_file(&mut guest).await;
+    assert_eq!(write.path, "/tmp/private.txt");
+    assert_eq!(write.content, b"secret");
+    assert!(write.private);
+    assert!(!write.append);
+    send_write_file_success(&mut guest, write.seq()).await;
+
+    write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_private_files_oversized_aggregate_falls_back_to_private_single_writes() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let first = vec![0xA1; 600];
+            let second = vec![0xB2; 600];
+            write_private_files_with_small_limits(
+                &host,
+                &[
+                    WriteFileEntry {
+                        path: "/tmp/private-a.txt",
+                        content: &first,
+                    },
+                    WriteFileEntry {
+                        path: "/tmp/private-b.txt",
+                        content: &second,
+                    },
+                ],
+                FrameWriteObserver::default(),
+            )
+            .await
+        })
+    };
+
+    let first = expect_write_file(&mut guest).await;
+    assert_eq!(first.path, "/tmp/private-a.txt");
+    assert!(first.private);
+    assert_eq!(first.content, vec![0xA1; 600]);
+    send_write_file_success(&mut guest, first.seq()).await;
+
+    let second = expect_write_file(&mut guest).await;
+    assert_eq!(second.path, "/tmp/private-b.txt");
+    assert!(second.private);
+    assert_eq!(second.content, vec![0xB2; 600]);
+    send_write_file_success(&mut guest, second.seq()).await;
+
+    write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_private_files_empty_batch_is_noop() {
+    let (host, guest) = setup_host_and_guest().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        host.write_private_files_with_write_observer(
+            &[],
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        ),
+    )
+    .await
+    .expect("empty write_private_files should return before waiting for the writer")
+    .unwrap();
+
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("empty write_private_files must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after empty write_private_files: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    drop(writer_guard);
+}
+
+#[tokio::test]
+async fn write_private_files_validates_every_path_before_fallback_writes() {
+    let (host, guest) = setup_host_and_guest().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let first = vec![0xA1; 600];
+    let second = vec![0xB2; 600];
+
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        write_private_files_with_small_limits(
+            &host,
+            &[
+                WriteFileEntry {
+                    path: "/tmp/private-a.txt",
+                    content: &first,
+                },
+                WriteFileEntry {
+                    path: "/tmp/has\0nul",
+                    content: &second,
+                },
+            ],
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        ),
+    )
+    .await
+    .expect("invalid write_private_files should return before waiting for the writer")
+    .unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("invalid write_private_files must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after invalid write_private_files: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    drop(writer_guard);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -14,7 +14,8 @@ use vsock_proto::{
     MSG_GUEST_DNS_READINESS_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
     MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, RawMessage,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, MSG_WRITE_PRIVATE_FILES,
+    RawMessage,
 };
 
 use crate::operation_tracker::NormalOperationReadiness;
@@ -153,6 +154,7 @@ fn message_type_name(msg_type: u8) -> &'static str {
         MSG_WRITE_FILE_RESULT => "write_file_result",
         MSG_WRITE_FILES => "write_files",
         MSG_WRITE_FILES_RESULT => "write_files_result",
+        MSG_WRITE_PRIVATE_FILES => "write_private_files",
         MSG_EXEC_START => "exec_start",
         MSG_EXEC_STARTED => "exec_started",
         MSG_EXEC_AGENT_READY => "exec_agent_ready",

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -58,10 +58,11 @@
 //! | 0x1A | H→G       | guest_state_restore | `[4B positive timeout_ms][8B unix_seconds][4B unix_nanoseconds][1B timezone_mode][2B timezone_len][timezone][256B entropy]` |
 //! | 0x1B | G→H       | guest_state_restore_result | same payload as `exec_result`, with empty stdout and stderr bounded to 64 KiB |
 //! | 0x1C | G→H       | exec_agent_ready | `[4B containment_create_us][4B placement_broker_setup_us][4B shell_spawn_us][4B bootstrap_ready_wait_us]` |
+//! | 0x1D | H→G       | write_private_files | same payload as `write_files`; result is `write_files_result` with the request sequence |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
-//! covers `write_file`, `write_files`, `exec_start`, `exec_cancel`,
+//! covers `write_file`, `write_files`, `write_private_files`, `exec_start`, `exec_cancel`,
 //! `exec_control`, `guest_dns_readiness`, `guest_storage_manifest`, and
 //! `guest_state_restore`; operation replies reuse the original non-zero request
 //! sequence. `exec_output.output_seq` is per exec
@@ -245,9 +246,10 @@ pub use payloads::memory_snapshot::{
 pub use payloads::write_file::{
     WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,
     decode_write_files_result, encode_private_write_file, encode_private_write_file_frame_into,
-    encode_write_file, encode_write_file_frame_into, encode_write_file_result, encode_write_files,
-    encode_write_files_frame_into, encode_write_files_result, validate_private_write_file,
-    validate_write_file, validate_write_files,
+    encode_private_write_files_frame_into, encode_write_file, encode_write_file_frame_into,
+    encode_write_file_result, encode_write_files, encode_write_files_frame_into,
+    encode_write_files_result, validate_private_write_file, validate_write_file,
+    validate_write_files,
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
@@ -258,6 +260,6 @@ pub use wire::{
     MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
     MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT,
-    WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, MSG_WRITE_PRIVATE_FILES,
+    VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -6,8 +6,8 @@ use crate::read::{
     ensure_u32_len, expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
 use crate::wire::{
-    MSG_WRITE_FILE, MSG_WRITE_FILES, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
-    WRITE_FILE_FLAG_SUDO,
+    MSG_WRITE_FILE, MSG_WRITE_FILES, MSG_WRITE_PRIVATE_FILES, WRITE_FILE_FLAG_APPEND,
+    WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };
 
 struct EncodedWriteFilePayload<'a> {
@@ -32,7 +32,7 @@ struct EncodedWriteFilesPayload<'a> {
     payload_len: usize,
 }
 
-/// One ordinary file write entry in a `write_files` batch payload.
+/// One file entry in a `write_files` or `write_private_files` batch payload.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WriteFileBatchEntry<'a> {
     /// Guest path to create or replace.
@@ -186,6 +186,32 @@ pub fn encode_write_files_frame_into(
     encode_into(frame, MSG_WRITE_FILES, seq, encoded.payload_len, |frame| {
         append_write_files_payload(frame, &encoded);
     })
+}
+
+/// Encode a full private write_files frame into `frame`.
+///
+/// The payload bytes and validation rules match
+/// [`encode_write_files_frame_into`]; the request message type selects
+/// runtime-private semantics for every entry.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] under the same conditions as
+/// [`encode_write_files_frame_into`].
+pub fn encode_private_write_files_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    files: &[WriteFileBatchEntry<'_>],
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let encoded = validate_write_files_payload(files)?;
+    encode_into(
+        frame,
+        MSG_WRITE_PRIVATE_FILES,
+        seq,
+        encoded.payload_len,
+        |frame| append_write_files_payload(frame, &encoded),
+    )
 }
 
 fn validate_write_files_payload<'a>(
@@ -560,6 +586,27 @@ mod tests {
     }
 
     #[test]
+    fn private_write_files_frame_reuses_batch_payload() {
+        let files = [
+            WriteFileBatchEntry {
+                path: "/tmp/a.txt",
+                content: b"alpha",
+            },
+            WriteFileBatchEntry {
+                path: "/tmp/b.txt",
+                content: b"beta",
+            },
+        ];
+        let payload = encode_write_files(&files).unwrap();
+        let expected = encode(MSG_WRITE_PRIVATE_FILES, 45, &payload).unwrap();
+        let mut frame = Vec::new();
+
+        encode_private_write_files_frame_into(&mut frame, 45, &files).unwrap();
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
     fn write_files_rejects_empty_batch() {
         let err = encode_write_files(&[]).unwrap_err();
 
@@ -570,6 +617,15 @@ mod tests {
     fn write_files_frame_rejects_empty_batch() {
         let mut frame = vec![0xFF];
         let err = encode_write_files_frame_into(&mut frame, 1, &[]).unwrap_err();
+
+        assert_invalid_payload(err, "write_files file count must be positive");
+        assert!(frame.is_empty());
+    }
+
+    #[test]
+    fn private_write_files_frame_rejects_empty_batch() {
+        let mut frame = vec![0xFF];
+        let err = encode_private_write_files_frame_into(&mut frame, 1, &[]).unwrap_err();
 
         assert_invalid_payload(err, "write_files file count must be positive");
         assert!(frame.is_empty());

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -104,6 +104,9 @@ pub const MSG_GUEST_STATE_RESTORE_RESULT: u8 = 0x1B;
 /// Guest-to-host acknowledgement that an Agent adopted runtime placement.
 pub const MSG_EXEC_AGENT_READY: u8 = 0x1C;
 
+/// Host-to-guest private multi-file write request.
+pub const MSG_WRITE_PRIVATE_FILES: u8 = 0x1D;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -186,6 +189,7 @@ mod tests {
                 0x1B,
             ),
             ("MSG_EXEC_AGENT_READY", MSG_EXEC_AGENT_READY, 0x1C),
+            ("MSG_WRITE_PRIVATE_FILES", MSG_WRITE_PRIVATE_FILES, 0x1D),
             ("MSG_ERROR", MSG_ERROR, 0xFF),
         ];
 


### PR DESCRIPTION
## Summary

- add a typed `write_private_files` vsock request that reuses the existing bounded multi-file payload and result format
- preserve private parent, permission, symlink, truncation, cancellation, and oversized-file fallback semantics across the guest helper, host transport, and sandbox interface
- write the required user-environment and run-payload files in one private batch when both are present; keep the connector context as a separate best-effort write and keep the empty-user-env path as one private write
- replace the two required-write telemetry actions with one `runner_required_private_files_write` action

## Performance

Compared with the 100-sample baseline in #29792 on `local-1.aws.vm3.ai`. The final after run used one dedicated Runner invocation with `max_concurrent=1`, `max_idle=1`, strict path classification, 100 samples per path, and zero failures. Measurement-only instrumentation was removed from this PR.

All values are p50/p90/p95/p99.

| Path / metric | Before | After |
| --- | --- | --- |
| exact reuse — required private files | 8.400 / 12.420 / 15.692 / 22.808 ms | 4.957 / 8.358 / 8.799 / 9.877 ms |
| exact reuse — Executor to Agent ready | 81 / 89 / 90 / 95 ms | 74 / 85 / 90 / 95 ms |
| workspace cache — required private files | 12.243 / 13.521 / 14.327 / 16.292 ms | 5.256 / 6.446 / 6.734 / 9.990 ms |
| workspace cache — Executor to Agent ready | 387 / 411 / 427 / 449 ms | 378 / 406 / 417 / 427 ms |
| fresh — required private files | 12.256 / 13.130 / 13.469 / 14.770 ms | 5.061 / 6.332 / 7.940 / 11.737 ms |
| fresh — Executor to Agent ready | 420 / 442 / 448 / 478 ms | 407 / 443 / 455 / 477 ms |

The primary exact-reuse target improves by 7/4/0/0 ms across the full boundary, while its required-write distribution improves by about 41.0% / 32.7% / 43.9% / 56.7%. Workspace-cache improves across the full boundary. Fresh p95 is 7 ms higher, but the unchanged Agent-start-to-ready p95 is also 7 ms higher while required-write p95 is 5.529 ms lower; fresh p90 is effectively flat and p99 is 1 ms lower. This is downstream distribution noise rather than a private-write regression.

## Compatibility and exclusions

- ordinary `write_files` wire bytes and behavior are unchanged
- Runner and guest binaries ship together, so this internal request does not need old-guest negotiation
- connector-context batching remains out of scope because its failure policy is independently best effort
- workspace-cache persisted formats are unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vsock-proto -p guest-write-file -p vsock-guest -p vsock-host -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-features`
- `cargo clippy -p vsock-proto -p guest-write-file -p vsock-guest -p vsock-host -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vsock-proto -p guest-write-file -p vsock-guest -p vsock-host -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-features --no-deps`
- `cargo check -p runner --all-targets --all-features`
- production-style Runner deployment and real runs on `local-1`
- 100-sample fresh, workspace-cache, and exact-reuse Agent-ready benchmarks on one corrected dedicated Runner invocation
- required CI gates: Turbo, Crates, and Security passed

Closes #29646
