### PR TITLE
test(e2e): make runner connector account mutations exact

### DIFF
--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -11,6 +11,7 @@ runner_e2e_setup_test() {
     AGENT_ID=""
     THREAD_ID=""
     RUN_ID=""
+    CONNECTOR_ACCOUNT_ID=""
 }
 
 runner_e2e_teardown_test() {
@@ -24,8 +25,11 @@ runner_e2e_teardown_test() {
     if [[ -n "${AGENT_ID:-}" ]]; then
         delete_runner_agent "$AGENT_ID" >/dev/null 2>&1 || true
     fi
-    if [[ -n "$connector_slug" ]]; then
-        runner_e2e_disconnect_single_connector_account "$connector_slug" >/dev/null 2>&1 || true
+    if [[ -n "$connector_slug" && -n "${CONNECTOR_ACCOUNT_ID:-}" ]]; then
+        runner_e2e_delete_connector_account \
+            "$connector_slug" \
+            "$CONNECTOR_ACCOUNT_ID" \
+            >/dev/null 2>&1 || true
     fi
 }
 
@@ -34,24 +38,57 @@ runner_e2e_connect_manual_connector() {
     local auth_method="$2"
     local agent_id="$3"
     local values="$4"
-    local payload
+    local existing_connection_id="${5:-}"
+    local account payload response returned_connection_id
+    if [[ -n "$existing_connection_id" ]]; then
+        account=$(jq -nc \
+            --arg connectionId "$existing_connection_id" \
+            '{intent: "reconnect", connectionId: $connectionId}')
+    else
+        account='{"intent":"add"}'
+    fi
     payload=$(jq -nc \
         --arg authMethod "$auth_method" \
         --arg agentId "$agent_id" \
+        --argjson account "$account" \
         --argjson values "$values" \
-        '{authMethod: $authMethod, agentId: $agentId, authorizeAgent: true, account: {intent: "single-account"}, values: $values}')
-    runner_api_curl "/api/connectors/${connector_slug}/manual-grant" \
+        '{authMethod: $authMethod, agentId: $agentId, authorizeAgent: true, account: $account, values: $values}')
+    response=$(runner_api_curl "/api/connectors/${connector_slug}/manual-grant" \
         -X POST \
-        -d "$payload"
+        -d "$payload") || return
+    returned_connection_id=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$response") || return
+
+    if [[ -n "$existing_connection_id" ]]; then
+        [[ "$returned_connection_id" == "$existing_connection_id" ]] || return
+    else
+        local default_payload default_response
+        default_payload=$(jq -nc \
+            --arg connectorSlug "$connector_slug" \
+            '{target: {kind: "builtin", connectorSlug: $connectorSlug}}')
+        default_response=$(runner_api_curl \
+            "/api/connector-accounts/${returned_connection_id}/default" \
+            -X POST \
+            -d "$default_payload") || return
+        jq -e \
+            --arg connectionId "$returned_connection_id" \
+            '.id == $connectionId and .isDefault == true' \
+            <<<"$default_response" \
+            >/dev/null || return
+    fi
+
+    printf '%s\n' "$response"
 }
 
-runner_e2e_disconnect_single_connector_account() {
+runner_e2e_delete_connector_account() {
     local connector_slug="$1"
+    local connection_id="$2"
     local payload
     payload=$(jq -nc \
         --arg connectorSlug "$connector_slug" \
         '{target: {kind: "builtin", connectorSlug: $connectorSlug}}')
-    runner_api_curl "/api/connector-accounts/single-account" \
+    runner_api_curl "/api/connector-accounts/${connection_id}" \
         -X DELETE \
         -d "$payload"
 }

--- a/e2e/tests/03-runner/run-t01-firewall-twilio.bats
+++ b/e2e/tests/03-runner/run-t01-firewall-twilio.bats
@@ -29,6 +29,9 @@ teardown() {
     run runner_e2e_connect_manual_connector twilio api-token "$AGENT_ID" "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
     public_surfaces="$output"$'\n'
 
     local prompt

--- a/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
+++ b/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
@@ -26,6 +26,9 @@ teardown() {
     run runner_e2e_connect_manual_connector discord-webhook api-token "$AGENT_ID" "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
 
     # Raw DNS has dedicated runner coverage. Pin the synthetic placeholder's
     # public sink so this test owns only firewall classification and rewriting.

--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -29,6 +29,9 @@ teardown() {
     run runner_e2e_connect_manual_connector zendesk api-token "$AGENT_ID" "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
 
     local prompt
     prompt=$(cat <<'EOF'

--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -24,6 +24,9 @@ teardown() {
     run runner_e2e_connect_manual_connector serpapi api-token "$AGENT_ID" "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
 
     local prompt
     prompt=$(cat <<'EOF'

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -27,6 +27,9 @@ teardown() {
     run runner_e2e_connect_manual_connector algolia api-key "$AGENT_ID" "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
 
     # Raw DNS has dedicated runner coverage. Pin the synthetic placeholder's
     # public sink so this test owns only firewall permission transitions.

--- a/e2e/tests/03-runner/run-t22-connector-refresh.bats
+++ b/e2e/tests/03-runner/run-t22-connector-refresh.bats
@@ -41,6 +41,9 @@ teardown() {
         "$values"
     echo "$output"
     assert_success
+    CONNECTOR_ACCOUNT_ID=$(jq -er \
+        '.id | select(type == "string" and length > 0)' \
+        <<<"$output")
     public_surfaces+="$output"$'\n'
 
     local probe_template
@@ -124,7 +127,8 @@ EOF
         bentoml \
         api-token \
         "$AGENT_ID" \
-        "$values"
+        "$values" \
+        "$CONNECTOR_ACCOUNT_ID"
     echo "$output"
     assert_success
     public_surfaces+="$output"$'\n'

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -69,7 +69,7 @@ teardown() {
     values_payload=$(jq -nc \
         --arg secret "$probe_secret" \
         '{
-            account: {intent: "single-account"},
+            account: {intent: "add"},
             values: [{key: "probe_secret", kind: "secret", value: $secret}]
         }')
     run runner_api_curl \


### PR DESCRIPTION
## Summary

- create runner E2E built-in connector accounts with explicit `add` and promote the returned exact row to default
- reconnect the exact original account in the credential-refresh scenario and delete exact test-owned rows during teardown
- switch the test-owned custom connector happy path from singleton mutation to explicit `add`

## Scope

This removes active singleton callers under `e2e/`. It intentionally leaves compact Settings, the `ConnectorAccounts` switch, API compatibility routes/contracts, persisted authorization state, and compatibility-focused tests unchanged.

No diagnostic logging was added.

## Validation

- `bash -n e2e/helpers/runner-api.bash`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/*.bats` (27 tests parsed)
- local public-API boundary simulation for add + set-default, exact reconnect, and exact delete
- `scripts/check-file-size.sh` for all changed files
- repository-wide `e2e/` inventory confirms no `single-account` literal or singleton endpoint call remains
- deployed runner E2E behavior will be validated by PR CI

Closes #30005

Parent context: #28571
