### PR TITLE
fix(platform): stabilize mobile skeleton viewport

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1080,6 +1080,26 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <script>
+      // iOS can report standalone display mode one paint after document
+      // startup. Resolve it synchronously from navigator.standalone so the
+      // skeleton never paints at 100dvh before moving to 100lvh.
+      (function () {
+        var standalone =
+          navigator.standalone === true ||
+          window.matchMedia("(display-mode: standalone)").matches;
+        if (
+          standalone &&
+          window.CSS &&
+          window.CSS.supports("height", "100lvh")
+        ) {
+          document.documentElement.style.setProperty(
+            "--zero-viewport-height",
+            "100lvh",
+          );
+        }
+      })();
+    </script>
+    <script>
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
       (function () {
         var p = localStorage.getItem("theme");

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -3,6 +3,68 @@ import { describe, expect, it } from "vitest";
 import indexHtml from "../../../../index.html?raw";
 import { readGlobalCss } from "./global-css.ts";
 
+type ViewportEntrypoint = (
+  windowObject: Pick<Window, "matchMedia"> & { CSS: typeof CSS },
+  documentObject: Document,
+  navigatorObject: Navigator & { standalone?: boolean },
+) => void;
+
+function getInlineScriptSource(marker: string): string {
+  const source = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)]
+    .map((match) => {
+      return match[1];
+    })
+    .find((script) => {
+      return script?.includes(marker);
+    });
+
+  if (source === undefined) {
+    throw new Error(`Unable to find inline script containing ${marker}`);
+  }
+  return source;
+}
+
+function resolveStandaloneViewport({
+  displayModeStandalone,
+  navigatorStandalone,
+  supportsLargeViewport,
+}: {
+  displayModeStandalone: boolean;
+  navigatorStandalone: boolean;
+  supportsLargeViewport: boolean;
+}): string {
+  const testDocument = document.implementation.createHTMLDocument();
+  const executeEntrypoint = new Function(
+    "window",
+    "document",
+    "navigator",
+    getInlineScriptSource("navigator.standalone === true"),
+  ) as ViewportEntrypoint;
+
+  executeEntrypoint(
+    {
+      CSS: {
+        supports(property: string, value: string) {
+          return (
+            supportsLargeViewport && property === "height" && value === "100lvh"
+          );
+        },
+      } as typeof CSS,
+      matchMedia() {
+        return { matches: displayModeStandalone } as MediaQueryList;
+      },
+    },
+    testDocument,
+    { standalone: navigatorStandalone } as Navigator & {
+      standalone?: boolean;
+    },
+  );
+
+  return testDocument.documentElement.style.getPropertyValue(
+    "--zero-viewport-height",
+  );
+}
+
 function getViewportDirectives(): string[] {
   const match = /<meta\s+name="viewport"\s+content="([^"]+)"/.exec(indexHtml);
   return (
@@ -37,6 +99,44 @@ describe("platform entrypoint safe area behavior", () => {
     expect(indexHtml).toMatch(
       /#app-bootstrap-skeleton\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);/,
     );
+  });
+
+  it("locks the standalone viewport height before the skeleton can paint", () => {
+    const standaloneResolverIndex = indexHtml.indexOf(
+      "navigator.standalone === true",
+    );
+    const skeletonIndex = indexHtml.indexOf('id="app-bootstrap-skeleton"');
+
+    expect(standaloneResolverIndex).toBeGreaterThan(-1);
+    expect(standaloneResolverIndex).toBeLessThan(skeletonIndex);
+    expect(
+      resolveStandaloneViewport({
+        displayModeStandalone: false,
+        navigatorStandalone: true,
+        supportsLargeViewport: true,
+      }),
+    ).toBe("100lvh");
+    expect(
+      resolveStandaloneViewport({
+        displayModeStandalone: true,
+        navigatorStandalone: false,
+        supportsLargeViewport: true,
+      }),
+    ).toBe("100lvh");
+    expect(
+      resolveStandaloneViewport({
+        displayModeStandalone: false,
+        navigatorStandalone: false,
+        supportsLargeViewport: true,
+      }),
+    ).toBe("");
+    expect(
+      resolveStandaloneViewport({
+        displayModeStandalone: true,
+        navigatorStandalone: false,
+        supportsLargeViewport: false,
+      }),
+    ).toBe("");
   });
 
   it("suppresses the bottom safe-area inset only while the keyboard is open", () => {


### PR DESCRIPTION
## Summary

- stabilize the mobile bootstrap skeleton before its first paint in iOS standalone mode
- resolve the intended large viewport height synchronously from `navigator.standalone` or the standard standalone media query
- cover iOS standalone, standard standalone, browser mode, unsupported `lvh`, and pre-skeleton execution order

## Root cause

On an iOS home-screen launch, standalone display mode can become visible to CSS one paint after document startup. The skeleton therefore first centers itself in `100dvh`, then switches to the existing standalone `100lvh` height. Half of that viewport-height delta appears as the character dropping by roughly 17 CSS pixels. The avatar itself does not change, and no login redirect is involved.

## Fix

An inline entrypoint script runs before the bootstrap skeleton is parsed. On iOS it reads the synchronous `navigator.standalone` signal; on other standalone installations it uses `(display-mode: standalone)`. If large viewport units are supported, it pins `--zero-viewport-height` to `100lvh` before the first skeleton paint.

Normal browser mode and browsers without `lvh` support keep their current behavior.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- workspace type checks excluding app/API packages
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts` (5 tests passed)

Mobile staging-browser verification passed on the exact PR preview: `--zero-viewport-height` was `100lvh` from the first sampled frame, and the avatar remained at `top: 368px` across 229 visible layout frames (`delta=0`). See the PR verification comment for the video, contact sheet, and environment details.
