### PR TITLE
refactor(api): remove legacy debug logging reader

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { EVENT } from "@axiomhq/logging";
 import { describe, it, expect, vi, beforeEach, onTestFinished } from "vitest";
 
@@ -11,121 +9,8 @@ const { axiom, axiomLogging, console: consoleOutput } = testContext().mocks;
 
 const CANONICAL_DEBUG_KEY = "OKOU_DEBUG";
 const LEGACY_DEBUG_KEY = "VM0_DEBUG";
-const DEBUG_ALIAS_RESOLUTION_EVENT = "debug_environment_alias_resolution";
-const DEBUG_ALIAS_LOG_CONTEXT = "DebugEnvironment";
-const DEBUG_ALIAS_CONFLICT_ERROR =
-  "Debug environment aliases conflict: canonicalKey=OKOU_DEBUG legacyKey=VM0_DEBUG state=conflicting-dual";
-
-type NonConflictingDebugAliasState =
-  | "absent"
-  | "canonical-only"
-  | "legacy-only"
-  | "equal-dual";
-
-interface DebugAliasFixture {
-  readonly description: string;
-  readonly canonical: string | undefined;
-  readonly legacy: string | undefined;
-  readonly state: NonConflictingDebugAliasState;
-  readonly expectedLevel: "debug" | "info";
-}
-
-const DEBUG_ALIAS_FIXTURES: readonly DebugAliasFixture[] = [
-  {
-    description: "missing aliases",
-    canonical: undefined,
-    legacy: undefined,
-    state: "absent",
-    expectedLevel: "info",
-  },
-  {
-    description: "empty aliases",
-    canonical: "",
-    legacy: "",
-    state: "absent",
-    expectedLevel: "info",
-  },
-  {
-    description: "empty canonical and missing legacy aliases",
-    canonical: "",
-    legacy: undefined,
-    state: "absent",
-    expectedLevel: "info",
-  },
-  {
-    description: "missing canonical and empty legacy aliases",
-    canonical: undefined,
-    legacy: "",
-    state: "absent",
-    expectedLevel: "info",
-  },
-  {
-    description: "canonical-only alias",
-    canonical: "debug-matrix-target",
-    legacy: undefined,
-    state: "canonical-only",
-    expectedLevel: "debug",
-  },
-  {
-    description: "canonical alias with empty legacy",
-    canonical: "debug-matrix-target",
-    legacy: "",
-    state: "canonical-only",
-    expectedLevel: "debug",
-  },
-  {
-    description: "legacy-only alias",
-    canonical: undefined,
-    legacy: "debug-matrix-target",
-    state: "legacy-only",
-    expectedLevel: "debug",
-  },
-  {
-    description: "legacy alias with empty canonical",
-    canonical: "",
-    legacy: "debug-matrix-target",
-    state: "legacy-only",
-    expectedLevel: "debug",
-  },
-  {
-    description: "byte-equal dual aliases",
-    canonical: "debug-matrix-target",
-    legacy: "debug-matrix-target",
-    state: "equal-dual",
-    expectedLevel: "debug",
-  },
-];
-
-function configureDebugAliases(
-  canonical: string | undefined,
-  legacy: string | undefined,
-): void {
-  mockEnv(CANONICAL_DEBUG_KEY, canonical);
-  mockEnv(LEGACY_DEBUG_KEY, legacy);
-}
-
-function debugAliasEvidence(state: string): Readonly<Record<string, unknown>> {
-  return {
-    [EVENT]: { source: "api" },
-    canonicalKey: CANONICAL_DEBUG_KEY,
-    legacyKey: LEGACY_DEBUG_KEY,
-    state,
-    context: DEBUG_ALIAS_LOG_CONTEXT,
-  };
-}
-
-function expectValueFree(diagnostics: string, values: readonly string[]): void {
-  for (const value of values) {
-    const forbiddenDerivatives = [
-      value,
-      String(value.length),
-      createHash("sha256").update(value).digest("hex"),
-      JSON.stringify(value),
-    ];
-    for (const derivative of forbiddenDerivatives) {
-      expect(diagnostics).not.toContain(derivative);
-    }
-  }
+function configureDebug(value: string | undefined): void {
+  mockEnv(CANONICAL_DEBUG_KEY, value);
 }
 
 beforeEach(() => {
@@ -133,55 +18,14 @@ beforeEach(() => {
   axiomLogging.flush.mockResolvedValue(undefined);
 });
 
-describe("debug environment aliases", () => {
-  it.each(DEBUG_ALIAS_FIXTURES)(
-    "resolves $description with bounded source evidence",
-    ({ canonical, legacy, state, expectedLevel }) => {
-      configureDebugAliases(canonical, legacy);
-      const infoLogCount = axiomLogging.info.mock.calls.length;
+describe("debug environment", () => {
+  it.each([
+    { description: "missing canonical input", value: undefined },
+    { description: "empty canonical input", value: "" },
+  ])("keeps the info level for $description", ({ value }) => {
+    configureDebug(value);
 
-      expect(logger("debug-matrix-target").level).toBe(expectedLevel);
-      expect(logger("another-logger").level).toBe("info");
-
-      const calls = axiomLogging.info.mock.calls.slice(infoLogCount);
-      expect(calls).toStrictEqual([
-        [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence(state)],
-      ]);
-      expectValueFree(
-        JSON.stringify(calls),
-        [canonical, legacy].filter((value): value is string => {
-          return Boolean(value);
-        }),
-      );
-      expect(axiomLogging.debug).not.toHaveBeenCalled();
-      expect(axiomLogging.warn).not.toHaveBeenCalled();
-    },
-  );
-
-  it("fails closed on byte-unequal aliases before pattern normalization", () => {
-    const canonical = `canonical-sentinel-${"x".repeat(113)}:*`;
-    const legacy = ` ${canonical} `;
-    configureDebugAliases(canonical, legacy);
-    const warnLogCount = axiomLogging.warn.mock.calls.length;
-
-    expect(() => {
-      logger("canonical-sentinel:child");
-    }).toThrow(DEBUG_ALIAS_CONFLICT_ERROR);
-    expect(() => {
-      logger("canonical-sentinel:child");
-    }).toThrow(DEBUG_ALIAS_CONFLICT_ERROR);
-
-    expect(axiomLogging.warn.mock.calls.slice(warnLogCount)).toStrictEqual([
-      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("conflicting-dual")],
-    ]);
-    expect(axiomLogging.debug).not.toHaveBeenCalled();
-    expect(axiomLogging.info).not.toHaveBeenCalled();
-
-    const diagnostics = JSON.stringify({
-      error: DEBUG_ALIAS_CONFLICT_ERROR,
-      logs: axiomLogging.warn.mock.calls,
-    });
-    expectValueFree(diagnostics, [canonical, legacy]);
+    expect(logger("debug-target").level).toBe("info");
   });
 
   it.each([
@@ -222,7 +66,7 @@ describe("debug environment aliases", () => {
       disabled: ["target-logger"],
     },
   ])("preserves $description behavior", ({ value, enabled, disabled }) => {
-    configureDebugAliases(value, undefined);
+    configureDebug(value);
 
     for (const name of enabled) {
       expect(logger(name).level).toBe("debug");
@@ -232,9 +76,37 @@ describe("debug environment aliases", () => {
     }
   });
 
+  it("ignores a retired legacy-only input", () => {
+    configureDebug(undefined);
+    mockOptionalEnv(LEGACY_DEBUG_KEY, "legacy-only-target");
+
+    expect(logger("legacy-only-target").level).toBe("info");
+  });
+
+  it("does not let a retired legacy value override or conflict with canonical", () => {
+    configureDebug("canonical:*");
+    mockOptionalEnv(LEGACY_DEBUG_KEY, "legacy:*");
+
+    expect(() => {
+      logger("canonical:child");
+    }).not.toThrow();
+    expect(logger("canonical:child").level).toBe("debug");
+    expect(logger("legacy:child").level).toBe("info");
+  });
+
+  it("does not emit the canonical environment value to logs", () => {
+    const value = `private-debug-pattern-${"x".repeat(113)}`;
+    configureDebug(value);
+
+    expect(logger(value).level).toBe("debug");
+    expect(axiomLogging.debug).not.toHaveBeenCalled();
+    expect(axiomLogging.info).not.toHaveBeenCalled();
+    expect(axiomLogging.warn).not.toHaveBeenCalled();
+    expect(axiomLogging.error).not.toHaveBeenCalled();
+  });
+
   it("keeps configuration and logger levels cached until the existing reset", () => {
-    configureDebugAliases("CachedLogger", undefined);
-    const infoLogCount = axiomLogging.info.mock.calls.length;
+    configureDebug("CachedLogger");
 
     const cached = logger("CachedLogger");
     expect(cached.level).toBe("debug");
@@ -243,21 +115,14 @@ describe("debug environment aliases", () => {
     expect(logger("CachedLogger")).toBe(cached);
     expect(logger("CachedLogger").level).toBe("debug");
     expect(logger("AfterResetLogger").level).toBe("info");
-    expect(axiomLogging.info.mock.calls.slice(infoLogCount)).toStrictEqual([
-      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
-    ]);
 
     __resetForTest();
 
     expect(logger("AfterResetLogger").level).toBe("debug");
-    expect(axiomLogging.info.mock.calls.slice(infoLogCount)).toStrictEqual([
-      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
-      [DEBUG_ALIAS_RESOLUTION_EVENT, debugAliasEvidence("canonical-only")],
-    ]);
   });
 
   it("keeps the generic DEBUG convention unrelated", () => {
-    configureDebugAliases(undefined, undefined);
+    configureDebug(undefined);
     mockOptionalEnv("DEBUG", "*");
 
     expect(logger("generic-debug-convention").level).toBe("info");

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -54,7 +54,6 @@ const SCHEMA = {
   ENV: z.enum(["production", "preview", "development"]),
   VITEST: z.enum(["true", "false"]).default("false"),
   OKOU_DEBUG: z.string().default(""),
-  VM0_DEBUG: z.string().default(""),
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().min(1).optional(),
   // Direct origin of the API backend for self-dispatched internal callbacks
   // (`/api/internal/**`). Optional; when unset, production defaults to the API

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -28,31 +28,6 @@ const LOG_LEVEL_PRIORITY: Readonly<Record<Level, number>> = {
   [Level.Fatal]: 4,
 };
 
-const CANONICAL_DEBUG_KEY = "OKOU_DEBUG";
-const LEGACY_DEBUG_KEY = "VM0_DEBUG";
-const DEBUG_ALIAS_RESOLUTION_EVENT = "debug_environment_alias_resolution";
-const DEBUG_ALIAS_LOG_CONTEXT = "DebugEnvironment";
-const DEBUG_ALIAS_CONFLICT_ERROR =
-  "Debug environment aliases conflict: canonicalKey=OKOU_DEBUG legacyKey=VM0_DEBUG state=conflicting-dual";
-
-type DebugAliasState =
-  | "absent"
-  | "canonical-only"
-  | "legacy-only"
-  | "equal-dual"
-  | "conflicting-dual";
-
-type DebugConfiguration =
-  | {
-      readonly state:
-        | "absent"
-        | "canonical-only"
-        | "legacy-only"
-        | "equal-dual";
-      readonly patterns: readonly string[];
-    }
-  | { readonly state: "conflicting-dual" };
-
 interface Logger {
   readonly debug: LogMethod;
   readonly info: LogMethod;
@@ -66,7 +41,6 @@ interface Logger {
 type RetainedAliasResolutionEvent =
   | "api_backend_url_alias_resolution"
   | "web_url_alias_resolution"
-  | "debug_environment_alias_resolution"
   | "billing_machine_secret_alias_resolution"
   | "stripe_preview_job_ref_alias_resolution";
 
@@ -101,63 +75,9 @@ function parseDebugPatterns(value: string | undefined): readonly string[] {
     });
 }
 
-function reportDebugAliasResolution(state: DebugAliasState): void {
-  logToAxiom(
-    state === "conflicting-dual" ? Level.Warn : Level.Info,
-    DEBUG_ALIAS_LOG_CONTEXT,
-    [
-      DEBUG_ALIAS_RESOLUTION_EVENT,
-      {
-        canonicalKey: CANONICAL_DEBUG_KEY,
-        legacyKey: LEGACY_DEBUG_KEY,
-        state,
-      },
-    ],
-  );
-}
-
-function resolveDebugConfiguration(): DebugConfiguration {
-  const canonical = env(CANONICAL_DEBUG_KEY);
-  const legacy = env(LEGACY_DEBUG_KEY);
-
-  if (!canonical) {
-    const state = legacy ? "legacy-only" : "absent";
-    reportDebugAliasResolution(state);
-    return { state, patterns: parseDebugPatterns(legacy) };
-  }
-  if (!legacy) {
-    reportDebugAliasResolution("canonical-only");
-    return {
-      state: "canonical-only",
-      patterns: parseDebugPatterns(canonical),
-    };
-  }
-  if (canonical === legacy) {
-    reportDebugAliasResolution("equal-dual");
-    return {
-      state: "equal-dual",
-      patterns: parseDebugPatterns(canonical),
-    };
-  }
-
-  reportDebugAliasResolution("conflicting-dual");
-  return { state: "conflicting-dual" };
-}
-
-// Repository-owned preview, local-development, and Turbo writers emit only
-// OKOU_DEBUG. This dual reader and value-free source telemetry remain for
-// external legacy input, old checkout/rerun visibility, and supported rollback
-// compatibility. Remove them only in a later #28914 cleanup after those sources
-// and the rollback window are proven drained.
-const debugConfiguration = singleton(resolveDebugConfiguration);
-
-function getDebugPatterns(): readonly string[] {
-  const configuration = debugConfiguration();
-  if (configuration.state === "conflicting-dual") {
-    throw new Error(DEBUG_ALIAS_CONFLICT_ERROR);
-  }
-  return configuration.patterns;
-}
+const debugPatterns = singleton(() => {
+  return parseDebugPatterns(env("OKOU_DEBUG"));
+});
 
 function matchesDebugPattern(name: string, pattern: string): boolean {
   if (pattern === "*") {
@@ -172,7 +92,7 @@ function matchesDebugPattern(name: string, pattern: string): boolean {
 }
 
 function isDebugEnabled(name: string): boolean {
-  return getDebugPatterns().some((pattern) => {
+  return debugPatterns().some((pattern) => {
     return matchesDebugPattern(name, pattern);
   });
 }
@@ -445,7 +365,7 @@ export function logAliasResolutionInfo(
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function __resetForTest(): void {
-  debugConfiguration.reset();
+  debugPatterns.reset();
   getAxiomLogger.reset();
   loggerRegistry.reset();
 }


### PR DESCRIPTION
Parent EPIC: #28914

Closes #29982

## Summary

- remove the terminal `VM0_DEBUG` API schema entry, reader constant, alias state/configuration types, dual/conflict resolver, fixed conflict diagnostic, source telemetry, and retained-event union entry
- resolve and cache debug patterns directly from `OKOU_DEBUG` while preserving wildcard, namespace-prefix, exact-name, comma/whitespace, empty-entry, non-match, logger-level caching, and reset behavior
- replace migration-only source/conflict coverage with the authorized terminal contract: legacy-only input is ignored, a retired value cannot override or conflict with canonical input, and environment values are not emitted to logs
- preserve the generic `DEBUG` convention test and all unrelated logger formatting, levels, registry, Axiom delivery, and retained alias-event behavior

## Scope evidence

- implementation base: `d3aadd74c482a682a198db736b331baf680730fc`
- published head: `7d622d5992088fc2842722c4435e234d2830155a`
- final diff: exactly the three API files authorized by #29982
- `VM0_DEBUG`: 3 occurrences in 2 files, confined to the focused terminal test constant and the two unchanged preview-action absence assertions
- `VM0_DEBUG` production schema/reader occurrences: 0
- `debug_environment_alias_resolution`, debug alias source/conflict types, resolver symbols, and conflict diagnostic occurrences: 0
- `OKOU_DEBUG`: 11 occurrences; the API reader is the direct `env("OKOU_DEBUG")` call and all canonical repository writers/pass-throughs remain unchanged
- all four retained non-debug alias events and their callers remain present
- excluded preview action, shell test, local dev script, and Turbo configuration have an empty diff

## JIT overlap audit

- pre-edit audit: 26 open PRs; 456 declared / 456 fetched changed files; 0 mismatches
- publication audit: 27 open PRs; 457 declared / 457 fetched changed files; 0 mismatches
- every open-PR list and changed-file page was fully paginated; #25722 was the only PR requiring a second changed-file page
- only stale #25722 overlaps the seven-file boundary, across 6 files. Its actual hunks cover Worker/Cloudflare deployment inputs, Worker runtime environment installation, invocation-scoped Axiom resources/runtime identity, and Turbo Cloudflare credentials; they do not change the `VM0_DEBUG` schema entry, reader/resolver, source telemetry, pattern semantics, or compatibility matrix removed here
- new #29983 changes one Guest Agent file and does not overlap this API boundary

These are inventory facts, not ordering blockers. This PR does not edit, rebase, wait for, or absorb another contributor's PR.

## Verification

Passed locally:

```text
pnpm exec prettier --version  # 3.8.1
pnpm exec prettier --write apps/api/src/lib/env.ts apps/api/src/lib/log.ts apps/api/src/lib/__tests__/log.test.ts
pnpm exec prettier --check apps/api/src/lib/env.ts apps/api/src/lib/log.ts apps/api/src/lib/__tests__/log.test.ts
pnpm --filter api lint
pnpm exec knip --workspace apps/api
pnpm --filter api run check-types
DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/lib/__tests__/log.test.ts --reporter=dot --silent=passed-only  # 50 passed
git diff --check origin/main...HEAD
```

The exact retired-literal/caller inventory, retained-event caller inventory, excluded-scope assertions, and three-file diff boundary also passed. No full Vitest suite or local development server was run.

## Rollback and non-goals

Reverting this focused commit restores the deployed dual reader, source telemetry, and migration matrix. This PR performs no release, deployment, production QA, environment or rollback mutation, namespace-guard removal, other-family cleanup, Worker/Cloudflare change, or Production Release thread message.
