### PR TITLE
fix(goal): allow mutations during autonomous continuation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1919,8 +1919,8 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     expect(appendSystemPrompt).toContain(goalBrief);
     expect(appendSystemPrompt).toContain("Autonomy budget: 9");
     expect(appendSystemPrompt).toContain("# How to operate");
-    expect(appendSystemPrompt).not.toContain(
-      "Do not create, edit, pause, resume, or clear goals",
+    expect(appendSystemPrompt).toContain(
+      "- Inspect goal state anytime with `okou goal get`.\n- Do not stop to ask the user and wait; act on the best available information.",
     );
     expect(goalContext.body.sessionId).toBe(
       cliAgentSessionIdForChatRun(first.runId),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1919,6 +1919,9 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     expect(appendSystemPrompt).toContain(goalBrief);
     expect(appendSystemPrompt).toContain("Autonomy budget: 9");
     expect(appendSystemPrompt).toContain("# How to operate");
+    expect(appendSystemPrompt).not.toContain(
+      "Do not create, edit, pause, resume, or clear goals",
+    );
     expect(goalContext.body.sessionId).toBe(
       cliAgentSessionIdForChatRun(first.runId),
     );

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -121,7 +121,6 @@ function buildGoalAppendSystemPrompt(goal: {
     "- When the objective is verifiably done, audit it requirement-by-requirement against the current external state; only then run `okou goal complete`.",
     "- If the same blocker stops you for 3 consecutive turns, run `okou goal block` and explain why.",
     "- Inspect goal state anytime with `okou goal get`.",
-    "- Do not create, edit, pause, resume, or clear goals from an autonomous goal continuation run.",
     "- Do not stop to ask the user and wait; act on the best available information.",
   );
   return lines.join("\n");


### PR DESCRIPTION
## Summary

- remove the autonomous goal continuation prompt restriction on creating, editing, pausing, resuming, or clearing goals
- add a regression assertion that the generated continuation system prompt omits the restriction

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'sources the goal system prompt from thread goals'`
