### PR TITLE
feat(runner): report host env alias sources

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,4 +1,5 @@
-//! Tracing layer that ships WARN+ events to Axiom.
+//! Tracing layer that ships WARN+ events and the dedicated host-env alias
+//! source event to Axiom.
 //!
 //! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
 //! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
@@ -235,7 +236,10 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
+    metadata.target() != INTERNAL_TARGET
+        && (*metadata.level() <= tracing::Level::WARN
+            || (*metadata.level() == tracing::Level::INFO
+                && metadata.target() == crate::host_env::HOST_ENV_ALIAS_SOURCE_TARGET))
 }
 
 fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -24,6 +24,8 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
+use crate::host_env::HOST_ENV_ALIAS_SOURCE_TARGET;
+
 #[derive(Clone, Debug)]
 struct RecordedEvent {
     level: tracing::Level,
@@ -345,6 +347,76 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         !has_event_with_message(&events, "info is below threshold, should not be ingested"),
         "INFO event should not be ingested: {events:#?}",
     );
+}
+
+#[tokio::test]
+async fn only_dedicated_host_env_info_target_is_ingested() {
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+    let (layer, guard) = init_with_base_url_and_hostname(
+        &server.base_url(),
+        "test-token",
+        "test",
+        Some("runner-host-1".to_string()),
+    )
+    .expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::info!(
+            target: HOST_ENV_ALIAS_SOURCE_TARGET,
+            concurrency_factor_alias_source = "canonical",
+            disk_bandwidth_mib_per_sec_alias_source = "legacy",
+            disk_iops_alias_source = "absent",
+            net_rx_mib_per_sec_alias_source = "canonical",
+            net_tx_mib_per_sec_alias_source = "legacy",
+            "runner host environment loaded"
+        );
+        tracing::info!(target: "runner::host_env", "unrelated host env info");
+        tracing::info!(
+            target: "runner::host_env::alias_sources::other",
+            "nearby target info"
+        );
+        tracing::warn!("ordinary warning");
+        tracing::warn!(target: INTERNAL_TARGET, "internal warning");
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    assert_eq!(events.len(), 2, "unexpected ingested events: {events:#?}");
+
+    let host_env = event_with_message(&events, "runner host environment loaded");
+    assert_eq!(host_env["level"], json!("info"));
+    assert_eq!(host_env["context"], json!(HOST_ENV_ALIAS_SOURCE_TARGET));
+    assert_eq!(host_env["runner_hostname"], json!("runner-host-1"));
+    assert_eq!(host_env["runner_version"], json!(env!("CARGO_PKG_VERSION")));
+    assert_eq!(
+        host_env["concurrency_factor_alias_source"],
+        json!("canonical")
+    );
+    assert_eq!(
+        host_env["disk_bandwidth_mib_per_sec_alias_source"],
+        json!("legacy")
+    );
+    assert_eq!(host_env["disk_iops_alias_source"], json!("absent"));
+    assert_eq!(
+        host_env["net_rx_mib_per_sec_alias_source"],
+        json!("canonical")
+    );
+    assert_eq!(host_env["net_tx_mib_per_sec_alias_source"], json!("legacy"));
+    event_with_message(&events, "ordinary warning");
+    for message in [
+        "unrelated host env info",
+        "nearby target info",
+        "internal warning",
+    ] {
+        assert!(
+            !has_event_with_message(&events, message),
+            "filtered event {message:?} reached ingest: {events:#?}",
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/host_env.rs
+++ b/crates/runner/src/host_env.rs
@@ -14,6 +14,7 @@ pub(crate) const RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV: &str =
 pub(crate) const RUNNER_DISK_IOPS_ENV: &str = "OKOU_RUNNER_DISK_IOPS";
 pub(crate) const RUNNER_NET_RX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_RX_MIB_PER_SEC";
 pub(crate) const RUNNER_NET_TX_MIB_PER_SEC_ENV: &str = "OKOU_RUNNER_NET_TX_MIB_PER_SEC";
+pub(crate) const HOST_ENV_ALIAS_SOURCE_TARGET: &str = "runner::host_env::alias_sources";
 
 // Deployed host.env files and retained runner rollback targets may still use VM0_*.
 // Remove these aliases only after every deployed host uses OKOU_* and every supported rollback
@@ -58,6 +59,23 @@ pub(crate) struct HostEnvValue {
     pub(crate) value: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostEnvAliasSource {
+    Absent,
+    Canonical,
+    Legacy,
+}
+
+impl HostEnvAliasSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::Canonical => "canonical",
+            Self::Legacy => "legacy",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct RunnerIoEnvValues {
     pub(crate) disk_bandwidth_mib_per_sec: Option<HostEnvValue>,
@@ -69,6 +87,7 @@ pub(crate) struct RunnerIoEnvValues {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct RunnerHostEnv {
     values: BTreeMap<&'static str, HostEnvValue>,
+    alias_sources: BTreeMap<&'static str, HostEnvAliasSource>,
 }
 
 impl RunnerHostEnv {
@@ -87,18 +106,49 @@ impl RunnerHostEnv {
             net_tx_mib_per_sec: self.values.get(RUNNER_NET_TX_MIB_PER_SEC_ENV).cloned(),
         }
     }
+
+    fn alias_source(&self, logical_key: &'static str) -> HostEnvAliasSource {
+        self.alias_sources
+            .get(logical_key)
+            .copied()
+            .unwrap_or(HostEnvAliasSource::Absent)
+    }
+
+    fn log_alias_sources(&self) {
+        tracing::info!(
+            target: HOST_ENV_ALIAS_SOURCE_TARGET,
+            concurrency_factor_alias_source = self
+                .alias_source(RUNNER_CONCURRENCY_FACTOR_ENV)
+                .label(),
+            disk_bandwidth_mib_per_sec_alias_source = self
+                .alias_source(RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV)
+                .label(),
+            disk_iops_alias_source = self.alias_source(RUNNER_DISK_IOPS_ENV).label(),
+            net_rx_mib_per_sec_alias_source = self
+                .alias_source(RUNNER_NET_RX_MIB_PER_SEC_ENV)
+                .label(),
+            net_tx_mib_per_sec_alias_source = self
+                .alias_source(RUNNER_NET_TX_MIB_PER_SEC_ENV)
+                .label(),
+            "runner host environment loaded"
+        );
+    }
 }
 
 pub(crate) fn read_runner_host_env() -> RunnerResult<RunnerHostEnv> {
-    Ok(RunnerHostEnv {
-        values: read_host_env_file()?,
-    })
+    finish_runner_host_env_load(read_host_env_file())
 }
 
-fn read_host_env_file() -> RunnerResult<BTreeMap<&'static str, HostEnvValue>> {
+fn finish_runner_host_env_load(result: RunnerResult<RunnerHostEnv>) -> RunnerResult<RunnerHostEnv> {
+    let host_env = result?;
+    host_env.log_alias_sources();
+    Ok(host_env)
+}
+
+fn read_host_env_file() -> RunnerResult<RunnerHostEnv> {
     let content = match std::fs::read_to_string(RUNNER_HOST_ENV_FILE) {
         Ok(content) => content,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(RunnerHostEnv::default()),
         Err(e) => {
             return Err(RunnerError::Config(format!(
                 "failed to read {RUNNER_HOST_ENV_FILE}: {e}"
@@ -109,9 +159,10 @@ fn read_host_env_file() -> RunnerResult<BTreeMap<&'static str, HostEnvValue>> {
     parse_host_env_file(&content)
 }
 
-fn parse_host_env_file(content: &str) -> RunnerResult<BTreeMap<&'static str, HostEnvValue>> {
+fn parse_host_env_file(content: &str) -> RunnerResult<RunnerHostEnv> {
     let mut values = BTreeMap::new();
     let mut provided_keys = BTreeMap::new();
+    let mut alias_sources = BTreeMap::new();
 
     for (line_number, line) in content.lines().enumerate() {
         let line_number = line_number + 1;
@@ -152,6 +203,14 @@ fn parse_host_env_file(content: &str) -> RunnerResult<BTreeMap<&'static str, Hos
         }
 
         provided_keys.insert(logical_key, provided_key);
+        alias_sources.insert(
+            logical_key,
+            if provided_key == logical_key {
+                HostEnvAliasSource::Canonical
+            } else {
+                HostEnvAliasSource::Legacy
+            },
+        );
         values.insert(
             logical_key,
             HostEnvValue {
@@ -160,28 +219,54 @@ fn parse_host_env_file(content: &str) -> RunnerResult<BTreeMap<&'static str, Hos
         );
     }
 
-    Ok(values)
+    Ok(RunnerHostEnv {
+        values,
+        alias_sources,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing::Level;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
+
+    const ALIAS_PAIRS: [(&str, &str); 5] = [
+        (
+            RUNNER_CONCURRENCY_FACTOR_ENV,
+            LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV,
+        ),
+        (
+            RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+            LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,
+        ),
+        (RUNNER_DISK_IOPS_ENV, LEGACY_RUNNER_DISK_IOPS_ENV),
+        (
+            RUNNER_NET_RX_MIB_PER_SEC_ENV,
+            LEGACY_RUNNER_NET_RX_MIB_PER_SEC_ENV,
+        ),
+        (
+            RUNNER_NET_TX_MIB_PER_SEC_ENV,
+            LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV,
+        ),
+    ];
 
     #[test]
     fn parse_host_env_file_accepts_allowed_keys_with_comments() {
-        let values = parse_host_env_file(
+        let host_env = parse_host_env_file(
             "\n# host-local runner overrides\nOKOU_RUNNER_CONCURRENCY_FACTOR = 1.5\nVM0_RUNNER_DISK_IOPS = 200000\n",
         )
         .unwrap();
 
         assert_eq!(
-            values.get(RUNNER_CONCURRENCY_FACTOR_ENV),
+            host_env.values.get(RUNNER_CONCURRENCY_FACTOR_ENV),
             Some(&HostEnvValue {
                 value: "1.5".to_string(),
             })
         );
         assert_eq!(
-            values.get(RUNNER_DISK_IOPS_ENV),
+            host_env.values.get(RUNNER_DISK_IOPS_ENV),
             Some(&HostEnvValue {
                 value: "200000".to_string(),
             })
@@ -190,14 +275,41 @@ mod tests {
 
     #[test]
     fn parse_host_env_file_returns_empty_map_for_empty_file() {
-        let values = parse_host_env_file("\n# nothing enabled\n").unwrap();
+        let host_env = parse_host_env_file("\n# nothing enabled\n").unwrap();
 
-        assert!(values.is_empty());
+        assert!(host_env.values.is_empty());
+    }
+
+    #[test]
+    fn parse_host_env_file_classifies_every_alias_pair() {
+        for (canonical, legacy) in ALIAS_PAIRS {
+            let absent = parse_host_env_file("").unwrap();
+            assert_eq!(
+                absent.alias_source(canonical),
+                HostEnvAliasSource::Absent,
+                "expected {canonical} to be absent",
+            );
+
+            let canonical_config =
+                parse_host_env_file(&format!("{canonical}=configured\n")).unwrap();
+            assert_eq!(
+                canonical_config.alias_source(canonical),
+                HostEnvAliasSource::Canonical,
+                "expected {canonical} to be canonical",
+            );
+
+            let legacy_config = parse_host_env_file(&format!("{legacy}=configured\n")).unwrap();
+            assert_eq!(
+                legacy_config.alias_source(canonical),
+                HostEnvAliasSource::Legacy,
+                "expected {legacy} to be legacy",
+            );
+        }
     }
 
     #[test]
     fn parse_host_env_file_preserves_legacy_only_configuration() {
-        let values = parse_host_env_file(
+        let host_env = parse_host_env_file(
             "\
 VM0_RUNNER_CONCURRENCY_FACTOR=1.5
 VM0_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
@@ -207,7 +319,6 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
 ",
         )
         .unwrap();
-        let host_env = RunnerHostEnv { values };
 
         assert_eq!(
             host_env.concurrency_factor(),
@@ -265,12 +376,12 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
         )
         .unwrap();
 
-        assert_eq!(canonical_values, legacy_values);
+        assert_eq!(canonical_values.values, legacy_values.values);
     }
 
     #[test]
     fn parse_host_env_file_normalizes_mixed_io_aliases() {
-        let values = parse_host_env_file(
+        let host_env = parse_host_env_file(
             "\
 OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
 VM0_RUNNER_DISK_IOPS=50000
@@ -279,7 +390,6 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
 ",
         )
         .unwrap();
-        let host_env = RunnerHostEnv { values };
 
         assert_eq!(
             host_env.io_values(),
@@ -302,7 +412,7 @@ VM0_RUNNER_NET_TX_MIB_PER_SEC=125
 
     #[test]
     fn mixed_alias_partial_io_group_remains_all_or_none() {
-        let values = parse_host_env_file(
+        let host_env = parse_host_env_file(
             "\
 OKOU_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC=1000
 VM0_RUNNER_DISK_IOPS=50000
@@ -310,7 +420,6 @@ OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
 ",
         )
         .unwrap();
-        let host_env = RunnerHostEnv { values };
         let profiles = BTreeMap::from([(
             "vm0/default".to_string(),
             crate::config::ProfileConfig {
@@ -331,6 +440,74 @@ OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
         };
         assert!(reason.contains(RUNNER_NET_TX_MIB_PER_SEC_ENV));
         assert_eq!(resolution.device_rate_limits(), None);
+    }
+
+    #[test]
+    fn successful_load_emits_one_value_free_event_with_all_classifications() {
+        const CONFIGURED_VALUES: [&str; 4] = [
+            "concurrency-value-should-not-leak",
+            "bandwidth-value-should-not-leak",
+            "iops-value-should-not-leak",
+            "tx-value-should-not-leak",
+        ];
+
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        captured.clear();
+
+        let host_env = finish_runner_host_env_load(parse_host_env_file(&format!(
+            "{RUNNER_CONCURRENCY_FACTOR_ENV}={}\n{LEGACY_RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV}={}\n{RUNNER_DISK_IOPS_ENV}={}\n{LEGACY_RUNNER_NET_TX_MIB_PER_SEC_ENV}={}\n",
+            CONFIGURED_VALUES[0],
+            CONFIGURED_VALUES[1],
+            CONFIGURED_VALUES[2],
+            CONFIGURED_VALUES[3],
+        )))
+        .unwrap();
+
+        assert_eq!(
+            host_env.concurrency_factor(),
+            Some(&HostEnvValue {
+                value: CONFIGURED_VALUES[0].to_string(),
+            }),
+        );
+        let events = captured.entries();
+        let loaded_events = events
+            .iter()
+            .filter(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message == "runner host environment loaded")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(loaded_events.len(), 1, "captured events: {events:#?}");
+
+        let event = loaded_events[0];
+        assert_eq!(event.level, Level::INFO);
+        for (field, expected) in [
+            ("concurrency_factor_alias_source", "canonical"),
+            ("disk_bandwidth_mib_per_sec_alias_source", "legacy"),
+            ("disk_iops_alias_source", "canonical"),
+            ("net_rx_mib_per_sec_alias_source", "absent"),
+            ("net_tx_mib_per_sec_alias_source", "legacy"),
+        ] {
+            assert_eq!(
+                event.fields.get(field).map(String::as_str),
+                Some(expected),
+                "unexpected {field} in event: {event:#?}",
+            );
+        }
+        for configured_value in CONFIGURED_VALUES {
+            assert!(
+                event
+                    .fields
+                    .values()
+                    .all(|field_value| !field_value.contains(configured_value)),
+                "configured value leaked into event: {event:#?}",
+            );
+        }
     }
 
     #[test]
@@ -373,6 +550,12 @@ OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
 
     #[test]
     fn parse_host_env_file_rejects_alias_conflicts_without_values() {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        captured.clear();
+
         for content in [
             format!(
                 "{LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV}=legacy-value-should-not-leak\n{RUNNER_CONCURRENCY_FACTOR_ENV}=canonical-value-should-not-leak\n"
@@ -384,7 +567,9 @@ OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
                 "{LEGACY_RUNNER_CONCURRENCY_FACTOR_ENV}=same-value-should-not-leak\n{RUNNER_CONCURRENCY_FACTOR_ENV}=same-value-should-not-leak\n"
             ),
         ] {
-            let err = parse_host_env_file(&content).unwrap_err().to_string();
+            let err = finish_runner_host_env_load(parse_host_env_file(&content))
+                .unwrap_err()
+                .to_string();
 
             assert!(err.contains("conflicting host env aliases"));
             assert!(err.contains(RUNNER_CONCURRENCY_FACTOR_ENV));
@@ -392,6 +577,15 @@ OKOU_RUNNER_NET_RX_MIB_PER_SEC=250
             assert!(!err.contains("canonical-value-should-not-leak"));
             assert!(!err.contains("same-value-should-not-leak"));
         }
+        assert!(
+            captured.entries().iter().all(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_none_or(|message| message != "runner host environment loaded")
+            }),
+            "conflicting aliases must fail before the successful-load event",
+        );
     }
 
     #[test]

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -98,6 +98,34 @@ requires atomically restoring the legacy spellings before starting the older
 binary. Every file change still requires the normal runner drain and restart;
 the running process does not reload it.
 
+Every successful `host.env` load emits exactly one informational `runner host
+environment loaded` event. Its dedicated tracing target, serialized to the
+Axiom `context` field, is `runner::host_env::alias_sources`. The Runner Axiom
+filter admits this exact informational target in addition to its existing
+warning-and-error traffic; other informational events remain local. The event
+contains these five fixed, value-free fields:
+
+| Field                                     | Classification                     |
+| ----------------------------------------- | ---------------------------------- |
+| `concurrency_factor_alias_source`         | `absent`, `canonical`, or `legacy` |
+| `disk_bandwidth_mib_per_sec_alias_source` | `absent`, `canonical`, or `legacy` |
+| `disk_iops_alias_source`                  | `absent`, `canonical`, or `legacy` |
+| `net_rx_mib_per_sec_alias_source`         | `absent`, `canonical`, or `legacy` |
+| `net_tx_mib_per_sec_alias_source`         | `absent`, `canonical`, or `legacy` |
+
+`absent` means the logical setting was omitted, `canonical` means the
+`OKOU_*` spelling supplied it, and `legacy` means the `VM0_*` spelling supplied
+it. Configured values, raw lines, and arbitrary input are never included.
+`runner_hostname` and `runner_version` are added automatically by the Axiom
+layer.
+
+Before removing the temporary legacy readers, use this event to cover every
+intended Runner host and supported rollback version for the full drain window.
+Every field must remain either `canonical` or `absent`, with no `legacy`
+classification during that window. A parse or alias-conflict failure emits no
+successful-load event, so missing expected host coverage is a failed gate, not
+evidence that the legacy spelling is absent.
+
 Bandwidth values may be fractional. After conversion from MiB/s, the byte/s
 value must be at least `1`, must fit in a `u64`, and is rounded down to an
 integer. Disk IOPS must parse directly as a nonzero `u64`.


### PR DESCRIPTION
Closes #30107

Parent: #28914

## Summary

- Preserve `absent`, `canonical`, and `legacy` source classifications for all five `/etc/vm0-runner/host.env` tuning alias pairs without changing effective values.
- Emit exactly one fixed, value-free informational event after a successful host environment load.
- Admit only the exact `runner::host_env::alias_sources` informational target to Axiom in addition to existing WARN+ traffic, while preserving the internal diagnostic exclusion.
- Document the event fields and the future legacy-reader drain gate.

## Safety boundaries

- No configured value, raw line, or arbitrary input is logged.
- Parser behavior, numeric validation, units, defaults, tuning, conflicts, precedence, and all-or-none I/O behavior remain unchanged.
- No host configuration, provisioning, writer, reader, rollback, or production state is changed.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `npx --yes --package=prettier@3.6.2 prettier --check docs/runner-host-configuration.md`
- `git diff --check` and focused file-size check
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner host_env::tests` reached only the known local final-link memory ceiling: exit 137 with cgroup `memory.max=3,991,613,440`, `memory.peak=3,991,621,632`, `oom=1`, `oom_kill=4`, and `oom_group_kill=1`. The test targets compiled successfully under strict Clippy/check; protected CI must execute them.

## Pre-edit inventory

The just-in-time base was `f9194d2e15e6d9b07468347f657f1c6d3c456f77`. A fully paginated scan covered 31 open PRs, 32 changed-file pages, and all 530 declared files with zero overlap across the focused targets and direct callers.