### PR TITLE
fix(python): omit encoding for empty streamed request bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -507,9 +507,12 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                     max_output=BODY_CAPTURE_LIMIT + 1,
                 )
                 if request_body is None:
-                    if request_stream_body.truncated or request_stream_incomplete:
-                        log_entry["request_body_truncated"] = True
-                    log_entry["request_body_encoding"] = "binary"
+                    _set_body_capture_failure(
+                        log_entry,
+                        "request",
+                        raw_request_body,
+                        truncated=request_stream_body.truncated or request_stream_incomplete,
+                    )
                 else:
                     _set_body_fields(
                         log_entry,

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -232,6 +232,33 @@ class TestBodyCaptureStreamBuffer:
         assert "request_body_encoding" not in entry
         assert entry["request_body_truncated"] is True
 
+    @pytest.mark.parametrize(
+        ("complete", "expected_truncated"),
+        [
+            pytest.param(True, False, id="complete"),
+            pytest.param(False, True, id="incomplete"),
+        ],
+    )
+    def test_empty_failed_request_stream_decode_omits_encoding(
+        self, real_flow, complete, expected_truncated
+    ):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            request_encoding="compress",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, b"", complete=complete)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        if expected_truncated:
+            assert entry["request_body_truncated"] is True
+        else:
+            assert "request_body_truncated" not in entry
+
     def test_binary_request_stream_buffer_truncated_marks_truncation(self, real_flow):
         body = b"\x00" * STREAM_BUFFER_LIMIT
         flow = real_flow(


### PR DESCRIPTION
## Summary

- route streamed request decode failures through the shared body-capture failure policy
- omit the `binary` encoding marker when an unsupported encoding is attached to a zero-byte request stream
- preserve incomplete-stream truncation metadata and non-empty decode-failure behavior

## Scope

- No API, schema, database, migration, UI, or configuration changes.
- Existing stored network-log entries are not rewritten.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,194 passed)

Closes #30126
