### PR TITLE
docs(rust): document valid exec-start process contracts

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -105,6 +105,11 @@
 //! - `0x00`: ordinary contained workload.
 //! - `0x01`: controlled Agent operation.
 //!
+//! `lifecycle`, `process_role`, and `control_policy` are validated as one
+//! process contract. See [`ExecStartEncodeRequest`] for the complete matrix;
+//! [`validate_exec_process_contract`] is applied by both
+//! [`encode_exec_start_with_expected_exit_codes`] and [`decode_exec_start`].
+//!
 //! `timeout_policy` values:
 //!
 //! - `0x00`: `[4B positive timeout_ms]`.

--- a/crates/vsock-proto/src/payloads/exec_operation/start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/start.rs
@@ -116,6 +116,23 @@ pub enum ExecControlPolicy {
 }
 
 /// Parameters for encoding an exec_start payload with extended metadata.
+///
+/// # Process contract
+///
+/// The `lifecycle`, `role`, and `control` fields form one semantic contract. The
+/// following combinations are accepted:
+///
+/// | Role | Lifecycle | Control | Meaning |
+/// | --- | --- | --- | --- |
+/// | [`ExecProcessRole::Workload`] | [`ExecLifecyclePolicy::OneShot`] | [`ExecControlPolicy::Disabled`] | One-shot contained workload |
+/// | [`ExecProcessRole::Workload`] | [`ExecLifecyclePolicy::Supervised`] | [`ExecControlPolicy::Disabled`] | Ordinary supervised workload |
+/// | [`ExecProcessRole::Workload`] | [`ExecLifecyclePolicy::Supervised`] | `Enabled { sink: false, .. }` | Controlled supervised workload without a guest sink |
+/// | [`ExecProcessRole::Agent`] | [`ExecLifecyclePolicy::Supervised`] | `Enabled { sink: true, .. }` | Controlled Agent operation with a guest sink |
+///
+/// An `Agent` therefore requires a supervised lifecycle and an enabled control
+/// sink. A controlled `Workload` is supervised with an enabled control channel
+/// but `sink: false`. Every other combination is rejected during both encoding
+/// and decoding by [`validate_exec_process_contract`].
 pub struct ExecStartEncodeRequest<'a> {
     /// Process lifecycle policy to encode.
     pub lifecycle: ExecLifecyclePolicy,
@@ -150,6 +167,10 @@ pub struct ExecStartEncodeRequest<'a> {
 }
 
 /// Decoded exec_start payload.
+///
+/// Its `lifecycle`, `role`, and `control` fields satisfy the process contract
+/// documented on [`ExecStartEncodeRequest`]. Decoding rejects every other
+/// combination.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedExecStart<'a> {
     /// Decoded process lifecycle policy.
@@ -294,6 +315,9 @@ fn validate_exec_timeout_policy(timeout: ExecTimeoutPolicy) -> Result<(), Protoc
 }
 
 /// Validate the semantic role, lifecycle, and transport-control combination.
+///
+/// The accepted combinations are documented on [`ExecStartEncodeRequest`].
+/// This same contract is enforced by the exec-start encoder and decoder.
 pub fn validate_exec_process_contract(
     role: ExecProcessRole,
     lifecycle: ExecLifecyclePolicy,


### PR DESCRIPTION
## Summary

- Enumerate the four valid `exec_start` role/lifecycle/control combinations in the public `vsock-proto` request rustdoc.
- Explain the controlled Workload `sink: false` contract and the Agent `sink: true` requirement.
- Link the canonical contract documentation from the decoded type, validator, and crate-level wire schema.

## Exclusions

- No protocol behavior, validation logic, payload layout, or wire encoding changed.
- No test source changed; the existing protocol tests already cover the accepted and rejected matrix.
- The provider-neutral lifecycle guide remains contextual documentation and is not duplicated.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo doc -p vsock-proto --no-deps`
- `cd crates && cargo test -p vsock-proto`
- `cd crates && cargo clippy --all-targets --all-features`
- `git diff --check`

Closes #30074
