### PR TITLE
refactor(runner): cut mitmdump runtime marker writer to canonical alias

### DIFF
--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -15,7 +15,7 @@ use super::flush::{
 };
 use super::managed_process::ManagedMitmdump;
 use super::registry::{ProxyRegistryHandle, SandboxRegistration, write_empty_registry};
-use super::runtime::{CANONICAL_RUNTIME_MARKER_ENV, LEGACY_RUNTIME_MARKER_ENV, MitmdumpRuntime};
+use super::runtime::{CANONICAL_RUNTIME_MARKER_ENV, MitmdumpRuntime};
 use super::stderr::log_mitmdump_stderr_line;
 use crate::error::{RunnerError, RunnerResult};
 
@@ -761,7 +761,6 @@ async fn spawn_mitmdump(
         .stderr(std::process::Stdio::piped());
     cmd.env("TMPDIR", &launch_path)
         .env(CANONICAL_RUNTIME_MARKER_ENV, &launch_path)
-        .env(LEGACY_RUNTIME_MARKER_ENV, &launch_path)
         .process_group(0);
     cmd.kill_on_drop(true);
 
@@ -972,6 +971,7 @@ fn send_usage_flush_signal(child: &tokio::process::Child) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::runtime::LEGACY_RUNTIME_MARKER_ENV;
     use super::*;
     use crate::paths::HomePaths;
     use std::os::unix::fs::PermissionsExt;
@@ -1131,14 +1131,6 @@ mod tests {
         );
     }
 
