### PR TITLE
refactor(runner): cut private payload writers to canonical aliases

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -162,7 +162,8 @@ pub const SETTINGS_ENV: &str = "VM0_SETTINGS";
 /// this exact name.
 pub const CLI_AGENT_TYPE_ENV: &str = "CLI_AGENT_TYPE";
 
-/// Path to the private user environment JSON file written by the runner.
+/// Legacy private user-environment file pointer retained by guest readers as a
+/// rollback fallback.
 ///
 /// The guest-agent validates that the path points at its per-run private
 /// runtime directory, parses it as a `HashMap<String, String>`, and removes the
@@ -170,11 +171,11 @@ pub const CLI_AGENT_TYPE_ENV: &str = "CLI_AGENT_TYPE";
 /// payload.
 pub const USER_ENV_FILE_ENV: &str = "VM0_USER_ENV_FILE";
 
-/// Canonical user-environment file pointer accepted by guest readers.
+/// Canonical user-environment file pointer written by the runner.
 ///
-/// Runners keep writing [`USER_ENV_FILE_ENV`] until the deployed reader floor,
-/// sandbox drain, rollback window, and legacy-read-zero gates in #28914 are
-/// complete.
+/// Guest readers retain [`USER_ENV_FILE_ENV`] until the canonical writer
+/// deployment, supported rollback window, and legacy-read-zero gates in #28914
+/// are complete.
 pub const CANONICAL_USER_ENV_FILE_ENV: &str = "OKOU_USER_ENV_FILE";
 
 /// Private runtime subdirectory used by [`USER_ENV_FILE_ENV`].
@@ -196,17 +197,18 @@ pub const CONNECTOR_ACCOUNT_CONTEXT_PRIVATE_DIR_NAME: &str = "connector-account-
 /// Private runtime filename used by [`CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV`].
 pub const CONNECTOR_ACCOUNT_CONTEXT_FILENAME: &str = "context.json";
 
-/// Path to the private runner-owned run payload JSON file.
+/// Legacy private runner-owned run-payload file pointer retained by guest
+/// readers as a rollback fallback.
 ///
 /// Large prompt-like and configuration payloads use this file instead of
 /// bootstrap environment values so guest-agent startup does not hit Linux
-/// argv/env limits. Production guest-agent startup requires this key.
+/// argv/env limits. Production guest-agent startup requires one pointer alias.
 pub const RUN_PAYLOAD_FILE_ENV: &str = "VM0_RUN_PAYLOAD_FILE";
 
-/// Canonical run-payload file pointer accepted by guest readers.
+/// Canonical run-payload file pointer written by the runner.
 ///
-/// Runners keep writing [`RUN_PAYLOAD_FILE_ENV`] until the deployed reader
-/// floor, sandbox drain, rollback window, and legacy-read-zero gates in #28914
+/// Guest readers retain [`RUN_PAYLOAD_FILE_ENV`] until the canonical writer
+/// deployment, supported rollback window, and legacy-read-zero gates in #28914
 /// are complete.
 pub const CANONICAL_RUN_PAYLOAD_FILE_ENV: &str = "OKOU_RUN_PAYLOAD_FILE";
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -2112,11 +2112,19 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
     let user_env_file = required_files.user_env_file;
     let run_payload_file = required_files.run_payload_file;
