### PR TITLE
refactor(test): cut guest runtime directory writers to canonical alias

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1149,7 +1149,7 @@ mod tests {
             std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token");
             std::env::set_var(guest_contracts::env::RUN_ID_ENV, "main-recovery-checkpoint");
             std::env::set_var(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 test_runtime_dir(),
             );
             std::env::set_var(

--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -90,7 +90,7 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
             &run_payload_path,
         )
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
     if launch_unprivileged {

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -365,7 +365,7 @@ fn assert_conflict_precedes_private_payload_consumption(tmp: &Path) -> TestResul
         remove_test_env(key);
     }
     set_test_env(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         &runtime_dir,
     );
     set_test_env(

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -24,7 +24,7 @@ async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, &run_id);
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             runtime_dir.as_os_str(),
         );
         common::set_run_payload_file_env_for_test(

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -84,10 +84,6 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &configured_runtime_dir,
         );
-        std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            &configured_runtime_dir,
-        );
     }
     let runtime_dir = guest_contracts::runtime_paths::run_dir_from_env(&run_id)?;
     let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);

--- a/crates/guest-agent/tests/codex_model_catalog_setup.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_setup.rs
@@ -90,7 +90,7 @@ async fn codex_setup_writes_model_catalog_before_cli_start() -> TestResult {
         )
         .env("OKOU_TEST_CODEX_HOME_DIR", &codex_home)
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         )
         .env("HOME", tmp.path());

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -193,7 +193,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
         )
         .env("OKOU_TEST_CODEX_HOME_DIR", args.home.join(".codex"))
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             args.runtime_dir,
         )
         .env("HOME", args.home);

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -157,7 +157,7 @@ async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::
         )
         .env("OKOU_TEST_CODEX_HOME_DIR", args.home.join(".codex"))
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             args.runtime_dir,
         )
         .env("HOME", args.home);

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -174,7 +174,7 @@ async fn run_event_failure_case(
                 &run_payload_file,
             )
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             ),
         Duration::from_secs(20),

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -130,7 +130,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
                 &run_payload_file,
             )
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             ),
         Duration::from_secs(20),

--- a/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
@@ -536,7 +536,7 @@ fn assert_conflict_precedes_private_file_consumption(
         remove_test_env(key);
     }
     set_test_env(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         &runtime_dir,
     );
     set_test_env(

--- a/crates/guest-agent/tests/guest_config_process_env.rs
+++ b/crates/guest-agent/tests/guest_config_process_env.rs
@@ -24,7 +24,7 @@ fn process_env_config_loads_user_env_once() {
             &user_env_path,
         );
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
     }

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -25,7 +25,7 @@ fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
         )
         .env("HOME", tmp.path().join("home"))
         .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         )
         .env(

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -28,7 +28,7 @@ fn runtime_bootstrap_scrubs_runner_env_and_installs_explicit_paths() {
         );
         std::env::set_var("HOME", tmp.path().join("home"));
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
         std::env::set_var(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "");

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1170,7 +1170,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
     let server = api.server();
     let _run_id_guard = EnvVarRestore::capture(guest_contracts::env::RUN_ID_ENV);
     let _runtime_dir_guard =
-        EnvVarRestore::capture(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+        EnvVarRestore::capture(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV);
 
     let tmp = tempfile::tempdir().unwrap();
     let runtime_dir = tmp.path().join("captured-runtime");
@@ -1214,7 +1214,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
     unsafe {
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, "stale-run-after-runtime");
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &stale_runtime_dir,
         );
     }

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -34,7 +34,7 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
         );
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, TEST_RUN_ID);
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             MOCK_RUNTIME_DIR.as_os_str(),
         );
         write_shared_run_payload_file_or_panic();
