### PR TITLE
refactor(test): cut api start-time writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -45,7 +45,10 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
             .duration_since(UNIX_EPOCH)?
             .as_millis()
             .saturating_sub(10_000);
-        std::env::set_var("VM0_API_START_TIME", api_start_time.to_string());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+            api_start_time.to_string(),
+        );
         let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)
             .map_err(|error| format!("resolve runtime dir: {error}"))?;
         common::set_run_payload_file_env_for_test(

--- a/crates/guest-agent/tests/codex_app_server_backend_output_timing_stale_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_output_timing_stale_scope.rs
@@ -25,7 +25,10 @@ async fn codex_app_server_backend_rejects_stale_turn_output_timing()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_START_TIME", "1700000000000");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+            "1700000000000",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -26,7 +26,10 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_START_TIME", "1700000000000");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+            "1700000000000",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -31,7 +31,10 @@ async fn codex_app_server_backend_ignores_secondary_thread_notifications()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_START_TIME", "1699999999000");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_START_TIME_ENV,
+            "1699999999000",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);


### PR DESCRIPTION
## Summary

- switch the four ordinary Guest Agent API start-time test writers to `CANONICAL_API_START_TIME_ENV`
- preserve all timestamp values and backend timing, stale-scope, active-thread, secondary-thread, event-ordering, timeout, and diagnostic assertions
- leave the dual reader, compatibility matrix and cleanup, production Runner writer, timing production code, diagnostics, telemetry, and adjacent environment contracts unchanged

Closes #29953.
Predecessor reader foundation: #28982.
Parent EPIC: #28914.

## Verification

Passed locally:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test run_metadata_env_aliases`
- `cargo test -p guest-agent --test codex_app_server_backend`
- `cargo test -p guest-agent --test codex_app_server_backend_output_timing_stale_scope`
- `cargo test -p guest-agent --test codex_app_server_backend_scope`
- `cargo test -p guest-agent --test codex_app_server_backend_secondary_thread`
- final exact-key inventory: four canonical ordinary writers, zero legacy literal or legacy-constant ordinary writers; remaining legacy references are limited to the compatibility constant and assertion, dual reader, alias matrix, cleanup, production Runner writer and assertions, and separately owned timing diagnostic
- `git diff --check`

## Base, head, and open-PR audit

- controller baseline reproduced at `89246ebfe7977ae609f05102fafe0dac6acc1b7b`: 29 open PRs, 531 declared / 531 fully paginated changed files, zero mismatches, zero scoped overlap
- `main` advanced before editing, so no edit was applied until the branch was fast-forwarded to implementation base `3941a9832964c22b647213509376be0fccb70683`
- refreshed pre-edit audit at the implementation base: 28 open PRs, 519 declared / 519 fully paginated changed files, zero mismatches, zero scoped overlap
- pre-publication audit: 29 open PRs, 528 declared / 528 fully paginated changed files, zero mismatches, zero scoped overlap
- published head: `76044c7d676256fccc07786f659d0abeb091a91d`

## Fallbacks

Reverting this focused PR restores the four legacy test writers. Production behavior and compatibility remain unchanged, so no production rollback or configuration action is required.