+    debug_assert!(
+        !env_map.contains_key(USER_ENV_FILE_ENV_KEY)
+            && !env_map.contains_key(guest_contracts::env::RUN_PAYLOAD_FILE_ENV),
+        "legacy private payload pointers must be absent before canonical insertion"
+    );
     if let Some(path) = user_env_file {
-        env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
+        env_map.insert(
+            guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV.into(),
+            path,
+        );
     }
     env_map.insert(
-        guest_contracts::env::RUN_PAYLOAD_FILE_ENV.into(),
+        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV.into(),
         run_payload_file,
     );
     let env_diagnostics = build_agent_env_diagnostics(&env_map, &user_env_map);

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1106,22 +1106,24 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert!(!start_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
     assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
     assert_eq!(
-        start_env.get(USER_ENV_FILE_ENV_KEY).map(String::as_str),
+        start_env
+            .get(guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV)
+            .map(String::as_str),
         Some(expected_user_env_file.as_str())
     );
     assert_eq!(
         start_env
-            .get(guest_contracts::env::RUN_PAYLOAD_FILE_ENV)
+            .get(guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV)
             .map(String::as_str),
         Some(expected_run_payload_file.as_str())
     );
-    for canonical_key in [
-        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
-        guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+    for legacy_key in [
+        USER_ENV_FILE_ENV_KEY,
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
     ] {
         assert!(
-            !start_env.contains_key(canonical_key),
-            "reader Stage 1 must not emit canonical key {canonical_key}"
+            !start_env.contains_key(legacy_key),
+            "canonical writer must not emit legacy key {legacy_key}"
         );
     }
     for key in [
@@ -1256,14 +1258,27 @@ async fn execute_inner_continues_when_connector_account_context_write_fails() {
         private_writes[0].path,
         guest_connector_account_context_file_path(context.run_id).unwrap()
     );
-    assert_eq!(
-        private_writes[1].path,
-        guest_run_payload_file_path(context.run_id).unwrap()
-    );
+    let expected_run_payload_file = guest_run_payload_file_path(context.run_id).unwrap();
+    assert_eq!(private_writes[1].path, expected_run_payload_file);
     let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
-    assert!(!start_env.contains_key(USER_ENV_FILE_ENV_KEY));
+    for user_env_key in [
+        USER_ENV_FILE_ENV_KEY,
+        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV,
+    ] {
+        assert!(
+            !start_env.contains_key(user_env_key),
+            "absent user environment must not emit {user_env_key}"
+        );
+    }
+    assert_eq!(
+        start_env
+            .get(guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV)
+            .map(String::as_str),
+        Some(expected_run_payload_file.as_str())
+    );
+    assert!(!start_env.contains_key(guest_contracts::env::RUN_PAYLOAD_FILE_ENV));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #30019

Parent EPIC: #28914  
Reader foundation: #29073 / #29082  
Same-checkout cleanup: #29967 / #29975

## Summary

- switch the optional private user-environment file pointer to canonical-only `OKOU_USER_ENV_FILE`
- switch the required private run-payload file pointer to canonical-only `OKOU_RUN_PAYLOAD_FILE`
- prove exact canonical paths, both legacy absences, and the optional-user-env-absent case in the existing fresh-sandbox coverage
- update only the adjacent shared rustdoc while retaining both legacy constants and dual readers

## Preserved contract

- the two production insertions remain adjacent and still occur only after `write_required_agent_files` succeeds
- the writer does not dual-write; a debug-only invariant asserts that neither legacy pointer is present before canonical insertion
- private batching, write count/order/content/mode/path, failure ordering, JSON wire shape, filtering, connector-account-context fallback, telemetry, cleanup, and CLI-child isolation are unchanged
- `GuestConfigRaw::from_process_env` and the private-payload resolver are unchanged, so both alias pairs are still resolved once before either private file is opened or destructively removed
- the full absent/empty/non-Unicode/legacy/canonical/equal-dual/conflict reader matrix remains intact
- no release, deployment, production QA, generated traffic, rollback-dashboard change, or legacy-reader removal is included

## Base, inventory, and overlap audit

- initial clean checkout before editing: `main@2a7f946a16b5cdb679ec8d285ffb20a19ed6e302`
- refreshed before the first edit after first-merge precedence: `main@23de3236a3d6abfbeda50b4fab5c9f8b0376a6c2`
- publication base: `fda17a2b5dd19ee32f24be2262854611abb146ad`
- publication head: `9f8f149b34bc90dda85ec8f90e0d418f89ac9461`
- final literal/symbol/caller inventory: 149 matching lines across 28 files; the only production insertions are the two adjacent canonical insertions in `agent_run.rs`
- final GitHub audit: 30 open PRs, 481 GitHub-declared changed files, 481 fetched file records, zero count/pagination mismatches
- sole final overlap: stale #25722 touches only `crates/guest-contracts/src/env.rs`; its actual hunks add `CF_ACCESS_CLIENT_ID_ENV` / `CF_ACCESS_CLIENT_SECRET_ENV` after the Vercel constant and add both to `NON_VM0_RUNNER_OWNED_ENV_KEYS`. It does not touch either private-payload alias, rustdoc block, writer, reader, test, or lifecycle semantic
- main changes that merged first, including #30013, #30020, #30025, #30038, and #30040, were preserved by rebasing this branch; none was treated as an ordering blocker

## Verification

Passed on the publication ancestry:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-targets --all-features --no-deps -- -D warnings`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-targets --all-features`
- `CARGO_INCREMENTAL=0 RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-features --no-deps`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-contracts` (123 unit tests plus all integration/doc tests)
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test private_payload_file_env_aliases`
- exact caller/insertion, untouched-reader/lifecycle, three-file diff, and `git diff --check` checks

The focused Runner test binary could not link in the local 4 GiB/no-swap environment. The first exact-test attempt and the single constrained retry (`CARGO_BUILD_JOBS=1`, incremental off, test debuginfo off, GNU ld `--no-keep-memory`) were both killed at final `rustc` link with exit 137. Kernel evidence recorded `anon-rss=3,739,492 kB` against a `3,898,060 kB` cgroup limit with zero swap; after the two attempts, `memory.events` reported `oom=2`, `oom_kill=6`, and `oom_group_kill=2`. No Runner test executable was produced and no Rust/test failure occurred before the OOM. Protected PR CI is authoritative for those linked fresh-sandbox tests.
