### PR TITLE
refactor(test): cut process-control prerequisite writers to canonical alias

### DIFF
--- a/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
+++ b/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
@@ -44,7 +44,7 @@ fn guest_agent_command() -> Command {
         command.env_remove(key);
     }
     command.env(
-        process_control_ipc::BOOTSTRAP_ENV,
+        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         "process-control-endpoint-must-not-leak",
     );
     command
@@ -334,7 +334,7 @@ async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumpti
         "require OKOU_PROCESS_CONTROL_ENDPOINT or VM0_PROCESS_CONTROL_ENDPOINT",
         |command, endpoint| {
             command
-                .env_remove(process_control_ipc::BOOTSTRAP_ENV)
+                .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
                 .env(workload_canonical, endpoint)
                 .env(tool_canonical, "canonical-tool-must-not-leak");
         },

--- a/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
@@ -268,7 +268,10 @@ async fn guest_agent_rejects_runtime_alias_conflict_before_capabilities_and_priv
         Some(legacy_dir.as_os_str()),
     );
     command
-        .env(process_control_ipc::BOOTSTRAP_ENV, &process_endpoint)
+        .env(
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            &process_endpoint,
+        )
         .env(
             guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             &workload_endpoint,
@@ -322,7 +325,10 @@ async fn guest_agent_rejects_relative_runtime_alias_before_capability_connection
     let mut command = guest_agent_command(root.path(), "relative-runtime", &private_files);
     apply_runtime_aliases(&mut command, Some(OsStr::new("relative-runtime")), None);
     command
-        .env(process_control_ipc::BOOTSTRAP_ENV, "process-control")
+        .env(
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            "process-control",
+        )
         .env(
             guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             &workload_endpoint,

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -229,7 +229,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             )
-            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint)
+            .env(process_control_ipc::CANONICAL_BOOTSTRAP_ENV, &endpoint)
             .env("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         Duration::from_secs(20),
         "guest-agent did not finish within its finalization budget",


### PR DESCRIPTION
## Summary

- switch the four ordinary Guest Agent process-control prerequisite writers to `process_control_ipc::CANONICAL_BOOTSTRAP_ENV`
- remove that canonical prerequisite in the existing missing-process-control cgroup scenario so it continues rejecting before workload capability consumption
- preserve the deployed dual reader, compatibility matrices, child isolation cleanup, endpoint values, assertions, and scenario behavior

## Scope and inventory

- refreshed clean implementation base: `528df1c9581610cc43644744abcbf1b89e06f304`
- implementation head: `44815fdf0a5f1107e43e313e399a6e1b04126704`
- the complete pre-edit inventory found 36 `BOOTSTRAP_ENV` symbol references across 18 files and 5 raw `VM0_PROCESS_CONTROL_ENDPOINT` literals across 5 files
- exactly four references were ordinary prerequisite writers and one was their matching missing-prerequisite removal; every remaining reference was classified as reader/error text, compatibility coverage, CLI isolation, stale-alias replacement, rollback behavior, documentation, or shared cleanup
- the fully paginated open-PR audit covered 29 open PRs and all 533/533 declared changed files with zero mismatch; PR #25722 required two changed-file pages, every other PR required one, and no open PR touched any of the three scoped files
- the final diff is limited to `crates/guest-agent/tests/cgroup_placement_env_aliases.rs`, `crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs`, and `crates/guest-agent/tests/user_cancellation_recovery.rs`

## Acceptance evidence

- all four prerequisite writes now use the canonical alias with byte-identical endpoint values
- the missing-process-control scenario removes the canonical prerequisite while retaining the existing dual-alias error assertion and pre-capability listener-idle assertion
- the cgroup child-command builder still removes both aliases before installing the canonical prerequisite
- Guest runtime conflict/relative-path ordering, private-file preservation, value-free errors, listener-idle assertions, the cgroup alias matrix, and cancellation recovery assertions are unchanged
- production code, `process-control-ipc`, `vsock-guest`, the dual reader, telemetry, shared cleanup lists, dedicated process-control compatibility tests, CLI isolation, child-leak coverage, and rollback behavior are byte-identical

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features --no-deps -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cgroup_placement_env_aliases` (2 passed)
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_runtime_dir_env_aliases` (3 passed)
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test user_cancellation_recovery` (2 passed)
- `git diff --check 528df1c9581610cc43644744abcbf1b89e06f304..44815fdf0a5f1107e43e313e399a6e1b04126704`

## Fallbacks

No fallback is added or changed. The deployed dual reader and deliberate compatibility coverage remain intact for rollback until the separately gated reader-removal stage in #28914.

Closes #29994
Parent: #28914
