### PR TITLE
fix: sanitize computer-use completion payloads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -1285,6 +1285,115 @@ describe("FILE-03 desktop computer-use runtime", () => {
     );
   });
 
+  it("normalizes NUL characters in completion results and errors", async () => {
+    const actor = bdd.user();
+    const host = await api.startComputerUseHost(actor);
+
+    const succeeded = await api.createComputerUseWriteCommand(actor);
+    const claimedSucceeded = await api.claimNextComputerUseCommand(
+      host.hostToken,
+    );
+    expect(claimedSucceeded.status).toBe("command");
+    if (claimedSucceeded.status !== "command") {
+      throw new Error("Expected the successful command to be claimed");
+    }
+    expect(claimedSucceeded.command.id).toBe(succeeded.commandId);
+
+    const nestedNulKey = "nested\0key";
+    const nestedReplacementKey = "nested\uFFFDkey";
+    const collisionNulKey = "collision\0key";
+    const collisionReplacementKey = "collision\uFFFDkey";
+    const succeededBody = {
+      status: "succeeded" as const,
+      result: {
+        payload: {
+          [nestedNulKey]: ["before\0after", { unicode: "中文🙂" }],
+          collision: {
+            [collisionNulKey]: "replaced",
+            [collisionReplacementKey]: "preserved",
+          },
+        },
+      },
+    };
+    await api.completeComputerUseCommandWith(
+      host.hostToken,
+      succeeded.commandId,
+      succeededBody,
+    );
+    await api.completeComputerUseCommandWith(
+      host.hostToken,
+      succeeded.commandId,
+      succeededBody,
+    );
+
+    const completed = await api.readComputerUseCommand(
+      actor,
+      succeeded.commandId,
+    );
+    expect(completed).toMatchObject({
+      status: "succeeded",
+      result: {
+        payload: {
+          [nestedReplacementKey]: ["before\uFFFDafter", { unicode: "中文🙂" }],
+          collision: { [collisionReplacementKey]: "preserved" },
+        },
+      },
+    });
+    const succeededAudit = await api.listComputerUseAuditEvents(actor, {
+      commandId: succeeded.commandId,
+    });
+    expect(succeededAudit.auditEvents).toHaveLength(1);
+    expect(succeededAudit.auditEvents[0]).toMatchObject({
+      event: "completed",
+      redactedResult: {
+        payload: {
+          [nestedReplacementKey]: ["before\uFFFDafter", { unicode: "中文🙂" }],
+          collision: { [collisionReplacementKey]: "preserved" },
+        },
+      },
+      error: null,
+    });
+
+    const failed = await api.createComputerUseWriteCommand(actor);
+    const claimedFailed = await api.claimNextComputerUseCommand(host.hostToken);
+    expect(claimedFailed.status).toBe("command");
+    if (claimedFailed.status !== "command") {
+      throw new Error("Expected the failed command to be claimed");
+    }
+    expect(claimedFailed.command.id).toBe(failed.commandId);
+
+    await api.completeComputerUseCommandWith(host.hostToken, failed.commandId, {
+      status: "failed",
+      error: {
+        code: "app_not_found",
+        message: "Finder\0is unavailable 中文🙂",
+      },
+    });
+    const failedCommand = await api.readComputerUseCommand(
+      actor,
+      failed.commandId,
+    );
+    expect(failedCommand).toMatchObject({
+      status: "failed",
+      error: {
+        code: "app_not_found",
+        message: "Finder\uFFFDis unavailable 中文🙂",
+      },
+    });
+    const failedAudit = await api.listComputerUseAuditEvents(actor, {
+      commandId: failed.commandId,
+    });
+    expect(failedAudit.auditEvents).toHaveLength(1);
+    expect(failedAudit.auditEvents[0]).toMatchObject({
+      event: "completed",
+      redactedResult: null,
+      error: {
+        code: "app_not_found",
+        message: "Finder\uFFFDis unavailable 中文🙂",
+      },
+    });
+  });
+
   it("times out stale running commands and reports completion failures", async () => {
     const actor = bdd.user();
     const base = now();

--- a/turbo/apps/api/src/signals/services/computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/computer-use.service.ts
@@ -171,6 +171,20 @@ type ClaimNextComputerUseHostCommandResult =
       readonly command: ReturnType<typeof serializeCommand>;
     };
 
+type CompleteComputerUseHostCommandParams =
+  | {
+      readonly hostToken: string;
+      readonly commandId: string;
+      readonly status: "succeeded";
+      readonly result: ComputerUseCommandResult;
+    }
+  | {
+      readonly hostToken: string;
+      readonly commandId: string;
+      readonly status: "failed";
+      readonly error: ComputerUseCommandError;
+    };
+
 type CompleteComputerUseHostCommandResult =
   | { readonly status: "completed" }
   | { readonly status: "invalid_token" }
@@ -482,6 +496,88 @@ function extensionForPluginMime(mimeType: string): string {
 function numberField(result: ComputerUseCommandResult, key: string): number {
   const value = result[key];
   return typeof value === "number" ? value : 0;
+}
+
+interface ComputerUseJsonSanitization<T> {
+  readonly value: T;
+  readonly nulCharacterCount: number;
+  readonly keyCollisionCount: number;
+}
+
+/**
+ * PostgreSQL JSONB rejects U+0000 in both string values and object keys.
+ * Preserve the invalid boundary visibly with U+FFFD before any completion
+ * result reaches object storage metadata, command persistence, or audit data.
+ */
+function sanitizeComputerUseJsonString(
+  value: string,
+): ComputerUseJsonSanitization<string> {
+  if (!value.includes("\0")) {
+    return { value, nulCharacterCount: 0, keyCollisionCount: 0 };
+  }
+  const parts = value.split("\0");
+  return {
+    value: parts.join("\uFFFD"),
+    nulCharacterCount: parts.length - 1,
+    keyCollisionCount: 0,
+  };
+}
+
+function isComputerUseJsonRecord(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeComputerUseJsonRecord(
+  value: Record<string, unknown>,
+): ComputerUseJsonSanitization<Record<string, unknown>> {
+  const entries: [string, unknown][] = [];
+  const keys = new Set<string>();
+  let nulCharacterCount = 0;
+  let keyCollisionCount = 0;
+  for (const [key, entry] of Object.entries(value)) {
+    const sanitizedKey = sanitizeComputerUseJsonString(key);
+    const sanitizedEntry = sanitizeComputerUseJsonValue(entry);
+    nulCharacterCount +=
+      sanitizedKey.nulCharacterCount + sanitizedEntry.nulCharacterCount;
+    keyCollisionCount += sanitizedEntry.keyCollisionCount;
+    if (keys.has(sanitizedKey.value)) {
+      keyCollisionCount += 1;
+    }
+    keys.add(sanitizedKey.value);
+    // Object.fromEntries keeps the later value when normalized keys collide.
+    entries.push([sanitizedKey.value, sanitizedEntry.value]);
+  }
+  return {
+    value: Object.fromEntries(entries),
+    nulCharacterCount,
+    keyCollisionCount,
+  };
+}
+
+function sanitizeComputerUseJsonValue(
+  value: unknown,
+): ComputerUseJsonSanitization<unknown> {
+  if (typeof value === "string") {
+    return sanitizeComputerUseJsonString(value);
+  }
+  if (Array.isArray(value)) {
+    const sanitized: unknown[] = [];
+    let nulCharacterCount = 0;
+    let keyCollisionCount = 0;
+    for (const entry of value) {
+      const sanitizedEntry = sanitizeComputerUseJsonValue(entry);
+      sanitized.push(sanitizedEntry.value);
+      nulCharacterCount += sanitizedEntry.nulCharacterCount;
+      keyCollisionCount += sanitizedEntry.keyCollisionCount;
+    }
+    return { value: sanitized, nulCharacterCount, keyCollisionCount };
+  }
+  if (isComputerUseJsonRecord(value)) {
+    return sanitizeComputerUseJsonRecord(value);
+  }
+  return { value, nulCharacterCount: 0, keyCollisionCount: 0 };
 }
 
 /**
@@ -1843,22 +1939,27 @@ function logComputerUseCommandStateMetrics(
   );
 }
 
+function logComputerUseCompletionSanitization(
+  row: ComputerUseCommandRow | null,
+  nulCharacterCount: number,
+  keyCollisionCount: number,
+): void {
+  if (!row || nulCharacterCount === 0) {
+    return;
+  }
+  L.warn("Replaced NUL characters in computer-use completion", {
+    commandId: row.id,
+    kind: row.kind,
+    status: row.status,
+    nulCharacterCount,
+    keyCollisionCount,
+  });
+}
+
 export const completeComputerUseHostCommand$ = command(
   async (
     { get, set },
-    params:
-      | {
-          readonly hostToken: string;
-          readonly commandId: string;
-          readonly status: "succeeded";
-          readonly result: ComputerUseCommandResult;
-        }
-      | {
-          readonly hostToken: string;
-          readonly commandId: string;
-          readonly status: "failed";
-          readonly error: ComputerUseCommandError;
-        },
+    params: CompleteComputerUseHostCommandParams,
     signal: AbortSignal,
   ): Promise<CompleteComputerUseHostCommandResult> => {
     const db = set(writeDb$);
@@ -1879,15 +1980,21 @@ export const completeComputerUseHostCommand$ = command(
       return commandState;
     }
 
+    let nulCharacterCount = 0;
+    let keyCollisionCount = 0;
     let storedResult: ComputerUseCommandResult | null = null;
+    let suppliedError: ComputerUseCommandError | null = null;
     if (params.status === "succeeded") {
+      const sanitizedResult = sanitizeComputerUseJsonRecord(params.result);
+      nulCharacterCount = sanitizedResult.nulCharacterCount;
+      keyCollisionCount = sanitizedResult.keyCollisionCount;
       storedResult = await get(
         offloadScreenshotForResult(
           db,
           {
             hostToken: params.hostToken,
             commandId: params.commandId,
-            result: params.result,
+            result: sanitizedResult.value,
           },
           signal,
         ),
@@ -1903,6 +2010,12 @@ export const completeComputerUseHostCommand$ = command(
           signal,
         ),
       );
+    } else {
+      const sanitizedMessage = sanitizeComputerUseJsonString(
+        params.error.message,
+      );
+      nulCharacterCount = sanitizedMessage.nulCharacterCount;
+      suppliedError = { ...params.error, message: sanitizedMessage.value };
     }
     const storageError = commandErrorFromResult(storedResult);
     const completedAt = nowDate();
@@ -1921,12 +2034,11 @@ export const completeComputerUseHostCommand$ = command(
         return currentState;
       }
 
-      const finalError =
-        storageError ?? (params.status === "failed" ? params.error : null);
+      const finalError = storageError ?? suppliedError;
       const finalStatus = finalError ? "failed" : params.status;
       const commandResult =
         finalStatus === "succeeded" && params.status === "succeeded"
-          ? (storedResult ?? params.result)
+          ? storedResult
           : { error: finalError };
       const [updated] = await tx
         .update(computerUseCommands)
@@ -1968,6 +2080,11 @@ export const completeComputerUseHostCommand$ = command(
       return { status: "completed" as const };
     });
     signal.throwIfAborted();
+    logComputerUseCompletionSanitization(
+      completedCommand,
+      nulCharacterCount,
+      keyCollisionCount,
+    );
     logComputerUseCommandStateMetrics(completedCommand);
     return result;
   },


### PR DESCRIPTION
## Summary

- recursively replace NUL characters in Computer Use completion result keys and values before storage offload, command persistence, and audit persistence
- apply the same normalization to failed completion messages, preserve ordinary Unicode, and emit count-only diagnostics when normalization occurs
- add PostgreSQL-backed BDD coverage for nested objects and arrays, normalized-key collisions, successful and failed completions, and idempotent retries

## Verification

- `pnpm exec prettier --check turbo/apps/api/src/signals/services/computer-use.service.ts turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts` (19 tests passed against local PostgreSQL)

Closes #30018
