### PR TITLE
docs(rust): document codex restore cleanup semantics

### DIFF
--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -1,3 +1,32 @@
+# Codex restore cleanup contract
+#
+# This helper is embedded by the runner and runs before history restoration
+# only when an idle sandbox is reused. It is destructive within the canonical
+# $codex_home/sessions tree: matching regular files and symlinks are removed,
+# while unrelated entries and directories are preserved.
+#
+# OKOU_CODEX_RESTORE_SESSION_ID and
+# OKOU_CODEX_RESTORE_SESSION_FILENAME_KEY identify the dashed and undashed
+# session-name forms. OKOU_CODEX_RESTORE_SESSION_PATH supplies the caller's
+# canonical sessions/YYYY/MM/DD restore path. The helper validates these
+# inputs' shape and the session root's directory components before scanning;
+# Rust independently validates any logical path returned by the helper.
+#
+# The collection pass walks the whole sessions tree, not only the fallback date
+# directory, and is bounded by OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET (default
+# 16384 entries). It records matching .jsonl, .jsonl.zst,
+# .jsonl.vm0tmp-*, and .jsonl.zst.vm0tmp-* entries first; only file-like
+# entries are later deleted. A canonical regular-file .jsonl or .jsonl.zst
+# match produces one logical path, with raw/zstd siblings normalized together.
+# No canonical match produces empty stdout; distinct canonical paths are
+# ambiguous and fail before deletion.
+#
+# On success, stdout is empty or exactly one LF-terminated logical path. The
+# Rust caller validates that path independently before writing. Validation,
+# scan, budget, ambiguity, temporary-file, or deletion failure exits nonzero;
+# collection completes before deletion, and any such failure prevents the
+# caller from writing replacement history. Exit traps remove helper temp files.
+
 root="$codex_home/sessions"
 restore_path="$OKOU_CODEX_RESTORE_SESSION_PATH"
 restore_dir="${restore_path%/*}"

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -26,12 +26,38 @@ fn codex_restore_rollout_timestamp(
     session.codex_timestamp().unwrap_or(fallback_timestamp)
 }
 
-/// Write a Codex session history file as canonical JSONL or zstd-compressed
+/// Restore a Codex session history file as canonical JSONL or zstd-compressed
 /// JSONL under
 /// `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl[.zst]`.
 ///
 /// Codex 0.137 filters filesystem resume candidates through its canonical
-/// rollout filename parser, so a bare `{thread_id}.jsonl` is ignored.
+/// rollout filename parser, so a bare `{thread_id}.jsonl` is ignored. The
+/// canonical path without the optional `.zst` suffix is the logical rollout
+/// path; the suffix is added only for compressed restored history.
+///
+/// On an idle-reused sandbox (`SandboxReuseResult::Reused`), cleanup runs
+/// before this function writes the replacement history. Every other reuse
+/// outcome writes to the timestamp-derived fallback path without scanning
+/// prior Codex state. The cleanup helper scans the complete
+/// `~/.codex/sessions` tree, bounded by `OKOU_CODEX_SESSION_CLEANUP_SCAN_BUDGET`
+/// (default: 16,384 entries), because duplicate resume candidates can exist
+/// outside the fallback date directory.
+///
+/// Cleanup removes matching regular files and symlinks whose names contain the
+/// dashed or undashed session key and end in `.jsonl`, `.jsonl.zst`,
+/// `.jsonl.vm0tmp-*`, or `.jsonl.zst.vm0tmp-*`. Unrelated entries and
+/// directories are preserved. A matching regular file in the canonical
+/// `YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl[.zst]` layout is a
+/// logical-path candidate: raw and zstd siblings map to the same logical path,
+/// no candidate selects the fallback, and multiple distinct candidates are an
+/// ambiguity that fails before deletion.
+///
+/// The helper emits either empty stdout or exactly one LF-terminated canonical
+/// logical path. Rust validates that output independently at the guest trust
+/// boundary, including its layout, date/time fields, and session ID, before it
+/// becomes the write destination. A scan, deletion, helper, ambiguity,
+/// malformed/truncated-output, or path-validation failure therefore prevents
+/// the replacement history from being written.
 pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,


### PR DESCRIPTION
## Summary

- Document the full Codex restore cleanup lifecycle and filesystem-safety contract at the Rust restore entry point.
- Add a matching header contract to the embedded cleanup helper, including its bounded whole-tree scan, deletion scope, canonical-path selection, stdout protocol, and fail-closed behavior.
- Preserve all executable Rust and shell behavior, existing tests, and the optional zstd path distinction.

## Scope

This is a documentation-only change in:

- `crates/runner/src/executor/session_restore/codex.rs`
- `crates/runner/scripts/codex-session-cleanup.sh`

No runtime code, test, generated file, dependency, migration, or compatibility behavior changed.

## Validation

- `cargo check --manifest-path crates/Cargo.toml -p runner --bin runner` — passed.
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check` — passed.
- `sh -n crates/runner/scripts/codex-session-cleanup.sh` — passed.
- `git diff --check` — passed.
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::session_restore::codex::tests` — the host terminated the link stage with exit 137 before tests ran. Retried with a workspace-local target and private `TMPDIR`, `CARGO_BUILD_JOBS=1`, debug info disabled, and the explicit `--bin runner` test target; both retries were also terminated with exit 137 and produced no test output.

Closes #30124
