### PR TITLE
fix(platform): recover shared database worker transport

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -380,7 +380,7 @@ describe("shared database MessagePort protocol", () => {
       const recoveredAttach = context.mocks.ably.deferNextSubscribe();
       await staleTab.heartbeat(heartbeat(), staleOwner.signal);
       await recoveredAttach.started;
-      expect(staleTabTransports).toBe(2);
+      expect(staleTabTransports).toBe(1);
       recoveredAttach.attach();
       await vi.waitFor(() => {
         expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
@@ -423,7 +423,7 @@ describe("shared database MessagePort protocol", () => {
         serverPort.postMessage({
           type: "result",
           requestId: message.requestId,
-          value: null,
+          value: { clientReconnected: false },
         });
         return;
       }

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -154,6 +154,22 @@ function installProtocolBridge(): {
   return { platformStore, workerStore, platformPort, workerPort };
 }
 
+function connectProtocolTransport(
+  events: SharedDatabaseBridgeEvents,
+): MessagePortSharedDatabaseBridge {
+  const [platformPort, workerPort] = messagePortPair();
+  new SharedDatabaseMessagePortServer(
+    context.workerStore,
+    workerPort,
+    context.signal,
+  );
+  return new MessagePortSharedDatabaseBridge(
+    platformPort,
+    location.origin,
+    events,
+  );
+}
+
 describe("shared database MessagePort protocol", () => {
   it("correlates out-of-order queries across structured-cloned independent stores", async () => {
     const { platformStore, workerStore } = installProtocolBridge();
@@ -287,21 +303,6 @@ describe("shared database MessagePort protocol", () => {
     workerStore.set(bootstrapSharedDatabaseWorker$, context.signal);
     const start = Date.parse("2030-01-01T00:00:00.000Z");
     mockNow(start, context.signal);
-    const connectProtocolTransport = (
-      events: SharedDatabaseBridgeEvents,
-    ): MessagePortSharedDatabaseBridge => {
-      const [platformPort, workerPort] = messagePortPair();
-      new SharedDatabaseMessagePortServer(
-        workerStore,
-        workerPort,
-        context.signal,
-      );
-      return new MessagePortSharedDatabaseBridge(
-        platformPort,
-        location.origin,
-        events,
-      );
-    };
 
     let firstTabTransports = 0;
     let staleTabTransports = 0;
@@ -393,6 +394,65 @@ describe("shared database MessagePort protocol", () => {
       subscription.abort();
       staleOwner.abort();
       firstOwner.abort();
+    }
+  });
+
+  it("renews a single expired tab over its existing MessagePort", async () => {
+    const workerStore = context.workerStore;
+    workerStore.set(bootstrapSharedDatabaseWorker$, context.signal);
+    const start = Date.parse("2030-01-01T00:00:00.000Z");
+    mockNow(start, context.signal);
+    let transports = 0;
+    const bridge = new ReconnectingSharedDatabaseBridge({
+      createBridge: (events) => {
+        transports += 1;
+        return connectProtocolTransport(events);
+      },
+      events: {
+        reloadRequired: vi.fn<() => void>(),
+        statusChanged:
+          vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
+      },
+    });
+    const owner = createChildAbortController(context.signal);
+    const subscription = createChildAbortController(context.signal);
+    try {
+      await bridge.heartbeat(heartbeat(), owner.signal);
+      const key = dataKey(crypto.randomUUID());
+      context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+        return respond(404, {
+          error: {
+            code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+            message: "Chat event snapshot not found",
+          },
+        });
+      });
+      context.mocks.api(chatThreadEventsContract.rows, ({ respond }) => {
+        return respond(200, { rows: [] });
+      });
+
+      const initialAttach = context.mocks.ably.deferNextSubscribe();
+      await bridge.on(key, vi.fn<() => void>(), subscription.signal);
+      await initialAttach.started;
+      initialAttach.attach();
+      await vi.waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+        expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
+      });
+
+      mockNow(start + 4 * 60 * 1000, context.signal);
+      const renewedAttach = context.mocks.ably.deferNextSubscribe();
+      await bridge.heartbeat(heartbeat(), owner.signal);
+      await renewedAttach.started;
+      renewedAttach.attach();
+      await vi.waitFor(() => {
+        expect(transports).toBe(1);
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+        expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(2);
+      });
+    } finally {
+      subscription.abort();
+      owner.abort();
     }
   });
 

--- a/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
@@ -20,7 +20,10 @@ import {
   type SharedDatabaseConnectionStatus,
   type SharedDatabaseHeartbeatResult,
 } from "../protocol.ts";
-import { ReconnectingSharedDatabaseBridge } from "../reconnecting-client.ts";
+import {
+  ReconnectingSharedDatabaseBridge,
+  SharedDatabaseTransportError,
+} from "../reconnecting-client.ts";
 
 class FakeBridge implements SharedDatabaseBridge {
   readonly callbacks: (() => void)[] = [];
@@ -262,6 +265,54 @@ describe("reconnecting shared database bridge", () => {
     expect(bridges[1]!.callbacks).toHaveLength(1);
 
     subscription.abort();
+    owner.abort();
+  });
+
+  it("allows a query caller to abort while shared transport recovery continues", async () => {
+    const bridges: FakeBridge[] = [];
+    const recovery = context.mocks.deferred<"reconnect">();
+    let recoveryCalls = 0;
+    const bridge = new ReconnectingSharedDatabaseBridge({
+      createBridge: () => {
+        const created = new FakeBridge();
+        bridges.push(created);
+        return created;
+      },
+      events: {
+        reloadRequired: vi.fn<() => void>(),
+        statusChanged:
+          vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
+      },
+    });
+    const owner = createChildAbortController(context.signal);
+    const caller = createChildAbortController(context.signal);
+    await bridge.heartbeat(heartbeat(), owner.signal);
+    bridges[0]!.queryError = new SharedDatabaseTransportError(
+      "Shared database worker failed to load",
+      () => {
+        recoveryCalls += 1;
+        return recovery.promise;
+      },
+    );
+
+    const query = bridge.query(
+      {
+        dataKey: dataKey(),
+        afterSeqId: null,
+        consistency: "cache-only",
+      },
+      caller.signal,
+    );
+    await vi.waitFor(() => {
+      expect(recoveryCalls).toBe(1);
+    });
+    caller.abort(new DOMException("Query cancelled", "AbortError"));
+
+    await expect(query).rejects.toMatchObject({ name: "AbortError" });
+    expect(bridges).toHaveLength(1);
+    expect(recoveryCalls).toBe(1);
+
+    recovery.resolve("reconnect");
     owner.abort();
   });
 });

--- a/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/reconnecting-client.test.ts
@@ -15,7 +15,11 @@ import type {
   SharedDatabaseQuery,
   SharedDatabaseQueryResult,
 } from "../data-key.ts";
-import type { SharedDatabaseConnectionStatus } from "../protocol.ts";
+import {
+  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
+  type SharedDatabaseConnectionStatus,
+  type SharedDatabaseHeartbeatResult,
+} from "../protocol.ts";
 import { ReconnectingSharedDatabaseBridge } from "../reconnecting-client.ts";
 
 class FakeBridge implements SharedDatabaseBridge {
@@ -23,24 +27,35 @@ class FakeBridge implements SharedDatabaseBridge {
   readonly heartbeats: SharedDatabaseHeartbeat[] = [];
   readonly heartbeatSignals: AbortSignal[] = [];
   heartbeatCalls = 0;
+  queryCalls = 0;
+  subscribeCalls = 0;
+  queryError: Error | null = null;
+  subscribeError: Error | null = null;
   timeoutHeartbeatCall: number | null = null;
 
   async heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<SharedDatabaseHeartbeatResult> {
     this.heartbeatCalls += 1;
     this.heartbeats.push(heartbeat);
     this.heartbeatSignals.push(signal);
     if (this.heartbeatCalls === this.timeoutHeartbeatCall) {
       await createDeferredPromise<void>(signal).promise;
     }
+    return { clientReconnected: false };
   }
 
   query<TKey extends SharedDatabaseDataKey>(
     _query: SharedDatabaseQuery<TKey>,
     _signal: AbortSignal,
   ): Promise<SharedDatabaseQueryResult<TKey>> {
+    this.queryCalls += 1;
+    if (this.queryError) {
+      const error = this.queryError;
+      this.queryError = null;
+      return Promise.reject(error);
+    }
     return Promise.resolve([] as SharedDatabaseQueryResult<TKey>);
   }
 
@@ -49,6 +64,12 @@ class FakeBridge implements SharedDatabaseBridge {
     callback: () => void,
     signal: AbortSignal,
   ): Promise<void> {
+    this.subscribeCalls += 1;
+    if (this.subscribeError) {
+      const error = this.subscribeError;
+      this.subscribeError = null;
+      return Promise.reject(error);
+    }
     this.callbacks.push(callback);
     signal.addEventListener(
       "abort",
@@ -92,6 +113,12 @@ function dataKey(): SharedDatabaseDataKey {
     orgId: currentIdentity.orgId,
     threadId: "reconnecting-thread",
   };
+}
+
+function clientNotConnectedError(): Error {
+  const error = new Error("Shared database client is not connected");
+  error.name = SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME;
+  return error;
 }
 
 describe("reconnecting shared database bridge", () => {
@@ -150,6 +177,91 @@ describe("reconnecting shared database bridge", () => {
 
     subscription.abort();
     expect(recoveredBridge.callbacks).toHaveLength(0);
+    owner.abort();
+  });
+
+  it("retries a query after client expiry and restores subscriptions once", async () => {
+    const bridges: FakeBridge[] = [];
+    const bridge = new ReconnectingSharedDatabaseBridge({
+      createBridge: () => {
+        const created = new FakeBridge();
+        bridges.push(created);
+        return created;
+      },
+      events: {
+        reloadRequired: vi.fn<() => void>(),
+        statusChanged:
+          vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
+      },
+    });
+    const owner = createChildAbortController(context.signal);
+    const subscription = createChildAbortController(context.signal);
+    await bridge.heartbeat(heartbeat(), owner.signal);
+    let appends = 0;
+    await bridge.on(
+      dataKey(),
+      () => {
+        appends += 1;
+      },
+      subscription.signal,
+    );
+    const firstBridge = bridges[0]!;
+    firstBridge.queryError = clientNotConnectedError();
+
+    await expect(
+      bridge.query(
+        {
+          dataKey: dataKey(),
+          afterSeqId: null,
+          consistency: "cache-only",
+        },
+        owner.signal,
+      ),
+    ).resolves.toStrictEqual([]);
+
+    expect(bridges).toHaveLength(2);
+    expect(firstBridge.queryCalls).toBe(1);
+    expect(firstBridge.callbacks).toHaveLength(0);
+    const recoveredBridge = bridges[1]!;
+    expect(recoveredBridge.queryCalls).toBe(1);
+    expect(recoveredBridge.subscribeCalls).toBe(1);
+    expect(recoveredBridge.callbacks).toHaveLength(1);
+    recoveredBridge.callbacks[0]?.();
+    expect(appends).toBe(1);
+
+    subscription.abort();
+    owner.abort();
+  });
+
+  it("retries a subscription once after client expiry", async () => {
+    const bridges: FakeBridge[] = [];
+    const bridge = new ReconnectingSharedDatabaseBridge({
+      createBridge: () => {
+        const created = new FakeBridge();
+        bridges.push(created);
+        return created;
+      },
+      events: {
+        reloadRequired: vi.fn<() => void>(),
+        statusChanged:
+          vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
+      },
+    });
+    const owner = createChildAbortController(context.signal);
+    const subscription = createChildAbortController(context.signal);
+    await bridge.heartbeat(heartbeat(), owner.signal);
+    const firstBridge = bridges[0]!;
+    firstBridge.subscribeError = clientNotConnectedError();
+
+    await bridge.on(dataKey(), vi.fn<() => void>(), subscription.signal);
+
+    expect(bridges).toHaveLength(2);
+    expect(firstBridge.subscribeCalls).toBe(1);
+    expect(firstBridge.callbacks).toHaveLength(0);
+    expect(bridges[1]!.subscribeCalls).toBe(1);
+    expect(bridges[1]!.callbacks).toHaveLength(1);
+
+    subscription.abort();
     owner.abort();
   });
 });

--- a/turbo/apps/platform/src/shared-database/bridge.ts
+++ b/turbo/apps/platform/src/shared-database/bridge.ts
@@ -4,7 +4,10 @@ import type {
   SharedDatabaseQuery,
   SharedDatabaseQueryResult,
 } from "./data-key.ts";
-import type { SharedDatabaseConnectionStatus } from "./protocol.ts";
+import type {
+  SharedDatabaseConnectionStatus,
+  SharedDatabaseHeartbeatResult,
+} from "./protocol.ts";
 
 export interface SharedDatabaseHeartbeat {
   readonly identity: SharedDatabaseIdentity;
@@ -15,7 +18,7 @@ export interface SharedDatabaseBridge {
   heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
-  ): Promise<void>;
+  ): Promise<SharedDatabaseHeartbeatResult>;
   query<TKey extends SharedDatabaseDataKey>(
     query: SharedDatabaseQuery<TKey>,
     signal: AbortSignal,

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -11,8 +11,10 @@ import type {
   SharedDatabasePortLike,
 } from "./bridge.ts";
 import {
+  sharedDatabaseHeartbeatResultSchema,
   sharedDatabaseWorkerMessageSchema,
   type SharedDatabaseClientMessage,
+  type SharedDatabaseHeartbeatResult,
 } from "./protocol.ts";
 import { createDeferredPromise, onRejection } from "../signals/utils.ts";
 
@@ -32,6 +34,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   private readonly handleMessage: (event: MessageEvent<unknown>) => void;
   private ownerSignal: AbortSignal | null = null;
   private closed = false;
+  private closeReason: unknown = new Error("Shared database bridge is closed");
 
   constructor(
     private readonly port: SharedDatabasePortLike,
@@ -75,9 +78,9 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   async heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<SharedDatabaseHeartbeatResult> {
     this.bindOwner(signal);
-    await this.request(
+    const value = await this.request(
       {
         type: "heartbeat",
         requestId: crypto.randomUUID(),
@@ -89,6 +92,11 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
       },
       signal,
     );
+    return sharedDatabaseHeartbeatResultSchema.parse(value);
+  }
+
+  fail(reason: unknown): void {
+    this.close(reason, false);
   }
 
   async query<TKey extends SharedDatabaseDataKey>(
@@ -165,7 +173,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   ): Promise<unknown> {
     signal.throwIfAborted();
     if (this.closed) {
-      throw new Error("Shared database bridge is closed");
+      throw this.closeReason;
     }
     const deferred = createDeferredPromise<unknown>(signal);
     const requestId = message.requestId;
@@ -192,11 +200,12 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     return deferred.promise;
   }
 
-  private close(reason: unknown): void {
+  private close(reason: unknown, reportDisconnected = true): void {
     if (this.closed) {
       return;
     }
     this.closed = true;
+    this.closeReason = reason;
     this.port.postMessage({ type: "disconnect" });
     this.port.removeEventListener("message", this.handleMessage);
     this.port.close();
@@ -205,6 +214,8 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
       pending.reject(reason);
     }
     this.pendingRequests.clear();
-    this.events.statusChanged("disconnected");
+    if (reportDisconnected) {
+      this.events.statusChanged("disconnected");
+    }
   }
 }

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -174,6 +174,7 @@ export class SharedDatabaseMessagePortServer {
           {
             identity: message.identity,
             apiBaseUrl: message.apiBaseUrl,
+            emit: this.emit,
             ...(message.vercelProtectionBypass
               ? {
                   vercelProtectionBypass: message.vercelProtectionBypass,

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -8,6 +8,14 @@ import {
 export const SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME =
   "SharedDatabaseClientNotConnectedError";
 
+export const sharedDatabaseHeartbeatResultSchema = z
+  .object({ clientReconnected: z.boolean() })
+  .strict();
+
+export type SharedDatabaseHeartbeatResult = z.infer<
+  typeof sharedDatabaseHeartbeatResultSchema
+>;
+
 const requestIdSchema = z.string().min(1);
 const subscriptionIdSchema = z.string().min(1);
 

--- a/turbo/apps/platform/src/shared-database/reconnecting-client.ts
+++ b/turbo/apps/platform/src/shared-database/reconnecting-client.ts
@@ -1,6 +1,7 @@
 import { delay } from "signal-timers";
 import {
   createChildAbortController,
+  createDeferredPromise,
   settle,
   withCleanup,
 } from "../signals/utils.ts";
@@ -9,7 +10,10 @@ import type {
   SharedDatabaseBridgeEvents,
   SharedDatabaseHeartbeat,
 } from "./bridge.ts";
-import { SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME } from "./protocol.ts";
+import {
+  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
+  type SharedDatabaseHeartbeatResult,
+} from "./protocol.ts";
 import type {
   SharedDatabaseDataKey,
   SharedDatabaseIdentity,
@@ -37,6 +41,7 @@ interface DurableSubscription {
   readonly callback: () => void;
   readonly dataKey: SharedDatabaseDataKey;
   registeredGeneration: number | null;
+  registrationController: AbortController | null;
 }
 
 class SharedDatabaseTransportTimeoutError extends Error {
@@ -46,9 +51,39 @@ class SharedDatabaseTransportTimeoutError extends Error {
   }
 }
 
+export type SharedDatabaseTransportRecovery = "reconnect" | "reload";
+
+export class SharedDatabaseTransportError extends Error {
+  private recoveryPromise: Promise<SharedDatabaseTransportRecovery> | null =
+    null;
+  private reloadRequested = false;
+
+  constructor(
+    message: string,
+    private readonly resolveRecovery: () => Promise<SharedDatabaseTransportRecovery>,
+  ) {
+    super(message);
+    this.name = "SharedDatabaseTransportError";
+  }
+
+  recover(): Promise<SharedDatabaseTransportRecovery> {
+    this.recoveryPromise ??= this.resolveRecovery();
+    return this.recoveryPromise;
+  }
+
+  claimReload(): boolean {
+    if (this.reloadRequested) {
+      return false;
+    }
+    this.reloadRequested = true;
+    return true;
+  }
+}
+
 function isReconnectableTransportError(error: unknown): boolean {
   return (
     error instanceof SharedDatabaseTransportTimeoutError ||
+    error instanceof SharedDatabaseTransportError ||
     (error instanceof Error &&
       error.name === SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME)
   );
@@ -108,7 +143,7 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
   async heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<SharedDatabaseHeartbeatResult> {
     this.bindOwner(signal);
     const credentialChanged = !sameCredential(
       this.heartbeatRegistration,
@@ -116,56 +151,38 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
     );
     this.heartbeatRegistration = heartbeat;
     if (credentialChanged) {
+      const credentialChange = new DOMException(
+        "Shared database credential changed",
+        "AbortError",
+      );
       for (const [id, subscription] of this.subscriptions) {
+        this.invalidateSubscriptionRegistration(subscription, credentialChange);
         if (!dataKeyMatchesIdentity(subscription.dataKey, heartbeat.identity)) {
           this.subscriptions.delete(id);
           this.subscriptionSignals.delete(id);
-        } else {
-          subscription.registeredGeneration = null;
         }
       }
     }
 
-    const current = this.connection;
-    if (!current) {
-      const result = await settle(this.ensureConnection(), signal);
-      if (result.ok) {
-        return;
+    const connectionToRenew = this.connection;
+    await this.runWithReconnect(async (connection) => {
+      if (connection === connectionToRenew) {
+        await this.renewConnection(connection, heartbeat, credentialChanged);
       }
-      if (!isReconnectableTransportError(result.error)) {
-        throw result.error;
-      }
-      await this.ensureConnection();
-      return;
-    }
-    const result = await settle(
-      this.renewConnection(current, heartbeat, credentialChanged),
-      signal,
-    );
-    if (result.ok) {
-      return;
-    }
-    if (!isReconnectableTransportError(result.error)) {
-      throw result.error;
-    }
-    this.resetConnection(current, result.error);
-    await this.ensureConnection();
+    }, signal);
+    return { clientReconnected: false };
   }
 
   async query<TKey extends SharedDatabaseDataKey>(
     query: SharedDatabaseQuery<TKey>,
     signal: AbortSignal,
   ): Promise<SharedDatabaseQueryResult<TKey>> {
-    const connection = await this.ensureConnection();
-    const result = await settle(connection.bridge.query(query, signal), signal);
-    if (result.ok) {
-      return result.value;
-    }
-    if (!(result.error instanceof SharedDatabaseTransportTimeoutError)) {
-      throw result.error;
-    }
-    const recovered = await this.ensureConnection();
-    return await recovered.bridge.query(query, signal);
+    return await this.runWithReconnect(async (connection) => {
+      return await this.runTransportRequest(
+        connection.bridge.query(query, signal),
+        connection,
+      );
+    }, signal);
   }
 
   async on(
@@ -185,6 +202,7 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
       callback,
       dataKey,
       registeredGeneration: null,
+      registrationController: null,
     };
     this.subscriptions.set(id, subscription);
     this.subscriptionSignals.set(id, signal);
@@ -194,15 +212,12 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
     };
     signal.addEventListener("abort", remove, { once: true });
     const result = await settle(
-      this.connectAndRegister(subscription, signal),
+      this.runWithReconnect(async (connection) => {
+        await this.registerSubscription(connection, subscription, signal);
+      }, signal),
       signal,
     );
     if (result.ok) {
-      return;
-    }
-    if (result.error instanceof SharedDatabaseTransportTimeoutError) {
-      const recovered = await this.ensureConnection();
-      await this.registerSubscription(recovered, subscription, signal);
       return;
     }
     signal.removeEventListener("abort", remove);
@@ -286,28 +301,25 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
     heartbeat: SharedDatabaseHeartbeat,
     registerSubscriptions: boolean,
   ): Promise<void> {
-    await this.runControlRequest(
+    const result = await this.runTransportRequest(
       connection.bridge.heartbeat(heartbeat, connection.controller.signal),
       connection,
     );
-    if (registerSubscriptions) {
+    if (result.clientReconnected) {
+      this.invalidateSubscriptionRegistrations(
+        new DOMException("Shared database client renewed", "AbortError"),
+      );
+    }
+    if (registerSubscriptions || result.clientReconnected) {
       await this.registerSubscriptions(connection);
     }
-  }
-
-  private async connectAndRegister(
-    subscription: DurableSubscription,
-    signal: AbortSignal,
-  ): Promise<void> {
-    const connection = await this.ensureConnection();
-    await this.registerSubscription(connection, subscription, signal);
   }
 
   private async initializeConnection(
     connection: Connection,
     heartbeat: SharedDatabaseHeartbeat,
   ): Promise<void> {
-    await this.runControlRequest(
+    await this.runTransportRequest(
       connection.bridge.heartbeat(heartbeat, connection.controller.signal),
       connection,
     );
@@ -338,28 +350,30 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
       subscriptionSignal,
       connection.controller.signal,
     ]);
+    const registrationController = createChildAbortController(signal);
+    subscription.registrationController = registrationController;
     const result = await settle(
-      this.runControlRequest(
+      this.runTransportRequest(
         connection.bridge.on(
           subscription.dataKey,
           subscription.callback,
-          signal,
+          registrationController.signal,
         ),
         connection,
       ),
-      signal,
+      registrationController.signal,
     );
-    if (result.ok) {
-      subscription.registeredGeneration = connection.generation;
-      return;
+    if (!result.ok) {
+      registrationController.abort(result.error);
+      if (subscription.registrationController === registrationController) {
+        subscription.registrationController = null;
+      }
+      throw result.error;
     }
-    if (result.error instanceof SharedDatabaseTransportTimeoutError) {
-      this.resetConnection(connection, result.error);
-    }
-    throw result.error;
+    subscription.registeredGeneration = connection.generation;
   }
 
-  private async runControlRequest<T>(
+  private async runTransportRequest<T>(
     work: Promise<T>,
     connection: Connection,
   ): Promise<T> {
@@ -368,6 +382,76 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
       this.controlRequestTimeoutMs,
       connection.controller.signal,
     );
+  }
+
+  private async runWithReconnect<T>(
+    operation: (connection: Connection) => Promise<T>,
+    signal: AbortSignal,
+  ): Promise<T> {
+    let attemptedConnection: Connection | null = null;
+    const run = async (): Promise<T> => {
+      attemptedConnection = await this.ensureConnection();
+      return await operation(attemptedConnection);
+    };
+    const first = await settle(run(), signal);
+    if (first.ok) {
+      return first.value;
+    }
+    if (!isReconnectableTransportError(first.error)) {
+      throw first.error;
+    }
+    if (attemptedConnection) {
+      this.resetConnection(attemptedConnection, first.error);
+    }
+    await this.waitForTransportRecovery(first.error, signal);
+
+    attemptedConnection = null;
+    const second = await settle(run(), signal);
+    if (second.ok) {
+      return second.value;
+    }
+    if (isReconnectableTransportError(second.error)) {
+      if (attemptedConnection) {
+        this.resetConnection(attemptedConnection, second.error);
+      }
+      await this.waitForTransportRecovery(second.error, signal);
+    }
+    throw second.error;
+  }
+
+  private async waitForTransportRecovery(
+    error: unknown,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (!(error instanceof SharedDatabaseTransportError)) {
+      return;
+    }
+    const recovery = await error.recover();
+    signal.throwIfAborted();
+    if (recovery === "reconnect") {
+      return;
+    }
+    if (error.claimReload()) {
+      this.options.events.reloadRequired();
+    }
+    await createDeferredPromise<never>(signal).promise;
+  }
+
+  private invalidateSubscriptionRegistrations(reason?: unknown): void {
+    for (const subscription of this.subscriptions.values()) {
+      this.invalidateSubscriptionRegistration(subscription, reason);
+    }
+  }
+
+  private invalidateSubscriptionRegistration(
+    subscription: DurableSubscription,
+    reason?: unknown,
+  ): void {
+    if (reason !== undefined) {
+      subscription.registrationController?.abort(reason);
+    }
+    subscription.registrationController = null;
+    subscription.registeredGeneration = null;
   }
 
   private resetConnection(
@@ -380,9 +464,7 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
     }
     this.connection = null;
     connection.controller.abort(reason);
-    for (const subscription of this.subscriptions.values()) {
-      subscription.registeredGeneration = null;
-    }
+    this.invalidateSubscriptionRegistrations();
     if (reportDisconnected && !this.ownerSignal?.aborted) {
       this.options.events.statusChanged("disconnected");
     }

--- a/turbo/apps/platform/src/shared-database/reconnecting-client.ts
+++ b/turbo/apps/platform/src/shared-database/reconnecting-client.ts
@@ -420,18 +420,28 @@ export class ReconnectingSharedDatabaseBridge implements SharedDatabaseBridge {
   }
 
   private async waitForTransportRecovery(
-    error: unknown,
+    failure: unknown,
     signal: AbortSignal,
   ): Promise<void> {
-    if (!(error instanceof SharedDatabaseTransportError)) {
+    if (!(failure instanceof SharedDatabaseTransportError)) {
       return;
     }
-    const recovery = await error.recover();
+    const waitController = createChildAbortController(signal);
+    const aborted = createDeferredPromise<never>(waitController.signal);
+    const recoveryWork = failure.recover();
+    const recovery = await withCleanup(
+      Promise.race([recoveryWork, aborted.promise]),
+      () => {
+        waitController.abort(
+          new DOMException("Transport recovery wait completed", "AbortError"),
+        );
+      },
+    );
     signal.throwIfAborted();
     if (recovery === "reconnect") {
       return;
     }
-    if (error.claimReload()) {
+    if (failure.claimReload()) {
       this.options.events.reloadRequired();
     }
     await createDeferredPromise<never>(signal).promise;

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -9,7 +9,10 @@ import type {
   SharedDatabaseBridge,
   SharedDatabaseHeartbeat,
 } from "./bridge.ts";
-import type { SharedDatabaseWorkerMessage } from "./protocol.ts";
+import type {
+  SharedDatabaseHeartbeatResult,
+  SharedDatabaseWorkerMessage,
+} from "./protocol.ts";
 import {
   bootstrapSharedDatabaseWorker$,
   connectSharedDatabaseWorkerClient$,
@@ -42,7 +45,10 @@ async function waitForWorkerOperation<T>(
 
 class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
   private readonly clientId = crypto.randomUUID();
-  private readonly callbacks = new Map<string, () => void>();
+  private readonly subscriptions = new Map<
+    string,
+    { readonly callback: () => void; readonly dataKey: SharedDatabaseDataKey }
+  >();
   private ownerSignal: AbortSignal | null = null;
 
   constructor(
@@ -55,35 +61,45 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     workerStore.set(
       connectSharedDatabaseWorkerClient$,
       this.clientId,
-      (event: DirectWorkerEvent) => {
-        if (event.type === "append") {
-          this.callbacks.get(event.subscriptionId)?.();
-          return;
-        }
-        if (event.type === "reload-required") {
-          location.reload();
-          return;
-        }
-        this.platformStore.set(
-          setSharedDatabaseConnectionStatus$,
-          event.status,
-        );
-      },
+      this.emit,
     );
   }
+
+  private readonly emit = (event: DirectWorkerEvent): void => {
+    if (event.type === "append") {
+      this.subscriptions.get(event.subscriptionId)?.callback();
+      return;
+    }
+    if (event.type === "reload-required") {
+      location.reload();
+      return;
+    }
+    this.platformStore.set(setSharedDatabaseConnectionStatus$, event.status);
+  };
 
   async heartbeat(
     heartbeat: SharedDatabaseHeartbeat,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<SharedDatabaseHeartbeatResult> {
     this.bindOwner(signal);
-    await this.workerStore.set(
+    const result = await this.workerStore.set(
       heartbeatSharedDatabaseWorker$,
       this.clientId,
-      { ...heartbeat, apiBaseUrl: this.apiBaseUrl },
+      { ...heartbeat, apiBaseUrl: this.apiBaseUrl, emit: this.emit },
       this.workerSignal,
     );
+    if (result.clientReconnected) {
+      for (const [subscriptionId, subscription] of this.subscriptions) {
+        this.workerStore.set(
+          subscribeSharedDatabaseWorker$,
+          this.clientId,
+          subscriptionId,
+          subscription.dataKey,
+        );
+      }
+    }
     await this.afterWorkerHeartbeat?.();
+    return result;
   }
 
   async query<TKey extends SharedDatabaseDataKey>(
@@ -109,7 +125,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
   ): Promise<void> {
     signal.throwIfAborted();
     const subscriptionId = crypto.randomUUID();
-    this.callbacks.set(subscriptionId, callback);
+    this.subscriptions.set(subscriptionId, { callback, dataKey });
     this.workerStore.set(
       subscribeSharedDatabaseWorker$,
       this.clientId,
@@ -119,7 +135,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     signal.addEventListener(
       "abort",
       () => {
-        this.callbacks.delete(subscriptionId);
+        this.subscriptions.delete(subscriptionId);
         this.workerStore.set(
           unsubscribeSharedDatabaseWorker$,
           this.clientId,
@@ -143,7 +159,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     signal.addEventListener(
       "abort",
       () => {
-        this.callbacks.clear();
+        this.subscriptions.clear();
         this.workerStore.set(
           disconnectSharedDatabaseWorkerClient$,
           this.clientId,

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -488,7 +488,15 @@ export class SharedDatabaseWorkerRuntime {
     vercelProtectionBypass: string | undefined,
   ): Promise<SharedDatabaseHeartbeatResult> {
     this.rootSignal.throwIfAborted();
+    const heartbeatAt = now();
     let client = this.clients.get(clientId);
+    if (
+      client &&
+      client.lastHeartbeatAt < heartbeatAt - STALE_CLIENT_AFTER_MS
+    ) {
+      this.expireClient(clientId);
+      client = undefined;
+    }
     const clientReconnected = client === undefined;
     if (!client) {
       if (!emit) {
@@ -496,8 +504,8 @@ export class SharedDatabaseWorkerRuntime {
       }
       client = this.registerClient(clientId, emit);
     }
-    client.lastHeartbeatAt = now();
-    this.pruneStaleClients();
+    client.lastHeartbeatAt = heartbeatAt;
+    this.pruneStaleClients(heartbeatAt);
     const previousCredentialId = client.identity
       ? sharedDatabaseCredentialId(client.identity)
       : null;
@@ -1778,8 +1786,8 @@ export class SharedDatabaseWorkerRuntime {
     }
   }
 
-  private pruneStaleClients(): void {
-    const staleBefore = now() - STALE_CLIENT_AFTER_MS;
+  private pruneStaleClients(currentTime: number): void {
+    const staleBefore = currentTime - STALE_CLIENT_AFTER_MS;
     const staleClientIds = Array.from(this.clients.values()).flatMap(
       (client) => {
         return client.lastHeartbeatAt < staleBefore ? [client.clientId] : [];

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -49,6 +49,7 @@ import {
 import {
   SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
   type SharedDatabaseConnectionStatus,
+  type SharedDatabaseHeartbeatResult,
   type SharedDatabaseWorkerMessage,
 } from "./protocol.ts";
 import { createSharedDatabaseContractClient } from "./worker-client.ts";
@@ -458,27 +459,45 @@ export class SharedDatabaseWorkerRuntime {
     if (this.clients.has(clientId)) {
       throw new Error("Shared database client is already connected");
     }
-    this.clients.set(clientId, {
+    this.registerClient(clientId, emit);
+  }
+
+  private registerClient(
+    clientId: string,
+    emit: WorkerClientEmitter,
+  ): WorkerClientRegistration {
+    const client: WorkerClientRegistration = {
       clientId,
       emit,
       subscriptions: new Map(),
       identity: null,
       apiBaseUrl: null,
       lastHeartbeatAt: now(),
-    });
+    };
+    this.clients.set(clientId, client);
     L.debug("client.register", { clientId });
     emit({ type: "status", status: "connecting" });
+    return client;
   }
 
   async heartbeat(
     clientId: string,
+    emit: WorkerClientEmitter | undefined,
     identity: SharedDatabaseIdentity,
     apiBaseUrl: string,
     vercelProtectionBypass: string | undefined,
-  ): Promise<void> {
+  ): Promise<SharedDatabaseHeartbeatResult> {
     this.rootSignal.throwIfAborted();
+    let client = this.clients.get(clientId);
+    const clientReconnected = client === undefined;
+    if (!client) {
+      if (!emit) {
+        throw new SharedDatabaseClientNotConnectedError();
+      }
+      client = this.registerClient(clientId, emit);
+    }
+    client.lastHeartbeatAt = now();
     this.pruneStaleClients();
-    const client = this.requireClient(clientId);
     const previousCredentialId = client.identity
       ? sharedDatabaseCredentialId(client.identity)
       : null;
@@ -494,7 +513,6 @@ export class SharedDatabaseWorkerRuntime {
     }
     client.identity = identity;
     client.apiBaseUrl = apiBaseUrl;
-    client.lastHeartbeatAt = now();
 
     let credential = this.credentials.get(nextCredentialId);
     if (!credential) {
@@ -541,12 +559,18 @@ export class SharedDatabaseWorkerRuntime {
     L.debug("client.heartbeat", {
       authBlocked: credential.authBlocked,
       clientId,
+      clientReconnected,
       orgId: identity.orgId,
       userId: identity.userId,
     });
+    return { clientReconnected };
   }
 
   disconnectClient(clientId: string): void {
+    this.expireClient(clientId);
+  }
+
+  private expireClient(clientId: string): void {
     const client = this.clients.get(clientId);
     if (!client) {
       return;
@@ -1762,7 +1786,7 @@ export class SharedDatabaseWorkerRuntime {
       },
     );
     for (const clientId of staleClientIds) {
-      this.disconnectClient(clientId);
+      this.expireClient(clientId);
     }
   }
 

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -5,6 +5,7 @@ import type {
   SharedDatabaseQueryResult,
 } from "./data-key.ts";
 import type { SharedDatabaseHeartbeat } from "./bridge.ts";
+import type { SharedDatabaseHeartbeatResult } from "./protocol.ts";
 import {
   SharedDatabaseWorkerRuntime,
   type WorkerClientEmitter,
@@ -14,6 +15,7 @@ const workerRuntimeState$ = state<SharedDatabaseWorkerRuntime | null>(null);
 
 interface SharedDatabaseWorkerHeartbeat extends SharedDatabaseHeartbeat {
   readonly apiBaseUrl: string;
+  readonly emit?: WorkerClientEmitter;
 }
 
 function requireRuntime(
@@ -46,15 +48,17 @@ export const heartbeatSharedDatabaseWorker$ = command(
     clientId: string,
     heartbeat: SharedDatabaseWorkerHeartbeat,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<SharedDatabaseHeartbeatResult> => {
     signal.throwIfAborted();
-    await requireRuntime(get(workerRuntimeState$)).heartbeat(
+    const result = await requireRuntime(get(workerRuntimeState$)).heartbeat(
       clientId,
+      heartbeat.emit,
       heartbeat.identity,
       heartbeat.apiBaseUrl,
       heartbeat.vercelProtectionBypass,
     );
     signal.throwIfAborted();
+    return result;
   },
 );
 

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -1,6 +1,10 @@
+import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
-import type { SharedDatabasePortLike } from "../../shared-database/bridge.ts";
+import type {
+  SharedDatabaseHeartbeat,
+  SharedDatabasePortLike,
+} from "../../shared-database/bridge.ts";
 import { heartbeatSharedDatabase$ } from "../shared-database.ts";
 import { setupSharedDatabaseBridge$ } from "../shared-database-browser.ts";
 import { testContext } from "./test-helpers.ts";
@@ -25,7 +29,11 @@ class TestSharedWorkerPort implements SharedDatabasePortLike {
     queueMicrotask(() => {
       this.listener?.(
         new MessageEvent("message", {
-          data: { type: "result", requestId, value: null },
+          data: {
+            type: "result",
+            requestId,
+            value: { clientReconnected: false },
+          },
         }),
       );
     });
@@ -54,46 +62,198 @@ class TestSharedWorkerPort implements SharedDatabasePortLike {
   }
 }
 
+interface SharedWorkerConstructorCall {
+  readonly options?: string | WorkerOptions;
+  readonly scriptURL: string | URL;
+}
+
+class TestSharedWorker {
+  readonly port = new TestSharedWorkerPort();
+  private errorListener: ((event: ErrorEvent) => void) | null = null;
+  private readonly scriptURL: string;
+
+  constructor(
+    scriptURL: string | URL,
+    options: string | WorkerOptions | undefined,
+    constructorCalls: SharedWorkerConstructorCall[],
+  ) {
+    this.scriptURL = String(scriptURL);
+    constructorCalls.push({ scriptURL, options });
+  }
+
+  addEventListener(
+    _type: "error",
+    listener: (event: ErrorEvent) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    this.errorListener = listener;
+    const signal = typeof options === "object" ? options.signal : undefined;
+    signal?.addEventListener(
+      "abort",
+      () => {
+        this.errorListener = null;
+      },
+      { once: true },
+    );
+  }
+
+  fail(): void {
+    this.errorListener?.(
+      new ErrorEvent("error", {
+        error: new Error("SharedWorker module script failed to load"),
+        filename: this.scriptURL,
+        message: "SharedWorker module script failed to load",
+      }),
+    );
+  }
+}
+
+function installSharedWorkerMock(): {
+  readonly constructorCalls: SharedWorkerConstructorCall[];
+  readonly workers: TestSharedWorker[];
+} {
+  const constructorCalls: SharedWorkerConstructorCall[] = [];
+  const workers: TestSharedWorker[] = [];
+  class SharedWorkerMock extends TestSharedWorker {
+    constructor(scriptURL: string | URL, options?: string | WorkerOptions) {
+      super(scriptURL, options, constructorCalls);
+      workers.push(this);
+    }
+  }
+  vi.stubGlobal("SharedWorker", SharedWorkerMock);
+  return { constructorCalls, workers };
+}
+
+function sharedDatabaseHeartbeat(): SharedDatabaseHeartbeat {
+  return {
+    identity: {
+      userId: "shared-worker-user",
+      orgId: "shared-worker-org",
+      token: "shared-worker-token",
+    },
+  };
+}
+
+async function setupBridge(): Promise<void> {
+  context.store.set(setupSharedDatabaseBridge$, context.signal);
+  await context.store.set(
+    heartbeatSharedDatabase$,
+    sharedDatabaseHeartbeat(),
+    context.signal,
+  );
+}
+
 describe("shared database browser bridge", () => {
   it("creates the shared worker with the Okou core service identity", async () => {
-    const constructorCalls: {
-      readonly options?: string | WorkerOptions;
-      readonly scriptURL: string | URL;
-    }[] = [];
+    const { constructorCalls } = installSharedWorkerMock();
 
-    class TestSharedWorker {
-      readonly port = new TestSharedWorkerPort();
-
-      constructor(scriptURL: string | URL, options?: string | WorkerOptions) {
-        constructorCalls.push({ scriptURL, options });
-      }
-
-      addEventListener(
-        _type: "error",
-        _listener: (event: ErrorEvent) => void,
-        _options?: AddEventListenerOptions | boolean,
-      ): void {}
-    }
-
-    vi.stubGlobal("SharedWorker", TestSharedWorker);
-
-    context.store.set(setupSharedDatabaseBridge$, context.signal);
-    await context.store.set(
-      heartbeatSharedDatabase$,
-      {
-        identity: {
-          userId: "shared-worker-user",
-          orgId: "shared-worker-org",
-          token: "shared-worker-token",
-        },
-      },
-      context.signal,
-    );
+    await setupBridge();
 
     expect(constructorCalls).toHaveLength(1);
     expect(constructorCalls[0]?.options).toStrictEqual({
       name: "okou core service",
       type: "module",
     });
+  });
+
+  it("recreates the shared worker when the module asset is still available", async () => {
+    const { constructorCalls, workers } = installSharedWorkerMock();
+    await setupBridge();
+    const workerUrl = String(constructorCalls[0]!.scriptURL);
+    context.mocks.http.get(workerUrl, () => {
+      return new HttpResponse("export {};", {
+        headers: { "content-type": "application/javascript" },
+      });
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    workers[0]!.fail();
+    await context.store.set(
+      heartbeatSharedDatabase$,
+      sharedDatabaseHeartbeat(),
+      context.signal,
+    );
+
+    expect(constructorCalls).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      label: "missing",
+      response: () => {
+        return new HttpResponse("Not found", { status: 404 });
+      },
+    },
+    {
+      label: "replaced by HTML",
+      response: () => {
+        return new HttpResponse("<!doctype html>", {
+          headers: { "content-type": "text/html" },
+        });
+      },
+    },
+  ])("reloads when the worker asset is $label", async ({ response }) => {
+    const reload = vi.fn<() => void>();
+    const { constructorCalls, workers } = installSharedWorkerMock();
+    await setupBridge();
+    vi.stubGlobal("location", {
+      href: window.location.href,
+      origin: window.location.origin,
+      reload,
+    });
+    const workerUrl = String(constructorCalls[0]!.scriptURL);
+    context.mocks.http.get(workerUrl, response);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    workers[0]!.fail();
+    const heartbeat = context.store.set(
+      heartbeatSharedDatabase$,
+      sharedDatabaseHeartbeat(),
+      context.signal,
+    );
+    context.track(heartbeat);
+
+    await vi.waitFor(() => {
+      expect(reload).toHaveBeenCalledOnce();
+    });
+    expect(constructorCalls).toHaveLength(1);
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it("waits for connectivity before recreating the shared worker", async () => {
+    const { constructorCalls, workers } = installSharedWorkerMock();
+    await setupBridge();
+    const workerUrl = String(constructorCalls[0]!.scriptURL);
+    let probeRequests = 0;
+    context.mocks.http.get(workerUrl, () => {
+      probeRequests += 1;
+      return HttpResponse.error();
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    workers[0]!.fail();
+    const heartbeat = context.store.set(
+      heartbeatSharedDatabase$,
+      sharedDatabaseHeartbeat(),
+      context.signal,
+    );
+    await vi.waitFor(() => {
+      expect(probeRequests).toBe(1);
+    });
+    expect(constructorCalls).toHaveLength(1);
+
+    await Promise.resolve();
+    window.dispatchEvent(new Event("online"));
+    await heartbeat;
+
+    expect(constructorCalls).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledOnce();
   });
 });

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -4,9 +4,21 @@ import { sentryLogContext } from "../lib/sentry-config.ts";
 import { resolveApiBaseForTarget } from "./api-base.ts";
 import { authRecovery$, authenticatedIdentity$ } from "./auth.ts";
 import { logger } from "./log.ts";
-import { jsonParseOr, onDomEventFn, setLoop } from "./utils.ts";
+import {
+  createChildAbortController,
+  createDeferredPromise,
+  jsonParseOr,
+  onDomEventFn,
+  setLoop,
+  settle,
+  withCleanup,
+} from "./utils.ts";
 import { MessagePortSharedDatabaseBridge } from "../shared-database/message-port-client.ts";
-import { ReconnectingSharedDatabaseBridge } from "../shared-database/reconnecting-client.ts";
+import {
+  ReconnectingSharedDatabaseBridge,
+  SharedDatabaseTransportError,
+  type SharedDatabaseTransportRecovery,
+} from "../shared-database/reconnecting-client.ts";
 import {
   heartbeatSharedDatabase$,
   installSharedDatabaseBridge$,
@@ -64,6 +76,67 @@ function heartbeatInterval(token: string): number {
   );
 }
 
+function isJavaScriptResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type")?.toLowerCase();
+  return (
+    contentType?.includes("javascript") === true ||
+    contentType?.includes("ecmascript") === true
+  );
+}
+
+async function waitForWorkerRetry(signal: AbortSignal): Promise<void> {
+  const controller = createChildAbortController(signal);
+  const ready = createDeferredPromise<void>(controller.signal);
+  const resolve = (): void => {
+    if (!ready.settled()) {
+      ready.resolve();
+    }
+  };
+  const resolveWhenVisible = (): void => {
+    if (document.visibilityState === "visible") {
+      resolve();
+    }
+  };
+  window.addEventListener("online", resolve, { signal: controller.signal });
+  window.addEventListener("focus", resolve, { signal: controller.signal });
+  document.addEventListener("visibilitychange", resolveWhenVisible, {
+    signal: controller.signal,
+  });
+  await withCleanup(ready.promise, () => {
+    controller.abort(new DOMException("Worker retry resumed", "AbortError"));
+  });
+}
+
+async function resolveWorkerRecovery(
+  workerUrl: string,
+  signal: AbortSignal,
+): Promise<SharedDatabaseTransportRecovery> {
+  if (!workerUrl) {
+    await waitForWorkerRetry(signal);
+    return "reconnect";
+  }
+  const probe = await settle(
+    fetch(new URL(workerUrl, location.href), { cache: "no-store", signal }),
+    signal,
+  );
+  if (!probe.ok) {
+    await waitForWorkerRetry(signal);
+    return "reconnect";
+  }
+  if (
+    probe.value.status === 404 ||
+    probe.value.status === 410 ||
+    !isJavaScriptResponse(probe.value)
+  ) {
+    return "reload";
+  }
+  if (probe.value.ok) {
+    return "reconnect";
+  }
+  await waitForWorkerRetry(signal);
+  return "reconnect";
+}
+
 export const setupSharedDatabaseBridge$ = command(
   ({ get, set }, signal: AbortSignal): void => {
     signal.throwIfAborted();
@@ -77,10 +150,21 @@ export const setupSharedDatabaseBridge$ = command(
           new URL("../shared-database-worker.ts", import.meta.url),
           { name: "okou core service", type: "module" },
         );
+        const portBridge = new MessagePortSharedDatabaseBridge(
+          worker.port,
+          apiBaseUrl,
+          events,
+        );
+        let recoveryStarted = false;
         worker.addEventListener(
           "error",
           (event) => {
+            if (recoveryStarted) {
+              return;
+            }
+            recoveryStarted = true;
             const workerError: unknown = event.error;
+            const workerUrl = event.filename;
             L.error(
               "Shared database worker failed to load",
               workerError instanceof Error ? workerError : event.message,
@@ -91,14 +175,18 @@ export const setupSharedDatabaseBridge$ = command(
                 },
               }),
             );
+            portBridge.fail(
+              new SharedDatabaseTransportError(
+                "Shared database worker failed to load",
+                async () => {
+                  return await resolveWorkerRecovery(workerUrl, signal);
+                },
+              ),
+            );
           },
           { signal },
         );
-        return new MessagePortSharedDatabaseBridge(
-          worker.port,
-          apiBaseUrl,
-          events,
-        );
+        return portBridge;
       },
       events: {
         reloadRequired: () => {


### PR DESCRIPTION
## Summary

- recover SharedWorker load failures by probing the actual failed module URL without cache
  - reload when the asset is missing (`404`/`410`) or no longer JavaScript
  - recreate the worker once when the asset is still available
  - wait for `online`, focus, or visible foreground before retrying network/unknown failures
- renew expired clients over an existing live MessagePort while still releasing stale subscriptions, actors, realtime sessions, credentials, and databases
- handle transport timeouts and `SharedDatabaseClientNotConnectedError` consistently across heartbeat, query, and subscription operations by resetting the failed generation and retrying once
- restore durable subscriptions exactly once after either a client lease renewal or transport recreation

The existing content-hashed worker URL and `okou core service` worker name remain unchanged. This PR intentionally does not add a reload-loop storage guard or change authentication recovery.

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/signals/__tests__/shared-database-browser.test.ts src/shared-database/__tests__/reconnecting-client.test.ts src/shared-database/__tests__/message-port.test.ts src/shared-database/__tests__/worker-runtime.test.ts --silent=passed-only` (32 tests)

A full local production build transformed all app modules but the sandbox was killed with exit 137 during whole-site chunk output; the PR pipeline will run the standard production build.

Closes #29437
