### PR TITLE
test(python): cover pending snapshot replace recovery

### DIFF
--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -340,6 +340,41 @@ class TestUsagePendingCounter:
 
     # ---- one-shot error signal on write failure (issue #10483) ----
 
+    def test_replace_failure_preserves_snapshot_cleans_temp_and_recovers(self, tmp_path, mitm_ctx):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="state-1")
+        baseline_state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
+        usage.increment_in_flight_flows()
+
+        with (
+            mitm_ctx() as mock_log,
+            patch.object(
+                usage.counters.Path,
+                "replace",
+                side_effect=OSError("replace failed\nretry"),
+            ),
+        ):
+            usage.write_pending_snapshot(flush_request_id="failed-1")
+            usage.write_pending_snapshot(flush_request_id="failed-2")
+
+        assert json.loads(pending_path.read_text()) == baseline_state
+        assert list(tmp_path.glob(f"{pending_path.name}.*.tmp")) == []
+        assert mock_log.error.call_count == 1
+        assert mock_log.warn.call_count == 0
+        message = mock_log.error.call_args.args[0]
+        assert "reason=pending_snapshot_write_failed" in message
+        assert "error=replace\\sfailed\\nretry" in message
+        assert "\n" not in message
+
+        usage.write_pending_snapshot(flush_request_id="recovered")
+        assert_pending(
+            pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="recovered",
+        )
+
     def test_write_failure_logs_underbilling_once_per_process(self, tmp_path, mitm_ctx):
         """Repeated OSErrors from pending snapshot writes emit exactly one
         ``ctx.log.error`` per addon process — enough to seed FS-trouble


### PR DESCRIPTION
## Summary

- cover the pending-snapshot path when a real temporary write succeeds but `Path.replace` fails
- verify the previous canonical JSON survives, UUID temporary files are cleaned, and repeated failures emit one sanitized underbilling error without raising
- verify an unpatched retry publishes current counters and the new flush request ID

## Scope

This is test-only. It does not change production code, logging, APIs, runner protocols, persisted state, migrations, dependencies, or deployment behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_counters.py::TestUsagePendingCounter::test_replace_failure_preserves_snapshot_cleans_temp_and_recovers`
- `uv run --no-sync python -m pytest tests/test_counters.py` — 20 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `uv run --no-sync python -m pytest tests/` — 7,192 passed
- `lefthook run pre-commit --file crates/runner/mitm-addon/tests/test_counters.py`

Closes #30095
