### PR TITLE
refactor(runner): translate timing tuning writers to canonical aliases

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -400,62 +400,90 @@ impl RunPayload {
     }
 }
 
-/// Guest-agent stuck-tool timeout override in seconds.
+/// Retained local input for the Guest Agent stuck-tool timeout in seconds.
 ///
-/// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The guest-agent parses the value as `u64`;
-/// unset or unparseable values use the compiled default.
+/// Local execution may pass this legacy name through ordinary user env via
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The runner translates it to
+/// [`CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV`] for Guest bootstrap. The
+/// guest-agent parses the value as `u64`; unset or unparseable values use the
+/// compiled default.
 pub const STUCK_TOOL_TIMEOUT_SECS_ENV: &str = "VM0_STUCK_TOOL_TIMEOUT_SECS";
 
-/// Canonical stuck-tool timeout alias accepted by guest readers.
+/// Canonical stuck-tool timeout bootstrap output written by the runner.
 ///
-/// The runner writer and supported local tuning interface remain on
-/// [`STUCK_TOOL_TIMEOUT_SECS_ENV`] during #28914 reader Stage 1.
+/// Guest readers retain [`STUCK_TOOL_TIMEOUT_SECS_ENV`] as a rollback fallback.
 pub const CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV: &str = "OKOU_STUCK_TOOL_TIMEOUT_SECS";
 
-/// Guest-agent grace period in seconds before sending SIGTERM after the CLI
-/// reports a final result.
+/// Retained local input for the Guest Agent SIGTERM grace period in seconds
+/// after the CLI reports a final result.
 ///
-/// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
-/// use the guest-agent's compiled default.
+/// Local execution may pass this legacy name through ordinary user env via
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The runner translates it to
+/// [`CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV`] for Guest bootstrap. Unset,
+/// unparseable, or out-of-range values use the guest-agent's compiled default.
 pub const POST_RESULT_SIGTERM_GRACE_SECS_ENV: &str = "VM0_POST_RESULT_SIGTERM_GRACE_SECS";
 
-/// Canonical post-result SIGTERM grace alias accepted by guest readers.
+/// Canonical post-result SIGTERM grace bootstrap output written by the runner.
 ///
-/// The runner writer and supported local tuning interface remain on
-/// [`POST_RESULT_SIGTERM_GRACE_SECS_ENV`] during #28914 reader Stage 1.
+/// Guest readers retain [`POST_RESULT_SIGTERM_GRACE_SECS_ENV`] as a rollback
+/// fallback.
 pub const CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV: &str =
     "OKOU_POST_RESULT_SIGTERM_GRACE_SECS";
 
-/// Guest-agent absolute cap in seconds before sending SIGTERM after the CLI
-/// reports a final result, regardless of later post-result stdout events.
+/// Retained local input for the Guest Agent absolute cap in seconds before
+/// sending SIGTERM after the CLI reports a final result, regardless of later
+/// post-result stdout events.
 ///
-/// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
-/// use the guest-agent's compiled default.
+/// Local execution may pass this legacy name through ordinary user env via
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The runner translates it to
+/// [`CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV`] for Guest bootstrap. Unset,
+/// unparseable, or out-of-range values use the guest-agent's compiled default.
 pub const POST_RESULT_TOTAL_CAP_SECS_ENV: &str = "VM0_POST_RESULT_TOTAL_CAP_SECS";
 
-/// Canonical post-result total-cap alias accepted by guest readers.
+/// Canonical post-result total-cap bootstrap output written by the runner.
 ///
-/// The runner writer and supported local tuning interface remain on
-/// [`POST_RESULT_TOTAL_CAP_SECS_ENV`] during #28914 reader Stage 1.
+/// Guest readers retain [`POST_RESULT_TOTAL_CAP_SECS_ENV`] as a rollback
+/// fallback.
 pub const CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV: &str = "OKOU_POST_RESULT_TOTAL_CAP_SECS";
 
-/// Guest-agent grace period in seconds before escalating from SIGTERM to
-/// SIGKILL after the CLI reports a final result.
+/// Retained local input for the Guest Agent grace period in seconds before
+/// escalating from SIGTERM to SIGKILL after the CLI reports a final result.
 ///
-/// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
-/// use the guest-agent's compiled default.
+/// Local execution may pass this legacy name through ordinary user env via
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The runner translates it to
+/// [`CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV`] for Guest bootstrap. Unset,
+/// unparseable, or out-of-range values use the guest-agent's compiled default.
 pub const POST_RESULT_SIGKILL_GRACE_SECS_ENV: &str = "VM0_POST_RESULT_SIGKILL_GRACE_SECS";
 
