### PR TITLE
refactor(test): cut sandbox metadata writers to canonical aliases

### DIFF
--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -69,10 +69,13 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
         .env(token_env, API_TOKEN)
         .env(guest_contracts::env::RUN_ID_ENV, format!("{RUN_ID}-{case}"))
         .env(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         )
-        .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        )
         .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "claude-code")
         .env(guest_contracts::env::USE_MOCK_CLAUDE_ENV, "true")
         .env(

--- a/crates/guest-agent/tests/codex_model_catalog_setup.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_setup.rs
@@ -77,8 +77,14 @@ async fn codex_setup_writes_model_catalog_before_cli_start() -> TestResult {
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
         .env("VM0_API_TOKEN", "")
-        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
-        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        )
         .env("OKOU_TEST_CODEX_HOME_DIR", &codex_home)
         .env(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -180,8 +180,14 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
         .env("VM0_API_TOKEN", "")
-        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
-        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        )
         .env("OKOU_TEST_CODEX_HOME_DIR", args.home.join(".codex"))
         .env(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -144,8 +144,14 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
         .env("VM0_API_TOKEN", "")
-        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
-        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        )
+        .env(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        )
         .env("OKOU_TEST_CODEX_HOME_DIR", args.home.join(".codex"))
         .env(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1185,8 +1185,14 @@ pub unsafe fn setup_codex_app_server_env(
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, config.run_id);
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", home);
         std::env::set_var("OKOU_TEST_CODEX_HOME_DIR", home.join("codex-home"));
         let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(home, config.run_id)
@@ -1346,8 +1352,14 @@ pub unsafe fn setup_env(
         // Empty API token → has_api() false → no network calls.
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         // Redirect HOME so the mock's session-history write
         // (`$CLAUDE_CONFIG_DIR/projects/.../<session>.jsonl`) stays inside
         // the tempdir and gets cleaned up with it, instead of

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -147,10 +147,13 @@ async fn run_event_failure_case(
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, run_id)
             .env(
-                guest_contracts::env::SANDBOX_ID_ENV,
+                guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",
             )
-            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(
+                guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+                "reused",
+            )
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", home.join(".codex"))
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -46,8 +46,14 @@ unsafe fn setup_api_env(
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", api_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", workdir);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -92,10 +92,13 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
             .env(
-                guest_contracts::env::SANDBOX_ID_ENV,
+                guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",
             )
-            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(
+                guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+                "reused",
+            )
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", home.join(".codex"))
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -33,8 +33,14 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
         );
         write_shared_run_payload_file_or_panic();
         std::env::set_var("VERCEL_PROTECTION_BYPASS", "test-bypass-value");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
     }
     server
 });

--- a/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
+++ b/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
@@ -91,10 +91,13 @@ printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandb
             std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
             std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
             std::env::set_var(
-                guest_contracts::env::SANDBOX_ID_ENV,
+                guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",
             );
-            std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+            std::env::set_var(
+                guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+                "reused",
+            );
             std::env::set_var("HOME", tmp.path());
             let mut paths = vec![bin_dir];
             paths.extend(std::env::split_paths(&base_path));

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -53,10 +53,13 @@ done
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         );
-        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", tmp.path());
         let mut paths = vec![bin_dir];
         paths.extend(std::env::split_paths(

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -104,10 +104,13 @@ fi
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         );
-        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", tmp.path());
         let mut paths = vec![bin_dir.clone()];
         paths.extend(std::env::split_paths(

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -72,10 +72,13 @@ fi
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         );
-        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", tmp.path());
         let mut paths = vec![bin_dir];
         paths.extend(std::env::split_paths(base_path));

--- a/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
+++ b/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
@@ -67,10 +67,13 @@ done
         );
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
         std::env::set_var(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         );
-        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var("HOME", tmp.path());
         let mut paths = vec![bin_dir];
         paths.extend(std::env::split_paths(

--- a/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
@@ -45,10 +45,13 @@ exec tail -f /dev/null
         std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
         std::env::set_var(
-            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
         );
-        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        );
         std::env::set_var(
             guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
             "3",

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -154,8 +154,14 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ),
         ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
         ("VM0_API_TOKEN", ""),
-        ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
-        ("VM0_SANDBOX_REUSE_RESULT", "reused"),
+        (
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        ),
+        (
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        ),
         ("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         ("HOME", workdir.as_str()),
     ];
@@ -285,8 +291,14 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
         ),
         ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
         ("VM0_API_TOKEN", ""),
-        ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
-        ("VM0_SANDBOX_REUSE_RESULT", "reused"),
+        (
+            guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        ),
+        (
+            guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+            "reused",
+        ),
         ("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         ("HOME", workdir.as_str()),
     ];

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -188,10 +188,13 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, scenario.run_id)
             .env(
-                guest_contracts::env::SANDBOX_ID_ENV,
+                guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",
             )
