### PR TITLE
test(api): make cron cleanup fixture teardown-safe

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
@@ -1,19 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import { connectorOauthStartContract } from "@okouai/api-contracts/contracts/connectors";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  onTestFinished,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
+import { createFixtureOperationOwner } from "./helpers/fixture-operation-owner";
 import { createRouteMocks } from "./helpers/route-test";
 import {
   type TestCronDeleteCleanupsStateActionBody,
@@ -64,10 +58,27 @@ async function requestFixture(
   return response.body;
 }
 
-function registerFixtureCleanup(marker: string): void {
-  onTestFinished(async () => {
+function createConnectorFixture(marker: string) {
+  const owner = createFixtureOperationOwner(async () => {
     await requestFixture({ action: "delete-connector", marker });
   });
+  return {
+    cleanup: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "cleanup-connector", marker });
+      });
+    },
+    read: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "read-connector", marker });
+      });
+    },
+    startOauth: async () => {
+      return await owner.run(async () => {
+        return await startGithubOauth(marker);
+      });
+    },
+  };
 }
 
 describe("connector OAuth state cleanup cron", () => {
@@ -83,26 +94,29 @@ describe("connector OAuth state cleanup cron", () => {
   });
 
   it("deletes expired states while preserving unexpired states", async () => {
-    const marker = `connector-oauth-cleanup-${randomUUID()}`;
-    const unrelatedMarker = `connector-oauth-cleanup-${randomUUID()}`;
-    registerFixtureCleanup(marker);
-    registerFixtureCleanup(unrelatedMarker);
+    const fixture = createConnectorFixture(
+      `connector-oauth-cleanup-${randomUUID()}`,
+    );
+    const unrelatedFixture = createConnectorFixture(
+      `connector-oauth-cleanup-${randomUUID()}`,
+    );
 
     mockNow(now() - 20 * 60 * 1000);
-    const expiredState = await startGithubOauth(marker);
-    const unrelatedExpiredState = await startGithubOauth(unrelatedMarker);
+    const expiredState = await fixture.startOauth();
+    const unrelatedExpiredState = await unrelatedFixture.startOauth();
     clearMockNow();
-    const unexpiredState = await startGithubOauth(marker);
+    const unexpiredState = await fixture.startOauth();
 
-    await expect(
-      requestFixture({ action: "cleanup-connector", marker }),
-    ).resolves.toStrictEqual({ ok: true, remaining: [], deleted: 1 });
-    await expect(
-      requestFixture({ action: "read-connector", marker }),
-    ).resolves.toStrictEqual({ ok: true, remaining: [unexpiredState] });
-    await expect(
-      requestFixture({ action: "read-connector", marker: unrelatedMarker }),
-    ).resolves.toStrictEqual({
+    await expect(fixture.cleanup()).resolves.toStrictEqual({
+      ok: true,
+      remaining: [],
+      deleted: 1,
+    });
+    await expect(fixture.read()).resolves.toStrictEqual({
+      ok: true,
+      remaining: [unexpiredState],
+    });
+    await expect(unrelatedFixture.read()).resolves.toStrictEqual({
       ok: true,
       remaining: [unrelatedExpiredState],
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
@@ -15,6 +15,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
+import { createFixtureOperationOwner } from "./helpers/fixture-operation-owner";
 import {
   type TestCronDeleteCleanupsStateActionBody,
   type TestCronDeleteCleanupsStateResponse,
@@ -25,7 +26,7 @@ import { cronTelegramCleanupRoutes } from "../cron-telegram-cleanup";
 
 const context = testContext();
 const CRON_SECRET = "test-delete-cleanups-secret";
-const CONNECTOR_EXPIRED_COUNT = 10_001;
+const CONNECTOR_EXPIRED_COUNT = 11;
 const TELEGRAM_EXPIRED_COUNT = 10_001;
 const CUTOFF_MS = Date.parse("1950-01-31T00:00:00.000Z");
 const TELEGRAM_CUTOFF_MS = Date.parse("1950-04-20T00:00:00.000Z");
@@ -48,7 +49,7 @@ async function requestFixture(
 }
 
 function registerFixtureCleanup(
-  action: "delete-connector" | "delete-telegram",
+  action: "delete-telegram",
   marker: string,
 ): void {
   onTestFinished(async () => {
@@ -56,16 +57,32 @@ function registerFixtureCleanup(
   });
 }
 
-async function seedConnectorFixture(expiredCount: number): Promise<string> {
+async function seedConnectorFixture(expiredCount: number) {
   const marker = `connector-cleanup-${randomUUID()}`;
-  registerFixtureCleanup("delete-connector", marker);
-  await requestFixture({
-    action: "seed-connector",
-    marker,
-    cutoff: new Date(CUTOFF_MS).toISOString(),
-    expiredCount,
+  const owner = createFixtureOperationOwner(async () => {
+    await requestFixture({ action: "delete-connector", marker });
   });
-  return marker;
+  await owner.run(async () => {
+    await requestFixture({
+      action: "seed-connector",
+      marker,
+      cutoff: new Date(CUTOFF_MS).toISOString(),
+      expiredCount,
+    });
+  });
+  return {
+    marker,
+    cleanup: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "cleanup-connector", marker });
+      });
+    },
+    read: async () => {
+      return await owner.run(async () => {
+        return await requestFixture({ action: "read-connector", marker });
+      });
+    },
+  };
 }
 
 async function seedTelegramFixture(expiredCount: number): Promise<string> {
@@ -82,10 +99,6 @@ async function seedTelegramFixture(expiredCount: number): Promise<string> {
 
 function cronHeaders() {
   return { authorization: `Bearer ${CRON_SECRET}` };
-}
-
-async function cleanupConnectorOauthStates(marker: string) {
-  return await requestFixture({ action: "cleanup-connector", marker });
 }
 
 async function cleanupTelegramMessages() {
@@ -112,44 +125,38 @@ describe("complete delete cleanup crons", () => {
   it("caps connector cleanup at ten batches and preserves the UTC cutoff outside UTC", async () => {
     stubTestTimezone("Asia/Shanghai");
     mockNow(CUTOFF_MS);
-    const marker = await seedConnectorFixture(CONNECTOR_EXPIRED_COUNT);
-    const unrelatedMarker = await seedConnectorFixture(1);
+    const fixture = await seedConnectorFixture(CONNECTOR_EXPIRED_COUNT);
+    const unrelatedFixture = await seedConnectorFixture(1);
 
-    const first = await cleanupConnectorOauthStates(marker);
-    expect(first.deleted).toBe(10_000);
-    await expect(
-      requestFixture({ action: "read-connector", marker }),
-    ).resolves.toStrictEqual({
+    const first = await fixture.cleanup();
+    expect(first.deleted).toBe(10);
+    await expect(fixture.read()).resolves.toStrictEqual({
       ok: true,
       remaining: [
-        connectorState(marker, "equal"),
-        connectorState(marker, "expired-10000"),
-        connectorState(marker, "future"),
+        connectorState(fixture.marker, "equal"),
+        connectorState(fixture.marker, "expired-10"),
+        connectorState(fixture.marker, "future"),
       ],
     });
-    await expect(
-      requestFixture({ action: "read-connector", marker: unrelatedMarker }),
-    ).resolves.toStrictEqual({
+    await expect(unrelatedFixture.read()).resolves.toStrictEqual({
       ok: true,
       remaining: [
-        connectorState(unrelatedMarker, "equal"),
-        connectorState(unrelatedMarker, "expired-0"),
-        connectorState(unrelatedMarker, "future"),
+        connectorState(unrelatedFixture.marker, "equal"),
+        connectorState(unrelatedFixture.marker, "expired-0"),
+        connectorState(unrelatedFixture.marker, "future"),
       ],
     });
 
-    const second = await cleanupConnectorOauthStates(marker);
+    const second = await fixture.cleanup();
     expect(second.deleted).toBe(2);
-    await expect(
-      requestFixture({ action: "read-connector", marker }),
-    ).resolves.toStrictEqual({
+    await expect(fixture.read()).resolves.toStrictEqual({
       ok: true,
-      remaining: [connectorState(marker, "future")],
+      remaining: [connectorState(fixture.marker, "future")],
     });
 
-    const empty = await cleanupConnectorOauthStates(marker);
+    const empty = await fixture.cleanup();
     expect(empty.deleted).toBe(0);
-  }, 15_000);
+  });
 
   it("runs full and short telegram batches across a non-UTC daylight-saving boundary", async () => {
     stubTestTimezone("America/New_York");

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fixture-operation-owner.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fixture-operation-owner.ts
@@ -1,0 +1,30 @@
+import { onTestFinished } from "vitest";
+
+interface FixtureOperationOwner {
+  run<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+export function createFixtureOperationOwner(
+  teardown: () => Promise<unknown>,
+): FixtureOperationOwner {
+  let teardownStarted = false;
+  const operations: Promise<unknown>[] = [];
+
+  async function run<T>(operation: () => Promise<T>): Promise<T> {
+    if (teardownStarted) {
+      throw new Error("Fixture teardown already started");
+    }
+    const pending = Promise.resolve().then(operation);
+    operations.push(pending);
+    return await pending;
+  }
+
+  onTestFinished(async () => {
+    teardownStarted = true;
+    // A timed-out route can still own a non-cancellable database query.
+    await Promise.allSettled(operations);
+    await teardown();
+  });
+
+  return { run };
+}

--- a/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
@@ -6,6 +6,7 @@ import { nowDate } from "../../lib/time";
 import { type Db, writeDb$ } from "../external/db";
 
 const DELETE_BATCH_SIZE = 1000;
+const TEST_DELETE_BATCH_SIZE = 1;
 const MAX_BATCHES = 10;
 
 interface ConnectorOauthStateCleanupOwner {
@@ -17,6 +18,7 @@ async function cleanupConnectorOauthStates(
   db: Db,
   cutoff: Date,
   owner: ConnectorOauthStateCleanupOwner | undefined,
+  batchSize: number,
   signal: AbortSignal,
 ): Promise<number> {
   const expiredWhere = owner
@@ -34,7 +36,7 @@ async function cleanupConnectorOauthStates(
       .from(connectorOauthStates)
       .where(expiredWhere)
       .orderBy(asc(connectorOauthStates.expiresAt))
-      .limit(DELETE_BATCH_SIZE);
+      .limit(batchSize);
     const { rowCount } = await db
       .delete(connectorOauthStates)
       .where(inArray(connectorOauthStates.id, expiredStates));
@@ -42,7 +44,7 @@ async function cleanupConnectorOauthStates(
 
     const batchDeleted = rowCount ?? 0;
     totalDeleted += batchDeleted;
-    if (batchDeleted < DELETE_BATCH_SIZE) {
+    if (batchDeleted < batchSize) {
       break;
     }
   }
@@ -56,6 +58,7 @@ export const cleanupConnectorOauthStates$ = command(
       set(writeDb$),
       nowDate(),
       undefined,
+      DELETE_BATCH_SIZE,
       signal,
     );
   },
@@ -67,6 +70,7 @@ export const cleanupConnectorOauthStatesForTest$ = command(
       set(writeDb$),
       nowDate(),
       { userId: marker, orgId: marker },
+      TEST_DELETE_BATCH_SIZE,
       signal,
     );
   },


### PR DESCRIPTION
## Summary

- make both connector cleanup fixtures own every request that can touch their rows and drain those operations before marker-scoped teardown
- exercise the shared ten-iteration cap with a one-row test-only batch, reducing the cap fixture from 10,001 expired rows to 11
- keep the production cleanup batch size at 1,000 and preserve the UTC cutoff and unrelated-marker assertions

## Root cause

When the test deadline fired, Vitest could start onTestFinished while the awaited cleanup route still owned a non-cancellable PostgreSQL batch delete. The independently registered marker-wide teardown then deleted the same rows and created the observed 40P01 cycle. The fixture owner now closes to new work and settles every already-owned operation before deleting its unique marker. The same barrier covers the only related caller of the marker-scoped cleanup command.

## Validation

- final exact regression matrix: 5/5 (test bodies 173-233 ms)
- related cron-connector-oauth-state-cleanup.test.ts: pass (243 ms)
- pnpm format and focused Prettier verification
- full monorepo lint, then final API lint after the shared helper change
- pnpm knip
- non-API/non-platform, platform, and API type-check gates; final API type gate after the shared helper change
- git diff --check

Closes #30078