-    // Mirrors the pre-#28989 reader retained by rollback runners. Keep this
-    // test-only so Stage 1 proves its dual writer remains legacy-readable.
-    fn legacy_only_runtime_marker(environ: &[u8]) -> Option<&[u8]> {
-        environ
-            .split(|byte| *byte == 0)
-            .find_map(|entry| entry.strip_prefix(b"VM0_MITMDUMP_RUNTIME_DIR="))
-    }
-
     fn write_fake_listening_mitmdump(path: &Path) {
         std::fs::write(
             path,
@@ -1146,7 +1138,7 @@ mod tests {
 set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
 printf '%s\n%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
-  "$VM0_MITMDUMP_RUNTIME_DIR" "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
+  "${VM0_MITMDUMP_RUNTIME_DIR-}" "${OKOU_MITM_RUNNER_TOKEN-}" > "$0.env"
 cp -f "/proc/$$/environ" "$0.environ"
 port=""
 ready_path=""
@@ -1210,7 +1202,7 @@ PY
             r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
-  "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+  "${VM0_MITMDUMP_RUNTIME_DIR-}" > "$0.env"
 ready_path=""
 usage_state_id=""
 for arg in "$@"; do
@@ -1257,7 +1249,7 @@ from pathlib import Path
 Path(f"{sys.argv[0]}.env").write_text(
     f"{os.environ['TMPDIR']}\n"
     f"{os.environ['OKOU_MITMDUMP_RUNTIME_DIR']}\n"
-    f"{os.environ['VM0_MITMDUMP_RUNTIME_DIR']}\n",
+    f"{os.environ.get('VM0_MITMDUMP_RUNTIME_DIR', '')}\n",
     encoding="utf-8",
 )
 port = None
@@ -1307,7 +1299,7 @@ while True:
             r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n%s\n%s\n' "$TMPDIR" "$OKOU_MITMDUMP_RUNTIME_DIR" \
-  "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+  "${VM0_MITMDUMP_RUNTIME_DIR-}" > "$0.env"
 printf 'attempt\n' >> "$0.attempts"
 python3 - "$0.descendant" <<'PY' &
 import os
@@ -1870,13 +1862,30 @@ exit 42
         let environment: Vec<&str> = environment.lines().collect();
         assert_eq!(environment.len(), 4);
         assert_eq!(environment[0], environment[1]);
-        assert_eq!(environment[0], environment[2]);
+        assert!(environment[2].is_empty());
         assert_eq!(environment[3], "runner-token");
         let launched_environ = std::fs::read(fake_mitmdump.with_extension("environ")).unwrap();
+        let tmpdir = launched_environ
+            .split(|byte| *byte == 0)
+            .find_map(|entry| entry.strip_prefix(b"TMPDIR="))
+            .expect("launched mitmdump environment should contain TMPDIR");
+        let mut canonical_markers = launched_environ
+            .split(|byte| *byte == 0)
+            .filter_map(|entry| entry.strip_prefix(b"OKOU_MITMDUMP_RUNTIME_DIR="));
         assert_eq!(
-            legacy_only_runtime_marker(&launched_environ),
-            Some(environment[0].as_bytes()),
-            "the pre-migration legacy-only reader must recognize Stage 1 launch environments"
+            canonical_markers.next(),
+            Some(tmpdir),
+            "the canonical runtime marker must equal TMPDIR"
+        );
+        assert!(
+            canonical_markers.next().is_none(),
+            "the launched mitmdump environment must contain exactly one canonical runtime marker"
+        );
+        assert!(
+            launched_environ
+                .split(|byte| *byte == 0)
+                .all(|entry| !entry.starts_with(b"VM0_MITMDUMP_RUNTIME_DIR=")),
+            "the launched mitmdump environment must not contain the legacy runtime marker"
         );
         let launch_path = Path::new(environment[0]);
         assert_eq!(launch_path.parent(), Some(config.runtime_dir.as_path()));

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -14,9 +14,9 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::process::{ProcessStat, ProcessStatRead, process_stat_is_live};
 
-// Marker-bearing descendants can outlive their runner. Expansion Stage 1 keeps
-// both names so current runners can reconcile old launches and rollback runners
-// can reconcile current launches; removal remains gated by #28914.
+// Marker-bearing descendants can outlive their runner. Writer Stage 2 makes new
+// launches canonical-only while the legacy reader remains for crash leftovers
+// and rollback-window observation; removal remains gated by #28914.
 pub(super) const CANONICAL_RUNTIME_MARKER_ENV: &str = "OKOU_MITMDUMP_RUNTIME_DIR";
 pub(super) const LEGACY_RUNTIME_MARKER_ENV: &str = "VM0_MITMDUMP_RUNTIME_DIR";
 const CANONICAL_RUNTIME_MARKER_PREFIX: &[u8] = b"OKOU_MITMDUMP_RUNTIME_DIR=";


### PR DESCRIPTION
## Summary

- stop writing `VM0_MITMDUMP_RUNTIME_DIR` into new mitmdump launches while keeping `OKOU_MITMDUMP_RUNTIME_DIR` byte-identical to the private `TMPDIR`
- make every lifecycle fake child tolerate the now-absent legacy variable under `set -u`, and assert the raw launched environment has exactly one canonical marker equal to `TMPDIR` and no legacy marker
- retain the legacy constant and byte prefix, legacy-only/canonical-only/equal-dual readers, conflict rejection, source telemetry, and every procfs/pidfd lifecycle recheck

## Scope and inventory

- reviewed base: `da100a97131334402bc194283be13feafa796e4b`
- implementation head: `40184267739a8069f7916630b40283c4eb858574`
- the refreshed exact literal/symbol inventory found 35 references in exactly `crates/runner/src/proxy/process.rs` and `crates/runner/src/proxy/runtime.rs`; the sole production writer was the dual launch chain in `spawn_mitmdump`
- immediately before editing, the fully paginated overlap audit covered all 25 open PRs and all 378 declared changed files; 378 files were fetched with zero pagination mismatch, including both pages and all 185 files for #25722, and no open PR touched either scoped file
- the final diff is limited to `crates/runner/src/proxy/process.rs` plus the adjacent migration-stage comment in `crates/runner/src/proxy/runtime.rs`

## Acceptance evidence

- new mitmdump commands set `TMPDIR` and `CANONICAL_RUNTIME_MARKER_ENV` to the same existing private launch path and no longer call `.env(LEGACY_RUNTIME_MARKER_ENV, ...)`
- the launcher fixture copies the actual child `/proc/$$/environ`; the focused assertion requires exactly one `OKOU_MITMDUMP_RUNTIME_DIR` value equal to the child `TMPDIR` and rejects every `VM0_MITMDUMP_RUNTIME_DIR=` entry
- Bash lifecycle fixtures use `${VM0_MITMDUMP_RUNTIME_DIR-}` and the Python fixture uses an absent-safe lookup, without adding the legacy marker through a test layer
- `LEGACY_RUNTIME_MARKER_ENV`, `LEGACY_RUNTIME_MARKER_PREFIX`, all three accepted source states, conflicting-dual fail-closed behavior, value-free source telemetry, immediate environment recheck, post-pidfd recheck, path/UID/PID-generation checks, locking, timeout, process-group, parent-death, CA, token, API-option, and unrelated-directory behavior remain unchanged

## Fallbacks

- `crates/runner/src/proxy/runtime.rs:resolve_runtime_marker` retains the legacy-only and equal-dual compatibility paths for crash leftovers and rolled-back Stage 1 writers. Surface: inherited mitmdump descendants and retained rollback runners. Removal remains a separate #28914 stage after the exact writer-cutover release, bounded source observation, supported rollback-window expiry, and authoritative legacy-only drain evidence.

## Verification

Passed locally:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path crates/Cargo.toml --no-deps -p runner --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `git diff --check`

The exact focused launcher test was attempted with `CARGO_BUILD_JOBS=1`; the 3.8 GiB local environment terminated the Runner test-binary link with exit 137 before any test executed. The strict all-target checks compiled the test code successfully. Protected PR CI is authoritative for the launcher, compatibility-reader, procfs/pidfd, restart, startup-failure, graceful-cleanup, and forced-owner-reacquisition tests.

Closes #29934

Parent: #28914