@@ -107,7 +107,8 @@ fn write_shared_run_payload_file_or_panic() {
 
 fn cleanup_integration_runtime_root() {
     let Some(runtime_dir) =
-        std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV).map(PathBuf::from)
+        std::env::var_os(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+            .map(PathBuf::from)
     else {
         return;
     };

--- a/crates/guest-agent/tests/private_payload_file_env_aliases.rs
+++ b/crates/guest-agent/tests/private_payload_file_env_aliases.rs
@@ -374,7 +374,7 @@ fn configure_private_files(files: &PrivateFiles, name: &str) -> TestResult {
     );
     set_test_env("HOME", root.join(format!("{name}-process-home")));
     set_test_env(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         &files.runtime_dir,
     );
     Ok(())

--- a/crates/guest-agent/tests/process_control_env_aliases.rs
+++ b/crates/guest-agent/tests/process_control_env_aliases.rs
@@ -179,7 +179,7 @@ fn configure_case(
         );
         std::env::set_var("HOME", root.join(format!("{name}-home")));
         std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
         std::env::set_var("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true");

--- a/crates/guest-agent/tests/run_metadata_env_aliases.rs
+++ b/crates/guest-agent/tests/run_metadata_env_aliases.rs
@@ -242,7 +242,7 @@ fn assert_guest_config_for_source(tmp: &Path, canonical: bool) -> TestResult {
     );
     set_test_env("HOME", tmp.join("home"));
     set_test_env(
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
         &runtime_dir,
     );
     set_test_env(

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -226,7 +226,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 &run_payload_file,
             )
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             )
             .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint)

--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -50,9 +50,9 @@ impl BinaryLoggingFixture {
         let mut command = guest_download_command();
         command
             .env(guest_contracts::env::RUN_ID_ENV, &self.run_id)
-            .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &self.logs.runtime_dir,
             );
         command

--- a/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
+++ b/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
@@ -58,7 +58,7 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
     assert_eq!(content.matches("Download completed").count(), 1);
     assert_eq!(
         source_messages(&content),
-        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=legacy-only"]
+        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=canonical-only"]
     );
     assert!(!content.contains(fixture.logs.runtime_dir.to_string_lossy().as_ref()));
 
@@ -297,7 +297,7 @@ fn binary_fails_with_relative_runtime_dir_for_runtime_log_setup() {
             .arg(&manifest_path)
             .env(guest_contracts::env::RUN_ID_ENV, run_id)
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 "relative-runtime-dir",
             ),
     )
@@ -350,7 +350,7 @@ fn binary_uses_absolute_runtime_dir_without_validating_run_id_as_path_segment() 
                 "ignored/when/runtime-dir/is-set",
             )
             .env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &logs.runtime_dir,
             ),
     )


### PR DESCRIPTION
## Summary

- switch ordinary same-checkout Guest Agent and guest-download runtime-directory test writers and matching readbacks from `VM0_GUEST_RUNTIME_DIR` to `OKOU_GUEST_RUNTIME_DIR`
- stop ordinary `cli_child_env` setup from authoring an equal legacy alias while retaining negative coverage that neither the canonical bootstrap key nor the retired key reaches the managed CLI child
- make guest-download's shared binary-logging fixture and generic relative/absolute override cases canonical-only while preserving its deliberate canonical/legacy/equal-dual/conflict compatibility helper and matrix
- preserve the deployed shared dual reader, fixed source telemetry, conflict and path semantics, inherited-environment cleanup, production writer assertions, Runner ownership checks, and the session-history identity alias matrix

Parent EPIC: #28914.

Closes #29990.

## Scope and inventory

