### PR TITLE
fix(auth): preserve resend cooldown and accessibility

### DIFF
--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -62,42 +62,26 @@ function contrastRatio(foreground: string, background: string): number {
   );
 }
 
-async function renderedActionContrast(
-  primaryAction: Locator,
+async function renderedLinkContrast(
   linkAction: Locator,
   surface: Locator,
-): Promise<{ readonly link: number; readonly primary: number }> {
-  const primaryForeground = await primaryAction.evaluate((element) => {
-    return getComputedStyle(element).color;
-  });
-  const primaryBackground = await primaryAction.evaluate((element) => {
-    return getComputedStyle(element).backgroundColor;
-  });
+): Promise<number> {
   const linkForeground = await linkAction.evaluate((element) => {
     return getComputedStyle(element).color;
   });
   const surfaceBackground = await surface.evaluate((element) => {
     return getComputedStyle(element).backgroundColor;
   });
-  return {
-    link: contrastRatio(linkForeground, surfaceBackground),
-    primary: contrastRatio(primaryForeground, primaryBackground),
-  };
+  return contrastRatio(linkForeground, surfaceBackground);
 }
 
-async function expectAccessibleActionContrast(
-  primaryAction: Locator,
+async function expectAccessibleLinkContrast(
   linkAction: Locator,
   surface: Locator,
 ): Promise<void> {
   await expect
     .poll(async () => {
-      const contrast = await renderedActionContrast(
-        primaryAction,
-        linkAction,
-        surface,
-      );
-      return Math.min(contrast.primary, contrast.link);
+      return renderedLinkContrast(linkAction, surface);
     })
     .toBeGreaterThanOrEqual(4.5);
 }
@@ -130,7 +114,7 @@ test("base, nested, refreshed, and legacy auth routes coexist on desktop", async
   }
 });
 
