### PR TITLE
refactor(test): cut agent execution timeout writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/claude_task_notification_result.rs
+++ b/crates/guest-agent/tests/claude_task_notification_result.rs
@@ -78,7 +78,10 @@ async fn task_notification_result_does_not_end_the_user_command()
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 1, 1)?;
         std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "1");
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "2");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "2",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
@@ -37,7 +37,10 @@ fn execution_timeout_terminates_a_stuck_active_input_steer()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
@@ -23,7 +23,10 @@ async fn codex_app_server_execution_timeout_interrupts_hung_turn_start()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -108,7 +108,10 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
                 "MOCK_CODEX_APP_SERVER_SCENARIO",
                 "runtime-turn-started-before-steer",
             )
-            .env(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1")
+            .env(
+                guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                "1",
+            )
             .env(
                 guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
                 "1",

--- a/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
+++ b/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
@@ -17,7 +17,10 @@ async fn execution_deadline_preserves_post_result_sigkill_pending()
         // post-result reaper sends SIGTERM after 1s, the execution deadline
         // lands at 5s, and the 8s SIGKILL grace then completes the reaper.
         common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 1, 8)?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "5");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "5",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -24,7 +24,10 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
         // happy path returns successfully, it returned before the reap
         // deadline could fire. sigkill grace is unused on this path.
         common::setup_env(&mock, tmp.path(), "@exit-after-result", 60, 1)?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "2");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "2",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -26,7 +26,10 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
         // timeout. SIGTERM is ignored, then the 1s SIGKILL grace completes
         // within the outer test bound.
         common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 60, 1)?;
-        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;


### PR DESCRIPTION
## Summary

- switch exactly seven same-checkout Guest Agent execution-timeout test writers from the legacy alias to `CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV`
- preserve every timeout value, deadline, reaping path, notification path, active-input path, and recovery behavior
- leave the production Runner writer, dual reader, alias matrix, CLI-child isolation, shared cleanup, telemetry, and compatibility surfaces unchanged

Parent EPIC: #28914

Closes #29954

## Scope evidence

- implementation base after refreshing `origin/main`: `3941a9832964c22b647213509376be0fccb70683`
- publication base after the final refresh and recheck: `3941a9832964c22b647213509376be0fccb70683`
- publication head: `00b7eb05e4d8c85717b3a20dbc2b77ccd8fabb05`
- pre-edit inventory: 29 open PRs, 528 declared / 528 fully paginated changed files, 0 pagination mismatches
- publication inventory: 31 open PRs, 561 declared / 561 fully paginated changed files, 0 pagination mismatches
- the only scoped open-PR overlap is #29955 in `execution_timeout_recovery.rs` for the separate resume-session alias; its patch has no execution-timeout identifier hit
- final diff: exactly the seven test files authorized by #29954, with 28 insertions and 7 deletions from canonical-name line wrapping

The final exact-key inventory has zero legacy execution-timeout writers in the seven scoped files and exactly one canonical writer in each. The retained legacy references are limited to the production Runner contract, dual reader, compatibility assertions, deliberate equal-dual CLI isolation, alias matrix, and shared cleanup.

## Verification

All commands passed with Rust 1.98.0:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS=-D warnings cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- complete alias matrix: `agent_execution_timeout_env_aliases`
- CLI-child isolation: `cli_child_env`
- all seven affected integration targets: `claude_task_notification_result`, `codex_app_server_backend_active_input_execution_timeout`, `codex_app_server_backend_execution_timeout`, `execution_timeout_recovery`, `post_result_reap_execution_deadline`, `post_result_reap_happy`, and `post_result_reap_sigkill`
- `git diff --check origin/main...HEAD`

The full local Vitest suite was not run and no local development server was started. Protected PR CI remains authoritative for repository-wide checks.

## Rollback

Reverting this test-only PR restores the legacy same-checkout test writers. The deployed dual reader and unchanged legacy production Runner writer continue accepting either supported test spelling throughout the rollback window.