### PR TITLE
refactor(guest-agent): remove legacy root cgroup placement readers

### DIFF
--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -33,37 +33,12 @@ const WORKLOAD_BOOTSTRAP_IO_TIMEOUT: std::time::Duration = std::time::Duration::
 #[cfg(debug_assertions)]
 const TEST_ALLOW_UNMANAGED_PROCESS_CONTROL_ENV: &str = "OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CgroupPlacementEnvSource {
-    CanonicalOnly,
-    LegacyOnly,
-    Dual,
-}
-
-impl CgroupPlacementEnvSource {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CanonicalOnly => "canonical-only",
-            Self::LegacyOnly => "legacy-only",
-            Self::Dual => "dual",
-        }
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-struct ResolvedCgroupPlacementEndpoint {
-    value: String,
-    source: CgroupPlacementEnvSource,
-}
-
 /// Root-opened capability used only to place CLI children in `workload/runtime`.
 #[derive(Clone, Debug)]
 pub struct WorkloadContainment {
     placement: Arc<OwnedFd>,
     workload_path: Arc<PathBuf>,
     tool_placement_endpoint: Arc<str>,
-    workload_endpoint_source: CgroupPlacementEnvSource,
-    tool_endpoint_source: CgroupPlacementEnvSource,
 }
 
 /// Resource enforcement observed for a completed workload.
