### PR TITLE
refactor(test): cut resume-session writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/cli_resume_id_stderr_visibility.rs
+++ b/crates/guest-agent/tests/cli_resume_id_stderr_visibility.rs
@@ -25,7 +25,10 @@ async fn cli_failure_preserves_resume_session_id_in_stderr()
             3,
             1,
         )?;
-        std::env::set_var("VM0_RESUME_SESSION_ID", resume_id);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+            resume_id,
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1199,9 +1199,12 @@ pub unsafe fn setup_codex_app_server_env(
             },
         )?;
         if let Some(resume_session_id) = config.resume_session_id {
-            std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
+            std::env::set_var(
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+                resume_session_id,
+            );
         } else {
-            std::env::remove_var("VM0_RESUME_SESSION_ID");
+            std::env::remove_var(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV);
         }
     }
     std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -158,7 +158,10 @@ async fn run_event_failure_case(
                 guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
                 &mock_codex,
             )
-            .env(guest_contracts::env::RESUME_SESSION_ID_ENV, THREAD_ID)
+            .env(
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+                THREAD_ID,
+            )
             .env("MOCK_CODEX_APP_SERVER_SCENARIO", mock_scenario)
             .env(
                 guest_contracts::env::RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -103,7 +103,10 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
                 guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
                 &mock_codex,
             )
-            .env(guest_contracts::env::RESUME_SESSION_ID_ENV, THREAD_ID)
+            .env(
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
+                THREAD_ID,
+            )
             .env(
                 "MOCK_CODEX_APP_SERVER_SCENARIO",
                 "runtime-turn-started-before-steer",

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -200,7 +200,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 &mock_codex,
             )
             .env(
-                guest_contracts::env::RESUME_SESSION_ID_ENV,
+                guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV,
                 scenario.thread_id,
             )
             .env(


### PR DESCRIPTION
## Summary

- switch the five same-checkout Guest Agent test/debug resume-session writers to `CANONICAL_RESUME_SESSION_ID_ENV`
- make `setup_codex_app_server_env` remove the same canonical alias in its paired no-value branch
- retain symmetric canonical/legacy process-global cleanup and all production/compatibility boundaries

## Scope evidence

- pre-edit base: `89246ebfe7977ae609f05102fafe0dac6acc1b7b`
- pre-edit open-PR audit: 29 open PRs, 531 declared / 531 fully paginated changed files, 0 pagination mismatches; #29949 overlapped four scoped files only for the separate mock-path contract
- publication base: `3941a9832964c22b647213509376be0fccb70683` (includes merged #29949)
- publication head: `730d5aad86a71bfe0e9f2d70dbc8d1ae5ef2f323`
- publication open-PR audit: 28 open PRs, 519 declared / 519 fully paginated changed files, 0 pagination mismatches, 0 scoped-file overlaps
- final diff: exactly the five test files authorized by #29952; 18 insertions and 6 deletions

The #29949 integration keeps both canonical contracts in adjacent command-environment hunks: its canonical mock-path writer and this PR's canonical resume-session writer.

## Exact-key inventory

- ordinary Guest Agent test harness legacy resume-session writers: 0
- shared process-global cleanup still removes both canonical and legacy aliases
- remaining legacy references are limited to the compatibility constant/contract coverage, deployed dual reader, canonical-only assertions, alias matrix, cleanup, CLI-child isolation, production Runner writer, and Runner assertions
- production readers, writers, telemetry, guards, and compatibility matrices are unchanged

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test run_metadata_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib cli::child_env::tests::apply_values_clears_resume_session_bootstrap_aliases -- --exact`
- affected integration targets: `cli_resume_id_stderr_visibility`, `codex_app_server_backend_invalid_resume_id`, `codex_app_server_backend_resume_mismatch`, `codex_app_server_backend_resume`, `codex_app_server_backend_error_visibility`, `event_delivery_failure_recovery`, `execution_timeout_recovery`, and `user_cancellation_recovery`
- `git diff --check origin/main...HEAD`

All commands passed on the publication head after integrating current `main`.

## Fallbacks

Reverting this PR restores the legacy same-checkout test writers. Production behavior, the Runner writer, and the deployed dual reader are unchanged.

Closes #29952
Related to #29065
Parent EPIC: #28914
