### PR TITLE
test(python): cover sigv4 admission attach cleanup

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -1211,6 +1211,37 @@ def test_payload_dependent_sigv4_rejects_saturated_admission_before_auth(
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
+def test_payload_dependent_sigv4_releases_new_admission_after_attach_failure(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        content_length="4",
+    )
+    original_admission = aws_sigv4_body_admission.reserve(4)
+    aws_sigv4_body_admission.attach_to_flow(flow, original_admission)
+
+    try:
+        with (
+            mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+            pytest.raises(RuntimeError, match="already attached"),
+        ):
+            mitm_addon.requestheaders(flow)
+
+        assert flow.metadata[metadata_keys.AWS_SIGV4_BODY_ADMISSION] is original_admission
+        assert aws_sigv4_body_admission.state_for_tests() == (1, 4)
+    finally:
+        aws_sigv4_body_admission.release_from_flow(flow)
+
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
 async def test_payload_dependent_sigv4_cancellation_releases_admission(
     tmp_path,
     real_flow,


### PR DESCRIPTION
## Summary

- add an AWS SigV4 request-handler regression for duplicate admission attachment
- verify the handler releases its newly reserved lease without replacing or releasing the flow's existing lease
- verify explicit cleanup removes the flow metadata and returns aggregate admission state to zero

## Scope

Test-only change. Production admission behavior, dependencies, APIs, persisted data, runner protocols, and deployment compatibility are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_aws_sigv4_body.py::test_payload_dependent_sigv4_releases_new_admission_after_attach_failure`
- `uv run --no-sync python -m pytest tests/test_request_handler_aws_sigv4_body.py`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,193 passed)

Closes #30125