-            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(
+                guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+                "reused",
+            )
             .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
             .env("OKOU_TEST_CODEX_HOME_DIR", &codex_home)
             .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")


### PR DESCRIPTION
## Summary

- switch exactly 38 ordinary same-checkout Guest Agent test writers for sandbox ID and sandbox reuse result to `CANONICAL_SANDBOX_ID_ENV` and `CANONICAL_SANDBOX_REUSE_RESULT_ENV`
- preserve every writer value, fixture, scenario, process behavior, and assertion
- retain the legacy production Runner writers, four-pair dual reader and alias matrix, conflict handling, telemetry, CLI-child isolation, symmetric alias cleanup, absent-metadata coverage, workspace reuse, and API start time contracts

## Scope evidence

- exact implementation base: `3941a9832964c22b647213509376be0fccb70683`
- refreshed publication base: `6b1f6b328efc2a747fbac17abafae66c70379d19`
- published head: `729daa44ef5c59942b7c412e73184f8f54193264`
- final diff: exactly the 17 test files authorized by #29956, with 122 insertions and 38 deletions
- exact diff semantics: 38 legacy writer tokens removed and 38 canonical constant tokens added
- the only legacy sandbox metadata references left in the scoped files are the two required shared-cleanup entries in `tests/common/mod.rs`
- no `WORKSPACE_REUSE_RESULT`, `API_START_TIME`, Runner, reader, matrix, CLI-child isolation, or production file appears in the diff

## Main and open-PR reconciliation

- pre-edit audit: 31 open PRs and 557 declared / 557 fully paginated changed files, with zero count mismatches; #29955 overlapped four scoped files only for the separate resume-session alias
- publication refresh integrated merged #29955 and #29957 from canonical `main`, preserving their resume-session and API-start-time writer changes
- final pre-publication audit: 30 open PRs and 561 declared / 561 fully paginated changed files, with zero count mismatches
- #29959 is the only final scoped-file overlap, touching `execution_timeout_recovery.rs` for the separate execution-timeout alias; it is inventory only and not an ordering dependency

## Verification

Passed on the publication head:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- warning-denied Guest Agent docs with all features and no dependencies
- complete `run_metadata_env_aliases` four-pair matrix
- full `cli_child_env` isolation target
- affected integration targets: `integration`, `codex_startup_telemetry`, `pi_cli_settlement_errors`, `pi_cli_malformed_tool_event`, `api_token_process_isolation`, `event_delivery_failure_recovery`, `codex_setup_fail_closed`, `pi_cli_run_id_env`, `pi_initial_prompt_stdin_reap_sigkill`, `execution_timeout_recovery`, `pi_cli_stalled_stdin_cancellation`, `pi_cli_handoff_boundary`, `user_cancellation_recovery`, `codex_model_catalog_setup`, and `execute_cli_api_mode`
- `codex_app_server_backend` for the changed shared app-server setup writer
- `process_control_channel::process_control_channel_reaches_guest_agent`
- `git diff --check`

Local environment limitation:

- `process_control_channel::process_control_enabled_plain_run_does_not_wait_for_stdin_eof` exits before sandbox metadata is consumed because this container provides the process-control endpoint without the required workload and tool cgroup endpoints
- exact error: `OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT or VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT, and OKOU_TOOL_CGROUP_PROCS_ENDPOINT or VM0_TOOL_CGROUP_PROCS_ENDPOINT, are required with OKOU_PROCESS_CONTROL_ENDPOINT or VM0_PROCESS_CONTROL_ENDPOINT`
- the identical failure was reproduced in a detached clean checkout at implementation base `3941a9832964c22b647213509376be0fccb70683` with the legacy sandbox writers, while the sibling process-control test passed; protected CI is authoritative for the environment-backed path

## Fallbacks

Reverting this focused test-only PR restores the legacy test writers. The deployed dual reader and legacy production Runner writers make both spellings valid throughout the supported rollback window.

Closes #29956
Parent EPIC: #28914
