### PR TITLE
refactor(test): cut codex fast-mode writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_fast_mode.rs
+++ b/crates/guest-agent/tests/codex_app_server_fast_mode.rs
@@ -15,7 +15,7 @@ async fn codex_app_server_enables_fast_mode_for_eligible_chatgpt_run()
             user_env: HashMap::from([
                 ("CHATGPT_ACCOUNT_ID".to_string(), "account-test".to_string()),
                 ("OPENAI_MODEL".to_string(), "gpt-5.5".to_string()),
-                ("VM0_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
+                ("OKOU_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
             ]),
             expect_fast_mode: true,
         },

--- a/crates/guest-agent/tests/codex_app_server_fast_mode_without_chatgpt.rs
+++ b/crates/guest-agent/tests/codex_app_server_fast_mode_without_chatgpt.rs
@@ -15,7 +15,7 @@ async fn codex_app_server_enables_fast_mode_without_chatgpt_account()
             user_env: HashMap::from([
                 ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
                 ("OPENAI_MODEL".to_string(), "gpt-5.6-luna".to_string()),
-                ("VM0_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
+                ("OKOU_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
             ]),
             expect_fast_mode: true,
         },


### PR DESCRIPTION
## Summary

- switch exactly two ordinary same-checkout Codex fast-mode functional-test writers from `VM0_CODEX_SERVICE_TIER` to `OKOU_CODEX_SERVICE_TIER`
- preserve both values as `fast` and retain the existing ChatGPT and API-key startup behavior, Codex argv/config ordering, mock process flow, assertions, and timeouts
- retain the deployed Guest dual reader, complete resolver and value-free telemetry matrix, canonical-only API writer, trusted `platformEnvironment` transport, Runner projection/filtering, and private user-env file helper

## Scope evidence

- initial base: `2bf4da08395d98bc1538dcfcb95e355ff0a7d049`
- initial open-PR audit: 30 open PRs, 565 declared / 565 fully paginated changed files, 0 pagination mismatches, 0 scoped-file overlaps
- publication refresh moved `main` forward by #29966; this commit was rebased normally and all verification was repeated on the refreshed base
- publication base: `ca0592e4ddb23f7ddcc15a8f9a52f5bfb99444e3`
- publication head: `2ae63149a0a75997032c96454fad148ded94b662`
- publication open-PR audit: 29 open PRs, 557 declared / 557 fully paginated changed files, 0 pagination mismatches, 0 scoped-file overlaps; the 185-file PR required and received two file pages
- final diff: exactly the two files authorized by #29968, with 2 insertions and 2 deletions

## Exact-key inventory

- scoped legacy writers: 0
- scoped canonical writers: 2, each with the unchanged value `fast`
- remaining legacy references are limited to the deployed Guest compatibility reader, Runner trusted-transport compatibility fixtures, and API canonical-only negative assertions
- `crates/guest-agent/src/cli/mod.rs`, `crates/guest-agent/tests/common/codex_app_server_startup.rs`, the shared test helper, API writer, Runner projection/filter, and API contracts are byte-identical to the publication base

## Verification

All commands passed on the publication head after rebasing onto refreshed `main`:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-D warnings' cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib codex_service_tier_ -- --test-threads=16` (6 passed)
- `env -u VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT -u VM0_TOOL_CGROUP_PROCS_ENDPOINT -u VM0_PROCESS_CONTROL_ENDPOINT CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_fast_mode` (1 passed, canonical-only source)
- `env -u VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT -u VM0_TOOL_CGROUP_PROCS_ENDPOINT -u VM0_PROCESS_CONTROL_ENDPOINT CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_fast_mode_without_chatgpt` (1 passed, canonical-only source)
- exact two-file allowlist, exact alias caller inventory, retained blob identity checks, and `git diff --check origin/main...HEAD`

## Non-goals

- no reader, resolver, telemetry, diagnostics, compatibility matrix, API writer, trusted transport, Runner, user-env helper, Codex config, payload, timing, sandbox, process, release, deployment, or production-QA changes
- no legacy-reader or guard removal and no changes to any other pull request

## Fallbacks

Reverting this test-only PR restores the two ordinary legacy test writers. The unchanged deployed dual reader and canonical-only production API writer remain outside this diff.

Closes #29968
Parent EPIC: #28914
