### PR TITLE
refactor(runner): cut execution timeout writer to canonical alias

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -119,11 +119,11 @@ pub const CANONICAL_API_START_TIME_ENV: &str = "OKOU_API_START_TIME";
 /// local user-tuning key.
 pub const AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
 
-/// Canonical agent execution timeout alias accepted by guest readers.
+/// Canonical agent execution timeout alias written by the runner.
 ///
-/// Runner writers keep using [`AGENT_EXECUTION_TIMEOUT_SECS_ENV`] until the
-/// deployed reader floor, sandbox drain, rollback window, and legacy-read-zero
-/// gates are complete.
+/// Guest readers retain [`AGENT_EXECUTION_TIMEOUT_SECS_ENV`] as a rollback
+/// fallback until the canonical writer deployment, supported rollback window,
+/// and legacy-read-zero gates in #28914 are complete.
 pub const CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "OKOU_AGENT_EXECUTION_TIMEOUT_SECS";
 
 /// Logical run-payload field name for sensitive values used by the guest-agent

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -613,7 +613,7 @@ fn build_env_json_with_host_env_inner(
         );
     }
     env.insert(
-        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV.into(),
+        guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV.into(),
         JOB_TIMEOUT.as_secs().to_string(),
     );
     insert_guest_agent_tuning_env(&mut env, context);

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -447,10 +447,11 @@ fn build_env_json_required_keys() {
     assert!(!env.contains_key("VM0_RUN_ID"));
     assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(
-        env.get(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV)
+        env.get(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV)
             .unwrap(),
         "7200"
     );
+    assert!(!env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
     assert_eq!(
         env.get(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
             .unwrap(),


### PR DESCRIPTION
Parent EPIC: #28914

Closes #30002

## Summary

- switch the sole production Runner execution-timeout writer from `AGENT_EXECUTION_TIMEOUT_SECS_ENV` to `CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV`
- preserve the exact `JOB_TIMEOUT.as_secs().to_string()` value path and the 7200-second lifecycle budget
- prove the canonical key is exactly `7200` and the legacy key is absent in the focused Runner required-env assertion
- update only the adjacent shared rustdoc to describe the canonical writer and retained legacy-reader rollback fallback

The Guest dual reader, conflict handling, value-free telemetry, full alias matrix, cleanup, CLI-child isolation, deadline/recovery/reaping/finalization behavior, API start time, metadata, tuning contracts, and every unrelated writer remain unchanged.

## Base and complete inventory

- clean JIT checkpoint: `main@2ee0e7ec048affe6075f413d3a9bfb3544ce12af`
- publication-time refreshed base: `2a7f946a16b5cdb679ec8d285ffb20a19ed6e302`
- published head: `34adf8918a895316090d00ab6e8fa869e8646fce`
- current-main timeout alias inventory: 46 lines across 16 files; exactly one production writer
- branch inventory: 47 lines across the same 16 files because the focused test adds one legacy-absence assertion
- final diff: exactly the three files authorized by #30002, `+7/-6`

During validation, #29943 and subsequent main commits merged first. This branch was refreshed onto canonical main and preserved their changes. No sibling PR was modified, rebased, pushed, delayed, or pressured.

## Production evidence

The fixed, aggregate-only, terminal, non-partial Axiom window was `2026-08-28T01:03:00Z..2026-08-28T01:48:00Z`. It examined 125,516 `vm0-sandbox-telemetry-system-prod` rows and matched 119 exact execution-timeout source markers across 119 distinct runs, from `2026-08-28T01:03:08.498Z` through `2026-08-28T01:47:28.146Z`.

All 119 markers were `legacy-only`; canonical-only, dual, and conflict were zero. No environment value was selected.

## Rollback ancestry

Every retained rollback target is ahead of reader merge `c27e3fa6ca856a65ef8d4b195f7da91dbf86942a`, behind by zero, with that exact merge as the merge base:

| Rollback target | Ahead | Behind |
| --- | ---: | ---: |
| `528df1c9581610cc43644744abcbf1b89e06f304` | 422 | 0 |
| `da100a97131334402bc194283be13feafa796e4b` | 394 | 0 |
| `b095c5abb22e1d1dd5ab8194ccb0eae9ae5affdc` | 385 | 0 |
| `f8145c9b4ec150fee574c31155d42a09069c0ab3` | 377 | 0 |
| `4855fb80e0cce894dce180ab0594845c9c3295e2` | 364 | 0 |
| `edebf90da51f6e86a95002499be2f6b4b4e679e6` | 350 | 0 |
| `ef41199bc788ed8ee6b192049389565c1a101c81` | 340 | 0 |

## Fully paginated open-PR audit

- initial checkpoint: 32 open PRs; 579 declared and 579 fetched changed files; zero mismatches
- publication checkpoint: 32 open PRs; 556 declared and 556 fetched changed files; zero mismatches
- #29943 initially overlapped `runner/env.rs` and `env_tests.rs` only for private guest-file batching; it merged as `97414e6c34b2241df1cbcf87fa85fa6248cf41d6` and is preserved in the refreshed base
- Wave 90 PR #30013 overlaps all three broad files only for API-start writer/assertions/rustdoc; its paginated patches contain no execution-timeout hunk
- stale #25722 overlaps all three broad files only for Cloudflare Access constants, host injection, and assertions; its file list spans two fetched pages and contains no execution-timeout hunk

Normal first-merge precedence applies. Neither open overlap is a functional dependency or ordering blocker.

## Verification

Passed locally with Rust 1.98.0:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- strict Guest Contracts all-targets/all-features Clippy with `-D warnings`
- strict Runner production-binary all-features Clippy with `-D warnings`
- Guest Contracts all-targets/all-features check
- Runner production-binary all-features check
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts env::tests::contract_names_match_wire_values`
- `git diff --check origin/main...HEAD`

The exact combined Runner/Guest Contracts all-targets Clippy and check passed on the initial clean checkpoint. After newly merged broad-file work was preserved on the publication lineage, rerunning the Runner test target exceeded the local 3.8 GiB/no-swap cgroup: `clippy-driver` or `rustc` was OOM-killed near 3.75 GiB RSS even with `CARGO_BUILD_JOBS=1`, with no compiler or lint diagnostic.

The focused Runner command `cargo test --manifest-path crates/Cargo.toml -p runner --all-features --bin runner executor::tests::env_tests` likewise reached final linking and was OOM-killed with exit 137 under default, single-job, and reduced-debug attempts; no test assertion ran. Protected PR CI is authoritative for the linked Runner test target and full all-targets checks.

The full local Vitest suite was not run and no local development server was started.

## Fallbacks

- `crates/guest-agent/src/env.rs:agent_execution_timeout_env_or_empty` retains `AGENT_EXECUTION_TIMEOUT_SECS_ENV` as the rollback fallback for a rolled-back Runner writer. Remove it only in the later reader-removal issue after exact writer deployment, a canonical-only observation window, supported rollback-writer expiry, and zero legacy-only, dual, or conflict evidence.
- reverting this focused PR restores the legacy-only Runner writer without changing the 7200-second budget, any reader, persisted state, or lifecycle semantics.