### PR TITLE
perf(mitm-addon): bound x billing unicode label work

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -344,6 +344,7 @@ _BARE_DOMAIN_CANDIDATE_RE = re.compile(
     re.IGNORECASE,
 )
 _MAX_DOMAIN_LABEL_CHARS = 63
+_MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS = 256
 _DOMAIN_LABEL_RE = re.compile(rf"^[a-z0-9-]{{1,{_MAX_DOMAIN_LABEL_CHARS}}}$")
 _INVALID_TLD_FOLLOWING_CHARS = "@+-"
 
@@ -404,7 +405,12 @@ def _normalize_billing_domain_label(label: str) -> _BillingDomainLabelNormalizat
         return _BillingDomainLabelNormalization(None, False)
 
 
-def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: str) -> bool:
+def _bare_domain_candidate_likely_contains_url(
+    candidate: str,
+    following_char: str,
+    label_normalizations: dict[str, _BillingDomainLabelNormalization],
+    label_tld_prefixes: dict[str, bool],
+) -> bool:
     if candidate.isascii():
         simple_ascii_candidate = candidate.lower()
         # Canonical A-label validation remains owned by the shared IDNA path.
@@ -413,13 +419,20 @@ def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: s
     else:
         use_simple_ascii_labels = False
         labels = candidate.split(".")
-    label_normalizations: dict[str, _BillingDomainLabelNormalization] = {}
-    label_tld_prefixes: dict[str, bool] = {}
     last_label_index = len(labels) - 1
     for index, label in enumerate(labels):
         if use_simple_ascii_labels:
             normalized_label = label
         else:
+            normalization = label_normalizations.get(label)
+            if (
+                normalization is None
+                and len(label_normalizations) >= _MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS
+            ):
+                # Exhausted inspection is ambiguous, so keep the conservative
+                # with-URL billing bucket.
+                return True
+
             if index > 0:
                 has_tld_prefix = label_tld_prefixes.get(label)
                 if has_tld_prefix is None:
@@ -428,7 +441,6 @@ def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: s
                 if has_tld_prefix:
                     return True
 
-            normalization = label_normalizations.get(label)
             if normalization is None:
                 normalization = _normalize_billing_domain_label(label)
                 label_normalizations[label] = normalization
@@ -458,9 +470,15 @@ def _tweet_text_likely_contains_url(text: str) -> bool:
         return True
     if "." not in text:
         return False
+    # Share bounded classification state across every candidate in this body.
+    label_normalizations: dict[str, _BillingDomainLabelNormalization] = {}
+    label_tld_prefixes: dict[str, bool] = {}
     return any(
         _bare_domain_candidate_likely_contains_url(
-            match.group(1), text[match.end(1) : match.end(1) + 1]
+            match.group(1),
+            text[match.end(1) : match.end(1) + 1],
+            label_normalizations,
+            label_tld_prefixes,
         )
         for match in _BARE_DOMAIN_CANDIDATE_RE.finditer(text)
     )

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -344,6 +344,8 @@ _BARE_DOMAIN_CANDIDATE_RE = re.compile(
     re.IGNORECASE,
 )
 _MAX_DOMAIN_LABEL_CHARS = 63
+# This stays above the 127 one-character labels that fit in a DNS name while
+# leaving a fixed ceiling for non-host text inspected by billing.
 _MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS = 256
 _DOMAIN_LABEL_RE = re.compile(rf"^[a-z0-9-]{{1,{_MAX_DOMAIN_LABEL_CHARS}}}$")
 _INVALID_TLD_FOLLOWING_CHARS = "@+-"

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -943,6 +943,55 @@ def test_tweet_create_repeated_unicode_labels_reuse_classification(x_usage, tmp_
     assert p["quantity"] == 1
 
 
+def test_tweet_create_distinct_unicode_labels_stop_at_body_work_limit(x_usage, tmp_path, real_flow):
+    """Distinct labels across candidates stop at one body-wide work limit."""
+    unicode_labels = [chr(0x4E00 + index) for index in range(10_000)]
+    labels_per_candidate = x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS // 2
+    text = " ".join(
+        "a." + ".".join(unicode_labels[start : start + labels_per_candidate]) + ".notatld"
+        for start in range(0, len(unicode_labels), labels_per_candidate)
+    )
+    request_body = json.dumps(
+        {"text": text},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    assert len(request_body) < REQUEST_BODY_BILLING_INSPECTION_LIMIT
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.content = request_body
+
+    with (
+        patch.object(
+            x_billing,
+            "normalize_idna_label",
+            wraps=x_billing.normalize_idna_label,
+        ) as normalize_idna_label,
+        patch.object(
+            x_billing,
+            "_label_has_tld_prefix_before_unicode",
+            wraps=x_billing._label_has_tld_prefix_before_unicode,
+        ) as label_has_tld_prefix_before_unicode,
+    ):
+        p = x_usage.call_and_get_single_billing(flow)
+
+    assert normalize_idna_label.call_count == x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS
+    assert (
+        label_has_tld_prefix_before_unicode.call_count
+        == x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS - 1
+    )
+    assert p["category"] == "content.create_with_url"
+    assert p["quantity"] == 1
+
+
 def test_tweet_create_rendered_link_signals_stay_on_with_url_bucket(x_usage, tmp_path, real_flow):
     """Quote tweets, attached media, cards, and DM deep links render links;
     we stay on the expensive bucket even when the text has no URL."""

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -946,7 +946,7 @@ def test_tweet_create_repeated_unicode_labels_reuse_classification(x_usage, tmp_
 def test_tweet_create_distinct_unicode_labels_stop_at_body_work_limit(x_usage, tmp_path, real_flow):
     """Distinct labels across candidates stop at one body-wide work limit."""
     unicode_labels = [chr(0x4E00 + index) for index in range(10_000)]
-    labels_per_candidate = x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS // 2
+    labels_per_candidate = 128
     text = " ".join(
         "a." + ".".join(unicode_labels[start : start + labels_per_candidate]) + ".notatld"
         for start in range(0, len(unicode_labels), labels_per_candidate)
@@ -983,11 +983,8 @@ def test_tweet_create_distinct_unicode_labels_stop_at_body_work_limit(x_usage, t
     ):
         p = x_usage.call_and_get_single_billing(flow)
 
-    assert normalize_idna_label.call_count == x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS
-    assert (
-        label_has_tld_prefix_before_unicode.call_count
-        == x_billing._MAX_BILLING_DOMAIN_LABEL_CLASSIFICATIONS - 1
-    )
+    assert normalize_idna_label.call_count == 256
+    assert label_has_tld_prefix_before_unicode.call_count == 255
     assert p["category"] == "content.create_with_url"
     assert p["quantity"] == 1
 


### PR DESCRIPTION
## Summary

- cap one X tweet-body URL scan at 256 distinct labels that require generic IDNA classification
- share request-local normalization and TLD-prefix results across all bare-domain candidates
- keep billing on `content.create_with_url` when the work budget is exhausted
- cover thousands of distinct Unicode labels across individually sub-limit candidates through the connector usage boundary

## Behavior

Pure ASCII candidates retain their normalization-free path, and repeated Unicode labels continue to reuse classification results. Bodies above the new unique-label ceiling fail closed to the existing more expensive billing bucket instead of continuing attacker-controlled synchronous work.

## Out of scope

- no process-global cache
- no request-body inspection limit change
- no API, schema, protocol, persisted-state, or deployment configuration change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py` (126 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,184 passed)
- `lefthook run pre-commit`

Closes #30037
