### PR TITLE
refactor(test): cut stuck-tool timeout writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/claude_tool_tracking_overflow.rs
+++ b/crates/guest-agent/tests/claude_tool_tracking_overflow.rs
@@ -90,7 +90,10 @@ async fn claude_tool_tracking_overflow_preserves_later_watchdog_coverage()
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt_lines.join("\n"), 1, 1)?;
-        std::env::set_var(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV, "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -15,7 +15,10 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     let tmp = tempfile::tempdir()?;
     unsafe {
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
-        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -15,7 +15,10 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     let tmp = tempfile::tempdir()?;
     unsafe {
         common::setup_env(&mock, tmp.path(), "@stuck-tool-closed-stdout-deaf", 1, 1)?;
-        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+            "1",
+        );
     }
 
     let runtime = common::guest_runtime_from_process_env()?;


### PR DESCRIPTION
## Summary

- switch exactly three ordinary same-checkout Guest Agent stuck-tool timeout test writers to `CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV`
- preserve each value `1` and the existing overflow, virtual-time, watchdog, SIGTERM/SIGKILL, stdout EOF, reaping, diagnostic, and timeout behavior
- retain the deployed dual reader and every production/local compatibility boundary

## Scope evidence

- pre-edit base: `086f2e1376400ef3feb818b896e751497bac0147`
- pre-edit open-PR audit: 31 open PRs, 565 declared / 565 fully paginated changed files, 0 pagination mismatches, 0 scoped-file overlaps
- controller pre-dispatch snapshot was 31 open PRs and 563 / 563 files; the pre-edit refresh observed two additional changed files without any scoped overlap
- publication refresh moved `main` from `086f2e1376400ef3feb818b896e751497bac0147` to `38b93ad6b0be1c85e20a4d1ce3d69edd38772ea3`; the single commit was rebased and the complete verification was repeated
- publication base: `38b93ad6b0be1c85e20a4d1ce3d69edd38772ea3`
- publication head: `f7785c47984c85abb2ca7118cbbd5dfad8ae558c`
- publication open-PR audit: 29 open PRs, 537 declared / 537 fully paginated changed files, 0 pagination mismatches, 0 scoped-file overlaps
- final diff: exactly the three files authorized by #29960; 12 insertions and 3 deletions

## Exact-key inventory

- scoped legacy stuck-tool timeout writers: 0
- scoped canonical stuck-tool timeout writers: 3, each with the unchanged value `1`
- remaining legacy references are limited to the active production/local tuning contract, deployed dual reader, value-free source telemetry, four-pair alias matrix, equal-dual CLI-child isolation, shared symmetric cleanup, constants/docs, ownership and pass-through assertions, and deliberate compatibility coverage
- production Runner/local writers, `GUEST_AGENT_TUNING_ENV_KEYS`, readers, telemetry, bounds, defaults, diagnostics, cleanup, ownership guards, and all other timing families have no diff

## Verification

All commands passed on the publication head after rebasing onto the refreshed `main`:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_agent_tuning_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test stuck_tool_stdout_eof_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test claude_tool_tracking_overflow`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test stuck_tool_reap_sigkill`
- exact-key caller inventory, exact three-file allowlist, and `git diff --check origin/main...HEAD`

## Non-goals

- no production Runner/local tuning writer or allowlist changes
- no dual-reader, telemetry, default, bound, diagnostic, error-text, alias-matrix, CLI-child, shared-cleanup, timing-family, ownership-guard, documentation, release, or production configuration changes
- no production release or legacy-reader removal

## Fallbacks

Reverting this test-only PR restores the three legacy same-checkout writers. The unchanged production/local tuning writer and deployed dual reader continue supporting the legacy alias throughout the rollback window.

Closes #29960
Parent EPIC: #28914
