### PR TITLE
fix(auth): gate v2 one tap by fedcm support

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -67,6 +67,12 @@ interface BrowserUrlOptions {
   readonly apiOriginMarker?: string | null;
 }
 
+interface BrowserFedCmOptions {
+  readonly credentials?: boolean;
+  readonly identityCredential?: boolean;
+  readonly secureContext?: boolean;
+}
+
 interface BrowserWebAuthnOptions {
   readonly credentials?: boolean;
   readonly platformAuthenticatorResult?: boolean | "error";
@@ -291,6 +297,48 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       },
       userAgent: (ua: string): void => {
         vi.spyOn(navigator, "userAgent", "get").mockReturnValue(ua);
+      },
+      fedCm: (options: BrowserFedCmOptions = {}): void => {
+        const secureContextDescriptor = defineWindowProperty(
+          window,
+          "isSecureContext",
+          options.secureContext ?? true,
+        );
+        const credentialsDescriptor = defineWindowProperty(
+          navigator,
+          "credentials",
+          options.credentials === false
+            ? undefined
+            : {
+                get: () => {
+                  return Promise.resolve(null);
+                },
+              },
+        );
+        const identityCredentialDescriptor = defineWindowProperty(
+          window,
+          "IdentityCredential",
+          options.identityCredential === false
+            ? undefined
+            : class TestIdentityCredential {},
+        );
+        restoreOnAbort(getSignal(), () => {
+          restoreWindowProperty(
+            window,
+            "isSecureContext",
+            secureContextDescriptor,
+          );
+          restoreWindowProperty(
+            navigator,
+            "credentials",
+            credentialsDescriptor,
+          );
+          restoreWindowProperty(
+            window,
+            "IdentityCredential",
+            identityCredentialDescriptor,
+          );
+        });
       },
       webAuthn: (options: BrowserWebAuthnOptions = {}): void => {
         const platformAuthenticatorResult = options.platformAuthenticatorResult;

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts
@@ -60,8 +60,20 @@ interface GoogleIdentityServices {
 
 type GoogleWindow = Window & { readonly google?: GoogleIdentityServices };
 
+type FedCmWindow = Window & {
+  readonly IdentityCredential?: unknown;
+};
+
 function googleIdentityApi(): GoogleIdentityApi | null {
   return (window as GoogleWindow).google?.accounts?.id ?? null;
+}
+
+function supportsGoogleOneTapFedCm(): boolean {
+  return (
+    window.isSecureContext !== false &&
+    typeof (window as FedCmWindow).IdentityCredential === "function" &&
+    typeof navigator.credentials?.get === "function"
+  );
 }
 
 function loadGoogleIdentityApi(
@@ -158,9 +170,10 @@ export function discoverAuthV2ExternalCapabilities(
     passkeyAttribute?.enabled === true &&
     passkeyAttribute.used_for_first_factor === true &&
     settings?.passkeySettings.show_sign_in_button === true;
-  const googleOneTapClientId = oauthStrategies.includes("oauth_google")
-    ? (environment?.displayConfig.googleOneTapClientId ?? null)
-    : null;
+  const googleOneTapClientId =
+    oauthStrategies.includes("oauth_google") && supportsGoogleOneTapFedCm()
+      ? (environment?.displayConfig.googleOneTapClientId ?? null)
+      : null;
   const lastAuthenticationStrategy = clerk.client?.lastAuthenticationStrategy;
   const lastUsedOAuthStrategy =
     typeof lastAuthenticationStrategy === "string" &&

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -499,6 +499,21 @@ function passkeyErrorCode(
   return null;
 }
 
+function isGoogleOneTapUnavailableError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const apiError = Array.isArray(error.errors)
+    ? error.errors.find(isRecord)
+    : null;
+  const normalizedError = apiError ?? error;
+  return (
+    stringProperty(normalizedError, "name") === "NotSupportedError" ||
+    stringProperty(normalizedError, "message") ===
+      "Error connecting to Web Authentication service."
+  );
+}
+
 function normalizeClerkError(
   error: unknown,
   fallbackField: AuthV2SignInErrorField,
@@ -1560,6 +1575,9 @@ function createGoogleOneTapCommand(
         signal,
       );
       if (!credential.ok) {
+        if (isGoogleOneTapUnavailableError(credential.error)) {
+          return;
+        }
         set(atoms.error$, normalizeClerkError(credential.error, "general"));
         return;
       }

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -765,6 +765,7 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it("exchanges one Google One Tap credential only on the exact base route", async () => {
+    context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
       googleOneTapClientId: "google-client-id",
@@ -808,6 +809,7 @@ describe("auth v2 sign-in flow", () => {
   it.each(["dismissed", "skipped"] as const)(
     "settles a FedCM %s moment without legacy notification methods",
     async (momentType) => {
+      context.mocks.browser.fedCm();
       mockAuthV2Capabilities({
         googleOAuth: true,
         googleOneTapClientId: "google-client-id",
@@ -832,6 +834,7 @@ describe("auth v2 sign-in flow", () => {
   );
 
   it("ignores a legacy display moment until a terminal moment arrives", async () => {
+    context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
       googleOneTapClientId: "google-client-id",
@@ -860,6 +863,7 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it("cancels an aborted FedCM prompt and ignores late credential events", async () => {
+    context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
       googleOneTapClientId: "google-client-id",
@@ -899,6 +903,7 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it("does not start Google One Tap on a nested sign-in route", async () => {
+    context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
       googleOneTapClientId: "google-client-id",
@@ -919,6 +924,7 @@ describe("auth v2 sign-in flow", () => {
   });
 
   it("retries Google One Tap after a script failure and back navigation", async () => {
+    context.mocks.browser.fedCm();
     mockAuthV2Capabilities({
       googleOAuth: true,
       googleOneTapClientId: "google-client-id",
@@ -970,6 +976,62 @@ describe("auth v2 sign-in flow", () => {
       });
       expect(mockedClerk.setActive).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it.each([
+    {
+      fedCm: { secureContext: false },
+      name: "an insecure context",
+    },
+    {
+      fedCm: { identityCredential: false },
+      name: "a missing IdentityCredential API",
+    },
+    {
+      fedCm: { credentials: false },
+      name: "a missing credentials container",
+    },
+  ] as const)("does not start Google One Tap for $name", async ({ fedCm }) => {
+    context.mocks.browser.fedCm(fedCm);
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+
+    setupSignInPage({ status: "needs_identifier" });
+
+    await expect(
+      screen.findByLabelText("Email address"),
+    ).resolves.toBeVisible();
+    expect(
+      document.querySelector("script[data-auth-v2-google-one-tap]"),
+    ).toBeNull();
+    expect(mockedGoogleOneTap.initialize).not.toHaveBeenCalled();
+    expect(mockedGoogleOneTap.prompt).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("silently falls back when the FedCM runtime is unavailable", async () => {
+    context.mocks.browser.fedCm();
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential(null);
+    mockedGoogleOneTap.prompt.mockImplementation(() => {
+      throw new Error("Error connecting to Web Authentication service.");
+    });
+
+    setupSignInPage({ status: "needs_identifier" });
+
+    await expect(
+      screen.findByLabelText("Email address"),
+    ).resolves.toBeVisible();
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- gate Auth v2 Google One Tap on the required secure-context and FedCM browser primitives before loading Google Identity Services
- silently fall back to the ordinary sign-in form when One Tap reports an unavailable Web Authentication runtime, instead of surfacing a Passkey error
- cover unsupported browser capabilities and the runtime fallback through the production page bootstrap path

## Fallbacks

- `turbo/apps/platform/src/signals/auth-v2/sign-in-external-strategies.ts:supportsGoogleOneTapFedCm` and `turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts:createGoogleOneTapCommand` — when the current Auth v2 client runs in a browser without the required FedCM primitives, or Google Identity Services reports that the Web Authentication runtime is unavailable, continue with the ordinary sign-in form. Surface: browser and Google Identity Services external runtime; this is not an old/new deployment-version interaction and has no rollout window or section 7 deployment gate. Retain while supported browsers or GIS can legitimately lack or reject the optional capability; remove only if that external contract guarantees FedCM availability across every supported browser. Follow-up: none, because no such removal condition is currently evidenced and this is permanent optional-capability handling rather than temporary migration compatibility.

## Verification

- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx` (62 tests)
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`

## Scope

This PR changes `/v2/sign-in` only. It does not switch the legacy sign-in route to Auth v2.
