### PR TITLE
docs(nbd-cow): clarify host disk benchmark attribution

### DIFF
--- a/crates/nbd-cow/src/bin/bench/diskstats.rs
+++ b/crates/nbd-cow/src/bin/bench/diskstats.rs
@@ -107,7 +107,21 @@ fn diskstats_contains_device(content: &str, device_name: &str) -> bool {
     })
 }
 
-/// Auto-detect the host disk by finding the block device backing /tmp.
+/// Select the host device whose `/proc/diskstats` counters will be sampled.
+///
+/// The direct lookup runs `df /tmp`. If its device can be normalized and found
+/// in `/proc/diskstats`, that device is selected. If `df` cannot be started or
+/// its output has no usable mapped device, including an unmappable filesystem
+/// such as `overlay` or the special `/dev/root` result, selection falls back to
+/// the following order:
+///
+/// 1. The first available device among `nvme0n1`, `xvda`, `sda`, and `vda`.
+/// 2. The first likely whole-disk entry in `/proc/diskstats` whose name starts
+///    with `nvme`, `mmcblk`, `xvd`, `sd`, or `vd`.
+///
+/// A fallback is heuristic. It does not prove that the selected device backs
+/// `/tmp` or the benchmark work directory, which is created under the process
+/// temp-directory configuration and may use a different path.
 pub(crate) fn detect_host_disk() -> Result<String, String> {
     let stats =
         std::fs::read_to_string("/proc/diskstats").map_err(|e| format!("read diskstats: {e}"))?;

--- a/crates/nbd-cow/src/bin/bench/fio.rs
+++ b/crates/nbd-cow/src/bin/bench/fio.rs
@@ -17,11 +17,17 @@ pub(crate) struct FioResult {
     pub(crate) vm_iops: u64,
     pub(crate) lat_p50_us: u64,
     pub(crate) lat_p99_us: u64,
-    /// Actual IOPS on the host disk during the test
+    /// Read-plus-write completion IOPS observed on the selected host device.
+    /// This is a whole-device counter delta and can include unrelated host I/O.
     pub(crate) host_disk_iops: u64,
 }
 
-/// Run fio while sampling /proc/diskstats before and after to measure actual host disk IOPS.
+/// Run fio while sampling `/proc/diskstats` before and after.
+///
+/// The host metric is the selected whole device's completed-read plus
+/// completed-write counter delta divided by the fio interval. It can include
+/// unrelated host I/O on that device and is not limited to requests issued by
+/// fio.
 pub(crate) async fn run_fio_with_iostat(
     device: &str,
     workload: &FioWorkload,
@@ -63,7 +69,7 @@ pub(crate) async fn run_fio_with_iostat(
     result.host_disk_iops = calculate_host_disk_iops(&before, &after, elapsed_secs)?;
 
     eprintln!(
-        "    VM IOPS: {}, Host disk IOPS: {}, Duration: {:.1}s",
+        "    VM IOPS: {}, Selected host-device IOPS: {}, Duration: {:.1}s",
         result.vm_iops, result.host_disk_iops, elapsed_secs
     );
 

--- a/crates/nbd-cow/src/bin/bench/main.rs
+++ b/crates/nbd-cow/src/bin/bench/main.rs
@@ -1,7 +1,15 @@
 //! Benchmark: NBD COW vs dm-snapshot.
 //!
 //! Runs fio workloads on both a dm-snapshot device and an NBD COW device,
-//! then compares VM-visible IOPS, latency, AND actual host disk IOPS.
+//! then compares VM-visible IOPS, latency, and I/O observed on a selected host
+//! block device.
+//!
+//! The selected host-device metric is a whole-device counter delta and can
+//! include unrelated host I/O. Host-device selection first tries `df /tmp` and
+//! otherwise uses a heuristic fallback, so it is not guaranteed to identify
+//! the device backing the benchmark work directory. The work directory is
+//! created under the process temp-directory configuration, which may differ
+//! from `/tmp`.
 //!
 //! Requires: root, nbd kernel module, fio, losetup, dmsetup.
 
@@ -58,12 +66,12 @@ async fn main() {
         std::process::exit(1);
     }
 
-    // Detect host disk
+    // Select the host device whose diskstats counters will be sampled.
     let host_disk = detect_host_disk().unwrap_or_else(|e| {
         eprintln!("ERROR: {e}");
         std::process::exit(1);
     });
-    eprintln!("Host disk: {host_disk}");
+    eprintln!("Host device sampled by diskstats: {host_disk}");
     eprintln!();
 
     let work_dir = tempfile::Builder::new()
@@ -160,11 +168,11 @@ async fn main() {
         "DM IOPS",
         "DM p50",
         "DM p99",
-        "DM disk-IO",
+        "DM host I/O",
         "NBD IOPS",
         "NBD p50",
         "NBD p99",
-        "NBD disk-IO"
+        "NBD host I/O"
     );
     println!("{}", "-".repeat(118));
 


### PR DESCRIPTION
## Summary

- document the direct `df /tmp` host-device lookup and the exact heuristic fallback order
- explain that fallback selection is not proof that the selected device backs `/tmp` or the benchmark work directory
- describe the host metric as a whole-device read-plus-write counter delta that can include unrelated host I/O
- align benchmark rustdoc, diagnostics, and result-table labels with those limitations

## Scope

This is a documentation and terminology change only. Host-device detection, counter sampling, fio workloads, calculations, result values, and the optional `bench` feature are unchanged. The PR does not add a new guide, change dependencies, or modify runtime behavior.

Closes #30008

## Validation

All checks were run with Rust 1.98.0 using a single build job, disabled incremental compilation, and reduced debug information for the resource-constrained container:

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features --locked` — passed
- `cargo test -p nbd-cow --all-features --locked` — all executed tests passed (244 library tests, 40 benchmark-binary tests, and all non-ignored integration/doc tests); 13 existing privileged integration tests remained ignored
- `cargo doc -p nbd-cow --all-features --no-deps --locked` — passed
- `git diff --check` — passed

No privileged benchmark invocation was run. The full Vitest suite and a local development server were not run because this is a Rust-only documentation change and repository guidance excludes them from this scope.
