### PR TITLE
fix(mitm-addon): reject uninspectable billable responses

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -38,6 +38,7 @@ from usage.underbilling import log_usage_underbilling
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
+_HTTP_STATUS_BAD_GATEWAY = 502
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
@@ -74,6 +75,7 @@ class _ResponseStreamSetup(NamedTuple):
     parser: _ResponseChunkParser | None
     needs_buffered_fallback: bool
     finish_stream: Callable[[], object] | None = None
+    reject_uninspectable: bool = False
 
 
 def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
@@ -268,7 +270,15 @@ def _configure_response_inspection_stream(
                         flow,
                         failure_observer.finish,
                     )
-                return _ResponseStreamSetup(None, False)
+                return _ResponseStreamSetup(
+                    None,
+                    False,
+                    reject_uninspectable=(
+                        is_billable_flow
+                        and is_observable_model_provider
+                        and _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
+                    ),
+                )
 
             finished = False
 
@@ -341,11 +351,20 @@ def _configure_response_inspection_stream(
                     flow,
                     failure_observer.finish,
                 )
-            return _ResponseStreamSetup(
-                None,
+            needs_buffered_fallback = (
                 is_observable_model_provider
                 and uses_model_json_fallback(flow)
-                and body_decoding.can_decode_json_usage_body(response.headers),
+                and body_decoding.can_decode_json_usage_body(response.headers)
+            )
+            return _ResponseStreamSetup(
+                None,
+                needs_buffered_fallback,
+                reject_uninspectable=(
+                    is_billable_flow
+                    and is_observable_model_provider
+                    and _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
+                    and not needs_buffered_fallback
+                ),
             )
 
         inspection: usage.ModelJsonResponseInspection | None = None
@@ -389,16 +408,21 @@ def _configure_response_inspection_stream(
         return _ResponseStreamSetup(None, False)
     if not body_decoding.can_stream_decode_usage(response.headers):
         firewall_name = flow_metadata.firewall_name(flow.metadata)
-        if (
+        requires_response_inspection = (
             _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
             and usage.has_connector_response_parser(firewall_name)
-        ):
+        )
+        if requires_response_inspection:
             _maybe_log_response_encoding_inspection_risk(flow, response)
-        return _ResponseStreamSetup(
-            None,
+        needs_buffered_fallback = (
             http_response_classification.can_have_body(flow, response)
             and body_decoding.can_decode_json_usage_body(response.headers)
-            and usage.needs_connector_response_buffer_fallback(flow),
+            and usage.needs_connector_response_buffer_fallback(flow)
+        )
+        return _ResponseStreamSetup(
+            None,
+            needs_buffered_fallback,
+            reject_uninspectable=(requires_response_inspection and not needs_buffered_fallback),
         )
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
@@ -460,6 +484,20 @@ def is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
     return response_accept == expected_accept
 
 
+def _discard_uninspectable_response_body(_chunk: bytes) -> bytes:
+    return b""
+
+
+def _reject_uninspectable_response(flow: http.HTTPFlow) -> None:
+    model_provider_failure.release_flow(flow)
+    flow.response = http.Response.make(
+        _HTTP_STATUS_BAD_GATEWAY,
+        b"",
+        {"Content-Type": "text/plain"},
+    )
+    flow.response.stream = _discard_uninspectable_response_body
+
+
 def configure_response_stream(flow: http.HTTPFlow) -> None:
     """Enable pass-through response streaming and body consumers.
 
@@ -472,10 +510,14 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
 
     metrics = {"total_bytes": 0}
     failure_observer = model_provider_failure.configure_response_observer(flow)
-    response_parser, needs_buffered_fallback, finish_stream = _configure_response_inspection_stream(
-        flow,
-        failure_observer,
-    )
+    setup = _configure_response_inspection_stream(flow, failure_observer)
+    if setup.reject_uninspectable:
+        _reject_uninspectable_response(flow)
+        return
+
+    response_parser = setup.parser
+    needs_buffered_fallback = setup.needs_buffered_fallback
+    finish_stream = setup.finish_stream
     retain_body = flow_metadata.should_capture_body(flow.metadata) or needs_buffered_fallback
     buf = bytearray() if retain_body else None
     buffer_state = {"truncated": False} if retain_body else None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -39,6 +39,7 @@ from .x_billing import (
 )
 from .x_response_inspection import (
     as_non_negative_response_count,
+    is_stream_path,
     parse_json_response_fields_from_body,
 )
 
@@ -618,7 +619,8 @@ def _response_usage_context(flow: http.HTTPFlow) -> _ResponseUsageContext | None
 
 def needs_response_buffer_fallback(flow: http.HTTPFlow) -> bool:
     """Return whether X billing may consume a buffered response body."""
-    return _response_usage_context(flow) is not None
+    context = _response_usage_context(flow)
+    return context is not None and not is_stream_path(context.request_path)
 
 
 def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
@@ -42,7 +42,7 @@ _STREAM_ENDPOINTS = frozenset(
 )
 
 
-def _is_stream_path(path: str) -> bool:
+def is_stream_path(path: str) -> bool:
     """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
 
     Exact match only — ``/2/tweets/search/stream/rules`` (rules management)
@@ -326,7 +326,7 @@ def create_response_parser(
         # Use the dispatcher-required original URL so parser registration and
         # final request metadata cannot diverge.
         stream_path = urllib.parse.urlparse(original_url).path
-        if _is_stream_path(stream_path):
+        if is_stream_path(stream_path):
             extractor = _NdjsonExtractor()
             # Deliberately NOT "model_provider_usage" — that key routes through
             # report_model_provider_usage and triggers the model-provider webhook.

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1663,6 +1663,41 @@ def test_conflicting_sse_event_type_is_not_reported(
         mitm_addon.response(flow)
 
 
+def test_uninspectable_billable_success_is_not_reported_as_provider_failure(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        firewall_name="model-provider:anthropic-api-key",
+        request_path="/v1/messages",
+        response_headers=header_map(
+            {
+                "content-type": "text/event-stream",
+                "content-encoding": "br",
+            }
+        ),
+    )
+    flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    stream = response_stream(flow)
+    assert stream(b"uninspectable upstream bytes") == b""
+    assert stream(b"") == b""
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
 def test_sse_failure_is_reported_before_response_hook(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage_openai_responses.py
@@ -161,7 +161,7 @@ class TestOpenAIResponsesSseUsage:
         assert model_sse_parse_warnings(flow) == []
 
     @pytest.mark.parametrize("capture_body", [False, True])
-    def test_brotli_sse_does_not_use_model_json_fallback(self, tmp_path, real_flow, capture_body):
+    def test_brotli_sse_is_rejected_without_body_capture(self, tmp_path, real_flow, capture_body):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         assert flow.response is not None
         flow.response.headers["content-encoding"] = "br"
@@ -174,9 +174,10 @@ class TestOpenAIResponsesSseUsage:
         )
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(brotli.compress(plaintext))
-        assert (metadata_keys.STREAM_BUFFER in flow.metadata) is capture_body
-        assert (metadata_keys.STREAM_BUFFER_STATE in flow.metadata) is capture_body
+        assert flow.response.status_code == 502
+        assert response_stream(flow)(brotli.compress(plaintext)) == b""
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         webhook = run_response(flow, self._usage_webhook_api)
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -8,6 +8,7 @@ from typing import Never
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mitmproxy import http
 from mitmproxy.flow import Error
 
 import auth
@@ -16,6 +17,7 @@ import mitm_addon
 import terminal_usage
 import usage
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.flow_helpers import response_stream
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
 from tests.requestheaders_helpers import await_requestheaders_result
@@ -802,6 +804,67 @@ async def test_billable_model_provider_records_model_usage_provider(
         buffered=0,
         reports=0,
         flush_request_id="request-1",
+    )
+
+
+async def test_billable_model_provider_rejects_uninspectable_response_and_drains_tracking(
+    tmp_path,
+    usage_pending_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    usage_webhook_server,
+):
+    reg_path = _write_model_provider_tracking_registry(
+        tmp_path,
+        billable=True,
+        sandbox_fields={"modelUsageProvider": "claude-sonnet-4-6"},
+    )
+    flow = _model_provider_tracking_flow(real_flow)
+    flow.request.headers["Accept-Encoding"] = "br, identity;q=0"
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+        assert flow.request.headers["Accept-Encoding"] == "br, identity;q=0"
+        usage.write_pending_snapshot(flush_request_id="before-response")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="before-response",
+        )
+
+        flow.response = http.Response.make(
+            200,
+            b"",
+            {
+                "Content-Type": "text/event-stream",
+                "Content-Encoding": "br",
+            },
+        )
+        mitm_addon.responseheaders(flow)
+
+        assert flow.response.status_code == 502
+        assert flow.response.content == b""
+        stream = response_stream(flow)
+        assert stream(b"uninspectable upstream bytes") == b""
+        assert stream(b"") == b""
+        mitm_addon.response(flow)
+        assert usage.flush_usage_events(trigger="test") == 0
+
+    assert usage_webhook_server.request_count == 0
+    usage.write_pending_snapshot(flush_request_id="after-response")
+    assert_pending(
+        usage_pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="after-response",
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -172,6 +172,28 @@ class TestResponseEncodingInspectionRisk:
         upstream_chunk = b"non-billable-brotli"
         assert response_stream(flow)(upstream_chunk) == upstream_chunk
 
+    def test_unsuccessful_billable_model_sse_keeps_pass_through(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="br",
+            content_type="text/event-stream",
+        )
+        assert flow.response is not None
+        flow.response.status_code = 429
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["status_code"] == 429
+        assert flow.response.status_code == 429
+        upstream_chunk = b"upstream-error-brotli"
+        assert response_stream(flow)(upstream_chunk) == upstream_chunk
+
     def test_non_observable_model_response_does_not_log_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
     ) -> None:

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -49,29 +49,41 @@ class TestResponseEncodingInspectionRisk:
         return flow
 
     @pytest.mark.parametrize(
-        ("content_encoding", "content_type", "decode_skip_reason"),
+        (
+            "content_encoding",
+            "content_type",
+            "decode_skip_reason",
+            "rejected",
+            "buffered_fallback",
+        ),
         [
             pytest.param(
                 "zstd",
                 "application/json",
                 "zstd streaming output cannot be hard-bounded",
+                False,
+                True,
                 id="model-json-zstd",
             ),
             pytest.param(
                 "br",
                 "text/event-stream",
                 "brotli streaming output cannot be bounded",
+                True,
+                False,
                 id="model-sse-brotli",
             ),
             pytest.param(
                 "private-encoding-value",
                 "application/json",
                 "unsupported content encoding",
+                True,
+                False,
                 id="model-json-unknown",
             ),
         ],
     )
-    def test_observable_model_provider_logs_non_streamable_encoding_risk(
+    def test_billable_model_provider_rejects_only_without_accounting_fallback(
         self,
         real_flow,
         tmp_path,
@@ -79,6 +91,8 @@ class TestResponseEncodingInspectionRisk:
         content_encoding: str,
         content_type: str,
         decode_skip_reason: str,
+        rejected: bool,
+        buffered_fallback: bool,
     ) -> None:
         flow = self._model_flow(
             real_flow,
@@ -99,7 +113,12 @@ class TestResponseEncodingInspectionRisk:
         assert entry["firewall_name"] == "model-provider:anthropic-api-key"
         assert entry["status_code"] == 200
         assert entry["decode_skip_reason"] == decode_skip_reason
-        assert callable(response_stream(flow))
+        upstream_chunk = b"compressed-upstream"
+        assert response_stream(flow)(upstream_chunk) == (b"" if rejected else upstream_chunk)
+        assert flow.response is not None
+        assert flow.response.status_code == (502 if rejected else 200)
+        assert (metadata_keys.STREAM_BUFFER in flow.metadata) is buffered_fallback
+        assert (metadata_keys.STREAM_BUFFER_STATE in flow.metadata) is buffered_fallback
 
     def test_unknown_encoding_value_is_not_persisted(self, real_flow, tmp_path, mitm_ctx) -> None:
         flow = self._model_flow(
@@ -115,6 +134,9 @@ class TestResponseEncodingInspectionRisk:
         assert "private-encoding-value" not in str(entry)
         assert "private-encoding-value" not in log.debug.call_args.args[0]
         assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert response_stream(flow)(b"unknown-encoding-body") == b""
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
@@ -128,6 +150,27 @@ class TestResponseEncodingInspectionRisk:
 
         assert "model_json_usage_finish" in flow.metadata
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+
+    def test_non_billable_observable_model_sse_keeps_pass_through(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="br",
+            content_type="text/event-stream",
+        )
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        upstream_chunk = b"non-billable-brotli"
+        assert response_stream(flow)(upstream_chunk) == upstream_chunk
 
     def test_non_observable_model_response_does_not_log_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
@@ -188,6 +231,12 @@ class TestResponseEncodingInspectionRisk:
         assert entry["firewall_name"] == "x"
         assert entry["status_code"] == 200
         assert entry["decode_skip_reason"] == "zstd streaming output cannot be hard-bounded"
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        upstream_chunk = b"bounded-json-fallback"
+        assert response_stream(flow)(upstream_chunk) == upstream_chunk
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
     def test_unknown_connector_encoding_does_not_retain_unusable_fallback(
         self, real_flow, tmp_path, mitm_ctx
@@ -204,6 +253,36 @@ class TestResponseEncodingInspectionRisk:
         [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert entry["reason"] == "response_encoding_not_stream_decodable"
         assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert response_stream(flow)(b"unknown-connector-encoding") == b""
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+
+    @pytest.mark.parametrize("content_encoding", ["br", "zstd"])
+    def test_billable_connector_stream_rejects_non_streamable_encoding(
+        self,
+        real_flow,
+        tmp_path,
+        mitm_ctx,
+        content_encoding: str,
+    ) -> None:
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/stream",
+            rule="GET /2/tweets/search/stream",
+            content_encoding=content_encoding,
+        )
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert response_stream(flow)(b"compressed-ndjson") == b""
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
@@ -238,5 +317,7 @@ class TestResponseEncodingInspectionRisk:
             mitm_addon.responseheaders(flow)
 
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+        assert flow.response is not None
+        assert flow.response.status_code == response_status
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata


### PR DESCRIPTION
## Summary

- Fail closed with an empty local 502 when a successful billable model or connector response cannot be inspected by either an incremental parser or an applicable bounded terminal fallback.
- Discard all upstream response bytes after rejection and release model-provider failure state so the proxy-generated response is not reported as a provider outage.
- Keep bounded JSON fallback for ordinary X responses while excluding X NDJSON stream endpoints that require incremental parser state.

## Explicit exclusions

- Non-billable observable model responses, non-billable connectors, bodyless responses, non-2xx responses, and connectors without response-body accounting parsers retain their existing behavior.
- This does not add a request-time rejection gate; the actual response encoding remains authoritative.
- No API, persisted-state, queue, database, or cross-version protocol changes are included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,189 passed)
- `lefthook run pre-commit`

Closes #30035