-/// Canonical post-result SIGKILL grace alias accepted by guest readers.
+/// Canonical post-result SIGKILL grace bootstrap output written by the runner.
 ///
-/// The runner writer and supported local tuning interface remain on
-/// [`POST_RESULT_SIGKILL_GRACE_SECS_ENV`] during #28914 reader Stage 1.
+/// Guest readers retain [`POST_RESULT_SIGKILL_GRACE_SECS_ENV`] as a rollback
+/// fallback.
 pub const CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV: &str =
     "OKOU_POST_RESULT_SIGKILL_GRACE_SECS";
+
+/// Complete mapping from retained legacy local tuning inputs to canonical
+/// Guest bootstrap outputs.
+///
+/// Each tuple is `(legacy_input, canonical_bootstrap_output)`.
+pub const GUEST_AGENT_TUNING_ENV_MAPPINGS: [(&str, &str); 4] = [
+    (
+        STUCK_TOOL_TIMEOUT_SECS_ENV,
+        CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+    ),
+    (
+        POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+        CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+    ),
+    (
+        POST_RESULT_TOTAL_CAP_SECS_ENV,
+        CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+    ),
+    (
+        POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+        CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+    ),
+];
 
 /// Test/debug bootstrap switch that makes the guest-agent use the mock Claude
 /// binary.
@@ -487,16 +515,17 @@ pub const CANONICAL_MOCK_CODEX_PATH_ENV: &str = "OKOU_MOCK_CODEX_PATH";
 /// boundary.
 pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
 
-/// Runner-owned guest-agent tuning keys that local user env may provide.
+/// Retained legacy Guest Agent tuning inputs that local user env may provide.
 ///
 /// These are the only `VM0_` keys intentionally allowed to cross the local
-/// user-env boundary. They tune guest-agent timing behavior and are copied into
-/// the bootstrap env separately from the general user environment payload.
+/// user-env boundary. The runner translates them to the corresponding canonical
+/// outputs in [`GUEST_AGENT_TUNING_ENV_MAPPINGS`] separately from the general
+/// user environment payload.
 pub const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
-    STUCK_TOOL_TIMEOUT_SECS_ENV,
-    POST_RESULT_SIGTERM_GRACE_SECS_ENV,
-    POST_RESULT_TOTAL_CAP_SECS_ENV,
-    POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+    GUEST_AGENT_TUNING_ENV_MAPPINGS[0].0,
+    GUEST_AGENT_TUNING_ENV_MAPPINGS[1].0,
+    GUEST_AGENT_TUNING_ENV_MAPPINGS[2].0,
+    GUEST_AGENT_TUNING_ENV_MAPPINGS[3].0,
 ];
 
 const EXPLICIT_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
@@ -885,7 +914,28 @@ mod tests {
     }
 
     #[test]
