### PR TITLE
refactor(ops): remove legacy monitoring collector environment aliases

### DIFF
--- a/.github/scripts/tests/vm0-monitoring-collect-test.sh
+++ b/.github/scripts/tests/vm0-monitoring-collect-test.sh
@@ -22,20 +22,18 @@ reset_dirs() {
   mkdir -p "$textfile_dir"
 }
 
-run_with_aliases() {
+run_with_path_env() {
   env \
     -u OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-    -u VM0_WORKSPACE_IMAGE_CACHE_DIR \
     -u OKOU_MONITORING_TEXTFILE_DIR \
-    -u VM0_MONITORING_TEXTFILE_DIR \
     "$@" \
     bash "$script" 2>"$stderr_file"
 }
 
 run_metrics() {
-  run_with_aliases \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
 
   [ -f "$output_file" ] || fail "metrics output file was not created"
 }
@@ -52,38 +50,21 @@ assert_no_match() {
   fi
 }
 
-assert_source_state() {
-  local canonical_key="$1"
-  local legacy_key="$2"
-  local state="$3"
-  local expected
-  expected="monitoring path alias source canonical_key=$canonical_key legacy_key=$legacy_key state=$state"
-
-  grep -qxF "$expected" "$stderr_file" ||
-    fail "expected fixed-shape alias source evidence"
-}
-
-assert_conflict_state() {
-  local canonical_key="$1"
-  local legacy_key="$2"
-  local expected
-  expected="monitoring path alias conflict canonical_key=$canonical_key legacy_key=$legacy_key state=conflict"
-
-  grep -qxF "$expected" "$stderr_file" ||
-    fail "expected fixed-shape alias conflict diagnostic"
-}
-
 assert_stderr_excludes_values() {
   local value
   for value in "$@"; do
     if grep -Fq -- "$value" "$stderr_file"; then
-      fail "alias diagnostic exposed a path value"
+      fail "collector diagnostics exposed an ignored value"
     fi
   done
 }
 
+assert_stderr_empty() {
+  [ ! -s "$stderr_file" ] || fail "collector emitted unexpected diagnostics"
+}
+
 assert_output_absent() {
-  [ ! -e "$output_file" ] || fail "collector published output before rejecting aliases"
+  [ ! -e "$output_file" ] || fail "collector published output unexpectedly"
 }
 
 assert_all_buckets_zero() {
@@ -206,148 +187,132 @@ test_ignores_incomplete_and_non_regular_entries() {
   assert_all_buckets_zero
 }
 
-test_workspace_image_cache_dir_alias_matrix() {
+test_workspace_image_cache_dir_canonical_and_defaults() {
   reset_dirs
-  mkdir -p "$cache_dir/alias-entry"
-  touch "$cache_dir/alias-entry/current.ext4"
+  mkdir -p "$cache_dir/canonical-entry"
+  touch "$cache_dir/canonical-entry/current.ext4"
 
-  run_with_aliases \
+  run_with_path_env \
     OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="" \
     OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
   assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR \
-    canonical-only
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
+  assert_stderr_empty
 
-  run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="" \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR \
-    legacy-only
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR \
-    dual
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
-
-  run_with_aliases OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line "vm0_workspace_image_cache_entries 0"
-
-  run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="" \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="" \
+  run_with_path_env \
     OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
   assert_line "vm0_workspace_image_cache_entries 0"
+  assert_stderr_empty
+
+  run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 0"
+  assert_stderr_empty
+}
+
+test_retired_workspace_image_cache_dir_is_ignored() {
+  reset_dirs
+  local retired_cache_dir="$tmp_root/retired-cache"
+  mkdir -p "$retired_cache_dir/retired-entry"
+  touch "$retired_cache_dir/retired-entry/current.ext4"
+
+  run_with_path_env \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$retired_cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 0"
+  assert_stderr_excludes_values \
+    "$retired_cache_dir" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+
+  mkdir -p "$cache_dir/canonical-entry"
+  touch "$cache_dir/canonical-entry/current.ext4"
+  run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR="$retired_cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_stderr_excludes_values \
+    "$retired_cache_dir" \
+    VM0_WORKSPACE_IMAGE_CACHE_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+}
+
+test_monitoring_textfile_dir_canonical_and_defaults() {
+  reset_dirs
+  mkdir -p "$cache_dir/canonical-entry"
+  touch "$cache_dir/canonical-entry/current.ext4"
+
+  run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_stderr_empty
 
   rm -f "$output_file"
-  local canonical_conflict="$tmp_root/cache-canonical-conflict-value"
-  local legacy_conflict="$tmp_root/cache-legacy-conflict-value"
-  if run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$canonical_conflict" \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="$legacy_conflict" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
-    fail "expected conflicting cache aliases to fail"
+  if run_with_path_env OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir"; then
+    fail "expected the absent canonical textfile path to use the missing default"
   fi
-  assert_conflict_state \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR
-  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "absent canonical textfile path did not use the fixed default"
+  assert_output_absent
+
+  if run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR=""; then
+    fail "expected an empty canonical textfile path to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "empty canonical textfile path did not use the fixed default"
   assert_output_absent
 }
 
-test_monitoring_textfile_dir_alias_matrix() {
+test_retired_monitoring_textfile_dir_is_ignored() {
   reset_dirs
-  mkdir -p "$cache_dir/alias-entry"
-  touch "$cache_dir/alias-entry/current.ext4"
+  local retired_textfile_dir="$tmp_root/retired-textfile"
+  mkdir -p "$cache_dir/canonical-entry" "$retired_textfile_dir"
+  touch "$cache_dir/canonical-entry/current.ext4"
 
-  run_with_aliases \
+  if run_with_path_env \
     OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    VM0_MONITORING_TEXTFILE_DIR=""
-  assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    canonical-only
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    legacy-only
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line "vm0_workspace_image_cache_entries 1"
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    dual
-  assert_stderr_excludes_values "$cache_dir" "$textfile_dir"
-
-  rm -f "$output_file"
-  if run_with_aliases OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir"; then
-    fail "expected the absent textfile alias pair to use the missing default"
+    VM0_MONITORING_TEXTFILE_DIR="$retired_textfile_dir"; then
+    fail "expected the retired textfile path to be ignored in favor of the missing default"
   fi
   grep -qF \
     'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
-    "$stderr_file" || fail "absent textfile aliases did not use the fixed default"
+    "$stderr_file" || fail "retired textfile path redirected the collector"
+  assert_stderr_excludes_values \
+    "$retired_textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR \
+    "monitoring path alias"
   assert_output_absent
+  [ ! -e "$retired_textfile_dir/workspace-image-cache.prom" ] ||
+    fail "retired textfile path received collector output"
 
-  if run_with_aliases \
+  run_with_path_env \
     OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="" \
-    VM0_MONITORING_TEXTFILE_DIR=""; then
-    fail "expected empty textfile aliases to use the missing default"
-  fi
-  grep -qF \
-    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
-    "$stderr_file" || fail "empty textfile aliases did not use the fixed default"
-  assert_output_absent
-
-  local canonical_conflict="$tmp_root/textfile-canonical-conflict-value"
-  local legacy_conflict="$tmp_root/textfile-legacy-conflict-value"
-  if run_with_aliases \
-    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$canonical_conflict" \
-    VM0_MONITORING_TEXTFILE_DIR="$legacy_conflict"; then
-    fail "expected conflicting textfile aliases to fail"
-  fi
-  assert_conflict_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR
-  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
-  assert_output_absent
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$retired_textfile_dir"
+  assert_line "vm0_workspace_image_cache_entries 1"
+  assert_stderr_excludes_values \
+    "$retired_textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+  [ ! -e "$retired_textfile_dir/workspace-image-cache.prom" ] ||
+    fail "retired textfile path overrode the canonical path"
 }
 
 test_missing_textfile_dir_fails() {
   rm -rf "$cache_dir" "$textfile_dir"
 
-  if run_with_aliases \
-    VM0_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
+  if run_with_path_env \
+    OKOU_WORKSPACE_IMAGE_CACHE_DIR="$cache_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
     fail "expected missing textfile directory to fail"
   fi
 
@@ -361,8 +326,10 @@ test_sparse_file_uses_allocated_bytes_not_logical_size
 test_regular_file_bucket_counts
 test_multiple_entries_aggregate_across_buckets
 test_ignores_incomplete_and_non_regular_entries
-test_workspace_image_cache_dir_alias_matrix
-test_monitoring_textfile_dir_alias_matrix
+test_workspace_image_cache_dir_canonical_and_defaults
+test_retired_workspace_image_cache_dir_is_ignored
+test_monitoring_textfile_dir_canonical_and_defaults
+test_retired_monitoring_textfile_dir_is_ignored
 test_missing_textfile_dir_fails
 
 echo "vm0 monitoring collector tests passed"

--- a/.github/scripts/tests/vm0-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-runner-status-collect-test.sh
@@ -32,20 +32,18 @@ reset_dirs() {
   mkdir -p "$textfile_dir"
 }
 
-run_with_aliases() {
+run_with_path_env() {
   env \
     -u OKOU_RUNNERS_DIR \
-    -u VM0_RUNNERS_DIR \
     -u OKOU_MONITORING_TEXTFILE_DIR \
-    -u VM0_MONITORING_TEXTFILE_DIR \
     "$@" \
     python3 "$script" 2>"$stderr_file"
 }
 
 run_collector() {
-  run_with_aliases \
-    VM0_RUNNERS_DIR="$runners_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  run_with_path_env \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
 
   [ -f "$output_file" ] || fail "metrics output file was not created"
 }
@@ -60,38 +58,21 @@ assert_playbook_contains() {
   grep -qF "$expected" "$playbook" || fail "playbook is missing: $expected"
 }
 
-assert_source_state() {
-  local canonical_key="$1"
-  local legacy_key="$2"
-  local state="$3"
-  local expected
-  expected="monitoring path alias source canonical_key=$canonical_key legacy_key=$legacy_key state=$state"
-
-  grep -qxF "$expected" "$stderr_file" ||
-    fail "expected fixed-shape alias source evidence"
-}
-
-assert_conflict_state() {
-  local canonical_key="$1"
-  local legacy_key="$2"
-  local expected
-  expected="monitoring path alias conflict canonical_key=$canonical_key legacy_key=$legacy_key state=conflict"
-
-  grep -qxF "$expected" "$stderr_file" ||
-    fail "expected fixed-shape alias conflict diagnostic"
-}
-
 assert_stderr_excludes_values() {
   local value
   for value in "$@"; do
     if grep -Fq -- "$value" "$stderr_file"; then
-      fail "alias diagnostic exposed a path value"
+      fail "collector diagnostics exposed an ignored value"
     fi
   done
 }
 
+assert_stderr_empty() {
+  [ ! -s "$stderr_file" ] || fail "collector emitted unexpected diagnostics"
+}
+
 assert_output_absent() {
-  [ ! -e "$output_file" ] || fail "collector published output before rejecting aliases"
+  [ ! -e "$output_file" ] || fail "collector published output unexpectedly"
 }
 
 assert_zero_snapshot() {
@@ -311,142 +292,139 @@ test_output_is_deterministic_and_replaced_atomically() {
   assert_line 'vm0_runner_sandboxes{state="idle"} 1'
 }
 
-test_runners_dir_alias_matrix() {
+test_runners_dir_canonical_and_defaults() {
   reset_dirs
-  mkdir -p "$runners_dir/alias-runner"
+  mkdir -p "$runners_dir/canonical-runner"
   printf '%s\n' '{"mode":"running"}' \
-    >"$runners_dir/alias-runner/status.json"
+    >"$runners_dir/canonical-runner/status.json"
 
-  run_with_aliases \
+  run_with_path_env \
     OKOU_RUNNERS_DIR="$runners_dir" \
-    VM0_RUNNERS_DIR="" \
     OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
   assert_line 'vm0_runner_instances{mode="running"} 1'
   assert_line 'vm0_runner_status_files{result="included"} 1'
-  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR canonical-only
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
+  assert_stderr_empty
 
-  run_with_aliases \
-    OKOU_RUNNERS_DIR="" \
-    VM0_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line 'vm0_runner_instances{mode="running"} 1'
-  assert_line 'vm0_runner_status_files{result="included"} 1'
-  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR legacy-only
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_RUNNERS_DIR="$runners_dir" \
-    VM0_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line 'vm0_runner_instances{mode="running"} 1'
-  assert_line 'vm0_runner_status_files{result="included"} 1'
-  assert_source_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR dual
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
-
-  run_with_aliases OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_zero_snapshot
-
-  run_with_aliases \
-    OKOU_RUNNERS_DIR="" \
-    VM0_RUNNERS_DIR="" \
+  run_with_path_env \
     OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
   assert_zero_snapshot
+  assert_stderr_empty
+
+  run_with_path_env \
+    OKOU_RUNNERS_DIR="" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_zero_snapshot
+  assert_stderr_empty
+}
+
+test_retired_runners_dir_is_ignored() {
+  reset_dirs
+  local retired_runners_dir="$tmp_root/retired-runners"
+  mkdir -p "$retired_runners_dir/retired-runner"
+  printf '%s\n' '{"mode":"draining"}' \
+    >"$retired_runners_dir/retired-runner/status.json"
+
+  run_with_path_env \
+    VM0_RUNNERS_DIR="$retired_runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_zero_snapshot
+  assert_stderr_excludes_values \
+    "$retired_runners_dir" \
+    VM0_RUNNERS_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+
+  mkdir -p "$runners_dir/canonical-runner"
+  printf '%s\n' '{"mode":"running"}' \
+    >"$runners_dir/canonical-runner/status.json"
+  run_with_path_env \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    VM0_RUNNERS_DIR="$retired_runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_line 'vm0_runner_instances{mode="draining"} 0'
+  assert_stderr_excludes_values \
+    "$retired_runners_dir" \
+    VM0_RUNNERS_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+}
+
+test_monitoring_textfile_dir_canonical_and_defaults() {
+  reset_dirs
+  mkdir -p "$runners_dir/canonical-runner"
+  printf '%s\n' '{"mode":"running"}' \
+    >"$runners_dir/canonical-runner/status.json"
+
+  run_with_path_env \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_stderr_empty
 
   rm -f "$output_file"
-  local canonical_conflict="$tmp_root/runners-canonical-conflict-value"
-  local legacy_conflict="$tmp_root/runners-legacy-conflict-value"
-  if run_with_aliases \
-    OKOU_RUNNERS_DIR="$canonical_conflict" \
-    VM0_RUNNERS_DIR="$legacy_conflict" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
-    fail "expected conflicting runners aliases to fail"
+  if run_with_path_env OKOU_RUNNERS_DIR="$runners_dir"; then
+    fail "expected the absent canonical textfile path to use the missing default"
   fi
-  assert_conflict_state OKOU_RUNNERS_DIR VM0_RUNNERS_DIR
-  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "absent canonical textfile path did not use the fixed default"
+  assert_output_absent
+
+  if run_with_path_env \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR=""; then
+    fail "expected an empty canonical textfile path to use the missing default"
+  fi
+  grep -qF \
+    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
+    "$stderr_file" || fail "empty canonical textfile path did not use the fixed default"
   assert_output_absent
 }
 
-test_monitoring_textfile_dir_alias_matrix() {
+test_retired_monitoring_textfile_dir_is_ignored() {
   reset_dirs
-  mkdir -p "$runners_dir/alias-runner"
+  local retired_textfile_dir="$tmp_root/retired-textfile"
+  mkdir -p "$runners_dir/canonical-runner" "$retired_textfile_dir"
   printf '%s\n' '{"mode":"running"}' \
-    >"$runners_dir/alias-runner/status.json"
+    >"$runners_dir/canonical-runner/status.json"
 
-  run_with_aliases \
+  if run_with_path_env \
     OKOU_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    VM0_MONITORING_TEXTFILE_DIR=""
-  assert_line 'vm0_runner_instances{mode="running"} 1'
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    canonical-only
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line 'vm0_runner_instances{mode="running"} 1'
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    legacy-only
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
-
-  run_with_aliases \
-    OKOU_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"
-  assert_line 'vm0_runner_instances{mode="running"} 1'
-  assert_source_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR \
-    dual
-  assert_stderr_excludes_values "$runners_dir" "$textfile_dir"
-
-  rm -f "$output_file"
-  if run_with_aliases OKOU_RUNNERS_DIR="$runners_dir"; then
-    fail "expected the absent textfile alias pair to use the missing default"
+    VM0_MONITORING_TEXTFILE_DIR="$retired_textfile_dir"; then
+    fail "expected the retired textfile path to be ignored in favor of the missing default"
   fi
   grep -qF \
     'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
-    "$stderr_file" || fail "absent textfile aliases did not use the fixed default"
+    "$stderr_file" || fail "retired textfile path redirected the collector"
+  assert_stderr_excludes_values \
+    "$retired_textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR \
+    "monitoring path alias"
   assert_output_absent
+  [ ! -e "$retired_textfile_dir/runner-status.prom" ] ||
+    fail "retired textfile path received collector output"
 
-  if run_with_aliases \
+  run_with_path_env \
     OKOU_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="" \
-    VM0_MONITORING_TEXTFILE_DIR=""; then
-    fail "expected empty textfile aliases to use the missing default"
-  fi
-  grep -qF \
-    'missing textfile directory: /var/lib/vm0-monitoring/textfile-collector' \
-    "$stderr_file" || fail "empty textfile aliases did not use the fixed default"
-  assert_output_absent
-
-  local canonical_conflict="$tmp_root/textfile-canonical-conflict-value"
-  local legacy_conflict="$tmp_root/textfile-legacy-conflict-value"
-  if run_with_aliases \
-    OKOU_RUNNERS_DIR="$runners_dir" \
-    OKOU_MONITORING_TEXTFILE_DIR="$canonical_conflict" \
-    VM0_MONITORING_TEXTFILE_DIR="$legacy_conflict"; then
-    fail "expected conflicting textfile aliases to fail"
-  fi
-  assert_conflict_state \
-    OKOU_MONITORING_TEXTFILE_DIR \
-    VM0_MONITORING_TEXTFILE_DIR
-  assert_stderr_excludes_values "$canonical_conflict" "$legacy_conflict"
-  assert_output_absent
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$retired_textfile_dir"
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_stderr_excludes_values \
+    "$retired_textfile_dir" \
+    VM0_MONITORING_TEXTFILE_DIR \
+    "monitoring path alias"
+  assert_stderr_empty
+  [ ! -e "$retired_textfile_dir/runner-status.prom" ] ||
+    fail "retired textfile path overrode the canonical path"
 }
 
 test_missing_textfile_dir_fails() {
   rm -rf "$runners_dir" "$textfile_dir"
 
-  if run_with_aliases \
-    VM0_RUNNERS_DIR="$runners_dir" \
-    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
+  if run_with_path_env \
+    OKOU_RUNNERS_DIR="$runners_dir" \
+    OKOU_MONITORING_TEXTFILE_DIR="$textfile_dir"; then
     fail "expected missing textfile directory to fail"
   fi
 
@@ -470,8 +448,10 @@ test_idle_field_compatibility_precedence
 test_invalid_files_publish_partial_metrics
 test_rejects_runner_and_status_symlinks
 test_output_is_deterministic_and_replaced_atomically
-test_runners_dir_alias_matrix
-test_monitoring_textfile_dir_alias_matrix
+test_runners_dir_canonical_and_defaults
+test_retired_runners_dir_is_ignored
+test_monitoring_textfile_dir_canonical_and_defaults
+test_retired_monitoring_textfile_dir_is_ignored
 test_missing_textfile_dir_fails
 test_playbook_provisions_independent_collector_cadence
 

--- a/ansible/files/vm0-monitoring-collect.sh
+++ b/ansible/files/vm0-monitoring-collect.sh
@@ -3,63 +3,8 @@
 set -euo pipefail
 set +x
 
-resolve_path_alias() {
-  local canonical_key="$1"
-  local legacy_key="$2"
-  local default_value="$3"
-  local canonical_value=""
-  local legacy_value=""
-  local state
-
-  if [[ -v "$canonical_key" ]]; then
-    canonical_value="${!canonical_key}"
-  fi
-  if [[ -v "$legacy_key" ]]; then
-    legacy_value="${!legacy_key}"
-  fi
-
-  if [[ -n "$canonical_value" && -n "$legacy_value" ]]; then
-    if [[ "$canonical_value" != "$legacy_value" ]]; then
-      printf 'monitoring path alias conflict canonical_key=%s legacy_key=%s state=conflict\n' \
-        "$canonical_key" \
-        "$legacy_key" \
-        >&2
-      return 1
-    fi
-    resolved_path_alias_value="$canonical_value"
-    state="dual"
-  elif [[ -n "$canonical_value" ]]; then
-    resolved_path_alias_value="$canonical_value"
-    state="canonical-only"
-  elif [[ -n "$legacy_value" ]]; then
-    resolved_path_alias_value="$legacy_value"
-    state="legacy-only"
-  else
-    resolved_path_alias_value="$default_value"
-    return 0
-  fi
-
-  printf 'monitoring path alias source canonical_key=%s legacy_key=%s state=%s\n' \
-    "$canonical_key" \
-    "$legacy_key" \
-    "$state" \
-    >&2
-}
-
-# Stage 1 keeps legacy aliases for operator-managed collector process
-# environments until #28914 records an all-host canonical configuration floor,
-# completes the rollback window, and verifies that no active host has a
-# legacy-only override.
-resolve_path_alias \
-  OKOU_WORKSPACE_IMAGE_CACHE_DIR \
-  VM0_WORKSPACE_IMAGE_CACHE_DIR \
-  /var/lib/vm0-runner/workspace-image-cache
-cache_dir="$resolved_path_alias_value"
-resolve_path_alias \
-  OKOU_MONITORING_TEXTFILE_DIR \
-  VM0_MONITORING_TEXTFILE_DIR \
-  /var/lib/vm0-monitoring/textfile-collector
-textfile_dir="$resolved_path_alias_value"
+cache_dir="${OKOU_WORKSPACE_IMAGE_CACHE_DIR:-/var/lib/vm0-runner/workspace-image-cache}"
+textfile_dir="${OKOU_MONITORING_TEXTFILE_DIR:-/var/lib/vm0-monitoring/textfile-collector}"
 output_file="$textfile_dir/workspace-image-cache.prom"
 
 mib=$((1024 * 1024))

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -15,45 +15,13 @@ RUNNER_MODES = ("starting", "running", "draining", "stopping", "unknown")
 STATUS_RESULTS = ("included", "stopped", "invalid")
 STATE_PRECEDENCE = {"unknown": 0, "preparing": 1, "active": 2, "idle": 3}
 CANONICAL_RUNNERS_DIR_ENV = "OKOU_RUNNERS_DIR"
-LEGACY_RUNNERS_DIR_ENV = "VM0_RUNNERS_DIR"
 DEFAULT_RUNNERS_DIR = "/var/lib/vm0-runner/runners"
 CANONICAL_TEXTFILE_DIR_ENV = "OKOU_MONITORING_TEXTFILE_DIR"
-LEGACY_TEXTFILE_DIR_ENV = "VM0_MONITORING_TEXTFILE_DIR"
 DEFAULT_TEXTFILE_DIR = "/var/lib/vm0-monitoring/textfile-collector"
 
 
 class InvalidStatus(ValueError):
     pass
-
-
-def resolve_path_alias(canonical_key: str, legacy_key: str, default: str) -> Path:
-    canonical = os.environ.get(canonical_key) or None
-    legacy = os.environ.get(legacy_key) or None
-
-    if canonical is not None and legacy is not None:
-        if canonical != legacy:
-            raise SystemExit(
-                "monitoring path alias conflict "
-                f"canonical_key={canonical_key} legacy_key={legacy_key} "
-                "state=conflict"
-            )
-        value = canonical
-        state = "dual"
-    elif canonical is not None:
-        value = canonical
-        state = "canonical-only"
-    elif legacy is not None:
-        value = legacy
-        state = "legacy-only"
-    else:
-        return Path(default)
-
-    print(
-        "monitoring path alias source "
-        f"canonical_key={canonical_key} legacy_key={legacy_key} state={state}",
-        file=sys.stderr,
-    )
-    return Path(value)
 
 
 def parse_sandbox_entry(entry: object) -> tuple[dict[object, object], str]:
@@ -257,19 +225,9 @@ def write_metrics(textfile_dir: Path, metrics: str) -> None:
 
 
 def main() -> None:
-    # Stage 1 keeps legacy aliases for operator-managed collector process
-    # environments until #28914 records an all-host canonical configuration floor,
-    # completes the rollback window, and verifies that no active host has a
-    # legacy-only override.
-    runners_dir = resolve_path_alias(
-        CANONICAL_RUNNERS_DIR_ENV,
-        LEGACY_RUNNERS_DIR_ENV,
-        DEFAULT_RUNNERS_DIR,
-    )
-    textfile_dir = resolve_path_alias(
-        CANONICAL_TEXTFILE_DIR_ENV,
-        LEGACY_TEXTFILE_DIR_ENV,
-        DEFAULT_TEXTFILE_DIR,
+    runners_dir = Path(os.environ.get(CANONICAL_RUNNERS_DIR_ENV) or DEFAULT_RUNNERS_DIR)
+    textfile_dir = Path(
+        os.environ.get(CANONICAL_TEXTFILE_DIR_ENV) or DEFAULT_TEXTFILE_DIR
     )
 
     metrics = render_metrics(*collect(runners_dir))


### PR DESCRIPTION
## Summary

- remove the production readers for `VM0_WORKSPACE_IMAGE_CACHE_DIR`, `VM0_MONITORING_TEXTFILE_DIR`, and `VM0_RUNNERS_DIR` from the two monitoring collectors
- resolve only the corresponding `OKOU_*` paths while preserving the exact fixed defaults for unset and empty canonical values
- remove migration-only alias resolution, conflict handling, source diagnostics, and legacy constants
- keep retired spellings only in bounded entry-point tests proving legacy-only values cannot redirect and conflicting legacy values cannot override canonical paths or create diagnostics

Closes #29945

Predecessor: #29064 / #29067

Parent EPIC: #28914

## Implementation baseline

- fetched `origin/main` immediately before the exact-key and open-PR inventory, then branched from clean current `main@5c46336786140483bda4208015e478fece4a6fec`
- committed reviewed implementation head `efb4fca401393ff0a6e50500a576ac32e423c91c`
- refreshed the target immediately before push at `origin/main@aad55f424b8a4b72c2b06e25335e06de53e10c7a`; the only intervening commit was #29938, whose 54 changed files have no overlap or functional dependency with this change
- merge base remains `5c46336786140483bda4208015e478fece4a6fec`; no speculative main update was performed solely for ordering

The pre-edit exact-key inventory found production readers only in:

- `ansible/files/vm0-monitoring-collect.sh`
- `ansible/files/vm0-runner-status-collect.py`

All other occurrences were in their two focused entry-point tests. After this change, neither production collector contains any retired key or migration source/conflict diagnostic; every remaining retired spelling is inside a bounded negative assertion in one of those tests.

## Fully paginated open-PR audit

The mandatory pre-edit audit covered all 26 open PRs and 474/474 declared/fetched changed files, with zero pagination mismatch and zero overlap against the four scoped files plus `ansible/playbooks/provision-monitoring.yml` and `.github/actions/provision/action.yml`.

The immediately pre-push refresh covered all 25 then-open PRs and 420/420 declared/fetched files, again with zero mismatch and zero overlap. Every changed-file page was fetched with `per_page=100`; each fetched total was checked against GitHub's `changed_files` count.

| PR | Audited head | Files fetched/declared | Scoped/protected overlap |
| --- | --- | ---: | --- |
| #25722 | `2aed1f0de2a54db881ca266151c1362ea6c9dd62` | 185/185 | none |
| #27177 | `ea90ade7071d0b712cc3264b781bca14c5a066b1` | 5/5 | none |
| #28110 | `431d74acf5364b5c3f27812af9b73e646eaf9157` | 2/2 | none |
| #28549 | `e6c5f00572fbd1f6c70a35be1e231a8e4a4fd69d` | 16/16 | none |
| #28665 | `1724554da2d5eb3b3a19eab50dd8b6eea7a66e21` | 4/4 | none |
| #28666 | `ccb634ac6344b59be2cb19dce31c17f19427c3f5` | 3/3 | none |
| #28667 | `1b8ced20fa060e9b5ba0327dc8d50b5c21e6a314` | 2/2 | none |
| #28668 | `5097513d3241d6125abc14f6a7391cf8e95dbcb2` | 2/2 | none |
| #28669 | `c177613f8004bd66039e90ec82395e871acc2bc7` | 2/2 | none |
| #28670 | `2f5dd568c6522bdffee4819b7e708906419fc3c7` | 2/2 | none |
| #28736 | `35f50a81405220c726494075214b0db1a2abec66` | 2/2 | none |
| #29068 | `d93f0fe028d0f0c96c0a5337a47054eb1f04490b` | 8/8 | none |
| #29120 | `3a63d7329cb751dbe32941ef42168941c6b7476a` | 2/2 | none |
| #29355 | `036894436fc3157e8c23b8c8efccb8800514f5ea` | 1/1 | none |
| #29357 | `3068fb80ba75be6a8d4cf44870ca63c3ae6dcdcf` | 1/1 | none |
| #29575 | `9b839d4678c6e2f641c7a90209313fdcf22e5c59` | 3/3 | none |
| #29722 | `c3c505ab5efc894e2093dd59730d6c1dc0ec0de5` | 2/2 | none |
| #29752 | `7ed31f2a66197f148e723fd989bdb87901202356` | 16/16 | none |
| #29757 | `35005696ea376a5b7b79c9f217d0474f98262956` | 53/53 | none |
| #29778 | `9aac2f3ad773fd11708235f06c5c3123d281f7fd` | 2/2 | none |
| #29875 | `ccd4cabddccd3170afd7aa4ded90c3b71b9162ee` | 26/26 | none |
| #29901 | `110d83d7382624946cc89e9fa5ad20fda18a216a` | 14/14 | none |
| #29939 | `9ff8a81105390a87626d15cba87c5d863def1aca` | 34/34 | none |
| #29941 | `8a13e7d4f971c8318acbbd294030b18a99740e7c` | 5/5 | none |
| #29943 | `7143c03c63ffa7101bf32cba614bd2f4bf8a871e` | 28/28 | none |
| **Total** |  | **420/420** | **none** |

## Behavior and scope

| Canonical value | Retired value | Result |
| --- | --- | --- |
| unset or empty | unset or non-empty | exact existing fixed default |
| non-empty | unset, equal, or different | canonical value |

The diff is limited to the two collectors and their two focused tests. Collector filenames, systemd unit/timer names, `vm0_*` Prometheus metrics and labels, cadence, permissions, symlink handling, partial-status behavior, temporary-file patterns, atomic replacement, and default filesystem layout are unchanged. Provisioning, systemd, Alloy, SSH, secrets, deployment variables, Runner binaries, `host.env`, and unrelated environment contracts are unchanged.

## Fallbacks

- no legacy runtime fallback remains in the changed collectors
- this merge changes repository source only and does not claim production completion
- if a later provisioned canonical-only collector needs rollback, re-provision the exact recorded dual-reader Ansible tree at `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` before relying on any legacy-only external override, as recorded in #29945

## Verification

- `PYTHONPATH=<isolated-ruff-0.16.0> python3 -m ruff format --check ansible/files/vm0-runner-status-collect.py`
- `npx --yes shellcheck@4.1.0 .github/scripts/tests/vm0-monitoring-collect-test.sh .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `npx --yes shellcheck@4.1.0 --exclude=SC2004 ansible/files/vm0-monitoring-collect.sh` (`SC2004` remains limited to pre-existing arithmetic-array expressions outside this change)
- `PYTHONPATH=<isolated-ruff-0.16.0> python3 -m ruff check ansible/files/vm0-runner-status-collect.py`
- `bash -n ansible/files/vm0-monitoring-collect.sh .github/scripts/tests/vm0-monitoring-collect-test.sh .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `PYTHONPYCACHEPREFIX=<isolated-temp-dir> python3 -m py_compile ansible/files/vm0-runner-status-collect.py`
- `bash .github/scripts/tests/vm0-monitoring-collect-test.sh`
- `bash .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `git diff --check`

No full local Vitest suite or development server was run. Protected PR CI is authoritative for repository-wide validation.