- reviewed implementation base and current `origin/main`: `528df1c9581610cc43644744abcbf1b89e06f304`
- published head: `e449d5dd8f7aaa205e9519b78a1ef3b7f98cb69a`
- final diff: exactly the 22 files authorized by #29990, 27 insertions and 30 deletions
- final full runtime-directory literal/caller inventory: 41 files; 15 files retain the legacy Rust symbol and 38 reference the canonical symbol
- scoped writer-shaped legacy matches: zero ordinary writers; the sole remaining match is the deliberate `apply_runtime_aliases` compatibility helper in guest-download
- retained legacy references are limited to the shared reader/constants, compatibility helpers and matrices, symmetric cleanup, Runner/managed-child negative retirement assertions, and production legacy-absence assertions
- unchanged out-of-scope anchors include `crates/guest-contracts/src/runtime_paths.rs`, `crates/guest-agent/src/run_context.rs`, `guest_runtime_dir_env_aliases.rs`, `session_history_identity_helper.rs`, all five production writers, and their tests
- runtime path bytes, fixed legacy error text, private payload and checkpoint paths, logger/telemetry sinks, CLI-child filtering, storage/session history, process-control/cgroup behavior, timeouts, recovery, and cancellation logic are unchanged

## Open-PR audits

- pre-edit: 29 open PRs; 533 declared / 533 fully paginated changed-file records fetched; zero pagination mismatch; zero overlap with the 22 scoped files
- pre-publication: 29 open PRs; 551 declared / 551 fully paginated changed-file records fetched; zero pagination mismatch; zero overlap with the 22 scoped files
- #29943 overlaps only the broader retained Runner inventory through private-file batching in `agent_run.rs`, `env.rs`, and `env_tests.rs`
- stale #25722 overlaps only the broader retained Guest Contracts/Runner inventory through unrelated Cloudflare Access constants, injection, and coverage

Those overlaps are inventory facts, not dependencies. This PR does not modify, rebase, wait for, pressure, or absorb another contributor PR.

## Verification

Passed locally:

```text
cargo fmt --manifest-path crates/Cargo.toml --all
cargo fmt --manifest-path crates/Cargo.toml --all -- --check
cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-download --all-targets --all-features -- -D warnings
RUSTFLAGS='-D warnings' cargo check --manifest-path crates/Cargo.toml -p guest-agent -p guest-download --all-targets --all-features
RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-download --all-features --no-deps
cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent
cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration success_checkpoint_uses_explicit_runtime_after_process_env_changes
cargo test --manifest-path crates/Cargo.toml -p guest-download --test integration 'binary_logging::'
git diff --check
```

The focused Guest Agent integration invocation also passed all tests in these 17 touched targets: `api_token_process_isolation`, `api_url_env_aliases`, `cli_agent_log_open_failure`, `cli_child_env`, `codex_model_catalog_setup`, `codex_setup_fail_closed`, `codex_startup_telemetry`, `event_delivery_failure_recovery`, `execution_timeout_recovery`, `guest_agent_tuning_env_aliases`, `guest_config_process_env`, `guest_runtime_missing_api_url`, `guest_runtime_process_env`, `private_payload_file_env_aliases`, `process_control_env_aliases`, `run_metadata_env_aliases`, and `user_cancellation_recovery`.

Focused test results:

- Guest Agent binary: 12 passed
- 17 touched Guest Agent integration targets: 22 passed
- explicit-runtime checkpoint case: 1 passed, 106 filtered
- guest-download binary logging: 36 passed, 42 filtered

No local Vitest suite or development server was run. Protected PR CI remains authoritative.

## Acceptance review

- every ordinary setup/readback in the 22 scoped files is canonical-only
- `cli_child_env` still proves both the canonical key and exact retired key are absent from the child environment
- guest-download's ordinary fixture and generic relative/absolute cases are canonical-only with unchanged error/log behavior
- dual-reader compatibility, source telemetry, conflict handling, non-Unicode, empty, relative, HOME, run-id, sink, and value-free evidence cases remain intact
- production writers, inherited cleanup, Runner ownership filtering, negative retirement assertions, and every other environment family remain unchanged

## Rollback

Revert this focused commit to restore legacy-authored same-checkout test fixtures. Deployed binaries, production readers and writers, release state, and production configuration are unaffected.