-    fn guest_agent_tuning_keys_are_explicit() {
+    fn guest_agent_tuning_mapping_and_local_inputs_are_explicit() {
+        assert_eq!(
+            GUEST_AGENT_TUNING_ENV_MAPPINGS,
+            [
+                (
+                    STUCK_TOOL_TIMEOUT_SECS_ENV,
+                    CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
+                ),
+                (
+                    POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                    CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                ),
+                (
+                    POST_RESULT_TOTAL_CAP_SECS_ENV,
+                    CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
+                ),
+                (
+                    POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                    CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                ),
+            ]
+        );
         assert_eq!(
             GUEST_AGENT_TUNING_ENV_KEYS,
             [
@@ -903,7 +953,7 @@ mod tests {
         ] {
             assert!(
                 !is_guest_agent_tuning_env_key(key),
-                "canonical reader alias {key} must not become a local tuning input"
+                "canonical bootstrap output {key} must not become a local tuning input"
             );
         }
         for key in [API_URL_ENV, CANONICAL_API_URL_ENV] {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -830,9 +830,11 @@ pub(super) fn insert_guest_agent_tuning_env(
     let Some(user_env) = &context.environment else {
         return;
     };
-    for key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
-        if let Some(value) = user_env.get(*key) {
-            env.insert((*key).into(), value.clone());
+    for (legacy_input, canonical_bootstrap_output) in
+        guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+    {
+        if let Some(value) = user_env.get(legacy_input) {
+            env.insert(canonical_bootstrap_output.into(), value.clone());
         }
     }
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -280,7 +280,7 @@ fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
 }
 
 #[test]
-fn execution_context_validation_rejects_tuning_env_nul_before_sandbox() {
+fn execution_context_validation_rejects_translated_tuning_env_nul_before_sandbox() {
     let secret = "3\0";
     let ctx = context_with_env(HashMap::from([(
         "VM0_STUCK_TOOL_TIMEOUT_SECS".into(),
@@ -291,7 +291,7 @@ fn execution_context_validation_rejects_tuning_env_nul_before_sandbox() {
 
     assert!(error.contains("bootstrap environment"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    assert!(error.contains(guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV));
     assert!(!error.contains(secret));
 }
 
@@ -949,44 +949,64 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
 }
 
 #[test]
-fn build_env_json_keeps_guest_agent_tuning_writer_legacy_only() {
+fn build_env_json_translates_guest_agent_tuning_inputs_to_canonical_outputs() {
     let mut ctx = minimal_context();
-    ctx.environment = Some(HashMap::from([
-        ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
-        ("VM0_POST_RESULT_SIGTERM_GRACE_SECS".into(), "1".into()),
-        ("VM0_POST_RESULT_TOTAL_CAP_SECS".into(), "4".into()),
-        ("VM0_POST_RESULT_SIGKILL_GRACE_SECS".into(), "2".into()),
-        (
-            guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV.into(),
-            "canonical-must-not-write".into(),
-        ),
-        (
-            guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV.into(),
-            "canonical-must-not-write".into(),
-        ),
-        (
-            guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV.into(),
-            "canonical-must-not-write".into(),
-        ),
-        (
-            guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV.into(),
-            "canonical-must-not-write".into(),
-        ),
-    ]));
+    let expected_values = ["3", "", " 4 ", "not-a-duration"];
+    let mut environment = HashMap::new();
+    for ((legacy_input, canonical_bootstrap_output), expected_value) in
+        guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+            .into_iter()
+            .zip(expected_values)
+    {
+        environment.insert(legacy_input.into(), expected_value.into());
+        environment.insert(
+            canonical_bootstrap_output.into(),
+            "hostile-canonical-must-not-override".into(),
+        );
+    }
+    ctx.environment = Some(environment);
 
     let env = build_env_for_test(&ctx, "http://localhost");
 
-    assert_eq!(env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
-    assert_eq!(env.get("VM0_POST_RESULT_SIGTERM_GRACE_SECS").unwrap(), "1");
-    assert_eq!(env.get("VM0_POST_RESULT_TOTAL_CAP_SECS").unwrap(), "4");
-    assert_eq!(env.get("VM0_POST_RESULT_SIGKILL_GRACE_SECS").unwrap(), "2");
-    for key in [
-        guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV,
-        guest_contracts::env::CANONICAL_POST_RESULT_SIGTERM_GRACE_SECS_ENV,
-        guest_contracts::env::CANONICAL_POST_RESULT_TOTAL_CAP_SECS_ENV,
-        guest_contracts::env::CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV,
-    ] {
-        assert!(!env.contains_key(key), "runner writer emitted {key}");
+    for ((legacy_input, canonical_bootstrap_output), expected_value) in
+        guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+            .into_iter()
+            .zip(expected_values)
+    {
+        assert_eq!(
+            env.get(canonical_bootstrap_output).map(String::as_str),
+            Some(expected_value)
+        );
+        assert!(
+            !env.contains_key(legacy_input),
+            "runner writer emitted legacy output {legacy_input}"
+        );
+    }
+}
+
+#[test]
+fn build_env_json_does_not_author_guest_agent_tuning_output_without_legacy_inputs() {
+    let canonical_only_environment = guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+        .into_iter()
+        .map(|(_, canonical_bootstrap_output)| {
+            (
+                canonical_bootstrap_output.into(),
+                "hostile-canonical-must-not-author".into(),
+            )
+        })
+        .collect();
+
+    for environment in [None, Some(canonical_only_environment)] {
+        let mut ctx = minimal_context();
+        ctx.environment = environment;
+        let env = build_env_for_test(&ctx, "http://localhost");
+
+        for (legacy_input, canonical_bootstrap_output) in
+            guest_contracts::env::GUEST_AGENT_TUNING_ENV_MAPPINGS
+        {
+            assert!(!env.contains_key(legacy_input));
+            assert!(!env.contains_key(canonical_bootstrap_output));
+        }
     }
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1104,7 +1104,13 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "tok"
     );
     assert!(!start_env.contains_key(guest_contracts::env::API_TOKEN_ENV));
-    assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
+    assert_eq!(
+        start_env
+            .get(guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV)
+            .map(String::as_str),
+        Some("3")
+    );
+    assert!(!start_env.contains_key(guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV));
     assert_eq!(
         start_env
             .get(guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV)


### PR DESCRIPTION
## Summary

- centralize the exact four-entry legacy-local-input to canonical-bootstrap-output mapping in Guest Contracts while keeping the local allowlist legacy-only
- translate each present legacy timing input to its corresponding `OKOU_*` Runner bootstrap key with an unchanged cloned value, never dual-writing
- cover all four mappings, hostile canonical non-authorship, every legacy output absence, and absent-input behavior in focused contract and Runner tests
- update the existing fresh-sandbox bootstrap assertion to require `OKOU_STUCK_TOOL_TIMEOUT_SECS="3"` and reject legacy output

Closes #30026
Wave 97 of #28914
Reader foundation: #29285
Cleanup prerequisites: #29960, #29961

## Reviewed base and head

- refreshed base: `237f6a84c78087d2fe9a446f3c9c3d040a3f6365`
- reviewed head: `17f444416b5b60688c45e22213cd0c2578bb6326`
- diff: exactly the four authorized files; 158 insertions and 80 deletions

The branch was rebased only onto canonical `origin/main` as it advanced. The final incoming sequence included private-payload writer cutover #30055, release #30054, pre-admission usage recovery #30057, and sandbox-metadata writer cutover #30066. Every authorized-file hunk was inspected: #30055 and #30066 were adjacent to this timing family and were retained unchanged; #30054 and #30057 had no timing overlap.

## Four-pair contract

| Retained local input | Canonical Runner bootstrap output |
| --- | --- |
| `VM0_STUCK_TOOL_TIMEOUT_SECS` | `OKOU_STUCK_TOOL_TIMEOUT_SECS` |
| `VM0_POST_RESULT_SIGTERM_GRACE_SECS` | `OKOU_POST_RESULT_SIGTERM_GRACE_SECS` |
| `VM0_POST_RESULT_TOTAL_CAP_SECS` | `OKOU_POST_RESULT_TOTAL_CAP_SECS` |
| `VM0_POST_RESULT_SIGKILL_GRACE_SECS` | `OKOU_POST_RESULT_SIGKILL_GRACE_SECS` |

`GUEST_AGENT_TUNING_ENV_KEYS` and `is_guest_agent_tuning_env_key` remain limited to the four legacy names. Canonical names remain platform-reserved. `insert_guest_agent_tuning_env` reads only legacy inputs, writes only mapped canonical outputs, clones values exactly, preserves absence, and ignores direct canonical values in `ExecutionContext.environment`.

## Exact inventory

The final branch inventory was rebuilt from literal names, symbols, local-input entry points, the production writer, reader resolution, compatibility states, telemetry, and timing consumers:

- literal spellings: 19 lines / 5 files
- contract and boundary symbols: 166 lines / 23 files
- semantic timing readers/consumers: 82 lines / 16 files
- literal + symbol union: 179 lines / 24 files
- complete literal + symbol + semantic union: 261 lines / 31 files

Complete union by file (`matching lines file`):

```text
11 crates/guest-agent/src/cli/mod.rs
1 crates/guest-agent/src/constants.rs
60 crates/guest-agent/src/env.rs
8 crates/guest-agent/src/main.rs
8 crates/guest-agent/tests/bootstrap_alias_source_events.rs
2 crates/guest-agent/tests/claude_task_notification_result.rs
1 crates/guest-agent/tests/claude_tool_tracking_overflow.rs
21 crates/guest-agent/tests/cli_child_env.rs
11 crates/guest-agent/tests/common/mod.rs
2 crates/guest-agent/tests/execute_cli_api_mode.rs
1 crates/guest-agent/tests/execution_timeout.rs
1 crates/guest-agent/tests/execution_timeout_recovery.rs
16 crates/guest-agent/tests/guest_agent_tuning_env_aliases.rs
1 crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
1 crates/guest-agent/tests/heartbeat_reap_sigkill.rs
1 crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
4 crates/guest-agent/tests/pi_initial_prompt_stdin_reap_sigkill.rs
3 crates/guest-agent/tests/post_result_reap_execution_deadline.rs
3 crates/guest-agent/tests/post_result_reap_refresh.rs
1 crates/guest-agent/tests/post_result_reap_sigkill.rs
2 crates/guest-agent/tests/post_result_reap_total_cap.rs
4 crates/guest-agent/tests/process_control_channel.rs
2 crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
2 crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
2 crates/guest-agent/tests/user_cancellation_recovery.rs
68 crates/guest-contracts/src/env.rs
1 crates/runner/src/cmd/local/submit.rs
7 crates/runner/src/cmd/local/submit/tests/request.rs
3 crates/runner/src/executor/env.rs
9 crates/runner/src/executor/tests/env_tests.rs
4 crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
```

Boundary classification:

- local input: the four constants, exact mapping, derived four-entry allowlist, and predicate are centralized in `guest-contracts`; the only production predicate caller remains local submit
- production writer: the only caller is `crates/runner/src/executor/env.rs:619`; the only writer is `insert_guest_agent_tuning_env` at lines 826-838; no API-process, host configuration, workflow, secret, or second production timing writer exists
- reader and telemetry: the deployed four-pair Guest resolver, value-free source/conflict events, parsing/default/range logic, and symmetric cleanup remain unchanged
- compatibility and tests: absent, legacy-only, canonical-only, equal-dual, conflict, invalid/range, CLI-child isolation, watchdog/post-result/reaping, local-submit enforcement, focused writer, and full-sandbox references are all present in the inventory and unchanged except for the focused writer contract

## Open-PR pagination and overlap audit

The immediate pre-publication numbered-page audit covered 38 open PRs (including this PR) on one complete PR-list page and every changed-file page. GitHub then declared 547 changed files and 547 records were fetched, with zero per-PR or aggregate mismatch. Publication changed only this owned PR's declared count from three to four; its sole page was re-fetched as 4/4, making the publication snapshot 548/548. All PRs had one changed-file page except stale #25722, whose two pages contained 100 and 85 files (185 total).

This PR covers all four authorized files. Exactly one other open PR overlapped the authorized file set:

- stale #25722: `crates/guest-contracts/src/env.rs`, `crates/runner/src/executor/env.rs`, and `crates/runner/src/executor/tests/env_tests.rs`

Every overlap patch was inspected, not inferred from filenames:

- stale #25722 touches Cloudflare Access constants/ownership, HostEnv insertion, and adjacent ownership tests; no timing hunk overlaps

These are inventory, not ordering blockers. No contributor branch was modified, rebased, absorbed, delayed, or pressured.

## Validation

Passed on the reviewed branch:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-features --no-deps`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-features` (134 passed plus doc tests)
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_agent_tuning_env_aliases`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test bootstrap_alias_source_events`
- exact inventory commands and `git diff --check`

The focused Runner/local-submit unit-test binary was attempted unchanged with:

```text
CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path crates/Cargo.toml -p runner --all-features --bin runner guest_agent_tuning
```

Linking was killed with exact exit status 137 after compiling `runner`, before any Rust test executed or emitted a failure. Immediate workload-cgroup evidence recorded `memory.max=3991613440`, `memory.peak=3991617536`, `oom=1`, and `oom_kill=3`, matching the known local approximately 4 GiB linker ceiling. The same Runner binary contains the focused env and local-submit rejection filters, so protected CI is authoritative for those tests; no target or test was weakened.

No full local Vitest suite or development server was run.

## Protected CI evidence

On prior reviewed head `727b62cd715ed4345eab4bea6ad0541067d1baab`, the Crates coverage job reported 3,347 passed, exactly two failed, and 26 ignored Runner tests.

- the NUL test expected the legacy input spelling after bootstrap translation; this head requires the canonical diagnostic key
- the fresh-sandbox test expected legacy bootstrap output; corrected issue #30026 authorizes this fourth file, and this head requires canonical value `"3"` plus explicit legacy absence

No production dual-write or test-only special case was added. The only scope expansion is the controller-authorized stale end-to-end assertion.

## Fallbacks

This change introduces no new fallback. The existing Guest canonical-first/legacy-fallback reader remains intact for rollback. Reverting this single writer commit restores legacy bootstrap output while retaining the dual reader; release and rollback configuration are unchanged.