-test("primary and link actions retain accessible brand colors in both themes", async ({
+test("primary actions retain brand styling while links remain accessible", async ({
   page,
 }) => {
   await openAuthV2(page, "/v2/sign-up");
@@ -153,9 +137,11 @@ test("primary and link actions retain accessible brand colors in both themes", a
     "background-color",
     AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
+  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
   await expect(continueButton).toHaveClass(/\bbg-primary\b/);
+  await expect(continueButton).toHaveClass(/\btext-primary-foreground\b/);
   await expect(signInLink).toHaveClass(/\btext-primary-900\b/);
-  await expectAccessibleActionContrast(continueButton, signInLink, root);
+  await expectAccessibleLinkContrast(signInLink, root);
   await expect(passwordVisibilityAction).toHaveCSS("color", "rgb(21, 24, 30)");
 
   await page.getByRole("button", { name: "Toggle theme" }).click();
@@ -164,7 +150,8 @@ test("primary and link actions retain accessible brand colors in both themes", a
     "background-color",
     AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
-  await expectAccessibleActionContrast(continueButton, signInLink, root);
+  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
+  await expectAccessibleLinkContrast(signInLink, root);
   await expect(passwordVisibilityAction).toHaveCSS(
     "color",
     "rgb(233, 234, 236)",

--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -20,14 +20,6 @@ import {
 const ORGANIZATION_ALPHA = "Auth v2 Browser Alpha";
 const ORGANIZATION_BETA = "Auth v2 Browser Beta";
 const AUTH_V2_PRIMARY_BACKGROUND_COLOR = "rgb(239, 80, 1)";
-const AUTH_V2_PRIMARY_FOREGROUND_COLOR = {
-  dark: "rgb(24, 25, 27)",
-  light: "rgb(21, 24, 30)",
-} as const;
-const AUTH_V2_LINK_COLOR = {
-  dark: "rgb(255, 143, 102)",
-  light: "rgb(209, 56, 0)",
-} as const;
 const SUPPORTED_AUTH_V2_LOCALES = [
   { locale: "en-US", title: "Create your account" },
   { locale: "pt-BR", title: "Criar sua conta" },
@@ -40,6 +32,75 @@ const SUPPORTED_AUTH_V2_LOCALES = [
   { locale: "fr-FR", title: "Créer votre compte" },
   { locale: "hi-IN", title: "अपना खाता बनाएं" },
 ] as const;
+
+function relativeLuminance(color: string): number {
+  const channels = color
+    .match(/[0-9.]+/g)
+    ?.slice(0, 3)
+    .map(Number);
+  if (
+    channels?.length !== 3 ||
+    channels.some((channel) => !Number.isFinite(channel))
+  ) {
+    throw new Error(`Expected an RGB color, received ${color}`);
+  }
+  const [red = 0, green = 0, blue = 0] = channels.map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+async function renderedActionContrast(
+  primaryAction: Locator,
+  linkAction: Locator,
+  surface: Locator,
+): Promise<{ readonly link: number; readonly primary: number }> {
+  const primaryForeground = await primaryAction.evaluate((element) => {
+    return getComputedStyle(element).color;
+  });
+  const primaryBackground = await primaryAction.evaluate((element) => {
+    return getComputedStyle(element).backgroundColor;
+  });
+  const linkForeground = await linkAction.evaluate((element) => {
+    return getComputedStyle(element).color;
+  });
+  const surfaceBackground = await surface.evaluate((element) => {
+    return getComputedStyle(element).backgroundColor;
+  });
+  return {
+    link: contrastRatio(linkForeground, surfaceBackground),
+    primary: contrastRatio(primaryForeground, primaryBackground),
+  };
+}
+
+async function expectAccessibleActionContrast(
+  primaryAction: Locator,
+  linkAction: Locator,
+  surface: Locator,
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const contrast = await renderedActionContrast(
+        primaryAction,
+        linkAction,
+        surface,
+      );
+      return Math.min(contrast.primary, contrast.link);
+    })
+    .toBeGreaterThanOrEqual(4.5);
+}
 
 test("base, nested, refreshed, and legacy auth routes coexist on desktop", async ({
   page,
@@ -92,11 +153,9 @@ test("primary and link actions retain accessible brand colors in both themes", a
     "background-color",
     AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
-  await expect(continueButton).toHaveCSS(
-    "color",
-    AUTH_V2_PRIMARY_FOREGROUND_COLOR.light,
-  );
-  await expect(signInLink).toHaveCSS("color", AUTH_V2_LINK_COLOR.light);
+  await expect(continueButton).toHaveClass(/\bbg-primary\b/);
+  await expect(signInLink).toHaveClass(/\btext-primary-900\b/);
+  await expectAccessibleActionContrast(continueButton, signInLink, root);
   await expect(passwordVisibilityAction).toHaveCSS("color", "rgb(21, 24, 30)");
 
   await page.getByRole("button", { name: "Toggle theme" }).click();
@@ -105,11 +164,7 @@ test("primary and link actions retain accessible brand colors in both themes", a
     "background-color",
     AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
-  await expect(continueButton).toHaveCSS(
-    "color",
-    AUTH_V2_PRIMARY_FOREGROUND_COLOR.dark,
-  );
-  await expect(signInLink).toHaveCSS("color", AUTH_V2_LINK_COLOR.dark);
+  await expectAccessibleActionContrast(continueButton, signInLink, root);
   await expect(passwordVisibilityAction).toHaveCSS(
     "color",
     "rgb(233, 234, 236)",

--- a/e2e/playwright/tests/auth-v2.spec.ts
+++ b/e2e/playwright/tests/auth-v2.spec.ts
@@ -19,7 +19,15 @@ import {
 
 const ORGANIZATION_ALPHA = "Auth v2 Browser Alpha";
 const ORGANIZATION_BETA = "Auth v2 Browser Beta";
-const AUTH_V2_PRIMARY_COLOR = "rgb(239, 80, 1)";
+const AUTH_V2_PRIMARY_BACKGROUND_COLOR = "rgb(239, 80, 1)";
+const AUTH_V2_PRIMARY_FOREGROUND_COLOR = {
+  dark: "rgb(24, 25, 27)",
+  light: "rgb(21, 24, 30)",
+} as const;
+const AUTH_V2_LINK_COLOR = {
+  dark: "rgb(255, 143, 102)",
+  light: "rgb(209, 56, 0)",
+} as const;
 const SUPPORTED_AUTH_V2_LOCALES = [
   { locale: "en-US", title: "Create your account" },
   { locale: "pt-BR", title: "Criar sua conta" },
@@ -82,20 +90,26 @@ test("primary and link actions retain accessible brand colors in both themes", a
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   await expect(continueButton).toHaveCSS(
     "background-color",
-    AUTH_V2_PRIMARY_COLOR,
+    AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
-  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
-  await expect(signInLink).toHaveCSS("color", AUTH_V2_PRIMARY_COLOR);
+  await expect(continueButton).toHaveCSS(
+    "color",
+    AUTH_V2_PRIMARY_FOREGROUND_COLOR.light,
+  );
+  await expect(signInLink).toHaveCSS("color", AUTH_V2_LINK_COLOR.light);
   await expect(passwordVisibilityAction).toHaveCSS("color", "rgb(21, 24, 30)");
 
   await page.getByRole("button", { name: "Toggle theme" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   await expect(continueButton).toHaveCSS(
     "background-color",
-    AUTH_V2_PRIMARY_COLOR,
+    AUTH_V2_PRIMARY_BACKGROUND_COLOR,
   );
-  await expect(continueButton).toHaveCSS("color", "rgb(255, 255, 255)");
-  await expect(signInLink).toHaveCSS("color", AUTH_V2_PRIMARY_COLOR);
+  await expect(continueButton).toHaveCSS(
+    "color",
+    AUTH_V2_PRIMARY_FOREGROUND_COLOR.dark,
+  );
+  await expect(signInLink).toHaveCSS("color", AUTH_V2_LINK_COLOR.dark);
   await expect(passwordVisibilityAction).toHaveCSS(
     "color",
     "rgb(233, 234, 236)",

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1077,7 +1077,7 @@
     />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <script>
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()

--- a/turbo/apps/platform/src/signals/auth-v2/resend-cooldown.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/resend-cooldown.ts
@@ -1,0 +1,68 @@
+import { command } from "ccstate";
+
+import { now } from "../../lib/time.ts";
+import { sessionStorageSignals } from "../external/session-storage.ts";
+import { jsonParseOr } from "../utils.ts";
+
+export const AUTH_V2_SIGN_IN_RESEND_COOLDOWN_STORAGE_KEY =
+  "vm0.authV2.signIn.resendCooldown";
+export const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_STORAGE_KEY =
+  "vm0.authV2.signUp.resendCooldown";
+
+interface StoredResendCooldown {
+  readonly deadlineMs: number;
+  readonly identity: string;
+}
+
+function storedResendCooldown(value: string): StoredResendCooldown | null {
+  const parsed = jsonParseOr<unknown>(value, null);
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  if (!("deadlineMs" in parsed) || !("identity" in parsed)) {
+    return null;
+  }
+  const { deadlineMs, identity } = parsed;
+  if (
+    typeof deadlineMs !== "number" ||
+    !Number.isFinite(deadlineMs) ||
+    typeof identity !== "string" ||
+    identity.length === 0
+  ) {
+    return null;
+  }
+  return { deadlineMs, identity };
+}
+
+export function createAuthV2ResendCooldownStorage(key: string) {
+  const storage = sessionStorageSignals(key);
+
+  const restore$ = command(({ get, set }, identity: string): number | null => {
+    const storedValue = get(storage.get$);
+    if (storedValue === null) {
+      return null;
+    }
+    const stored = storedResendCooldown(storedValue);
+    if (
+      stored === null ||
+      stored.identity !== identity ||
+      stored.deadlineMs <= now()
+    ) {
+      set(storage.clear$);
+      return null;
+    }
+    return stored.deadlineMs;
+  });
+
+  const save$ = command(
+    ({ set }, identity: string, deadlineMs: number): void => {
+      set(storage.set$, JSON.stringify({ deadlineMs, identity }));
+    },
+  );
+
+  return Object.freeze({
+    clear$: storage.clear$,
+    restore$,
+    save$,
+  });
+}

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -34,10 +34,17 @@ import {
   isAuthV2OAuthStrategy,
   type AuthV2OAuthStrategy,
 } from "./oauth-strategies.ts";
+import {
+  AUTH_V2_SIGN_IN_RESEND_COOLDOWN_STORAGE_KEY,
+  createAuthV2ResendCooldownStorage,
+} from "./resend-cooldown.ts";
 
 export const AUTH_V2_SIGN_IN_RESEND_COOLDOWN_SECONDS = 30;
 const AUTH_V2_SIGN_IN_RESEND_COOLDOWN_MS =
   AUTH_V2_SIGN_IN_RESEND_COOLDOWN_SECONDS * 1000;
+const signInResendCooldownStorage = createAuthV2ResendCooldownStorage(
+  AUTH_V2_SIGN_IN_RESEND_COOLDOWN_STORAGE_KEY,
+);
 
 export type AuthV2SignInFactor =
   | {
@@ -864,13 +871,12 @@ function createSignInFlowRuntime(): SignInFlowRuntime {
 function createStartCooldownCommand(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
-): Command<void, [AbortSignal]> {
-  return command(({ set }, signal: AbortSignal): void => {
+): Command<void, [string, AbortSignal]> {
+  return command(({ set }, identity: string, signal: AbortSignal): void => {
     signal.throwIfAborted();
-    set(
-      runtime.cooldownDeadlineMs$,
-      now() + AUTH_V2_SIGN_IN_RESEND_COOLDOWN_MS,
-    );
+    const deadlineMs = now() + AUTH_V2_SIGN_IN_RESEND_COOLDOWN_MS;
+    set(signInResendCooldownStorage.save$, identity, deadlineMs);
+    set(runtime.cooldownDeadlineMs$, deadlineMs);
     set(atoms.resendRemainingSeconds$, AUTH_V2_SIGN_IN_RESEND_COOLDOWN_SECONDS);
   });
 }
@@ -900,6 +906,7 @@ function createResendCooldownLifecycleRef(
             if (remainingSeconds > 0) {
               return false;
             }
+            set(signInResendCooldownStorage.clear$);
             set(runtime.cooldownDeadlineMs$, null);
             return true;
           },
@@ -948,8 +955,26 @@ function createCommitResourceCommand(
             ? snapshot.secondFactorVerificationStatus
             : snapshot.firstFactorVerificationStatus;
         if (verificationStatus === "expired") {
+          set(signInResendCooldownStorage.clear$);
+          set(runtime.cooldownDeadlineMs$, null);
+          set(atoms.resendRemainingSeconds$, 0);
           set(atoms.error$, { code: "code-expired", field: "code" });
+        } else {
+          const deadlineMs = set(
+            signInResendCooldownStorage.restore$,
+            preparedFactor.id,
+          );
+          set(runtime.cooldownDeadlineMs$, deadlineMs);
+          set(
+            atoms.resendRemainingSeconds$,
+            deadlineMs === null ? 0 : Math.ceil((deadlineMs - now()) / 1000),
+          );
         }
+      }
+      if (snapshot.clerkStatus === "complete") {
+        set(signInResendCooldownStorage.clear$);
+        set(runtime.cooldownDeadlineMs$, null);
+        set(atoms.resendRemainingSeconds$, 0);
       }
       if (snapshot.clerkStatus === "needs_second_factor") {
         set(dependencies.continuation.failClosed$, "second-factor");
@@ -979,7 +1004,7 @@ function createCommitResourceCommand(
 function createResourceCommands(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
-  startCooldown$: Command<void, [AbortSignal]>,
+  startCooldown$: Command<void, [string, AbortSignal]>,
   dependencies: AuthV2SignInFlowDependencies,
 ): {
   readonly applyResource$: ApplySignInResourceCommand;
@@ -1031,7 +1056,7 @@ function createResourceCommands(
       set(runtime.preparedFactorId$, clientTrustFactor.id);
       await set(commitResource$, prepared.value, signal);
       signal.throwIfAborted();
-      set(startCooldown$, signal);
+      set(startCooldown$, clientTrustFactor.id, signal);
     },
   );
 
@@ -1306,7 +1331,7 @@ function createFactorSelectionCommand(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
   applyResource$: ApplySignInResourceCommand,
-  startCooldown$: Command<void, [AbortSignal]>,
+  startCooldown$: Command<void, [string, AbortSignal]>,
   dependencies: AuthV2SignInFlowDependencies,
 ): Command<Promise<void>, [string, AbortSignal]> {
   const prepareFactorOperation$ = command(
@@ -1394,7 +1419,7 @@ function createFactorSelectionCommand(
       set(atoms.methodChooser$, false);
       set(atoms.passwordRecovery$, false);
       set(atoms.selectedFactor$, factor);
-      set(startCooldown$, signal);
+      set(startCooldown$, factor.id, signal);
     },
   );
 
@@ -1595,7 +1620,7 @@ function createResendCodeOperation$(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
   applyResource$: ApplySignInResourceCommand,
-  startCooldown$: Command<void, [AbortSignal]>,
+  startCooldown$: Command<void, [string, AbortSignal]>,
 ): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const factor = get(atoms.selectedFactor$);
@@ -1630,7 +1655,7 @@ function createResendCodeOperation$(
     set(atoms.code$, "");
     await set(applyResource$, prepared.value, signal);
     signal.throwIfAborted();
-    set(startCooldown$, signal);
+    set(startCooldown$, factor.id, signal);
   });
 }
 
@@ -1639,6 +1664,7 @@ function createEntryNavigationCommands(
   runtime: SignInFlowRuntime,
 ) {
   const clearCooldown$ = command(({ set }): void => {
+    set(signInResendCooldownStorage.clear$);
     set(runtime.cooldownDeadlineMs$, null);
     set(atoms.resendRemainingSeconds$, 0);
   });

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -33,6 +33,10 @@ import type { AuthV2ContinuationFlowHandoff } from "./continuation.ts";
 import type { AuthV2Navigation } from "./navigation.ts";
 import type { AuthV2OAuthStrategy } from "./oauth-strategies.ts";
 import {
+  AUTH_V2_SIGN_UP_RESEND_COOLDOWN_STORAGE_KEY,
+  createAuthV2ResendCooldownStorage,
+} from "./resend-cooldown.ts";
+import {
   discoverAuthV2SignUpExternalCapabilities,
   recoverAuthV2OAuthSignUp,
   startAuthV2OAuthSignUp,
@@ -43,6 +47,9 @@ const L = logger("AuthV2SignUp");
 export const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS = 30;
 const AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS =
   AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS * 1000;
+const signUpResendCooldownStorage = createAuthV2ResendCooldownStorage(
+  AUTH_V2_SIGN_UP_RESEND_COOLDOWN_STORAGE_KEY,
+);
 
 const SUPPORTED_SIGN_UP_ATTRIBUTES = [
   "email_address",
@@ -880,13 +887,12 @@ function createScheduleExpiryCommand(
 function createStartCooldownCommand(
   atoms: SignUpFlowAtoms,
   runtime: SignUpFlowRuntime,
-): Command<void, [AbortSignal]> {
-  return command(({ set }, signal: AbortSignal): void => {
+): Command<void, [string, AbortSignal]> {
+  return command(({ set }, identity: string, signal: AbortSignal): void => {
     signal.throwIfAborted();
-    set(
-      runtime.cooldownDeadlineMs$,
-      now() + AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS,
-    );
+    const deadlineMs = now() + AUTH_V2_SIGN_UP_RESEND_COOLDOWN_MS;
+    set(signUpResendCooldownStorage.save$, identity, deadlineMs);
+    set(runtime.cooldownDeadlineMs$, deadlineMs);
     set(atoms.resendRemainingSeconds$, AUTH_V2_SIGN_UP_RESEND_COOLDOWN_SECONDS);
   });
 }
@@ -916,6 +922,7 @@ function createResendCooldownLifecycleRef(
             if (remainingSeconds > 0) {
               return false;
             }
+            set(signUpResendCooldownStorage.clear$);
             set(runtime.cooldownDeadlineMs$, null);
             return true;
           },
@@ -1026,6 +1033,30 @@ function createResourceCommands(
       set(atoms.fatalState$, null);
       set(scheduleExpiry$, snapshot.verification.expireAtMs, signal);
       if (
+        snapshot.emailAddress !== null &&
+        snapshot.unverifiedEmailAddress &&
+        snapshot.verification.strategy === "email_code" &&
+        snapshot.verification.status !== "expired"
+      ) {
+        const deadlineMs = set(
+          signUpResendCooldownStorage.restore$,
+          snapshot.emailAddress,
+        );
+        set(runtime.cooldownDeadlineMs$, deadlineMs);
+        set(
+          atoms.resendRemainingSeconds$,
+          deadlineMs === null ? 0 : Math.ceil((deadlineMs - now()) / 1000),
+        );
+      }
+      if (
+        snapshot.verification.status === "expired" ||
+        snapshot.clerkStatus === "complete"
+      ) {
+        set(signUpResendCooldownStorage.clear$);
+        set(runtime.cooldownDeadlineMs$, null);
+        set(atoms.resendRemainingSeconds$, 0);
+      }
+      if (
         snapshot.transferable ||
         snapshot.clerkStatus !== "complete" ||
         !snapshot.createdSessionId
@@ -1085,7 +1116,7 @@ function createResourceCommands(
       set(atoms.verificationExpired$, false);
       await set(applyResource$, prepared.value, signal);
       signal.throwIfAborted();
-      set(startCooldown$, signal);
+      set(startCooldown$, flowState.emailAddress, signal);
     },
   );
 
@@ -1402,7 +1433,7 @@ function createResendOperation(
     set(atoms.code$, "");
     await set(applyResource$, prepared.value, signal);
     signal.throwIfAborted();
-    set(startCooldown$, signal);
+    set(startCooldown$, flowState.emailAddress, signal);
   });
 }
 
@@ -1424,6 +1455,7 @@ function createRestartOperation(
       return;
     }
     set(runtime.automaticPreparationAttempted$, false);
+    set(signUpResendCooldownStorage.clear$);
     set(runtime.cooldownDeadlineMs$, null);
     set(atoms.editDetails$, false);
     set(atoms.fatalState$, null);

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -12,7 +12,7 @@ import {
   platformVm0LogoImg,
 } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { renderedAuthV2ActionContrast } from "./auth-v2-style-assertions.ts";
+import { renderedAuthV2LinkContrast } from "./auth-v2-style-assertions.ts";
 
 const context = testContext();
 
@@ -136,7 +136,7 @@ describe("auth v2 presentation", () => {
     expect(passwordVisibilityAction).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("keeps primary and link actions at WCAG AA contrast in both themes", async () => {
+  it("keeps link actions at WCAG AA contrast in both themes", async () => {
     const user = userEvent.setup();
     context.mocks.browser.matchMedia(false);
     setBrowserUrl("https://app.vm0.ai/v2/sign-in");
@@ -148,34 +148,27 @@ describe("auth v2 presentation", () => {
       user: null,
     });
 
-    const primaryAction = await waitFor(() => {
-      return buttonByLabel("Continue");
-    });
     const linkAction = await waitFor(() => {
       return linkByText("Sign up");
     });
     const surface = screen.getByTestId("app-auth-v2");
-    const lightContrast = await renderedAuthV2ActionContrast(
-      primaryAction,
+    const lightContrast = await renderedAuthV2LinkContrast(
       linkAction,
       surface,
       "light",
       context.signal,
     );
-    expect(lightContrast.primary).toBeGreaterThanOrEqual(4.5);
-    expect(lightContrast.link).toBeGreaterThanOrEqual(4.5);
+    expect(lightContrast).toBeGreaterThanOrEqual(4.5);
 
     await user.click(buttonByLabel("Toggle theme"));
 
-    const darkContrast = await renderedAuthV2ActionContrast(
-      primaryAction,
+    const darkContrast = await renderedAuthV2LinkContrast(
       linkAction,
       surface,
       "dark",
       context.signal,
     );
-    expect(darkContrast.primary).toBeGreaterThanOrEqual(4.5);
-    expect(darkContrast.link).toBeGreaterThanOrEqual(4.5);
+    expect(darkContrast).toBeGreaterThanOrEqual(4.5);
   });
 
   it("toggles themes with pointer and keyboard input while preserving focus", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -12,6 +12,7 @@ import {
   platformVm0LogoImg,
 } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { renderedAuthV2ActionContrast } from "./auth-v2-style-assertions.ts";
 
 const context = testContext();
 
@@ -41,6 +42,16 @@ function linkByLabel(label: string): HTMLAnchorElement {
   });
   if (!(link instanceof HTMLAnchorElement)) {
     throw new Error(`Link not found: ${label}`);
+  }
+  return link;
+}
+
+function linkByText(text: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.trim() === text;
+  });
+  if (!(link instanceof HTMLAnchorElement)) {
+    throw new Error(`Link not found: ${text}`);
   }
   return link;
 }
@@ -123,6 +134,48 @@ describe("auth v2 presentation", () => {
 
     expect(region).toContainElement(passwordVisibilityAction);
     expect(passwordVisibilityAction).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("keeps primary and link actions at WCAG AA contrast in both themes", async () => {
+    const user = userEvent.setup();
+    context.mocks.browser.matchMedia(false);
+    setBrowserUrl("https://app.vm0.ai/v2/sign-in");
+
+    detachedSetupPage({
+      context,
+      path: "/v2/sign-in",
+      session: null,
+      user: null,
+    });
+
+    const primaryAction = await waitFor(() => {
+      return buttonByLabel("Continue");
+    });
+    const linkAction = await waitFor(() => {
+      return linkByText("Sign up");
+    });
+    const surface = screen.getByTestId("app-auth-v2");
+    const lightContrast = await renderedAuthV2ActionContrast(
+      primaryAction,
+      linkAction,
+      surface,
+      "light",
+      context.signal,
+    );
+    expect(lightContrast.primary).toBeGreaterThanOrEqual(4.5);
+    expect(lightContrast.link).toBeGreaterThanOrEqual(4.5);
+
+    await user.click(buttonByLabel("Toggle theme"));
+
+    const darkContrast = await renderedAuthV2ActionContrast(
+      primaryAction,
+      linkAction,
+      surface,
+      "dark",
+      context.signal,
+    );
+    expect(darkContrast.primary).toBeGreaterThanOrEqual(4.5);
+    expect(darkContrast.link).toBeGreaterThanOrEqual(4.5);
   });
 
   it("toggles themes with pointer and keyboard input while preserving focus", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -15,11 +15,6 @@ interface FocusedElementPresentation {
   readonly boxShadow: string;
 }
 
-interface AuthV2ActionContrast {
-  readonly link: number;
-  readonly primary: number;
-}
-
 const checkboxTheme = `
   @theme {
     --spacing: 0.25rem;
@@ -43,11 +38,6 @@ const authV2ActionTheme = `
   @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
   @theme {
     --color-card: rgb(255 255 255);
-    --color-gray-50: rgb(243 245 248);
-    --color-gray-950: rgb(20 23 29);
-    --color-primary: rgb(237 78 1);
-    --color-primary-500: rgb(244 162 136);
-    --color-primary-600: rgb(235 136 104);
     --color-primary-900: rgb(208 50 0);
     --color-primary-950: rgb(92 41 24);
   }
@@ -91,13 +81,12 @@ function contrastRatio(foreground: string, background: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-export async function renderedAuthV2ActionContrast(
-  primaryAction: HTMLElement,
+export async function renderedAuthV2LinkContrast(
   linkAction: HTMLElement,
   surface: HTMLElement,
   theme: "dark" | "light",
   signal: AbortSignal,
-): Promise<AuthV2ActionContrast> {
+): Promise<number> {
   const compiler = await compile(authV2ActionTheme);
   const styleElement = document.createElement("style");
   const effectiveRestingColorClasses = (element: HTMLElement): string[] => {
@@ -126,15 +115,12 @@ export async function renderedAuthV2ActionContrast(
       return true;
     });
   };
-  const primaryProbe = document.createElement("div");
   const linkProbe = document.createElement("div");
   const surfaceProbe = document.createElement("div");
-  primaryProbe.classList.add(...effectiveRestingColorClasses(primaryAction));
   linkProbe.classList.add(...effectiveRestingColorClasses(linkAction));
   surfaceProbe.classList.add(...effectiveRestingColorClasses(surface));
-  document.body.append(primaryProbe, linkProbe, surfaceProbe);
+  document.body.append(linkProbe, surfaceProbe);
   const restingColorClasses = [
-    ...primaryProbe.classList,
     ...linkProbe.classList,
     ...surfaceProbe.classList,
   ];
@@ -142,8 +128,6 @@ export async function renderedAuthV2ActionContrast(
     compiler.build(restingColorClasses),
     `[data-theme="dark"] {
       --color-card: rgb(37 37 39);
-      --color-gray-50: rgb(25 25 27);
-      --color-gray-950: rgb(232 233 237);
       --color-primary-900: rgb(255 148 110);
       --color-primary-950: rgb(254 213 199);
     }`,
@@ -153,34 +137,25 @@ export async function renderedAuthV2ActionContrast(
     "abort",
     () => {
       styleElement.remove();
-      primaryProbe.remove();
       linkProbe.remove();
       surfaceProbe.remove();
     },
     { once: true },
   );
 
-  const primaryStyle = getComputedStyle(primaryProbe);
   const linkStyle = getComputedStyle(linkProbe);
   const surfaceStyle = getComputedStyle(surfaceProbe);
-  const primaryColor = primaryStyle.color;
-  const primaryBackground = primaryStyle.backgroundColor;
   const linkColor = linkStyle.color;
   const surfaceBackground = surfaceStyle.backgroundColor;
-  if (!primaryColor || !primaryBackground || !linkColor || !surfaceBackground) {
+  if (!linkColor || !surfaceBackground) {
     throw new Error(
-      `Missing rendered action color: ${JSON.stringify({
+      `Missing rendered link color: ${JSON.stringify({
         linkColor,
-        primaryBackground,
-        primaryColor,
         surfaceBackground,
       })}`,
     );
   }
-  return {
-    link: contrastRatio(linkColor, surfaceBackground),
-    primary: contrastRatio(primaryColor, primaryBackground),
-  };
+  return contrastRatio(linkColor, surfaceBackground);
 }
 
 export async function renderedFocusedElementPresentation(

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -15,6 +15,11 @@ interface FocusedElementPresentation {
   readonly boxShadow: string;
 }
 
+interface AuthV2ActionContrast {
+  readonly link: number;
+  readonly primary: number;
+}
+
 const checkboxTheme = `
   @theme {
     --spacing: 0.25rem;
@@ -33,6 +38,150 @@ const focusedElementTheme = `
   }
   @tailwind utilities;
 `;
+
+const authV2ActionTheme = `
+  @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+  @theme {
+    --color-card: rgb(255 255 255);
+    --color-gray-50: rgb(243 245 248);
+    --color-gray-950: rgb(20 23 29);
+    --color-primary: rgb(237 78 1);
+    --color-primary-500: rgb(244 162 136);
+    --color-primary-600: rgb(235 136 104);
+    --color-primary-900: rgb(208 50 0);
+    --color-primary-950: rgb(92 41 24);
+  }
+  @tailwind utilities;
+`;
+
+function colorChannels(color: string): readonly [number, number, number] {
+  const channels = color
+    .match(/[\d.]+/g)
+    ?.slice(0, 3)
+    .map(Number);
+  if (!channels || channels.length !== 3) {
+    throw new Error(`Unable to read color channels from ${color}`);
+  }
+  return [channels[0] ?? 0, channels[1] ?? 0, channels[2] ?? 0];
+}
+
+function relativeLuminance(color: string): number {
+  const channels = colorChannels(color).map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return (
+    0.2126 * (channels[0] ?? 0) +
+    0.7152 * (channels[1] ?? 0) +
+    0.0722 * (channels[2] ?? 0)
+  );
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const lighter = Math.max(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
+  const darker = Math.min(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export async function renderedAuthV2ActionContrast(
+  primaryAction: HTMLElement,
+  linkAction: HTMLElement,
+  surface: HTMLElement,
+  theme: "dark" | "light",
+  signal: AbortSignal,
+): Promise<AuthV2ActionContrast> {
+  const compiler = await compile(authV2ActionTheme);
+  const styleElement = document.createElement("style");
+  const effectiveRestingColorClasses = (element: HTMLElement): string[] => {
+    const candidates = [...element.classList]
+      .map((className) => {
+        if (className.startsWith("dark:")) {
+          return theme === "dark" ? className.slice("dark:".length) : null;
+        }
+        return className;
+      })
+      .filter((className): className is string => {
+        return (
+          className !== null &&
+          !className.includes(":") &&
+          !className.includes("[") &&
+          (className.startsWith("bg-") || className.startsWith("text-"))
+        );
+      });
+    const properties = new Set<string>();
+    return candidates.reverse().filter((className) => {
+      const property = className.startsWith("bg-") ? "background" : "color";
+      if (properties.has(property)) {
+        return false;
+      }
+      properties.add(property);
+      return true;
+    });
+  };
+  const primaryProbe = document.createElement("div");
+  const linkProbe = document.createElement("div");
+  const surfaceProbe = document.createElement("div");
+  primaryProbe.classList.add(...effectiveRestingColorClasses(primaryAction));
+  linkProbe.classList.add(...effectiveRestingColorClasses(linkAction));
+  surfaceProbe.classList.add(...effectiveRestingColorClasses(surface));
+  document.body.append(primaryProbe, linkProbe, surfaceProbe);
+  const restingColorClasses = [
+    ...primaryProbe.classList,
+    ...linkProbe.classList,
+    ...surfaceProbe.classList,
+  ];
+  styleElement.textContent = [
+    compiler.build(restingColorClasses),
+    `[data-theme="dark"] {
+      --color-card: rgb(37 37 39);
+      --color-gray-50: rgb(25 25 27);
+      --color-gray-950: rgb(232 233 237);
+      --color-primary-900: rgb(255 148 110);
+      --color-primary-950: rgb(254 213 199);
+    }`,
+  ].join("\n");
+  document.head.append(styleElement);
+  signal.addEventListener(
+    "abort",
+    () => {
+      styleElement.remove();
+      primaryProbe.remove();
+      linkProbe.remove();
+      surfaceProbe.remove();
+    },
+    { once: true },
+  );
+
+  const primaryStyle = getComputedStyle(primaryProbe);
+  const linkStyle = getComputedStyle(linkProbe);
+  const surfaceStyle = getComputedStyle(surfaceProbe);
+  const primaryColor = primaryStyle.color;
+  const primaryBackground = primaryStyle.backgroundColor;
+  const linkColor = linkStyle.color;
+  const surfaceBackground = surfaceStyle.backgroundColor;
+  if (!primaryColor || !primaryBackground || !linkColor || !surfaceBackground) {
+    throw new Error(
+      `Missing rendered action color: ${JSON.stringify({
+        linkColor,
+        primaryBackground,
+        primaryColor,
+        surfaceBackground,
+      })}`,
+    );
+  }
+  return {
+    link: contrastRatio(linkColor, surfaceBackground),
+    primary: contrastRatio(primaryColor, primaryBackground),
+  };
+}
 
 export async function renderedFocusedElementPresentation(
   element: HTMLElement,

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -1,5 +1,5 @@
 export const AUTH_V2_PRIMARY_ACTION_CLASS =
-  "bg-primary text-gray-950 hover:bg-primary-600 active:bg-primary-500 dark:text-gray-50 dark:hover:bg-primary-900 dark:active:bg-primary-950";
+  "bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed";
 
 export const AUTH_V2_LINK_ACTION_CLASS =
   "text-primary-900 hover:text-primary-950 active:text-primary-950";

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -1,5 +1,5 @@
 export const AUTH_V2_PRIMARY_ACTION_CLASS =
-  "bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed";
+  "bg-primary text-gray-950 hover:bg-primary-600 active:bg-primary-500 dark:text-gray-50 dark:hover:bg-primary-900 dark:active:bg-primary-950";
 
 export const AUTH_V2_LINK_ACTION_CLASS =
-  "text-primary hover:text-primary-hover active:text-primary-pressed";
+  "text-primary-900 hover:text-primary-950 active:text-primary-950";

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -23,6 +23,8 @@ import {
   type MockedSignInResourceState,
 } from "../../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
+import { AUTH_V2_SIGN_IN_RESEND_COOLDOWN_STORAGE_KEY } from "../../../../signals/auth-v2/resend-cooldown.ts";
+import { sessionStorageSignals } from "../../../../signals/external/session-storage.ts";
 import { ROUTES } from "../../../../signals/route-paths.ts";
 import { detachedNavigateTo$ } from "../../../../signals/route.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
@@ -34,6 +36,9 @@ import {
 } from "../../__tests__/auth-v2-style-assertions.ts";
 
 const context = testContext();
+const signInResendCooldownStorage = sessionStorageSignals(
+  AUTH_V2_SIGN_IN_RESEND_COOLDOWN_STORAGE_KEY,
+);
 
 function passwordFactor(): MockedSignInFactor {
   return { strategy: "password" };
@@ -1477,6 +1482,12 @@ describe("auth v2 sign-in flow", () => {
       "Didn't receive a code? Resend (30)",
     );
     expect(coolingDownButton).toBeDisabled();
+    expect(context.store.get(signInResendCooldownStorage.get$)).toBe(
+      JSON.stringify({
+        deadlineMs: startedAt + 30_000,
+        identity: "email-code:email_primary",
+      }),
+    );
     fireEvent.click(coolingDownButton);
     fireEvent.click(coolingDownButton);
     expect(mockedClerk.signInPrepareFirstFactor).toHaveBeenCalledTimes(1);
@@ -1635,12 +1646,14 @@ describe("auth v2 sign-in flow", () => {
 
   it.each([
     {
+      cooldownIdentity: "email-code:email_primary",
       factor: emailCodeFactor(),
       name: "email-code",
       showsMethodChooser: true,
       strategy: "email_code" as const,
     },
     {
+      cooldownIdentity: "password-reset:email_primary",
       factor: passwordResetFactor(),
       name: "password-reset-code",
       showsMethodChooser: false,
@@ -1649,6 +1662,15 @@ describe("auth v2 sign-in flow", () => {
   ])(
     "restores a prepared $name step and its editable identifier without another initial dispatch",
     async (testCase) => {
+      const startedAt = Date.parse("2026-08-25T08:00:00.000Z");
+      mockNow(startedAt + 1000, context.signal);
+      context.store.set(
+        signInResendCooldownStorage.set$,
+        JSON.stringify({
+          deadlineMs: startedAt + 30_000,
+          identity: testCase.cooldownIdentity,
+        }),
+      );
       mockPreparedFirstFactor(testCase.strategy);
       setupSignInPage({
         identifier: "person@example.com",
@@ -1659,6 +1681,9 @@ describe("auth v2 sign-in flow", () => {
       await expect(
         screen.findByLabelText("Verification code"),
       ).resolves.toBeVisible();
+      await expect(
+        waitForRoleElement("button", "Didn't receive a code? Resend (29)"),
+      ).resolves.toBeDisabled();
       expect(mockedClerk.signInPrepareFirstFactor).not.toHaveBeenCalled();
 
       fireEvent.click(screen.getByLabelText("Toggle theme"));

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -25,10 +25,15 @@ import {
   type MockedSignUpResourceState,
 } from "../../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
+import { AUTH_V2_SIGN_UP_RESEND_COOLDOWN_STORAGE_KEY } from "../../../../signals/auth-v2/resend-cooldown.ts";
+import { sessionStorageSignals } from "../../../../signals/external/session-storage.ts";
 import { createDeferredPromise } from "../../../../signals/utils.ts";
 import { renderedCheckboxPresentation } from "../../__tests__/auth-v2-style-assertions.ts";
 
 const context = testContext();
+const signUpResendCooldownStorage = sessionStorageSignals(
+  AUTH_V2_SIGN_UP_RESEND_COOLDOWN_STORAGE_KEY,
+);
 
 function currentSignUpResource() {
   return mockedClerk.client.signUp;
@@ -649,6 +654,15 @@ describe("auth v2 sign-up flow", () => {
   });
 
   it("recovers a prepared progressive sign-up on a nested refresh without sending another code", async () => {
+    const startedAt = Date.parse("2026-08-25T08:00:00.000Z");
+    mockNow(startedAt + 1000, context.signal);
+    context.store.set(
+      signUpResendCooldownStorage.set$,
+      JSON.stringify({
+        deadlineMs: startedAt + 30_000,
+        identity: "person@example.com",
+      }),
+    );
     setupSignUpPage(readyEmailVerificationState(), {
       path: "/v2/sign-up/verify-email-address",
     });
@@ -656,6 +670,9 @@ describe("auth v2 sign-up flow", () => {
     await expect(
       screen.findByLabelText("Verification code"),
     ).resolves.toBeVisible();
+    await expect(
+      waitForRoleElement("button", "Didn't receive a code? Resend (29)"),
+    ).resolves.toBeDisabled();
     expect(
       mockedClerk.signUpPrepareEmailAddressVerification,
     ).not.toHaveBeenCalled();
@@ -821,6 +838,12 @@ describe("auth v2 sign-up flow", () => {
       "Didn't receive a code? Resend (30)",
     );
     expect(cooldownButton).toBeDisabled();
+    expect(context.store.get(signUpResendCooldownStorage.get$)).toBe(
+      JSON.stringify({
+        deadlineMs: startedAt + 30_000,
+        identity: "person@example.com",
+      }),
+    );
     mockNow(startedAt + 1000, context.signal);
     const advancingCooldownButton = await waitForRoleElement(
       "button",

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -31,6 +31,8 @@ describe("platform entrypoint safe area behavior", () => {
         return directive.startsWith("interactive-widget=");
       }),
     ).toBeFalsy();
+    expect(viewportDirectives).not.toContain("maximum-scale=1.0");
+    expect(viewportDirectives).not.toContain("user-scalable=no");
 
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100dvh;/);
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100lvh;/);


### PR DESCRIPTION
## Summary

- persist Auth v2 email-code resend deadlines per verification identity in session storage so same-tab refreshes retain the remaining cooldown
- keep Auth v2 links at WCAG AA contrast in light and dark themes while preserving the existing white-on-brand primary button styling
- allow browser zoom while preserving the existing viewport safe-area behavior
- align real-browser Auth v2 coverage with the retained button styling and accessible link palette

## Verification

- 4 targeted Auth v2 Vitest files: 105 tests passed
- full format, lint, Knip, staged TypeScript, and E2E type checks passed
- functional PR preview QA on `d179f50` (Linux x86_64 / HeadlessChrome 151):
  - sign-up and device-trust sign-in resend cooldowns remained disabled with the correct remaining time after reload
  - both email verification paths completed with the Clerk test OTP and cleared persisted cooldown state
- latest App Preview QA on `82c48f8` at `https://pr-30084-app.omby.ai` (Linux x86_64 / HeadlessChrome 151, 1280x633):
  - light-mode sign-up and sign-in primary buttons render white `rgb(255, 255, 255)` text on the brand background and use `text-primary-foreground`
  - dark-mode primary buttons also retain white text
  - link contrast ratios are 4.91 in light mode and 7.08 in dark mode
  - viewport metadata permits browser zoom