### PR TITLE
perf(platform): lazy-load mermaid core

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/mermaid-diagram-imports.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/mermaid-diagram-imports.test.ts
@@ -15,8 +15,10 @@ if (sourcePath === undefined) {
 const source = readFileSync(sourcePath, "utf8");
 
 describe("mermaid diagram imports", () => {
-  it("keeps mermaid in the static import graph", () => {
-    expect(source).toMatch(/^import mermaid from "mermaid";$/m);
-    expect(source).not.toMatch(/\bimport\s*\(\s*["']mermaid["']\s*\)/);
+  it("loads mermaid through the diagram computed", () => {
+    expect(source).not.toMatch(/^import mermaid from "mermaid";$/m);
+    expect(source).toMatch(
+      /const mermaidModule\$ = computed\(\(\) => \{\s*return import\("mermaid"\);\s*\}\);/,
+    );
   });
 });

--- a/turbo/apps/platform/src/signals/mermaid-diagram.ts
+++ b/turbo/apps/platform/src/signals/mermaid-diagram.ts
@@ -1,6 +1,5 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { Element, Root } from "hast";
-import mermaid from "mermaid";
 
 import { createObjectUrlResource } from "./object-url-resource.ts";
 import { theme$ } from "./theme.ts";
@@ -9,11 +8,11 @@ import { settle } from "./utils.ts";
 /**
  * Mermaid diagrams render through a pull model. Each diagram source owns one
  * `MermaidDiagramSignals` in the registry of the surface showing it; its
- * `diagram$` computed lays the diagram out and resolves to an image the view
- * shows in an `<img>` — or to `null` when the parser rejects the source, in
- * which case the fence simply stays a code block. Reading the theme inside the
- * computed makes a theme switch re-render every diagram without any
- * remounting.
+ * `diagram$` computed loads mermaid, lays the diagram out and resolves to an
+ * image the view shows in an `<img>` — or to `null` when the parser rejects
+ * the source, in which case the fence simply stays a code block. Reading the
+ * theme inside the computed makes a theme switch re-render every diagram
+ * without any remounting.
  *
  * The command that parses a tree registers each diagram and embeds the
  * returned signals on the marker node, so rendering receives the signals
@@ -69,6 +68,14 @@ export function embedMermaidSignals(
   visitNode(tree);
 }
 
+// Mermaid core adds about 150 KB gzip and is only needed once a diagram
+// renders. Keep it behind the diagram signal; ccstate memoizes the module
+// promise, and the bootstrap preload-error handler owns recovery when a later
+// deployment removes that chunk.
+const mermaidModule$ = computed(() => {
+  return import("mermaid");
+});
+
 /**
  * mermaid needs a DOM id per `render` call. Concurrent renders only happen for
  * distinct code+theme pairs — the same pair is one deduplicated computed — so
@@ -84,6 +91,7 @@ function diagramRenderId(seed: string): string {
 
 /** Returns the diagram SVG, or undefined when the source is not valid mermaid. */
 async function renderDiagramSvg(
+  mermaid: (typeof import("mermaid"))["default"],
   id: string,
   code: string,
 ): Promise<string | undefined> {
@@ -179,8 +187,11 @@ export function createMermaidDiagramSignals(
     if (existing !== undefined) {
       return existing;
     }
+    const mermaidModule = get(mermaidModule$);
     const renderQueue = get(mermaidRenderQueue$);
     const image = (async (): Promise<MermaidDiagramImage | null> => {
+      const { default: mermaid } = await mermaidModule;
+      ownerSignal.throwIfAborted();
       // Read the tail and replace it in the same synchronous block, so two
       // resuming renders cannot both chain onto the same predecessor.
       const previousRender = renderQueue.tail;
@@ -208,7 +219,11 @@ export function createMermaidDiagramSignals(
           themeVariables: { fontSize: "14px" },
           flowchart: { nodeSpacing: 30, rankSpacing: 32, padding: 8 },
         });
-        return renderDiagramSvg(diagramRenderId(`${theme}:${code}`), code);
+        return renderDiagramSvg(
+          mermaid,
+          diagramRenderId(`${theme}:${code}`),
+          code,
+        );
       })();
       renderQueue.tail = render;
       const markup = await render;


### PR DESCRIPTION
## Summary

- move Mermaid core out of the platform startup import graph
- load and memoize the module when a Mermaid diagram signal first renders
- preserve the existing render queue, theme/image caches, and Mermaid's per-diagram renderer splitting
- update the import regression test to enforce the lazy boundary

## Context

#27155 made Mermaid core static to avoid a deployment-time lazy chunk miss, at the cost of roughly 150 KB gzip in startup for every user. The localized `vite:preloadError` recovery added in #29738 now owns the old-open-client case: if a later deployment removes the requested content-hashed chunk, the page asks the user to confirm a refresh.

This change accepts that existing recovery behavior so users without Mermaid diagrams do not download Mermaid core. The first rendered diagram downloads core plus the diagram-specific renderer it needs.

## Verification

- `pnpm format`
- `pnpm exec prettier --check apps/platform/src/signals/mermaid-diagram.ts apps/platform/src/signals/__tests__/mermaid-diagram-imports.test.ts`
- `pnpm --filter @okouai/app run lint`
- `pnpm knip`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/mermaid-diagram-imports.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/mermaid-diagram.test.ts`

## Build note

`pnpm --filter @okouai/app run build` transformed 7,491 modules successfully, then the local container was OOM-killed with exit 137 during final chunk generation. The PR pipeline build remains the authoritative production-bundle check.
