### PR TITLE
perf(platform): add skeleton duration to bootstrap phases

### DIFF
--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -528,6 +528,8 @@ function elapsedDuration(
   if (
     startedAt === undefined ||
     completedAt === undefined ||
+    !Number.isFinite(startedAt) ||
+    !Number.isFinite(completedAt) ||
     completedAt < startedAt
   ) {
     return undefined;
@@ -583,6 +585,11 @@ export const captureBootstrapPhaseTiming$ = command(({ get, set }) => {
       properties,
       "entry_module_ready_ms",
       entryModuleReadyDurationMs,
+    );
+    setDurationProperty(
+      properties,
+      "skeleton_duration_ms",
+      elapsedDuration(window.__appBootstrapStart, capturedAt),
     );
     setDurationProperty(
       properties,

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-phase-telemetry.test.ts
@@ -128,6 +128,7 @@ describe("bootstrap phase telemetry", () => {
         local_thread_metadata_ms: expect.any(Number),
         remote_thread_metadata_ms: expect.any(Number),
         route_setup_ms: expect.any(Number),
+        skeleton_duration_ms: expect.any(Number),
         standalone_pwa: false,
         thread_metadata_source:
           "not_found" satisfies BootstrapThreadMetadataSource,
@@ -135,6 +136,12 @@ describe("bootstrap phase telemetry", () => {
         was_hidden: false,
       }),
     );
+    const skeletonDurationMs = properties?.skeleton_duration_ms;
+    if (typeof skeletonDurationMs !== "number") {
+      throw new TypeError("expected a numeric skeleton duration");
+    }
+    expect(Number.isFinite(skeletonDurationMs)).toBeTruthy();
+    expect(skeletonDurationMs).toBeGreaterThanOrEqual(0);
     expect(JSON.stringify(properties)).not.toContain(THREAD_ID);
   });
 
@@ -153,6 +160,9 @@ describe("bootstrap phase telemetry", () => {
           : [];
       }),
     ).toStrictEqual(["app_first_skeleton_hide", BOOTSTRAP_PHASE_TIMING_EVENT]);
+    expect(timingEvents()[0]).toStrictEqual(
+      expect.objectContaining({ skeleton_duration_ms: expect.any(Number) }),
+    );
   });
 
   it("discards thread timing from an aborted navigation", async () => {
@@ -206,6 +216,7 @@ describe("bootstrap phase telemetry", () => {
 
     expect(timingEvents()).toHaveLength(1);
     expect(timingEvents()[0]).not.toHaveProperty("entry_module_ready_ms");
+    expect(timingEvents()[0]).not.toHaveProperty("skeleton_duration_ms");
     expect(timingEvents()[0]).toStrictEqual(
       expect.objectContaining({
         final_route: ROUTES.error,
@@ -214,5 +225,24 @@ describe("bootstrap phase telemetry", () => {
         route_setup_ms: expect.any(Number),
       }),
     );
+    expect(
+      posthog.capture.mock.calls.filter(([eventName]) => {
+        return eventName === "app_first_skeleton_hide";
+      }),
+    ).toHaveLength(0);
+  });
+
+  it("omits an invalid skeleton timing without changing the total event", async () => {
+    window.__appBootstrapStart = Number.NaN;
+
+    await setupPage({ context, path: ROUTES.error, withoutRender: true });
+
+    expect(timingEvents()).toHaveLength(1);
+    expect(timingEvents()[0]).not.toHaveProperty("skeleton_duration_ms");
+    expect(
+      posthog.capture.mock.calls.filter(([eventName]) => {
+        return eventName === "app_first_skeleton_hide";
+      }),
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- add `skeleton_duration_ms` to the existing `app_bootstrap_phase_timing` event at the first skeleton-hide boundary
- compute the value from `window.__appBootstrapStart` to the phase event's existing `capturedAt`, so PostHog can calculate phase-to-total shares without joining separate events
- keep all phase durations finite and non-negative by omitting missing, non-finite, or reversed timing boundaries
- leave `app_first_skeleton_hide` unchanged, including its existing handling of invalid numeric start marks

No new event, startup identifier, dashboard, or entry download/parse/evaluation subphase is added.

## Tests

- captures one finite, non-negative skeleton duration on the phase event at first hide
- preserves the once-only total-then-phase event order
- omits the new field when the bootstrap start mark is missing or invalid
- preserves the existing total event behavior for missing and invalid start marks

## Local verification

- lockfile-pinned Prettier 3.8.1 on both touched files
- targeted Oxlint and type-aware Oxlint
- targeted ESLint with zero warnings
- platform production and test TypeScript checks
- platform Knip
- `bootstrap-phase-telemetry.test.ts` (5/5)

Follow-up to #29583.
