### PR TITLE
test(runner): verify dns reservation socket lifetime

### DIFF
--- a/crates/runner/src/dns/port.rs
+++ b/crates/runner/src/dns/port.rs
@@ -84,9 +84,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reserve_port_returns_nonzero() {
+    fn reservation_holds_tcp_and_udp_until_drop() {
         let reservation = reserve_port().unwrap();
-        assert!(reservation.port() > 0);
+        let port = reservation.port();
+
+        let tcp_error = std::net::TcpListener::bind(("0.0.0.0", port)).unwrap_err();
+        assert_eq!(tcp_error.kind(), std::io::ErrorKind::AddrInUse);
+
+        let udp_error = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap_err();
+        assert_eq!(udp_error.kind(), std::io::ErrorKind::AddrInUse);
+
+        drop(reservation);
+
+        let _tcp_listener = std::net::TcpListener::bind(("0.0.0.0", port)).unwrap();
+        let _udp_socket = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap();
     }
 
     fn bind_tcp_udp_pair() -> std::io::Result<(ReservedTcpPort, std::net::UdpSocket)> {


### PR DESCRIPTION
## Summary

- replace the DNS reservation's port-number smoke test with a complete socket-lifetime regression
- verify competing TCP and UDP binds report `AddrInUse` while the production reservation is alive
- verify both protocols can bind the same port again after the reservation is dropped

## Scope

This is a test-only change in the runner DNS port module. It does not change production allocation, retry behavior, visibility, dnsmasq handoff, configuration, persistence, protocols, or deployment compatibility.

Closes #30029

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::port::tests::reservation_holds_tcp_and_udp_until_drop -- --exact`
- focused lifecycle test repeated sequentially 25 times
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner dns::port::tests`
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3347 passed, 26 ignored; guest inventory 1 passed)
- `git diff --check`
- repository pre-commit hooks (workspace Cargo fmt, docs, Clippy, file size, commitlint)
