### PR TITLE
refactor(api): require connection failure sources

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -204,27 +204,54 @@ pub mod runners {
 
         /// DTOs for reporting bounded built-in model provider failures.
         pub mod model_provider_failures {
-            /// Bounded provider-independent failure eligible for route cooldown.
-            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-            pub enum RequestFailureKind {
+            /// Request body for reporting a built-in model provider failure.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(tag = "failureKind", rename_all_fields = "camelCase")]
+            pub enum Request {
                 /// Provider authentication failed.
                 #[serde(rename = "authentication")]
-                Authentication,
+                Authentication {
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
                 /// Provider billing rejected the request.
                 #[serde(rename = "billing")]
-                Billing,
+                Billing {
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
                 /// Provider rate limiting rejected the request.
                 #[serde(rename = "rate_limit")]
-                RateLimit,
+                RateLimit {
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
                 /// The provider route was unavailable or overloaded.
                 #[serde(rename = "provider_unavailable")]
-                ProviderUnavailable,
+                ProviderUnavailable {
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
                 /// The provider inference request timed out.
                 #[serde(rename = "timeout")]
-                Timeout,
+                Timeout {
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
                 /// The provider connection failed.
                 #[serde(rename = "connection")]
-                Connection,
+                Connection {
+                    /// Required source of the connection failure.
+                    connection_source: RequestConnectionSource,
+                    /// Optional bounded provider retry delay in seconds.
+                    #[serde(default, skip_serializing_if = "Option::is_none")]
+                    retry_after_seconds: Option<i64>,
+                },
             }
 
             /// Source of an eligible connection failure.
@@ -236,20 +263,6 @@ pub mod runners {
                 /// The runner observed an upstream transport failure.
                 #[serde(rename = "upstream_transport")]
                 UpstreamTransport,
-            }
-
-            /// Request body for reporting a built-in model provider failure.
-            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            pub struct Request {
-                /// Normalized eligible provider failure kind.
-                pub failure_kind: RequestFailureKind,
-                /// Optional source for connection failures; omitted by legacy runners.
-                #[serde(default, skip_serializing_if = "Option::is_none")]
-                pub connection_source: Option<RequestConnectionSource>,
-                /// Optional bounded provider retry delay in seconds.
-                #[serde(default, skip_serializing_if = "Option::is_none")]
-                pub retry_after_seconds: Option<i64>,
             }
         }
     }

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -5,7 +5,7 @@ use api_contracts::generated::types::{
         runs::{
             CodexRuntimeConfig, PiLaunchConfig, PiLaunchConfigApiFirstTurn,
             PiLaunchConfigApiFirstTurnBaseSession, PiModelConfig, PiModelConfigApiKeyEnv,
-            PiModelConfigProvider,
+            PiModelConfigProvider, model_provider_failures,
         },
         storage as runner_storage,
     },
@@ -15,6 +15,28 @@ use api_contracts::generated::types::{
     },
 };
 use serde_json::json;
+
+#[test]
+fn generated_model_provider_failure_request_requires_connection_source() {
+    let request = model_provider_failures::Request::Connection {
+        connection_source: model_provider_failures::RequestConnectionSource::UpstreamTransport,
+        retry_after_seconds: None,
+    };
+
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({
+            "failureKind": "connection",
+            "connectionSource": "upstream_transport",
+        })
+    );
+    assert!(
+        serde_json::from_value::<model_provider_failures::Request>(json!({
+            "failureKind": "connection",
+        }))
+        .is_err()
+    );
+}
 
 #[test]
 fn generated_codex_runtime_config_round_trips_full_wire_shape() {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -456,68 +456,52 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   it.each([
     {
       caseName: "authentication intervention",
-      failureKind: "authentication",
-      connectionSource: undefined,
-      retryAfterSeconds: 1,
+      body: { failureKind: "authentication", retryAfterSeconds: 1 },
+      source: "unspecified",
       cooldownSeconds: 30 * 60,
     },
     {
       caseName: "billing intervention",
-      failureKind: "billing",
-      connectionSource: undefined,
-      retryAfterSeconds: 1,
+      body: { failureKind: "billing", retryAfterSeconds: 1 },
+      source: "unspecified",
       cooldownSeconds: 30 * 60,
     },
     {
       caseName: "rate limit default",
-      failureKind: "rate_limit",
-      connectionSource: undefined,
-      retryAfterSeconds: undefined,
+      body: { failureKind: "rate_limit" },
+      source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "provider unavailable default",
-      failureKind: "provider_unavailable",
-      connectionSource: undefined,
-      retryAfterSeconds: undefined,
+      body: { failureKind: "provider_unavailable" },
+      source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "timeout default",
-      failureKind: "timeout",
-      connectionSource: undefined,
-      retryAfterSeconds: undefined,
-      cooldownSeconds: 5 * 60,
-    },
-    {
-      caseName: "connection default",
-      failureKind: "connection",
-      connectionSource: undefined,
-      retryAfterSeconds: undefined,
+      body: { failureKind: "timeout" },
+      source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "provider-response connection default",
-      failureKind: "connection",
-      connectionSource: "provider_response",
-      retryAfterSeconds: undefined,
+      body: {
+        failureKind: "connection",
+        connectionSource: "provider_response",
+      },
+      source: "provider_response",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "bounded provider retry delay",
-      failureKind: "rate_limit",
-      connectionSource: undefined,
-      retryAfterSeconds: 120,
+      body: { failureKind: "rate_limit", retryAfterSeconds: 120 },
+      source: "unspecified",
       cooldownSeconds: 120,
     },
   ] as const)(
     "records the $caseName cooldown for only the persisted built-in model route",
-    async ({
-      failureKind,
-      connectionSource,
-      retryAfterSeconds,
-      cooldownSeconds,
-    }) => {
+    async ({ body, source, cooldownSeconds }) => {
       const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
       await withMockNowForTest(startedAt, async () => {
         const claimed = await createClaimedVm0Run();
@@ -536,11 +520,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         );
 
         await expect(
-          runs.reportRunnerModelProviderFailure(claimed.runId, {
-            failureKind,
-            ...(connectionSource === undefined ? {} : { connectionSource }),
-            ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
-          }),
+          runs.reportRunnerModelProviderFailure(claimed.runId, body),
         ).resolves.toStrictEqual({ outcome: "recorded" });
         expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
           "Built-in model provider failure report recorded",
@@ -551,9 +531,9 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
             selectedModel: claimed.selectedModel,
             providerType: primary.provider_type,
             upstreamModel: primary.upstream_model,
-            failureKind,
-            source: connectionSource ?? "unspecified",
-            reason: failureKind,
+            failureKind: body.failureKind,
+            source,
+            reason: body.failureKind,
             retryAfterSeconds: cooldownSeconds,
             unavailableUntil: new Date(
               startedAt + cooldownSeconds * 1000,
@@ -1247,6 +1227,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         [401],
         {
           failureKind: "connection",
+          connectionSource: "provider_response",
         },
       );
       expectApiError(missingAuth.body);
@@ -1257,6 +1238,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         [401],
         {
           failureKind: "connection",
+          connectionSource: "provider_response",
         },
       );
       expectApiError(sandboxAuth.body);
@@ -1268,6 +1250,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         [403],
         {
           failureKind: "connection",
+          connectionSource: "provider_response",
         },
       );
       expectApiError(patAuth.body);
@@ -1275,6 +1258,10 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       for (const body of [
         {
           failureKind: "connection",
+        },
+        {
+          failureKind: "connection",
+          connectionSource: "provider_response",
           selectedModel: claimed.selectedModel,
         },
         {
@@ -1282,6 +1269,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         },
         {
           failureKind: "connection",
+          connectionSource: "provider_response",
           retryAfterSeconds: 301,
         },
         {

--- a/turbo/apps/api/src/signals/services/built-in-model-provider-failure.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-provider-failure.service.ts
@@ -1,7 +1,9 @@
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
+import type { runnersModelProviderFailuresContract } from "@okouai/api-contracts/contracts/runners";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { builtInModelCandidateCooldown } from "@okouai/db/schema/built-in-model-cooldown";
 import { and, eq } from "drizzle-orm";
+import type { z } from "zod";
 
 import type { Db } from "../external/db";
 
@@ -15,17 +17,15 @@ const INACTIVE_COOLDOWN_DEADLINE_MS = 0;
 
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
+type BuiltInModelProviderFailureBody = z.infer<
+  (typeof runnersModelProviderFailuresContract.report)["body"]
+>;
 type BuiltInModelProviderFailureKind =
-  | "authentication"
-  | "billing"
-  | "rate_limit"
-  | "provider_unavailable"
-  | "timeout"
-  | "connection";
-
-type BuiltInModelProviderConnectionSource =
-  | "provider_response"
-  | "upstream_transport";
+  BuiltInModelProviderFailureBody["failureKind"];
+type BuiltInModelProviderConnectionSource = Extract<
+  BuiltInModelProviderFailureBody,
+  { readonly failureKind: "connection" }
+>["connectionSource"];
 
 interface BuiltInModelRouteIdentity {
   readonly selectedModel: string;
@@ -55,13 +55,20 @@ type BuiltInModelProviderFailureTransition =
       readonly cooldown: CooldownMutation | null;
     };
 
-interface BuiltInModelProviderFailureReport {
+interface BuiltInModelProviderFailureMetadata {
   readonly runId: string;
   readonly receivedAt: Date;
-  readonly failureKind: BuiltInModelProviderFailureKind;
-  readonly connectionSource?: BuiltInModelProviderConnectionSource;
-  readonly retryAfterSeconds?: number;
 }
+
+type BuiltInModelProviderConnectionFailureReport =
+  BuiltInModelProviderFailureMetadata &
+    Extract<
+      BuiltInModelProviderFailureBody,
+      { readonly failureKind: "connection" }
+    >;
+
+type BuiltInModelProviderFailureReport = BuiltInModelProviderFailureMetadata &
+  BuiltInModelProviderFailureBody;
 
 function routeCondition(route: BuiltInModelRouteIdentity) {
   return and(
@@ -201,7 +208,7 @@ async function activateCooldown(
 async function observeTransportFailure(
   tx: WriteTx,
   route: LockedBuiltInModelRoute,
-  report: BuiltInModelProviderFailureReport,
+  report: BuiltInModelProviderConnectionFailureReport,
 ): Promise<BuiltInModelProviderFailureTransition> {
   const interval = observationInterval(route);
   const receivedAtMs = report.receivedAt.getTime();
@@ -274,19 +281,21 @@ export async function reportBuiltInModelProviderFailure(
       return { outcome: "ignored" };
     }
     const lockedRoute = await materializeAndLockRoute(tx, route);
-    if (
-      report.failureKind === "connection" &&
-      report.connectionSource === "upstream_transport"
-    ) {
-      return await observeTransportFailure(tx, lockedRoute, report);
+    if (report.failureKind === "connection") {
+      if (report.connectionSource === "upstream_transport") {
+        return await observeTransportFailure(tx, lockedRoute, report);
+      }
+      return await activateCooldown(tx, lockedRoute, {
+        receivedAt: report.receivedAt,
+        failureKind: report.failureKind,
+        connectionSource: report.connectionSource,
+        retryAfterSeconds: immediateCooldownSeconds(report),
+        reason: report.failureKind,
+      });
     }
-    // Source-less connection reports can arrive from old runners during the
-    // #29672 rollout. Remove this immediate path after their two-hour sandbox
-    // drain plus bounded finalization; #29805 tracks that cleanup.
     return await activateCooldown(tx, lockedRoute, {
       receivedAt: report.receivedAt,
       failureKind: report.failureKind,
-      connectionSource: report.connectionSource,
       retryAfterSeconds: immediateCooldownSeconds(report),
       reason: report.failureKind,
     });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -123,21 +123,18 @@ const runnerProcessIdentitySchema = z
   })
   .strict();
 
-const builtInModelProviderFailureKindSchema = z.enum([
-  "authentication",
-  "billing",
-  "rate_limit",
-  "provider_unavailable",
-  "timeout",
-  "connection",
-]);
-
-const builtInModelProviderConnectionSourceSchema = z.enum([
+export const builtInModelProviderConnectionSourceSchema = z.enum([
   "provider_response",
   "upstream_transport",
 ]);
 
 const BUILT_IN_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
+const builtInModelProviderRetryAfterSecondsSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(BUILT_IN_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS)
+  .optional();
 
 /**
  * Atomic advisory decision for cross-runner reuse coordination. A preferred
@@ -1188,27 +1185,45 @@ export const runnersModelProviderFailuresContract = c.router({
     pathParams: z.object({
       runId: z.uuid(),
     }),
-    body: z
-      .object({
-        failureKind: builtInModelProviderFailureKindSchema,
-        connectionSource: builtInModelProviderConnectionSourceSchema.optional(),
-        retryAfterSeconds: z
-          .number()
-          .int()
-          .positive()
-          .max(BUILT_IN_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS)
-          .optional(),
-      })
-      .strict()
-      .superRefine((body, context) => {
-        if (body.connectionSource && body.failureKind !== "connection") {
-          context.addIssue({
-            code: "custom",
-            path: ["connectionSource"],
-            message: "connectionSource requires failureKind connection",
-          });
-        }
-      }),
+    body: z.discriminatedUnion("failureKind", [
+      z
+        .object({
+          failureKind: z.literal("authentication"),
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+      z
+        .object({
+          failureKind: z.literal("billing"),
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+      z
+        .object({
+          failureKind: z.literal("rate_limit"),
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+      z
+        .object({
+          failureKind: z.literal("provider_unavailable"),
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+      z
+        .object({
+          failureKind: z.literal("timeout"),
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+      z
+        .object({
+          failureKind: z.literal("connection"),
+          connectionSource: builtInModelProviderConnectionSourceSchema,
+          retryAfterSeconds: builtInModelProviderRetryAfterSecondsSchema,
+        })
+        .strict(),
+    ]),
     responses: {
       200: z
         .object({

--- a/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/schema.test.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/schema.test.ts
@@ -21,6 +21,48 @@ function binding(id: string, path: string): RuntimeApiRouteBinding {
 }
 
 describe("runtime API schema namespaces", () => {
+  it("publishes the strict model provider failure report contract", () => {
+    const document = buildRuntimeApiSchemaDocument("2026-08-12T00:00:00.000Z");
+    const route = document.routes.find(({ id }) => {
+      return id === "runners.runs.modelProviderFailures";
+    });
+
+    expect(route).toMatchObject({
+      method: "POST",
+      owner: "mitm-addon",
+      path: "/api/runners/runs/:runId/model-provider-failures",
+    });
+    const body = route?.request.body;
+    if (!body || body.kind !== "json-schema") {
+      throw new Error("Expected the model provider failure request schema");
+    }
+    const alternatives = body.schema.oneOf;
+    if (!Array.isArray(alternatives)) {
+      throw new Error("Expected failure-kind request alternatives");
+    }
+    expect(alternatives).toHaveLength(6);
+    expect(alternatives).toContainEqual({
+      additionalProperties: false,
+      properties: {
+        connectionSource: {
+          enum: ["provider_response", "upstream_transport"],
+          type: "string",
+        },
+        failureKind: {
+          const: "connection",
+          type: "string",
+        },
+        retryAfterSeconds: {
+          exclusiveMinimum: 0,
+          maximum: 300,
+          type: "integer",
+        },
+      },
+      required: ["failureKind", "connectionSource"],
+      type: "object",
+    });
+  });
+
   it.each(["/api/zero/example", "/api/okou/example"] as const)(
     "publishes both branded namespaces from $sourcePath with schema parity",
     (sourcePath) => {

--- a/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
@@ -4,6 +4,7 @@ import {
   runnersConnectorRuntimeSyncContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
+  runnersModelProviderFailuresContract,
   runnersPollContract,
 } from "../contracts/runners";
 import {
@@ -68,6 +69,11 @@ export const runtimeApiRouteBindings = [
     id: "runners.connectorRuntime.sync",
     owner: "runner",
     route: runnersConnectorRuntimeSyncContract.sync,
+  },
+  {
+    id: "runners.runs.modelProviderFailures",
+    owner: "mitm-addon",
+    route: runnersModelProviderFailuresContract.report,
   },
   {
     id: "webhooks.agent.events",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -58,6 +58,11 @@ const expectedBindings = [
     direction: "request",
   },
   {
+    rustModulePath: ["runners", "runs", "model_provider_failures"],
+    rustTypeName: "RequestConnectionSource",
+    direction: "request",
+  },
+  {
     rustModulePath: ["runners", "storage"],
     rustTypeName: "ArtifactEntryMissingRootPolicy",
     direction: "response",

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -4,6 +4,7 @@ import {
   activeInputDeliveryReserveResponseSchema,
   activeInputDeliveryReceiptResponseSchema,
   artifactMissingRootPolicySchema,
+  builtInModelProviderConnectionSourceSchema,
   piLaunchConfigSchema,
   piModelConfigSchema,
   runnersModelProviderFailuresContract,
@@ -286,15 +287,36 @@ export const rustTypeBindings = [
     ],
   },
   {
+    schema: builtInModelProviderConnectionSourceSchema,
+    rustModulePath: ["runners", "runs", "model_provider_failures"],
+    rustTypeName: "RequestConnectionSource",
+    direction: "request",
+    declarations: [
+      {
+        rustTypeName: "RequestConnectionSource",
+        rustDoc: ["Source of an eligible connection failure."],
+        variants: {
+          provider_response: ["The provider returned a connection failure."],
+          upstream_transport: [
+            "The runner observed an upstream transport failure.",
+          ],
+        },
+      },
+    ],
+  },
+  {
     schema: runnersModelProviderFailuresContract.report.body,
     rustModulePath: ["runners", "runs", "model_provider_failures"],
     rustTypeName: "Request",
     direction: "request",
+    fieldTypeOverrides: {
+      connectionSource: "RequestConnectionSource",
+    },
     declarations: [
       {
-        rustTypeName: "RequestFailureKind",
+        rustTypeName: "Request",
         rustDoc: [
-          "Bounded provider-independent failure eligible for route cooldown.",
+          "Request body for reporting a built-in model provider failure.",
         ],
         variants: {
           authentication: ["Provider authentication failed."],
@@ -306,27 +328,8 @@ export const rustTypeBindings = [
           timeout: ["The provider inference request timed out."],
           connection: ["The provider connection failed."],
         },
-      },
-      {
-        rustTypeName: "RequestConnectionSource",
-        rustDoc: ["Source of an eligible connection failure."],
-        variants: {
-          provider_response: ["The provider returned a connection failure."],
-          upstream_transport: [
-            "The runner observed an upstream transport failure.",
-          ],
-        },
-      },
-      {
-        rustTypeName: "Request",
-        rustDoc: [
-          "Request body for reporting a built-in model provider failure.",
-        ],
         fields: {
-          failureKind: ["Normalized eligible provider failure kind."],
-          connectionSource: [
-            "Optional source for connection failures; omitted by legacy runners.",
-          ],
+          connectionSource: ["Required source of the connection failure."],
           retryAfterSeconds: [
             "Optional bounded provider retry delay in seconds.",
           ],


### PR DESCRIPTION
## Summary

- require `connectionSource` for connection failure reports and reject it for non-connection kinds through a strict discriminated request contract
- derive the service input from that contract while preserving immediate `provider_response`, sustained `upstream_transport`, and existing non-connection cooldown policies
- inventory the mitm-addon report route and regenerate the Rust request as a tagged enum whose `Connection` variant requires a source

## Deployment compatibility

- the production drain and old-runner maximum lifetime recorded in #29805 clear the intentional old-runner-to-new-API contraction
- the new-runner-to-old-API HTTP 400 fallback owned by #29882 is unchanged
- no endpoint path, response, authentication, cooldown duration, observation threshold, database schema, or production data changes are included

## Validation

- `pnpm -F @okouai/api-contracts exec vitest run src/rust-bindings/__tests__/types.test.ts src/runtime-api-schema/__tests__/schema.test.ts src/runtime-api-schema/__tests__/compat.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @okouai/api-contracts`
- `pnpm knip --workspace api`
- `pnpm -F @okouai/api-contracts generate:rust`
- `pnpm -F @okouai/api-contracts generate:python`
- runtime API candidate comparison against release `runtime-api-schema-prod` (passed with no findings)
- `cargo fmt --all -- --check`
- `cargo clippy -p api-contracts --all-targets --all-features`
- `cargo doc -p api-contracts --all-features --no-deps`
- `cargo test -p api-contracts`
- pre-commit hooks (full Knip, Turbo type checks, Rust format/docs/Clippy, file-size check)

Closes #29805

Parent: #29645
