### PR TITLE
test(platform): wait for chat readiness before workflow input

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -721,6 +721,10 @@ describe("chat composer models", () => {
           `chatThreadWorkflowsChanged:${THREAD_ID}`,
         ),
       ).toBeTruthy();
+      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
     });
     const editor = await findComposerEditor();
     await user.click(editor);


### PR DESCRIPTION
## Summary

- wait for the chat shell to finish bootstrap before capturing the composer used by the workflow reload test
- keep the realtime subscription gate and real `/` keyboard interaction
- preserve coverage that workflow reload updates suggestions and highlighting without remounting the stable composer

## Root cause

The test only waited for the workflow-change Ably subscription, which can be ready before page bootstrap replaces the first-paint composer. Under CI scheduling, `/` could be typed into the detached editor and silently disappear, leaving the mounted composer empty and the slash menu closed.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx -t 'reloads workflow suggestions and highlights without remounting the composer' --maxWorkers=1 --silent=passed-only`
- 10 additional sequential focused Vitest runs with one worker (10/10 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --maxWorkers=1 --silent=passed-only` (22 tests)
- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- pre-commit hook: Prettier, Knip, full Turbo `check-types`, file-size check, and commitlint

## Exclusions

- no production behavior, API, persistence, protocol, deployment, or timeout changes
- the original ephemeral merge-group interleaving cannot be replayed exactly; repeated local runs and PR CI cover the timing-sensitive test path

Closes #30033
