### PR TITLE
docs(rust): document nbd-cow benchmark invocation and prerequisites

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -59,6 +59,30 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 - [Multi-architecture rollout](../docs/runner-multi-architecture.md): select,
   build, deploy, and validate architecture-specific runner artifacts.
 
+## nbd-cow Benchmark
+
+The `nbd-cow` benchmark compares NBD COW with dm-snapshot using fio workloads. It is an opt-in,
+feature-gated benchmark that must run as root on a host with the required device tooling.
+
+Run it from the repository root:
+
+```bash
+cargo run --manifest-path crates/Cargo.toml -p nbd-cow --features bench --bin bench -- [base-size-mb]
+```
+
+`base-size-mb` is optional. It specifies the base image size in MB, defaults to 1024 MB, and must
+be at least 1024 MB (inclusive).
+
+Before running the benchmark, ensure that:
+
+- the process runs as root;
+- `fio`, `losetup`, and `dmsetup` are available on `PATH`; and
+- the NBD kernel module is loaded:
+
+  ```bash
+  modprobe nbd nbds_max=4096
+  ```
+
 ## Logging
 
 Runner Rust logs are recorded to local files, stderr, and CI at `info` and

--- a/crates/nbd-cow/src/bin/bench/args.rs
+++ b/crates/nbd-cow/src/bin/bench/args.rs
@@ -24,7 +24,10 @@ pub(crate) fn parse_bench_args(args: &[String]) -> Result<BenchCommand, String> 
 }
 
 pub(crate) fn usage() -> &'static str {
-    "usage: bench [base-size-mb]"
+    "NBD COW vs dm-snapshot benchmark\n\n\
+Usage:\n  cargo run --manifest-path crates/Cargo.toml -p nbd-cow --features bench --bin bench -- [base-size-mb]\n\n\
+Arguments:\n  [base-size-mb]  Base image size in MB (default: 1024 MB; inclusive minimum: 1024 MB)\n\n\
+Requirements:\n  - Run as root.\n  - fio, losetup, and dmsetup must be available on PATH.\n  - The NBD kernel module must be loaded:\n    modprobe nbd nbds_max=4096"
 }
 
 pub(crate) fn base_size_bytes(base_size_mb: u64) -> Option<u64> {
@@ -59,7 +62,29 @@ mod tests {
         assert!(invalid.contains("invalid base image size"), "{invalid}");
 
         let extra = parse_bench_args(&["1024".to_string(), "extra".to_string()]).unwrap_err();
-        assert!(extra.contains("usage"), "{extra}");
+        assert!(extra.contains("Usage:"), "{extra}");
+    }
+
+    #[test]
+    fn usage_describes_benchmark_invocation_and_prerequisites() {
+        let help = usage();
+
+        for expected in [
+            "NBD COW vs dm-snapshot benchmark",
+            "cargo run --manifest-path crates/Cargo.toml -p nbd-cow --features bench --bin bench -- [base-size-mb]",
+            "Base image size in MB",
+            "default: 1024 MB",
+            "inclusive minimum: 1024 MB",
+            "Run as root",
+            "fio, losetup, and dmsetup",
+            "NBD kernel module",
+            "modprobe nbd nbds_max=4096",
+        ] {
+            assert!(
+                help.contains(expected),
+                "missing {expected:?} from help: {help}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Document the feature-gated `nbd-cow` benchmark invocation in the Rust workspace README.
- Expand `bench --help` with the benchmark purpose, base-size semantics, and host prerequisites.
- Add focused help-content assertions without changing benchmark workload or device behavior.

## Scope

The benchmark remains an explicit `bench` feature and binary target. The normal run remains root-only and still requires `fio`, `losetup`, `dmsetup`, and the loaded NBD kernel module. No workload, device setup, manifest, migration, or runtime behavior was changed.

Closes #30075

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p nbd-cow --features bench --bin bench`
- `cargo run --manifest-path crates/Cargo.toml -p nbd-cow --features bench --bin bench -- --help`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `env PATH=/nonexistent crates/target/debug/bench --help`