@@ -80,15 +55,11 @@ impl WorkloadContainment {
     ///
     /// This must run before any other thread can read or mutate process-global
     /// environment state. The caller supplies the once-resolved canonical or
-    /// legacy process-control presence. A process-control bootstrap requires a
-    /// matching workload capability in production. Direct local execution is
-    /// unmanaged when neither bootstrap value exists.
-    ///
-    /// This reader fallback covers existing runners and reusable sandboxes for
-    /// the two-hour guest runtime budget plus bounded finalization. #28914 owns
-    /// the writer-cutover and reader-removal follow-ups; remove the legacy
-    /// branches only after the reader floor, drain, rollback window, and
-    /// legacy-read-zero gates are complete.
+    /// legacy process-control presence. A process-control bootstrap requires
+    /// the canonical workload and tool capabilities in production. Direct
+    /// local execution is unmanaged when neither canonical capability exists.
+    /// Retired root-bootstrap aliases are ignored during selection and scrubbed
+    /// after the canonical pair is captured successfully.
     pub fn from_process_env(process_control_present: bool) -> Result<Option<Self>, String> {
         let (placement_endpoint, tool_endpoint) =
             resolve_cgroup_placement_endpoints_from_process_env()?;
@@ -98,41 +69,30 @@ impl WorkloadContainment {
             (true, None, None) if test_allows_unmanaged_process_control() => Ok(None),
             (true, Some(placement), Some(tool)) => {
                 reject_empty_cgroup_placement_endpoint(
-                    &placement.value,
+                    &placement,
                     CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                    WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 )?;
-                reject_empty_cgroup_placement_endpoint(
-                    &tool.value,
-                    CANONICAL_TOOL_CGROUP_PROCS_ENV,
-                    TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-                )?;
+                reject_empty_cgroup_placement_endpoint(&tool, CANONICAL_TOOL_CGROUP_PROCS_ENV)?;
                 // SAFETY: production calls this before constructing the Tokio
                 // runtime, so no other thread can access the environment.
                 unsafe {
                     remove_cgroup_placement_endpoint_aliases();
                 }
-                Self::receive(&placement.value, tool.value, placement.source, tool.source)
-                    .map(Some)
-                    .map_err(|error| {
-                        format!("invalid {WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV}: {error}")
-                    })
+                Self::receive(&placement, tool).map(Some).map_err(|error| {
+                    format!("invalid {CANONICAL_WORKLOAD_CGROUP_PROCS_ENV}: {error}")
+                })
             }
             (true, _, _) => Err(format!(
-                "{} or {}, and {} or {}, are required with {} or {}",
+                "{} and {} are required with {} or {}",
                 CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 CANONICAL_TOOL_CGROUP_PROCS_ENV,
-                TOOL_CGROUP_PROCS_ENDPOINT_ENV,
                 process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
             (false, _, _) => Err(format!(
-                "{} or {}, and {} or {}, require {} or {}",
+                "{} and {} require {} or {}",
                 CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 CANONICAL_TOOL_CGROUP_PROCS_ENV,
-                TOOL_CGROUP_PROCS_ENDPOINT_ENV,
                 process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
@@ -192,43 +152,22 @@ impl WorkloadContainment {
 
     pub(crate) fn env_source_evidence(&self) -> [(&'static str, &'static str); 2] {
         [
-            (
-                CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                self.workload_endpoint_source.label(),
-            ),
-            (
-                CANONICAL_TOOL_CGROUP_PROCS_ENV,
-                self.tool_endpoint_source.label(),
-            ),
+            (CANONICAL_WORKLOAD_CGROUP_PROCS_ENV, "canonical-only"),
+            (CANONICAL_TOOL_CGROUP_PROCS_ENV, "canonical-only"),
         ]
     }
 
-    fn receive(
-        endpoint: &str,
-        tool_endpoint: String,
-        workload_endpoint_source: CgroupPlacementEnvSource,
-        tool_endpoint_source: CgroupPlacementEnvSource,
-    ) -> io::Result<Self> {
+    fn receive(endpoint: &str, tool_endpoint: String) -> io::Result<Self> {
         let stream = process_control_ipc::connect_abstract(endpoint)?;
         stream.set_read_timeout(Some(WORKLOAD_BOOTSTRAP_IO_TIMEOUT))?;
         stream.set_write_timeout(Some(WORKLOAD_BOOTSTRAP_IO_TIMEOUT))?;
         let placement = process_control_ipc::receive_workload_placement(&stream)?;
-        let containment = Self::adopt(
-            placement,
-            tool_endpoint,
-            workload_endpoint_source,
-            tool_endpoint_source,
-        )?;
+        let containment = Self::adopt(placement, tool_endpoint)?;
         process_control_ipc::write_workload_placement_confirmation(&stream)?;
         Ok(containment)
     }
 
-    fn adopt(
-        placement: OwnedFd,
-        tool_endpoint: String,
-        workload_endpoint_source: CgroupPlacementEnvSource,
-        tool_endpoint_source: CgroupPlacementEnvSource,
-    ) -> io::Result<Self> {
+    fn adopt(placement: OwnedFd, tool_endpoint: String) -> io::Result<Self> {
         // SAFETY: F_GETFD only inspects the supplied descriptor.
         let descriptor_flags = unsafe { libc::fcntl(placement.as_raw_fd(), libc::F_GETFD) };
         if descriptor_flags < 0 {
@@ -246,73 +185,25 @@ impl WorkloadContainment {
             placement: Arc::new(placement),
             workload_path: Arc::new(workload_path),
             tool_placement_endpoint: Arc::from(tool_endpoint),
-            workload_endpoint_source,
-            tool_endpoint_source,
         })
     }
 }
 
-fn resolve_cgroup_placement_endpoints_from_process_env() -> Result<
-    (
-        Option<ResolvedCgroupPlacementEndpoint>,
-        Option<ResolvedCgroupPlacementEndpoint>,
-    ),
-    String,
-> {
+fn resolve_cgroup_placement_endpoints_from_process_env()
+-> Result<(Option<String>, Option<String>), String> {
     let workload_canonical = std::env::var_os(CANONICAL_WORKLOAD_CGROUP_PROCS_ENV);
-    let workload_legacy = std::env::var_os(WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV);
     let tool_canonical = std::env::var_os(CANONICAL_TOOL_CGROUP_PROCS_ENV);
-    let tool_legacy = std::env::var_os(TOOL_CGROUP_PROCS_ENDPOINT_ENV);
 
     Ok((
-        resolve_cgroup_placement_endpoint_aliases(
+        canonical_cgroup_placement_endpoint(
             CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-            WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             workload_canonical,
-            workload_legacy,
         )?,
-        resolve_cgroup_placement_endpoint_aliases(
-            CANONICAL_TOOL_CGROUP_PROCS_ENV,
-            TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-            tool_canonical,
-            tool_legacy,
-        )?,
+        canonical_cgroup_placement_endpoint(CANONICAL_TOOL_CGROUP_PROCS_ENV, tool_canonical)?,
     ))
 }
 
-fn resolve_cgroup_placement_endpoint_aliases(
-    canonical_key: &'static str,
-    legacy_key: &'static str,
-    canonical: Option<OsString>,
-    legacy: Option<OsString>,
-) -> Result<Option<ResolvedCgroupPlacementEndpoint>, String> {
-    let canonical = cgroup_placement_endpoint_value(canonical_key, canonical)?;
-    let legacy = cgroup_placement_endpoint_value(legacy_key, legacy)?;
-
-    match (canonical, legacy) {
-        (None, None) => Ok(None),
-        (Some(value), None) => Ok(Some(ResolvedCgroupPlacementEndpoint {
-            value,
-            source: CgroupPlacementEnvSource::CanonicalOnly,
-        })),
-        (None, Some(value)) => Ok(Some(ResolvedCgroupPlacementEndpoint {
-            value,
-            source: CgroupPlacementEnvSource::LegacyOnly,
-        })),
-        (Some(canonical), Some(legacy)) if canonical == legacy => {
-            Ok(Some(ResolvedCgroupPlacementEndpoint {
-                value: canonical,
-                source: CgroupPlacementEnvSource::Dual,
-            }))
-        }
-        (Some(_), Some(_)) => Err(format!(
-            "conflicting cgroup placement environment aliases: canonical_key={canonical_key} \
-             legacy_key={legacy_key} state=conflict"
-        )),
-    }
-}
-
-fn cgroup_placement_endpoint_value(
+fn canonical_cgroup_placement_endpoint(
     key: &'static str,
     value: Option<OsString>,
 ) -> Result<Option<String>, String> {
@@ -325,15 +216,10 @@ fn cgroup_placement_endpoint_value(
         .transpose()
 }
 
-fn reject_empty_cgroup_placement_endpoint(
-    endpoint: &str,
-    canonical_key: &'static str,
-    legacy_key: &'static str,
-) -> Result<(), String> {
+fn reject_empty_cgroup_placement_endpoint(endpoint: &str, key: &'static str) -> Result<(), String> {
     if endpoint.is_empty() {
         return Err(format!(
-            "invalid cgroup placement environment aliases: canonical_key={canonical_key} \
-             legacy_key={legacy_key} state=empty"
+            "invalid cgroup placement environment: key={key} state=empty"
         ));
     }
     Ok(())
@@ -510,8 +396,6 @@ mod tests {
             placement: Arc::new(placement.try_clone().unwrap().into()),
             workload_path: Arc::new(PathBuf::from("/unused")),
             tool_placement_endpoint: Arc::from("test-tool-endpoint"),
-            workload_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
-            tool_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
         };
         let placement_fd = containment.placement.as_raw_fd();
         let mut command = tokio::process::Command::new("/bin/sh");
@@ -543,8 +427,6 @@ mod tests {
             placement: Arc::new(tempfile::tempfile().unwrap().into()),
             workload_path: Arc::new(PathBuf::from("/unused")),
             tool_placement_endpoint: Arc::from("runner-tool-endpoint"),
-            workload_endpoint_source: CgroupPlacementEnvSource::CanonicalOnly,
-            tool_endpoint_source: CgroupPlacementEnvSource::Dual,
         };
 
         assert_eq!(
@@ -562,135 +444,45 @@ mod tests {
             containment.env_source_evidence(),
             [
                 (CANONICAL_WORKLOAD_CGROUP_PROCS_ENV, "canonical-only"),
-                (CANONICAL_TOOL_CGROUP_PROCS_ENV, "dual"),
+                (CANONICAL_TOOL_CGROUP_PROCS_ENV, "canonical-only"),
             ]
         );
     }
 
     #[test]
-    fn resolves_cgroup_placement_alias_values_without_collapsing_empty() {
-        let success_cases = [
-            ("absent", None, None, None),
-            (
-                "canonical-only",
-                Some("canonical-endpoint"),
-                None,
-                Some((
-                    "canonical-endpoint",
-                    CgroupPlacementEnvSource::CanonicalOnly,
-                )),
-            ),
-            (
-                "legacy-only",
-                None,
-                Some("legacy-endpoint"),
-                Some(("legacy-endpoint", CgroupPlacementEnvSource::LegacyOnly)),
-            ),
-            (
-                "equal-dual",
-                Some("shared-endpoint"),
-                Some("shared-endpoint"),
-                Some(("shared-endpoint", CgroupPlacementEnvSource::Dual)),
-            ),
-            (
-                "canonical-empty",
-                Some(""),
-                None,
-                Some(("", CgroupPlacementEnvSource::CanonicalOnly)),
-            ),
-            (
-                "legacy-empty",
-                None,
-                Some(""),
-                Some(("", CgroupPlacementEnvSource::LegacyOnly)),
-            ),
-            (
-                "dual-empty",
-                Some(""),
-                Some(""),
-                Some(("", CgroupPlacementEnvSource::Dual)),
-            ),
-        ];
-
-        for (name, canonical, legacy, expected) in success_cases {
-            let resolved = resolve_cgroup_placement_endpoint_aliases(
+    fn canonical_cgroup_placement_endpoint_preserves_values_and_empty() {
+        assert_eq!(
+            canonical_cgroup_placement_endpoint(CANONICAL_WORKLOAD_CGROUP_PROCS_ENV, None),
+            Ok(None)
+        );
+        assert_eq!(
+            canonical_cgroup_placement_endpoint(
                 CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-                canonical.map(OsString::from),
-                legacy.map(OsString::from),
-            )
-            .unwrap();
-            assert_eq!(
-                resolved
-                    .as_ref()
-                    .map(|endpoint| (endpoint.value.as_str(), endpoint.source)),
-                expected,
-                "{name} resolved incorrectly"
-            );
-        }
+                Some(OsString::from("canonical-endpoint")),
+            ),
+            Ok(Some("canonical-endpoint".to_string()))
+        );
+        assert_eq!(
+            canonical_cgroup_placement_endpoint(
+                CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+                Some(OsString::new()),
+            ),
+            Ok(Some(String::new()))
+        );
     }
 
     #[test]
-    fn rejects_cgroup_placement_alias_conflicts_and_invalid_encoding_without_values() {
-        let canonical_key = CANONICAL_WORKLOAD_CGROUP_PROCS_ENV;
-        let legacy_key = WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV;
-        let expected_conflict = format!(
-            "conflicting cgroup placement environment aliases: canonical_key={canonical_key} \
-             legacy_key={legacy_key} state=conflict"
+    fn rejects_non_unicode_canonical_cgroup_placement_endpoint_without_values() {
+        let error = canonical_cgroup_placement_endpoint(
+            CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+            Some(OsString::from_vec(vec![0xff])),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            format!("{CANONICAL_WORKLOAD_CGROUP_PROCS_ENV} must be valid UTF-8")
         );
-
-        for (name, canonical, legacy) in [
-            ("unequal", "canonical-must-not-leak", "legacy-must-not-leak"),
-            ("canonical-empty", "", "legacy-must-not-leak"),
-            ("legacy-empty", "canonical-must-not-leak", ""),
-        ] {
-            let error = resolve_cgroup_placement_endpoint_aliases(
-                canonical_key,
-                legacy_key,
-                Some(OsString::from(canonical)),
-                Some(OsString::from(legacy)),
-            )
-            .unwrap_err();
-            assert_eq!(error, expected_conflict, "{name} returned the wrong error");
-            assert!(
-                !error.contains("must-not-leak"),
-                "{name} exposed an endpoint"
-            );
-        }
-
-        for (name, canonical, legacy, expected_key) in [
-            (
-                "canonical-non-unicode",
-                Some(OsString::from_vec(vec![0xff])),
-                None,
-                canonical_key,
-            ),
-            (
-                "legacy-non-unicode",
-                None,
-                Some(OsString::from_vec(vec![0xff])),
-                legacy_key,
-            ),
-            (
-                "readable-with-non-unicode",
-                Some(OsString::from("canonical-must-not-leak")),
-                Some(OsString::from_vec(vec![0xff])),
-                legacy_key,
-            ),
-        ] {
-            let error = resolve_cgroup_placement_endpoint_aliases(
-                canonical_key,
-                legacy_key,
-                canonical,
-                legacy,
-            )
-            .unwrap_err();
-            assert_eq!(error, format!("{expected_key} must be valid UTF-8"));
-            assert!(
-                !error.contains("must-not-leak"),
-                "{name} exposed an endpoint"
-            );
-        }
     }
 
     #[test]
@@ -717,8 +509,6 @@ mod tests {
             placement: Arc::new(tempfile::tempfile().unwrap().into()),
             workload_path: Arc::new(directory.path().to_path_buf()),
             tool_placement_endpoint: Arc::from("test-tool-endpoint"),
-            workload_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
-            tool_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
         };
 
         let diagnostics = containment.resource_diagnostics().unwrap();
@@ -768,8 +558,6 @@ mod tests {
             placement: Arc::new(tempfile::tempfile().unwrap().into()),
             workload_path: Arc::new(directory.path().to_path_buf()),
             tool_placement_endpoint: Arc::from("test-tool-endpoint"),
-            workload_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
-            tool_endpoint_source: CgroupPlacementEnvSource::LegacyOnly,
         };
 
         let diagnostics = containment.resource_diagnostics().unwrap();

--- a/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
+++ b/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
@@ -1,12 +1,14 @@
-//! Cgroup placement aliases are resolved before capability consumption.
+//! Canonical cgroup placement endpoints are captured before capability consumption.
 
 #![cfg(unix)]
 
 mod common;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
+use std::io::{BufRead, Write};
 use std::os::fd::AsFd;
 use std::os::unix::ffi::OsStringExt;
+use std::process::Stdio;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
@@ -16,14 +18,17 @@ type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
 const ENDPOINT_MARKER: &str = "must-not-leak";
+const SCRUB_CHILD_TEST: &str = "canonical_pair_ignores_and_scrubs_retired_aliases_isolated";
+const SCRUB_CHILD_GUARD: &str = "OKOU_CGROUP_PLACEMENT_SCRUB_CHILD";
+const SCRUB_CHILD_GUARD_VALUE: &str = "1";
+const SCRUB_CHILD_MARKER: &str = "cgroup placement scrub child active";
+const BROKER_CHILD_TEST: &str = "canonical_pair_scrub_broker_isolated";
+const BROKER_CHILD_GUARD: &str = "OKOU_CGROUP_PLACEMENT_BROKER_CHILD";
+const BROKER_CHILD_GUARD_VALUE: &str = "1";
+const BROKER_ENDPOINT_ENV: &str = "OKOU_CGROUP_PLACEMENT_BROKER_ENDPOINT";
+const BROKER_READY_MARKER: &str = "cgroup placement broker ready";
+const ISOLATED_CHILD_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 static NEXT_ENDPOINT: AtomicU32 = AtomicU32::new(1);
-
-#[derive(Clone, Copy)]
-enum AliasSource {
-    CanonicalOnly,
-    LegacyOnly,
-    Dual,
-}
 
 fn unique_endpoint() -> String {
     let seq = std::process::id().wrapping_add(NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed));
@@ -48,42 +53,6 @@ fn guest_agent_command() -> Command {
         "process-control-endpoint-must-not-leak",
     );
     command
-}
-
-fn apply_pair(
-    command: &mut Command,
-    canonical_key: &'static str,
-    legacy_key: &'static str,
-    source: AliasSource,
-    value: &OsStr,
-) {
-    match source {
-        AliasSource::CanonicalOnly => {
-            command.env(canonical_key, value);
-        }
-        AliasSource::LegacyOnly => {
-            command.env(legacy_key, value);
-        }
-        AliasSource::Dual => {
-            command.env(canonical_key, value).env(legacy_key, value);
-        }
-    }
-}
-
-fn apply_values(
-    command: &mut Command,
-    canonical_key: &'static str,
-    legacy_key: &'static str,
-    canonical: Option<OsString>,
-    legacy: Option<OsString>,
-) {
-    command.env_remove(canonical_key).env_remove(legacy_key);
-    if let Some(value) = canonical {
-        command.env(canonical_key, value);
-    }
-    if let Some(value) = legacy {
-        command.env(legacy_key, value);
-    }
 }
 
 async fn command_output(command: &mut Command, context: &str) -> TestResult<std::process::Output> {
@@ -147,114 +116,112 @@ where
     Ok(())
 }
 
-#[tokio::test]
-async fn guest_agent_accepts_each_resolved_alias_source_for_both_pairs() -> TestResult {
-    let sources = [
-        AliasSource::CanonicalOnly,
-        AliasSource::LegacyOnly,
-        AliasSource::Dual,
-    ];
-
-    for (workload_index, workload_source) in sources.into_iter().enumerate() {
-        for (tool_index, tool_source) in sources.into_iter().enumerate() {
-            let endpoint = unique_endpoint();
-            let listener = process_control_ipc::bind_abstract_listener(&endpoint)?;
-            let broker = std::thread::spawn(move || -> std::io::Result<()> {
-                let stream =
-                    process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(5))?;
-                let invalid_placement =
-                    std::fs::OpenOptions::new().write(true).open("/dev/null")?;
-                process_control_ipc::send_workload_placement(&stream, invalid_placement.as_fd())
-            });
-            let tool_endpoint = format!("tool-{workload_index}-{tool_index}-{ENDPOINT_MARKER}");
-            let mut command = guest_agent_command();
-            apply_pair(
-                &mut command,
-                guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
-                guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-                workload_source,
-                OsStr::new(&endpoint),
-            );
-            apply_pair(
-                &mut command,
-                guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
-                guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-                tool_source,
-                OsStr::new(&tool_endpoint),
-            );
-
-            let output = command_output(
-                &mut command,
-                "resolved cgroup placement alias scenario did not finish",
-            )
-            .await?;
-            broker
-                .join()
-                .map_err(|_| "workload placement broker thread panicked")??;
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
-            assert!(
-                stderr.contains("workload placement fd is not on cgroup v2"),
-                "stderr: {stderr}"
-            );
-            assert_value_free(&stderr, &endpoint, "resolved alias source");
-            assert!(!stderr.contains(&tool_endpoint));
-        }
-    }
+fn assert_listener_idle(listener: &std::os::unix::net::UnixListener, context: &str) -> TestResult {
+    listener.set_nonblocking(true)?;
+    let error = match listener.accept() {
+        Err(error) => error,
+        Ok(_) => return Err(format!("{context} accepted an unexpected connection").into()),
+    };
+    assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock, "{context}");
     Ok(())
 }
 
 #[tokio::test]
-async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumption() -> TestResult {
+async fn guest_agent_accepts_the_canonical_pair_and_preserves_endpoint_bytes() -> TestResult {
+    let endpoint = unique_endpoint();
+    let listener = process_control_ipc::bind_abstract_listener(&endpoint)?;
+    let broker = std::thread::spawn(move || -> std::io::Result<()> {
+        let stream = process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(5))?;
+        let invalid_placement = std::fs::OpenOptions::new().write(true).open("/dev/null")?;
+        process_control_ipc::send_workload_placement(&stream, invalid_placement.as_fd())
+    });
+    let tool_endpoint = format!("canonical-tool-{ENDPOINT_MARKER}");
+    let mut command = guest_agent_command();
+    command
+        .env(
+            guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
+            &endpoint,
+        )
+        .env(
+            guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
+            &tool_endpoint,
+        );
+
+    let output = command_output(
+        &mut command,
+        "canonical cgroup placement scenario did not finish",
+    )
+    .await?;
+    broker
+        .join()
+        .map_err(|_| "workload placement broker thread panicked")??;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("workload placement fd is not on cgroup v2"),
+        "stderr: {stderr}"
+    );
+    assert_value_free(&stderr, &endpoint, "canonical pair");
+    assert!(!stderr.contains(&tool_endpoint));
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_rejects_invalid_canonical_input_before_capability_consumption() -> TestResult {
     let workload_canonical =
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV;
-    let workload_legacy = guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV;
+    let workload_retired = guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV;
     let tool_canonical = guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV;
-    let tool_legacy = guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV;
-    let workload_conflict = format!(
-        "conflicting cgroup placement environment aliases: canonical_key={workload_canonical} \
-         legacy_key={workload_legacy} state=conflict"
-    );
-    let tool_conflict = format!(
-        "conflicting cgroup placement environment aliases: canonical_key={tool_canonical} \
-         legacy_key={tool_legacy} state=conflict"
-    );
-    let workload_empty = format!(
-        "invalid cgroup placement environment aliases: canonical_key={workload_canonical} \
-         legacy_key={workload_legacy} state=empty"
-    );
-    let tool_empty = format!(
-        "invalid cgroup placement environment aliases: canonical_key={tool_canonical} \
-         legacy_key={tool_legacy} state=empty"
-    );
+    let tool_retired = guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV;
+    let pair_required = format!("{workload_canonical} and {tool_canonical} are required with");
+    let workload_empty =
+        format!("invalid cgroup placement environment: key={workload_canonical} state=empty");
+    let tool_empty =
+        format!("invalid cgroup placement environment: key={tool_canonical} state=empty");
 
     assert_rejected_before_workload_connection(
-        "workload-conflict",
-        &workload_conflict,
-        |command, _endpoint| {
-            apply_values(
-                command,
-                workload_canonical,
-                workload_legacy,
-                Some(OsString::from("canonical-workload-must-not-leak")),
-                Some(OsString::from("legacy-workload-must-not-leak")),
-            );
-            command.env(tool_legacy, "legacy-tool-must-not-leak");
+        "missing-canonical-tool",
+        &pair_required,
+        |command, endpoint| {
+            command.env(workload_canonical, endpoint);
         },
     )
     .await?;
     assert_rejected_before_workload_connection(
-        "tool-conflict-after-workload-resolution",
-        &tool_conflict,
+        "missing-canonical-workload",
+        &pair_required,
+        |command, _endpoint| {
+            command.env(tool_canonical, "canonical-tool-must-not-leak");
+        },
+    )
+    .await?;
+    assert_rejected_before_workload_connection(
+        "retired-only",
+        &pair_required,
         |command, endpoint| {
-            command.env(workload_canonical, endpoint);
-            apply_values(
-                command,
-                tool_canonical,
-                tool_legacy,
-                Some(OsString::from("canonical-tool-must-not-leak")),
-                Some(OsString::from("legacy-tool-must-not-leak")),
-            );
+            command
+                .env(workload_retired, endpoint)
+                .env(tool_retired, "legacy-tool-must-not-leak");
+        },
+    )
+    .await?;
+    assert_rejected_before_workload_connection(
+        "canonical-workload-with-retired-tool",
+        &pair_required,
+        |command, endpoint| {
+            command
+                .env(workload_canonical, endpoint)
+                .env(tool_retired, "legacy-tool-must-not-leak");
+        },
+    )
+    .await?;
+    assert_rejected_before_workload_connection(
+        "retired-workload-with-canonical-tool",
+        &pair_required,
+        |command, endpoint| {
+            command
+                .env(workload_retired, endpoint)
+                .env(tool_canonical, "canonical-tool-must-not-leak");
         },
     )
     .await?;
@@ -264,42 +231,15 @@ async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumpti
         |command, _endpoint| {
             command
                 .env(workload_canonical, "")
-                .env(tool_legacy, "legacy-tool-must-not-leak");
+                .env(tool_canonical, "canonical-tool-must-not-leak");
         },
     )
     .await?;
-    assert_rejected_before_workload_connection(
-        "tool-dual-empty",
-        &tool_empty,
-        |command, endpoint| {
-            command
-                .env(workload_legacy, endpoint)
-                .env(tool_canonical, "")
-                .env(tool_legacy, "");
-        },
-    )
-    .await?;
-    assert_rejected_before_workload_connection(
-        "workload-empty-nonempty-conflict",
-        &workload_conflict,
-        |command, _endpoint| {
-            command
-                .env(workload_canonical, "")
-                .env(workload_legacy, "legacy-workload-must-not-leak")
-                .env(tool_legacy, "legacy-tool-must-not-leak");
-        },
-    )
-    .await?;
-    assert_rejected_before_workload_connection(
-        "tool-empty-nonempty-conflict",
-        &tool_conflict,
-        |command, endpoint| {
-            command
-                .env(workload_legacy, endpoint)
-                .env(tool_canonical, "")
-                .env(tool_legacy, "legacy-tool-must-not-leak");
-        },
-    )
+    assert_rejected_before_workload_connection("tool-empty", &tool_empty, |command, endpoint| {
+        command
+            .env(workload_canonical, endpoint)
+            .env(tool_canonical, "");
+    })
     .await?;
     assert_rejected_before_workload_connection(
         "workload-non-unicode",
@@ -307,25 +247,17 @@ async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumpti
         |command, _endpoint| {
             command
                 .env(workload_canonical, OsString::from_vec(vec![0xff]))
-                .env(tool_legacy, "legacy-tool-must-not-leak");
+                .env(tool_canonical, "canonical-tool-must-not-leak");
         },
     )
     .await?;
     assert_rejected_before_workload_connection(
         "tool-non-unicode-after-workload-resolution",
-        &format!("{tool_legacy} must be valid UTF-8"),
+        &format!("{tool_canonical} must be valid UTF-8"),
         |command, endpoint| {
             command
                 .env(workload_canonical, endpoint)
-                .env(tool_legacy, OsString::from_vec(vec![0xff]));
-        },
-    )
-    .await?;
-    assert_rejected_before_workload_connection(
-        "missing-tool-pair",
-        "are required with",
-        |command, endpoint| {
-            command.env(workload_canonical, endpoint);
+                .env(tool_canonical, OsString::from_vec(vec![0xff]));
         },
     )
     .await?;
@@ -341,5 +273,140 @@ async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumpti
     )
     .await?;
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_agent_ignores_and_scrubs_retired_aliases_after_canonical_capture() -> TestResult {
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .arg("--exact")
+        .arg(SCRUB_CHILD_TEST)
+        .arg("--ignored")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env_clear()
+        .env("PATH", ISOLATED_CHILD_PATH)
+        .env(SCRUB_CHILD_GUARD, SCRUB_CHILD_GUARD_VALUE);
+    if let Some(llvm_profile_file) = std::env::var_os("LLVM_PROFILE_FILE") {
+        command.env("LLVM_PROFILE_FILE", llvm_profile_file);
+    }
+
+    let output = command_output(
+        &mut command,
+        "isolated cgroup placement scrub test did not finish",
+    )
+    .await?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "isolated scrub test failed with {}; stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status
+    );
+    assert!(stdout.contains(SCRUB_CHILD_MARKER), "stdout:\n{stdout}");
+    Ok(())
+}
+
+#[test]
+#[ignore = "spawned exactly by the cgroup placement scrub parent test"]
+fn canonical_pair_ignores_and_scrubs_retired_aliases_isolated() -> TestResult {
+    if std::env::var(SCRUB_CHILD_GUARD).ok().as_deref() != Some(SCRUB_CHILD_GUARD_VALUE) {
+        return Ok(());
+    }
+
+    let canonical_endpoint = unique_endpoint();
+    let retired_endpoint = unique_endpoint();
+    let retired_listener = process_control_ipc::bind_abstract_listener(&retired_endpoint)?;
+    let workload_canonical =
+        guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV;
+    let workload_retired = guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV;
+    let tool_canonical = guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV;
+    let tool_retired = guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV;
+
+    // SAFETY: this exact ignored test is the only active test in its process,
+    // and no thread exists while the environment is configured or scrubbed.
+    unsafe {
+        std::env::set_var(workload_canonical, &canonical_endpoint);
+        std::env::set_var(workload_retired, &retired_endpoint);
+        std::env::set_var(tool_canonical, "canonical-tool-must-not-leak");
+        std::env::set_var(tool_retired, OsString::from_vec(vec![0xff]));
+    }
+
+    let mut broker_command = std::process::Command::new(std::env::current_exe()?);
+    broker_command
+        .arg("--exact")
+        .arg(BROKER_CHILD_TEST)
+        .arg("--ignored")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env_clear()
+        .env("PATH", ISOLATED_CHILD_PATH)
+        .env(BROKER_CHILD_GUARD, BROKER_CHILD_GUARD_VALUE)
+        .env(BROKER_ENDPOINT_ENV, &canonical_endpoint)
+        .stdout(Stdio::piped());
+    if let Some(llvm_profile_file) = std::env::var_os("LLVM_PROFILE_FILE") {
+        broker_command.env("LLVM_PROFILE_FILE", llvm_profile_file);
+    }
+    let mut broker = broker_command.spawn()?;
+    let mut broker_stdout = std::io::BufReader::new(
+        broker
+            .stdout
+            .take()
+            .ok_or("cgroup placement broker stdout is unavailable")?,
+    );
+    let mut readiness = String::new();
+    loop {
+        let read = broker_stdout.read_line(&mut readiness)?;
+        if readiness.contains(BROKER_READY_MARKER) {
+            break;
+        }
+        if read == 0 {
+            return Err("cgroup placement broker exited before readiness".into());
+        }
+    }
+
+    let error = guest_agent::workload_containment::WorkloadContainment::from_process_env(true)
+        .expect_err("invalid placement descriptor should reject canonical bootstrap");
+    assert!(
+        error.contains("workload placement fd is not on cgroup v2"),
+        "unexpected canonical bootstrap error: {error}"
+    );
+    assert_value_free(&error, &canonical_endpoint, "canonical scrub child");
+    assert_value_free(&error, &retired_endpoint, "retired scrub child");
+
+    let broker_status = broker.wait()?;
+    assert!(broker_status.success(), "broker status: {broker_status}");
+    assert_listener_idle(&retired_listener, "retired workload endpoint")?;
+    for key in [
+        workload_canonical,
+        workload_retired,
+        tool_canonical,
+        tool_retired,
+    ] {
+        assert!(
+            std::env::var_os(key).is_none(),
+            "Guest Agent retained {key} after canonical capture"
+        );
+    }
+
+    println!("{SCRUB_CHILD_MARKER}");
+    Ok(())
+}
+
+#[test]
+#[ignore = "spawned exactly by the cgroup placement scrub child test"]
+fn canonical_pair_scrub_broker_isolated() -> TestResult {
+    if std::env::var(BROKER_CHILD_GUARD).ok().as_deref() != Some(BROKER_CHILD_GUARD_VALUE) {
+        return Ok(());
+    }
+
+    let endpoint = std::env::var(BROKER_ENDPOINT_ENV)?;
+    let listener = process_control_ipc::bind_abstract_listener(&endpoint)?;
+    println!("{BROKER_READY_MARKER}");
+    std::io::stdout().flush()?;
+    let stream = process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(5))?;
+    let invalid_placement = std::fs::OpenOptions::new().write(true).open("/dev/null")?;
+    process_control_ipc::send_workload_placement(&stream, invalid_placement.as_fd())?;
     Ok(())
 }

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -44,8 +44,9 @@ async fn process_control_endpoint_aliases_without_workload_capability_fail_close
         assert_eq!(output.status.code(), Some(1));
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
-            stderr
-                .contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
+            stderr.contains(
+                guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV
+            ),
             "{bootstrap_env} stderr: {stderr}"
         );
         assert!(
@@ -84,18 +85,18 @@ async fn workload_capability_is_received_over_scm_rights_and_validated()
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
     command
         .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
-        .env_remove(guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV)
-        .env_remove(guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV)
+        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
+        .env_remove(guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV)
         .env(
             process_control_ipc::BOOTSTRAP_ENV,
             "process-control-present",
         )
         .env(
-            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+            guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
             endpoint,
         )
         .env(
-            guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
+            guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,
             "test-tool-placement",
         )
         .env_remove("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL");

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -43,35 +43,38 @@ pub const REQUIRED_CGROUP_CONTROLLERS: [&str; 3] = ["cpu", "memory", "pids"];
 /// Value written to `cgroup.subtree_control` to enable required controllers.
 pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 
-/// Runner-owned bootstrap variable containing the nonce-authenticated local
-/// endpoint that transfers a workload `cgroup.procs` descriptor.
+/// Retired root-bootstrap spelling for the nonce-authenticated workload
+/// `cgroup.procs` descriptor endpoint.
 ///
 /// The root guest supervisor keeps the write-only descriptor out of the user
 /// launch chain and sends it with `SCM_RIGHTS` only after Guest Agent connects
-/// from the matching operation `control` cgroup. Guest Agent consumes this
-/// variable and uses cloned descriptors only from CLI-child `pre_exec` hooks.
+/// from the matching operation `control` cgroup. Guest Agent no longer reads
+/// this spelling, but still scrubs it after capturing the canonical pair.
 pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
 /// Canonical alias for [`WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV`].
 ///
-/// `vsock-guest` writes only this canonical alias. Guest readers retain
-/// [`WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback fallback until the
-/// cutover release, observation window, rollback window, and legacy-read-zero
-/// gates in #28914 are complete.
+/// `vsock-guest` writes only this alias, and Guest Agent requires it at the root
+/// bootstrap boundary before receiving the placement descriptor. Guest Agent
+/// uses cloned descriptors only from CLI-child `pre_exec` hooks.
 pub const CANONICAL_WORKLOAD_CGROUP_PROCS_ENV: &str = "OKOU_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
-/// Runner-owned endpoint used by [`TOOL_EXEC_PATH`] to request a unique tool
-/// cgroup before it executes user code.
+/// Legacy tool-placement endpoint spelling retained for downstream rollback.
+///
+/// Guest Agent no longer reads this spelling from the root bootstrap, but
+/// still scrubs it after capturing the canonical pair. `guest-tool-exec` and
+/// the managed mock launcher continue reading it from rollback-retained managed
+/// CLI children until the downstream cleanup gates in #28914 are complete.
 pub const TOOL_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_TOOL_CGROUP_PROCS_ENDPOINT";
 
 /// Canonical alias for [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`].
 ///
-/// `vsock-guest` writes only this canonical alias to Guest Agent. Guest readers
-/// retain [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback fallback until the
-/// root-writer cutover release, observation window, rollback window, and
-/// legacy-read-zero gates in #28914 are complete.
+/// `vsock-guest` writes only this alias to Guest Agent, whose root bootstrap
+/// reader requires it and no longer reads [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`].
+/// Guest Agent also writes only this alias to managed CLI children, where it is
+/// used by [`TOOL_EXEC_PATH`] to request a unique tool cgroup before executing
+/// user code.
 ///
-/// Guest Agent also writes only this canonical alias to managed CLI children.
 /// `guest-tool-exec` retains [`TOOL_CGROUP_PROCS_ENDPOINT_ENV`] as a rollback
 /// fallback until the downstream-writer cutover is released, pre-cutover Guest
 /// runtimes and reusable sandboxes are drained, the observation and rollback
@@ -313,7 +316,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cgroup_placement_environment_contracts_preserve_legacy_writers() {
+    fn cgroup_placement_environment_contracts_preserve_legacy_aliases() {
         assert_eq!(
             WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT"


### PR DESCRIPTION
## Summary

- remove only the Guest Agent root-bootstrap reads for `VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT` and `VM0_TOOL_CGROUP_PROCS_ENDPOINT`
- require the canonical workload/tool pair before capability consumption while retaining four-key post-capture scrubbing and canonical-only source evidence
- replace the obsolete root dual-reader matrix with focused canonical rejection, stale-legacy non-selection, value-free diagnostics, and process-isolated scrubbing coverage
- document the retired root fallback separately from the rollback-required downstream managed-child readers

## Scope and inventory

- Implementation base: `f9194d2e15e6d9b07468347f657f1c6d3c456f77`
- Initial head: `f8490d0d48fed3bb7093f59c02ea76e3845845c6`
- Refreshed open-PR audit before editing: 29 open PRs, 30 changed-file pages, 525/525 declared files fetched, zero count mismatches, and zero overlap across the expected target files
- Refreshed Rust caller inventory before editing: 17 files with legacy placement symbols/literals and 14 with canonical symbols/literals; exactly four production legacy reads
- Post-change production reads: Guest Agent reads only the two canonical root keys; the two downstream legacy tool reads remain in `guest-tool-exec` and `guest-mock-claude`
- Current `main` advanced after implementation to `f3bb3c589879d6782f7942afff00b8e9af242706`; its changed files do not overlap this PR
- Root writer, managed-child writer, downstream readers, process control, namespace ownership guard, and behavior script remain unchanged

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features --no-deps -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cgroup_placement_env_aliases`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib workload_containment::tests::`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env`
- exact shared-contract, root-writer, managed-child writer, `guest-tool-exec`, and `guest-mock-claude` regressions
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- exact changed-file and production-reader checks

Local `process_control_channel` remains red 2/2 on both this branch and the untouched exact implementation base `f9194d2e15e6d9b07468347f657f1c6d3c456f77`, with the same missing cgroup-pair bootstrap failure. It is an existing environment-sensitive baseline failure rather than a change regression; protected CI remains authoritative.

## Fallbacks

- Rolling back the full Runner artifact restores the former Guest Agent dual reader together with a canonical root writer.
- The downstream managed-child legacy readers remain unchanged for rollback-retained Runner v0.177.2 and v0.177.3.

Closes #30103

Refs #28914
