### PR TITLE
docs(vsock-host): document copy byte limit

### DIFF
--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -24,7 +24,14 @@ const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COPY_TEMP_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 pub(super) const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
-pub(super) const COPY_FILE_STREAM_MAX_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Inclusive maximum number of bytes accepted by the guest-to-host copy
+/// operation.
+///
+/// The current limit is 128 MiB (`134_217_728` bytes). A larger
+/// [`CopyFileOptions::max_bytes`] value is rejected with
+/// `io::ErrorKind::InvalidInput` before guest work starts.
+pub const COPY_FILE_STREAM_MAX_BYTES: u64 = 128 * 1024 * 1024;
 // Copying is the one built-in streaming consumer that must tolerate the host
 // reader briefly outrunning the temp-file writer without failing the exec operation.
 const COPY_FILE_STREAM_QUEUE_CAPACITY: usize = exec_operation::MAX_EXEC_STREAM_CAPACITY;
@@ -36,9 +43,11 @@ static COPY_TEMP_NONCE: AtomicU64 = AtomicU64::new(1);
 pub struct CopyFileOptions {
     /// Maximum bytes to stream from the guest before the copy fails.
     ///
-    /// This value must be positive and no larger than the host copy stream
-    /// limit. The copy fails if the streamed file contents exceed this byte
-    /// count.
+    /// This value must be positive and no larger than the inclusive
+    /// [`crate::COPY_FILE_STREAM_MAX_BYTES`] limit (128 MiB, or
+    /// `134_217_728` bytes). A value above the limit returns
+    /// `io::ErrorKind::InvalidInput` before guest work starts. The copy also
+    /// fails if the streamed file contents exceed this byte count.
     pub max_bytes: u64,
     /// Guest-side copy exec timeout in milliseconds.
     ///

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 use crate::exec_operation;
 
-pub use copy::{CopyFileOptions, CopyFileResult};
+pub use copy::{COPY_FILE_STREAM_MAX_BYTES, CopyFileOptions, CopyFileResult};
 pub use write::WriteFileEntry;
 
 const MISSING_FILE_EXIT_CODE: i32 = 66;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -100,7 +100,7 @@ pub use exec_operation::{
     ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest, SupervisedExecCancelHandle,
     SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest, SupervisedExecStartTiming,
 };
-pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
+pub use file::{COPY_FILE_STREAM_MAX_BYTES, CopyFileOptions, CopyFileResult, WriteFileEntry};
 pub use guest_dns_readiness::GuestDnsReadinessResult;
 pub use guest_state_restore::GuestStateRestoreResult;
 pub use guest_storage_manifest::GuestStorageManifestResult;


### PR DESCRIPTION
## Summary

- Expose the existing `COPY_FILE_STREAM_MAX_BYTES` limit through the public `vsock-host` crate API.
- Document the inclusive 128 MiB (`134,217,728` byte) `CopyFileOptions::max_bytes` ceiling and the pre-guest `io::ErrorKind::InvalidInput` behavior for larger values.
- Keep copy execution, protocol behavior, and the higher-level `sandbox` API unchanged.

Closes #30028

## Scope

This is a public-rustdoc and export-only clarification. The runtime validation continues to use the
same constant and the existing boundary/error tests remain unchanged. No database, migration,
queue, deployment, or 128 MiB fixture changes are included.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host` — 387 passed
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- Inspected generated rustdoc for the public constant and `CopyFileOptions::max_bytes` link and wording.
