### PR TITLE
refactor(runner): cut api token writer to canonical alias

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -37,16 +37,16 @@ pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
 /// file path resolution.
 pub const RUN_ID_ENV: &str = "OKOU_RUN_ID";
 
-/// Sensitive backend API bearer token for guest-agent calls.
+/// Legacy backend API bearer token alias retained by guest readers for rollback.
 ///
 /// This value is runner-owned and must not be exposed through user-provided
 /// environment or CLI child env.
 pub const API_TOKEN_ENV: &str = "VM0_API_TOKEN";
 
-/// Canonical API token alias accepted by guest readers during migration.
+/// Canonical backend API bearer token alias written by the runner.
 ///
-/// Runner writers keep using [`API_TOKEN_ENV`] until the deployed reader floor,
-/// sandbox drain, rollback window, and legacy-read-zero gates are complete.
+/// Guest readers retain [`API_TOKEN_ENV`] as the rollback fallback. This value
+/// has the same runner-owned isolation contract as the legacy alias.
 pub const CANONICAL_API_TOKEN_ENV: &str = "OKOU_API_TOKEN";
 
 /// Sandbox identifier assigned by the runner.

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -591,7 +591,7 @@ fn build_env_json_with_host_env_inner(
         context.run_id.to_string(),
     );
     env.insert(
-        guest_contracts::env::API_TOKEN_ENV.into(),
+        guest_contracts::env::CANONICAL_API_TOKEN_ENV.into(),
         context.sandbox_token.clone(),
     );
     env.insert(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -445,7 +445,12 @@ fn build_env_json_required_keys() {
         &RunId::nil().to_string()
     );
     assert!(!env.contains_key("VM0_RUN_ID"));
-    assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
+    assert_eq!(
+        env.get(guest_contracts::env::CANONICAL_API_TOKEN_ENV)
+            .unwrap(),
+        "tok"
+    );
+    assert!(!env.contains_key(guest_contracts::env::API_TOKEN_ENV));
     assert_eq!(
         env.get(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV)
             .unwrap(),
@@ -783,7 +788,13 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
         build_run_payload_for_run(&ctx).unwrap().prompt,
         "test prompt"
     );
-    assert_eq!(bootstrap_env.get("VM0_API_TOKEN").unwrap(), "tok");
+    assert_eq!(
+        bootstrap_env
+            .get(guest_contracts::env::CANONICAL_API_TOKEN_ENV)
+            .unwrap(),
+        "tok"
+    );
+    assert!(!bootstrap_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
     assert_eq!(
         bootstrap_env.get(guest_contracts::env::RUN_ID_ENV).unwrap(),
         &ctx.run_id.to_string()
@@ -1646,11 +1657,17 @@ fn build_env_json_environment_cannot_override_system() {
     // System variables take precedence over user environment
     assert!(!env.contains_key("VM0_PROMPT"));
     assert_eq!(payload.prompt, "test prompt");
-    assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
+    assert_eq!(
+        env.get(guest_contracts::env::CANONICAL_API_TOKEN_ENV)
+            .unwrap(),
+        "tok"
+    );
+    assert!(!env.contains_key(guest_contracts::env::API_TOKEN_ENV));
     assert!(!env.contains_key("CUSTOM_ENV"));
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert!(!user_env.contains_key("VM0_PROMPT"));
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
+    assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1097,7 +1097,13 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let expected_run_payload_file = guest_run_payload_file_path(ctx.run_id).unwrap();
     let expected_connector_account_context_file =
         guest_connector_account_context_file_path(ctx.run_id).unwrap();
-    assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
+    assert_eq!(
+        start_env
+            .get(guest_contracts::env::CANONICAL_API_TOKEN_ENV)
+            .unwrap(),
+        "tok"
+    );
+    assert!(!start_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
     assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
     assert_eq!(
         start_env.get(USER_ENV_FILE_ENV_KEY).map(String::as_str),
@@ -1193,6 +1199,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert_eq!(user_env.get("TZ").unwrap(), "Asia/Shanghai");
     assert!(!user_env.contains_key("VM0_APP_URL"));
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
+    assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
     assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
     assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
     assert_eq!(


### PR DESCRIPTION
Parent EPIC: #28914

Closes #30003

## Summary

- Switch the sole production Runner API-token bootstrap writer to `CANONICAL_API_TOKEN_ENV`.
- Preserve the exact `context.sandbox_token.clone()` value expression, authentication behavior, single-key write, and existing secret-isolation boundaries.
- Prove in required-key, user-override, and real start-agent coverage that the canonical trusted key is present and the legacy bootstrap key is absent, while leaving deliberate legacy attack, reader, isolation, cleanup, telemetry, and diagnostic coverage unchanged.
- Update only the adjacent Guest Contracts rustdoc to describe the canonical writer and legacy reader fallback.

## Refreshed evidence

- Publication base: `8e9d333effada141917385e0482bcc35fd419fab`
- Published head: `29f5043b70acb45de59ace30103a41933170f561`
- Current-main caller inventory: 91 matching reference lines across 46 Rust files. Classification is 4 scoped contract/writer tests, 3 Guest reader/diagnostic/cleanup sources, 6 deliberate compatibility/isolation/telemetry/cleanup fixtures, and 33 ordinary canonical Guest test writers. There is exactly one production writer.
- Fixed Axiom window `2026-08-28T01:03:00Z..2026-08-28T02:02:00Z`: the JIT record examined 126,287 rows; the aggregate-only refresh returned 169 matching rows across 169 distinct runs, all `legacy_only`, with `canonical_only=0`, `dual=0`, and `conflict=0`. The query selected no token values.
- Rollback ancestry: all seven retained targets (`2ee0e7ec…`, `528df1c9…`, `da100a97…`, `b095c5ab…`, `f8145c9b…`, `4855fb80…`, `edebf90d…`) still resolve `1f21af778ef9513a49ee40de8e6176aba08e80ac` as the exact merge base, with `behind=0` and ahead counts 520, 518, 490, 481, 473, 460, and 446 respectively.
- Fully paginated open-PR audit: 28 open PRs, 474 declared changed files, 474 fetched files across 29 pages, and zero count mismatches. Only #30020 (Wave 91 execution-timeout writer; three shared files) and #25722 (Cloudflare Access; three shared files, two pages) overlap scoped files; their hunks do not change API-token writer semantics. #29943 and Wave 90 PR #30013 are already preserved in the refreshed base. No sibling PR was modified or used as an ordering dependency.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features -- -D warnings` (with single-job/no-debuginfo memory controls)
- `cargo check --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features` (same memory controls)
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-features` (134 tests plus doc tests)
- `git diff --check`
- The two requested focused Runner selectors share the same Runner test binary. Its sources compile, but the final local link was killed by the 4 GiB cgroup OOM under both default and single-job/no-debuginfo attempts, before any test diagnostics. Protected CI is authoritative for the focused env and fresh-sandbox start-env executions.
- No local Vitest suite or development server was run.

## Scope and rollback

- The diff is limited to the four files named by #30003.
- There is no dual write, reader removal, telemetry removal, namespace-guard removal, release, or deployment change.
- Reverting this commit restores the legacy production writer and its assertions; the already-deployed dual reader remains unchanged.
