### PR TITLE
fix(platform): keep connector category menu above cards

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -48,6 +48,7 @@ import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@okouai/conne
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse } from "msw";
+import { compile } from "tailwindcss";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -2603,6 +2604,52 @@ describe("connectors page", () => {
       expect(screen.getByRole("dialog", { name: "Axiom" })).toBeInTheDocument();
       expect(screen.getByText("Save")).toBeInTheDocument();
     });
+  });
+
+  it("keeps the expanded category menu above connector access controls", async () => {
+    mockConnectors([{ connectorSlug: "github", externalUsername: "octocat" }]);
+    context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledConnectorSlugs: [] });
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const categoryMenuItem = await screen.findByTestId(
+      "connector-category-menu-ai",
+    );
+    categoryMenuItem.focus();
+    expect(categoryMenuItem).toHaveFocus();
+
+    const categoryMenuLayer = categoryMenuItem.closest("aside");
+    const accessControl = within(connectorCardByLabel("GitHub")).getByLabelText(
+      "Manage GitHub access",
+    );
+    const accessControlLayer = accessControl.parentElement;
+    if (
+      !(categoryMenuLayer instanceof HTMLElement) ||
+      !(accessControlLayer instanceof HTMLElement)
+    ) {
+      throw new Error("Connector stacking layers not found");
+    }
+
+    const tailwindCompiler = await compile("@tailwind utilities;");
+    const styleElement = document.createElement("style");
+    styleElement.textContent = tailwindCompiler.build([
+      ...categoryMenuLayer.classList,
+      ...accessControlLayer.classList,
+    ]);
+    document.head.append(styleElement);
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        styleElement.remove();
+      },
+      { once: true },
+    );
+
+    expect(Number(getComputedStyle(categoryMenuLayer).zIndex)).toBeGreaterThan(
+      Number(getComputedStyle(accessControlLayer).zIndex),
+    );
   });
 
   it("filters connectors by slug", async () => {

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -312,7 +312,7 @@ function ConnectorCategoryMenu({
   }
 
   return (
-    <aside className="pointer-events-none fixed right-6 top-[28vh] z-20 hidden w-44 min-[1332px]:block">
+    <aside className="pointer-events-none fixed right-6 top-[28vh] z-30 hidden w-44 min-[1332px]:block">
       <nav
         aria-label={t(($) => {
           return $.connectors.catalog.categoriesAria;


### PR DESCRIPTION
## Summary

- raise the fixed connector category navigation above in-card actions
- prevent access labels and card dividers from painting through the expanded menu

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx` (119 tests)