### PR TITLE
refactor(runner): cut sandbox metadata writers to canonical aliases

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -51,28 +51,30 @@ pub const API_TOKEN_ENV: &str = "VM0_API_TOKEN";
 pub const CANONICAL_API_TOKEN_ENV: &str = "OKOU_API_TOKEN";
 
 /// Sandbox identifier assigned by the runner.
+///
+/// Guest readers retain this legacy alias as a rollback fallback.
 pub const SANDBOX_ID_ENV: &str = "VM0_SANDBOX_ID";
 
-// These four canonical aliases are reader-only during #28914 migration Stage 1.
-// Runner writers keep using the legacy constants until the deployed reader floor,
-// sandbox drain, rollback window, and legacy-read-zero gates are complete.
-// #28914 owns creation of the later writer-cutover and reader-removal issues.
-/// Canonical alias for the sandbox identifier accepted by guest readers.
+/// Canonical alias for the sandbox identifier written by the runner.
 pub const CANONICAL_SANDBOX_ID_ENV: &str = "OKOU_SANDBOX_ID";
 
 /// Wire value for the runner's sandbox-reuse decision.
 ///
 /// `reused` means an idle VM was unparked. Other values describe why reuse did
 /// not happen, such as `poolMiss` or `noReuseKey`.
+///
+/// Guest readers retain this legacy alias as a rollback fallback.
 pub const SANDBOX_REUSE_RESULT_ENV: &str = "VM0_SANDBOX_REUSE_RESULT";
 
-/// Canonical alias for the sandbox-reuse decision accepted by guest readers.
+/// Canonical alias for the sandbox-reuse decision written by the runner.
 pub const CANONICAL_SANDBOX_REUSE_RESULT_ENV: &str = "OKOU_SANDBOX_REUSE_RESULT";
 
 /// Wire value for the runner's final workspace-reuse decision.
+///
+/// Guest readers retain this legacy alias as a rollback fallback.
 pub const WORKSPACE_REUSE_RESULT_ENV: &str = "VM0_WORKSPACE_REUSE_RESULT";
 
