### PR TITLE
refactor(runner): cut resume-session writer to canonical alias

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -93,13 +93,12 @@ pub const VERCEL_PROTECTION_BYPASS_ENV: &str = "VERCEL_PROTECTION_BYPASS";
 /// Optional CLI session or thread identifier used when resuming a prior agent
 /// session.
 ///
-/// The runner normalizes Codex thread ids before emitting this key.
+/// Guest readers retain this legacy alias as a rollback fallback.
 pub const RESUME_SESSION_ID_ENV: &str = "VM0_RESUME_SESSION_ID";
 
-/// Canonical resume-session alias accepted by guest readers during migration.
+/// Canonical resume-session alias written by the runner.
 ///
-/// Runner writers keep using [`RESUME_SESSION_ID_ENV`] until the deployed reader
-/// floor, sandbox drain, rollback window, and legacy-read-zero gates are complete.
+/// The runner normalizes Codex thread ids before emitting this key.
 pub const CANONICAL_RESUME_SESSION_ID_ENV: &str = "OKOU_RESUME_SESSION_ID";
 
 /// Optional Unix epoch millisecond timestamp for when the API accepted the

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -648,7 +648,7 @@ fn build_env_json_with_host_env_inner(
                 session.cli_agent_session_id.clone()
             };
         env.insert(
-            guest_contracts::env::RESUME_SESSION_ID_ENV.into(),
+            guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV.into(),
             session_id,
         );
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -959,11 +959,11 @@ fn build_env_json_codex_keeps_shared_runner_env() {
     assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
     assert_eq!(payload.append_system_prompt, "Use terse answers.");
     assert_eq!(
-        env.get(guest_contracts::env::RESUME_SESSION_ID_ENV)
+        env.get(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV)
             .unwrap(),
         "019e9154-c304-70f0-adde-36efb1be1701"
     );
-    assert!(!env.contains_key(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV));
+    assert!(!env.contains_key(guest_contracts::env::RESUME_SESSION_ID_ENV));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
 }
 
@@ -1140,11 +1140,11 @@ fn build_env_json_with_resume_session() {
 
     let env = build_env_for_test(&ctx, "http://localhost");
     assert_eq!(
-        env.get(guest_contracts::env::RESUME_SESSION_ID_ENV)
+        env.get(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV)
             .unwrap(),
         "sess-123"
     );
-    assert!(!env.contains_key(guest_contracts::env::CANONICAL_RESUME_SESSION_ID_ENV));
+    assert!(!env.contains_key(guest_contracts::env::RESUME_SESSION_ID_ENV));
 }
 
 #[test]


### PR DESCRIPTION
Closes #30015.
Parent EPIC: #28914.
Reader foundation: #29065 / PR #29069.
Same-checkout prerequisite: #29952 / PR #29955.

## Summary

- switch only the sole production Runner resume-session insertion from `RESUME_SESSION_ID_ENV` to `CANONICAL_RESUME_SESSION_ID_ENV`
- preserve the unchanged `context.resume_session` presence gate, Codex UUID normalization and validation, and exact non-Codex session value
- update the two focused Runner assertion pairs to require canonical presence with the exact existing value and legacy absence
- update only the adjacent shared-contract rustdoc to describe the canonical Runner writer and retained legacy Guest-reader rollback fallback

The deployed Guest dual reader, value-free source telemetry, full alias matrix, conflict/absent/empty/non-Unicode behavior, symmetric cleanup, managed CLI-child isolation, history transport/materialization/persistence/reuse/checkpoint behavior, namespace guard, and every adjacent environment family remain unchanged.

## Base, head, and complete inventory

- clean pre-edit implementation base: `e8e129417a3e77e507f2892854f8291d71d97d8e`
- publication-time `origin/main`: `895b70cc33b936090afc7c86a4c71bf82a591324`
- published head: `47e0ac5a91805a8a02b21d7cf22dd7358483a9b4`
- final diff: exactly three authorized files, 8 insertions and 9 deletions
- final exact-key inventory: 36 literal/symbol references across 15 files; the only production insertion is canonical, while legacy references remain limited to the compatibility constant, dual reader, alias/source matrix, cleanup/isolation, and deliberate assertions

The fully paginated pre-edit audit covered 32 open PRs and all 581 declared / 581 fetched changed files with zero mismatch. Exact scoped overlaps were stale #25722 (Cloudflare Access only) and then-open #30013 (API start time only).

#30013 merged normally during local validation as `23de3236a` and is preserved from current `main`. The later adjacent execution-timeout cutover #30020 also merged normally as `89628c1f2`; neither migration was modified or absorbed by this commit.

The final publication audit covered 32 open PRs and all 510 declared / 510 fetched changed files with zero mismatch. Exact scoped overlap hunks were:

- stale #25722: Cloudflare Access constants/ownership, HostEnv injection/configuration, and focused assertions; no resume-session alias, insertion, value, reader, normalization, or focused assertion
- #30025: API-token rustdoc, the separate API-token insertion, and API-token presence/isolation assertions; no resume-session alias, insertion, value, reader, normalization, or focused assertion

These overlaps are inventory only. Normal first-merge precedence applies.

## Verification

Passed locally on Rust 1.98 with `CARGO_BUILD_JOBS=1` after integrating merged #30013; the resume-session diff is byte-identical on the published head:

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts` (134 tests passed across unit and integration targets; doc tests passed)
- final published-head `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- final literal/symbol/writer inventory and fully paginated open-PR audit
- `git diff --check origin/main...HEAD`

The exact Runner test command for `executor::tests::env_tests::build_env_json_codex_keeps_shared_runner_env` compiled every affected crate and entered the silent final-link phase, then exited 137 on the local 3.8 GiB / no-swap host. It emitted no compiler diagnostic and executed no assertion. The second exact assertion uses the same unavailable linked test binary, so it was not retried. Strict all-targets Clippy/check passed; protected PR CI is authoritative for linked Runner execution.

## Fallbacks

- `crates/guest-agent/src/env.rs` retains `RESUME_SESSION_ID_ENV` as the rollback fallback for a rolled-back Runner writer, together with the complete alias/source behavior.
- Reverting this focused PR restores the legacy-only Runner writer without changing any reader, value semantics, environment isolation, or persisted session state.
- Legacy-reader removal remains a separate later #28914 wave after release, drain, canonical-only observation, and supported rollback gates close.
