### PR TITLE
refactor(test): cut mock binary path writers to canonical aliases

### DIFF
--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -75,7 +75,10 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
         .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
         .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "claude-code")
         .env(guest_contracts::env::USE_MOCK_CLAUDE_ENV, "true")
-        .env(guest_contracts::env::MOCK_CLAUDE_PATH_ENV, &probe_path)
+        .env(
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            &probe_path,
+        )
         .env(
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             &run_payload_path,

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -38,7 +38,7 @@ async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("USE_MOCK_CLAUDE", "true");
-        std::env::set_var("VM0_MOCK_CLAUDE_PATH", &mock);
+        std::env::set_var(guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV, &mock);
         std::env::set_var("HOME", tmp.path());
     }
     common::ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/codex_model_catalog_setup.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_setup.rs
@@ -63,7 +63,10 @@ async fn codex_setup_writes_model_catalog_before_cli_start() -> TestResult {
         .env_clear()
         .env("CLI_AGENT_TYPE", "codex")
         .env("USE_MOCK_CODEX", "true")
-        .env("VM0_MOCK_CODEX_PATH", &recording_codex)
+        .env(
+            guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+            &recording_codex,
+        )
         .env(
             guest_contracts::env::RUN_ID_ENV,
             "codex-model-catalog-setup",

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -169,7 +169,10 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
         .env_clear()
         .env("CLI_AGENT_TYPE", "codex")
         .env("USE_MOCK_CODEX", "true")
-        .env("VM0_MOCK_CODEX_PATH", args.fake_codex)
+        .env(
+            guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+            args.fake_codex,
+        )
         .env(guest_contracts::env::RUN_ID_ENV, args.run_id)
         .env(
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -161,7 +161,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             command
                 .env("CLI_AGENT_TYPE", "codex")
                 .env("USE_MOCK_CODEX", "true")
-                .env("VM0_MOCK_CODEX_PATH", binary);
+                .env(guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV, binary);
             if let Some(scenario) = app_server_scenario {
                 command.env("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
             }
@@ -170,7 +170,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             command
                 .env("CLI_AGENT_TYPE", "claude-code")
                 .env("USE_MOCK_CLAUDE", "true")
-                .env("VM0_MOCK_CLAUDE_PATH", binary);
+                .env(guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV, binary);
         }
     }
 

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1085,7 +1085,9 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
         guest_contracts::env::USE_MOCK_CLAUDE_ENV,
         guest_contracts::env::USE_MOCK_CODEX_ENV,
+        guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
         guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+        guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
@@ -1170,7 +1172,10 @@ pub unsafe fn setup_codex_app_server_env(
     unsafe {
         clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+            mock_path,
+        );
         std::env::set_var("USE_MOCK_CODEX", "true");
         if let Some(scenario) = config.scenario {
             std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
@@ -1301,7 +1306,10 @@ pub unsafe fn setup_env(
         clear_guest_agent_bootstrap_env_for_test();
         // Route the CLI binary resolution to the cargo-built mock.
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
-        std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            mock_path,
+        );
         std::env::set_var("USE_MOCK_CLAUDE", "true");
         std::env::set_var(
             "VM0_POST_RESULT_SIGTERM_GRACE_SECS",

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -154,7 +154,10 @@ async fn run_event_failure_case(
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", home.join(".codex"))
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
-            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(
+                guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+                &mock_codex,
+            )
             .env(guest_contracts::env::RESUME_SESSION_ID_ENV, THREAD_ID)
             .env("MOCK_CODEX_APP_SERVER_SCENARIO", mock_scenario)
             .env(

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -21,7 +21,10 @@ unsafe fn setup_api_env(
     unsafe {
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
-        std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            mock_path,
+        );
         std::env::set_var("USE_MOCK_CLAUDE", "true");
         std::env::set_var("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "3");
         std::env::set_var("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1");

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -99,7 +99,10 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", home.join(".codex"))
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
-            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(
+                guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+                &mock_codex,
+            )
             .env(guest_contracts::env::RESUME_SESSION_ID_ENV, THREAD_ID)
             .env(
                 "MOCK_CODEX_APP_SERVER_SCENARIO",

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -140,7 +140,10 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let run_payload_path = run_payload_path.to_string_lossy().into_owned();
     let env = [
         ("CLI_AGENT_TYPE", "claude-code"),
-        ("VM0_MOCK_CLAUDE_PATH", mock_path.as_str()),
+        (
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            mock_path.as_str(),
+        ),
         ("USE_MOCK_CLAUDE", "true"),
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
@@ -268,7 +271,10 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
     let run_payload_path = run_payload_path.to_string_lossy().into_owned();
     let env = [
         ("CLI_AGENT_TYPE", "claude-code"),
-        ("VM0_MOCK_CLAUDE_PATH", mock_path.as_str()),
+        (
+            guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
+            mock_path.as_str(),
+        ),
         ("USE_MOCK_CLAUDE", "true"),
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -195,7 +195,10 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", &codex_home)
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
-            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(
+                guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+                &mock_codex,
+            )
             .env(
                 guest_contracts::env::RESUME_SESSION_ID_ENV,
                 scenario.thread_id,

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -474,9 +474,8 @@ pub const MOCK_CLAUDE_PATH_ENV: &str = "VM0_MOCK_CLAUDE_PATH";
 
 /// Canonical mock Claude binary path alias accepted by guest readers.
 ///
-/// Existing test/debug writers keep using [`MOCK_CLAUDE_PATH_ENV`] until the
-/// reader floor, rollback window, and legacy-read-zero gates in #28914 are
-/// complete.
+/// Repository-owned test/debug writers use this alias exclusively. Legacy
+/// [`MOCK_CLAUDE_PATH_ENV`] remains only for compatibility removal under #28914.
 pub const CANONICAL_MOCK_CLAUDE_PATH_ENV: &str = "OKOU_MOCK_CLAUDE_PATH";
 
 /// Optional test/debug override for the mock Codex binary path.
@@ -486,9 +485,8 @@ pub const MOCK_CODEX_PATH_ENV: &str = "VM0_MOCK_CODEX_PATH";
 
 /// Canonical mock Codex binary path alias accepted by guest readers.
 ///
-/// Existing test/debug writers keep using [`MOCK_CODEX_PATH_ENV`] until the
-/// reader floor, rollback window, and legacy-read-zero gates in #28914 are
-/// complete.
+/// Repository-owned test/debug writers use this alias exclusively. Legacy
+/// [`MOCK_CODEX_PATH_ENV`] remains only for compatibility removal under #28914.
 pub const CANONICAL_MOCK_CODEX_PATH_ENV: &str = "OKOU_MOCK_CODEX_PATH";
 
 /// Retired runner bootstrap key that must remain protected at the user-env


### PR DESCRIPTION
## Summary

- switch all 14 repository-owned Guest Agent test/debug mock-binary path writers to `CANONICAL_MOCK_CLAUDE_PATH_ENV` or `CANONICAL_MOCK_CODEX_PATH_ENV`
- clear both canonical and legacy mock-path spellings in `clear_guest_agent_bootstrap_env_for_test` while compatibility readers and tests remain
- update the Stage 1 contract comments to record canonical-only repository writers and compatibility-only legacy aliases
- preserve the complete dual-reader/source-telemetry matrix, compiled defaults, framework selection, mock toggles, scenarios, and adjacent bootstrap contracts

Closes #29946.
Predecessor reader foundation: #29380 / #29385.
Parent EPIC: #28914.

## Verification

Passed locally:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts --all-targets --all-features -- -D warnings`
- `cargo check -p guest-contracts --all-targets --all-features`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-contracts -p guest-agent --all-features --no-deps`
- `cargo test -p guest-contracts` (134 tests)
- `cargo test -p guest-agent --test mock_binary_path_env_aliases` (focused canonical/legacy/equal-dual/conflict/absent/non-Unicode/present-empty matrix)
- affected Guest Agent integration targets: `api_token_process_isolation`, `cli_agent_log_open_failure`, `codex_app_server_backend`, `codex_model_catalog_setup`, `codex_setup_fail_closed`, `codex_startup_telemetry`, `event_delivery_failure_recovery`, `execute_cli_api_mode`, `execution_timeout_recovery`, `no_api_mode`, and `user_cancellation_recovery`
- `process_control_channel::process_control_channel_reaches_guest_agent`
- final exact-key/caller inventory: 14 canonical writers, two canonical cleanup entries, no legacy literal writer, and legacy symbols limited to compatibility constants/docs, dual readers, the alias matrix, cleanup, process isolation, and negative untrusted-input assertions
- `git diff --check`

Local baseline limitation:

- `process_control_channel::process_control_enabled_plain_run_does_not_wait_for_stdin_eof` exits because current Guest Agent requires workload/tool cgroup endpoints when process control is present. The same exact failure reproduced in a detached clean `origin/main@aad55f424b8a4b72c2b06e25335e06de53e10c7a` worktree using the legacy mock-path writer, so it is not introduced by this diff. Protected PR CI remains authoritative.

## Base, head, and open-PR audit

- implementation base and current `origin/main`: `aad55f424b8a4b72c2b06e25335e06de53e10c7a`
- published head: `d35d4bcf35881bd7a5e07a5373e8a031ea59c6a6`
- pre-edit audit: 25 open PRs, 420 declared / 420 fully paginated changed files, zero mismatches
- pre-publication audit: 27 open PRs, 481 declared / 481 fully paginated changed files, zero mismatches
- only #25722 overlaps a scoped file: its exact `crates/guest-contracts/src/env.rs` hunks add unrelated Cloudflare Access constants and ownership entries, with no mock-path semantic or hunk overlap; it is inventory only, not an ordering dependency

## Fallbacks

Reverting this focused PR restores the legacy test/debug writers. The production dual reader and all compatibility behavior remain unchanged, so no production release, rollback, or configuration action is required.