-/// Canonical alias for the workspace-reuse decision accepted by guest readers.
+/// Canonical alias for the workspace-reuse decision written by the runner.
 pub const CANONICAL_WORKSPACE_REUSE_RESULT_ENV: &str = "OKOU_WORKSPACE_REUSE_RESULT";
 
 /// Logical run-payload field name for the user prompt.

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -595,7 +595,7 @@ fn build_env_json_with_host_env_inner(
         context.sandbox_token.clone(),
     );
     env.insert(
-        guest_contracts::env::SANDBOX_ID_ENV.into(),
+        guest_contracts::env::CANONICAL_SANDBOX_ID_ENV.into(),
         sandbox_id.into(),
     );
     env.insert(
@@ -603,12 +603,12 @@ fn build_env_json_with_host_env_inner(
         guest_runtime_dir(context.run_id)?,
     );
     env.insert(
-        guest_contracts::env::SANDBOX_REUSE_RESULT_ENV.into(),
+        guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV.into(),
         reuse_result.as_wire().into(),
     );
     if let Some(workspace_reuse_result) = workspace_reuse_result {
         env.insert(
-            guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV.into(),
+            guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV.into(),
             workspace_reuse_result.as_wire().into(),
         );
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -12,10 +12,10 @@ use super::super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::super::env::{
-    HostEnv, build_env_json_with_host_env, build_run_payload_for_run, build_user_env_json,
-    guest_connector_account_context_file_path, is_runner_owned_env_key,
-    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
-    write_connector_account_context_file,
+    HostEnv, build_env_json_with_host_env, build_env_json_with_host_env_for_run,
+    build_run_payload_for_run, build_user_env_json, guest_connector_account_context_file_path,
+    is_runner_owned_env_key, validate_execution_context_before_sandbox,
+    validate_model_provider_env_placeholders, write_connector_account_context_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -32,6 +32,7 @@ use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
 use crate::types::{
     ConnectorRuntimeTargetRegistration, ExecutionContext, ResumeSession, SandboxReuseResult,
+    WorkspaceReuseResult,
 };
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
@@ -434,7 +435,16 @@ fn model_provider_env_placeholder_validation_accepts_codex_oauth_placeholders() 
 #[test]
 fn build_env_json_required_keys() {
     let ctx = minimal_context();
-    let env = build_env_for_test(&ctx, "https://api.example.com");
+    let sandbox_id = "00000000-0000-4000-8000-000000000abc";
+    let env = build_env_json_with_host_env_for_run(
+        &ctx,
+        "https://api.example.com",
+        sandbox_id,
+        SandboxReuseResult::Reused,
+        WorkspaceReuseResult::SandboxReused,
+        &HostEnv::default(),
+    )
+    .expect("test env should build");
 
     assert_eq!(
         env.get("VM0_API_BACKEND_URL").unwrap(),
@@ -467,17 +477,20 @@ fn build_env_json_required_keys() {
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
     // checkpoint lands before sandbox teardown.
-    assert!(
-        env.get("VM0_SANDBOX_ID")
-            .unwrap()
-            .parse::<uuid::Uuid>()
-            .is_ok()
-    );
-    assert_eq!(env.get("VM0_SANDBOX_REUSE_RESULT").unwrap(), "reused");
     assert_eq!(
-        env.get(guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV)
-            .unwrap(),
-        "sandboxReused"
+        env.get(guest_contracts::env::CANONICAL_SANDBOX_ID_ENV)
+            .map(String::as_str),
+        Some(sandbox_id)
+    );
+    assert_eq!(
+        env.get(guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV)
+            .map(String::as_str),
+        Some("reused")
+    );
+    assert_eq!(
+        env.get(guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV)
+            .map(String::as_str),
+        Some("sandboxReused")
     );
     assert_eq!(
         env.get(guest_contracts::env::CANONICAL_API_START_TIME_ENV)
@@ -485,14 +498,14 @@ fn build_env_json_required_keys() {
         ""
     );
     assert!(!env.contains_key(guest_contracts::env::API_START_TIME_ENV));
-    for canonical_key in [
-        guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
-        guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
-        guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV,
+    for legacy_key in [
+        guest_contracts::env::SANDBOX_ID_ENV,
+        guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,
+        guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV,
     ] {
         assert!(
-            !env.contains_key(canonical_key),
-            "reader Stage 1 must not emit canonical key {canonical_key}"
+            !env.contains_key(legacy_key),
+            "canonical writer emitted legacy key {legacy_key}"
         );
     }
 }
@@ -536,7 +549,30 @@ fn build_env_json_sandbox_reuse_result_wire_format() {
             &HostEnv::default(),
         )
         .expect("test env should build");
-        assert_eq!(env.get("VM0_SANDBOX_REUSE_RESULT").unwrap(), expected);
+        assert_eq!(
+            env.get(guest_contracts::env::CANONICAL_SANDBOX_ID_ENV)
+                .map(String::as_str),
+            Some(sid.as_str())
+        );
+        assert_eq!(
+            env.get(guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV)
+                .map(String::as_str),
+            Some(expected)
+        );
+        assert!(
+            !env.contains_key(guest_contracts::env::CANONICAL_WORKSPACE_REUSE_RESULT_ENV),
+            "no-workspace builder emitted canonical workspace reuse metadata"
+        );
+        for legacy_key in [
+            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,
+            guest_contracts::env::WORKSPACE_REUSE_RESULT_ENV,
+        ] {
+            assert!(
+                !env.contains_key(legacy_key),
+                "canonical writer emitted legacy key {legacy_key}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- cut the Runner's sandbox ID, sandbox reuse result, and optional workspace reuse result bootstrap writers to their canonical `OKOU_*` aliases
- preserve the caller-provided sandbox ID, all reuse `as_wire()` values, the workspace `Some`/`None` behavior, and the settled production workspace result
- strengthen only the focused Runner env assertions for exact canonical values, legacy absence, all six sandbox-reuse wires, and the lower-level no-workspace path
- keep every legacy constant, compatibility reader, source-telemetry path, ownership guard, cleanup path, and adjacent environment family unchanged

Closes #30021.
Parent EPIC: #28914.
Reader prerequisite: #28982 / #29022.
Same-checkout prerequisite: #29956 / #29962.

## Contract preservation

- canonical-only output: no dual writes
- `sandbox_id` is inserted without transformation
- `SandboxReuseResult::as_wire()` remains byte-for-byte unchanged for `reused`, `noReuseKey`, `poolMiss`, `profileMismatch`, `deviceLimitMismatch`, and `unparkFailed`
- `WorkspaceReuseResult::as_wire()` and its ten variants remain unchanged; production still passes the settled `start.workspace_reuse_result`
- `build_env_json_with_host_env` still supplies `None`, while `build_env_json_with_host_env_for_run` still supplies `Some(workspace_reuse_result)`
- the guest reader still resolves canonical-only, legacy-only, equal dual, absent/empty/non-Unicode, and conflicting aliases exactly as before and still emits value-free `run_metadata_env_source` evidence

## Reviewed base and head

- publication base: `763e8ab9d7949514f9a9f7013e4e9746059caa54`
- reviewed head: `a913c86879ee623b7e96501839195412dfd065a7`
- focused diff: 3 authorized files, 69 insertions, 31 deletions

## Exact inventory evidence

### Before editing

The pre-edit snapshot was collected on `8e9d333effada141917385e0482bcc35fd419fab` before the first file edit.

- exact six-symbol inventory: 105 lines across 26 files; SHA-256 `a6f529dcca1875d971240914c11cbffb097792064925593c4d9ece5d03b15464`
- literal refs/files: `VM0_SANDBOX_ID` 5/4, `OKOU_SANDBOX_ID` 2/1, `VM0_SANDBOX_REUSE_RESULT` 6/4, `OKOU_SANDBOX_REUSE_RESULT` 2/1, `VM0_WORKSPACE_REUSE_RESULT` 2/1, `OKOU_WORKSPACE_REUSE_RESULT` 2/1
- symbol refs/files: legacy/canonical sandbox ID 7/6 and 31/23; legacy/canonical sandbox reuse 7/6 and 31/23; legacy/canonical workspace reuse 8/7 and 12/7
- fully paginated open-PR audit: list pages `[28]`; GitHub declared 474 changed files and 474 were fetched, with zero mismatches. Actual authorized-file patches existed only in #25722 (Cloudflare Access) and #30020 (execution timeout). #30020 subsequently merged into `main` and was preserved by the rebases.

### Immediately before publication

The inventory was repeated on publication base/head `763e8ab9d7949514f9a9f7013e4e9746059caa54` / `a913c86879ee623b7e96501839195412dfd065a7`.

- exact six-symbol inventory: 104 lines across 24 files; SHA-256 `089cac233602b579efd546ea4fab3e368186893a6d1a13c172017c9d5e004565`
- literal refs/files: `VM0_SANDBOX_ID` 4/3, `OKOU_SANDBOX_ID` 2/1, `VM0_SANDBOX_REUSE_RESULT` 4/3, `OKOU_SANDBOX_REUSE_RESULT` 2/1, `VM0_WORKSPACE_REUSE_RESULT` 2/1, `OKOU_WORKSPACE_REUSE_RESULT` 2/1
- symbol refs/files: legacy/canonical sandbox ID 8/6 and 33/24; legacy/canonical sandbox reuse 8/6 and 33/24; legacy/canonical workspace reuse 8/6 and 14/8
- production writers are exactly `crates/runner/src/executor/env.rs:598`, `:606`, and `:611`, all canonical; no production legacy writer remains for these families
- the sole production call remains `agent_run.rs:2065-2070`, forwarding `sandbox.id()`, `start.reuse_result`, and settled `start.workspace_reuse_result`
- readers remain the three `run_metadata_env_or_empty` calls in `guest-agent/src/env.rs:663-679`; the current five-pair matrix (including newer API-start/resume work on `main`) retains these three canonical/legacy pairs unchanged
- test-symbol inventory is 68 refs across 20 test files: 19 Guest Agent reader/source/cleanup/same-checkout fixtures plus `runner/src/executor/tests/env_tests.rs` (12 refs). The two focused Runner tests independently assert exact canonical values and all three legacy absences; the reuse table covers all six wire values and canonical plus legacy workspace absence on the no-workspace builder.
- telemetry inventory retains one fixed `run_metadata_env_source` entry per family at `bootstrap_alias_source_events.rs:71-80`; payload values are not logged
- CLI-child isolation still rejects the legacy literals, symmetric test cleanup still contains all six aliases, and the temporary `VM0_*` ownership guard is unchanged
- `SandboxReuseResult`, `WorkspaceReuseResult`, serde mappings, `as_wire()` mappings, diagnostics/finalization callers, completion metadata, checkpointing, reporting, and telemetry have no diff

## Fully paginated publication overlap audit

- open-PR list pages: `[38]`
- changed files: GitHub declared 516; fetched 516; mismatches 0
- every changed-file endpoint was requested with `per_page=100 --paginate --slurp`; #25722 produced pages `[100,85]`, and every other open PR fit on one reconciled page
- #30060 (`727b62cd715ed4345eab4bea6ad0541067d1baab`) touches all three files for the separate timing-tuning family; inspected hunks are at Guest Contracts tuning docs/mappings, `insert_guest_agent_tuning_env`, and its focused tests, not the sandbox/reuse writer hunks
- #30055 (`9f8f149b34bc90dda85ec8f90e0d418f89ac9461`) touches only Guest Contracts private-payload pointer rustdoc, not these symbols or writer hunks
- #25722 (`2aed1f0de2a54db881ca266151c1362ea6c9dd62`) touches all three files for Cloudflare Access constants, host forwarding, ownership, and tests; its stale-base patches contain no sandbox/reuse symbol or wire-value change

These overlaps are inventory only and did not change publication order or scope.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p runner --all-features --no-deps --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-features --locked` (134 passed)
- exact literal/symbol/writer/reader/test/telemetry/caller inventories described above
- `git diff --check origin/main...HEAD`

### Local Runner test limitation

The exact focused Runner command reached the final monolithic Runner test-binary link and was killed before any test assertion ran:

`CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner --all-features --bin runner executor::tests::env_tests::build_env_json_required_keys -- --exact`

It exited 137 at the known local ceiling (`memory.max=3,997,175,808`, `memory.peak=3,995,856,896`; `oom_kill=3`, `oom_group_kill=1` at capture). The second exact test uses the same unavailable binary and was not redundantly relinked. Strict all-target/all-feature Clippy and check type-checked both focused tests; protected CI remains the runtime authority without weakened coverage.

## Fallbacks

- retained rollback fallback: deployed Guest Agent readers continue accepting the three legacy `VM0_*` aliases
- removal gate remains owned by #28914 after the supported reader floor, sandbox drain, rollback window, and legacy-read-zero evidence
- rollback of this writer cutover is a normal revert; this PR introduces no new compatibility branch or rollback configuration
