### PR TITLE
refactor(guest): remove legacy guest runtime directory readers

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -603,12 +603,11 @@ impl GuestConfigRaw {
         Self::from_process_env_with_guest_runtime_dir(guest_runtime_dir)
     }
 
-    /// Capture all remaining startup values after the runtime-directory alias
-    /// pair was resolved at the outer single-threaded bootstrap boundary.
+    /// Capture all remaining startup values after the canonical runtime
+    /// directory was resolved at the outer single-threaded bootstrap boundary.
     pub(crate) fn from_process_env_with_guest_runtime_dir(
-        guest_runtime_dir: guest_contracts::runtime_paths::GuestRuntimeDirEnvResolution,
+        guest_runtime_dir: Option<PathBuf>,
     ) -> Result<Self, String> {
-        let (guest_runtime_dir, _source) = guest_runtime_dir.into_parts();
         let mut bootstrap_alias_sources = BootstrapAliasSourceEvents::default();
         let api_url = api_url_env_or_empty(&mut bootstrap_alias_sources)?;
 

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -25,13 +25,12 @@
 //!
 //! ## Shared runtime-path rules
 //!
-//! Commands resolve the canonical `OKOU_GUEST_RUNTIME_DIR` and legacy
-//! [`GUEST_RUNTIME_DIR_ENV`](guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
-//! (`VM0_GUEST_RUNTIME_DIR`) aliases through one shared contract. Empty values
-//! are absent, one non-empty absolute value is selected, equal dual values are
-//! accepted, and conflicting non-empty values fail closed. Without an
-//! override, [`run_dir_from_env`](guest_contracts::runtime_paths::run_dir_from_env)
-//! derives `$HOME/.vm0/guest-agent/runs/<run-id>` from
+//! Commands resolve the canonical
+//! [`OKOU_GUEST_RUNTIME_DIR`](guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
+//! override through one shared contract. An empty value is absent and a
+//! non-empty absolute value is selected. Without an override,
+//! [`run_dir_from_env`](guest_contracts::runtime_paths::run_dir_from_env) derives
+//! `$HOME/.vm0/guest-agent/runs/<run-id>` from
 //! [`RUN_ID_ENV`](guest_contracts::env::RUN_ID_ENV) (`OKOU_RUN_ID`) and `HOME`.
 //! A relative override is invalid.
 //!

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1203,7 +1203,6 @@ mod tests {
             guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
             guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             process_control_ipc::BOOTSTRAP_ENV,
             process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
             guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -57,7 +57,6 @@ impl GuestRuntime {
         let guest_runtime_dir =
             guest_contracts::runtime_paths::guest_runtime_dir_env_from_process_env()
                 .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
-        let guest_runtime_dir_source = guest_runtime_dir.source();
         let (process_control_endpoint, process_control_source) =
             process_control_endpoint_from_process_env()?;
         let workload_containment =
@@ -67,14 +66,6 @@ impl GuestRuntime {
         let paths = paths_from_raw(&raw)?;
         guest_common::log::set_system_log_file(paths.system_log_file());
         guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());
-        if let Some(source) = guest_runtime_dir_source {
-            guest_common::log_info!(
-                LOG_TAG,
-                "guest_runtime_dir_env_source key={} source={}",
-                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-                source.label()
-            );
-        }
         if let Some(source) = process_control_source {
             guest_common::log_info!(
                 LOG_TAG,

--- a/crates/guest-agent/tests/api_url_env_aliases.rs
+++ b/crates/guest-agent/tests/api_url_env_aliases.rs
@@ -356,7 +356,6 @@ fn assert_conflict_precedes_private_payload_consumption(tmp: &Path) -> TestResul
 
     for key in [
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
         guest_contracts::env::USER_ENV_FILE_ENV,
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -243,7 +243,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     }
     for key in [
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        "VM0_GUEST_RUNTIME_DIR",
         guest_contracts::env::USER_ENV_FILE_ENV,
         guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
         guest_contracts::env::RUN_PAYLOAD_FILE_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1088,7 +1088,6 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
         guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,

--- a/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
@@ -529,7 +529,6 @@ fn assert_conflict_precedes_private_file_consumption(
 
     for key in [
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
         guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
     ] {

--- a/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
+++ b/crates/guest-agent/tests/guest_runtime_dir_env_aliases.rs
@@ -1,10 +1,11 @@
-//! Guest runtime-directory aliases resolve before bootstrap side effects.
+//! Guest runtime-directory overrides resolve before bootstrap side effects.
 
 #![cfg(unix)]
 
 mod common;
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -14,12 +15,20 @@ use tokio::process::Command;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const CHILD_TIMEOUT: Duration = Duration::from_secs(15);
-const SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
+const RETIRED_GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
+const RETIRED_SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
 static NEXT_ENDPOINT: AtomicU32 = AtomicU32::new(1);
 
 struct PrivateFiles {
     user_env_path: PathBuf,
     run_payload_path: PathBuf,
+}
+
+#[derive(Clone, Copy)]
+enum RuntimeInput {
+    Absent,
+    Empty,
+    Selected,
 }
 
 fn unique_endpoint(label: u8) -> String {
@@ -74,30 +83,31 @@ fn guest_agent_command(root: &Path, run_id: &str, private_files: &PrivateFiles) 
     command
 }
 
-fn apply_runtime_aliases(command: &mut Command, canonical: Option<&OsStr>, legacy: Option<&OsStr>) {
+fn apply_runtime_env(command: &mut Command, canonical: Option<&OsStr>, retired: Option<&OsStr>) {
     command
         .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
-        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+        .env_remove(RETIRED_GUEST_RUNTIME_DIR_ENV);
     if let Some(value) = canonical {
         command.env(
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             value,
         );
     }
-    if let Some(value) = legacy {
-        command.env(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV, value);
+    if let Some(value) = retired {
+        command.env(RETIRED_GUEST_RUNTIME_DIR_ENV, value);
+    }
+}
+
+fn input_value(input: RuntimeInput, selected: &Path) -> Option<&OsStr> {
+    match input {
+        RuntimeInput::Absent => None,
+        RuntimeInput::Empty => Some(OsStr::new("")),
+        RuntimeInput::Selected => Some(selected.as_os_str()),
     }
 }
 
 async fn command_output(command: &mut Command, context: &str) -> TestResult<std::process::Output> {
     Ok(common::command_output_with_timeout(command, CHILD_TIMEOUT, context).await?)
-}
-
-fn source_messages(log: &str) -> Vec<&str> {
-    log.lines()
-        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
-        .filter(|message| message.starts_with(SOURCE_EVENT))
-        .collect()
 }
 
 fn assert_value_free(text: &str, forbidden: &[&str], context: &str) {
@@ -114,7 +124,9 @@ fn assert_listener_idle(listener: &std::os::unix::net::UnixListener, context: &s
     let error = match listener.accept() {
         Err(error) => error,
         Ok(_) => {
-            return Err(format!("{context} connected before rejecting runtime aliases").into());
+            return Err(
+                format!("{context} connected before rejecting the runtime override").into(),
+            );
         }
     };
     assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock, "{context}");
@@ -122,101 +134,82 @@ fn assert_listener_idle(listener: &std::os::unix::net::UnixListener, context: &s
 }
 
 #[tokio::test]
-async fn guest_agent_uses_shared_runtime_alias_semantics_and_sink_scoped_evidence() -> TestResult {
+async fn guest_agent_reads_only_the_canonical_runtime_override() -> TestResult {
     struct Case {
         name: &'static str,
-        canonical: Option<&'static str>,
-        legacy: Option<&'static str>,
-        source: Option<&'static str>,
-        fallback: bool,
+        canonical: RuntimeInput,
+        retired: RuntimeInput,
+        use_canonical: bool,
     }
 
     let cases = [
         Case {
             name: "absent",
-            canonical: None,
-            legacy: None,
-            source: None,
-            fallback: true,
-        },
-        Case {
-            name: "dual-empty",
-            canonical: Some(""),
-            legacy: Some(""),
-            source: None,
-            fallback: true,
-        },
-        Case {
-            name: "canonical-only",
-            canonical: Some("selected"),
-            legacy: None,
-            source: Some("canonical-only"),
-            fallback: false,
-        },
-        Case {
-            name: "legacy-only",
-            canonical: None,
-            legacy: Some("selected"),
-            source: Some("legacy-only"),
-            fallback: false,
-        },
-        Case {
-            name: "equal-dual",
-            canonical: Some("selected"),
-            legacy: Some("selected"),
-            source: Some("dual"),
-            fallback: false,
+            canonical: RuntimeInput::Absent,
+            retired: RuntimeInput::Absent,
+            use_canonical: false,
         },
         Case {
             name: "canonical-empty",
-            canonical: Some(""),
-            legacy: Some("selected"),
-            source: Some("legacy-only"),
-            fallback: false,
+            canonical: RuntimeInput::Empty,
+            retired: RuntimeInput::Absent,
+            use_canonical: false,
         },
         Case {
-            name: "legacy-empty",
-            canonical: Some("selected"),
-            legacy: Some(""),
-            source: Some("canonical-only"),
-            fallback: false,
+            name: "canonical-absolute",
+            canonical: RuntimeInput::Selected,
+            retired: RuntimeInput::Absent,
+            use_canonical: true,
+        },
+        Case {
+            name: "retired-only-is-ignored",
+            canonical: RuntimeInput::Absent,
+            retired: RuntimeInput::Selected,
+            use_canonical: false,
+        },
+        Case {
+            name: "canonical-is-not-overridden-by-retired",
+            canonical: RuntimeInput::Selected,
+            retired: RuntimeInput::Selected,
+            use_canonical: true,
+        },
+        Case {
+            name: "canonical-empty-does-not-fall-back-to-retired",
+            canonical: RuntimeInput::Empty,
+            retired: RuntimeInput::Selected,
+            use_canonical: false,
         },
     ];
 
     let root = tempfile::tempdir()?;
     for case in cases {
-        let run_id = format!("runtime-alias-{}", case.name);
-        let runtime_dir = if case.fallback {
-            guest_contracts::runtime_paths::run_dir_for_home(
-                root.path().join("process-home"),
-                &run_id,
-            )?
+        let run_id = format!("runtime-env-{}", case.name);
+        let fallback_dir = guest_contracts::runtime_paths::run_dir_for_home(
+            root.path().join("process-home"),
+            &run_id,
+        )?;
+        let canonical_dir = root
+            .path()
+            .join(format!("{}-canonical-must-not-leak", case.name));
+        let retired_dir = root
+            .path()
+            .join(format!("{}-retired-must-not-leak", case.name));
+        let expected_dir = if case.use_canonical {
+            &canonical_dir
         } else {
-            root.path()
-                .join(format!("{}-runtime-value-must-not-leak", case.name))
+            &fallback_dir
         };
-        let private_files = write_private_files(&runtime_dir, false)?;
+        let private_files = write_private_files(expected_dir, false)?;
         let mut command = guest_agent_command(root.path(), &run_id, &private_files);
-        let selected = runtime_dir.as_os_str();
-        let canonical = case.canonical.map(|value| {
-            if value.is_empty() {
-                OsStr::new("")
-            } else {
-                selected
-            }
-        });
-        let legacy = case.legacy.map(|value| {
-            if value.is_empty() {
-                OsStr::new("")
-            } else {
-                selected
-            }
-        });
-        apply_runtime_aliases(&mut command, canonical, legacy);
+        apply_runtime_env(
+            &mut command,
+            input_value(case.canonical, &canonical_dir),
+            input_value(case.retired, &retired_dir),
+        );
 
         let output = command_output(
             &mut command,
-            &format!("{} runtime alias scenario did not finish", case.name),
+            &format!("{} runtime scenario did not finish", case.name),
         )
         .await?;
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -228,44 +221,84 @@ async fn guest_agent_uses_shared_runtime_alias_semantics_and_sink_scoped_evidenc
         );
 
         let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
-            &runtime_dir,
+            expected_dir,
         ))?;
-        let messages = source_messages(&log);
-        let expected = case.source.map(|source| {
-            format!(
-                "{SOURCE_EVENT} key={} source={source}",
-                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
-            )
-        });
-        match expected {
-            Some(expected) => assert_eq!(messages, [expected.as_str()], "{}", case.name),
-            None => assert!(messages.is_empty(), "{}", case.name),
+        assert!(!log.contains(RETIRED_SOURCE_EVENT), "{}", case.name);
+        assert!(!stderr.contains(RETIRED_SOURCE_EVENT), "{}", case.name);
+        assert_value_free(
+            &stderr,
+            &["canonical-must-not-leak", "retired-must-not-leak"],
+            case.name,
+        );
+        assert_value_free(
+            &log,
+            &["canonical-must-not-leak", "retired-must-not-leak"],
+            case.name,
+        );
+        if !case.use_canonical {
+            assert!(!guest_contracts::runtime_paths::system_log_file(&canonical_dir).exists());
         }
-        let runtime_marker = format!("{}-runtime-value-must-not-leak", case.name);
-        assert_value_free(&stderr, &[&runtime_marker], case.name);
-        assert_value_free(&log, &[&runtime_marker], case.name);
+        assert!(!guest_contracts::runtime_paths::system_log_file(&retired_dir).exists());
     }
 
     Ok(())
 }
 
 #[tokio::test]
-async fn guest_agent_rejects_runtime_alias_conflict_before_capabilities_and_private_files()
--> TestResult {
+async fn guest_agent_preserves_a_non_unicode_canonical_runtime_override() -> TestResult {
     let root = tempfile::tempdir()?;
-    let canonical_dir = root.path().join("canonical-runtime-must-not-leak");
-    let legacy_dir = root.path().join("legacy-runtime-must-not-leak");
-    std::fs::create_dir_all(&legacy_dir)?;
-    let private_files = write_private_files(&canonical_dir, true)?;
+    let runtime_dir = root
+        .path()
+        .join(OsString::from_vec(b"canonical-runtime-\xff".to_vec()));
+    let retired_dir = root.path().join("retired-runtime-must-not-leak");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+    command
+        .env_clear()
+        .env(guest_contracts::env::RUN_ID_ENV, "non-unicode-runtime")
+        .env("HOME", root.path().join("process-home"));
+    apply_runtime_env(
+        &mut command,
+        Some(runtime_dir.as_os_str()),
+        Some(retired_dir.as_os_str()),
+    );
+
+    let output = command_output(
+        &mut command,
+        "non-Unicode canonical runtime scenario did not finish",
+    )
+    .await?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("VM0_RUN_PAYLOAD_FILE is required"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("OKOU_GUEST_RUNTIME_DIR must be an absolute path"));
+    assert!(!stderr.contains(RETIRED_SOURCE_EVENT));
+    assert!(!guest_contracts::runtime_paths::system_log_file(&runtime_dir).exists());
+    assert!(!guest_contracts::runtime_paths::system_log_file(retired_dir).exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_rejects_relative_canonical_runtime_before_bootstrap_side_effects() -> TestResult
+{
+    let root = tempfile::tempdir()?;
+    let run_id = "relative-runtime";
+    let fallback_dir =
+        guest_contracts::runtime_paths::run_dir_for_home(root.path().join("process-home"), run_id)?;
+    let retired_dir = root.path().join("retired-runtime-must-not-leak");
+    let private_files = write_private_files(&fallback_dir, true)?;
     let process_endpoint = unique_endpoint(1);
     let workload_endpoint = unique_endpoint(2);
     let process_listener = process_control_ipc::bind_abstract_listener(&process_endpoint)?;
     let workload_listener = process_control_ipc::bind_abstract_listener(&workload_endpoint)?;
-    let mut command = guest_agent_command(root.path(), "runtime-conflict", &private_files);
-    apply_runtime_aliases(
+    let mut command = guest_agent_command(root.path(), run_id, &private_files);
+    command.current_dir(root.path());
+    apply_runtime_env(
         &mut command,
-        Some(canonical_dir.as_os_str()),
-        Some(legacy_dir.as_os_str()),
+        Some(OsStr::new("relative-runtime-must-not-leak")),
+        Some(retired_dir.as_os_str()),
     );
     command
         .env(
@@ -283,71 +316,33 @@ async fn guest_agent_rejects_runtime_alias_conflict_before_capabilities_and_priv
 
     let output = command_output(
         &mut command,
-        "guest runtime alias conflict did not fail closed",
+        "relative canonical runtime did not fail before bootstrap side effects",
     )
     .await?;
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
-    assert!(stderr.contains(
-        "conflicting guest runtime directory environment aliases: \
-         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
-    ));
+    assert!(stderr.contains("OKOU_GUEST_RUNTIME_DIR must be an absolute path"));
+    assert!(!stderr.contains(RETIRED_SOURCE_EVENT));
     assert_value_free(
         &stderr,
         &[
-            "canonical-runtime-must-not-leak",
-            "legacy-runtime-must-not-leak",
+            "relative-runtime-must-not-leak",
+            "retired-runtime-must-not-leak",
             "tool-endpoint-must-not-leak",
             &process_endpoint,
             &workload_endpoint,
         ],
-        "runtime conflict",
+        "relative canonical runtime",
     );
     assert_listener_idle(&process_listener, "process-control socket")?;
     assert_listener_idle(&workload_listener, "workload placement socket")?;
     assert!(private_files.user_env_path.exists());
     assert!(private_files.run_payload_path.exists());
-    assert!(!guest_contracts::runtime_paths::system_log_file(&canonical_dir).exists());
-    assert!(!guest_contracts::runtime_paths::system_log_file(&legacy_dir).exists());
-    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&canonical_dir).exists());
-    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&legacy_dir).exists());
+    let relative_dir = root.path().join("relative-runtime-must-not-leak");
+    assert!(!guest_contracts::runtime_paths::system_log_file(&relative_dir).exists());
+    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&relative_dir).exists());
+    assert!(!guest_contracts::runtime_paths::system_log_file(&retired_dir).exists());
+    assert!(!guest_contracts::runtime_paths::sandbox_ops_log_file(&retired_dir).exists());
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn guest_agent_rejects_relative_runtime_alias_before_capability_connection() -> TestResult {
-    let root = tempfile::tempdir()?;
-    let runtime_dir = root.path().join("private-runtime");
-    let private_files = write_private_files(&runtime_dir, true)?;
-    let workload_endpoint = unique_endpoint(3);
-    let workload_listener = process_control_ipc::bind_abstract_listener(&workload_endpoint)?;
-    let mut command = guest_agent_command(root.path(), "relative-runtime", &private_files);
-    apply_runtime_aliases(&mut command, Some(OsStr::new("relative-runtime")), None);
-    command
-        .env(
-            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-            "process-control",
-        )
-        .env(
-            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-            &workload_endpoint,
-        )
-        .env(
-            guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-            "tool-endpoint",
-        );
-
-    let output = command_output(
-        &mut command,
-        "relative runtime alias did not fail before capability connection",
-    )
-    .await?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
-    assert!(stderr.contains("VM0_GUEST_RUNTIME_DIR must be an absolute path"));
-    assert_listener_idle(&workload_listener, "relative runtime workload socket")?;
-    assert!(private_files.user_env_path.exists());
-    assert!(private_files.run_payload_path.exists());
     Ok(())
 }

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -28,6 +28,7 @@ use tokio::process::Command;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const SESSION_HISTORY_HELPER_TIMEOUT: Duration = Duration::from_secs(10);
+const RETIRED_GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
 
 fn claude_history_fixture(
     root: &Path,
@@ -630,10 +631,25 @@ async fn export_session_history_sidecar_rejects_symlinked_metadata_without_openi
 }
 
 #[tokio::test]
-async fn default_identity_path_dual_reads_runtime_aliases_without_protocol_output() -> TestResult {
+async fn default_identity_path_reads_only_canonical_runtime_without_protocol_output() -> TestResult
+{
+    #[derive(Clone, Copy)]
+    enum CanonicalInput {
+        Absent,
+        Empty,
+        Selected,
+    }
+
+    struct Case {
+        name: &'static str,
+        canonical: CanonicalInput,
+        retired: bool,
+        use_canonical: bool,
+    }
+
     let dir = tempfile::tempdir()?;
     let history = br#"{"type":"system"}"#;
-    let session_id = "runtime-alias-default-path";
+    let session_id = "runtime-env-default-path";
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
     let identity = SessionHistoryIdentity::new(
@@ -645,83 +661,105 @@ async fn default_identity_path_dual_reads_runtime_aliases_without_protocol_outpu
         history_source,
     )?;
 
-    for (name, canonical, legacy) in [
-        ("canonical-only", true, false),
-        ("legacy-only", false, true),
-        ("equal-dual", true, true),
+    for case in [
+        Case {
+            name: "canonical-only",
+            canonical: CanonicalInput::Selected,
+            retired: false,
+            use_canonical: true,
+        },
+        Case {
+            name: "canonical-is-not-overridden-by-retired",
+            canonical: CanonicalInput::Selected,
+            retired: true,
+            use_canonical: true,
+        },
+        Case {
+            name: "retired-only-is-ignored",
+            canonical: CanonicalInput::Absent,
+            retired: true,
+            use_canonical: false,
+        },
+        Case {
+            name: "canonical-empty-does-not-fall-back-to-retired",
+            canonical: CanonicalInput::Empty,
+            retired: true,
+            use_canonical: false,
+        },
     ] {
-        let runtime_dir = dir.path().join(name);
+        let run_id = if case.use_canonical {
+            "not/validated/when/runtime-dir-is-set".to_string()
+        } else {
+            format!("helper-runtime-{}", case.name)
+        };
+        let home = dir.path().join(format!("{}-home", case.name));
+        let canonical_dir = dir.path().join(format!("{}-canonical", case.name));
+        let retired_dir = dir.path().join(format!("{}-retired", case.name));
+        let fallback_dir = if case.use_canonical {
+            None
+        } else {
+            Some(guest_contracts::runtime_paths::run_dir_for_home(
+                &home, &run_id,
+            )?)
+        };
+        let runtime_dir = if case.use_canonical {
+            &canonical_dir
+        } else {
+            fallback_dir
+                .as_ref()
+                .ok_or("fallback runtime is required")?
+        };
         let metadata_path =
-            guest_contracts::runtime_paths::final_session_history_identity_file(&runtime_dir);
+            guest_contracts::runtime_paths::final_session_history_identity_file(runtime_dir);
         guest_contracts::runtime_paths::write_private(&metadata_path, identity.to_json_vec()?)?;
         let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
         command
             .env_clear()
-            .env(
-                guest_contracts::env::RUN_ID_ENV,
-                "not/validated/when/runtime-dir-is-set",
-            )
+            .env(guest_contracts::env::RUN_ID_ENV, &run_id)
+            .env("HOME", &home)
             .arg("verify-session-history-identity");
-        if canonical {
-            command.env(
-                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-                &runtime_dir,
-            );
+        match case.canonical {
+            CanonicalInput::Absent => {}
+            CanonicalInput::Empty => {
+                command.env(
+                    guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+                    "",
+                );
+            }
+            CanonicalInput::Selected => {
+                command.env(
+                    guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+                    &canonical_dir,
+                );
+            }
         }
-        if legacy {
-            command.env(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-                &runtime_dir,
-            );
+        if case.retired {
+            command.env(RETIRED_GUEST_RUNTIME_DIR_ENV, &retired_dir);
         }
 
         let output = common::command_output_with_timeout(
             &mut command,
             SESSION_HISTORY_HELPER_TIMEOUT,
-            &format!("{name} default identity-path helper exceeded its completion budget"),
+            &format!(
+                "{} default identity-path helper exceeded its completion budget",
+                case.name
+            ),
         )
         .await?;
         assert!(
             output.status.success(),
-            "{name}: stdout={}, stderr={}",
+            "{}: stdout={}, stderr={}",
+            case.name,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-        assert!(output.stdout.is_empty(), "{name} changed stdout");
-        assert!(output.stderr.is_empty(), "{name} changed stderr");
+        assert!(output.stdout.is_empty(), "{} changed stdout", case.name);
+        assert!(output.stderr.is_empty(), "{} changed stderr", case.name);
+        assert!(
+            !guest_contracts::runtime_paths::final_session_history_identity_file(retired_dir)
+                .exists()
+        );
     }
-
-    let canonical_dir = dir.path().join("canonical-must-not-leak");
-    let legacy_dir = dir.path().join("legacy-must-not-leak");
-    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
-    command
-        .env_clear()
-        .env(guest_contracts::env::RUN_ID_ENV, "run-id")
-        .env(
-            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-            &canonical_dir,
-        )
-        .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            &legacy_dir,
-        )
-        .arg("verify-session-history-identity");
-    let output = common::command_output_with_timeout(
-        &mut command,
-        SESSION_HISTORY_HELPER_TIMEOUT,
-        "conflicting default identity-path aliases exceeded their completion budget",
-    )
-    .await?;
-    assert!(!output.status.success());
-    assert!(output.stdout.is_empty());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains(
-        "conflicting guest runtime directory environment aliases: \
-         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
-    ));
-    assert!(!stderr.contains("canonical-must-not-leak"));
-    assert!(!stderr.contains("legacy-must-not-leak"));
-    assert!(!stderr.contains("guest_runtime_dir_env_source"));
 
     Ok(())
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -6,7 +6,8 @@
 //! bootstrap controls directly.
 //!
 //! The `OKOU_` and `VM0_` namespaces are runner-owned, including keys defined
-//! in sibling modules such as [`crate::runtime_paths::GUEST_RUNTIME_DIR_ENV`].
+//! in sibling modules such as
+//! [`crate::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV`].
 //! User env filtering should treat current and future `OKOU_` keys plus current,
 //! future, and retired `VM0_` keys as protected. Bootstrap keys outside those
 //! namespaces are listed explicitly below.

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -26,15 +26,6 @@ use uuid::Uuid;
 ///
 /// When set to a non-empty absolute path, this value is used as the run
 /// directory directly instead of deriving one from `HOME` and a run id.
-pub const GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
-/// Canonical reader alias for [`GUEST_RUNTIME_DIR_ENV`].
-///
-/// This bounded fallback lets new embedded readers accept the five legacy-only
-/// writers on the existing runner and reusable-sandbox surface, where a claim
-/// can live for the two-hour guest runtime budget plus bounded finalization.
-/// Remove the legacy branch only after #28914 records the exact-artifact reader
-/// floor, service and reusable-sandbox drain, rollback window, and
-/// legacy-read-zero gates.
 pub const CANONICAL_GUEST_RUNTIME_DIR_ENV: &str = "OKOU_GUEST_RUNTIME_DIR";
 /// Fixed fallback path used when a storage manifest exceeds the stdin limit.
 pub const STORAGE_MANIFEST_PATH: &str = "/tmp/storage-manifest.json";
@@ -53,10 +44,8 @@ pub enum RuntimePathError {
     InvalidRunId,
     /// The fallback runtime directory layout requires a non-empty `HOME`.
     MissingHome,
-    /// `VM0_GUEST_RUNTIME_DIR` was set to a relative path.
+    /// `OKOU_GUEST_RUNTIME_DIR` was set to a relative path.
     InvalidRuntimeDir,
-    /// Both runtime-directory aliases were non-empty and unequal.
-    ConflictingRuntimeDirEnvAliases,
 }
 
 impl std::fmt::Display for RuntimePathError {
@@ -66,14 +55,8 @@ impl std::fmt::Display for RuntimePathError {
             Self::InvalidRunId => f.write_str("OKOU_RUN_ID must be a single safe path segment"),
             Self::MissingHome => f.write_str("HOME is required for guest runtime paths"),
             Self::InvalidRuntimeDir => {
-                f.write_str("VM0_GUEST_RUNTIME_DIR must be an absolute path")
+                f.write_str("OKOU_GUEST_RUNTIME_DIR must be an absolute path")
             }
-            Self::ConflictingRuntimeDirEnvAliases => write!(
-                f,
-                "conflicting guest runtime directory environment aliases: canonical_key={} \
-                 legacy_key={} state=conflict",
-                CANONICAL_GUEST_RUNTIME_DIR_ENV, GUEST_RUNTIME_DIR_ENV
-            ),
         }
     }
 }
@@ -118,104 +101,22 @@ pub fn run_dir_for_home(
         .join(run_id))
 }
 
-/// Value-free provenance for a selected guest runtime-directory override.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GuestRuntimeDirEnvSource {
-    /// Only `OKOU_GUEST_RUNTIME_DIR` supplied a non-empty value.
-    CanonicalOnly,
-    /// Only `VM0_GUEST_RUNTIME_DIR` supplied a non-empty value.
-    LegacyOnly,
-    /// Both aliases supplied the same non-empty value.
-    Dual,
-}
-
-impl GuestRuntimeDirEnvSource {
-    /// Fixed label used by bounded source evidence.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::CanonicalOnly => "canonical-only",
-            Self::LegacyOnly => "legacy-only",
-            Self::Dual => "dual",
-        }
-    }
-}
-
-/// One value-preserving resolution of the guest runtime-directory aliases.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GuestRuntimeDirEnvResolution {
-    runtime_dir: Option<PathBuf>,
-    source: Option<GuestRuntimeDirEnvSource>,
-}
-
-impl GuestRuntimeDirEnvResolution {
-    /// Selected non-empty absolute override, if either alias supplied one.
-    pub fn runtime_dir(&self) -> Option<&Path> {
-        self.runtime_dir.as_deref()
-    }
-
-    /// Value-free source for the selected override.
-    pub fn source(&self) -> Option<GuestRuntimeDirEnvSource> {
-        self.source
-    }
-
-    /// Consume the resolution into its owned path and source.
-    pub fn into_parts(self) -> (Option<PathBuf>, Option<GuestRuntimeDirEnvSource>) {
-        (self.runtime_dir, self.source)
-    }
-}
-
-/// Resolve canonical and legacy guest runtime-directory aliases without
-/// converting their values to UTF-8.
-///
-/// Empty values are absent. One non-empty value wins, equal non-empty values
-/// resolve once, and unequal non-empty values fail closed without exposing
-/// either path.
-pub fn resolve_guest_runtime_dir_env(
-    canonical: Option<OsString>,
-    legacy: Option<OsString>,
-) -> Result<GuestRuntimeDirEnvResolution, RuntimePathError> {
-    let canonical = canonical.filter(|value| !value.is_empty());
-    let legacy = legacy.filter(|value| !value.is_empty());
-
-    let (runtime_dir, source) = match (canonical, legacy) {
-        (None, None) => (None, None),
-        (Some(runtime_dir), None) => (
-            Some(PathBuf::from(runtime_dir)),
-            Some(GuestRuntimeDirEnvSource::CanonicalOnly),
-        ),
-        (None, Some(runtime_dir)) => (
-            Some(PathBuf::from(runtime_dir)),
-            Some(GuestRuntimeDirEnvSource::LegacyOnly),
-        ),
-        (Some(canonical), Some(legacy)) if canonical == legacy => (
-            Some(PathBuf::from(canonical)),
-            Some(GuestRuntimeDirEnvSource::Dual),
-        ),
-        (Some(_), Some(_)) => {
-            return Err(RuntimePathError::ConflictingRuntimeDirEnvAliases);
-        }
-    };
-
+fn canonical_guest_runtime_dir(
+    value: Option<OsString>,
+) -> Result<Option<PathBuf>, RuntimePathError> {
+    let runtime_dir = value.filter(|value| !value.is_empty()).map(PathBuf::from);
     if runtime_dir
         .as_deref()
         .is_some_and(|runtime_dir| !runtime_dir.is_absolute())
     {
         return Err(RuntimePathError::InvalidRuntimeDir);
     }
-
-    Ok(GuestRuntimeDirEnvResolution {
-        runtime_dir,
-        source,
-    })
+    Ok(runtime_dir)
 }
 
-/// Capture and resolve both guest runtime-directory aliases exactly once.
-pub fn guest_runtime_dir_env_from_process_env()
--> Result<GuestRuntimeDirEnvResolution, RuntimePathError> {
-    resolve_guest_runtime_dir_env(
-        env::var_os(CANONICAL_GUEST_RUNTIME_DIR_ENV),
-        env::var_os(GUEST_RUNTIME_DIR_ENV),
-    )
+/// Capture the canonical guest runtime-directory override exactly once.
+pub fn guest_runtime_dir_env_from_process_env() -> Result<Option<PathBuf>, RuntimePathError> {
+    canonical_guest_runtime_dir(env::var_os(CANONICAL_GUEST_RUNTIME_DIR_ENV))
 }
 
 /// Resolve a complete run directory from already captured values.
@@ -237,26 +138,17 @@ pub fn run_dir_from_captured_env(
     run_dir_for_home(home, run_id)
 }
 
-/// Resolve the process runtime directory and return value-free alias source.
-pub fn run_dir_from_env_with_source(
-    run_id: &str,
-) -> Result<(PathBuf, Option<GuestRuntimeDirEnvSource>), RuntimePathError> {
-    let resolution = guest_runtime_dir_env_from_process_env()?;
-    let home = env::var_os("HOME").map(PathBuf::from);
-    let run_dir = run_dir_from_captured_env(run_id, resolution.runtime_dir(), home.as_deref())?;
-    Ok((run_dir, resolution.source()))
-}
-
 /// Resolve the runtime directory from process environment.
 ///
-/// A non-empty absolute canonical or legacy override wins and is returned as
-/// the complete runtime directory. In that override branch, `run_id` is not
-/// validated and is not appended. Empty overrides are ignored, relative
-/// overrides return [`RuntimePathError::InvalidRuntimeDir`], conflicting
-/// non-empty aliases fail closed, and fallback resolution uses `HOME` plus
-/// [`run_dir_for_home`].
+/// A non-empty absolute canonical override wins and is returned as the complete
+/// runtime directory. In that override branch, `run_id` is not validated and
+/// is not appended. An empty override is ignored, a relative override returns
+/// [`RuntimePathError::InvalidRuntimeDir`], and fallback resolution uses `HOME`
+/// plus [`run_dir_for_home`].
 pub fn run_dir_from_env(run_id: &str) -> Result<PathBuf, RuntimePathError> {
-    run_dir_from_env_with_source(run_id).map(|(run_dir, _source)| run_dir)
+    let runtime_dir = guest_runtime_dir_env_from_process_env()?;
+    let home = env::var_os("HOME").map(PathBuf::from);
+    run_dir_from_captured_env(run_id, runtime_dir.as_deref(), home.as_deref())
 }
 
 fn file(run_dir: impl AsRef<Path>, name: &str) -> PathBuf {
@@ -1397,92 +1289,33 @@ mod tests {
     }
 
     #[test]
-    fn guest_runtime_dir_aliases_preserve_paths_and_source() {
-        assert_eq!(GUEST_RUNTIME_DIR_ENV, "VM0_GUEST_RUNTIME_DIR");
+    fn canonical_guest_runtime_dir_preserves_path_and_empty_semantics() {
         assert_eq!(CANONICAL_GUEST_RUNTIME_DIR_ENV, "OKOU_GUEST_RUNTIME_DIR");
-
-        let success_cases = [
-            ("absent", None, None, None, None),
-            ("both-empty", Some(""), Some(""), None, None),
-            (
-                "canonical-only",
-                Some("/canonical"),
-                None,
-                Some("/canonical"),
-                Some(GuestRuntimeDirEnvSource::CanonicalOnly),
-            ),
-            (
-                "legacy-only",
-                None,
-                Some("/legacy"),
-                Some("/legacy"),
-                Some(GuestRuntimeDirEnvSource::LegacyOnly),
-            ),
-            (
-                "equal-dual",
-                Some("/shared"),
-                Some("/shared"),
-                Some("/shared"),
-                Some(GuestRuntimeDirEnvSource::Dual),
-            ),
-            (
-                "canonical-empty",
-                Some(""),
-                Some("/legacy"),
-                Some("/legacy"),
-                Some(GuestRuntimeDirEnvSource::LegacyOnly),
-            ),
-            (
-                "legacy-empty",
-                Some("/canonical"),
-                Some(""),
-                Some("/canonical"),
-                Some(GuestRuntimeDirEnvSource::CanonicalOnly),
-            ),
-        ];
-
-        for (name, canonical, legacy, expected_path, expected_source) in success_cases {
-            let resolution = resolve_guest_runtime_dir_env(
-                canonical.map(OsString::from),
-                legacy.map(OsString::from),
-            )
-            .unwrap();
-            assert_eq!(
-                resolution.runtime_dir(),
-                expected_path.map(Path::new),
-                "{name} selected the wrong path"
-            );
-            assert_eq!(
-                resolution.source(),
-                expected_source,
-                "{name} selected the wrong source"
-            );
-        }
-
-        let error = resolve_guest_runtime_dir_env(
-            Some(OsString::from("/canonical-must-not-leak")),
-            Some(OsString::from("/legacy-must-not-leak")),
-        )
-        .unwrap_err();
-        assert_eq!(error, RuntimePathError::ConflictingRuntimeDirEnvAliases);
-        let diagnostic = error.to_string();
         assert_eq!(
-            diagnostic,
-            "conflicting guest runtime directory environment aliases: \
-             canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR \
-             state=conflict"
+            canonical_guest_runtime_dir(None),
+            Ok(None),
+            "an absent override must use fallback resolution"
         );
-        assert!(!diagnostic.contains("must-not-leak"));
+        assert_eq!(
+            canonical_guest_runtime_dir(Some(OsString::new())),
+            Ok(None),
+            "an empty override must use fallback resolution"
+        );
+        assert_eq!(
+            canonical_guest_runtime_dir(Some(OsString::from("/canonical"))),
+            Ok(Some(PathBuf::from("/canonical")))
+        );
     }
 
     #[test]
-    fn guest_runtime_dir_aliases_preserve_non_unicode_and_fallback_contract() {
+    fn canonical_guest_runtime_dir_preserves_non_unicode_and_fallback_contract() {
         #[cfg(unix)]
         {
             let absolute = PathBuf::from(OsString::from_vec(vec![b'/', b'r', b'u', b'n', 0xff]));
-            let resolution =
-                resolve_guest_runtime_dir_env(Some(absolute.as_os_str().to_owned()), None).unwrap();
-            assert_eq!(resolution.runtime_dir(), Some(absolute.as_path()));
+            assert_eq!(
+                canonical_guest_runtime_dir(Some(absolute.as_os_str().to_owned())),
+                Ok(Some(absolute))
+            );
 
             let home = PathBuf::from(OsString::from_vec(vec![b'/', b'h', b'o', b'm', b'e', 0xfe]));
             let fallback = run_dir_from_captured_env("run-123", None, Some(&home)).unwrap();
@@ -1505,7 +1338,7 @@ mod tests {
             Err(RuntimePathError::InvalidRuntimeDir)
         );
         assert_eq!(
-            resolve_guest_runtime_dir_env(Some(OsString::from("relative-runtime")), None),
+            canonical_guest_runtime_dir(Some(OsString::from("relative-runtime"))),
             Err(RuntimePathError::InvalidRuntimeDir)
         );
     }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -53,18 +53,10 @@ fn install_runtime_log_paths() -> Result<(), String> {
         ));
     }
 
-    let (run_dir, source) = runtime_paths::run_dir_from_env_with_source(&run_id)
+    let run_dir = runtime_paths::run_dir_from_env(&run_id)
         .map_err(|error| format!("failed to resolve guest-download runtime paths: {error}"))?;
     guest_common::log::set_system_log_file(runtime_paths::system_log_file(&run_dir));
     guest_common::telemetry::set_sandbox_ops_log_file(runtime_paths::sandbox_ops_log_file(run_dir));
-    if let Some(source) = source {
-        log_info!(
-            LOG_TAG,
-            "guest_runtime_dir_env_source key={} source={}",
-            runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-            source.label()
-        );
-    }
     Ok(())
 }
 

--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -50,7 +50,6 @@ impl BinaryLoggingFixture {
         let mut command = guest_download_command();
         command
             .env(guest_contracts::env::RUN_ID_ENV, &self.run_id)
-            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
             .env(
                 guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &self.logs.runtime_dir,
@@ -102,9 +101,7 @@ impl BinaryLoggingFixture {
 
 pub(super) fn guest_download_command() -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-download"));
-    command
-        .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
-        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+    command.env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV);
     command
 }
 

--- a/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
+++ b/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
@@ -9,32 +9,26 @@ use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
 
-const SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
+const RETIRED_GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
+const RETIRED_SOURCE_EVENT: &str = "guest_runtime_dir_env_source";
 
-fn apply_runtime_aliases(
+fn apply_runtime_env(
     command: &mut std::process::Command,
     canonical: Option<&OsStr>,
-    legacy: Option<&OsStr>,
+    retired: Option<&OsStr>,
 ) {
     command
         .env_remove(guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV)
-        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+        .env_remove(RETIRED_GUEST_RUNTIME_DIR_ENV);
     if let Some(value) = canonical {
         command.env(
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             value,
         );
     }
-    if let Some(value) = legacy {
-        command.env(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV, value);
+    if let Some(value) = retired {
+        command.env(RETIRED_GUEST_RUNTIME_DIR_ENV, value);
     }
-}
-
-fn source_messages(log: &str) -> Vec<&str> {
-    log.lines()
-        .filter_map(|line| line.rsplit_once("] ").map(|(_, message)| message))
-        .filter(|message| message.starts_with(SOURCE_EVENT))
-        .collect()
 }
 
 #[test]
@@ -56,10 +50,7 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
         "unexpected system log: {content:?}"
     );
     assert_eq!(content.matches("Download completed").count(), 1);
-    assert_eq!(
-        source_messages(&content),
-        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=canonical-only"]
-    );
+    assert!(!content.contains(RETIRED_SOURCE_EVENT));
     assert!(!content.contains(fixture.logs.runtime_dir.to_string_lossy().as_ref()));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -71,24 +62,53 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
 }
 
 #[test]
-fn binary_dual_reads_runtime_aliases_with_value_free_sink_scoped_evidence() {
-    for (name, canonical, legacy, expected_source) in [
-        ("canonical-only", true, false, "canonical-only"),
-        ("legacy-only", false, true, "legacy-only"),
-        ("equal-dual", true, true, "dual"),
+fn binary_reads_only_the_canonical_runtime_override() {
+    for (name, canonical, retired, use_canonical) in [
+        ("absent", None, false, false),
+        ("canonical-empty", Some(""), false, false),
+        ("canonical-absolute", Some("selected"), false, true),
+        ("retired-only-is-ignored", None, true, false),
+        (
+            "canonical-is-not-overridden-by-retired",
+            Some("selected"),
+            true,
+            true,
+        ),
+        (
+            "canonical-empty-does-not-fall-back-to-retired",
+            Some(""),
+            true,
+            false,
+        ),
     ] {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = write_manifest(&dir, &[], None).unwrap();
-        let runtime_dir = dir.path().join(format!("{name}-must-not-leak"));
+        let run_id = unique_run_id(name);
+        let home = dir.path().join("home");
+        let fallback_dir =
+            guest_contracts::runtime_paths::run_dir_for_home(&home, &run_id).unwrap();
+        let canonical_dir = dir.path().join(format!("{name}-canonical-must-not-leak"));
+        let retired_dir = dir.path().join(format!("{name}-retired-must-not-leak"));
+        let expected_dir = if use_canonical {
+            &canonical_dir
+        } else {
+            &fallback_dir
+        };
         let mut command = guest_download_command();
         command
             .arg(&manifest_path)
-            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id")
-            .env("HOME", dir.path().join("unused-home"));
-        apply_runtime_aliases(
+            .env(guest_contracts::env::RUN_ID_ENV, &run_id)
+            .env("HOME", &home);
+        apply_runtime_env(
             &mut command,
-            canonical.then_some(runtime_dir.as_os_str()),
-            legacy.then_some(runtime_dir.as_os_str()),
+            canonical.map(|value| {
+                if value.is_empty() {
+                    OsStr::new("")
+                } else {
+                    canonical_dir.as_os_str()
+                }
+            }),
+            retired.then_some(retired_dir.as_os_str()),
         );
 
         let output = process::run(&mut command).unwrap();
@@ -98,100 +118,20 @@ fn binary_dual_reads_runtime_aliases_with_value_free_sink_scoped_evidence() {
             String::from_utf8_lossy(&output.stderr)
         );
         let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
-            &runtime_dir,
+            expected_dir,
         ))
         .unwrap();
-        let expected = format!(
-            "{SOURCE_EVENT} key={} source={expected_source}",
-            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
-        );
-        assert_eq!(source_messages(&log), [expected.as_str()], "{name}");
+        assert!(!log.contains(RETIRED_SOURCE_EVENT), "{name}");
         assert!(!log.contains("must-not-leak"), "{name}");
         assert!(
             !String::from_utf8_lossy(&output.stderr).contains("must-not-leak"),
             "{name}"
         );
+        if !use_canonical {
+            assert!(!guest_contracts::runtime_paths::system_log_file(&canonical_dir).exists());
+        }
+        assert!(!guest_contracts::runtime_paths::system_log_file(&retired_dir).exists());
     }
-}
-
-#[test]
-fn binary_treats_empty_runtime_alias_as_absent() {
-    for (name, canonical_empty) in [("canonical-empty", true), ("legacy-empty", false)] {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = write_manifest(&dir, &[], None).unwrap();
-        let runtime_dir = dir.path().join(format!("{name}-runtime"));
-        let mut command = guest_download_command();
-        command
-            .arg(&manifest_path)
-            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id")
-            .env("HOME", dir.path().join("unused-home"));
-        let empty = OsStr::new("");
-        apply_runtime_aliases(
-            &mut command,
-            Some(if canonical_empty {
-                empty
-            } else {
-                runtime_dir.as_os_str()
-            }),
-            Some(if canonical_empty {
-                runtime_dir.as_os_str()
-            } else {
-                empty
-            }),
-        );
-
-        let output = process::run(&mut command).unwrap();
-        assert!(
-            output.status.success(),
-            "{name}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let log = std::fs::read_to_string(guest_contracts::runtime_paths::system_log_file(
-            &runtime_dir,
-        ))
-        .unwrap();
-        let expected_source = if canonical_empty {
-            "legacy-only"
-        } else {
-            "canonical-only"
-        };
-        let expected = format!(
-            "{SOURCE_EVENT} key={} source={expected_source}",
-            guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV
-        );
-        assert_eq!(source_messages(&log), [expected.as_str()], "{name}");
-    }
-}
-
-#[test]
-fn binary_rejects_runtime_alias_conflict_without_path_or_log_side_effects() {
-    let dir = tempfile::tempdir().unwrap();
-    let manifest_path = write_manifest(&dir, &[], None).unwrap();
-    let canonical_dir = dir.path().join("canonical-must-not-leak");
-    let legacy_dir = dir.path().join("legacy-must-not-leak");
-    let mut command = guest_download_command();
-    command
-        .arg(&manifest_path)
-        .env(guest_contracts::env::RUN_ID_ENV, "run-id")
-        .env("HOME", dir.path().join("home"));
-    apply_runtime_aliases(
-        &mut command,
-        Some(canonical_dir.as_os_str()),
-        Some(legacy_dir.as_os_str()),
-    );
-
-    let output = process::run(&mut command).unwrap();
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains(
-        "conflicting guest runtime directory environment aliases: \
-         canonical_key=OKOU_GUEST_RUNTIME_DIR legacy_key=VM0_GUEST_RUNTIME_DIR state=conflict"
-    ));
-    assert!(!stderr.contains("canonical-must-not-leak"));
-    assert!(!stderr.contains("legacy-must-not-leak"));
-    assert!(!guest_contracts::runtime_paths::system_log_file(canonical_dir).exists());
-    assert!(!guest_contracts::runtime_paths::system_log_file(legacy_dir).exists());
-    assert!(manifest_path.exists());
 }
 
 #[cfg(unix)]
@@ -207,7 +147,12 @@ fn binary_accepts_non_unicode_runtime_override_and_home_fallback() {
     override_command
         .arg(&override_manifest)
         .env(guest_contracts::env::RUN_ID_ENV, "invalid/run-id");
-    apply_runtime_aliases(&mut override_command, Some(override_dir.as_os_str()), None);
+    let retired_dir = dir.path().join("retired-non-unicode-runtime");
+    apply_runtime_env(
+        &mut override_command,
+        Some(override_dir.as_os_str()),
+        Some(retired_dir.as_os_str()),
+    );
     let override_output = process::run(&mut override_command).unwrap();
     assert!(
         override_output.status.success(),
@@ -218,10 +163,8 @@ fn binary_accepts_non_unicode_runtime_override_and_home_fallback() {
         &override_dir,
     ))
     .unwrap();
-    assert_eq!(
-        source_messages(&override_log),
-        ["guest_runtime_dir_env_source key=OKOU_GUEST_RUNTIME_DIR source=canonical-only"]
-    );
+    assert!(!override_log.contains(RETIRED_SOURCE_EVENT));
+    assert!(!guest_contracts::runtime_paths::system_log_file(retired_dir).exists());
 
     let fallback_manifest = write_manifest(&dir, &[], None).unwrap();
     let home = dir.path().join(OsString::from_vec(b"home-\xfe".to_vec()));
@@ -232,7 +175,7 @@ fn binary_accepts_non_unicode_runtime_override_and_home_fallback() {
         .arg(&fallback_manifest)
         .env(guest_contracts::env::RUN_ID_ENV, &run_id)
         .env("HOME", &home);
-    apply_runtime_aliases(&mut fallback_command, None, None);
+    apply_runtime_env(&mut fallback_command, None, None);
     let fallback_output = process::run(&mut fallback_command).unwrap();
     assert!(
         fallback_output.status.success(),
@@ -243,7 +186,7 @@ fn binary_accepts_non_unicode_runtime_override_and_home_fallback() {
         fallback_dir,
     ))
     .unwrap();
-    assert!(source_messages(&fallback_log).is_empty());
+    assert!(!fallback_log.contains(RETIRED_SOURCE_EVENT));
 }
 
 #[test]
@@ -291,26 +234,31 @@ fn binary_fails_with_relative_runtime_dir_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
     let run_id = unique_run_id("relative-runtime-dir");
+    let retired_dir = dir.path().join("retired-runtime-must-not-leak");
+    let mut command = guest_download_command();
+    command
+        .arg(&manifest_path)
+        .env(guest_contracts::env::RUN_ID_ENV, run_id);
+    apply_runtime_env(
+        &mut command,
+        Some(OsStr::new("relative-runtime-dir")),
+        Some(retired_dir.as_os_str()),
+    );
 
-    let output = process::run(
-        guest_download_command()
-            .arg(&manifest_path)
-            .env(guest_contracts::env::RUN_ID_ENV, run_id)
-            .env(
-                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-                "relative-runtime-dir",
-            ),
-    )
-    .unwrap();
+    let output = process::run(&mut command).unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(
-            "failed to resolve guest-download runtime paths: VM0_GUEST_RUNTIME_DIR must be an absolute path"
+            "failed to resolve guest-download runtime paths: OKOU_GUEST_RUNTIME_DIR must be an absolute path"
         ),
         "unexpected stderr: {stderr}"
     );
+    assert!(!stderr.contains("retired-runtime-must-not-leak"));
+    assert!(!stderr.contains(RETIRED_SOURCE_EVENT));
+    assert!(!guest_contracts::runtime_paths::system_log_file(retired_dir).exists());
+    assert!(manifest_path.exists());
 }
 
 #[test]
@@ -321,8 +269,7 @@ fn binary_fails_with_invalid_run_id_for_runtime_log_setup() {
     let output = process::run(
         guest_download_command()
             .arg(&manifest_path)
-            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run/id")
-            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV),
+            .env(guest_contracts::env::RUN_ID_ENV, "invalid/run/id"),
     )
     .unwrap();
 
@@ -378,7 +325,6 @@ fn binary_fails_without_home_or_runtime_dir_for_runtime_log_setup() {
         guest_download_command()
             .arg(&manifest_path)
             .env(guest_contracts::env::RUN_ID_ENV, run_id)
-            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
             .env_remove("HOME"),
     )
     .unwrap();

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -267,7 +267,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
             !call
                 .env_keys
                 .iter()
-                .any(|key| { key == guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV })
+                .any(|key| { key == "VM0_GUEST_RUNTIME_DIR" })
         );
         assert!(!call.sudo);
         assert!(call.stdin_bytes.is_none());

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -457,7 +457,7 @@ fn build_env_json_required_keys() {
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
-    assert!(!env.contains_key(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV));
+    assert!(!env.contains_key("VM0_GUEST_RUNTIME_DIR"));
     assert!(!env.contains_key("VM0_PROMPT"));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
@@ -728,7 +728,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
             "/legacy".into(),
         ),
         (
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV.into(),
+            "VM0_GUEST_RUNTIME_DIR".into(),
             "/user/controlled/runtime".into(),
         ),
         (
@@ -795,7 +795,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
-    assert!(!bootstrap_env.contains_key(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV));
+    assert!(!bootstrap_env.contains_key("VM0_GUEST_RUNTIME_DIR"));
     assert_eq!(bootstrap_env.get("CLI_AGENT_TYPE").unwrap(), "codex");
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert_eq!(user_env.get("OKOU_TOKEN").unwrap(), "legitimate-okou-token");
@@ -808,7 +808,7 @@ fn fieldless_context_preserves_pre_platform_environment_filtering() {
         guest_contracts::env::PROMPT_ENV,
         guest_contracts::env::API_TOKEN_ENV,
         guest_contracts::env::WORKING_DIR_ENV,
-        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        "VM0_GUEST_RUNTIME_DIR",
         guest_contracts::env::FEATURE_FLAGS_ENV,
         "VM0_FUTURE_RUNNER_KEY",
         LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV,

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -89,7 +89,7 @@ fn guest_download_env_contains_run_identity_values() {
     );
     assert!(
         !env.iter()
-            .any(|(key, _)| { *key == guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV })
+            .any(|(key, _)| { *key == "VM0_GUEST_RUNTIME_DIR" })
     );
 }
 


### PR DESCRIPTION
## Summary

- make `OKOU_GUEST_RUNTIME_DIR` the only accepted runtime-directory override for the normal Guest Agent, runner-only helpers, and guest-download
- remove the retired legacy constant, dual/conflict/source resolution machinery, and runtime-directory migration telemetry
- retain exact `VM0_GUEST_RUNTIME_DIR` negative retirement, writer-absence, managed-child isolation, and namespace-guard coverage

## Preserved contract

- canonical absolute, empty, relative, non-Unicode, fallback, and invalid run-id behavior
- override bypass of run-id validation
- existing failure ordering, helper stdout/stderr protocols, paths, and all five canonical production writers

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked -p guest-contracts -p guest-agent -p guest-download --all-targets --all-features`
- `cargo clippy --locked -p guest-contracts -p guest-agent -p guest-download --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p guest-contracts -p guest-agent -p guest-download --no-deps --all-features`
- focused guest-contracts, Guest Agent runtime, session-history helper, bootstrap source-event, reuse helper, CLI child-env, guest-download runtime-path, and vsock guest-storage-manifest tests
- `cargo check --locked -p runner --tests`

Direct local Runner unit-test execution reached the runtime 3.8 GiB memory-cgroup limit while linking (`rustc` RSS 3,595,236 kB; kernel OOM kill). All Runner test targets compile successfully; protected CI remains authoritative for execution.

## Publication inventory

- reviewed base: `895b70cc33b936090afc7c86a4c71bf82a591324`
- reviewed head: `abf789602c23091d5f95ac864802c2a89c357c88`
- 30 open PRs audited through every changed-files page and full diff: 507 declared / 507 fetched / 507 actual files, 1,597 actual hunks, 0 mismatches
- overlapping broad env files in #30025 and #25722 have zero runtime-directory literal, symbol, or caller hunk matches
- 11 remaining exact retired-literal occurrences are negative retirement assertions only
- deleted dual/conflict/source symbols have zero remaining occurrences; source telemetry remains only as two negative test assertions
- all five canonical production writer blobs match the reviewed base

Closes #30006
Parent EPIC: #28914