### PR TITLE
refactor(guest-agent): remove legacy process-control endpoint reader

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1203,7 +1203,6 @@ mod tests {
             guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
             guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-            process_control_ipc::BOOTSTRAP_ENV,
             process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
             guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
             guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -7,25 +7,6 @@ use crate::workload_containment::WorkloadContainment;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-#[derive(Clone, Copy)]
-enum ProcessControlEnvSource {
-    CanonicalOnly,
-    LegacyOnly,
-    Dual,
-}
-
-type ProcessControlEnvResolution = (Option<String>, Option<ProcessControlEnvSource>);
-
-impl ProcessControlEnvSource {
-    fn label(self) -> &'static str {
-        match self {
-            Self::CanonicalOnly => "canonical-only",
-            Self::LegacyOnly => "legacy-only",
-            Self::Dual => "dual",
-        }
-    }
-}
-
 /// Production runtime services for one guest-agent run.
 #[derive(Clone)]
 pub struct GuestRuntime {
@@ -57,8 +38,8 @@ impl GuestRuntime {
         let guest_runtime_dir =
             guest_contracts::runtime_paths::guest_runtime_dir_env_from_process_env()
                 .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
-        let (process_control_endpoint, process_control_source) =
-            process_control_endpoint_from_process_env()?;
+        let process_control_endpoint =
+            process_control_env_value(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)?;
         let workload_containment =
             WorkloadContainment::from_process_env(process_control_endpoint.is_some())?;
         let raw = GuestConfigRaw::from_process_env_with_guest_runtime_dir(guest_runtime_dir)?;
@@ -66,14 +47,6 @@ impl GuestRuntime {
         let paths = paths_from_raw(&raw)?;
         guest_common::log::set_system_log_file(paths.system_log_file());
         guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());
-        if let Some(source) = process_control_source {
-            guest_common::log_info!(
-                LOG_TAG,
-                "process_control_env_source key={} source={}",
-                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-                source.label()
-            );
-        }
         if let Some(containment) = &workload_containment {
             for (key, source) in containment.env_source_evidence() {
                 guest_common::log_info!(
@@ -94,34 +67,6 @@ impl GuestRuntime {
             workload_containment,
             process_control_endpoint,
         })
-    }
-}
-
-/// Resolve Stage 1 compatibility between an existing runner or sandbox and a
-/// new guest reader. Existing instances can expose the legacy writer for the
-/// two-hour guest runtime budget plus bounded finalization. #28914 owns the
-/// later writer-cutover and reader-removal issues; remove the legacy branch
-/// only after the reader floor, sandbox drain, rollback window, and
-/// legacy-read-zero gates are complete.
-fn process_control_endpoint_from_process_env() -> Result<ProcessControlEnvResolution, String> {
-    let canonical = process_control_env_value(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)?;
-    let legacy = process_control_env_value(process_control_ipc::BOOTSTRAP_ENV)?;
-
-    match (canonical, legacy) {
-        (None, None) => Ok((None, None)),
-        (Some(endpoint), None) => {
-            Ok((Some(endpoint), Some(ProcessControlEnvSource::CanonicalOnly)))
-        }
-        (None, Some(endpoint)) => Ok((Some(endpoint), Some(ProcessControlEnvSource::LegacyOnly))),
-        (Some(canonical), Some(legacy)) if canonical == legacy => {
-            Ok((Some(canonical), Some(ProcessControlEnvSource::Dual)))
-        }
-        (Some(_), Some(_)) => Err(format!(
-            "conflicting process control environment aliases: canonical_key={} legacy_key={} \
-             state=conflict",
-            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-            process_control_ipc::BOOTSTRAP_ENV
-        )),
     }
 }
 

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -79,16 +79,10 @@ impl WorkloadContainment {
     /// Receive and adopt the production bootstrap descriptor.
     ///
     /// This must run before any other thread can read or mutate process-global
-    /// environment state. The caller supplies the once-resolved canonical or
-    /// legacy process-control presence. A process-control bootstrap requires a
-    /// matching workload capability in production. Direct local execution is
-    /// unmanaged when neither bootstrap value exists.
-    ///
-    /// This reader fallback covers existing runners and reusable sandboxes for
-    /// the two-hour guest runtime budget plus bounded finalization. #28914 owns
-    /// the writer-cutover and reader-removal follow-ups; remove the legacy
-    /// branches only after the reader floor, drain, rollback window, and
-    /// legacy-read-zero gates are complete.
+    /// environment state. The caller supplies the once-resolved canonical
+    /// process-control presence. A process-control bootstrap requires a matching
+    /// workload capability in production. Direct local execution is unmanaged
+    /// when the canonical bootstrap value is absent.
     pub fn from_process_env(process_control_present: bool) -> Result<Option<Self>, String> {
         let (placement_endpoint, tool_endpoint) =
             resolve_cgroup_placement_endpoints_from_process_env()?;
@@ -119,22 +113,20 @@ impl WorkloadContainment {
                     })
             }
             (true, _, _) => Err(format!(
-                "{} or {}, and {} or {}, are required with {} or {}",
+                "{} or {}, and {} or {}, are required with {}",
                 CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
                 WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 CANONICAL_TOOL_CGROUP_PROCS_ENV,
                 TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-                process_control_ipc::BOOTSTRAP_ENV
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV
             )),
             (false, _, _) => Err(format!(
-                "{} or {}, and {} or {}, require {} or {}",
+                "{} or {}, and {} or {}, require {}",
                 CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
                 WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 CANONICAL_TOOL_CGROUP_PROCS_ENV,
                 TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-                process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-                process_control_ipc::BOOTSTRAP_ENV
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV
             )),
         }
     }

