### PR TITLE
fix(platform): reserve growth entry space before loading

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1249,12 +1249,28 @@ test("chat page displays tagline after onboarding", async ({ page }) => {
   });
 });
 
-test("home content stays fixed while the growth entry loads", async ({
+test("home content keeps its reserved offset while the growth entry loads", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
+  const orgRequested = deferred();
+  const releaseOrg = deferred();
   const slackStatusRequested = deferred();
   const releaseSlackStatus = deferred();
+  await page.route(
+    (url) => url.pathname === "/api/org",
+    async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      orgRequested.resolve();
+      await releaseOrg.promise;
+      await route.fulfill({
+        json: { id: "org_admin", name: "Admin Org", role: "admin" },
+      });
+    },
+  );
   await page.route("**/api/integrations/slack", async (route) => {
     if (route.request().method() !== "GET") {
       await route.continue();
@@ -1284,7 +1300,7 @@ test("home content stays fixed while the growth entry loads", async ({
 
   await page.goto(appUrl);
   await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
-  await slackStatusRequested.promise;
+  await orgRequested.promise;
 
   const growthEntry = page.getByTestId("growth-entry");
   const main = page.locator("main");
@@ -1296,9 +1312,20 @@ test("home content stays fixed while the growth entry loads", async ({
   if (!mainBefore || !taglineBefore) {
     throw new Error("Home content has no measurable layout before entry load");
   }
-  // The async entry is absolute, but its former 56px header slot remains in
-  // flow so the landing content does not jump upward.
+  // Reserve the former 56px header slot before either async dependency resolves.
   expect(mainBefore.y).toBe(56);
+
+  releaseOrg.resolve();
+  await slackStatusRequested.promise;
+  await expect(growthEntry).not.toBeAttached();
+  const mainAfterRole = await main.boundingBox();
+  const taglineAfterRole = await tagline.boundingBox();
+  if (!mainAfterRole || !taglineAfterRole) {
+    throw new Error("Home content has no measurable layout after role load");
+  }
+  expect(mainAfterRole.y).toBe(mainBefore.y);
+  expect(mainAfterRole.height).toBe(mainBefore.height);
+  expect(taglineAfterRole.y).toBe(taglineBefore.y);
 
   releaseSlackStatus.resolve();
   await expect(growthEntry).toBeVisible();
@@ -1314,7 +1341,9 @@ test("home content stays fixed while the growth entry loads", async ({
   expect(taglineAfter.y).toBe(taglineBefore.y);
 });
 
-test("non-admin home content keeps its original top edge", async ({ page }) => {
+test("non-admin home content keeps the reserved desktop offset", async ({
+  page,
+}) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.route(
     (url) => url.pathname === "/api/org",
@@ -1359,7 +1388,7 @@ test("non-admin home content keeps its original top edge", async ({ page }) => {
   if (!mainBox) {
     throw new Error("Non-admin home content has no measurable layout");
   }
-  expect(mainBox.y).toBe(0);
+  expect(mainBox.y).toBe(56);
 });
 
 test("checkmark keeps its column across selection states and previews deactivation", async ({

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -295,16 +295,13 @@ function AdminGrowthEntryHeader() {
 export function GrowthEntryHeader() {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
-  if (!isAdmin) {
-    return null;
-  }
   return (
     <>
       {/* Match the former in-flow header's 16px + 32px + 8px height. The
-          controls stay absolute, but the home content keeps its established
-          desktop position before and after the async entry resolves. */}
+          slot exists from the first render so async role and entry resolution
+          cannot move the home content. The admin controls stay absolute. */}
       <div aria-hidden className="hidden h-14 shrink-0 md:block" />
-      <AdminGrowthEntryHeader />
+      {isAdmin ? <AdminGrowthEntryHeader /> : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- reserve the desktop 56px growth-entry slot from the first render, before organization role or Slack status resolves
- keep the actual growth controls admin-only and absolutely positioned, preserving the loaded composer position and mobile layout
- cover stable page geometry before role resolution, after role resolution, and after `Invite humans 🤝` appears

## Context

The existing spacer mounts only after `/api/org` resolves to an admin role. That moves the already-visible avatar, tagline, and composer from `y = 0` to `y = 56`.

This PR intentionally applies the newly selected invariant that every desktop role reserves the same slot. It is related to #29935 and the overlapping #29941, but has no merge-order dependency on that PR.

## Verification

- `npx --yes prettier@3.8.1 --check turbo/apps/platform/src/views/okou-page/growth-entry.tsx e2e/playwright/tests/chat.spec.ts`
- `cd e2e && npx --yes pnpm@10.33.4 check-types`
- `cd e2e/playwright && npx --yes pnpm@10.33.4 exec playwright test tests/chat.spec.ts --list` (22 tests discovered)
- `cd turbo && npx --yes pnpm@10.33.4 -F @okouai/app lint`
- `cd turbo && npx --yes pnpm@10.33.4 -F @okouai/app check-types`
- `cd turbo && npx --yes pnpm@10.33.4 -F @okouai/app exec vitest run src/views/okou-page/__tests__/home-growth-entry.test.tsx --maxWorkers=1 --silent=passed-only` (7 tests passed)
- `cd turbo && npx --yes pnpm@10.33.4 knip --workspace @okouai/app`

Local browser/E2E execution was not run because repository instructions prohibit starting a local dev server unless explicitly requested; the geometry regression runs in the PR pipeline.
