### PR TITLE
perf(api): stop persisting run-output progress per event batch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -28,6 +28,7 @@ import {
   holdChatEventInsertTransactionFixture,
   holdGoalThreadLockFixture,
   holdModelPolicyReadsFixture,
+  holdRunOutputMaterializationRowFixture,
   invalidateChatCallbackPayloadFixture,
   insertQueuedSlackMissingContextFixture,
   readChatEventContextFixture,
@@ -1732,7 +1733,6 @@ describe("CHAT-02: completed chat callback", () => {
       "api_dispatch_pre_create_zero_chat_callback_load_terminal",
       "api_dispatch_pre_create_zero_chat_callback_prepare_completed",
       "api_dispatch_pre_create_zero_chat_callback_load_db_output_state",
-      "api_dispatch_pre_create_zero_chat_callback_db_output_complete",
       "api_dispatch_pre_create_zero_chat_callback_insert_lifecycle_marker",
       "api_dispatch_pre_create_zero_chat_callback_load_followup_context",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
@@ -3191,8 +3191,8 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
   }, 90_000);
 });
 
-describe("CHAT-02: chat output extraction and progress callbacks", () => {
-  it("uses DB-complete assistant output for queued auto-send without querying Axiom output", async () => {
+describe("CHAT-02: chat output extraction and terminal callbacks", () => {
+  it("uses durable assistant output for queued auto-send without querying Axiom output", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -3275,7 +3275,6 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
         "api_dispatch_pre_create_zero_chat_callback_load_terminal",
         "api_dispatch_pre_create_zero_chat_callback_prepare_completed",
         "api_dispatch_pre_create_zero_chat_callback_load_db_output_state",
-        "api_dispatch_pre_create_zero_chat_callback_db_output_complete",
         "api_dispatch_pre_create_zero_chat_callback_insert_lifecycle_marker",
         "api_dispatch_pre_create_zero_chat_callback_load_followup_context",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
@@ -3403,6 +3402,76 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     expect(chatOutputAxiomQueryCalls()).toHaveLength(0);
   }, 90_000);
 
+  it("persists assistant-only batches without writing the run-output materialization", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt:
+        "persist assistant output while the callback projection is locked",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 0,
+            result: "Seed the callback projection row",
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    const held = await holdRunOutputMaterializationRowFixture({
+      runId: run.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 1,
+            message: {
+              id: "msg_bdd_no_output_materialization_write",
+              content: [
+                {
+                  type: "text",
+                  text: "Durable assistant output while the projection row is locked",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+
+    await expect(held.blockedWaiterCount()).resolves.toBe(0);
+    const messages = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      eventBackedContents(messages.events, run.runId).map((message) => {
+        return message.content;
+      }),
+    ).toStrictEqual([
+      "Durable assistant output while the projection row is locked",
+    ]);
+    await flushWaitUntilForTest();
+    held.release();
+    await held.done;
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await flushWaitUntilForTest();
+  }, 30_000);
+
   it("persists normalized Claude text blocks independently across tool-only sequences", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -3464,8 +3533,6 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
       [200],
     );
     context.mocks.axiom.query.mockClear();
-    context.mocks.axiomLogging.warn.mockClear();
-
     await completeChatRunOk(run.runId, sandboxHeaders, {
       lastEventSequence: 3,
     });
@@ -3506,16 +3573,6 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     ).toBe(3);
     expect(chatOutputAxiomQueryCalls()).toHaveLength(0);
     await flushWaitUntilForTest();
-    expect(
-      context.mocks.axiomLogging.warn.mock.calls.some(([message, fields]) => {
-        return (
-          message ===
-            "Run output projection is incomplete at terminal callback" &&
-          isRecord(fields) &&
-          fields.runId === run.runId
-        );
-      }),
-    ).toBeFalsy();
   }, 90_000);
 
   it("returns 503 when the required DB output projection is locked", async () => {
@@ -3658,21 +3715,10 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     const messages = await chat.listThreadEvents(actor, run.threadId);
     expect(eventBackedContents(messages.events, run.runId)).toHaveLength(6);
 
-    context.mocks.axiomLogging.warn.mockClear();
     await completeChatRunOk(run.runId, sandboxHeaders, {
       lastEventSequence: 5,
     });
     await flushWaitUntilForTest();
-    expect(
-      context.mocks.axiomLogging.warn.mock.calls.some(([message, fields]) => {
-        return (
-          message ===
-            "Run output projection is incomplete at terminal callback" &&
-          isRecord(fields) &&
-          fields.runId === run.runId
-        );
-      }),
-    ).toBeFalsy();
   }, 30_000);
 
   it("keeps rejected event reservations as sequence gaps", async () => {
@@ -3786,7 +3832,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     expect(firstAssistantEventsForRun(run.runId)).toHaveLength(1);
   });
 
-  it("uses DB projection for both no-output and result-only runs", async () => {
+  it("completes no-output runs and preserves the newest result-only output across retries", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -3855,8 +3901,36 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
         events: [
           {
             type: "result",
-            sequenceNumber: 0,
+            sequenceNumber: 2,
             result: "DB result fallback answer",
+          },
+        ],
+      },
+      resultOnlyHeaders,
+      [200],
+    );
+    await webhooks.requestAgentEvents(
+      {
+        runId: resultOnly.runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 2,
+            result: "DB result fallback answer",
+          },
+        ],
+      },
+      resultOnlyHeaders,
+      [200],
+    );
+    await webhooks.requestAgentEvents(
+      {
+        runId: resultOnly.runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 1,
+            result: "Older result must not replace the latest output",
           },
         ],
       },
@@ -3866,7 +3940,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     context.mocks.axiom.query.mockClear();
 
     await completeChatRunOk(resultOnly.runId, resultOnlyHeaders, {
-      lastEventSequence: 0,
+      lastEventSequence: 2,
     });
     messages = await waitForThreadMessages(
       actor,
@@ -3887,7 +3961,48 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     expect(firstAssistantEventsForRun(resultOnly.runId)).toHaveLength(1);
   }, 90_000);
 
-  it("completes with DB-only output when the projection is incomplete", async () => {
+  it("excludes stored result output above the terminal event boundary", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "exclude future result output",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 1,
+            result: "Future result must stay outside the completed run",
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    const messages = await waitForThreadMessages(
+      actor,
+      run.threadId,
+      (threadMessages) => {
+        return (
+          lifecycleMarkers(threadMessages, run.runId, "completed").length === 1
+        );
+      },
+    );
+    expect(eventBackedContents(messages.events, run.runId)).toHaveLength(0);
+    await flushWaitUntilForTest();
+    expect(firstAssistantEventsForRun(run.runId)).toStrictEqual([]);
+  }, 90_000);
+
+  it("completes when no output materialization exists", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -3922,7 +4037,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     expect(eventBackedContents(messages.events, run.runId)).toHaveLength(0);
   }, 90_000);
 
-  it("extracts assistant output from Codex items and result fallbacks, skips non-events, and acknowledges progress without reading events", async () => {
+  it("extracts assistant output from Codex items and result fallbacks, skips non-events, and handles heartbeats without reading events", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const routeRequests = chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -5056,8 +5171,6 @@ describe("CHAT-02: auto-send after failures", () => {
     expectNoChatCallbackPreCreateTimingActions(timingEvents, [
       "api_dispatch_pre_create_zero_chat_callback_prepare_completed",
       "api_dispatch_pre_create_zero_chat_callback_load_db_output_state",
-      "api_dispatch_pre_create_zero_chat_callback_db_output_complete",
-      "api_dispatch_pre_create_zero_chat_callback_db_output_incomplete",
       "api_dispatch_pre_create_zero_chat_callback_insert_lifecycle_marker",
       "api_dispatch_pre_create_zero_chat_callback_load_followup_context",
     ]);

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -36,7 +36,6 @@ import {
   toolUseIdForRunEvent,
 } from "./assistant-event-id";
 
-const INITIAL_PROCESSED_THROUGH_SEQUENCE = -1;
 const RUN_OUTPUT_PROJECTION_LOCK_TIMEOUT = "1s";
 const RUN_OUTPUT_PROJECTION_STATEMENT_TIMEOUT = "5s";
 interface OutputCandidate {
@@ -59,6 +58,13 @@ export interface MaterializedChatProjection {
     readonly apiStartedAt: number;
     readonly acknowledgedAt: number;
   } | null;
+}
+
+export class AgentEventRunNotFoundError extends Error {
+  constructor(runId: string) {
+    super(`Run ${runId} is missing during output materialization`);
+    this.name = "AgentEventRunNotFoundError";
+  }
 }
 
 function recordOf(value: unknown): Record<string, unknown> | null {
@@ -179,67 +185,6 @@ function eventOutputId(event: AgentEvent): string {
   }
 
   return `event:${event.sequenceNumber}`;
-}
-
-function nextProjectionSequenceState(
-  currentProcessedThroughSequence: number,
-  currentPendingSequenceNumbers: readonly number[],
-  events: readonly AgentEvent[],
-): {
-  readonly processedThroughSequence: number;
-  readonly pendingSequenceNumbers: number[];
-} {
-  const sortedSequences = Array.from(
-    new Set(
-      [
-        ...currentPendingSequenceNumbers,
-        ...events.map((event) => {
-          return event.sequenceNumber;
-        }),
-      ].filter((sequenceNumber) => {
-        return Number.isInteger(sequenceNumber) && sequenceNumber >= 0;
-      }),
-    ),
-  ).sort((left, right) => {
-    return left - right;
-  });
-
-  let nextProcessedThroughSequence = currentProcessedThroughSequence;
-  for (const sequenceNumber of sortedSequences) {
-    if (sequenceNumber <= nextProcessedThroughSequence) {
-      continue;
-    }
-    if (sequenceNumber !== nextProcessedThroughSequence + 1) {
-      break;
-    }
-    nextProcessedThroughSequence = sequenceNumber;
-  }
-
-  return {
-    processedThroughSequence: nextProcessedThroughSequence,
-    pendingSequenceNumbers: sortedSequences.filter((sequenceNumber) => {
-      return sequenceNumber > nextProcessedThroughSequence;
-    }),
-  };
-}
-
-function nextStoredProjectionSequenceState(
-  current:
-    | {
-        readonly processedThroughSequence: number;
-        readonly pendingSequenceNumbers: readonly number[];
-      }
-    | undefined,
-  events: readonly AgentEvent[],
-): {
-  readonly processedThroughSequence: number;
-  readonly pendingSequenceNumbers: number[];
-} {
-  return nextProjectionSequenceState(
-    current?.processedThroughSequence ?? INITIAL_PROCESSED_THROUGH_SEQUENCE,
-    current?.pendingSequenceNumbers ?? [],
-    events,
-  );
 }
 
 function toolRunEventId(sequenceNumber: number): string {
@@ -468,6 +413,23 @@ async function lockRunOutputProjection(
   signal.throwIfAborted();
 }
 
+async function lockAgentRunForOutputMaterialization(
+  tx: Tx,
+  runId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const [run] = await tx
+    .select({ id: agentRuns.id })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .for("key share")
+    .limit(1);
+  signal.throwIfAborted();
+  if (!run) {
+    throw new AgentEventRunNotFoundError(runId);
+  }
+}
+
 async function materializeRunOutputEvents(
   writeDb: Db,
   payload: EventConsumerPayload,
@@ -478,6 +440,7 @@ async function materializeRunOutputEvents(
 
   return await writeDb.transaction(async (tx) => {
     await lockRunOutputProjection(tx, payload.runId, signal);
+    await lockAgentRunForOutputMaterialization(tx, payload.runId, signal);
 
     const thread = await chatThreadForRunFromDb(tx, payload.runId);
     signal.throwIfAborted();
@@ -496,57 +459,41 @@ async function materializeRunOutputEvents(
         insertion.shouldAttemptFirstAssistantEventClaim;
     }
 
-    const [existingState] = await tx
-      .select({
-        processedThroughSequence:
-          runOutputMaterializations.processedThroughSequence,
-        pendingSequenceNumbers:
-          runOutputMaterializations.pendingSequenceNumbers,
-      })
-      .from(runOutputMaterializations)
-      .where(eq(runOutputMaterializations.runId, payload.runId))
-      .limit(1);
-    signal.throwIfAborted();
-
-    const { processedThroughSequence, pendingSequenceNumbers } =
-      nextStoredProjectionSequenceState(existingState, payload.events);
-    const updatedAt = nowDate();
-    await tx
-      .insert(runOutputMaterializations)
-      .values({
-        runId: payload.runId,
-        processedThroughSequence,
-        pendingSequenceNumbers,
-        latestResultSequence: latestResult?.sequenceNumber,
-        latestResultText: latestResult?.content,
-        latestOutputSequence: latestOutput?.sequenceNumber,
-        latestOutputText: latestOutput?.content,
-        updatedAt,
-      })
-      .onConflictDoUpdate({
-        target: runOutputMaterializations.runId,
-        set: {
-          processedThroughSequence: sql`greatest(${runOutputMaterializations.processedThroughSequence}, ${processedThroughSequence})`,
-          pendingSequenceNumbers,
-          latestResultSequence:
-            latestResult === null
-              ? runOutputMaterializations.latestResultSequence
-              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.sequenceNumber} else ${runOutputMaterializations.latestResultSequence} end`,
-          latestResultText:
-            latestResult === null
-              ? runOutputMaterializations.latestResultText
-              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.content} else ${runOutputMaterializations.latestResultText} end`,
-          latestOutputSequence:
-            latestOutput === null
-              ? runOutputMaterializations.latestOutputSequence
-              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.sequenceNumber} else ${runOutputMaterializations.latestOutputSequence} end`,
-          latestOutputText:
-            latestOutput === null
-              ? runOutputMaterializations.latestOutputText
-              : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.content} else ${runOutputMaterializations.latestOutputText} end`,
+    if (latestResult !== null || latestOutput !== null) {
+      const updatedAt = nowDate();
+      await tx
+        .insert(runOutputMaterializations)
+        .values({
+          runId: payload.runId,
+          latestResultSequence: latestResult?.sequenceNumber,
+          latestResultText: latestResult?.content,
+          latestOutputSequence: latestOutput?.sequenceNumber,
+          latestOutputText: latestOutput?.content,
           updatedAt,
-        },
-      });
+        })
+        .onConflictDoUpdate({
+          target: runOutputMaterializations.runId,
+          set: {
+            latestResultSequence:
+              latestResult === null
+                ? runOutputMaterializations.latestResultSequence
+                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.sequenceNumber} else ${runOutputMaterializations.latestResultSequence} end`,
+            latestResultText:
+              latestResult === null
+                ? runOutputMaterializations.latestResultText
+                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestResultSequence}, -1)`, latestResult.sequenceNumber)} then ${latestResult.content} else ${runOutputMaterializations.latestResultText} end`,
+            latestOutputSequence:
+              latestOutput === null
+                ? runOutputMaterializations.latestOutputSequence
+                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.sequenceNumber} else ${runOutputMaterializations.latestOutputSequence} end`,
+            latestOutputText:
+              latestOutput === null
+                ? runOutputMaterializations.latestOutputText
+                : sql`case when ${lte(sql`coalesce(${runOutputMaterializations.latestOutputSequence}, -1)`, latestOutput.sequenceNumber)} then ${latestOutput.content} else ${runOutputMaterializations.latestOutputText} end`,
+            updatedAt,
+          },
+        });
+    }
     signal.throwIfAborted();
 
     if (!thread) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -13,6 +13,7 @@ import type { SandboxAuth } from "../../types/auth";
 import { refreshAgentPhoneTypingEvents$ } from "./agent-event-consumer-agentphone-typing.service";
 import { ingestAxiomEvents } from "./agent-event-consumer-axiom.service";
 import {
+  AgentEventRunNotFoundError,
   materializeRunOutputEvents$,
   publishMaterializedChatProjection,
   type MaterializedChatProjection,
@@ -178,7 +179,10 @@ export const receiveAgentEvents$ = command(
     );
     signal.throwIfAborted();
     if (!projectionResult.ok) {
-      if (isForeignKeyViolation(projectionResult.error)) {
+      if (
+        projectionResult.error instanceof AgentEventRunNotFoundError ||
+        isForeignKeyViolation(projectionResult.error)
+      ) {
         L.debug("Ignored events for deleted run", {
           runId: payload.runId,
           ...range,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -245,8 +245,6 @@ type ChatCallbackPreCreateTimingActionType =
   | "api_dispatch_pre_create_zero_chat_callback_prepare_completed"
   | "api_dispatch_pre_create_zero_chat_callback_prepare_failed"
   | "api_dispatch_pre_create_zero_chat_callback_load_db_output_state"
-  | "api_dispatch_pre_create_zero_chat_callback_db_output_complete"
-  | "api_dispatch_pre_create_zero_chat_callback_db_output_incomplete"
   | "api_dispatch_pre_create_zero_chat_callback_insert_assistant_items"
   | "api_dispatch_pre_create_zero_chat_callback_insert_lifecycle_marker"
   | "api_dispatch_pre_create_zero_chat_callback_load_followup_context"
@@ -454,8 +452,7 @@ interface ResultEventItem {
   readonly content: string;
 }
 
-interface DbCompletedChatOutputState {
-  readonly kind: "complete" | "incomplete";
+interface DbCompletedChatOutput {
   readonly latestAssistant: AssistantEventItem | null;
   readonly resultFallback: ResultEventItem | null;
 }
@@ -1076,14 +1073,13 @@ async function latestEventBackedAssistantEvent(
   };
 }
 
-async function loadDbCompletedChatOutputState(args: {
+async function loadDbCompletedChatOutput(args: {
   readonly db: Db;
   readonly runId: string;
   readonly lastEventSequence: number | null;
-}): Promise<DbCompletedChatOutputState> {
+}): Promise<DbCompletedChatOutput> {
   if (args.lastEventSequence === null) {
     return {
-      kind: "complete",
       latestAssistant: null,
       resultFallback: null,
     };
@@ -1091,8 +1087,6 @@ async function loadDbCompletedChatOutputState(args: {
 
   const [state] = await args.db
     .select({
-      processedThroughSequence:
-        runOutputMaterializations.processedThroughSequence,
       latestResultSequence: runOutputMaterializations.latestResultSequence,
       latestResultText: runOutputMaterializations.latestResultText,
     })
@@ -1116,27 +1110,9 @@ async function loadDbCompletedChatOutputState(args: {
         }
       : null;
   return {
-    kind:
-      state && state.processedThroughSequence >= args.lastEventSequence
-        ? "complete"
-        : "incomplete",
     latestAssistant,
     resultFallback,
   };
-}
-
-async function recordDbOutputStateTiming(
-  timing: ChatCallbackPreCreateTimingCollector,
-  state: DbCompletedChatOutputState,
-): Promise<void> {
-  await measureChatCallbackPreCreateTiming(
-    timing,
-    state.kind === "complete"
-      ? "api_dispatch_pre_create_zero_chat_callback_db_output_complete"
-      : "api_dispatch_pre_create_zero_chat_callback_db_output_incomplete",
-    "nested",
-    () => {},
-  );
 }
 
 async function loadCompletedChatOutput(
@@ -1148,12 +1124,12 @@ async function loadCompletedChatOutput(
   },
   signal: AbortSignal,
 ): Promise<CompletedChatOutputLoad> {
-  const dbOutputState = await measureChatCallbackPreCreateTiming(
+  const dbOutput = await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_load_db_output_state",
     "nested",
     () => {
-      return loadDbCompletedChatOutputState({
+      return loadDbCompletedChatOutput({
         db: args.db,
         runId: args.runId,
         lastEventSequence: args.lastEventSequence,
@@ -1162,20 +1138,10 @@ async function loadCompletedChatOutput(
   );
   signal.throwIfAborted();
 
-  await recordDbOutputStateTiming(args.timing, dbOutputState);
-  signal.throwIfAborted();
-
-  if (dbOutputState.kind === "incomplete") {
-    log.warn("Run output projection is incomplete at terminal callback", {
-      runId: args.runId,
-      lastEventSequence: args.lastEventSequence,
-    });
-  }
-
   return {
     assistantItemsToInsert: [],
-    latestAssistant: dbOutputState.latestAssistant,
-    resultFallback: dbOutputState.resultFallback,
+    latestAssistant: dbOutput.latestAssistant,
+    resultFallback: dbOutput.resultFallback,
   };
 }
 

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -31,6 +31,7 @@ import { conversations } from "@okouai/db/schema/conversation";
 import { githubChatThreadRoutes } from "@okouai/db/schema/github-chat-thread-route";
 import { githubInstallations } from "@okouai/db/schema/github-installation";
 import { orgModelPolicies } from "@okouai/db/schema/org-model-policy";
+import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
 import {
   and,
@@ -2492,6 +2493,56 @@ export async function holdChatEventInsertTransactionFixture(args: {
     done,
     blockedWaiterCount: async () => {
       return await transitiveBlockedWaiterCount(pid);
+    },
+  };
+}
+
+/** Holds one existing run-output row to expose writes from later event batches. */
+export async function holdRunOutputMaterializationRowFixture(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`
+        SELECT pg_backend_pid() AS "pid"
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = pidRows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the run-output row lock holder pid");
+    }
+    const [row] = await tx
+      .select({ runId: runOutputMaterializations.runId })
+      .from(runOutputMaterializations)
+      .where(eq(runOutputMaterializations.runId, args.runId))
+      .for("update")
+      .limit(1);
+    if (!row) {
+      throw new Error("Expected an existing run-output materialization");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await transitiveBlockedWaiterCount(holderPid);
     },
   };
 }


### PR DESCRIPTION
## Summary

- stop reading, advancing, classifying, and persisting per-batch run-output progress state
- only upsert `chat_output_materializations` when a result or callback-output candidate exists, preserving the existing sequence-wins semantics
- keep Chat assistant/reasoning/tool persistence in the original transaction and keep terminal output bounded by `lastEventSequence`
- remove complete/incomplete output-state warnings and timing actions while retaining DB output-load timing

This is the runtime-contraction sub-step of #29933. It does not implement Guest batching.

## Durability and compatibility

- required Chat event persistence still completes before the event webhook returns HTTP 200
- duplicate, retry, lower-sequence, and out-of-order candidates cannot replace newer stored output
- advisory serialization, tool correlation, realtime publication, and first-assistant acknowledgement metrics remain intact
- missing/deleted runs are explicitly detected under an `agent_runs` key-share lock, preserving the existing safe acknowledgement boundary without relying on an output-row FK side effect
- **no migration is included**
- **physical `processed_through_sequence` and `pending_sequence_numbers` columns remain in Drizzle and PostgreSQL**, including their existing defaults, so draining and rollback API versions can continue reading and writing them
- new runtime inserts omit those columns and rely on their defaults

## Validation

All commands were run from `turbo/` unless noted.

- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm format` — passed
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run lint --concurrency=1 --log-order grouped` — passed, 13/13 tasks
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm knip` — passed
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — passed, 12/12 tasks
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/app run check-types` — passed
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api run lint` — passed after the CI follow-up
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api run check-types` — passed after the CI follow-up
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'uses durable assistant output|uses every acknowledged DB assistant event|does not query Axiom when repeated DB event batches are idempotent|persists assistant-only batches without writing the run-output materialization|persists normalized Claude text blocks|returns 503 when the required DB output projection is locked|returns the route deadline while a required DB projection remains blocked|persists concurrent event batches|keeps rejected event reservations as sequence gaps|completes no-output runs and preserves the newest result-only output|excludes stored result output above the terminal event boundary|completes when no output materialization exists|extracts assistant output from Codex items'` — passed, 13/13 selected tests before and after the follow-up
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t 'acknowledges an event batch when its required DB run is missing'` — passed, 1/1 selected test
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api exec vitest run src/signals/routes/__tests__/agent-tool-materialization.bdd.test.ts` — passed, 3/3 tests
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-automation-result-email.test.ts` — passed, 9/9 tests
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_30099_test pnpm --filter api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts -t 'builds Feishu DM context and canonical response metadata'` — passed, 1/1 selected test
- `pnpm prettier --check apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts apps/api/src/signals/services/agent-event-consumer-run-output.service.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/test-fixtures/chat-events.ts` — passed after rebase
- `git diff --check origin/main...HEAD` — passed

A first unfiltered Chat callback run used a locally initialized PostgreSQL cluster whose server timezone was Asia/Shanghai and failed before event processing at runner-job claim expiry (52 identical 404 claim failures; queued jobs and heartbeats were present). A fresh UTC database matching CI was migrated before the issue-focused runs above; all selected scenarios passed.

The first PR CI pass exposed one changed-path regression in `test-api (5)`: removing the unconditional output insert also removed its incidental FK-based missing-run detection, allowing optional Axiom delivery. The current revision replaces that incidental behavior with an explicit `agent_runs` key-share check; the exact failing test and the core Chat selection pass locally on the updated SHA.

## Self-review against #30099

- repo-wide API runtime search has no references to `processedThroughSequence`, `pendingSequenceNumbers`, their removed helpers, complete/incomplete timing actions, or the removed warning
- schema and migration snapshots still contain both physical progress columns and defaults
- the diff contains no schema or migration files
- terminal Chat reads retain the `lastEventSequence` upper bound for both assistant events and result fallback
- `latestResult*` and `latestOutput*` readers remain wired for Chat, Feishu Org, and Official Workflow Automation result email; Chat-backed Slack, Teams, Telegram, AgentPhone, GitHub, and web delivery continue through the same completion path

Closes #30099