--- a/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
+++ b/crates/guest-agent/tests/agent_execution_timeout_env_aliases.rs
@@ -498,7 +498,6 @@ fn process_env_dual_reads_agent_execution_timeout_aliases_without_value_leaks() 
         LEGACY_CONFLICT_TIMEOUT,
     );
     for key in [
-        process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -375,7 +375,6 @@ fn process_env_dual_reads_api_token_aliases_without_value_leaks() -> TestResult 
     );
     set_test_env(guest_contracts::env::API_TOKEN_ENV, LEGACY_TOKEN);
     for key in [
-        process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,

--- a/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
+++ b/crates/guest-agent/tests/cgroup_placement_env_aliases.rs
@@ -33,7 +33,6 @@ fn unique_endpoint() -> String {
 fn guest_agent_command() -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
     for key in [
-        process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
@@ -331,7 +330,7 @@ async fn guest_agent_rejects_the_full_invalid_matrix_before_capability_consumpti
     .await?;
     assert_rejected_before_workload_connection(
         "cgroup-endpoints-without-process-control",
-        "require OKOU_PROCESS_CONTROL_ENDPOINT or VM0_PROCESS_CONTROL_ENDPOINT",
+        "require OKOU_PROCESS_CONTROL_ENDPOINT",
         |command, endpoint| {
             command
                 .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -52,10 +52,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             std::env::set_var(legacy, std::env::var(canonical)?);
         }
         std::env::set_var("VM0_SECRET_VALUES", "runner-secret-values");
-        std::env::set_var(
-            process_control_ipc::BOOTSTRAP_ENV,
-            "runner-control-endpoint",
-        );
+        std::env::set_var("VM0_PROCESS_CONTROL_ENDPOINT", "runner-control-endpoint");
         std::env::set_var(
             process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
             "runner-control-endpoint",
@@ -291,7 +288,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     }
     assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
     for key in [
-        process_control_ipc::BOOTSTRAP_ENV,
+        "VM0_PROCESS_CONTROL_ENDPOINT",
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
     ] {
         assert!(

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1088,7 +1088,6 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::CANONICAL_MOCK_CLAUDE_PATH_ENV,
         guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
-        process_control_ipc::BOOTSTRAP_ENV,
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -13,7 +13,6 @@ fn runtime_bootstrap_scrubs_runner_env_and_installs_explicit_paths() {
     let runtime_dir = tmp.path().join("runtime");
 
     unsafe {
-        std::env::remove_var(process_control_ipc::BOOTSTRAP_ENV);
         std::env::remove_var(
             guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         );

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -177,7 +177,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
 
     common::ensure_canonical_workspace_for_test()?;
     let connection = start_host_and_guest(tmp.path()).await?;
-    let command = canonical_process_control_guest_agent_wrapper_command(guest_agent);
+    let command = cgroup_isolated_guest_agent_wrapper_command(guest_agent);
     let sudo = needs_sudo_for_canonical_workspace();
     let mut handle = connection
         .host()
@@ -537,15 +537,11 @@ fn guest_agent_wrapper_command(guest_agent: &str) -> String {
     quote_shell_arg(guest_agent)
 }
 
-fn canonical_process_control_guest_agent_wrapper_command(guest_agent: &str) -> String {
+fn cgroup_isolated_guest_agent_wrapper_command(guest_agent: &str) -> String {
     // The test process can itself run under vm0 and inherit an incomplete
     // cgroup bootstrap pair. Keep this unmanaged fixture isolated from it.
     format!(
-        "if [ -z \"${{{}+x}}\" ]; then export {}=\"${}\"; fi; unset {} {} {} {} {}; exec {}",
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-        process_control_ipc::BOOTSTRAP_ENV,
-        process_control_ipc::BOOTSTRAP_ENV,
+        "unset {} {} {} {}; exec {}",
         guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV,

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -16,47 +16,49 @@ const ISOLATED_CHILD_MOCK_PATH: &str = "OKOU_PROCESS_CONTROL_ENV_ISOLATED_MOCK_P
 const ISOLATED_CHILD_MARKER: &str = "vm0 process-control env isolated child active";
 const ISOLATED_CHILD_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 const PROCESS_CONTROL_CHILD_TIMEOUT: Duration = Duration::from_secs(30);
+const RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
 
 #[tokio::test]
-async fn process_control_endpoint_aliases_without_workload_capability_fail_closed()
+async fn canonical_process_control_without_workload_capability_fails_closed()
 -> Result<(), Box<dyn std::error::Error>> {
-    for bootstrap_env in [
-        process_control_ipc::BOOTSTRAP_ENV,
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-    ] {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
-        command
-            .env_remove(process_control_ipc::BOOTSTRAP_ENV)
-            .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
-            .env(bootstrap_env, "missing-capability")
-            .env_remove(guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV)
-            .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
-            .env_remove(guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV)
-            .env_remove(guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV)
-            .env_remove("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL");
-        let output = common::command_output_with_timeout(
-            &mut command,
-            PROCESS_CONTROL_CHILD_TIMEOUT,
-            "missing-workload-capability guest-agent scenario did not finish",
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+    command
+        .env_remove(RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV)
+        .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
+        .env(
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+            "missing-capability",
         )
-        .await?;
+        .env_remove(guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV)
+        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
+        .env_remove(guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV)
+        .env_remove(guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV)
+        .env_remove("OKOU_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL");
+    let output = common::command_output_with_timeout(
+        &mut command,
+        PROCESS_CONTROL_CHILD_TIMEOUT,
+        "missing-workload-capability guest-agent scenario did not finish",
+    )
+    .await?;
 
-        assert_eq!(output.status.code(), Some(1));
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            stderr
-                .contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
-            "{bootstrap_env} stderr: {stderr}"
-        );
-        assert!(
-            stderr.contains("are required with"),
-            "{bootstrap_env} stderr: {stderr}"
-        );
-        assert!(
-            !stderr.contains("missing-capability"),
-            "{bootstrap_env} stderr exposed endpoint material"
-        );
-    }
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("are required with OKOU_PROCESS_CONTROL_ENDPOINT"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains(RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV),
+        "stderr retained the retired process-control prerequisite"
+    );
+    assert!(
+        !stderr.contains("missing-capability"),
+        "stderr exposed endpoint material"
+    );
     Ok(())
 }
 
@@ -83,11 +85,12 @@ async fn workload_capability_is_received_over_scm_rights_and_validated()
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
     command
+        .env_remove(RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV)
         .env_remove(process_control_ipc::CANONICAL_BOOTSTRAP_ENV)
         .env_remove(guest_contracts::process_containment::CANONICAL_WORKLOAD_CGROUP_PROCS_ENV)
         .env_remove(guest_contracts::process_containment::CANONICAL_TOOL_CGROUP_PROCS_ENV)
         .env(
-            process_control_ipc::BOOTSTRAP_ENV,
+            process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
             "process-control-present",
         )
         .env(
@@ -182,7 +185,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child_isolated()
     let runtime = common::guest_runtime_from_process_env()?;
     unsafe {
         std::env::set_var(
-            process_control_ipc::BOOTSTRAP_ENV,
+            RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV,
             "stale-legacy-process-control-endpoint",
         );
         std::env::set_var(

--- a/crates/guest-agent/tests/process_control_env_aliases.rs
+++ b/crates/guest-agent/tests/process_control_env_aliases.rs
@@ -16,7 +16,6 @@ const CANONICAL_ENDPOINT: &str = "canonical-endpoint-must-not-leak";
 const RETIRED_ENDPOINT: &str = "retired-endpoint-must-not-leak";
 const ENDPOINT_VALUES: [&str; 2] = [CANONICAL_ENDPOINT, RETIRED_ENDPOINT];
 const RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
-const RETIRED_SOURCE_EVENT: &str = "process_control_env_source";
 
 #[derive(Clone, Copy)]
 enum EnvInput {
@@ -182,13 +181,7 @@ fn startup_reads_only_canonical_process_control_without_value_leaks() -> TestRes
             "{} unexpectedly initialized workload containment",
             case.name
         );
-        let log = read_system_log(&runtime_dir)?;
-        assert!(
-            !log.contains(RETIRED_SOURCE_EVENT),
-            "{} emitted retired process-control source telemetry",
-            case.name
-        );
-        assert_value_free(&log, case.name);
+        assert_value_free(&read_system_log(&runtime_dir)?, case.name);
     }
 
     for (name, retired) in [

--- a/crates/guest-agent/tests/process_control_env_aliases.rs
+++ b/crates/guest-agent/tests/process_control_env_aliases.rs
@@ -1,4 +1,4 @@
-//! Process-control aliases are resolved once at the guest startup boundary.
+//! Process-control bootstrap is captured only from the canonical startup key.
 
 #![cfg(unix)]
 
@@ -13,13 +13,13 @@ use guest_agent::run_context::GuestRuntime;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const CANONICAL_ENDPOINT: &str = "canonical-endpoint-must-not-leak";
-const LEGACY_ENDPOINT: &str = "legacy-endpoint-must-not-leak";
-const SHARED_ENDPOINT: &str = "shared-endpoint-must-not-leak";
-const ENDPOINT_VALUES: [&str; 3] = [CANONICAL_ENDPOINT, LEGACY_ENDPOINT, SHARED_ENDPOINT];
-const SOURCE_EVENT: &str = "process_control_env_source";
+const RETIRED_ENDPOINT: &str = "retired-endpoint-must-not-leak";
+const ENDPOINT_VALUES: [&str; 2] = [CANONICAL_ENDPOINT, RETIRED_ENDPOINT];
+const RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
+const RETIRED_SOURCE_EVENT: &str = "process_control_env_source";
 
 #[derive(Clone, Copy)]
-enum AliasInput {
+enum EnvInput {
     Absent,
     Readable(&'static str),
     NonUnicode,
@@ -28,110 +28,59 @@ enum AliasInput {
 #[derive(Clone, Copy)]
 struct SuccessCase {
     name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
+    canonical: EnvInput,
+    retired: EnvInput,
     expected_endpoint: Option<&'static str>,
-    expected_source: Option<&'static str>,
 }
 
-#[derive(Clone, Copy)]
-struct InvalidEncodingCase {
-    name: &'static str,
-    canonical: AliasInput,
-    legacy: AliasInput,
-    expected_key: &'static str,
-}
-
-const SUCCESS_CASES: [SuccessCase; 9] = [
+const SUCCESS_CASES: [SuccessCase; 8] = [
     SuccessCase {
         name: "absent",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Absent,
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Absent,
         expected_endpoint: None,
-        expected_source: None,
     },
     SuccessCase {
         name: "canonical-empty",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Absent,
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Absent,
         expected_endpoint: None,
-        expected_source: None,
     },
     SuccessCase {
-        name: "legacy-empty",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(""),
-        expected_endpoint: None,
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "dual-empty",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Readable(""),
-        expected_endpoint: None,
-        expected_source: None,
-    },
-    SuccessCase {
-        name: "canonical-only",
-        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
-        legacy: AliasInput::Absent,
+        name: "canonical-present",
+        canonical: EnvInput::Readable(CANONICAL_ENDPOINT),
+        retired: EnvInput::Absent,
         expected_endpoint: Some(CANONICAL_ENDPOINT),
-        expected_source: Some("canonical-only"),
     },
     SuccessCase {
-        name: "legacy-only",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
-        expected_endpoint: Some(LEGACY_ENDPOINT),
-        expected_source: Some("legacy-only"),
+        name: "retired-only-is-ignored",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::Readable(RETIRED_ENDPOINT),
+        expected_endpoint: None,
     },
     SuccessCase {
-        name: "equal-dual",
-        canonical: AliasInput::Readable(SHARED_ENDPOINT),
-        legacy: AliasInput::Readable(SHARED_ENDPOINT),
-        expected_endpoint: Some(SHARED_ENDPOINT),
-        expected_source: Some("dual"),
+        name: "retired-non-unicode-is-ignored",
+        canonical: EnvInput::Absent,
+        retired: EnvInput::NonUnicode,
+        expected_endpoint: None,
     },
     SuccessCase {
-        name: "canonical-empty-with-legacy",
-        canonical: AliasInput::Readable(""),
-        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
-        expected_endpoint: Some(LEGACY_ENDPOINT),
-        expected_source: Some("legacy-only"),
-    },
-    SuccessCase {
-        name: "canonical-with-legacy-empty",
-        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
-        legacy: AliasInput::Readable(""),
+        name: "canonical-is-not-overridden-by-retired",
+        canonical: EnvInput::Readable(CANONICAL_ENDPOINT),
+        retired: EnvInput::Readable(RETIRED_ENDPOINT),
         expected_endpoint: Some(CANONICAL_ENDPOINT),
-        expected_source: Some("canonical-only"),
     },
-];
-
-const INVALID_ENCODING_CASES: [InvalidEncodingCase; 4] = [
-    InvalidEncodingCase {
-        name: "canonical-non-unicode",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Absent,
-        expected_key: process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    SuccessCase {
+        name: "canonical-ignores-non-unicode-retired",
+        canonical: EnvInput::Readable(CANONICAL_ENDPOINT),
+        retired: EnvInput::NonUnicode,
+        expected_endpoint: Some(CANONICAL_ENDPOINT),
     },
-    InvalidEncodingCase {
-        name: "legacy-non-unicode",
-        canonical: AliasInput::Absent,
-        legacy: AliasInput::NonUnicode,
-        expected_key: process_control_ipc::BOOTSTRAP_ENV,
-    },
-    InvalidEncodingCase {
-        name: "canonical-with-non-unicode-legacy",
-        canonical: AliasInput::Readable(CANONICAL_ENDPOINT),
-        legacy: AliasInput::NonUnicode,
-        expected_key: process_control_ipc::BOOTSTRAP_ENV,
-    },
-    InvalidEncodingCase {
-        name: "non-unicode-canonical-with-legacy",
-        canonical: AliasInput::NonUnicode,
-        legacy: AliasInput::Readable(LEGACY_ENDPOINT),
-        expected_key: process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
+    SuccessCase {
+        name: "canonical-empty-does-not-fall-back-to-retired",
+        canonical: EnvInput::Readable(""),
+        retired: EnvInput::Readable(RETIRED_ENDPOINT),
+        expected_endpoint: None,
     },
 ];
 
@@ -151,20 +100,20 @@ fn remove_test_env(key: impl AsRef<OsStr>) {
     }
 }
 
-fn apply_alias(key: &str, input: AliasInput) {
+fn apply_input(key: &str, input: EnvInput) {
     remove_test_env(key);
     match input {
-        AliasInput::Absent => {}
-        AliasInput::Readable(value) => set_test_env(key, value),
-        AliasInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
+        EnvInput::Absent => {}
+        EnvInput::Readable(value) => set_test_env(key, value),
+        EnvInput::NonUnicode => set_test_env(key, OsString::from_vec(vec![0xff])),
     }
 }
 
 fn configure_case(
     root: &Path,
     name: &str,
-    canonical: AliasInput,
-    legacy: AliasInput,
+    canonical: EnvInput,
+    retired: EnvInput,
 ) -> Result<PathBuf, String> {
     let runtime_dir = root.join(format!("{name}-runtime"));
     guest_common::log::clear_system_log_file();
@@ -175,7 +124,7 @@ fn configure_case(
         common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(
             guest_contracts::env::RUN_ID_ENV,
-            format!("process-control-alias-{name}"),
+            format!("process-control-env-{name}"),
         );
         std::env::set_var("HOME", root.join(format!("{name}-home")));
         std::env::set_var(
@@ -188,8 +137,8 @@ fn configure_case(
             &guest_contracts::env::RunPayload::default(),
         )?;
     }
-    apply_alias(process_control_ipc::CANONICAL_BOOTSTRAP_ENV, canonical);
-    apply_alias(process_control_ipc::BOOTSTRAP_ENV, legacy);
+    apply_input(process_control_ipc::CANONICAL_BOOTSTRAP_ENV, canonical);
+    apply_input(RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV, retired);
     Ok(runtime_dir)
 }
 
@@ -211,58 +160,16 @@ fn assert_value_free(text: &str, context: &str) {
     }
 }
 
-fn assert_source_evidence(log: &str, case: SuccessCase) {
-    assert_value_free(log, case.name);
-    let source_lines = log
-        .lines()
-        .filter(|line| line.contains(SOURCE_EVENT))
-        .collect::<Vec<_>>();
-    match case.expected_source {
-        Some(source) => {
-            let expected = format!(
-                "{SOURCE_EVENT} key={} source={source}",
-                process_control_ipc::CANONICAL_BOOTSTRAP_ENV
-            );
-            assert!(
-                source_lines.len() == 1
-                    && source_lines
-                        .first()
-                        .and_then(|line| line.rsplit_once("] "))
-                        .is_some_and(|(_, message)| message == expected),
-                "{} emitted incorrect fixed source evidence",
-                case.name
-            );
-        }
-        None => assert!(
-            source_lines.is_empty(),
-            "{} emitted source evidence without an endpoint",
-            case.name
-        ),
-    }
-}
-
-fn expected_conflict_error() -> String {
-    format!(
-        "conflicting process control environment aliases: canonical_key={} legacy_key={} state=conflict",
-        process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
-        process_control_ipc::BOOTSTRAP_ENV
-    )
-}
-
 #[test]
-fn startup_dual_reads_process_control_aliases_without_value_leaks() -> TestResult {
+fn startup_reads_only_canonical_process_control_without_value_leaks() -> TestResult {
     assert_eq!(
         process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
         "OKOU_PROCESS_CONTROL_ENDPOINT"
     );
-    assert_eq!(
-        process_control_ipc::BOOTSTRAP_ENV,
-        "VM0_PROCESS_CONTROL_ENDPOINT"
-    );
     let tmp = tempfile::tempdir()?;
 
     for case in SUCCESS_CASES {
-        let runtime_dir = configure_case(tmp.path(), case.name, case.canonical, case.legacy)?;
+        let runtime_dir = configure_case(tmp.path(), case.name, case.canonical, case.retired)?;
         let runtime = GuestRuntime::from_process_env().map_err(std::io::Error::other)?;
         assert_eq!(
             runtime.process_control_endpoint.as_deref(),
@@ -275,49 +182,42 @@ fn startup_dual_reads_process_control_aliases_without_value_leaks() -> TestResul
             "{} unexpectedly initialized workload containment",
             case.name
         );
-        assert_source_evidence(&read_system_log(&runtime_dir)?, case);
+        let log = read_system_log(&runtime_dir)?;
+        assert!(
+            !log.contains(RETIRED_SOURCE_EVENT),
+            "{} emitted retired process-control source telemetry",
+            case.name
+        );
+        assert_value_free(&log, case.name);
     }
 
-    configure_case(
-        tmp.path(),
-        "conflict",
-        AliasInput::Readable(CANONICAL_ENDPOINT),
-        AliasInput::Readable(LEGACY_ENDPOINT),
-    )?;
-    set_test_env(
-        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
-        OsString::from_vec(vec![0xff]),
-    );
-    set_test_env(
-        guest_contracts::process_containment::TOOL_CGROUP_PROCS_ENDPOINT_ENV,
-        "must-not-be-consumed",
-    );
-    let conflict_error = match GuestRuntime::from_process_env() {
-        Ok(_) => return Err("conflicting process-control aliases were accepted".into()),
-        Err(error) => error,
-    };
-    assert_eq!(conflict_error, expected_conflict_error());
-    assert_value_free(&conflict_error, "conflict");
-    assert!(
-        std::env::var_os(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
-            .is_some(),
-        "conflict reached workload-containment initialization"
-    );
-
-    for case in INVALID_ENCODING_CASES {
-        configure_case(tmp.path(), case.name, case.canonical, case.legacy)?;
+    for (name, retired) in [
+        ("canonical-non-unicode", EnvInput::Absent),
+        (
+            "canonical-non-unicode-does-not-fall-back-to-retired",
+            EnvInput::Readable(RETIRED_ENDPOINT),
+        ),
+    ] {
+        configure_case(tmp.path(), name, EnvInput::NonUnicode, retired)?;
         let error = match GuestRuntime::from_process_env() {
-            Ok(_) => return Err(format!("{} accepted a non-Unicode alias", case.name).into()),
+            Ok(_) => return Err(format!("{name} accepted a non-Unicode canonical value").into()),
             Err(error) => error,
         };
-        assert_eq!(error, format!("{} must be valid UTF-8", case.expected_key));
-        assert_value_free(&error, case.name);
+        assert_eq!(
+            error,
+            format!(
+                "{} must be valid UTF-8",
+                process_control_ipc::CANONICAL_BOOTSTRAP_ENV
+            )
+        );
+        assert_value_free(&error, name);
     }
 
     // SAFETY: the single test has not started threads and is finished reading
     // the process environment.
     unsafe {
         common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::remove_var(RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV);
     }
     Ok(())
 }

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -9,9 +9,8 @@
 //! descriptors move with `SCM_RIGHTS` and are never inherited through the
 //! sandbox-user launch chain.
 //!
-//! The endpoint is bootstrapped through [`BOOTSTRAP_ENV`] or its reader-only
-//! canonical alias [`CANONICAL_BOOTSTRAP_ENV`]. `vsock-guest` creates the
-//! endpoint name with [`endpoint_name`], binds it with
+//! The endpoint is bootstrapped through [`CANONICAL_BOOTSTRAP_ENV`].
+//! `vsock-guest` creates the endpoint name with [`endpoint_name`], binds it with
 //! [`bind_abstract_listener`], accepts a single control sink connection, and
 //! then drives request/response exchange. `guest-agent` resolves the endpoint
 //! name from the environment, connects with [`connect_abstract`], sends a hello
@@ -90,14 +89,6 @@ pub use transport::{
 /// starts a guest operation that supports a local control sink. `guest-agent`
 /// reads it during startup and connects to that abstract socket. Child agent
 /// CLI processes must not inherit this variable.
-pub const BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
-
-/// Canonical operation-control endpoint alias accepted by guest readers.
-///
-/// `vsock-guest` writes only this canonical alias. Guest readers retain
-/// [`BOOTSTRAP_ENV`] as a rollback fallback until the cutover release,
-/// observation window, rollback window, and legacy-read-zero gates in #28914
-/// are complete.
 pub const CANONICAL_BOOTSTRAP_ENV: &str = "OKOU_PROCESS_CONTROL_ENDPOINT";
 
 /// Maximum request payload size carried by a local control request frame.

--- a/crates/process-control-ipc/src/transport.rs
+++ b/crates/process-control-ipc/src/transport.rs
@@ -19,7 +19,8 @@ const LISTENER_BACKLOG: libc::c_int = 128;
 ///
 /// The name includes the guest operation sequence number and a hexadecimal
 /// encoding of the 16-byte control nonce. The returned string is suitable for
-/// [`bind_abstract_listener`], [`connect_abstract`], and [`crate::BOOTSTRAP_ENV`].
+/// [`bind_abstract_listener`], [`connect_abstract`], and
+/// [`crate::CANONICAL_BOOTSTRAP_ENV`].
 pub fn endpoint_name(seq: u32, nonce: &[u8; 16]) -> String {
     let mut out =
         String::with_capacity(ENDPOINT_PREFIX.len() + MAX_U32_DECIMAL_DIGITS + 1 + NONCE_HEX_LEN);

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -100,6 +100,7 @@ const EXEC_CAPTURED_OUTPUT_OVERHEAD: usize = 1 + 1 + 4;
 const EXEC_DISCARDED_OUTPUT_LEN: usize = 1;
 const EXEC_OPERATION_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const AGENT_READY_OBSERVATION_INTERVAL: Duration = Duration::from_millis(10);
+const RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV: &str = "VM0_PROCESS_CONTROL_ENDPOINT";
 
 #[derive(Clone, Default)]
 pub(crate) struct ExecOperationRegistry {
@@ -2053,7 +2054,7 @@ fn append_exec_control_environment<'a>(
     workload_endpoints: Option<(&'a str, &'a str)>,
 ) {
     env.retain(|(key, _)| {
-        *key != process_control_ipc::BOOTSTRAP_ENV
+        *key != RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV
             && *key != process_control_ipc::CANONICAL_BOOTSTRAP_ENV
             && *key != WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV
             && *key != CANONICAL_WORKLOAD_CGROUP_PROCS_ENV
@@ -2305,7 +2306,7 @@ mod tests {
                 "stale-legacy-workload-endpoint",
             ),
             (
-                process_control_ipc::BOOTSTRAP_ENV,
+                RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV,
                 "stale-legacy-process-control-endpoint",
             ),
             ("SECOND_USER_KEY", "second-user-value"),
@@ -2356,7 +2357,7 @@ mod tests {
             );
         }
         for legacy_key in [
-            process_control_ipc::BOOTSTRAP_ENV,
+            RETIRED_PROCESS_CONTROL_BOOTSTRAP_ENV,
             WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             TOOL_CGROUP_PROCS_ENDPOINT_ENV,
         ] {

--- a/crates/vsock-guest/tests/connection/exec_control.rs
+++ b/crates/vsock-guest/tests/connection/exec_control.rs
@@ -132,7 +132,7 @@ fn supervised_exec_control_forwards_to_bootstrap_sink() {
             timeout: ExecTimeoutPolicy::None,
             command: &command,
             env: &[
-                (process_control_ipc::BOOTSTRAP_ENV, "stale-legacy-endpoint"),
+                ("VM0_PROCESS_CONTROL_ENDPOINT", "stale-legacy-endpoint"),
                 (
                     process_control_ipc::CANONICAL_BOOTSTRAP_ENV,
                     "stale-canonical-endpoint",


### PR DESCRIPTION
## Summary

- make `OKOU_PROCESS_CONTROL_ENDPOINT` the only Guest Agent process-control bootstrap input
- remove the legacy/dual/conflict reader and migration-only source telemetry, and retire the public legacy IPC constant
- preserve the canonical vsock writer while privately scrubbing stale `VM0_PROCESS_CONTROL_ENDPOINT` input
- replace the migration alias matrix with canonical-contract and retired-input negative coverage

## Preserved contract

- canonical absent, empty, readable, and non-Unicode semantics with value-free diagnostics
- CLI isolation for canonical and retired process-control bootstrap material
- endpoint, nonce, framing, control worker, active-input, cancellation, containment, ordering, and transport behavior
- unrelated cgroup compatibility readers and telemetry

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked -p guest-agent -p process-control-ipc -p vsock-guest --all-targets --all-features`
- `cargo clippy --locked -p guest-agent -p process-control-ipc -p vsock-guest --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p guest-agent -p process-control-ipc -p vsock-guest --no-deps --all-features`
- `cargo test --locked -p process-control-ipc`
- focused Guest Agent suites: process-control environment/aliases/channel, cgroup placement aliases, CLI isolation, runtime process environment, cancellation recovery, execution timeout aliases, and API token aliases
- focused vsock suites: canonical environment replacement, exact forwarding, and all `exec_control` connection tests

The focused subprocess tests were run with the unrelated ambient `VM0_API_BACKEND_URL` and incomplete `OKOU_TOOL_CGROUP_PROCS_ENDPOINT` removed from the test harness environment. No focused test hit the local final-link memory ceiling.

Implementation base: `main@cf8d733f24d719323d58106db591c12f0c7c2b15` (newest clean `main` immediately before editing).

Closes #30110

Parent EPIC: #28914
