### PR TITLE
refactor(test): cut api backend url writers to canonical alias

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1142,7 +1142,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&*MAIN_TEST_RUNTIME_ROOT);
         unsafe {
             clear_test_env();
-            std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+            std::env::set_var(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                server.base_url(),
+            );
             std::env::set_var("VM0_API_TOKEN", "test-token");
             std::env::set_var(guest_contracts::env::RUN_ID_ENV, "main-recovery-checkpoint");
             std::env::set_var(

--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -65,7 +65,10 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
         )
         .env("SHELL", "/bin/sh")
         .env("HOME", &home)
-        .env(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1")
+        .env(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        )
         .env(token_env, API_TOKEN)
         .env(guest_contracts::env::RUN_ID_ENV, format!("{RUN_ID}-{case}"))
         .env(

--- a/crates/guest-agent/tests/claude_provider_event_normalization.rs
+++ b/crates/guest-agent/tests/claude_provider_event_normalization.rs
@@ -88,7 +88,10 @@ async fn claude_content_blocks_are_masked_and_sequenced_in_source_order()
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -34,7 +34,10 @@ async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("USE_MOCK_CLAUDE", "true");

--- a/crates/guest-agent/tests/codex_app_server_env_isolation.rs
+++ b/crates/guest-agent/tests/codex_app_server_env_isolation.rs
@@ -5,17 +5,14 @@
 
 mod common;
 
-const INHERITED_CANONICAL_API_URL: &str = "https://inherited.example.invalid";
+const INHERITED_LEGACY_API_URL: &str = "https://inherited.example.invalid";
 
 #[test]
-fn codex_app_server_setup_clears_inherited_canonical_api_url()
--> Result<(), Box<dyn std::error::Error>> {
+fn codex_app_server_setup_clears_inherited_legacy_api_url() -> Result<(), Box<dyn std::error::Error>>
+{
     let tmp = tempfile::tempdir()?;
     unsafe {
-        std::env::set_var(
-            guest_contracts::env::CANONICAL_API_URL_ENV,
-            INHERITED_CANONICAL_API_URL,
-        );
+        std::env::set_var(guest_contracts::env::API_URL_ENV, INHERITED_LEGACY_API_URL);
         common::setup_codex_app_server_env(
             &tmp.path().join("unused-mock-codex"),
             tmp.path(),
@@ -29,13 +26,13 @@ fn codex_app_server_setup_clears_inherited_canonical_api_url()
     }
 
     assert!(
-        std::env::var_os(guest_contracts::env::CANONICAL_API_URL_ENV).is_none(),
-        "Codex app-server setup retained the inherited canonical API URL"
+        std::env::var_os(guest_contracts::env::API_URL_ENV).is_none(),
+        "Codex app-server setup retained the inherited legacy API URL"
     );
-    let installed_api_url = std::env::var(guest_contracts::env::API_URL_ENV)?;
+    let installed_api_url = std::env::var(guest_contracts::env::CANONICAL_API_URL_ENV)?;
     let runtime = common::guest_runtime_from_process_env()?;
     assert_eq!(runtime.config.api_url, installed_api_url);
-    assert_ne!(runtime.config.api_url, INHERITED_CANONICAL_API_URL);
+    assert_ne!(runtime.config.api_url, INHERITED_LEGACY_API_URL);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -32,7 +32,10 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
@@ -27,7 +27,10 @@ async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
@@ -27,7 +27,10 @@ async fn codex_app_server_event_delivery_count_overload_terminates_promptly()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -32,7 +32,10 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/codex_model_catalog_setup.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_setup.rs
@@ -75,7 +75,10 @@ async fn codex_setup_writes_model_catalog_before_cli_start() -> TestResult {
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             &run_payload_path,
         )
-        .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
+        .env(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        )
         .env("VM0_API_TOKEN", "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -178,7 +178,10 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             args.run_payload_path,
         )
-        .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
+        .env(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        )
         .env("VM0_API_TOKEN", "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -142,7 +142,10 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             args.run_payload_path,
         )
-        .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
+        .env(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        )
         .env("VM0_API_TOKEN", "")
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1183,7 +1183,10 @@ pub unsafe fn setup_codex_app_server_env(
             std::env::remove_var("MOCK_CODEX_APP_SERVER_SCENARIO");
         }
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, config.run_id);
-        std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
@@ -1353,7 +1356,10 @@ pub unsafe fn setup_env(
             },
         )?;
         // Empty API token → has_api() false → no network calls.
-        std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -29,7 +29,10 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_batching.rs
+++ b/crates/guest-agent/tests/event_delivery_batching.rs
@@ -92,7 +92,10 @@ async fn claude_code_drains_healthy_backlog_in_bounded_fifo_batches()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_byte_overload.rs
@@ -33,7 +33,10 @@ async fn claude_code_event_delivery_byte_overload_terminates_promptly()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_count_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_count_overload.rs
@@ -21,7 +21,10 @@ async fn claude_code_event_delivery_count_overload_terminates_promptly()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -29,7 +29,10 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -143,7 +143,10 @@ async fn run_event_failure_case(
             )
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
-            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                server.base_url(),
+            )
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, run_id)
             .env(

--- a/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
@@ -31,7 +31,10 @@ async fn nonretryable_client_rejection_records_one_attempt()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_oversized.rs
+++ b/crates/guest-agent/tests/event_delivery_oversized.rs
@@ -28,7 +28,10 @@ async fn oversized_single_event_fails_before_network_delivery()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_singleton.rs
+++ b/crates/guest-agent/tests/event_delivery_singleton.rs
@@ -22,7 +22,10 @@ async fn claude_code_sends_a_no_backlog_event_without_collection_delay()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -58,7 +58,10 @@ async fn run_connect_failure() -> Result<EventDeliveryDiagnostic, Box<dyn std::e
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
@@ -100,7 +103,10 @@ async fn run_transport_failure()
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
@@ -174,7 +180,7 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
 
     unsafe {
         common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
-        std::env::set_var("VM0_API_BACKEND_URL", &base_url);
+        std::env::set_var(guest_contracts::env::CANONICAL_API_URL_ENV, &base_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -50,7 +50,7 @@ unsafe fn setup_api_env(
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", api_url);
+        std::env::set_var(guest_contracts::env::CANONICAL_API_URL_ENV, api_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -88,7 +88,10 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             )
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
-            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                server.base_url(),
+            )
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
             .env(

--- a/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
@@ -58,7 +58,10 @@ fn guest_agent_command(root: &Path, run_id: &str, private_files: &PrivateFiles) 
         .env_clear()
         .env(guest_contracts::env::RUN_ID_ENV, run_id)
         .env("HOME", root.join("process-home"))
-        .env(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1")
+        .env(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        )
         .env(guest_contracts::env::API_TOKEN_ENV, "")
         .env(
             guest_contracts::env::USER_ENV_FILE_ENV,

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -24,7 +24,10 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
     let server = MockServer::start();
     unsafe {
         crate::common::clear_guest_agent_bootstrap_env_for_test();
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            server.base_url(),
+        );
         std::env::set_var("VM0_API_TOKEN", "test-token-abc123");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, TEST_RUN_ID);
         std::env::set_var(

--- a/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
+++ b/crates/guest-agent/tests/pi_cli_handoff_boundary.rs
@@ -88,7 +88,10 @@ printf '%s\n' '{"type":"vm0_pi_api_first_turn_boundary","schemaVersion":1,"sandb
             common::clear_guest_agent_bootstrap_env_for_test();
             std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
             std::env::set_var(guest_contracts::env::RUN_ID_ENV, &run_id);
-            std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+            std::env::set_var(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                &server.base_url,
+            );
             std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
             std::env::set_var(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -50,7 +50,10 @@ done
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
-        std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -101,7 +101,10 @@ fi
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
-        std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -69,7 +69,10 @@ fi
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
-        std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            &server.base_url,
+        );
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
+++ b/crates/guest-agent/tests/pi_cli_stalled_stdin_cancellation.rs
@@ -60,7 +60,6 @@ done
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, RUN_ID);
-        std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
         std::env::set_var(
             guest_contracts::env::CANONICAL_API_URL_ENV,
             "http://127.0.0.1:1",

--- a/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
@@ -42,7 +42,10 @@ exec tail -f /dev/null
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
-        std::env::set_var(guest_contracts::env::API_URL_ENV, "http://127.0.0.1:1");
+        std::env::set_var(
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        );
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
         std::env::set_var(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -158,7 +158,10 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             run_payload_path.as_str(),
         ),
-        ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
+        (
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        ),
         ("VM0_API_TOKEN", ""),
         (
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
@@ -301,7 +304,10 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
             guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             run_payload_path.as_str(),
         ),
-        ("VM0_API_BACKEND_URL", "http://127.0.0.1:1"),
+        (
+            guest_contracts::env::CANONICAL_API_URL_ENV,
+            "http://127.0.0.1:1",
+        ),
         ("VM0_API_TOKEN", ""),
         (
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -184,7 +184,10 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             )
             .env("SHELL", "/bin/sh")
             .env("HOME", &home)
-            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                server.base_url(),
+            )
             .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
             .env(guest_contracts::env::RUN_ID_ENV, scenario.run_id)
             .env(


### PR DESCRIPTION
Parent EPIC: #28914

Closes #29965

## Summary

- Switch exactly 38 ordinary same-checkout Guest Agent API backend URL writers in the 34 authorized files from the legacy alias to `guest_contracts::env::CANONICAL_API_URL_ENV`.
- Preserve every URL byte-for-byte, all API-token/runtime behavior, and sibling timing/API-token key changes already merged to `main`.
- Minimally invert `codex_app_server_env_isolation.rs`: install inherited legacy state, prove the helper clears it, read the installed canonical value, and prove runtime config uses that value rather than the inherited one.
- Keep the production Runner writer, managed CLI-child legacy exposure, fail-closed dual reader and telemetry, full alias matrix, symmetric cleanup, bootstrap canonical writer, and three deliberate legacy compatibility/diagnostic writers unchanged.

## Scope and base evidence

- Controller issue snapshot: `67626477d495d55587405b39964a88acf1793f37`.
- Controller-updated intermediate base: `2bf4da08395d98bc1538dcfcb95e355ff0a7d049`.
- Original publication reviewed base/head: `ca0592e4ddb23f7ddcc15a8f9a52f5bfb99444e3` / `93fe2f0943d2a6ea5de784a9f60f7bd4a3290885`.
- Final pr-auto reviewed base: `e39f845c8d6fa3932be90019dc6599c388a820d3` (includes merged #29969 API-token writer cutover and #29978 connector-catalog capacity fix).
- Final reviewed head: `e3f335917557107939f274b403a43f47aa4a0e65`.
- Final diff: exactly 35 authorized files, 150 insertions, and 49 deletions.
- Exact writer audit: 38 legacy writer removals, 37 canonical writer additions, and one pre-existing identical canonical writer retained after deleting its redundant legacy twin; final total is exactly 38 canonical writers across 34 writer files.
- Per-file writer counts match the issue inventory; normalized whole-file comparison after alias substitution reports zero URL/value/behavior mismatches.
- The only support file is `codex_app_server_env_isolation.rs`; its final content matches the originally reviewed support change byte-for-byte and proves the required direction.
- Final fully paginated open-PR audit covered all 34 open PRs and all 602 declared/fetched changed files with zero pagination mismatch. #29975 overlaps 11 files for private-payload keys and #29977 overlaps 2 files for mock-binary-path keys; both are inventory-only, not functional dependencies, and neither PR was modified or awaited.
- Retained-surface diff is empty for the production Runner writer, managed CLI-child exposure, dual reader/source telemetry, 14-success + 3-conflict URL alias matrix, bootstrap writer, CLI-child isolation, Codex child isolation, and missing-URL diagnostic coverage. Symmetric cleanup remains present in both changed helper files.
- Changed-line audit found zero API-token, sandbox, timing, timeout, run-ID, reuse-result, workspace, or prompt key changes relative to the final base.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- Focused Guest Agent suite passed with 40 selected targets:
  - `--bin guest-agent`
  - `--test api_url_env_aliases --test api_token_process_isolation --test bootstrap_alias_source_events --test cli_child_env`
  - `--test codex_app_server_backend --test codex_app_server_backend_child_env --test codex_app_server_env_isolation`
  - all changed Claude/Codex event-delivery, setup, model-catalog, and startup-telemetry targets
  - all changed generic event-delivery targets
  - `--test execute_cli_api_mode --test execution_timeout_recovery --test guest_runtime_dir_env_aliases --test guest_runtime_missing_api_url --test integration`
  - all changed Pi targets plus `--test process_control_channel --test user_cancellation_recovery`
- The focused suite passed with inherited `VM0_API_BACKEND_URL` and four workload/tool cgroup endpoint aliases unset only for the local command. The Okou container injects a production legacy API URL and one incomplete tool-cgroup endpoint; an unmodified-base comparison reproduced the cgroup failure, while the environment-normalized current suite passed both process-control cases. No source adjustment was made for host-environment normalization.
- After preserving #29969's first-merged changes through 36 adjacent-key conflict blocks, the complete audit and focused verification above were rerun against `main@e39f845c8d6fa3932be90019dc6599c388a820d3` and passed.
- `git diff --check` and repeated exact changed-file, writer-count, normalized-value, retained-surface, and fully paginated open-PR audits all passed against the final reviewed base.

The full local Vitest suite and full-workspace Rust suite were not run, and no development server was started, per repository instructions.

## Rollback

Revert this test-only PR to restore legacy test writer keys. The production legacy writer and fail-closed dual reader remain unchanged, so no release, deployment, sandbox drain, or production cutover is involved.
