### PR TITLE
refactor(guest): cut managed tool placement writer to canonical alias

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -159,9 +159,9 @@ grep -qw memory "$parent/workload/tools/cgroup.subtree_control"
 test "$(cat "/sys/fs/cgroup$relative/memory.oom.group")" = 1
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT+x}"
 test -z "${OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT+x}"
-test -z "${OKOU_TOOL_CGROUP_PROCS_ENDPOINT+x}"
-test "${VM0_TOOL_CGROUP_PROCS_ENDPOINT+x}" = x
-test -n "$VM0_TOOL_CGROUP_PROCS_ENDPOINT"
+test -z "${VM0_TOOL_CGROUP_PROCS_ENDPOINT+x}"
+test "${OKOU_TOOL_CGROUP_PROCS_ENDPOINT+x}" = x
+test -n "$OKOU_TOOL_CGROUP_PROCS_ENDPOINT"
 control_member_count=$(wc -l < "$parent/control/cgroup.procs")
 if [ "$control_member_count" -ne 1 ]; then
   echo "control cgroup must contain only Guest Agent; members=$(tr '\n' ' ' < "$parent/control/cgroup.procs")" >&2

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -185,7 +185,7 @@ impl WorkloadContainment {
     /// Runner-owned endpoint injected into managed CLI environments.
     pub(crate) fn tool_placement_env(&self) -> (&'static str, String) {
         (
-            TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+            CANONICAL_TOOL_CGROUP_PROCS_ENV,
             self.tool_placement_endpoint.to_string(),
         )
     }
@@ -550,13 +550,13 @@ mod tests {
         assert_eq!(
             containment.tool_placement_env(),
             (
-                TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+                CANONICAL_TOOL_CGROUP_PROCS_ENV,
                 "runner-tool-endpoint".to_string()
             )
         );
         assert_ne!(
             containment.tool_placement_env().0,
-            CANONICAL_TOOL_CGROUP_PROCS_ENV
+            TOOL_CGROUP_PROCS_ENDPOINT_ENV
         );
         assert_eq!(
             containment.env_source_evidence(),

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -71,9 +71,11 @@ pub const TOOL_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_TOOL_CGROUP_PROCS_ENDPOINT
 /// root-writer cutover release, observation window, rollback window, and
 /// legacy-read-zero gates in #28914 are complete.
 ///
-/// Guest Agent keeps writing the legacy alias to managed CLI children until
-/// the deployed reader floor, sandbox drain, rollback window, and
-/// legacy-read-zero gates in #28914 are complete.
+/// Guest Agent also writes only this canonical alias to managed CLI children.
+/// `guest-tool-exec` retains [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback
+/// fallback until the downstream-writer cutover is released, pre-cutover Guest
+/// runtimes and reusable sandboxes are drained, the observation and rollback
+/// windows are complete, and legacy reads are zero under #28914.
 pub const CANONICAL_TOOL_CGROUP_PROCS_ENV: &str = "OKOU_TOOL_CGROUP_PROCS_ENDPOINT";
 
 /// Smallest Runner profile vCPU count validated for workload containment.


### PR DESCRIPTION
Closes #29995
Parent: #28914

## Summary

- return `CANONICAL_TOOL_CGROUP_PROCS_ENV` from the sole shared Guest Agent managed-child tool-placement writer while preserving the operation-local endpoint value
- keep both ordinary CLI and Codex app-server construction on that unchanged shared writer, with child normalization, validation, cwd, pre-exec containment, and supervision unchanged
- update the focused unit assertion, adjacent shared-contract rustdoc, and protected Runner behavior assertions for canonical-only downstream emission

## Scope and audit

- exact base: `528df1c9581610cc43644744abcbf1b89e06f304`
- exact implementation head: `19e04b82f961789a34f0da94f1fe037b27406d41`
- the complete current-main Cgroup alias inventory contained 144 direct literal/symbol references across 18 files; the implementation head remains 144/18, with canonical tool references changing from 41 to 43 and legacy tool references from 43 to 41 while workload references remain unchanged at 36 canonical and 39 legacy
- the fully paginated pre-edit audit covered 30 open PRs, one PR-list page, 31 changed-file pages, and all 559/559 declared changed files with zero mismatch and zero overlap on the three scoped files; compared with the issue snapshot, new PR #29996 accounts for the `+1 PR / +26 files` delta
- the diff is limited to `crates/guest-agent/src/workload_containment.rs`, `crates/guest-contracts/src/process_containment.rs`, and `.github/scripts/runner-behavior-process-containment.sh`

## Release and rollback evidence

- reader floor: PR #29081 / `7beb4d545bef801b7dd0bd2c107829869cd022ed`
- root canonical writer: PR #29917 / `ae935e632c1a1c1bee1bd3c014ca556370e59a4a`
- post-sink source telemetry: PR #29927 / `784a12fd385e00a2f28306873c7ebdb747013410`
- fixed non-partial Axiom window `2026-08-28T01:03:00Z..2026-08-28T01:25:00Z` examined 123,849 `vm0-sandbox-telemetry-system-prod` rows; the workload and tool root source markers each appeared 59 times across the same 59 distinct runs, all canonical-only with zero legacy-only, dual, or conflict observations, and no endpoint value selected
- rollback dashboard #6792 refreshed at `2026-08-28T01:35:07Z` to seven retained targets. Every target has `behind=0` from the reader floor and exact merge base `7beb4d545bef801b7dd0bd2c107829869cd022ed`:
  - `528df1c9581610cc43644744abcbf1b89e06f304` — ahead 499
  - `da100a97131334402bc194283be13feafa796e4b` — ahead 471
  - `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` — ahead 462
  - `f8145c9b4ec150fee574c31155d42a09069c0ab3` — ahead 454
  - `4855fb80e0cce894dce180ab0594845c9c3295e2` — ahead 441
  - `edebf90da51f6e86a95002499be2f6b4b4e679e6` — ahead 427
  - `ef41199bc788ed8ee6b192049389565c1a101c81` — ahead 417

## Acceptance evidence

- managed children receive one non-empty `OKOU_TOOL_CGROUP_PROCS_ENDPOINT`, no `VM0_TOOL_CGROUP_PROCS_ENDPOINT`, and neither workload placement alias
- the shared method still returns the byte-identical `tool_placement_endpoint` value and both child call sites remain byte-identical
- the root `vsock-guest` writer, Guest Agent root dual readers/source evidence, `guest-tool-exec` dual reader, and `guest-mock-claude` alias-aware launcher selection remain byte-identical
- no reader, constant, telemetry, namespace guard, endpoint generation, descriptor protocol, containment behavior, environment ordering, command behavior, resource accounting, cleanup, or supervision logic changed
- no release, deployment, sandbox drain, reader removal, telemetry removal, or per-tool telemetry is included

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features --no-deps -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib workload_containment::tests::exposes_runner_owned_tool_endpoint_for_cli_environment -- --exact`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- ShellCheck is not installed in the local environment; protected PR CI is authoritative for ShellCheck and the focused Runner behavior lane
- `git diff --check`

The full local test suite and a development server were intentionally not run.

## Fallback

`guest-tool-exec` remains the unchanged downstream dual reader. A rollback to the prior Guest Agent restores the legacy-only managed-child writer, while current and rollback-retained readers continue accepting both canonical-only and legacy-only input. Reader removal remains a separate #28914 stage after release, drain, observation, and rollback gates close.
