### PR TITLE
refactor(runner): cut guest api url writer to canonical alias

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -213,11 +213,11 @@ fn env_or_empty(name: &str) -> String {
 }
 
 /// Resolve the Runner-to-Guest Agent API URL at the single process-env capture
-/// boundary. The canonical alias is reader-only during #28914 Stage 1; Runner
-/// writers and managed CLI-child exposure remain [`guest_contracts::env::API_URL_ENV`].
-/// Remove the legacy reader only after the exact production Runner plus
-/// embedded-Guest reader floor, complete pre-reader service and reusable-sandbox
-/// drain, supported rollback window, and value-free legacy-source-zero gates.
+/// boundary. The production Runner writer is canonical-only, while managed
+/// CLI-child exposure remains [`guest_contracts::env::API_URL_ENV`]. Retain this
+/// fail-closed legacy reader until the exact canonical writer production release,
+/// complete legacy-writer service and reusable-sandbox drain, supported rollback
+/// window, and value-free legacy-source-zero gates.
 fn api_url_env_or_empty(events: &mut BootstrapAliasSourceEvents) -> Result<String, String> {
     let canonical_key = guest_contracts::env::CANONICAL_API_URL_ENV;
     let legacy_key = guest_contracts::env::API_URL_ENV;

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -22,16 +22,17 @@
 /// processes by the guest-agent's curated child environment.
 pub const API_URL_ENV: &str = "VM0_API_BACKEND_URL";
 
-/// Canonical backend API URL spelling shared by migration readers.
+/// Canonical backend API URL spelling written by the production Runner.
 ///
 /// The Guest Agent bootstrap reader and Runner operator parser reuse this exact
 /// spelling but have independent rollout floors. On the Runner-to-Guest surface,
-/// Runner writers keep using [`API_URL_ENV`], and the guest-agent keeps exposing
-/// that legacy spelling to managed CLI children. Remove that legacy reader only
-/// after the exact production Runner plus embedded-Guest reader floor, complete
-/// pre-reader service and reusable-sandbox drain, supported rollback window,
-/// and value-free legacy-source-zero gates in #28914. Runner operator input and
-/// managed CLI-child exposure each have their own later support floors.
+/// the Runner emits only this canonical alias, while the Guest Agent retains
+/// [`API_URL_ENV`] as a rollback reader fallback and keeps exposing that legacy
+/// spelling to managed CLI children. Remove the legacy bootstrap reader only
+/// after the exact canonical writer production release, complete legacy-writer
+/// service and reusable-sandbox drain, supported rollback window, and value-free
+/// legacy-source-zero gates in #28914. Runner operator input and managed
+/// CLI-child exposure each have their own later support floors.
 pub const CANONICAL_API_URL_ENV: &str = "OKOU_API_BACKEND_URL";
 
 /// Stable run identifier used by guest-agent logs, telemetry, and runtime

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -585,7 +585,10 @@ fn build_env_json_with_host_env_inner(
 ) -> RunnerResult<HashMap<String, String>> {
     let mut env = HashMap::new();
 
-    env.insert(guest_contracts::env::API_URL_ENV.into(), api_url.into());
+    env.insert(
+        guest_contracts::env::CANONICAL_API_URL_ENV.into(),
+        api_url.into(),
+    );
     env.insert(
         guest_contracts::env::RUN_ID_ENV.into(),
         context.run_id.to_string(),

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -447,9 +447,11 @@ fn build_env_json_required_keys() {
     .expect("test env should build");
 
     assert_eq!(
-        env.get("VM0_API_BACKEND_URL").unwrap(),
+        env.get(guest_contracts::env::CANONICAL_API_URL_ENV)
+            .unwrap(),
         "https://api.example.com"
     );
+    assert!(!env.contains_key(guest_contracts::env::API_URL_ENV));
     assert_eq!(
         env.get(guest_contracts::env::RUN_ID_ENV).unwrap(),
         &RunId::nil().to_string()
@@ -511,18 +513,18 @@ fn build_env_json_required_keys() {
 }
 
 #[test]
-fn build_env_json_keeps_api_url_writer_legacy_only() {
+fn build_env_json_keeps_api_url_writer_canonical_only() {
     let ctx = minimal_context();
     let env = build_env_for_test(&ctx, "https://api.example.com");
 
     assert_eq!(
-        env.get(guest_contracts::env::API_URL_ENV)
+        env.get(guest_contracts::env::CANONICAL_API_URL_ENV)
             .map(String::as_str),
         Some("https://api.example.com")
     );
     assert!(
-        !env.contains_key(guest_contracts::env::CANONICAL_API_URL_ENV),
-        "Runner bootstrap writer emitted the reader-only canonical API URL alias"
+        !env.contains_key(guest_contracts::env::API_URL_ENV),
+        "canonical Runner bootstrap writer emitted the legacy API URL alias"
     );
 }
 


### PR DESCRIPTION
Closes #30097.

Parent EPIC: #28914.

## Summary

- switch the sole production Runner-to-Guest API URL bootstrap insertion to `CANONICAL_API_URL_ENV` / `OKOU_API_BACKEND_URL`
- preserve the unchanged `api_url.into()` value path and prove the exact canonical value plus legacy-key absence in both directly affected Runner assertions
- update only the two stale migration comments to describe the canonical-only Runner writer, retained fail-closed dual reader, and managed CLI-child legacy boundary

## Preserved contract

- the Guest Agent API URL dual reader, conflict handling, empty/non-Unicode behavior, source telemetry, and full alias matrix are unchanged
- managed CLI children still receive `VM0_API_BACKEND_URL`, while API tokens and all other bootstrap controls remain isolated
- the Runner operator API URL parser, Turbo/CLI/E2E/API/GitHub configuration, release and rollback workflows, ownership guard, every legacy constant, and every other environment family are unchanged
- the URL value remains byte-identical because only the `HashMap` key changed; the existing `api_url.into()` expression is untouched

## Base and inventory

- clean final pre-edit base: `e5f7b2b55a08842428ed0a15976093f3d2b7681c`
- published head: `87a0229ed71cee007f66a0db3866787e1ee681ee`
- final diff: exactly the four files authorized by #30097, `+24/-18`
- final pre-edit open-PR audit: 33 open PRs, 523 GitHub-declared changed files, 523 fetched file records across 34 pages, and zero pagination/count mismatches
- sole scoped overlap: stale #25722 at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`, with 185 files across pages `[100,85]`; its three overlapping patches add unrelated Cloudflare Access constants, host injection, and assertions
- post-edit exact inventory: `API_URL_ENV` 30 lines / 11 files, `CANONICAL_API_URL_ENV` 62 / 43, `VM0_API_BACKEND_URL` 212 / 128, `OKOU_API_BACKEND_URL` 75 / 44, and `api_url_env_source` 4 / 3

## Verification

Passed locally, sequentially, with one Cargo build job where applicable:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- strict all-targets/all-features Clippy with `-D warnings` for `guest-contracts`, `guest-agent`, and `runner`
- `RUSTFLAGS='-D warnings' cargo check --manifest-path crates/Cargo.toml -p runner -p guest-agent -p guest-contracts --all-targets --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-agent -p guest-contracts --all-features --no-deps --locked`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-features --locked` (123 unit and 11 integration tests passed; doc tests passed)
- Guest Agent integration targets: `api_url_env_aliases`, `bootstrap_alias_source_events`, `cli_child_env`, `codex_app_server_backend_child_env`, `codex_app_server_env_isolation`, and `api_token_process_isolation`
- exact changed-file, caller, production-insertion, unchanged-boundary, and `git diff --check` checks

The exact Runner selector `executor::tests::env_tests::build_env_json_required_keys` compiled the complete test graph and entered the final monolithic link under single-job, no-incremental, no-test-debuginfo, linker-memory-constrained settings. The memcg then killed `rustc` at `anon-rss=3,740,476 kB` against `memory.max=3,991,613,440` with zero swap; `memory.events` recorded `oom=1`, `oom_kill=3`, and `oom_group_kill=1`. No test binary was produced and no assertion ran. The second exact selector uses the same unavailable binary and was not redundantly relinked. Strict all-targets Clippy/check type-checked both assertions; protected PR CI is authoritative for linked Runner execution.

No local Vitest suite was run and no local development server was started.

## Rollback

Reverting this focused commit restores the legacy-only Runner writer. The deployed Guest Agent dual reader remains compatible with either writer, and this PR changes no persisted state or external configuration.
