### PR TITLE
refactor(test): cut post-result timing writers to canonical aliases

### DIFF
--- a/crates/guest-agent/tests/claude_task_notification_result.rs
+++ b/crates/guest-agent/tests/claude_task_notification_result.rs
@@ -77,7 +77,10 @@ async fn task_notification_result_does_not_end_the_user_command()
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 1, 1)?;
-        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "1",
+        );
         std::env::set_var(
             guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV,
             "2",

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -31,25 +31,25 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "http://127.0.0.1:1",
         );
         std::env::set_var(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV, "300");
-        for (canonical, legacy) in [
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+            std::env::var(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV)?,
+        );
+        for (legacy, canonical) in [
             (
-                guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
-                guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
-            ),
-            (
-                guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
                 guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
             ),
             (
-                guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
                 guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
             ),
             (
-                guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
                 guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
             ),
         ] {
-            std::env::set_var(canonical, std::env::var(legacy)?);
+            std::env::set_var(legacy, std::env::var(canonical)?);
         }
         std::env::set_var("VM0_SECRET_VALUES", "runner-secret-values");
         std::env::set_var(

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1321,14 +1321,17 @@ pub unsafe fn setup_env(
         );
         std::env::set_var("USE_MOCK_CLAUDE", "true");
         std::env::set_var(
-            "VM0_POST_RESULT_SIGTERM_GRACE_SECS",
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
             sigterm_grace_secs.to_string(),
         );
         std::env::set_var(
-            "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
             sigkill_grace_secs.to_string(),
         );
-        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "60");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "60",
+        );
         // Derive run_id from the test binary's filename (which cargo
         // hashes per target) so concurrently running integration-test
         // binaries don't collide on the run-scoped files that paths.rs

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -26,8 +26,14 @@ unsafe fn setup_api_env(
             mock_path,
         );
         std::env::set_var("USE_MOCK_CLAUDE", "true");
-        std::env::set_var("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "3");
-        std::env::set_var("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "3",
+        );
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "1",
+        );
         let run_id = std::env::current_exe()
             .ok()
             .as_deref()

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -119,7 +119,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
                 "1",
             )
             .env(
-                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
                 "1",
             )
             .env(

--- a/crates/guest-agent/tests/post_result_reap_refresh.rs
+++ b/crates/guest-agent/tests/post_result_reap_refresh.rs
@@ -13,7 +13,10 @@ async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
     let tmp = tempfile::tempdir()?;
     unsafe {
         common::setup_env(&mock, tmp.path(), "@hang-after-result-then-event", 2, 1)?;
-        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "10");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "10",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -19,7 +19,10 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
             2,
             1,
         )?;
-        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "3");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+            "3",
+        );
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -145,8 +145,14 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
             mock_path.as_str(),
         ),
         ("USE_MOCK_CLAUDE", "true"),
-        ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
-        ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
+        (
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "1",
+        ),
+        (
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "1",
+        ),
         (guest_contracts::env::RUN_ID_ENV, run_id.as_str()),
         (
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
@@ -282,8 +288,14 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
             mock_path.as_str(),
         ),
         ("USE_MOCK_CLAUDE", "true"),
-        ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
-        ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
+        (
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            "1",
+        ),
+        (
+            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            "1",
+        ),
         (guest_contracts::env::RUN_ID_ENV, run_id.as_str()),
         (
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -211,11 +211,11 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 "runtime-turn-started-before-steer",
             )
             .env(
-                guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
                 "1",
             )
             .env(
-                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
                 "1",
             )
             .env(


### PR DESCRIPTION
## Summary

- cut exactly 15 ordinary post-result timing test writers in the eight Wave 75 files from the legacy `VM0_*` aliases to the corresponding shared canonical `OKOU_*` constants
- preserve all values, timing checkpoints, deadline refreshes, total-cap bounds, escalation paths, recovery behavior, diagnostics, mock scenarios, and outer timeouts
- keep CLI-child equal-dual isolation intact by retaining the stuck-tool legacy-to-canonical mirror and mirroring only the three canonical post-result values back to their legacy aliases

Closes #29961.
Parent EPIC: #28914.

## Scope evidence

- controller snapshot: base `086f2e1376400ef3feb818b896e751497bac0147`; 31 open PRs; 565 declared and 565 fully paginated changed files; 0 mismatches
- refreshed pre-edit inventory: base `6b1f6b328efc2a747fbac17abafae66c70379d19`; 30 open PRs; 561 declared and 561 fully paginated changed files; 0 mismatches
- publication base: `67626477d495d55587405b39964a88acf1793f37`
- publication head: `0777da121ea80ace7cb01391aa37615ccbc1e8d8`
- publication inventory: 29 open PRs; 524 declared and 524 fully paginated changed files; 0 mismatches; 0 PRs overlap the exact nine-file allowlist
- caller inventory: all six exact raw keys and all six legacy/canonical identifiers were enumerated before editing and again at publication; the original eight files contain 0 legacy raw-key writers after the change
- exact diff shape: 9 files, 54 insertions, 24 deletions; 15 legacy writer removals paired with 15 canonical writer additions; 3 deliberate legacy assignments remain in `cli_child_env.rs` as compatibility setup

### Overlap classification

- #29959 previously overlapped `claude_task_notification_result.rs` and `execution_timeout_recovery.rs` only for the separate execution-timeout alias; it merged and its canonical change is preserved
- #29962 later overlapped five authorized files only for separate sandbox metadata; it merged and was integrated before publication
- open #29963 handles the separate stuck-tool timeout and does not overlap this nine-file allowlist
- none of these changes is a functional dependency for Wave 75

## Verification

Passed after integrating the final publication base:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo check -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent` for:
  - `guest_agent_tuning_env_aliases`
  - `cli_child_env`
  - `post_result_reap_refresh`
  - `process_control_channel`
  - `execution_timeout_recovery`
  - `user_cancellation_recovery`
  - `post_result_reap_total_cap`
  - `claude_task_notification_result`
  - `execute_cli_api_mode`
  - `post_result_reap_happy`
  - `post_result_reap_execution_deadline`
  - `post_result_reap_sigkill`
- the targeted test command cleared inherited tool/workload cgroup endpoint variables so the process-control test received its intended isolated environment
- exact nine-file allowlist proof
- exact 15-removal/15-addition writer-site proof
- byte-identical shared cleanup-function proof
- no-diff proofs for constants, dual readers/source telemetry, production Runner writer, Guest Agent bootstrap ownership, alias matrix, bootstrap source-event test, and already-canonical PI writer
- `git diff --check origin/main...HEAD`

Per the issue contract, no full local Rust/Vitest suite or dev server was run; protected CI remains authoritative repository-wide.

## Non-goals

This does not change production/local tuning writers, `GUEST_AGENT_TUNING_ENV_KEYS`, dual readers, source telemetry, defaults, bounds, parsing, error text, the four-pair alias matrix, equal-dual assertions, symmetric cleanup, already-canonical PI/bootstrap writers, other alias families, ownership guards, or production/release configuration.

## Rollback

Revert this PR. That restores the 15 ordinary test writers to the legacy aliases and restores the prior CLI-child mirror direction without changing production behavior or contract definitions.
