### PR TITLE
refactor(runner): cut api start-time writer to canonical alias

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -105,10 +105,12 @@ pub const CANONICAL_RESUME_SESSION_ID_ENV: &str = "OKOU_RESUME_SESSION_ID";
 /// Optional Unix epoch millisecond timestamp for when the API accepted the
 /// run.
 ///
-/// The runner emits an empty string when the timestamp is unavailable.
+/// Guest readers retain this legacy alias as a rollback fallback.
 pub const API_START_TIME_ENV: &str = "VM0_API_START_TIME";
 
-/// Canonical alias for the API start timestamp accepted by guest readers.
+/// Canonical alias for the API start timestamp written by the runner.
+///
+/// The runner emits an empty string when the timestamp is unavailable.
 pub const CANONICAL_API_START_TIME_ENV: &str = "OKOU_API_START_TIME";
 
 /// Maximum agent execution duration in seconds.

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -603,7 +603,7 @@ fn build_env_json_with_host_env_inner(
     );
     insert_guest_agent_tuning_env(&mut env, context);
     env.insert(
-        guest_contracts::env::API_START_TIME_ENV.into(),
+        guest_contracts::env::CANONICAL_API_START_TIME_ENV.into(),
         context
             .api_start_time
             .map(|t| t.to_string())

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -475,14 +475,15 @@ fn build_env_json_required_keys() {
         "sandboxReused"
     );
     assert_eq!(
-        env.get(guest_contracts::env::API_START_TIME_ENV).unwrap(),
+        env.get(guest_contracts::env::CANONICAL_API_START_TIME_ENV)
+            .unwrap(),
         ""
     );
+    assert!(!env.contains_key(guest_contracts::env::API_START_TIME_ENV));
     for canonical_key in [
         guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
         guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
         guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
-        guest_contracts::env::CANONICAL_API_START_TIME_ENV,
     ] {
         assert!(
             !env.contains_key(canonical_key),
@@ -1403,7 +1404,12 @@ fn build_env_json_with_api_start_time() {
     ctx.api_start_time = Some(1_700_000_000_500);
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(env.get("VM0_API_START_TIME").unwrap(), "1700000000500");
+    assert_eq!(
+        env.get(guest_contracts::env::CANONICAL_API_START_TIME_ENV)
+            .unwrap(),
+        "1700000000500"
+    );
+    assert!(!env.contains_key(guest_contracts::env::API_START_TIME_ENV));
 }
 
 #[test]


### PR DESCRIPTION
Closes #29998.
Parent EPIC: #28914.

## Summary

- switch only `build_env_json_with_host_env_inner` API start-time output from `API_START_TIME_ENV` to `CANONICAL_API_START_TIME_ENV`
- preserve present decimal Unix epoch milliseconds via the unchanged `to_string()` path and preserve absent timestamps as the unchanged empty string
- prove canonical empty/present values and legacy absence while leaving sandbox ID, sandbox reuse, and workspace reuse writers legacy-only
- update only the adjacent shared rustdoc to describe the canonical Runner writer and retained legacy Guest-reader rollback fallback

The deployed Guest dual reader, source telemetry, conflict/empty/non-Unicode behavior, timing diagnostics and computation, ownership predicate, user-environment separation, serialization, clock source, sandbox lifecycle, reporting, CLI exposure, and every unrelated writer remain unchanged. This does not dual-write and does not remove a reader, constant, test, telemetry item, or namespace guard.

## Rollout evidence

Reader precedent #28982 / #29022 merged as `928d53b17819c1c82f76da3aa8e4e672c69431d1` and first shipped in Runner `v0.171.9` at `feda3aafb652aca6dd3369ef18dd802635349e7f`. Same-checkout cleanup #29957 merged as `6b1f6b328efc2a747fbac17abafae66c70379d19`; post-sink telemetry #29927 merged as `784a12fd385e00a2f28306873c7ebdb747013410` and is deployed in `da100a97131334402bc194283be13feafa796e4b`.

The fixed, terminal, non-partial Axiom window was `2026-08-28T01:03:00Z..2026-08-28T01:33:00Z`: 124,731 system-telemetry rows, 85 exact API-start markers across 85 distinct runs, from `2026-08-28T01:03:08.498Z` through `2026-08-28T01:32:33.337Z`. All 85 were legacy-only; canonical-only, dual, and conflict were zero. No timestamp value was selected or returned.

Every retained rollback target is ahead of the reader merge, behind by zero, and has merge base exactly `928d53b17819c1c82f76da3aa8e4e672c69431d1`:

| Rollback target | Ahead | Behind |
| --- | ---: | ---: |
| `528df1c9581610cc43644744abcbf1b89e06f304` | 549 | 0 |
| `da100a97131334402bc194283be13feafa796e4b` | 521 | 0 |
| `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` | 512 | 0 |
| `f8145c9b4ec150fee574c31155d42a09069c0ab3` | 504 | 0 |
| `4855fb80e0cce894dce180ab0594845c9c3295e2` | 491 | 0 |
| `edebf90da51f6e86a95002499be2f6b4b4e679e6` | 477 | 0 |
| `ef41199bc788ed8ee6b192049389565c1a101c81` | 467 | 0 |

## Base, head, and complete inventory

- clean pre-edit implementation base: `076afcef21eda68013427bb5636c971d506c992c`
- publication-time `origin/main`: `97414e6c34b2241df1cbcf87fa85fa6248cf41d6`
- published head: `643eedaf0d46b727fc6a5bd6cdeb415c4e67aa88`
- pre-edit search `API_START_TIME_ENV|OKOU_API_START_TIME|VM0_API_START_TIME`: exactly 26 references across 13 files; the sole production writer was `crates/runner/src/executor/env.rs:606`
- post-edit search: 27 references across the same 13 files because the explicit value test now adds a focused legacy-absence assertion; reader, telemetry, timing, compatibility, cleanup, constant, and ownership references remain

The fully paginated pre-edit audit covered 32 open PRs and all 579 declared / 579 fetched changed files, with zero mismatches. Exact scoped overlap hunks were:

- #29943, `crates/runner/src/executor/env.rs`: `@@ -9,7 +9,7 @@` and `@@ -480,34 +480,49 @@`; private-file batching imports and `write_required_agent_files`, not `build_env_json_with_host_env_inner` or API start time.
- #29943, `crates/runner/src/executor/tests/env_tests.rs`: `@@ -13,15 +13,14 @@`, `@@ -1175,97 +1174,6 @@`, and `@@ -1343,53 +1251,6 @@`; private-file test imports/removals, not either API start-time assertion.
- stale #25722, `crates/guest-contracts/src/env.rs`: `@@ -60,6 +60,12 @@` and `@@ -377,6 +383,8 @@`; Cloudflare Access constants and ownership entries.
- stale #25722, `crates/runner/src/executor/env.rs`: `@@ -472,6 +472,16 @@` and `@@ -667,14 +677,35 @@`; Cloudflare Access injection and host configuration.
- stale #25722, `crates/runner/src/executor/tests/env_tests.rs`: `@@ -10,10 +10,10 @@`, `@@ -571,6 +571,14 @@`, `@@ -629,6 +637,8 @@`, `@@ -680,6 +690,10 @@`, and `@@ -696,6 +710,8 @@`; Cloudflare Access imports and assertions.

#29943 merged normally during local validation as `97414e6c34b2241df1cbcf87fa85fa6248cf41d6`; this branch neither modified nor absorbed it. The pre-publication audit then covered 30 open PRs and all 565 declared / 565 fetched files with zero mismatches; stale #25722 was the sole open scoped overlap. Normal first-merge precedence applies.

## Verification

Passed locally on Rust 1.98 with one build job:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts` (134 tests passed across unit and integration targets; doc tests passed)
- `git diff --check`

The exact Runner test command for `executor::tests::env_tests::build_env_json_required_keys` compiled through the Runner test target and entered the silent final-link phase, then the local 3.8 GiB/no-swap environment killed it with exit 137. No compiler diagnostic or test assertion ran. The second exact test would require the same unavailable linked binary, so it was not retried. Strict all-targets check passed; protected PR CI is authoritative for linked Runner execution.

## Fallbacks

- `crates/guest-agent/src/env.rs:run_metadata_env_or_empty` retains `API_START_TIME_ENV` as the rollback fallback for a rolled-back Runner writer. Remove it only in the later reader-removal issue after an exact writer release, canonical-only observation window, supported rollback-writer expiry, and zero legacy-only/dual/conflict evidence.
- Reverting this focused PR restores the legacy-only Runner writer without changing any reader, value semantics, configuration, or persisted state.
