### PR TITLE
refactor(test): cut api token writers to canonical alias

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1143,7 +1143,7 @@ mod tests {
         unsafe {
             clear_test_env();
             std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-            std::env::set_var("VM0_API_TOKEN", "test-token");
+            std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
             std::env::set_var(guest_contracts::env::RUN_ID_ENV, "main-recovery-checkpoint");
             std::env::set_var(
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/claude_provider_event_normalization.rs
+++ b/crates/guest-agent/tests/claude_provider_event_normalization.rs
@@ -89,7 +89,7 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -35,7 +35,7 @@ async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("USE_MOCK_CLAUDE", "true");
         std::env::set_var(guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV, &mock);

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -33,7 +33,7 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     runtime.http = guest_agent::http::HttpClient::with_api_config(

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
@@ -28,7 +28,7 @@ async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     runtime.http = guest_agent::http::HttpClient::with_api_config(

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
@@ -28,7 +28,7 @@ async fn codex_app_server_event_delivery_count_overload_terminates_promptly()
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     runtime.http = guest_agent::http::HttpClient::with_api_config(

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -33,7 +33,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     runtime.http = guest_agent::http::HttpClient::with_api_config(

--- a/crates/guest-agent/tests/codex_model_catalog_setup.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_setup.rs
@@ -76,7 +76,7 @@ async fn codex_setup_writes_model_catalog_before_cli_start() -> TestResult {
             &run_payload_path,
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
-        .env("VM0_API_TOKEN", "")
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -179,7 +179,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             args.run_payload_path,
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
-        .env("VM0_API_TOKEN", "")
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -143,7 +143,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             args.run_payload_path,
         )
         .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
-        .env("VM0_API_TOKEN", "")
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1184,7 +1184,7 @@ pub unsafe fn setup_codex_app_server_env(
         }
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, config.run_id);
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
@@ -1351,7 +1351,7 @@ pub unsafe fn setup_env(
         )?;
         // Empty API token → has_api() false → no network calls.
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -30,7 +30,7 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/event_delivery_batching.rs
+++ b/crates/guest-agent/tests/event_delivery_batching.rs
@@ -93,7 +93,7 @@ async fn claude_code_drains_healthy_backlog_in_bounded_fifo_batches()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_byte_overload.rs
@@ -34,7 +34,7 @@ async fn claude_code_event_delivery_byte_overload_terminates_promptly()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/event_delivery_count_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_count_overload.rs
@@ -22,7 +22,7 @@ async fn claude_code_event_delivery_count_overload_terminates_promptly()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -30,7 +30,7 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -144,7 +144,7 @@ async fn run_event_failure_case(
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
             .env(guest_contracts::env::API_URL_ENV, server.base_url())
-            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, run_id)
             .env(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
@@ -32,7 +32,7 @@ async fn nonretryable_client_rejection_records_one_attempt()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/event_delivery_oversized.rs
+++ b/crates/guest-agent/tests/event_delivery_oversized.rs
@@ -29,7 +29,7 @@ async fn oversized_single_event_fails_before_network_delivery()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-agent/tests/event_delivery_singleton.rs
+++ b/crates/guest-agent/tests/event_delivery_singleton.rs
@@ -23,7 +23,7 @@ async fn claude_code_sends_a_no_backlog_event_without_collection_delay()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -59,7 +59,7 @@ async fn run_connect_failure() -> Result<EventDeliveryDiagnostic, Box<dyn std::e
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();
@@ -101,7 +101,7 @@ async fn run_transport_failure()
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();
@@ -175,7 +175,7 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
         std::env::set_var("VM0_API_BACKEND_URL", &base_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -45,7 +45,7 @@ unsafe fn setup_api_env(
             },
         )?;
         std::env::set_var("VM0_API_BACKEND_URL", api_url);
-        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -89,7 +89,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
             .env(guest_contracts::env::API_URL_ENV, server.base_url())
-            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
             .env(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
@@ -59,7 +59,7 @@ fn guest_agent_command(root: &Path, run_id: &str, private_files: &PrivateFiles) 
         .env(guest_contracts::env::RUN_ID_ENV, run_id)
         .env("HOME", root.join("process-home"))
         .env(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1")
-        .env(guest_contracts::env::API_TOKEN_ENV, "")
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
         .env(
             guest_contracts::env::USER_ENV_FILE_ENV,
             &private_files.user_env_path,

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -29,7 +29,7 @@ fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
             &runtime_dir,
         )
         .env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, run_payload_file)
-        .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
         .env(guest_contracts::env::API_URL_ENV, "")
         .output()
         .unwrap();

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -31,7 +31,7 @@ fn runtime_bootstrap_scrubs_runner_env_and_installs_explicit_paths() {
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
     }
 

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -25,7 +25,10 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
     unsafe {
         crate::common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token-abc123");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_TOKEN_ENV,
+            "test-token-abc123",
+        );
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, TEST_RUN_ID);
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
+++ b/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
@@ -89,7 +89,7 @@ printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandb
             std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
             std::env::set_var(guest_contracts::env::RUN_ID_ENV, &run_id);
             std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
-            std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+            std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
             std::env::set_var(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -51,7 +51,7 @@ done
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -102,7 +102,7 @@ fi
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -70,7 +70,7 @@ fi
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
         std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
+++ b/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
@@ -65,7 +65,7 @@ done
             guest_contracts::env::CANONICAL_API_URL_ENV,
             "http://127.0.0.1:1",
         );
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
@@ -43,7 +43,7 @@ exec tail -f /dev/null
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
         std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -153,7 +153,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
             run_payload_path.as_str(),
         ),
         ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
-        ("VM0_API_TOKEN", ""),
+        (guest_contracts::env::CANONICAL_API_TOKEN_ENV, ""),
         (
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
@@ -290,7 +290,7 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
             run_payload_path.as_str(),
         ),
         ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
-        ("VM0_API_TOKEN", ""),
+        (guest_contracts::env::CANONICAL_API_TOKEN_ENV, ""),
         (
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -185,7 +185,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
             .env(guest_contracts::env::API_URL_ENV, server.base_url())
-            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, scenario.run_id)
             .env(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,


### PR DESCRIPTION
Parent EPIC: #28914

Closes #29964

## Summary

- Switch exactly 39 ordinary same-checkout Guest Agent API-token test writers in the 35 authorized files from the legacy key to `guest_contracts::env::CANONICAL_API_TOKEN_ENV`.
- Preserve every token value (including intentional empty strings), fixture, process boundary, assertion, HTTP/event/Pi/process-control/runtime behavior, and sibling changes already merged to `main`.
- Keep the production Runner writer legacy-only and leave the dual reader, alias matrix, process/CLI-child isolation, telemetry, symmetric cleanup, API URL contracts, and rollback surfaces unchanged.

## Scope evidence

- Controller snapshot and initial branch base: `38b93ad6b0be1c85e20a4d1ce3d69edd38772ea3`.
- Refreshed publication base: `2bf4da08395d98bc1538dcfcb95e355ff0a7d049`.
- Published head: `78cc82ac83e262aa551de2f606d8b73986180f99`.
- Initial open-PR audit: 30 PRs, 540 declared/fetched files, zero pagination mismatch.
- Publication open-PR audit: all 29 open PRs and all 530 declared/fetched files, zero mismatch; #25722 required two changed-file pages. The only scoped overlap is #29966 in five files for separate post-result timing keys; it is inventory only and is not modified or awaited here.
- Final diff: 35 authorized files, 42 insertions, 39 deletions. Zero API URL changed lines.
- Exact writer inventory: 39 added canonical writer lines and 39 removed legacy writer lines. Current scoped files contain 41 canonical references (39 writers plus two symmetric cleanup references), two retained legacy constant references (the same cleanup pairs), and zero `"VM0_API_TOKEN"` literals.
- Retained-surface diff is empty for the production Runner writer, API-token alias matrix, token process-isolation variants, bootstrap source telemetry, CLI-child isolation, and API URL alias coverage.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- Focused Guest Agent suite covering every changed writer plus the complete token compatibility/retained isolation surfaces (38 selectors total):
  - `--bin guest-agent`
  - `--test api_token_env_aliases --test api_token_process_isolation --test bootstrap_alias_source_events --test cli_child_env`
  - `--test claude_provider_event_normalization --test cli_agent_log_open_failure --test codex_app_server_event_delivery --test codex_app_server_event_delivery_byte_overload --test codex_app_server_event_delivery_overload --test codex_app_server_oversized_event_delivery --test codex_model_catalog_setup --test codex_setup_fail_closed --test codex_startup_telemetry`
  - `--test event_delivery_batch_failure --test event_delivery_batching --test event_delivery_byte_overload --test event_delivery_count_overload --test event_delivery_drain_timeout --test event_delivery_failure_recovery --test event_delivery_nonretryable_failure --test event_delivery_oversized --test event_delivery_singleton --test event_delivery_transport_classification`
  - `--test execute_cli_api_mode --test execution_timeout_recovery --test guest_runtime_dir_env_aliases --test guest_runtime_missing_api_url --test guest_runtime_process_env --test integration`
  - `--test pi_cli_handoff_boundary --test pi_cli_malformed_tool_event --test pi_cli_run_id_env --test pi_cli_settlement_errors --test pi_cli_stalled_stdin_cancellation --test pi_initial_prompt_stdin_reap_sigkill --test process_control_channel --test user_cancellation_recovery`
- The focused suite passed with the four inherited cgroup endpoint aliases unset only for the local test command; the container exposed one incomplete legacy endpoint without its pair. Both `process_control_channel` cases passed, and no source semantics were changed for that environment normalization.
- `git diff --check origin/main...HEAD`
- Repeated full-repository API-token caller inventory, exact scoped writer inventory, production Runner writer inspection, symmetric cleanup inspection, retained-file diff inspection, and changed-line-only API URL audit.

The full local Vitest suite was not run, and no development server was started, per repository instructions.

## Rollback

Revert this test-only PR to restore the legacy test writer keys. The dual reader and production legacy Runner writer remain unchanged, so no release, deployment, sandbox drain, or production cutover is involved.
