### PR TITLE
fix(api): align connector catalog capacity with publisher

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -113,7 +113,7 @@ pub mod runners {
     pub const BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION: u32 = 1;
 
     /// Maximum builtin firewall catalog response and cache size accepted by runners.
-    /// This is generated from the TypeScript connector catalog raw-byte contract so source ingestion and runner delivery stay aligned.
+    /// This Runner wire and cache boundary is independent of the larger full connector catalog source-ingestion limit.
     pub const BUILTIN_FIREWALL_CATALOG_MAX_BYTES: u64 = 16777216;
 
     /// Maximum API admission hold after public user cancellation when recovery completion is lost.

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -6387,23 +6387,29 @@ describe("connector catalog executable compatibility", () => {
 });
 
 describe("connector catalog rejection and latest-valid retention", () => {
-  it("accepts catalogs below the shared byte limit and rejects larger catalogs", async () => {
+  it("accepts a full catalog at 32 MiB and rejects 32 MiB plus one with latest-valid retention", async () => {
     configureSource();
+    expect(CONNECTOR_CATALOG_MAX_RAW_BYTES).toBe(32 * 1024 * 1024);
+    const acceptedVersion = "2026-07-15.thirty-two-mib-limit";
+    const unpadded = buildRelease({
+      version: acceptedVersion,
+      mutateCatalog: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").description = "";
+      },
+    });
+    const descriptionBytes =
+      CONNECTOR_CATALOG_MAX_RAW_BYTES -
+      releaseCatalogBytes(unpadded).byteLength;
     const accepted = buildRelease({
-      version: "2026-07-15.sixteen-mib-limit",
+      version: acceptedVersion,
       mutateCatalog: (artifact) => {
         firstRecord(artifact.connectors, "connectors").description = "x".repeat(
-          CONNECTOR_CATALOG_MAX_RAW_BYTES / 2,
+          descriptionBytes,
         );
       },
     });
     const acceptedBytes = releaseCatalogBytes(accepted);
-    expect(acceptedBytes.byteLength).toBeGreaterThan(
-      CONNECTOR_CATALOG_MAX_RAW_BYTES / 2,
-    );
-    expect(acceptedBytes.byteLength).toBeLessThanOrEqual(
-      CONNECTOR_CATALOG_MAX_RAW_BYTES,
-    );
+    expect(acceptedBytes.byteLength).toBe(CONNECTOR_CATALOG_MAX_RAW_BYTES);
     serveObjects(catalogObjects([accepted], accepted));
 
     expect((await syncCatalog()).body).toMatchObject({
@@ -6412,7 +6418,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
     });
 
     const rejected = buildRelease({
-      version: "2026-07-15.over-sixteen-mib-limit",
+      version: "2026-07-15.over-thirty-two-mib-limit",
       catalogBytes: Buffer.alloc(CONNECTOR_CATALOG_MAX_RAW_BYTES + 1),
     });
     serveObjects(catalogObjects([rejected], rejected));

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { gunzipSync } from "node:zlib";
 
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { cronConnectorCatalogContract } from "@okouai/api-contracts/contracts/cron";
@@ -53,9 +54,11 @@ import {
   deleteApiTestConnectorCatalogCompatibilityEvaluation,
   deleteApiTestConnectorCatalogRuntimeProjectionSet,
   expireApiTestConnectorCatalogRuntimeProjectionAuthority,
+  installApiTestConnectorCatalog,
   invalidateApiTestConnectorCatalogCompatibility,
   mockApiTestConnectorProviderConfiguration,
   readApiTestConnectorCatalogCompatibilityEvaluations,
+  readApiTestConnectorCatalogSnapshot,
   readApiTestConnectorCatalogRuntimeProjection,
   readApiTestConnectorCatalogRuntimeProjectionAuthority,
   readApiTestConnectorCatalogValidationAuthority,
@@ -140,6 +143,7 @@ const DIAGNOSTICS_ORG_ID = `org_${randomUUID()}`;
 const PRIVATE_VALUE = "SECRET_TOKEN";
 const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
+const LEGACY_CONNECTOR_CATALOG_MAX_RAW_BYTES = 16 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
   "sha256:1bf96aab55b264a18add3139029db3f6502883ac97b16982d1fa4d668444bae7";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -1425,6 +1429,17 @@ function configureSource(): string {
   const bucket = `connector-catalog-test-${randomUUID()}`;
   mockEnv("R2_USER_STORAGES_BUCKET_NAME", bucket);
   return bucket;
+}
+
+function legacyConnectorCatalogSourceId(bucket: string): string {
+  const endpoint =
+    env("S3_ENDPOINT") ??
+    `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
+  return createHash("sha256")
+    .update(new URL(endpoint).origin)
+    .update("\0")
+    .update(bucket)
+    .digest("hex");
 }
 
 function setApiVersion(version: string): void {
@@ -6387,8 +6402,24 @@ describe("connector catalog executable compatibility", () => {
 });
 
 describe("connector catalog rejection and latest-valid retention", () => {
-  it("accepts a full catalog at 32 MiB and rejects 32 MiB plus one with latest-valid retention", async () => {
-    configureSource();
+  it("accepts 32 MiB in a rollback-isolated source generation and rejects 32 MiB plus one with latest-valid retention", async () => {
+    const bucket = configureSource();
+    const legacySourceId = legacyConnectorCatalogSourceId(bucket);
+    await installApiTestConnectorCatalog({
+      catalogVersion: "2026-07-14.rollback-compatible",
+      sourceId: legacySourceId,
+    });
+    const legacySnapshot =
+      await readApiTestConnectorCatalogSnapshot(legacySourceId);
+    expect(legacySnapshot.catalogRawSize).toBeLessThanOrEqual(
+      LEGACY_CONNECTOR_CATALOG_MAX_RAW_BYTES,
+    );
+    const legacyRawBytes = gunzipSync(legacySnapshot.catalogGzip, {
+      maxOutputLength: LEGACY_CONNECTOR_CATALOG_MAX_RAW_BYTES,
+    });
+    expect(legacyRawBytes.byteLength).toBe(legacySnapshot.catalogRawSize);
+    expect(digest(legacyRawBytes)).toBe(legacySnapshot.catalogDigest);
+
     expect(CONNECTOR_CATALOG_MAX_RAW_BYTES).toBe(32 * 1024 * 1024);
     const acceptedVersion = "2026-07-15.thirty-two-mib-limit";
     const unpadded = buildRelease({
@@ -6416,6 +6447,9 @@ describe("connector catalog rejection and latest-valid retention", () => {
       outcome: "accepted",
       active: { catalogVersion: accepted.version },
     });
+    await expect(
+      readApiTestConnectorCatalogSnapshot(legacySourceId),
+    ).resolves.toStrictEqual(legacySnapshot);
 
     const rejected = buildRelease({
       version: "2026-07-15.over-thirty-two-mib-limit",
@@ -6432,6 +6466,9 @@ describe("connector catalog rejection and latest-valid retention", () => {
         failureCode: "object-too-large",
       },
     });
+    await expect(
+      readApiTestConnectorCatalogSnapshot(legacySourceId),
+    ).resolves.toStrictEqual(legacySnapshot);
   });
 
   it("classifies unavailable and oversized objects before acceptance", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { CONNECTOR_CATALOG_MAX_RAW_BYTES } from "@okouai/api-contracts/contracts/connector-catalog";
 import { CLIENT_VERSION_HEADER } from "@okouai/api-contracts/contracts/client-headers";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
@@ -12,9 +11,10 @@ import {
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import {
-  DEFAULT_PROFILE,
+  BUILTIN_FIREWALL_CATALOG_MAX_BYTES,
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
+  DEFAULT_PROFILE,
   type ConnectorRuntimeSyncResult,
   type ExecutionContext,
   type Job as RunnerJob,
@@ -2933,7 +2933,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     {
       payloadState: "oversized",
       createPayload: (): Buffer => {
-        return Buffer.alloc(CONNECTOR_CATALOG_MAX_RAW_BYTES + 1);
+        return Buffer.alloc(BUILTIN_FIREWALL_CATALOG_MAX_BYTES + 1);
       },
     },
   ] satisfies readonly {

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime-projection.service.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
-import { CONNECTOR_CATALOG_MAX_RAW_BYTES } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
+import { BUILTIN_FIREWALL_CATALOG_MAX_BYTES } from "@okouai/api-contracts/contracts/runners";
 import {
   connectorCatalogActiveSnapshot,
   connectorCatalogCompatibilityEvaluation,
@@ -451,7 +451,7 @@ function parseAttestedConnectorCatalogRuntimeProjection(
 ): ConnectorCatalogArtifactConnector | undefined {
   if (
     payload.byteLength === 0 ||
-    payload.byteLength > CONNECTOR_CATALOG_MAX_RAW_BYTES
+    payload.byteLength > BUILTIN_FIREWALL_CATALOG_MAX_BYTES
   ) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-source.ts
@@ -8,6 +8,8 @@ export interface ConnectorCatalogSource {
   readonly sourceId: string;
 }
 
+const CONNECTOR_CATALOG_PERSISTED_SNAPSHOT_GENERATION = 2;
+
 export function connectorCatalogSource(): ConnectorCatalogSource {
   const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
   const endpoint =
@@ -21,10 +23,15 @@ export function connectorCatalogSource(): ConnectorCatalogSource {
     throw new Error("Connector catalog source endpoint is invalid");
   }
   const authority = endpointUrl.origin;
+  // Generation 2 isolates snapshots accepted under the 32 MiB ceiling from
+  // rollback APIs whose generation-1 persisted decoder is capped at 16 MiB.
+  // A persisted decoder ceiling change must use a new stable generation.
   const sourceId = createHash("sha256")
     .update(authority)
     .update("\0")
     .update(bucket)
+    .update("\0connector-catalog-persisted-snapshot-generation:")
+    .update(String(CONNECTOR_CATALOG_PERSISTED_SNAPSHOT_GENERATION))
     .digest("hex");
   return { bucket, sourceId };
 }

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -87,6 +87,7 @@ export async function installApiTestConnectorCatalog(
   options: {
     readonly catalogVersion?: string;
     readonly runtimeProjection?: boolean;
+    readonly sourceId?: string;
   } = {},
 ): Promise<void> {
   const catalogVersion =
@@ -102,7 +103,7 @@ export async function installApiTestConnectorCatalog(
   const rawBytes = Buffer.from(`${JSON.stringify(catalog)}\n`);
   const catalogDigest = sha256Digest(rawBytes);
   const catalogGzip = encodeConnectorCatalogSnapshot(rawBytes);
-  const source = connectorCatalogSource();
+  const sourceId = options.sourceId ?? connectorCatalogSource().sourceId;
   const capability = connectorCatalogExecutableCapabilityState();
   const activatedAt = nowDate();
   const db = store.set(writeDb$);
@@ -138,7 +139,7 @@ export async function installApiTestConnectorCatalog(
     await tx
       .insert(connectorCatalogSyncState)
       .values({
-        sourceId: source.sourceId,
+        sourceId,
         schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
         ...syncStateValues,
       })
@@ -152,7 +153,7 @@ export async function installApiTestConnectorCatalog(
     await tx
       .insert(connectorCatalogActiveSnapshot)
       .values({
-        sourceId: source.sourceId,
+        sourceId,
         schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
         ...snapshotValues,
       })
@@ -165,7 +166,7 @@ export async function installApiTestConnectorCatalog(
       });
     await persistConnectorCatalogCompatibility({
       db: tx,
-      sourceId: source.sourceId,
+      sourceId,
       identity: {
         catalogVersion,
         catalogDigest,
@@ -177,13 +178,46 @@ export async function installApiTestConnectorCatalog(
     if (options.runtimeProjection === true) {
       await persistConnectorCatalogRuntimeProjection({
         db: tx,
-        sourceId: source.sourceId,
+        sourceId,
         identity: { catalogVersion, catalogDigest },
         artifact: catalog,
         validator: currentConnectorCatalogValidatorIdentity(),
       });
     }
   });
+}
+
+export async function readApiTestConnectorCatalogSnapshot(
+  sourceId: string,
+): Promise<{
+  readonly catalogVersion: string;
+  readonly catalogDigest: string;
+  readonly catalogRawSize: number;
+  readonly catalogGzip: Buffer;
+}> {
+  const db = store.set(writeDb$);
+  const [snapshot] = await db
+    .select({
+      catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
+      catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
+      catalogRawSize: connectorCatalogActiveSnapshot.catalogRawSize,
+      catalogGzip: connectorCatalogActiveSnapshot.catalogGzip,
+    })
+    .from(connectorCatalogActiveSnapshot)
+    .where(
+      and(
+        eq(connectorCatalogActiveSnapshot.sourceId, sourceId),
+        eq(
+          connectorCatalogActiveSnapshot.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+      ),
+    )
+    .limit(1);
+  if (snapshot === undefined) {
+    throw new Error("Expected an active API test connector catalog snapshot");
+  }
+  return snapshot;
 }
 
 export function setApiTestConnectorCatalogRuntimeProjectionIdentityReplacements(

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
@@ -11,7 +11,7 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-export const CONNECTOR_CATALOG_MAX_RAW_BYTES = 16 * 1024 * 1024;
+export const CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 
 const publicConnectorCatalogAuthMethodSummarySchema = z.object({
   id: connectorAuthMethodIdSchema,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -9,7 +9,6 @@ import {
   networkPolicySchema,
   networkPoliciesSchema,
 } from "@okouai/connectors/firewall-types";
-import { CONNECTOR_CATALOG_MAX_RAW_BYTES } from "./connector-catalog";
 import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import { modelProviderCodexRuntimeConfigSchema } from "./model-providers";
@@ -54,8 +53,7 @@ export const RUNNER_CANCELLATION_RECOVERY_GRACE_MS = 90_000;
 export const CANCELLATION_RECOVERY_STALE_AFTER_MS =
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS + 30_000;
 export const BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION = 1;
-export const BUILTIN_FIREWALL_CATALOG_MAX_BYTES =
-  CONNECTOR_CATALOG_MAX_RAW_BYTES;
+export const BUILTIN_FIREWALL_CATALOG_MAX_BYTES = 16 * 1024 * 1024;
 export const RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX = 512;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -110,7 +110,7 @@ const agentExecutionTimeoutSecondsDoc = [
 ] as const;
 const builtinFirewallCatalogMaxBytesDoc = [
   "Maximum builtin firewall catalog response and cache size accepted by runners.",
-  "This is generated from the TypeScript connector catalog raw-byte contract so source ingestion and runner delivery stay aligned.",
+  "This Runner wire and cache boundary is independent of the larger full connector catalog source-ingestion limit.",
 ] as const;
 const builtinFirewallCatalogCacheSchemaVersionDoc = [
   "Schema version written to builtin firewall catalog cache files and accepted by the mitm addon.",

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -316,7 +316,7 @@ export const rustConstantBindings = [
     value: rustU64(BUILTIN_FIREWALL_CATALOG_MAX_BYTES),
     rustDoc: [
       "Maximum builtin firewall catalog response and cache size accepted by runners.",
-      "This is generated from the TypeScript connector catalog raw-byte contract so source ingestion and runner delivery stay aligned.",
+      "This Runner wire and cache boundary is independent of the larger full connector catalog source-ingestion limit.",
     ],
   },
   {


### PR DESCRIPTION
Closes #29976

## Summary

- Raise only the full connector catalog consumer limit from 16 MiB to 32 MiB so API ingestion matches the publisher.
- Keep the Runner builtin-firewall catalog boundary independent at exactly 16 MiB and validate per-connector runtime projection payloads against that limit.
- Isolate snapshots admitted under the 32 MiB ceiling in persisted source generation 2, leaving generation-1 snapshot rows unchanged and readable by a retained rollback API whose decoder is capped at 16 MiB.
- Cover acceptance at exactly 32 MiB, rejection at 32 MiB + 1 byte with latest-valid retention, and byte-for-byte preservation plus 16 MiB decode validation of the rollback snapshot.

## Capacity contract

- Full connector catalog ingestion and generation-2 persisted snapshot decoding: 32 MiB (`33,554,432` bytes).
- Runner builtin-firewall catalog and per-connector runtime projection payloads: 16 MiB (`16,777,216` bytes).
- Generated Rust and Python `BUILTIN_FIREWALL_CATALOG_MAX_BYTES` numeric values remain unchanged at `16777216` and `16_777_216`, respectively.
- The generated Rust documentation now describes the intentional 32/16 MiB split; the generated Python file remains byte-for-byte unchanged.

## Deployment compatibility

The prior API derives generation-1 source IDs from `sha256(authority + NUL + bucket)`. This change appends a stable persisted-snapshot generation discriminator when deriving generation-2 source IDs. All catalog sync state, active snapshots, compatibility rows, and runtime projections are therefore written under a different `source_id`. A rollback promotes the retained prior API, which continues to address its unchanged generation-1 snapshot and never decodes the larger generation-2 row. No database rollback, catalog schema bump, dual read, or fallback branch is introduced.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/api-contracts run check-types`
- `pnpm --filter @okouai/api-contracts run generate:rust`
- `pnpm --filter @okouai/api-contracts run generate:python`
- `pnpm --filter @okouai/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts src/python-bindings/__tests__/generate.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts -t "accepts 32 MiB in a rollback-isolated source generation and rejects 32 MiB plus one with latest-valid retention"`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "falls back when an attested projection payload is 'oversized'"`
- `git diff --check`

The PR preview `deploy-api` seed is the authoritative integration check for accepting the currently published connector catalog.
