### PR TITLE
perf(vsock-host): move exec output copy outside state lock

### DIFF
--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -15,7 +15,7 @@ use super::state::{
 };
 use super::types::{
     ExecControlAck, ExecControlGuestStatus, ExecControlOutcome, ExecOperationResult,
-    ExecOwnedCapturedOutput, SupervisedExecStartTiming,
+    ExecOutputEvent, ExecOwnedCapturedOutput, SupervisedExecStartTiming,
 };
 use super::{exec_operation_guest_error, exec_operation_protocol_error};
 
@@ -119,6 +119,19 @@ fn owned_captured_output(output: ExecCapturedOutput<'_>) -> ExecOwnedCapturedOut
     }
 }
 
+fn owned_output_event(
+    output: vsock_proto::DecodedExecOutput<'_>,
+    before_copy: impl FnOnce(),
+) -> ExecOutputEvent {
+    before_copy();
+    ExecOutputEvent {
+        stream: output.stream,
+        output_seq: output.output_seq,
+        chunk: output.chunk.to_vec(),
+        truncated: output.truncated,
+    }
+}
+
 #[cfg(test)]
 fn run_exec_output_before_copy_hook(shared: &Arc<Shared>) {
     let hook = shared
@@ -218,8 +231,10 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
     drop(senders_to_drop);
 
     let returned_sender = if let Some((permit, decoded)) = prepared_output {
-        #[cfg(test)]
-        run_exec_output_before_copy_hook(shared);
+        let event = owned_output_event(decoded, || {
+            #[cfg(test)]
+            run_exec_output_before_copy_hook(shared);
+        });
 
         {
             let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -234,7 +249,7 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
                 false
             };
             if sender_matches {
-                Some(permit.send(decoded))
+                Some(permit.send(event))
             } else {
                 None
             }

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -471,20 +471,12 @@ impl ExecStreamPermit {
         }
     }
 
-    pub(in crate::exec_operation) fn send(
-        self,
-        output: vsock_proto::DecodedExecOutput<'_>,
-    ) -> ExecStreamSender {
+    pub(in crate::exec_operation) fn send(self, output: ExecOutputEvent) -> ExecStreamSender {
         match self {
-            Self::Events(permit) => ExecStreamSender::Events(permit.send(ExecOutputEvent {
-                stream: output.stream,
-                output_seq: output.output_seq,
-                chunk: output.chunk.to_vec(),
-                truncated: output.truncated,
-            })),
+            Self::Events(permit) => ExecStreamSender::Events(permit.send(output)),
             Self::ProcessOutput(permit) => {
                 ExecStreamSender::ProcessOutput(permit.send(ProcessOutputChunk {
-                    bytes: output.chunk.to_vec(),
+                    bytes: output.chunk,
                     truncated: output.truncated,
                 }))
             }

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -534,7 +534,7 @@ async fn exec_operation_stream_handles_output_and_pending_response_from_one_writ
 }
 
 #[tokio::test]
-async fn exec_output_teardown_before_copy_discards_reserved_event() {
+async fn exec_output_teardown_at_copy_boundary_discards_reserved_event() {
     let (host, mut guest) = setup_host_and_guest().await;
     let mut handle = host
         .exec_operation_stream(stream_request("stream-copy-teardown"))
@@ -563,7 +563,7 @@ async fn exec_output_teardown_before_copy_discards_reserved_event() {
         .expect("operation teardown thread should not panic");
         assert!(
             removed,
-            "operation teardown should acquire the unlocked state and remove the operation"
+            "operation teardown should acquire state at the payload-copy boundary"
         );
     });
 


### PR DESCRIPTION
## Summary

- materialize streamed exec output before reacquiring the connection-wide state lock
- make `ExecStreamPermit::send` accept owned output and move bytes into both queue variants without copying
- bind the teardown regression hook to the actual payload-copy boundary

## Scope

- no wire protocol, public API, queue capacity, or error behavior changes
- no new logs

## Validation

- `cargo test -p vsock-host exec_output_teardown_at_copy_boundary_discards_reserved_event`
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-host --no-deps`
- `cargo test -p vsock-host` (387 passed)
- `lefthook run pre-commit`

Closes #30069
